### PR TITLE
Consolidate materialization and execution

### DIFF
--- a/python_modules/dagster/README.rst
+++ b/python_modules/dagster/README.rst
@@ -196,12 +196,12 @@ We can specify in order to get artifacts for the results. We can materialize out
   materializations = [
       config.Materialization(
           solid='sum',
-          materialization_type='CSV',
+          name='CSV',
           args={'path': 'path/to/output.csv'},
       ),
       config.Materialization(
           solid='sum_sq',
-          materialization_type='CSV',
+          name='CSV',
           args={'path': 'path/to/output.csv'},
       )
   ]
@@ -407,12 +407,12 @@ addition to your environment, you must specify your materializations.
     materializations = [
         config.Materialization(
             solid='sum',
-            materialization_type='CSV',
+            name='CSV',
             args={'path': 'path/to/output.csv'},
         )
     ]
 
-    dagster.materialize_pipeline(
+    dagster.execute_pipeline(
         dagster.ExecutionContext(),
         pipeline,
         environment,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -4,7 +4,6 @@ from builtins import *  # pylint: disable=W0622,W0401
 from dagster.core.execution import (
     execute_pipeline,
     execute_pipeline_through_solid,
-    materialize_pipeline,
     ExecutionContext,
 )
 

--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -4,12 +4,12 @@ from dagster import check
 
 
 # lifted from https://bit.ly/2HcQAuv
-class Materialization(namedtuple('MaterializationData', 'solid materialization_type args')):
-    def __new__(cls, solid, materialization_type, args):
+class Materialization(namedtuple('MaterializationData', 'solid name args')):
+    def __new__(cls, solid, name, args):
         return super(Materialization, cls).__new__(
             cls,
             solid=check.str_param(solid, 'solid'),
-            materialization_type=check.str_param(materialization_type, 'materialization_type'),
+            name=check.str_param(name, 'name'),
             args=check.dict_param(args, 'args', key_type=str),
         )
 
@@ -21,19 +21,24 @@ class Context(namedtuple('ContextData', 'name args')):
         )
 
 
-class Environment(namedtuple('EnvironmentData', 'sources context')):
-    def __new__(cls, sources, context=None):
+class Environment(namedtuple('EnvironmentData', 'context sources materializations')):
+    def __new__(cls, sources, *, context=None, materializations=None):
         check.dict_param(sources, 'sources', key_type=str, value_type=dict)
         for _solid_name, source_dict in sources.items():
             check.dict_param(source_dict, 'source_dict', key_type=str, value_type=Source)
+
+        check.opt_inst_param(context, 'context', Context)
 
         if context is None:
             context = Context(name='default', args={})
 
         return super(Environment, cls).__new__(
             cls,
-            sources=sources,
             context=context,
+            sources=sources,
+            materializations=check.opt_list_param(
+                materializations, 'materializations', of_type=Materialization
+            ),
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/core/core_tests/test_core_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_core_execution.py
@@ -144,7 +144,7 @@ def test_execute_output_with_args():
         test_output['thearg'] = arg_dict['out_arg']
 
     materialization = MaterializationDefinition(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=materialization_fn_inst,
         argument_def_dict={'out_arg': ArgumentDefinition(types.String)}
     )
@@ -158,7 +158,7 @@ def test_execute_output_with_args():
 
 def test_execute_materialization_arg_mismatch():
     materialization = MaterializationDefinition(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=lambda out, dict: [],
         argument_def_dict={'out_arg': ArgumentDefinition(types.String)}
     )
@@ -180,7 +180,7 @@ def test_execute_materialization_arg_mismatch():
 
 def test_execute_materialization_arg_type_mismatch():
     custom_output = MaterializationDefinition(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=lambda out, dict: [],
         argument_def_dict={'out_arg': ArgumentDefinition(types.String)}
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -175,7 +175,7 @@ def test_materializations():
         create_test_context(),
         hello,
         environment=config.Environment(sources={}),
-        materialization_type='CONTEXT',
+        name='CONTEXT',
         arg_dict={'foo': 'bar'}
     )
 
@@ -187,7 +187,7 @@ def test_materializations():
         create_test_context(),
         hello,
         environment=config.Environment(sources={}),
-        materialization_type='NO_CONTEXT',
+        name='NO_CONTEXT',
         arg_dict={'foo': 'bar'}
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_error_handling.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_error_handling.py
@@ -50,7 +50,7 @@ def test_basic_materialization_runtime_error_handling():
         raise Exception('error during output')
 
     materialization_def = MaterializationDefinition(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=materialization_fn_inst,
         argument_def_dict={}
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
@@ -54,7 +54,7 @@ def test_execute_solid_no_args():
         test_output['thedata'] = data
 
     custom_output = create_single_materialization_output(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=materialization_fn_inst,
         argument_def_dict={},
     )
@@ -70,7 +70,7 @@ def test_execute_solid_no_args():
         create_test_context(),
         single_solid,
         environment=single_input_env('some_node', 'some_input'),
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         arg_dict={}
     )
 
@@ -93,7 +93,7 @@ def create_noop_output(test_output, expectations=None):
         test_output['thedata'] = output
 
     return create_single_materialization_output(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=set_test_output,
         argument_def_dict={},
         expectations=expectations
@@ -127,7 +127,7 @@ def test_hello_world():
         ],
         transform_fn=transform_fn,
         output=create_single_materialization_output(
-            materialization_type='CUSTOM',
+            name='CUSTOM',
             materialization_fn=materialization_fn,
             argument_def_dict={}
         ),
@@ -149,7 +149,7 @@ def test_hello_world():
         create_test_context(),
         hello_world,
         environment=single_input_env('hello_world', 'hello_world_input'),
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         arg_dict={}
     )
 
@@ -175,7 +175,7 @@ def test_execute_solid_with_args():
         create_test_context(),
         single_solid,
         environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         arg_dict={},
     )
 
@@ -194,7 +194,7 @@ def test_execute_solid_with_failed_input_expectation_non_throwing():
         create_test_context(),
         single_solid,
         environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         arg_dict={},
         throw_on_error=False,
     )
@@ -212,7 +212,7 @@ def test_execute_solid_with_failed_input_expectation_throwing():
             create_test_context(),
             single_solid,
             environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-            materialization_type='CUSTOM',
+            name='CUSTOM',
             arg_dict={},
         )
 
@@ -221,7 +221,7 @@ def test_execute_solid_with_failed_input_expectation_throwing():
             create_test_context(),
             single_solid,
             environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-            materialization_type='CUSTOM',
+            name='CUSTOM',
             arg_dict={},
         )
 
@@ -249,7 +249,7 @@ def test_execute_solid_with_failed_output_expectation_non_throwing():
         create_test_context(),
         failing_solid,
         environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         arg_dict={},
         throw_on_error=False
     )
@@ -267,7 +267,7 @@ def test_execute_solid_with_failed_output_expectation_throwing():
             create_test_context(),
             failing_solid,
             environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-            materialization_type='CUSTOM',
+            name='CUSTOM',
             arg_dict={},
         )
 
@@ -276,7 +276,7 @@ def test_execute_solid_with_failed_output_expectation_throwing():
             create_test_context(),
             failing_solid,
             environment=single_input_env('some_node', 'some_input', {'str_arg': 'an_input_arg'}),
-            materialization_type='CUSTOM',
+            name='CUSTOM',
             arg_dict={},
         )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_iterator_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_iterator_execution.py
@@ -30,7 +30,7 @@ def test_iterator_solid():
         # and stream to disk
 
     custom_output = create_single_materialization_output(
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         materialization_fn=materialization_fn,
         argument_def_dict={},
     )
@@ -50,7 +50,7 @@ def test_iterator_solid():
                 'iter_numbers': config.Source('CUSTOM', {})
             }}
         ),
-        materialization_type='CUSTOM',
+        name='CUSTOM',
         arg_dict={}
     )
 

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -119,7 +119,7 @@ def _create_source_wrapper(fn, arg_def_dict, include_context=False):
 
 class _Materialization:
     def __init__(self, name=None, argument_def_dict=None):
-        self.materialization_type = check.opt_str_param(name, 'name')
+        self.name = check.opt_str_param(name, 'name')
         self.argument_def_dict = check.opt_dict_param(
             argument_def_dict, 'argument_def_dict'
         )
@@ -129,18 +129,18 @@ class _Materialization:
         if include_context:
             fn = fn.fn
 
-        if not self.materialization_type:
-            self.materialization_type = fn.__name__
+        if not self.name:
+            self.name = fn.__name__
 
         _validate_materialization_fn(
-            fn, self.materialization_type, self.argument_def_dict, include_context
+            fn, self.name, self.argument_def_dict, include_context
         )
         materialization_fn = _create_materialization_wrapper(
             fn, self.argument_def_dict, include_context
         )
 
         return MaterializationDefinition(
-            materialization_type=self.materialization_type,
+            name=self.name,
             materialization_fn=materialization_fn,
             argument_def_dict=self.argument_def_dict
         )

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -338,8 +338,8 @@ class MaterializationDefinition:
         argument_def_dict = { 'path' : dagster.core.types.Path }
     '''
 
-    def __init__(self, materialization_type, materialization_fn, *, argument_def_dict=None):
-        self.materialization_type = check_valid_name(materialization_type)
+    def __init__(self, name, materialization_fn, *, argument_def_dict=None):
+        self.name = check_valid_name(name)
         self.materialization_fn = check.callable_param(materialization_fn, 'materialization_fn')
         self.argument_def_dict = check_argument_def_dict(argument_def_dict)
 
@@ -349,7 +349,7 @@ def create_no_materialization_output(expectations=None):
 
 
 def create_single_materialization_output(
-    materialization_type, materialization_fn, argument_def_dict, expectations=None
+    name, materialization_fn, argument_def_dict, expectations=None
 ):
     '''
     Similar to create_single_source_input this exists because a move in the primitive APIs.
@@ -360,7 +360,7 @@ def create_single_materialization_output(
     return OutputDefinition(
         materializations=[
             MaterializationDefinition(
-                materialization_type=materialization_type,
+                name=name,
                 materialization_fn=materialization_fn,
                 argument_def_dict=argument_def_dict,
             )
@@ -380,12 +380,12 @@ class OutputDefinition:
         )
         self.output_callback = check.opt_callable_param(output_callback, 'output_callback')
 
-    def materialization_of_type(self, materialization_type):
+    def materialization_of_type(self, name):
         for materialization in self.materializations:
-            if materialization.materialization_type == materialization_type:
+            if materialization.name == name:
                 return materialization
 
-        check.failed('Did not find materialization {type}'.format(type=materialization_type))
+        check.failed('Did not find materialization {type}'.format(type=name))
 
 
 # One or more inputs

--- a/python_modules/dagster/dagster/pandas_kernel/definitions.py
+++ b/python_modules/dagster/dagster/pandas_kernel/definitions.py
@@ -118,7 +118,7 @@ def dataframe_csv_materialization():
         df.to_csv(path, index=False)
 
     return MaterializationDefinition(
-        materialization_type='CSV',
+        name='CSV',
         materialization_fn=to_csv_fn,
         argument_def_dict={'path': ArgumentDefinition(types.Path)},
     )
@@ -134,7 +134,7 @@ def dataframe_parquet_materialization():
         df.to_parquet(path)
 
     return MaterializationDefinition(
-        materialization_type='PARQUET',
+        name='PARQUET',
         materialization_fn=to_parquet_fn,
         argument_def_dict={'path': ArgumentDefinition(types.Path)},
     )

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
@@ -44,7 +44,7 @@ def run_hello_world(hello_world):
             dagster.ExecutionContext(),
             hello_world,
             environment=create_num_csv_environment(),
-            materialization_type='CSV',
+            name='CSV',
             arg_dict={'path': temp_file_name},
         )
 

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
@@ -37,7 +37,7 @@ def create_hello_world_solid_no_api():
     )
 
     csv_materialization = MaterializationDefinition(
-        materialization_type='CSV',
+        name='CSV',
         materialization_fn=lambda df, arg_dict: df.to_csv(arg_dict['path'], index=False),
         argument_def_dict={'path': ArgumentDefinition(types.Path)}
     )
@@ -109,7 +109,7 @@ def create_dataframe_output():
     return OutputDefinition(
         materializations=[
             MaterializationDefinition(
-                materialization_type='CSV',
+                name='CSV',
                 materialization_fn=mat_fn,
                 argument_def_dict={'path': ArgumentDefinition(types.Path)},
             ),
@@ -204,17 +204,22 @@ def test_pipeline():
     }
 
     sum_sq_path_args = {'path': '/tmp/sum_sq.csv'}
-    dagster.materialize_pipeline(
-        pipeline,
-        environment=environment,
+    environment_two = config.Environment(
+        sources={
+            'solid_one': {
+                'num_df': config.Source('CSV', {'path': script_relative_path('num.csv')})
+            }
+        },
         materializations=[
             config.Materialization(
                 solid='solid_two',
-                materialization_type='CSV',
+                name='CSV',
                 args=sum_sq_path_args,
             ),
-        ],
+        ]
     )
+
+    dagster.execute_pipeline(pipeline, environment=environment_two)
 
     sum_sq_df = pd.read_csv('/tmp/sum_sq.csv')
 

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
@@ -4,7 +4,6 @@ from dagster import config
 from dagster.core.execution import (
     output_single_solid,
     execute_pipeline,
-    materialize_pipeline,
 )
 
 from dagster.sqlalchemy_kernel.subquery_builder_experimental import (
@@ -63,7 +62,7 @@ def test_sql_sum_solid():
         context,
         sum_table_solid,
         environment=environment,
-        materialization_type='CREATE',
+        name='CREATE',
         arg_dict={'table_name': 'sum_table'},
     )
     assert result.success
@@ -129,19 +128,16 @@ def test_output_sql_sum_sq_solid():
                 'num_table': config.Source('TABLENAME', {'table_name': 'num_table'})
             }
         },
-    )
-
-    pipeline_result = materialize_pipeline(
-        pipeline=pipeline,
-        environment=environment,
         materializations=[
             config.Materialization(
                 solid='sum_sq_table',
-                materialization_type='CREATE',
+                name='CREATE',
                 args={'table_name': 'sum_sq_table'},
             )
         ],
     )
+
+    pipeline_result = execute_pipeline(pipeline=pipeline, environment=environment)
 
     assert pipeline_result.success
 

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
@@ -66,7 +66,7 @@ def create_table_output():
         context.engine.connect().execute(total_sql)
 
     return create_single_materialization_output(
-        materialization_type='CREATE',
+        name='CREATE',
         materialization_fn=materialization_fn,
         argument_def_dict={'table_name': ArgumentDefinition(types.String)}
     )

--- a/python_modules/dagster/dagster_tests/test_config.py
+++ b/python_modules/dagster/dagster_tests/test_config.py
@@ -4,13 +4,13 @@ from dagster import config
 
 
 def test_config():
-    mat = config.Materialization(solid='some_solid', materialization_type='a_mat_type', args={})
+    mat = config.Materialization(solid='some_solid', name='a_mat_type', args={})
     assert isinstance(mat, config.Materialization)
     assert mat.solid == 'some_solid'
-    assert mat.materialization_type == 'a_mat_type'
+    assert mat.name == 'a_mat_type'
     assert mat.args == {}
 
 
 def test_bad_config():
     with pytest.raises(Exception):
-        config.Materialization(solid='name', materialization_type=1, args={})
+        config.Materialization(solid='name', name=1, args={})


### PR DESCRIPTION
This eliminates the two species of execution, execution and
materialization. Instead materializations are part of the environment,
and everything just goes through execution.

This simplifies a ton of stuff and I'm pumped up about it.