### PR TITLE
Context creation function can now yield

### DIFF
--- a/python_modules/dagster/dagster/core/argument_handling.py
+++ b/python_modules/dagster/dagster/core/argument_handling.py
@@ -52,14 +52,15 @@ def validate_args(argument_def_dict, arg_dict, error_context_str):
         arg_def = argument_def_dict[arg_name]
         if not arg_def.dagster_type.is_python_valid_value(arg_value):
             format_string = (
-                'Expected type {typename} for arg {arg_name}' +
-                'for {error_context_str} but got {arg_value}'
+                'Expected type {typename} for arg {arg_name} ' +
+                'for {error_context_str} but got type "{arg_type}" value {arg_value}'
             )
             raise DagsterTypeError(
                 format_string.format(
                     typename=arg_def.dagster_type.name,
                     arg_name=arg_name,
                     error_context_str=error_context_str,
+                    arg_type=type(arg_value).__name__,
                     arg_value=repr(arg_value),
                 )
             )

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -22,7 +22,7 @@ def silencing_default_context():
         'default':
         dagster.PipelineContextDefinition(
             argument_def_dict={},
-            context_fn=lambda _args: ExecutionContext(),
+            context_fn=lambda _pipeline, _args: ExecutionContext(),
         )
     }
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -51,13 +51,14 @@ def check_argument_def_dict(argument_def_dict):
 
 
 class PipelineContextDefinition:
-    def __init__(self, *, argument_def_dict, context_fn):
+    def __init__(self, *, argument_def_dict, context_fn, description=None):
         self.argument_def_dict = check_argument_def_dict(argument_def_dict)
         self.context_fn = check.callable_param(context_fn, 'context_fn')
+        self.description = description
 
 
 def _default_pipeline_context_definitions():
-    def _default_context_fn(args):
+    def _default_context_fn(_pipeline, args):
         # This has a circular dependency between execution and definition
         # The likely solution is to move the ExecutionContext to definitions.py
         # -- schrockn (07-28-18)

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
@@ -25,11 +25,11 @@ def create_persisted_context():
 def create_mem_sql_pipeline_context_tuple(solids):
     default_def = dagster.PipelineContextDefinition(
         argument_def_dict={},
-        context_fn=lambda _args: in_mem_context(),
+        context_fn=lambda _pipeline, _args: in_mem_context(),
     )
     persisted_def = dagster.PipelineContextDefinition(
         argument_def_dict={},
-        context_fn=lambda _args: create_persisted_context(),
+        context_fn=lambda _pipeline, _args: create_persisted_context(),
     )
     return dagster.PipelineDefinition(
         solids=solids, context_definitions={

--- a/python_modules/dagster/dagster/graphviz.py
+++ b/python_modules/dagster/dagster/graphviz.py
@@ -11,16 +11,21 @@ def build_graphviz_graph(pipeline):
     for solid in pipeline.solids:
         graphviz_graph.node(solid.name)
 
-    graphviz_graph.attr('node', color='grey')
-
-    for input_def in pipeline.external_inputs:
-        graphviz_graph.node(input_def.name)
+    graphviz_graph.attr('node', color='grey', shape='box')
 
     for solid in pipeline.solids:
         for input_def in solid.inputs:
+            input_node = solid.name + '.' + input_def.name
+            graphviz_graph.node(input_node)
+
+    for solid in pipeline.solids:
+        for input_def in solid.inputs:
+
+            input_node = solid.name + '.' + input_def.name
+
+            graphviz_graph.edge(input_node, solid.name)
+
             if input_def.depends_on:
-                graphviz_graph.edge(input_def.depends_on.name, solid.name)
-            else:
-                graphviz_graph.edge(input_def.name, solid.name)
+                graphviz_graph.edge(input_def.depends_on.name, input_node)
 
     return graphviz_graph

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
@@ -21,7 +21,7 @@ def pipeline_test_def(solids, context):
             'default':
             dagster.PipelineContextDefinition(
                 argument_def_dict={},
-                context_fn=lambda _args: context,
+                context_fn=lambda _pipeline, _args: context,
             ),
         }
     )

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_sql_tests.py
@@ -16,7 +16,7 @@ def pipeline_test_def(solids, context):
             'default':
             dagster.PipelineContextDefinition(
                 argument_def_dict={},
-                context_fn=lambda _args: context,
+                context_fn=lambda _pipeline, _args: context,
             ),
         }
     )

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
@@ -32,7 +32,7 @@ def pipeline_test_def(solids, context):
             'default':
             dagster.PipelineContextDefinition(
                 argument_def_dict={},
-                context_fn=lambda _args: context,
+                context_fn=lambda _pipeline, _args: context,
             ),
         }
     )


### PR DESCRIPTION
Sometimes contexts need to clean up after themselves after a
pipeline execution run. In order to support this a context_fn
in a PipelineContextDefinition can either return a context object
directly or yield a context object. The calling code dynamically tests
which case it is.