### PR TITLE
Add ArgumentDefintion

### DIFF
--- a/python_modules/dagster/README.rst
+++ b/python_modules/dagster/README.rst
@@ -38,7 +38,7 @@ Example
       # Name of the source
       name="CSV",
       # What arguments it should get from environment
-      argument_def_dict={'path': dagster.core.types.PATH})
+      argument_def_dict={'path': ArgumentDefinition(dagster.core.types.Path) })
   )
   def csv_to_dataframe_source(path):
       return pd.read_csv(path)
@@ -52,7 +52,7 @@ Example
       # Name of the materialization
       name="CSV",
       # What arguments it should get from environment
-      argument_def_dict={'path': dagster.core.types.PATH})
+      argument_def_dict={'path': ArgumentDefinition(dagster.core.types.Path) })
   )
   def dataframe_to_csv_materialization(data, path):
       data.to_csv(path)
@@ -441,7 +441,7 @@ and squared that value. (Fancy!)
         sources=[
             SourceDefinition(
                 source_type='CSV',
-                argument_def_dict={'path': types.PATH},
+                argument_def_dict={'path': ArgumentDefinition(types.Path)},
                 source_fn=lambda arg_dict: pd.read_csv(arg_dict['path']),
             ),
         ],

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -17,6 +17,7 @@ from dagster.core.definitions import (
     ExpectationDefinition,
     SourceDefinition,
     SolidDefinition,
+    ArgumentDefinition,
 )
 
 from dagster.core.decorators import (

--- a/python_modules/dagster/dagster/core/__init__.py
+++ b/python_modules/dagster/dagster/core/__init__.py
@@ -15,17 +15,9 @@ from .definitions import (
     PipelineDefinition,
 )
 
-# def pipeline(**kwargs):
-#     return PipelineDefinition(**kwargs)
-
 
 def input_definition(**kwargs):
     return create_custom_source_input(**kwargs)
-
-
-def file_input_definition(argument_def_dict=None, **kwargs):
-    check.param_invariant(argument_def_dict is None, 'Should not provide argument_def_dict')
-    return create_custom_source_input(argument_def_dict={'path': types.PATH}, **kwargs)
 
 
 def create_json_input(name):

--- a/python_modules/dagster/dagster/core/core_tests/test_core_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_core_execution.py
@@ -8,6 +8,7 @@ from dagster.core.definitions import (
     create_custom_source_input,
     MaterializationDefinition,
     SourceDefinition,
+    ArgumentDefinition,
 )
 
 from dagster.core.execution import (
@@ -52,7 +53,7 @@ def test_source_arg_mismiatch():
     some_input_with_arg = create_custom_source_input(
         name='some_input_with_arg',
         source_fn=lambda context, arg_dict: [],
-        argument_def_dict={'in_arg': types.STRING}
+        argument_def_dict={'in_arg': ArgumentDefinition(types.String)},
     )
 
     with pytest.raises(DagsterTypeError):
@@ -63,7 +64,7 @@ def test_materialize_input_arg_type_mismatch():
     some_input_with_arg = create_custom_source_input(
         name='some_input_with_arg',
         source_fn=lambda context, arg_dict: [],
-        argument_def_dict={'in_arg': types.STRING}
+        argument_def_dict={'in_arg': ArgumentDefinition(types.String)},
     )
 
     with pytest.raises(DagsterTypeError):
@@ -74,7 +75,7 @@ def test_materialize_input_int_type():
     int_arg_source = SourceDefinition(
         source_type='SOMETHING',
         source_fn=lambda _context, _args: True,
-        argument_def_dict={'an_int': types.INT},
+        argument_def_dict={'an_int': ArgumentDefinition(types.Int)},
     )
     assert _read_source(create_test_context(), int_arg_source, {'an_int': 0})
     assert _read_source(create_test_context(), int_arg_source, {'an_int': 1})
@@ -123,7 +124,7 @@ def test_materialize_input_with_args():
     some_input = create_custom_source_input(
         name='some_input',
         source_fn=lambda context, arg_dict: [{'key': arg_dict['str_arg']}],
-        argument_def_dict={'str_arg': types.STRING}
+        argument_def_dict={'str_arg': ArgumentDefinition(types.String)},
     )
 
     output = _read_new_single_source_input(
@@ -131,18 +132,6 @@ def test_materialize_input_with_args():
     )
     expected_output = [{'key': 'passed_value'}]
     assert output == expected_output
-
-
-def single_materialization_output(materialization_type, materialization_fn, argument_def_dict):
-    return OutputDefinition(
-        materializations=[
-            MaterializationDefinition(
-                materialization_type=materialization_type,
-                materialization_fn=materialization_fn,
-                argument_def_dict=argument_def_dict
-            )
-        ]
-    )
 
 
 def test_execute_output_with_args():
@@ -157,7 +146,7 @@ def test_execute_output_with_args():
     materialization = MaterializationDefinition(
         materialization_type='CUSTOM',
         materialization_fn=materialization_fn_inst,
-        argument_def_dict={'out_arg': types.STRING}
+        argument_def_dict={'out_arg': ArgumentDefinition(types.String)}
     )
 
     _execute_materialization(
@@ -171,7 +160,7 @@ def test_execute_materialization_arg_mismatch():
     materialization = MaterializationDefinition(
         materialization_type='CUSTOM',
         materialization_fn=lambda out, dict: [],
-        argument_def_dict={'out_arg': types.STRING}
+        argument_def_dict={'out_arg': ArgumentDefinition(types.String)}
     )
 
     with pytest.raises(DagsterTypeError):
@@ -193,7 +182,7 @@ def test_execute_materialization_arg_type_mismatch():
     custom_output = MaterializationDefinition(
         materialization_type='CUSTOM',
         materialization_fn=lambda out, dict: [],
-        argument_def_dict={'out_arg': types.STRING}
+        argument_def_dict={'out_arg': ArgumentDefinition(types.String)}
     )
 
     with pytest.raises(DagsterTypeError):

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -37,12 +37,16 @@ def test_custom_contexts():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                argument_def_dict={'arg_one': types.STRING},
+                argument_def_dict={
+                    'arg_one': dagster.ArgumentDefinition(dagster_type=types.String)
+                },
                 context_fn=lambda args: dagster.ExecutionContext(args=args),
             ),
             'custom_two':
             PipelineContextDefinition(
-                argument_def_dict={'arg_one': types.STRING},
+                argument_def_dict={
+                    'arg_one': dagster.ArgumentDefinition(dagster_type=types.String)
+                },
                 context_fn=lambda args: dagster.ExecutionContext(args=args),
             )
         },
@@ -101,7 +105,7 @@ def test_invalid_context():
         context_definitions={
             'default':
             PipelineContextDefinition(
-                argument_def_dict={'string_arg': types.STRING}, context_fn=lambda _args: _args
+                argument_def_dict={'string_arg': types.String}, context_fn=lambda _args: _args
             )
         }
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -5,6 +5,7 @@ from dagster.core import types
 from dagster.core.definitions import (
     OutputDefinition,
     InputDefinition,
+    ArgumentDefinition,
 )
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.decorators import solid, source, materialization, with_context
@@ -78,7 +79,7 @@ def test_solid_with_context():
 
 
 def test_solid_with_input():
-    @source(name="TEST", argument_def_dict={'foo': types.STRING})
+    @source(name="TEST", argument_def_dict={'foo': ArgumentDefinition(types.String)})
     def test_source(foo):
         return {'foo': foo}
 
@@ -104,12 +105,12 @@ def test_solid_with_input():
 
 
 def test_sources():
-    @source(name="WITH_CONTEXT", argument_def_dict={'foo': types.STRING})
+    @source(name="WITH_CONTEXT", argument_def_dict={'foo': ArgumentDefinition(types.String)})
     @with_context
     def context_source(_context, foo):
         return {'foo': foo}
 
-    @source(name="NO_CONTEXT", argument_def_dict={'foo': types.STRING})
+    @source(name="NO_CONTEXT", argument_def_dict={'foo': ArgumentDefinition(types.String)})
     def no_context_source(foo):
         return {'foo': foo}
 
@@ -149,12 +150,16 @@ def test_sources():
 def test_materializations():
     test_output = {}
 
-    @materialization(name="CONTEXT", argument_def_dict={'foo': types.STRING})
+    @materialization(
+        name="CONTEXT", argument_def_dict={'foo': ArgumentDefinition(types.String)}
+    )
     @with_context
     def materialization_with_context(_context, data, foo):
         test_output['test'] = data
 
-    @materialization(name="NO_CONTEXT", argument_def_dict={'foo': types.STRING})
+    @materialization(
+        name="NO_CONTEXT", argument_def_dict={'foo': ArgumentDefinition(types.String)}
+    )
     def materialization_no_context(data, foo):
         test_output['test'] = data
 
@@ -294,56 +299,76 @@ def test_solid_definition_errors():
 def test_source_definition_errors():
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @source(argument_def_dict={'foo': types.STRING})
+        @source(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         @with_context
         def vargs(context, foo, *args):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @source(argument_def_dict={'foo': types.STRING})
+        @source(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         def wrong_name(bar):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @source(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+        @source(
+            argument_def_dict={
+                'foo': ArgumentDefinition(types.String),
+                'bar': ArgumentDefinition(types.String)
+            }
+        )
         def wrong_name_2(foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @source(argument_def_dict={'foo': types.STRING})
+        @source(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         @with_context
         def no_context(foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @source(argument_def_dict={'foo': types.STRING})
+        @source(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         def yes_context(context, foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @source(argument_def_dict={'foo': types.STRING})
+        @source(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         def extras(foo, bar):
             pass
 
-    @source(argument_def_dict={'foo': types.STRING})
+    @source(argument_def_dict={'foo': ArgumentDefinition(types.String)})
     def valid_kwargs(**kwargs):
         pass
 
-    @source(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+    @source(
+        argument_def_dict={
+            'foo': ArgumentDefinition(types.String),
+            'bar': ArgumentDefinition(types.String)
+        }
+    )
     def valid(foo, bar):
         pass
 
-    @source(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+    @source(
+        argument_def_dict={
+            'foo': ArgumentDefinition(types.String),
+            'bar': ArgumentDefinition(types.String)
+        }
+    )
     @with_context
     def valid_rontext(context, foo, bar):
         pass
 
-    @source(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+    @source(
+        argument_def_dict={
+            'foo': ArgumentDefinition(types.String),
+            'bar': ArgumentDefinition(types.String)
+        }
+    )
     @with_context
     def valid_context_2(_context, foo, bar):
         pass
@@ -352,63 +377,63 @@ def test_source_definition_errors():
 def test_materialization_definition_errors():
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         @with_context
         def no_data(context, foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         @with_context
         def vargs(context, data, foo, *args):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         def wrong_name(data, bar):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String), 'bar': ArgumentDefinition(types.String)})
         def wrong_name_2(data, foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         @with_context
         def no_context(data, foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         def yes_context(context, data, foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
-        @materialization(argument_def_dict={'foo': types.STRING})
+        @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
         def extras(data, foo, bar):
             pass
 
-    @materialization(argument_def_dict={'foo': types.STRING})
+    @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String)})
     def valid_kwargs(data, **kwargs):
         pass
 
-    @materialization(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+    @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String), 'bar': ArgumentDefinition(types.String)})
     def valid(data, foo, bar):
         pass
 
-    @materialization(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+    @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String), 'bar': ArgumentDefinition(types.String)})
     @with_context
     def valid_rontext(context, data, foo, bar):
         pass
 
-    @materialization(argument_def_dict={'foo': types.STRING, 'bar': types.STRING})
+    @materialization(argument_def_dict={'foo': ArgumentDefinition(types.String), 'bar': ArgumentDefinition(types.String)})
     @with_context
     def valid_context_2(_context, _data, foo, bar):
         pass

--- a/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
@@ -10,6 +10,7 @@ from dagster.core.definitions import (
     create_custom_source_input,
     create_single_materialization_output,
     create_no_materialization_output,
+    ArgumentDefinition,
 )
 
 from dagster.core.execution import (
@@ -80,7 +81,7 @@ def create_single_dict_input(expectations=None):
     return create_custom_source_input(
         name='some_input',
         source_fn=lambda context, arg_dict: [{'key': arg_dict['str_arg']}],
-        argument_def_dict={'str_arg': types.STRING},
+        argument_def_dict={'str_arg' : ArgumentDefinition(types.String)},
         expectations=expectations or [],
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_input_expectations.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_input_expectations.py
@@ -1,7 +1,10 @@
 import pytest
 
 from dagster.core.definitions import (
-    ExpectationDefinition, ExpectationResult, create_custom_source_input
+    ExpectationDefinition,
+    ExpectationResult,
+    create_custom_source_input,
+    ArgumentDefinition,
 )
 from dagster.core.execution import (
     _execute_input_expectation, DagsterUserCodeExecutionError, ExecutionContext
@@ -20,7 +23,7 @@ def test_basic_failing_input_expectation():
     some_input = create_custom_source_input(
         name='some_input',
         source_fn=lambda arg_dict: [{'key': arg_dict['str_arg']}],
-        argument_def_dict={'str_arg': types.STRING},
+        argument_def_dict={'str_arg': ArgumentDefinition(types.String)},
         expectations=[
             ExpectationDefinition(name='failing', expectation_fn=failing_expectation)
         ]
@@ -42,7 +45,7 @@ def test_basic_passing_input_expectation():
     some_input = create_custom_source_input(
         name='some_input',
         source_fn=lambda arg_dict: [{'key': arg_dict['str_arg']}],
-        argument_def_dict={'str_arg': types.STRING},
+        argument_def_dict={'str_arg': ArgumentDefinition(types.String)},
         expectations=[
             ExpectationDefinition(name='passing', expectation_fn=passing_expectation)
         ]
@@ -64,7 +67,7 @@ def test_input_expectation_user_error():
     failing_during_expectation_input = create_custom_source_input(
         name='failing_during_expectation',
         source_fn=lambda arg_dict: [{'key': arg_dict['str_arg']}],
-        argument_def_dict={'str_arg': types.STRING},
+        argument_def_dict={'str_arg': ArgumentDefinition(types.String)},
         expectations=[
             ExpectationDefinition(name='passing', expectation_fn=throwing)
         ]

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -2,7 +2,11 @@ import dagster
 from dagster import config
 
 from dagster.core.definitions import (
-    SolidDefinition, InputDefinition, SourceDefinition, create_no_materialization_output
+    SolidDefinition,
+    InputDefinition,
+    SourceDefinition,
+    create_no_materialization_output,
+    ArgumentDefinition,
 )
 
 from dagster.core.execution import (ExecutionContext, execute_single_solid, execute_pipeline)
@@ -20,7 +24,7 @@ def test_execute_solid_with_input_same_name():
                     SourceDefinition(
                         source_type='a_source_type',
                         source_fn=lambda context, arg_dict: arg_dict['an_arg'],
-                        argument_def_dict={'an_arg': types.STRING},
+                        argument_def_dict={'an_arg': ArgumentDefinition(types.String)},
                     ),
                 ],
             ),
@@ -52,7 +56,7 @@ def test_execute_two_solids_with_same_input_name():
             SourceDefinition(
                 source_type='a_source_type',
                 source_fn=lambda context, arg_dict: arg_dict['an_arg'],
-                argument_def_dict={'an_arg': types.STRING},
+                argument_def_dict={'an_arg': ArgumentDefinition(types.String)},
             ),
         ],
     )
@@ -103,7 +107,7 @@ def test_execute_dep_solid_different_input_name():
                     SourceDefinition(
                         source_type='a_source_type',
                         source_fn=lambda context, arg_dict: arg_dict['an_arg'],
-                        argument_def_dict={'an_arg': types.STRING},
+                        argument_def_dict={'an_arg': ArgumentDefinition(types.String)},
                     ),
                 ],
             ),
@@ -164,7 +168,7 @@ def test_execute_dep_solid_same_input_name():
                         source_type='TABLE',
                         source_fn=
                         lambda context, arg_dict: s_fn(arg_dict, executed, 's1_t1_source'),
-                        argument_def_dict={'name': types.STRING},
+                        argument_def_dict={'name': ArgumentDefinition(types.String)},
                     ),
                 ],
             ),
@@ -183,7 +187,7 @@ def test_execute_dep_solid_same_input_name():
                         source_type='TABLE',
                         source_fn=
                         lambda context, arg_dict: s_fn(arg_dict, executed, 's2_t1_source'),
-                        argument_def_dict={'name': types.STRING},
+                        argument_def_dict={'name': ArgumentDefinition(types.String)},
                     ),
                 ],
                 depends_on=table_one,
@@ -195,7 +199,7 @@ def test_execute_dep_solid_same_input_name():
                         source_type='TABLE',
                         source_fn=
                         lambda context, arg_dict: s_fn(arg_dict, executed, 's2_t2_source'),
-                        argument_def_dict={'name': types.STRING},
+                        argument_def_dict={'name': ArgumentDefinition(types.String)},
                     ),
                 ],
             ),

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -19,7 +19,13 @@ from dagster.core.execution import (
 
 
 def silencing_default_context():
-    return {'default': dagster.PipelineContextDefinition({}, lambda _args: ExecutionContext())}
+    return {
+        'default':
+        dagster.PipelineContextDefinition(
+            argument_def_dict={},
+            context_fn=lambda _args: ExecutionContext(),
+        )
+    }
 
 
 def silencing_pipeline(solids):

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -74,7 +74,9 @@ def _create_transform_wrapper(fn, inputs, include_context=False):
 class _Source:
     def __init__(self, name=None, argument_def_dict=None):
         self.source_type = check.opt_str_param(name, 'name')
-        self.argument_def_dict = check.opt_dict_param(argument_def_dict, 'argument_def_dict')
+        self.argument_def_dict = check.opt_dict_param(
+            argument_def_dict, 'argument_def_dict'
+        )
 
     def __call__(self, fn):
         include_context = getattr(fn, 'has_context', False)
@@ -90,7 +92,7 @@ class _Source:
         return SourceDefinition(
             source_type=self.source_type,
             source_fn=source_fn,
-            argument_def_dict=self.argument_def_dict
+            argument_def_dict=self.argument_def_dict,
         )
 
 
@@ -118,7 +120,9 @@ def _create_source_wrapper(fn, arg_def_dict, include_context=False):
 class _Materialization:
     def __init__(self, name=None, argument_def_dict=None):
         self.materialization_type = check.opt_str_param(name, 'name')
-        self.argument_def_dict = check.opt_dict_param(argument_def_dict, 'argument_def_dict')
+        self.argument_def_dict = check.opt_dict_param(
+            argument_def_dict, 'argument_def_dict'
+        )
 
     def __call__(self, fn):
         include_context = getattr(fn, 'has_context', False)

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -302,15 +302,15 @@ def _validate_args(argument_def_dict, arg_dict, error_context_str):
         )
 
     for arg_name, arg_value in arg_dict.items():
-        arg_def_type = argument_def_dict[arg_name]
-        if not arg_def_type.is_python_valid_value(arg_value):
+        arg_def = argument_def_dict[arg_name]
+        if not arg_def.dagster_type.is_python_valid_value(arg_value):
             format_string = (
                 'Expected type {typename} for arg {arg_name}' +
                 'for {error_context_str} but got {arg_value}'
             )
             raise DagsterTypeError(
                 format_string.format(
-                    typename=arg_def_type.name,
+                    typename=arg_def.dagster_type.name,
                     arg_name=arg_name,
                     error_context_str=error_context_str,
                     arg_value=repr(arg_value),
@@ -438,10 +438,10 @@ def _execute_materialization(context, materialiation_def, arg_dict, value):
 
     for arg_name, arg_value in arg_dict.items():
         arg_def_type = materialiation_def.argument_def_dict[arg_name]
-        if not arg_def_type.is_python_valid_value(arg_value):
+        if not arg_def_type.dagster_type.is_python_valid_value(arg_value):
             raise DagsterTypeError(
                 'Expected type {typename} for arg {arg_name} in output but got {arg_value}'.format(
-                    typename=arg_def_type.name,
+                    typename=arg_def_type.dagster_type.name,
                     arg_name=arg_name,
                     arg_value=repr(arg_value),
                 )

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -24,6 +24,6 @@ class _SolidIntType(DagsterType):
         return isinstance(value, integer_types)
 
 
-STRING = _SolidStringType(name='String')
-PATH = _SolidStringType(name='Path')
-INT = _SolidIntType()
+String = _SolidStringType(name='String')
+Path = _SolidStringType(name='Path')
+Int = _SolidIntType()

--- a/python_modules/dagster/dagster/pandas_kernel/definitions.py
+++ b/python_modules/dagster/dagster/pandas_kernel/definitions.py
@@ -8,6 +8,7 @@ from dagster.core.definitions import (
     MaterializationDefinition,
     OutputDefinition,
     SourceDefinition,
+    ArgumentDefinition,
 )
 from dagster.core.errors import DagsterInvariantViolationError
 
@@ -28,7 +29,7 @@ def parquet_dataframe_source(**read_parquet_kwargs):
         source_type='PARQUET',
         source_fn=callback,
         argument_def_dict={
-            'path': types.PATH,
+            'path': ArgumentDefinition(types.Path),
         },
     )
 
@@ -45,7 +46,7 @@ def csv_dataframe_source(name=None, **read_csv_kwargs):
         source_type=check.opt_str_param(name, 'name', 'CSV'),
         source_fn=callback,
         argument_def_dict={
-            'path': types.PATH,
+            'path': ArgumentDefinition(types.Path),
         },
     )
 
@@ -62,7 +63,7 @@ def table_dataframe_source(**read_table_kwargs):
         source_type='TABLE',
         source_fn=callback,
         argument_def_dict={
-            'path': types.PATH,
+            'path': ArgumentDefinition(types.Path),
         },
     )
 
@@ -119,7 +120,7 @@ def dataframe_csv_materialization():
     return MaterializationDefinition(
         materialization_type='CSV',
         materialization_fn=to_csv_fn,
-        argument_def_dict={'path': types.PATH}
+        argument_def_dict={'path': ArgumentDefinition(types.Path)},
     )
 
 
@@ -135,7 +136,7 @@ def dataframe_parquet_materialization():
     return MaterializationDefinition(
         materialization_type='PARQUET',
         materialization_fn=to_parquet_fn,
-        argument_def_dict={'path': types.PATH}
+        argument_def_dict={'path': ArgumentDefinition(types.Path)},
     )
 
 

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
@@ -9,6 +9,7 @@ from dagster.core.definitions import (
     OutputDefinition,
     SolidDefinition,
     SourceDefinition,
+    ArgumentDefinition,
 )
 from dagster.core.execution import (ExecutionContext, execute_single_solid)
 from dagster.utils.test import script_relative_path
@@ -29,7 +30,7 @@ def create_hello_world_solid_no_api():
         sources=[
             SourceDefinition(
                 source_type='CSV',
-                argument_def_dict={'path': types.PATH},
+                argument_def_dict={'path': ArgumentDefinition(types.Path)},
                 source_fn=lambda context, arg_dict: pd.read_csv(arg_dict['path']),
             ),
         ],
@@ -38,7 +39,7 @@ def create_hello_world_solid_no_api():
     csv_materialization = MaterializationDefinition(
         materialization_type='CSV',
         materialization_fn=lambda df, arg_dict: df.to_csv(arg_dict['path'], index=False),
-        argument_def_dict={'path': types.PATH}
+        argument_def_dict={'path': ArgumentDefinition(types.Path)}
     )
 
     hello_world = SolidDefinition(
@@ -80,7 +81,7 @@ def create_dataframe_input(name):
         sources=[
             SourceDefinition(
                 source_type='CSV',
-                argument_def_dict={'path': types.PATH},
+                argument_def_dict={'path': ArgumentDefinition(types.Path)},
                 source_fn=lambda context, arg_dict: pd.read_csv(arg_dict['path']),
             ),
         ],
@@ -93,7 +94,7 @@ def create_dataframe_dependency(name, depends_on):
         sources=[
             SourceDefinition(
                 source_type='CSV',
-                argument_def_dict={'path': types.PATH},
+                argument_def_dict={'path': ArgumentDefinition(types.Path)},
                 source_fn=lambda context, arg_dict: pd.read_csv(arg_dict['path']),
             ),
         ],
@@ -110,7 +111,7 @@ def create_dataframe_output():
             MaterializationDefinition(
                 materialization_type='CSV',
                 materialization_fn=mat_fn,
-                argument_def_dict={'path': types.PATH},
+                argument_def_dict={'path': ArgumentDefinition(types.Path)},
             ),
         ],
     )

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
@@ -6,7 +6,7 @@ import dagster
 from dagster import check
 from dagster import config
 from dagster.core import types
-from dagster.core.definitions import (SolidDefinition, create_single_materialization_output)
+from dagster.core.definitions import (SolidDefinition, create_single_materialization_output, ArgumentDefinition)
 from dagster.core.decorators import solid
 from dagster.core.execution import (
     ExecutionContext,
@@ -117,7 +117,7 @@ def test_pandas_csv_to_csv():
     csv_output_def = create_single_materialization_output(
         materialization_type='CSV',
         materialization_fn=materialization_fn_inst,
-        argument_def_dict={'path': types.PATH}
+        argument_def_dict={'path': ArgumentDefinition(types.Path)}
     )
 
     solid_def = SolidDefinition(

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
@@ -1,11 +1,16 @@
 import dagster
 from dagster import (config, check)
 from dagster.core.definitions import (
-    InputDefinition, SolidDefinition, SourceDefinition, create_no_materialization_output
+    InputDefinition,
+    SolidDefinition,
+    SourceDefinition,
+    create_no_materialization_output,
+    ArgumentDefinition,
 )
 from dagster.sqlalchemy_kernel.templated import (
-    _create_templated_sql_transform_with_output, _render_template_string,
-    create_templated_sql_transform_solid
+    _create_templated_sql_transform_with_output,
+    _render_template_string,
+    create_templated_sql_transform_solid,
 )
 
 from .math_test_db import in_mem_context
@@ -46,7 +51,7 @@ def test_single_templated_sql_solid_single_table_raw_api():
                 source_type='TABLENAME',
                 source_fn=lambda context, arg_dict: arg_dict,
                 argument_def_dict={
-                    'name': dagster.core.types.STRING,
+                    'name': ArgumentDefinition(dagster.core.types.String),
                 },
             )
         ]
@@ -124,7 +129,7 @@ def test_single_templated_sql_solid_double_table_raw_api():
                 source_type='TABLENAME',
                 source_fn=lambda context, arg_dict: arg_dict,
                 argument_def_dict={
-                    'name': dagster.core.types.STRING,
+                    'name': ArgumentDefinition(dagster.core.types.String),
                 },
             )
         ]
@@ -137,7 +142,7 @@ def test_single_templated_sql_solid_double_table_raw_api():
                 source_type='TABLENAME',
                 source_fn=lambda context, arg_dict: arg_dict,
                 argument_def_dict={
-                    'name': dagster.core.types.STRING,
+                    'name': ArgumentDefinition(dagster.core.types.String),
                 },
             )
         ]

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/templated.py
@@ -7,6 +7,7 @@ from dagster.core.definitions import (
     InputDefinition,
     SourceDefinition,
     create_no_materialization_output,
+    ArgumentDefinition,
 )
 
 from .common import execute_sql_text_on_context
@@ -19,7 +20,7 @@ def _create_table_input(name, depends_on=None):
             SourceDefinition(
                 source_type='TABLENAME',
                 source_fn=lambda context, arg_dict: arg_dict,
-                argument_def_dict={'name': dagster.core.types.STRING},
+                argument_def_dict={'name': ArgumentDefinition(dagster.core.types.String)},
             )
         ],
         depends_on=depends_on


### PR DESCRIPTION
Instead of a dictionary from string to bare type for defining the set of
arguments, we move to ArgumentDefinition. This will allow things like
attaching descriptions to arguments, optionality, default values, and
other concepts