### PR TITLE
Change inputs to be scoped by solid- rather than pipeline-scoped

### DIFF
--- a/python_modules/dagster/README.rst
+++ b/python_modules/dagster/README.rst
@@ -112,9 +112,11 @@ You might notice that there is no actual CSV file specified as inputs. This is b
 
 .. code-block:: python
 
-  environment = config.environment(
+  environment = config.Environment(
     sources={
+      'sum_solid' : {
         'num' : config.Source(name='CSV', args={'path': 'path/to/num.csv'})
+      }
     }
   )
 
@@ -185,7 +187,9 @@ We can specify in order to get artifacts for the results. We can materialize out
 
     environment = config.Environment(
         sources={
+          'sum' : {
             'num' : config.Source(name='CSV', args={'path': 'path/to/num.csv'})
+          }
         }
     )
 
@@ -374,7 +378,9 @@ enough source data to create all the inputs necessary for the pipeline.
 
     environment = config.Environment(
         sources={
+          'sum' : {
             'num_df' : config.Source(name='CSV', args={'path': 'path/to/input.csv'})
+          }
         }
     )
 
@@ -460,7 +466,9 @@ isolation or in the context of a pipeline.
 
     environment = config.Environment(
         sources={
-            'num_df' : config.Source(name='CSV', args={'path': 'path/to/num.csv'})
+          'sum' : {
+              'num_df' : config.Source(name='CSV', args={'path': 'path/to/num.csv'})
+          }
         }
     )
 
@@ -499,7 +507,9 @@ would have to be changed.
 
     environment = config.Environment(
         sources={
-            'sum_df' : config.Source(name='CSV', args={'path': 'path/to/sum.csv'})
+          'sum_sq' : { 
+              'sum_df' : config.Source(name='CSV', args={'path': 'path/to/sum.csv'})
+          }
         }
     )
 
@@ -507,7 +517,7 @@ would have to be changed.
         dagster.context(),
         pipeline,
         environment,
-        from=['sum'],
+        from=['sum_sq'],
         through=['sum_sq'],
     )
 

--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -16,7 +16,9 @@ class Materialization(namedtuple('MaterializationData', 'solid materialization_t
 
 class Environment(namedtuple('EnvironmentData', 'sources')):
     def __new__(cls, sources):
-        check.dict_param(sources, 'sources', key_type=str, value_type=Source)
+        check.dict_param(sources, 'sources', key_type=str, value_type=dict)
+        for _solid_name, source_dict in sources.items():
+            check.dict_param(source_dict, 'source_dict', key_type=str, value_type=Source)
 
         return super(Environment, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -90,7 +90,11 @@ def test_solid_with_input():
         create_test_context(),
         hello_world,
         environment=config.Environment(
-            sources={'foo_to_foo': config.Source(name='TEST', args={'foo': 'bar'})}
+            sources={
+                'hello_world': {
+                    'foo_to_foo': config.Source(name='TEST', args={'foo': 'bar'})
+                }
+            }
         ),
     )
 
@@ -117,7 +121,9 @@ def test_sources():
         create_test_context(),
         hello_world,
         environment=config.Environment(
-            sources={'i': config.Source(name='NO_CONTEXT', args={'foo': 'bar'})}
+            sources={'hello_world': {
+                'i': config.Source(name='NO_CONTEXT', args={'foo': 'bar'})
+            }}
         ),
     )
 
@@ -129,7 +135,9 @@ def test_sources():
         create_test_context(),
         hello_world,
         environment=config.Environment(
-            sources={'i': config.Source(name='NO_CONTEXT', args={'foo': 'bar'})}
+            sources={'hello_world': {
+                'i': config.Source(name='NO_CONTEXT', args={'foo': 'bar'})
+            }}
         ),
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
@@ -27,10 +27,11 @@ def create_test_context():
     return DagsterExecutionContext()
 
 
-def single_input_env(input_name, args=None):
+def single_input_env(solid_name, input_name, args=None):
+    check.str_param(solid_name, 'solid_name')
     check.str_param(input_name, 'input_name')
     args = check.opt_dict_param(args, 'args')
-    return config.Environment(sources={input_name: config.Source('CUSTOM', args)})
+    return config.Environment(sources={solid_name: {input_name: config.Source('CUSTOM', args)}})
 
 
 def test_execute_solid_no_args():
@@ -67,7 +68,7 @@ def test_execute_solid_no_args():
     output_single_solid(
         create_test_context(),
         single_solid,
-        environment=single_input_env('some_input'),
+        environment=single_input_env('some_node', 'some_input'),
         materialization_type='CUSTOM',
         arg_dict={}
     )
@@ -134,7 +135,7 @@ def test_hello_world():
     result = execute_single_solid(
         create_test_context(),
         hello_world,
-        environment=single_input_env('hello_world_input'),
+        environment=single_input_env('hello_world', 'hello_world_input'),
     )
 
     assert result.success
@@ -146,7 +147,7 @@ def test_hello_world():
     output_result = output_single_solid(
         create_test_context(),
         hello_world,
-        environment=single_input_env('hello_world_input'),
+        environment=single_input_env('hello_world', 'hello_world_input'),
         materialization_type='CUSTOM',
         arg_dict={}
     )
@@ -172,7 +173,7 @@ def test_execute_solid_with_args():
     result = output_single_solid(
         create_test_context(),
         single_solid,
-        environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+        environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
         materialization_type='CUSTOM',
         arg_dict={},
     )
@@ -191,7 +192,7 @@ def test_execute_solid_with_failed_input_expectation_non_throwing():
     solid_execution_result = output_single_solid(
         create_test_context(),
         single_solid,
-        environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+        environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
         materialization_type='CUSTOM',
         arg_dict={},
         throw_on_error=False,
@@ -209,7 +210,7 @@ def test_execute_solid_with_failed_input_expectation_throwing():
         output_single_solid(
             create_test_context(),
             single_solid,
-            environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+            environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
             materialization_type='CUSTOM',
             arg_dict={},
         )
@@ -218,7 +219,7 @@ def test_execute_solid_with_failed_input_expectation_throwing():
         output_single_solid(
             create_test_context(),
             single_solid,
-            environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+            environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
             materialization_type='CUSTOM',
             arg_dict={},
         )
@@ -246,7 +247,7 @@ def test_execute_solid_with_failed_output_expectation_non_throwing():
     solid_execution_result = output_single_solid(
         create_test_context(),
         failing_solid,
-        environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+        environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
         materialization_type='CUSTOM',
         arg_dict={},
         throw_on_error=False
@@ -264,7 +265,7 @@ def test_execute_solid_with_failed_output_expectation_throwing():
         output_single_solid(
             create_test_context(),
             failing_solid,
-            environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+            environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
             materialization_type='CUSTOM',
             arg_dict={},
         )
@@ -273,7 +274,7 @@ def test_execute_solid_with_failed_output_expectation_throwing():
         output_single_solid(
             create_test_context(),
             failing_solid,
-            environment=single_input_env('some_input', {'str_arg': 'an_input_arg'}),
+            environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
             materialization_type='CUSTOM',
             arg_dict={},
         )

--- a/python_modules/dagster/dagster/core/core_tests/test_iterator_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_iterator_execution.py
@@ -45,7 +45,11 @@ def test_iterator_solid():
     output_single_solid(
         dagster.context(),
         iterable_solid,
-        environment=config.Environment(sources={'iter_numbers': config.Source('CUSTOM', {})}),
+        environment=config.Environment(
+            sources={'some_node': {
+                'iter_numbers': config.Source('CUSTOM', {})
+            }}
+        ),
         materialization_type='CUSTOM',
         arg_dict={}
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -110,8 +110,12 @@ def create_root_output_failure_solid(name):
     )
 
 
-def no_args_env(input_name):
-    return config.Environment(sources={input_name: config.Source(name='CUSTOM', args={})})
+def no_args_env(solid_name, input_name):
+    return config.Environment(
+        sources={solid_name: {
+            input_name: config.Source(name='CUSTOM', args={})
+        }}
+    )
 
 
 def test_transform_failure_pipeline():
@@ -119,7 +123,7 @@ def test_transform_failure_pipeline():
     pipeline_result = execute_pipeline(
         create_test_context(),
         pipeline,
-        environment=no_args_env('failing_input'),
+        environment=no_args_env('failing', 'failing_input'),
         throw_on_error=False
     )
 
@@ -137,7 +141,7 @@ def test_input_failure_pipeline():
     pipeline_result = execute_pipeline(
         create_test_context(),
         pipeline,
-        environment=no_args_env('failing_input_input'),
+        environment=no_args_env('failing_input', 'failing_input_input'),
         throw_on_error=False
     )
 
@@ -154,7 +158,7 @@ def test_output_failure_pipeline():
     pipeline_result = materialize_pipeline(
         create_test_context(),
         pipeline,
-        environment=no_args_env('failing_output_input'),
+        environment=no_args_env('failing_output', 'failing_output_input'),
         materializations=[
             config.Materialization(solid='failing_output', materialization_type='CUSTOM', args={})
         ],
@@ -190,8 +194,12 @@ def test_failure_midstream():
 
     environment = config.Environment(
         sources={
-            'A_input': config.Source('CUSTOM', {}),
-            'B_input': config.Source('CUSTOM', {}),
+            'A': {
+                'A_input': config.Source('CUSTOM', {}),
+            },
+            'B': {
+                'B_input': config.Source('CUSTOM', {})
+            }
         }
     )
     pipeline = dagster.core.pipeline(solids=[solid_a, solid_b, solid_c])

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -206,7 +206,6 @@ def test_execution_graph_diamond():
     full_execution_graph = solid_graph.create_execution_subgraph(
         from_solids=['A'],
         to_solids=['D'],
-        # output_names=['D'], input_names=['A_input']
     )
     assert full_execution_graph.topological_order == ['A', 'B', 'C', 'D']
     assert len(full_execution_graph._solid_dict) == 4
@@ -255,7 +254,7 @@ def assert_all_results_equivalent(expected_results, result_results):
 def test_pipeline_execution_graph_diamond():
     solid_graph = create_diamond_graph()
     pipeline = DagsterPipeline(solids=solid_graph.solids)
-    environment = config.Environment(sources={'A_input': config.Source('CUSTOM', {})})
+    environment = config.Environment(sources={'A': {'A_input': config.Source('CUSTOM', {})}})
     return _do_test(pipeline, lambda: execute_pipeline_iterator(
         create_test_context(),
         pipeline,

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -285,6 +285,13 @@ class SolidDefinition:
     def input_names(self):
         return [inp.name for inp in self.inputs]
 
+    def has_input(self, name):
+        check.str_param(name, 'name')
+        for input_def in self.inputs:
+            if input_def.name == name:
+                return True
+        return False
+
     def input_def_named(self, name):
         check.str_param(name, 'name')
         for input_def in self.inputs:

--- a/python_modules/dagster/dagster/core/graph.py
+++ b/python_modules/dagster/dagster/core/graph.py
@@ -64,9 +64,12 @@ class DagsterPipeline:
                     yield solid
                     break
 
-    def has_input(self, name):
+    def has_solid(self, name):
         check.str_param(name, 'name')
-        return name in [input_def.name for input_def in self.all_inputs]
+        for solid in self.solids:
+            if solid.name == name:
+                return True
+        return False
 
     @property
     def all_inputs(self):

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -14,7 +14,11 @@ def test_pipeline_include():
 def test_execute_pipeline():
     pipeline = define_pipeline()
     environment = config.Environment(
-        sources={'num': config.Source(name='CSV', args={'path': script_relative_path('num.csv')})}
+        sources={
+            'sum_solid': {
+                'num': config.Source(name='CSV', args={'path': script_relative_path('num.csv')})
+            }
+        }
     )
 
     result = execute_pipeline(

--- a/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/env.yml
+++ b/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/env.yml
@@ -1,9 +1,12 @@
+
+
 environment:
   sources:
-    num:
+    num_df:
       name: CSV
       args:
         path: 'pandas_hello_world/num.csv'
+
 
 materializations:
   - solid: sum_solid

--- a/python_modules/dagster/dagster/pandas_kernel/definitions.py
+++ b/python_modules/dagster/dagster/pandas_kernel/definitions.py
@@ -33,7 +33,7 @@ def parquet_dataframe_source(**read_parquet_kwargs):
     )
 
 
-def csv_dataframe_source(**read_csv_kwargs):
+def csv_dataframe_source(name=None, **read_csv_kwargs):
     def callback(context, arg_dict):
         check.inst_param(context, 'context', DagsterExecutionContext)
         check.str_param(arg_dict['path'], 'path')
@@ -42,7 +42,7 @@ def csv_dataframe_source(**read_csv_kwargs):
         return df
 
     return SourceDefinition(
-        source_type='CSV',
+        source_type=check.opt_str_param(name, 'name', 'CSV'),
         source_fn=callback,
         argument_def_dict={
             'path': types.PATH,

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
@@ -11,7 +11,11 @@ import dagster.pandas_kernel as dagster_pd
 
 def create_num_csv_environment():
     return config.Environment(
-        sources={'num_csv': config.Source('CSV', {'path': script_relative_path('num.csv')})}
+        sources={
+            'hello_world': {
+                'num_csv': config.Source('CSV', {'path': script_relative_path('num.csv')})
+            }
+        }
     )
 
 

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
@@ -17,7 +17,6 @@ from dagster.utils.test import script_relative_path
 def create_test_context():
     return DagsterExecutionContext()
 
-
 def create_hello_world_solid_no_api():
     def hello_world_transform_fn(_context, args):
         num_df = args['num_df']
@@ -57,7 +56,11 @@ def test_hello_world_no_library_support():
         create_test_context(),
         hello_world,
         environment=config.Environment(
-            sources={'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})}
+            sources={
+                'hello_world': {
+                    'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})
+                }
+            }
         ),
     )
 
@@ -134,7 +137,11 @@ def test_hello_world_composed():
         create_test_context(),
         hello_world,
         environment=config.Environment(
-            sources={'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})}
+            sources={
+                'hello_world': {
+                    'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})
+                }
+            }
         ),
     )
 
@@ -175,7 +182,11 @@ def test_pipeline():
     pipeline = dagster.pipeline(solids=[solid_one, solid_two])
 
     environment = config.Environment(
-        sources={'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})}
+        sources={
+            'solid_one': {
+                'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})
+            }
+        }
     )
 
     execute_pipeline_result = dagster.execute_pipeline(

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_user_error.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_user_error.py
@@ -27,9 +27,11 @@ def test_wrong_output_value():
             df_solid,
             environment=config.Environment(
                 sources={
-                    'num_csv': config.Source('CSV', {'path': script_relative_path('num.csv')})
-                }
-            )
+                    'test_wrong_output': {
+                        'num_csv': config.Source('CSV', {'path': script_relative_path('num.csv')})
+                    },
+                },
+            ),
         )
 
 
@@ -48,7 +50,11 @@ def test_wrong_input_value():
         execute_single_solid(
             dagster.context(),
             df_solid,
-            environment=config.Environment(sources={'foo': config.Source('WRONG', {})})
+            environment=config.Environment(
+                sources={'test_wrong_input': {
+                    'foo': config.Source('WRONG', {})
+                }}
+            )
         )
 
 
@@ -68,10 +74,10 @@ def test_wrong_input_arg_dict():
             df_solid,
             environment=config.Environment(
                 sources={
-                    'num_jdkfjskdfjs': config.Source(
-                        'CSV',
-                        {'path': script_relative_path('num.csv')}
-                    )
-                }
+                    'test_wrong_value': {
+                        'num_jdkfjskdfjs':
+                        config.Source('CSV', {'path': script_relative_path('num.csv')})
+                    },
+                },
             ),
         )

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
@@ -40,12 +40,18 @@ def test_sql_sum_solid():
     engine = sa.create_engine('sqlite://')
     create_num_table(engine)
 
+    environment = config.Environment(
+        sources={
+            'sum_table': {
+                'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})
+            }
+        },
+    )
+
     result = output_single_solid(
         DagsterSqlAlchemyExecutionContext(engine=engine),
         sum_table_solid,
-        environment=config.Environment(
-            sources={'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})}
-        ),
+        environment=environment,
         materialization_type='CREATE',
         arg_dict={'table_name': 'sum_table'},
     )
@@ -82,7 +88,11 @@ def test_execute_sql_sum_sq_solid():
     engine = in_mem_engine()
 
     environment = config.Environment(
-        sources={'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})}
+        sources={
+            'sum_table': {
+                'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})
+            }
+        },
     )
 
     pipeline_result = execute_pipeline(
@@ -110,7 +120,11 @@ def test_output_sql_sum_sq_solid():
     engine = in_mem_engine()
 
     environment = config.Environment(
-        sources={'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})}
+        sources={
+            'sum_table': {
+                'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})
+            }
+        },
     )
 
     pipeline_result = materialize_pipeline(


### PR DESCRIPTION
Previous to this PR input names were globally scope to a pipeline.

This means that if two solids specified the same input name you
could specify the input once in the config.Environment object
and then it would be filled in. However this also broke
modularity as collision could occur between solids that didn't
know anything about eachother.