### PR TITLE
Adding optional and default values for arguments

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -26,3 +26,5 @@ from dagster.core.decorators import (
     materialization,
     with_context,
 )
+
+import dagster.core.types as types

--- a/python_modules/dagster/dagster/core/argument_handling.py
+++ b/python_modules/dagster/dagster/core/argument_handling.py
@@ -1,0 +1,67 @@
+from dagster import check
+from .errors import DagsterTypeError
+from .definitions import check_argument_def_dict
+
+
+def validate_args(argument_def_dict, arg_dict, error_context_str):
+    check_argument_def_dict(argument_def_dict)
+    check.dict_param(arg_dict, 'arg_dict', key_type=str)
+    check.str_param(error_context_str, 'error_context_str')
+
+    defined_args = set(argument_def_dict.keys())
+    received_args = set(arg_dict.keys())
+
+    for received_arg in received_args:
+        if received_arg not in defined_args:
+            raise DagsterTypeError(
+                'Argument {received} not found in {error_context_str}. Defined args: {defined}'.
+                format(
+                    error_context_str=error_context_str,
+                    defined=repr(defined_args),
+                    received=received_arg,
+                )
+            )
+
+    for expected_arg, arg_def in argument_def_dict.items():
+        if arg_def.is_optional:
+            continue
+
+        check.invariant(not arg_def.default_provided)
+
+        if expected_arg not in received_args:
+            raise DagsterTypeError(
+                'Did not not find {expected} in {error_context_str}. Defined args: {defined}'.
+                format(
+                    error_context_str=error_context_str,
+                    expected=expected_arg,
+                    defined=repr(defined_args),
+                )
+            )
+
+    args_to_pass = {}
+
+    for expected_arg, arg_def in argument_def_dict.items():
+        if expected_arg in received_args:
+            args_to_pass[expected_arg] = arg_dict[expected_arg]
+        elif arg_def.default_provided:
+            args_to_pass[expected_arg] = arg_def.default_value
+        else:
+            check.invariant(arg_def.is_optional and not arg_def.default_provided)
+
+    for arg_name, arg_value in arg_dict.items():
+        arg_def = argument_def_dict[arg_name]
+        if not arg_def.dagster_type.is_python_valid_value(arg_value):
+            format_string = (
+                'Expected type {typename} for arg {arg_name}' +
+                'for {error_context_str} but got {arg_value}'
+            )
+            raise DagsterTypeError(
+                format_string.format(
+                    typename=arg_def.dagster_type.name,
+                    arg_name=arg_name,
+                    error_context_str=error_context_str,
+                    arg_value=repr(arg_value),
+                )
+            )
+
+    return args_to_pass

--- a/python_modules/dagster/dagster/core/core_tests/test_argument_handling.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_argument_handling.py
@@ -1,0 +1,150 @@
+import pytest
+
+from dagster import (ArgumentDefinition, types)
+from dagster.core.argument_handling import validate_args
+from dagster.core.errors import DagsterTypeError
+
+
+def _validate(argument_def_dict, arg_dict):
+    return validate_args(argument_def_dict, arg_dict, 'dummy')
+
+
+def _single_required_string_arg_def_dict():
+    return {'string_arg': ArgumentDefinition(types.String)}
+
+
+def _multiple_required_args_def_dict():
+    return {
+        'arg_one': ArgumentDefinition(types.String),
+        'arg_two': ArgumentDefinition(types.String)
+    }
+
+
+def _single_optional_string_arg_def_dict():
+    return {'optional_arg': ArgumentDefinition(types.String, is_optional=True)}
+
+
+def _single_optional_string_arg_def_dict_with_default():
+    return {
+        'optional_arg':
+        ArgumentDefinition(types.String, is_optional=True, default_value='some_default')
+    }
+
+
+def _mixed_required_optional_string_arg_def_dict_with_default():
+    return {
+        'optional_arg':
+        ArgumentDefinition(types.String, is_optional=True, default_value='some_default'),
+        'required_arg':
+        ArgumentDefinition(types.String, is_optional=False),
+        'optional_arg_no_default':
+        ArgumentDefinition(types.String, is_optional=True),
+    }
+
+
+def test_empty():
+    _validate({}, {})
+
+
+def test_required_single_arg_passing():
+    _validate(_single_required_string_arg_def_dict(), {'string_arg': 'value'})
+
+
+def test_multiple_required_arg_passing():
+    _validate(_multiple_required_args_def_dict(), {'arg_one': 'value_one', 'arg_two': 'value_two'})
+
+
+def test_single_required_arg_failures():
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_required_string_arg_def_dict(), {})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_required_string_arg_def_dict(), {'extra': 'yup'})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_required_string_arg_def_dict(), {'string_arg': 'yupup', 'extra': 'yup'})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_required_string_arg_def_dict(), {'string_arg': 1})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_required_string_arg_def_dict(), {'string_arg': None})
+
+
+def test_multiple_required_args_failing():
+    with pytest.raises(DagsterTypeError):
+        _validate(_multiple_required_args_def_dict(), {})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_multiple_required_args_def_dict(), {'arg_one': 'yup'})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_multiple_required_args_def_dict(), {'arg_one': 'yup', 'extra': 'yup'})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_multiple_required_args_def_dict(), {'arg_one': 'value_one', 'arg_two': 2})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_multiple_required_args_def_dict(), {'arg_one': 'value_one', 'arg_two': None})
+
+
+def test_single_optional_arg_passing():
+    assert _validate(_single_optional_string_arg_def_dict(), {'optional_arg': 'value'}) == {
+        'optional_arg': 'value'
+    }
+    assert _validate(_single_optional_string_arg_def_dict(), {}) == {}
+
+
+def test_single_optional_arg_failing():
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_optional_string_arg_def_dict(), {'optional_arg': None})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_optional_string_arg_def_dict(), {'optional_arg': 1})
+
+    with pytest.raises(DagsterTypeError):
+        _validate(_single_optional_string_arg_def_dict(), {'optional_argdfd': 1})
+
+
+def test_single_optional_arg_passing_with_default():
+    assert _validate(_single_optional_string_arg_def_dict_with_default(), {}) == {
+        'optional_arg': 'some_default'
+    }
+
+    assert _validate(
+        _single_optional_string_arg_def_dict_with_default(), {'optional_arg': 'override'}
+    ) == {
+        'optional_arg': 'override'
+    }
+
+
+def test_mixed_args_passing():
+    assert _validate(
+        _mixed_required_optional_string_arg_def_dict_with_default(), {
+            'optional_arg': 'value_one',
+            'required_arg': 'value_two',
+        }
+    ) == {
+        'optional_arg': 'value_one',
+        'required_arg': 'value_two',
+    }
+
+    assert _validate(
+        _mixed_required_optional_string_arg_def_dict_with_default(), {
+            'required_arg': 'value_two',
+        }
+    ) == {
+        'optional_arg': 'some_default',
+        'required_arg': 'value_two',
+    }
+
+    assert _validate(
+        _mixed_required_optional_string_arg_def_dict_with_default(), {
+            'required_arg': 'value_two',
+            'optional_arg_no_default': 'value_three',
+        }
+    ) == {
+        'optional_arg': 'some_default',
+        'required_arg': 'value_two',
+        'optional_arg_no_default': 'value_three',
+    }

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
@@ -6,7 +6,9 @@ import dagster
 from dagster import check
 from dagster import config
 from dagster.core import types
-from dagster.core.definitions import (SolidDefinition, create_single_materialization_output, ArgumentDefinition)
+from dagster.core.definitions import (
+    SolidDefinition, create_single_materialization_output, ArgumentDefinition
+)
 from dagster.core.decorators import solid
 from dagster.core.execution import (
     ExecutionContext,
@@ -35,7 +37,6 @@ def get_solid_transformed_value(context, solid_inst, environment):
 
 def get_num_csv_environment(solid_name):
     return config.Environment(
-        context=config.Context('default', {'log_level': 'ERROR'}),
         sources={
             solid_name: {
                 'num_csv': config.Source('CSV', args={'path': script_relative_path('num.csv')})


### PR DESCRIPTION
This adds an optional flag and default values to ArgumentDefinition.
This will allow contexts (e.g the default context where one can
parameterize logging) to have optional arguments with default values.
Same for solids.