### PR TITLE
Introduce resource pattern to the dagster sql context

### DIFF
--- a/python_modules/dagster/dagster/sqlalchemy_kernel/__init__.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 from builtins import *  # pylint: disable=W0622,W0401
 from .templated import execute_sql_text_on_context
-from .common import DagsterSqlAlchemyExecutionContext
+from .common import (create_sql_alchemy_context_from_engine, SqlAlchemyResource)
 from .subquery_builder_experimental import sql_file_solid

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/math_test_db.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/math_test_db.py
@@ -27,4 +27,4 @@ def in_mem_engine(num_table_name='num_table'):
 
 
 def in_mem_context(num_table_name='num_table'):
-    return dagster_sa.DagsterSqlAlchemyExecutionContext(engine=in_mem_engine(num_table_name))
+    return dagster_sa.create_sql_alchemy_context_from_engine(engine=in_mem_engine(num_table_name))

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
@@ -67,7 +67,7 @@ def test_sql_sum_solid():
     )
     assert result.success
 
-    results = context.engine.connect().execute('SELECT * FROM sum_table').fetchall()
+    results = context.resources.sa.engine.connect().execute('SELECT * FROM sum_table').fetchall()
     assert results == [(1, 2, 3), (3, 4, 7)]
 
 
@@ -144,6 +144,6 @@ def test_output_sql_sum_sq_solid():
     result_list = pipeline_result.result_list
 
     assert len(result_list) == 2
-    engine = pipeline_result.context.engine
+    engine = pipeline_result.context.resources.sa.engine
     result_list = engine.connect().execute('SELECT * FROM sum_sq_table').fetchall()
     assert result_list == [(1, 2, 3, 9), (3, 4, 7, 49)]

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_sql_tests.py
@@ -35,7 +35,7 @@ def test_basic_isolated_sql_solid():
 
     assert result.success
 
-    results = context.engine.connect().execute('SELECT * from sum_table').fetchall()
+    results = context.resources.sa.engine.connect().execute('SELECT * from sum_table').fetchall()
     assert results == [(1, 2, 3), (3, 4, 7)]
 
 
@@ -73,7 +73,7 @@ def test_basic_pipeline():
     for exec_result in exec_results:
         assert exec_result.success is True
 
-    engine = pipeline_result.context.engine
+    engine = pipeline_result.context.resources.sa.engine
 
     results = engine.connect().execute('SELECT * from sum_table').fetchall()
     assert results == [(1, 2, 3), (3, 4, 7)]
@@ -103,7 +103,7 @@ def test_pipeline_from_files():
     for exec_result in exec_results:
         assert exec_result.success is True
 
-    engine = pipeline_result.context.engine
+    engine = pipeline_result.context.resources.sa.engine
 
     results = engine.connect().execute('SELECT * from sum_table').fetchall()
     assert results == [(1, 2, 3), (3, 4, 7)]

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
@@ -17,7 +17,7 @@ from .math_test_db import in_mem_context
 
 
 def _load_table(context, table_name):
-    return context.engine.connect().execute(f'SELECT * FROM {table_name}').fetchall()
+    return context.resources.sa.engine.connect().execute(f'SELECT * FROM {table_name}').fetchall()
 
 
 def table_name_source(table_name):

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
@@ -13,10 +13,7 @@ from dagster.core.definitions import (
     ArgumentDefinition,
 )
 
-from dagster.sqlalchemy_kernel import (
-    DagsterSqlAlchemyExecutionContext,
-    execute_sql_text_on_context,
-)
+from dagster.sqlalchemy_kernel import execute_sql_text_on_context
 
 
 class DagsterSqlExpression:
@@ -56,14 +53,13 @@ class DagsterSqlTableExpression(DagsterSqlExpression):
 def create_table_output():
     def materialization_fn(context, arg_dict, sql_expr):
         check.inst_param(sql_expr, 'sql_expr', DagsterSqlExpression)
-        check.inst_param(context, 'context', DagsterSqlAlchemyExecutionContext)
         check.dict_param(arg_dict, 'arg_dict')
 
         output_table_name = check.str_elem(arg_dict, 'table_name')
         total_sql = '''CREATE TABLE {output_table_name} AS {query_text}'''.format(
             output_table_name=output_table_name, query_text=sql_expr.query_text
         )
-        context.engine.connect().execute(total_sql)
+        context.resources.sa.engine.connect().execute(total_sql)
 
     return create_single_materialization_output(
         name='CREATE',
@@ -73,7 +69,6 @@ def create_table_output():
 
 
 def _table_name_read_fn(context, arg_dict):
-    check.inst_param(context, 'context', DagsterSqlAlchemyExecutionContext)
     check.dict_param(arg_dict, 'arg_dict')
 
     table_name = check.str_elem(arg_dict, 'table_name')


### PR DESCRIPTION
This introduces the mixin-esque strategy to manage contexts. Instead
of subclassing per resource (e.g. A sqlalchemy-specific context), this will allow
a context to be utilize a number of different resources. Libraries will
assume that a resource of a certain name and type exist. Right now
the sqlalchemy kernel just does runtime type checks to enforce this.