### PR TITLE
Add PipelineContextDefinition

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -7,6 +7,8 @@ from dagster.core.execution import (
     execute_pipeline, execute_pipeline_through_solid, materialize_pipeline
 )
 
+from dagster.core.graph import PipelineContextDefinition
+
 # Note that the structure of this file might end up causing some pretty problematic
 # circular dependency issues. Fully qualifying the class names "fixes" issue
 # but this is quite fragile -- schrockn (06/04/2018)

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -135,10 +135,10 @@ def callable_param(obj, param_name):
     return obj
 
 
-def opt_callable_param(obj, param_name):
+def opt_callable_param(obj, param_name, default=None):
     if obj is not None and not callable(obj):
         raise_with_traceback(_not_callable_exception(obj, param_name))
-    return obj
+    return default if obj is None else obj
 
 
 def int_param(obj, param_name):

--- a/python_modules/dagster/dagster/check/check_tests/test_check.py
+++ b/python_modules/dagster/dagster/check/check_tests/test_check.py
@@ -276,6 +276,8 @@ def test_opt_callable_param():
     lamb = lambda: 1
     assert check.opt_callable_param(lamb, 'lamb') == lamb
     assert check.opt_callable_param(None, 'lamb') is None
+    assert check.opt_callable_param(None, 'lamb', default=None) is None
+    assert check.opt_callable_param(None, 'lamb', default=lamb) == lamb
 
     with pytest.raises(ParameterCheckError):
         check.opt_callable_param(2, 'lamb')

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import logging
 import os
 import textwrap
@@ -7,13 +8,8 @@ import yaml
 
 from dagster import config as dagster_config
 from dagster import check
-from dagster.core.execution import (
-    DagsterExecutionContext,
-    DagsterExecutionFailureReason,
-    materialize_pipeline_iterator,
-)
+from dagster.core.execution import (DagsterExecutionFailureReason, materialize_pipeline_iterator)
 from dagster.graphviz import build_graphviz_graph
-from dagster.utils.logging import define_logger
 
 from .context import Config
 
@@ -164,14 +160,21 @@ def load_yaml(path):
 @click.option('--from-solid', type=click.STRING, help="Solid to start execution from", default=None)
 @click.option('--log-level', type=click.Choice(LOGGING_DICT.keys()), default='INFO')
 def execute_command(pipeline_config, env, from_solid, log_level):
+    # loading environment from yaml should be its own reuable function and tested
     env_config = load_yaml(env)
-    sources = {}
-    for input_name, source_yml in check.dict_elem(env_config['environment'], 'sources').items():
-        sources[input_name] = dagster_config.Source(
-            name=source_yml['name'], args=source_yml['args']
-        )
+    sources = defaultdict(dict)
+    for solid_name, args_yml in check.dict_elem(env_config['environment'], 'sources').items():
+        for input_name, source_yml in args_yml.items():
+            sources[solid_name][input_name] = dagster_config.Source(
+                name=source_yml['name'], args=source_yml['args']
+            )
 
-    environment = dagster_config.Environment(sources=sources)
+    # TODO: drive commandline execution context from yaml file
+    # https://github.com/dagster-io/dagster/issues/55
+    environment = dagster_config.Environment(
+        context=dagster_config.Context(name='default', args={'log_level': log_level}),
+        sources=sources
+    )
 
     materializations = []
     if 'materializations' in env_config:
@@ -181,10 +184,7 @@ def execute_command(pipeline_config, env, from_solid, log_level):
             ) for m in check.list_elem(env_config, 'materializations')
         ]
 
-    context = DagsterExecutionContext(loggers=[define_logger('dagster')], log_level=log_level)
-
     pipeline_iter = materialize_pipeline_iterator(
-        context,
         pipeline_config.pipeline,
         environment=environment,
         materializations=materializations,
@@ -192,27 +192,29 @@ def execute_command(pipeline_config, env, from_solid, log_level):
         use_materialization_through_solids=False,
     )
 
-    process_results_for_console(pipeline_iter, context)
+    process_results_for_console(pipeline_iter)
 
 
-def process_results_for_console(pipeline_iter, context):
+def process_results_for_console(pipeline_iter):
     results = []
+
     for result in pipeline_iter:
         if not result.success:
             if result.reason == DagsterExecutionFailureReason.USER_CODE_ERROR:
                 raise result.user_exception
             elif result.reason == DagsterExecutionFailureReason.EXPECTATION_FAILURE:
                 for expectation_result in result.failed_expectation_results:
-                    context.error(expectation_result.message, solid=result.solid.name)
+                    result.context.error(expectation_result.message, solid=result.solid.name)
                 click_context = click.get_current_context()
                 click_context.exit(1)
         results.append(result)
 
-    print_metrics_to_console(results, context)
+    print_metrics_to_console(results)
 
 
-def print_metrics_to_console(results, context):
+def print_metrics_to_console(results):
     for result in results:
+        context = result.context
         metrics_of_solid = list(context.metrics_matching_context({'solid': result.name}))
 
         print('Metrics for {name}'.format(name=result.name))

--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -14,15 +14,26 @@ class Materialization(namedtuple('MaterializationData', 'solid materialization_t
         )
 
 
-class Environment(namedtuple('EnvironmentData', 'sources')):
-    def __new__(cls, sources):
+class Context(namedtuple('ContextData', 'name args')):
+    def __new__(cls, name, args):
+        return super(Context, cls).__new__(
+            cls, check.str_param(name, 'name'), check.dict_param(args, 'args', key_type=str)
+        )
+
+
+class Environment(namedtuple('EnvironmentData', 'sources context')):
+    def __new__(cls, sources, context=None):
         check.dict_param(sources, 'sources', key_type=str, value_type=dict)
         for _solid_name, source_dict in sources.items():
             check.dict_param(source_dict, 'source_dict', key_type=str, value_type=Source)
 
+        if context is None:
+            context = Context(name='default', args={})
+
         return super(Environment, cls).__new__(
             cls,
             sources=sources,
+            context=context,
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/core/__init__.py
+++ b/python_modules/dagster/dagster/core/__init__.py
@@ -10,7 +10,7 @@ from dagster.core.execution import DagsterExecutionContext
 from .definitions import (
     InputDefinition, create_dagster_single_file_input, create_custom_source_input
 )
-from .graph import DagsterPipeline
+from .graph import (DagsterPipeline, PipelineContextDefinition)
 
 
 def pipeline(**kwargs):

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -1,0 +1,129 @@
+import pytest
+import dagster
+from dagster import (config, PipelineContextDefinition)
+from dagster.core import types
+from dagster.core.decorators import (solid, with_context)
+from dagster.core.definitions import OutputDefinition
+from dagster.core.execution import execute_pipeline
+from dagster.core.errors import (DagsterInvariantViolationError, DagsterTypeError)
+
+
+def test_default_context():
+    @solid(
+        inputs=[],
+        output=OutputDefinition(),
+    )
+    @with_context
+    def default_context_transform(context):
+        assert context.args == {}
+
+    pipeline = dagster.pipeline(solids=[default_context_transform])
+    environment = config.Environment(sources={}, context=config.Context('default', {}))
+
+    execute_pipeline(pipeline, environment=environment)
+
+
+def test_custom_contexts():
+    @solid(
+        inputs=[],
+        output=OutputDefinition(),
+    )
+    @with_context
+    def custom_context_transform(context):
+        assert context.args == {'arg_one': 'value_two'}
+
+    pipeline = dagster.pipeline(
+        solids=[custom_context_transform],
+        context_definitions={
+            'custom_one':
+            PipelineContextDefinition(
+                argument_def_dict={'arg_one': types.STRING},
+                context_fn=lambda args: dagster.context(args=args),
+            ),
+            'custom_two':
+            PipelineContextDefinition(
+                argument_def_dict={'arg_one': types.STRING},
+                context_fn=lambda args: dagster.context(args=args),
+            )
+        },
+    )
+
+    environment_one = config.Environment(
+        sources={}, context=config.Context('custom_one', {'arg_one': 'value_two'})
+    )
+
+    execute_pipeline(pipeline, environment=environment_one)
+
+    environment_two = config.Environment(
+        sources={}, context=config.Context('custom_two', {'arg_one': 'value_two'})
+    )
+
+    execute_pipeline(pipeline, environment=environment_two)
+
+
+# TODO: reenable pending the ability to specific optional arguments
+# https://github.com/dagster-io/dagster/issues/56
+@pytest.mark.skip
+def test_invalid_context():
+    @solid(
+        inputs=[],
+        output=OutputDefinition(),
+    )
+    def never_transform():
+        raise Exception('should never execute')
+
+    default_context_pipeline = dagster.pipeline(solids=[never_transform])
+
+    environment_context_not_found = config.Environment(
+        sources={}, context=config.Context('not_found', {})
+    )
+
+    with pytest.raises(DagsterInvariantViolationError, message='Context not_found not found'):
+        execute_pipeline(
+            default_context_pipeline,
+            environment=environment_context_not_found,
+            throw_on_error=True
+        )
+
+    environment_arg_name_mismatch = config.Environment(
+        sources={}, context=config.Context('default', {'unexpected': 'value'})
+    )
+
+    with pytest.raises(DagsterTypeError, message='Argument mismatch in context default'):
+        execute_pipeline(
+            default_context_pipeline,
+            environment=environment_arg_name_mismatch,
+            throw_on_error=True
+        )
+
+    with_argful_context_pipeline = dagster.pipeline(
+        solids=[never_transform],
+        context_definitions={
+            'default':
+            PipelineContextDefinition(
+                argument_def_dict={'string_arg': types.STRING}, context_fn=lambda _args: _args
+            )
+        }
+    )
+
+    environment_no_args_error = config.Environment(
+        sources={}, context=config.Context('default', {})
+    )
+
+    with pytest.raises(DagsterTypeError, message='Argument mismatch in context default'):
+        execute_pipeline(
+            with_argful_context_pipeline,
+            environment=environment_no_args_error,
+            throw_on_error=True
+        )
+
+    environment_type_mismatch_error = config.Environment(
+        sources={}, context=config.Context('default', {'string_arg': 1})
+    )
+
+    with pytest.raises(DagsterTypeError, message='Argument mismatch in context default'):
+        execute_pipeline(
+            with_argful_context_pipeline,
+            environment=environment_type_mismatch_error,
+            throw_on_error=True
+        )

--- a/python_modules/dagster/dagster/core/core_tests/test_error_handling.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_error_handling.py
@@ -12,7 +12,7 @@ from dagster.core.execution import (
     MaterializationDefinition,
 )
 
-from dagster.core.errors import (DagsterUserCodeExecutionError, DagsterTypeError)
+from dagster.core.errors import DagsterUserCodeExecutionError
 
 
 def create_test_context():

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -74,7 +74,6 @@ def test_execute_two_solids_with_same_input_name():
     pipeline = dagster.pipeline(solids=[solid_one, solid_two])
 
     result = execute_pipeline(
-        dagster.context(),
         pipeline,
         environment=config.Environment(
             sources={
@@ -128,7 +127,6 @@ def test_execute_dep_solid_different_input_name():
 
     pipeline = dagster.pipeline(solids=[first_solid, second_solid])
     result = dagster.execute_pipeline(
-        DagsterExecutionContext(),
         pipeline,
         environment=config.Environment(
             sources={
@@ -220,9 +218,7 @@ def test_execute_dep_solid_same_input_name():
         }
     )
 
-    both_solids_result = dagster.execute_pipeline(
-        DagsterExecutionContext(), pipeline, environment=complete_environment
-    )
+    both_solids_result = dagster.execute_pipeline(pipeline, environment=complete_environment)
 
     assert executed == {
         's1_t1_source': True,
@@ -242,10 +238,7 @@ def test_execute_dep_solid_same_input_name():
     executed['s2_t2_source'] = False
 
     second_solid_only_result = dagster.execute_pipeline(
-        DagsterExecutionContext(),
-        pipeline,
-        environment=complete_environment,
-        from_solids=['table_two']
+        pipeline, environment=complete_environment, from_solids=['table_two']
     )
 
     assert second_solid_only_result.success
@@ -267,7 +260,6 @@ def test_execute_dep_solid_same_input_name():
     executed['s2_t2_source'] = False
 
     first_solid_only_result = dagster.execute_pipeline(
-        DagsterExecutionContext(),
         pipeline,
         environment=complete_environment,
         through_solids=['table_one'],

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -10,15 +10,10 @@ from dagster.core.definitions import (
     InputDefinition,
 )
 from dagster.core.execution import (
-    DagsterExecutionContext,
     DagsterExecutionFailureReason,
     execute_pipeline,
     materialize_pipeline,
 )
-
-
-def create_test_context():
-    return DagsterExecutionContext()
 
 
 def create_failing_output_def():
@@ -121,10 +116,7 @@ def no_args_env(solid_name, input_name):
 def test_transform_failure_pipeline():
     pipeline = dagster.core.pipeline(solids=[create_root_transform_failure_solid('failing')])
     pipeline_result = execute_pipeline(
-        create_test_context(),
-        pipeline,
-        environment=no_args_env('failing', 'failing_input'),
-        throw_on_error=False
+        pipeline, environment=no_args_env('failing', 'failing_input'), throw_on_error=False
     )
 
     assert not pipeline_result.success
@@ -139,7 +131,6 @@ def test_transform_failure_pipeline():
 def test_input_failure_pipeline():
     pipeline = dagster.core.pipeline(solids=[create_root_input_failure_solid('failing_input')])
     pipeline_result = execute_pipeline(
-        create_test_context(),
         pipeline,
         environment=no_args_env('failing_input', 'failing_input_input'),
         throw_on_error=False
@@ -156,7 +147,6 @@ def test_output_failure_pipeline():
     pipeline = dagster.core.pipeline(solids=[create_root_output_failure_solid('failing_output')])
 
     pipeline_result = materialize_pipeline(
-        create_test_context(),
         pipeline,
         environment=no_args_env('failing_output', 'failing_output_input'),
         materializations=[
@@ -204,7 +194,6 @@ def test_failure_midstream():
     )
     pipeline = dagster.core.pipeline(solids=[solid_a, solid_b, solid_c])
     pipeline_result = execute_pipeline(
-        create_test_context(),
         pipeline,
         environment=environment,
         throw_on_error=False,

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -1,4 +1,3 @@
-import copy
 import pytest
 
 from dagster import check
@@ -256,7 +255,6 @@ def test_pipeline_execution_graph_diamond():
     pipeline = DagsterPipeline(solids=solid_graph.solids)
     environment = config.Environment(sources={'A': {'A_input': config.Source('CUSTOM', {})}})
     return _do_test(pipeline, lambda: execute_pipeline_iterator(
-        create_test_context(),
         pipeline,
         environment=environment,
     ))
@@ -267,7 +265,7 @@ def test_pipeline_execution_graph_diamond_in_memory():
     pipeline = DagsterPipeline(solids=solid_graph.solids)
     input_values = {'A_input': [{'A_input': 'input_set'}]}
     return _do_test(pipeline, lambda: execute_pipeline_iterator_in_memory(
-        create_test_context(),
+        DagsterExecutionContext(),
         pipeline,
         input_values=input_values,
     ))
@@ -281,7 +279,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
     results = list()
 
     for result in do_execute_pipeline_iter():
-        results.append(copy.deepcopy(result))
+        results.append(result.copy())
 
     assert results[0].transformed_value[0] == input_set('A_input')
     assert results[0].transformed_value[1] == transform_called('A')

--- a/python_modules/dagster/dagster/core/core_tests/test_transform_only_pipeline.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_transform_only_pipeline.py
@@ -40,9 +40,7 @@ def test_execute_solid_with_dep_only_inputs_no_api():
 
     # from dagster.utils import logging
 
-    pipeline_result = dagster.execute_pipeline(
-        dagster.context(), pipeline, environment=config.Environment.empty()
-    )
+    pipeline_result = dagster.execute_pipeline(pipeline, environment=config.Environment.empty())
 
     assert pipeline_result.success
 
@@ -72,9 +70,7 @@ def test_execute_solid_with_dep_only_inputs_with_api():
 
     pipeline = dagster.pipeline(solids=[step_one_solid, step_two_solid])
 
-    pipeline_result = dagster.execute_pipeline(
-        dagster.context(), pipeline, environment=config.Environment.empty()
-    )
+    pipeline_result = dagster.execute_pipeline(pipeline, environment=config.Environment.empty())
 
     for result in pipeline_result.result_list:
         assert result.success

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -28,8 +28,7 @@ import sys
 
 import six
 
-from dagster import check
-from dagster import config
+from dagster import check, config
 
 from dagster.utils.logging import (CompositeLogger, ERROR, get_formatted_stack_trace)
 from dagster.utils.timing import time_execution_scope
@@ -43,7 +42,7 @@ from .errors import (
     DagsterUserCodeExecutionError, DagsterTypeError, DagsterExecutionFailureReason,
     DagsterExpectationFailedError, DagsterInvariantViolationError
 )
-from .graph import DagsterPipeline
+from .graph import (DagsterPipeline, PipelineContextDefinition)
 
 Metric = namedtuple('Metric', 'context_dict metric_name value')
 
@@ -60,10 +59,11 @@ class DagsterExecutionContext:
     reporting.
     '''
 
-    def __init__(self, loggers=None, log_level=ERROR):
+    def __init__(self, loggers=None, log_level=ERROR, args=None):
         self._logger = CompositeLogger(loggers=loggers, level=log_level)
         self._context_dict = OrderedDict()
         self._metrics = []
+        self.args = check.opt_dict_param(args, 'args', key_type=str)
 
     def _maybe_quote(self, val):
         str_val = str(val)
@@ -174,8 +174,10 @@ class DagsterExecutionContext:
 class DagsterPipelineExecutionResult:
     def __init__(
         self,
+        context,
         result_list,
     ):
+        self.context = check.inst_param(context, 'context', DagsterExecutionContext)
         self.result_list = check.list_param(
             result_list, 'result_list', of_type=DagsterExecutionResult
         )
@@ -208,6 +210,7 @@ class DagsterExecutionResult:
         reason=None,
         exception=None,
         failed_expectation_results=None,
+        context=None,
     ):
         self.success = check.bool_param(success, 'success')
         if not success:
@@ -238,6 +241,8 @@ class DagsterExecutionResult:
             check.invariant(failed_expectation_results is None)
             self.failed_expectation_results = None
 
+        self.context = context
+
     def reraise_user_error(self):
         check.invariant(self.reason == DagsterExecutionFailureReason.USER_CODE_ERROR)
         check.inst(self.exception, DagsterUserCodeExecutionError)
@@ -254,6 +259,7 @@ class DagsterExecutionResult:
             success=self.success,
             solid=self.solid,
             transformed_value=copy.deepcopy(self.transformed_value),
+            context=self.context,
             reason=self.reason,
             exception=self.exception,
             failed_expectation_results=None if self.failed_expectation_results is None else
@@ -283,6 +289,34 @@ def _user_code_error_boundary(context, msg, **kwargs):
             msg.format(**kwargs), e, user_exception=e, original_exc_info=sys.exc_info()
         )
 
+def _validate_args(argument_def_dict, arg_dict, error_context_str):
+    expected_args = set(argument_def_dict.keys())
+    received_args = set(arg_dict.keys())
+    if expected_args != received_args:
+        raise DagsterTypeError(
+            'Argument mismatch in {error_context_str}. Expected {expected} got {received}'.
+            format(
+                error_context_str=error_context_str,
+                expected=repr(expected_args),
+                received=repr(received_args),
+            )
+        )
+
+    for arg_name, arg_value in arg_dict.items():
+        arg_def_type = argument_def_dict[arg_name]
+        if not arg_def_type.is_python_valid_value(arg_value):
+            format_string = (
+                'Expected type {typename} for arg {arg_name}' +
+                'for {error_context_str} but got {arg_value}'
+            )
+            raise DagsterTypeError(
+                format_string.format(
+                    typename=arg_def_type.name,
+                    arg_name=arg_name,
+                    error_context_str=error_context_str,
+                    arg_value=repr(arg_value),
+                )
+            )
 
 def _read_source(context, source_definition, arg_dict):
     '''
@@ -296,34 +330,8 @@ def _read_source(context, source_definition, arg_dict):
 
     with context.value('source_type', source_definition.source_type), \
          context.value('arg_dict', arg_dict):
-        expected_args = set(source_definition.argument_def_dict.keys())
-        received_args = set(arg_dict.keys())
-        if expected_args != received_args:
-            raise DagsterTypeError(
-                'Argument mismatch in source type {source}. Expected {expected} got {received}'.
-                format(
-                    source=source_definition.source_type,
-                    expected=repr(expected_args),
-                    received=repr(received_args),
-                )
-            )
-
-        for arg_name, arg_value in arg_dict.items():
-            arg_def_type = source_definition.argument_def_dict[arg_name]
-            if not arg_def_type.is_python_valid_value(arg_value):
-                format_string = (
-                    'Expected type {typename} for arg {arg_name}' +
-                    'for {source_type} but got {arg_value}'
-                )
-                raise DagsterTypeError(
-                    format_string.format(
-                        typename=arg_def_type.name,
-                        arg_name=arg_name,
-                        source_type=source_definition.source_type,
-                        arg_value=repr(arg_value),
-                    )
-                )
-
+        error_context_str = 'source type {source}'.format(source=source_definition.source_type)
+        _validate_args(source_definition.argument_def_dict, arg_dict, error_context_str)
         error_str = 'Error occured while loading source "{source_type}"'
         with _user_code_error_boundary(
             context,
@@ -518,6 +526,7 @@ def _pipeline_solid_in_memory(context, solid, transform_values_dict):
             success=False,
             transformed_value=None,
             solid=solid,
+            context=context,
             reason=DagsterExecutionFailureReason.EXPECTATION_FAILURE,
             failed_expectation_results=all_run_result.all_fails,
         )
@@ -549,12 +558,22 @@ def _pipeline_solid_in_memory(context, solid, transform_values_dict):
             success=False,
             transformed_value=None,
             solid=solid,
+            context=context,
             reason=DagsterExecutionFailureReason.EXPECTATION_FAILURE,
             failed_expectation_results=output_expectation_failures,
         )
 
     return transformed_value
 
+
+
+def _create_default_pipeline_context_definition(context):
+    check.inst_param(context, 'context', DagsterExecutionContext)
+    context_definition = PipelineContextDefinition(
+        argument_def_dict={},
+        context_fn=lambda _args: context
+    )
+    return {'default': context_definition}
 
 def execute_single_solid(context, solid, environment, throw_on_error=True):
     check.inst_param(context, 'context', DagsterExecutionContext)
@@ -564,7 +583,11 @@ def execute_single_solid(context, solid, environment, throw_on_error=True):
 
     results = list(
         execute_pipeline_iterator(
-            context, DagsterPipeline(solids=[solid]), environment=environment
+            DagsterPipeline(
+                solids=[solid],
+                context_definitions=_create_default_pipeline_context_definition(context),
+            ),
+            environment=environment,
         )
     )
 
@@ -598,9 +621,6 @@ def _do_throw_on_error(execution_result):
         raise execution_result.exception
 
 
-
-
-
 def output_single_solid(
     context,
     solid,
@@ -616,10 +636,13 @@ def output_single_solid(
     check.dict_param(arg_dict, 'arg_dict', key_type=str)
     check.bool_param(throw_on_error, 'throw_on_error')
 
+
     results = list(
         materialize_pipeline_iterator(
-            context,
-            DagsterPipeline(solids=[solid]),
+            DagsterPipeline(
+                solids=[solid],
+                context_definitions=_create_default_pipeline_context_definition(context),
+            ),
             environment=environment,
             materializations=[
                 config.Materialization(
@@ -642,7 +665,6 @@ def output_single_solid(
 
 
 def execute_pipeline_through_solid(
-    context,
     pipeline,
     *,
     environment,
@@ -651,13 +673,12 @@ def execute_pipeline_through_solid(
     '''
     Execute a pipeline through a single solid, and then output *only* that result
     '''
-    check.inst_param(context, 'context', DagsterExecutionContext)
     check.inst_param(pipeline, 'pipeline', DagsterPipeline)
     check.inst_param(environment, 'environment', config.Environment)
     check.str_param(solid_name, 'solid_name')
 
     for result in execute_pipeline_iterator(
-        context, pipeline, environment=environment, through_solids=[solid_name]
+        pipeline, environment=environment, through_solids=[solid_name]
     ):
 
         if result.name == solid_name:
@@ -718,6 +739,7 @@ def _execute_pipeline_solid_step(context, solid, input_manager):
     return DagsterExecutionResult(
         success=True,
         solid=solid,
+        context=context,
         transformed_value=input_manager.intermediate_values[solid.name],
         exception=None
     )
@@ -725,6 +747,9 @@ def _execute_pipeline_solid_step(context, solid, input_manager):
 class InputManager:
     def __init__(self):
         self.intermediate_values = {}
+
+    def get_context(self):
+        check.not_implemented('must implement in subclass')
 
     def get_input_value(self, solid, input_def):
         if input_def.depends_on and input_def.depends_on.name in self.intermediate_values:
@@ -738,12 +763,16 @@ class InputManager:
         check.not_implemented('must implement in subclass')
 
 class InMemoryInputManager(InputManager):
-    def __init__(self, input_values):
+    def __init__(self, context, input_values):
         super().__init__()
         self.input_values = check.dict_param(input_values, 'input_values', key_type=str)
+        self.context = check.inst_param(context, 'context', DagsterExecutionContext)
 
     def _get_sourced_input_value(self, _solid_name, input_name):
         return self.input_values[input_name]
+
+    def get_context(self):
+        return self.context
 
 
 def _validate_environment(environment, pipeline):
@@ -762,14 +791,36 @@ def _validate_environment(environment, pipeline):
                     f'Input must be one of {repr(pipeline.input_names)}'
                 )
 
+    context_name = environment.context.name
+
+    if context_name not in pipeline.context_definitions:
+        avaiable_context_keys = list(pipeline.context_definitions.keys())
+        raise DagsterInvariantViolationError(f'Context {context_name} not found in ' + \
+            f'pipeline definiton. Available contexts {repr(avaiable_context_keys)}'
+        )
+
+    # TODO: reenable pending the ability to specific optional arguments
+    # https://github.com/dagster-io/dagster/issues/56
+    # _validate_args(
+    #     pipeline.context_definitions[context_name].argument_def_dict,
+    #     environment.context.args,
+    #     'context {context_name}'.format(context_name=context_name)
+    # )
+
 class EnvironmentInputManager(InputManager):
-    def __init__(self, context, pipeline, environment):
+    def __init__(self, pipeline, environment):
         super().__init__()
-        # This is not necessarily the best spot for this call
+        # This is not necessarily the best spot for these calls
         _validate_environment(environment, pipeline)
-        self.context = check.inst_param(context, 'context', DagsterExecutionContext)
+        context_name = environment.context.name
+        context_definition = pipeline.context_definitions[context_name]
+
+        self.context = context_definition.context_fn(environment.context.args)
         self.pipeline = check.inst_param(pipeline, 'pipeline', DagsterPipeline)
         self.environment = check.inst_param(environment, 'environment', config.Environment)
+
+    def get_context(self):
+        return self.context
 
     def _get_sourced_input_value(self, solid_name, input_name):
         source_config = self.environment.sources[solid_name][input_name]
@@ -786,18 +837,16 @@ class EnvironmentInputManager(InputManager):
 
 
 def execute_pipeline_iterator(
-    context,
     pipeline,
     environment,
     through_solids=None,
     from_solids=None,
 ):
     return _execute_pipeline_iterator(
-        context,
         pipeline,
         through_solids,
         from_solids,
-        EnvironmentInputManager(context, pipeline, environment)
+        EnvironmentInputManager(pipeline, environment)
     )
 
 def execute_pipeline_iterator_in_memory(
@@ -808,15 +857,13 @@ def execute_pipeline_iterator_in_memory(
     from_solids=None,
 ):
     return _execute_pipeline_iterator(
-        context,
         pipeline,
         through_solids,
         from_solids,
-        InMemoryInputManager(input_values),
+        InMemoryInputManager(context, input_values),
     )
 
 def _execute_pipeline_iterator(
-    context,
     pipeline,
     through_solids,
     from_solids,
@@ -837,11 +884,13 @@ def _execute_pipeline_iterator(
     once the entire pipeline has been executed.
     '''
 
-    check.inst_param(context, 'context', DagsterExecutionContext)
+    # check.inst_param(context, 'context', DagsterExecutionContext)
     check.inst_param(pipeline, 'pipeline', DagsterPipeline)
     check.opt_list_param(through_solids, 'through_solids', of_type=str)
     check.opt_list_param(from_solids, 'from_solids', of_type=str)
     check.inst_param(input_manager, 'input_manager', InputManager)
+
+    context = input_manager.get_context()
 
     pipeline_context_value = pipeline.name if pipeline.name else 'unnamed'
 
@@ -892,13 +941,13 @@ def _execute_pipeline_iterator(
                     success=False,
                     reason=DagsterExecutionFailureReason.USER_CODE_ERROR,
                     solid=solid,
+                    context=context,
                     transformed_value=None,
                     exception=see,
                 )
                 break
 
 def execute_pipeline(
-    context,
     pipeline,
     *,
     environment,
@@ -908,9 +957,8 @@ def execute_pipeline(
 ):
     check.inst_param(environment, 'environment', config.Environment)
     return _execute_pipeline(
-        context,
         pipeline,
-        EnvironmentInputManager(context, pipeline, environment),
+        EnvironmentInputManager(pipeline, environment),
         from_solids,
         through_solids,
         throw_on_error,
@@ -927,16 +975,15 @@ def execute_pipeline_in_memory(
 ):
     check.dict_param(input_values, 'input_values', key_type=str)
     return _execute_pipeline(
-        context,
         pipeline,
-        InMemoryInputManager(input_values),
+        InMemoryInputManager(context, input_values),
         from_solids,
         through_solids,
         throw_on_error,
     )
 
 def _execute_pipeline(
-    context,
+    # context,
     pipeline,
     input_manager,
     from_solids=None,
@@ -951,7 +998,7 @@ def _execute_pipeline(
 
     Note: throw_on_error is very useful in testing contexts when not testing for error conditions
     '''
-    check.inst_param(context, 'context', DagsterExecutionContext)
+    # check.inst_param(context, 'context', DagsterExecutionContext)
     check.inst_param(pipeline, 'pipeline', DagsterPipeline)
     check.inst_param(input_manager, 'input_manager', InputManager)
     from_solids = check.opt_list_param(from_solids, 'from_solids', of_type=str)
@@ -960,7 +1007,6 @@ def _execute_pipeline(
 
     results = []
     for result in _execute_pipeline_iterator(
-        context,
         pipeline,
         input_manager=input_manager,
         through_solids=through_solids,
@@ -971,7 +1017,7 @@ def _execute_pipeline(
                 _do_throw_on_error(result)
 
         results.append(result.copy())
-    return DagsterPipelineExecutionResult(results)
+    return DagsterPipelineExecutionResult(input_manager.get_context(), results)
 
 
 class MaterializationArgs:
@@ -993,11 +1039,12 @@ class MaterializationArgs:
 
 
 def materialize_pipeline(
-    context,
     pipeline,
     *,
     environment,
     materializations,
+    from_solids=None,
+    through_solids=None,
     throw_on_error=True,
 ):
     '''
@@ -1006,32 +1053,52 @@ def materialize_pipeline(
     encountered instead of returning a result in an error state. Especially useful in testing
     contexts.
     '''
-    check.inst_param(context, 'context', DagsterExecutionContext)
     check.inst_param(pipeline, 'pipeline', DagsterPipeline)
     check.inst_param(environment, 'environment', config.Environment)
     check.list_param(materializations, 'materializations', of_type=config.Materialization)
     check.bool_param(throw_on_error, 'throw_on_error')
 
     results = []
-    for result in materialize_pipeline_iterator(
-        context,
+    input_manager = EnvironmentInputManager(pipeline, environment)
+    context = input_manager.get_context()
+    for result in _materialize_pipeline_iterator(
         pipeline,
         materializations=materializations,
-        environment=environment,
+        input_manager=input_manager,
+        from_solids=from_solids,
+        through_solids=through_solids,
     ):
         if throw_on_error:
             if not result.success:
                 _do_throw_on_error(result)
         results.append(result.copy())
-    return DagsterPipelineExecutionResult(results)
-
+    return DagsterPipelineExecutionResult(context, results)
 
 def materialize_pipeline_iterator(
-    context,
     pipeline,
     *,
     materializations,
     environment,
+    through_solids=None,
+    from_solids=None,
+    use_materialization_through_solids=True,
+):
+
+    input_manager = EnvironmentInputManager(pipeline, environment)
+
+    return _materialize_pipeline_iterator(
+        pipeline,
+        materializations,
+        input_manager,
+        through_solids,
+        from_solids,
+        use_materialization_through_solids
+    )
+
+def _materialize_pipeline_iterator(
+    pipeline,
+    materializations,
+    input_manager,
     through_solids=None,
     from_solids=None,
     use_materialization_through_solids=True,
@@ -1041,22 +1108,22 @@ def materialize_pipeline_iterator(
     specified in module docblock) to create externally accessible materializations of
     the computations in pipeline.
     '''
-    check.inst_param(context, 'context', DagsterExecutionContext)
     check.inst_param(pipeline, 'pipeline', DagsterPipeline)
     check.list_param(materializations, 'materializations', of_type=config.Materialization)
-    check.inst_param(environment, 'environment', config.Environment)
+    check.inst_param(input_manager, 'input_manager', InputManager)
 
     materialization_args = MaterializationArgs(pipeline, materializations)
 
     if through_solids is None and use_materialization_through_solids:
         through_solids = materialization_args.through_solids
 
-    for result in execute_pipeline_iterator(
-        context,
+    context = input_manager.get_context()
+
+    for result in _execute_pipeline_iterator(
         pipeline,
         through_solids=through_solids,
         from_solids=from_solids,
-        environment=environment
+        input_manager=input_manager,
     ):
         if not result.success:
             yield result
@@ -1087,6 +1154,7 @@ def materialize_pipeline_iterator(
                         materialization_result = DagsterExecutionResult(
                             success=False,
                             solid=result.solid,
+                            context=context,
                             reason=DagsterExecutionFailureReason.USER_CODE_ERROR,
                             exception=see,
                             transformed_value=result.transformed_value,

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -1,4 +1,3 @@
-import dagster
 from dagster import config
 
 from dagster.core.execution import execute_pipeline
@@ -22,7 +21,6 @@ def test_execute_pipeline():
     )
 
     result = execute_pipeline(
-        dagster.context(),
         pipeline,
         environment=environment,
         from_solids=['sum_solid'],

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
@@ -8,12 +8,35 @@ from dagster.sqlalchemy_kernel.subquery_builder_experimental import sql_file_sol
 
 
 def in_mem_engine():
-    engine = sa.create_engine('sqlite://')
+    engine = sa.create_engine('sqlite://', echo=False)
     return engine
 
 
 def in_mem_context():
     return dagster_sa.DagsterSqlAlchemyExecutionContext(engine=in_mem_engine())
+
+
+def create_persisted_context():
+    full_path = script_relative_path('testdb.db')
+    engine = sa.create_engine(f'sqlite:///{full_path}', echo=False)
+    return dagster_sa.DagsterSqlAlchemyExecutionContext(engine=engine)
+
+
+def create_mem_sql_pipeline_context_tuple(solids):
+    default_def = dagster.PipelineContextDefinition(
+        argument_def_dict={},
+        context_fn=lambda _args: in_mem_context(),
+    )
+    persisted_def = dagster.PipelineContextDefinition(
+        argument_def_dict={},
+        context_fn=lambda _args: create_persisted_context(),
+    )
+    return dagster.pipeline(
+        solids=solids, context_definitions={
+            'default': default_def,
+            'persisted': persisted_def
+        }
+    )
 
 
 def _get_sql_script_path(name):
@@ -27,15 +50,14 @@ def _get_project_solid(name, inputs=None):
 def test_sql_create_tables():
     create_all_tables_solids = _get_project_solid('create_all_tables')
 
-    pipeline = dagster.pipeline(solids=[create_all_tables_solids])
+    pipeline = create_mem_sql_pipeline_context_tuple(solids=[create_all_tables_solids])
 
-    context = in_mem_context()
-    pipeline_result = dagster.execute_pipeline(
-        context, pipeline, environment=config.Environment.empty()
-    )
+    pipeline_result = dagster.execute_pipeline(pipeline, environment=config.Environment.empty())
     assert pipeline_result.success
 
-    assert set(context.engine.table_names()) == set(['num_table', 'sum_sq_table', 'sum_table'])
+    assert set(pipeline_result.context.engine.table_names()) == set(
+        ['num_table', 'sum_sq_table', 'sum_table']
+    )
 
 
 def test_sql_populate_tables():
@@ -45,16 +67,17 @@ def test_sql_populate_tables():
         'populate_num_table', inputs=[dagster.dep_only_input(create_all_tables_solids)]
     )
 
-    pipeline = dagster.pipeline(solids=[create_all_tables_solids, populate_num_table_solid])
-
-    context = in_mem_context()
-    pipeline_result = dagster.execute_pipeline(
-        context, pipeline, environment=config.Environment.empty()
+    pipeline = create_mem_sql_pipeline_context_tuple(
+        solids=[create_all_tables_solids, populate_num_table_solid]
     )
+
+    pipeline_result = dagster.execute_pipeline(pipeline, environment=config.Environment.empty())
 
     assert pipeline_result.success
 
-    assert context.engine.execute('SELECT * FROM num_table').fetchall() == [(1, 2), (3, 4)]
+    assert pipeline_result.context.engine.execute('SELECT * FROM num_table').fetchall() == [
+        (1, 2), (3, 4)
+    ]
 
 
 def create_full_pipeline():
@@ -75,7 +98,7 @@ def create_full_pipeline():
         inputs=[dagster.dep_only_input(insert_into_sum_table_solid)],
     )
 
-    return dagster.pipeline(
+    return create_mem_sql_pipeline_context_tuple(
         solids=[
             create_all_tables_solids,
             populate_num_table_solid,
@@ -88,10 +111,8 @@ def create_full_pipeline():
 def test_full_in_memory_pipeline():
 
     pipeline = create_full_pipeline()
-    context = in_mem_context()
-    pipeline_result = dagster.execute_pipeline(
-        context, pipeline, environment=config.Environment.empty()
-    )
+    pipeline_result = dagster.execute_pipeline(pipeline, environment=config.Environment.empty())
+    context = pipeline_result.context
     assert pipeline_result.success
 
     assert context.engine.execute('SELECT * FROM num_table').fetchall() == [(1, 2), (3, 4)]
@@ -102,13 +123,12 @@ def test_full_in_memory_pipeline():
 
 
 def test_full_persisted_pipeline():
-    full_path = script_relative_path('testdb.db')
-    engine = sa.create_engine(f'sqlite:///{full_path}', echo=True)
-    context = dagster_sa.DagsterSqlAlchemyExecutionContext(engine=engine)
-
     pipeline = create_full_pipeline()
     pipeline_result = dagster.execute_pipeline(
-        context, pipeline, environment=config.Environment.empty()
+        pipeline,
+        environment=config.Environment(
+            sources={}, context=config.Context(name='persisted', args={})
+        )
     )
 
     assert pipeline_result.success

--- a/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/env.yml
+++ b/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/env.yml
@@ -2,10 +2,11 @@
 
 environment:
   sources:
-    num_df:
-      name: CSV
-      args:
-        path: 'pandas_hello_world/num.csv'
+    sum_solid:
+      num:
+        name: CSV
+        args:
+          path: 'pandas_hello_world/num.csv'
 
 
 materializations:

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
@@ -17,6 +17,7 @@ from dagster.utils.test import script_relative_path
 def create_test_context():
     return DagsterExecutionContext()
 
+
 def create_hello_world_solid_no_api():
     def hello_world_transform_fn(_context, args):
         num_df = args['num_df']
@@ -190,7 +191,6 @@ def test_pipeline():
     )
 
     execute_pipeline_result = dagster.execute_pipeline(
-        DagsterExecutionContext(),
         pipeline,
         environment=environment,
     )
@@ -204,7 +204,6 @@ def test_pipeline():
 
     sum_sq_path_args = {'path': '/tmp/sum_sq.csv'}
     dagster.materialize_pipeline(
-        DagsterExecutionContext(),
         pipeline,
         environment=environment,
         materializations=[

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
@@ -35,6 +35,7 @@ def get_solid_transformed_value(context, solid_inst, environment):
 
 def get_num_csv_environment(solid_name):
     return config.Environment(
+        context=config.Context('default', {'log_level': 'ERROR'}),
         sources={
             solid_name: {
                 'num_csv': config.Source('CSV', args={'path': script_relative_path('num.csv')})
@@ -379,10 +380,8 @@ def test_diamond_dag_run():
 
 
 def test_pandas_in_memory_diamond_pipeline():
-    context = create_test_context()
     pipeline = create_diamond_pipeline()
     result = execute_pipeline_through_solid(
-        context,
         pipeline,
         environment=get_num_csv_environment('num_table'),
         solid_name='sum_mult_table'
@@ -398,14 +397,11 @@ def test_pandas_in_memory_diamond_pipeline():
 
 
 def test_pandas_output_csv_pipeline():
-    context = create_test_context()
-
     with get_temp_file_name() as temp_file_name:
         pipeline = create_diamond_pipeline()
         environment = get_num_csv_environment('num_table')
 
         for _result in materialize_pipeline_iterator(
-            context,
             pipeline=pipeline,
             environment=environment,
             materializations=[
@@ -438,7 +434,6 @@ def _result_named(results, name):
 
 
 def test_pandas_output_intermediate_csv_files():
-    context = create_test_context()
     pipeline = create_diamond_pipeline()
 
     with get_temp_file_names(2) as temp_tuple:
@@ -447,7 +442,6 @@ def test_pandas_output_intermediate_csv_files():
         environment = get_num_csv_environment('num_table')
 
         subgraph_one_result = materialize_pipeline(
-            context,
             pipeline,
             environment=environment,
             materializations=[
@@ -486,7 +480,6 @@ def test_pandas_output_intermediate_csv_files():
         assert mult_table_result.transformed_value.to_dict('list') == expected_mult
 
         pipeline_result = execute_pipeline(
-            context,
             pipeline,
             environment=config.Environment(
                 sources={
@@ -532,14 +525,12 @@ def parquet_materialization(solid_name, path):
 
 
 def test_pandas_output_intermediate_parquet_files():
-    context = create_test_context()
     pipeline = create_diamond_pipeline()
 
     with get_temp_file_names(2) as temp_tuple:
         # false positive on pylint error
         sum_file, mult_file = temp_tuple  # pylint: disable=E0632
         pipeline_result = materialize_pipeline(
-            context,
             pipeline,
             environment=get_num_csv_environment('num_table'),
             materializations=[
@@ -560,8 +551,6 @@ def test_pandas_output_intermediate_parquet_files():
 
 
 def test_pandas_multiple_inputs():
-
-    context = create_test_context()
 
     environment = config.Environment(
         sources={
@@ -584,7 +573,6 @@ def test_pandas_multiple_inputs():
     pipeline = dagster.core.pipeline(solids=[double_sum])
 
     output_df = execute_pipeline_through_solid(
-        context,
         pipeline,
         environment=environment,
         solid_name='double_sum',
@@ -599,15 +587,12 @@ def test_pandas_multiple_inputs():
 
 
 def test_pandas_multiple_outputs():
-    context = create_test_context()
-
     with get_temp_file_names(2) as temp_tuple:
         # false positive on pylint error
         csv_file, parquet_file = temp_tuple  # pylint: disable=E0632
         pipeline = create_diamond_pipeline()
 
         for _result in materialize_pipeline_iterator(
-            context,
             pipeline=pipeline,
             environment=get_num_csv_environment('num_table'),
             materializations=[
@@ -640,7 +625,6 @@ def test_pandas_multiple_outputs():
 
 def test_rename_input():
     result = execute_pipeline(
-        create_test_context(),
         dagster.pipeline(solids=[sum_table, sum_sq_table_renamed_input]),
         environment=get_num_csv_environment('sum_table'),
     )

--- a/python_modules/dagster/dagster/utils/logging.py
+++ b/python_modules/dagster/dagster/utils/logging.py
@@ -1,8 +1,8 @@
 import copy
 import json
 import logging
+from logging import (CRITICAL, DEBUG, ERROR, INFO, WARNING)
 import traceback
-from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 
 import coloredlogs
 
@@ -38,7 +38,8 @@ class JsonFileHandler(logging.Handler):
             with open(self.json_path, 'a') as ff:
                 text_line = json.dumps(logged_properties)
                 ff.write(text_line + '\n')
-        except Exception as e:
+        # Need to catch Exception here, so disabling lint
+        except Exception as e: # pylint: disable=W0703
             logging.critical('Error during logging!')
             logging.exception(str(e))
 


### PR DESCRIPTION
This adds the ability for pipeline to define all the contexts that it
supports. One can pass arguments to this context via the config. This
will pipelines to define contexts such as "debug" and "prod" as well as
others that are made available to all nodes in the pipeline. This is
excellent for concepts like handles to s3 and database connections.