### PR TITLE
Productionize expectations execution

### DIFF
--- a/python_modules/dagster-ge/dagster_ge/__init__.py
+++ b/python_modules/dagster-ge/dagster_ge/__init__.py
@@ -12,7 +12,7 @@ from dagster.core.definitions import (ExpectationDefinition, ExpectationResult)
 #     dagster_ge.json_config_expectation('num_expectations', 'num_expectations.json')
 # ]
 def json_config_expectation(name, file_path):
-    def _file_passes(df):
+    def _file_passes(_context, _info, df):
         with open(file_path) as ff:
             expt_config = json.load(ff)
             # This is necessary because ge ends up coercing a type change
@@ -38,7 +38,7 @@ def json_config_expectation(name, file_path):
 #   dagster_ge.ge_expectation(name, lambda ge_df: ge_df.expect_column_to_exist(col_name)),
 # ]
 def ge_expectation(name, ge_callback):
-    def _do_expectation(df):
+    def _do_expectation(_context, _info, df):
         ge_df = ge.from_pandas(df)
         ge_result = ge_callback(ge_df)
         check.invariant('success' in ge_result)

--- a/python_modules/dagster-ge/setup.py
+++ b/python_modules/dagster-ge/setup.py
@@ -27,7 +27,7 @@ setup(
         'enum34>=1.1.6',
         'future>=0.16.0',
         'dagster>=0.1.2',
-        'great-expectations>=0.4.3',
-    ],
+        'great-expectations>=0.4.2',
+    ]
     # scripts=['bin/dagster']
 )

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -5,6 +5,11 @@ from dagster.core.execution import (
     execute_pipeline,
     execute_pipeline_through_solid,
     ExecutionContext,
+    ExpectationResult,
+    InputExpectationInfo,
+    OutputExpectationInfo,
+    InputExpectationResult,
+    InputExpectationResults,
 )
 
 from dagster.core.definitions import (

--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -21,8 +21,8 @@ class Context(namedtuple('ContextData', 'name args')):
         )
 
 
-class Environment(namedtuple('EnvironmentData', 'context sources materializations')):
-    def __new__(cls, sources, *, context=None, materializations=None):
+class Environment(namedtuple('EnvironmentData', 'context sources materializations expectations')):
+    def __new__(cls, sources, *, context=None, materializations=None, expectations=None):
         check.dict_param(sources, 'sources', key_type=str, value_type=dict)
         for _solid_name, source_dict in sources.items():
             check.dict_param(source_dict, 'source_dict', key_type=str, value_type=Source)
@@ -32,6 +32,9 @@ class Environment(namedtuple('EnvironmentData', 'context sources materialization
         if context is None:
             context = Context(name='default', args={})
 
+        if expectations is None:
+            expectations = Expectations(evaluate=True)
+
         return super(Environment, cls).__new__(
             cls,
             context=context,
@@ -39,6 +42,7 @@ class Environment(namedtuple('EnvironmentData', 'context sources materialization
             materializations=check.opt_list_param(
                 materializations, 'materializations', of_type=Materialization
             ),
+            expectations=expectations,
         )
 
     @staticmethod
@@ -52,6 +56,13 @@ class Source(namedtuple('SourceData', 'name args')):
             cls,
             name=check.str_param(name, 'name'),
             args=check.dict_param(args, 'args', key_type=str),
+        )
+
+
+class Expectations(namedtuple('ExpectationsData', 'evaluate')):
+    def __new__(cls, evaluate):
+        return super(Expectations, cls).__new__(
+            cls, evaluate=check.bool_param(evaluate, 'evaluate')
         )
 
 

--- a/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
@@ -15,7 +15,7 @@ from dagster.core.definitions import (
 
 from dagster.core.execution import (
     output_single_solid,
-    DagsterExecutionResult,
+    SolidExecutionResult,
     DagsterExecutionFailureReason,
     ExecutionContext,
     execute_single_solid,
@@ -127,9 +127,7 @@ def test_hello_world():
         ],
         transform_fn=transform_fn,
         output=create_single_materialization_output(
-            name='CUSTOM',
-            materialization_fn=materialization_fn,
-            argument_def_dict={}
+            name='CUSTOM', materialization_fn=materialization_fn, argument_def_dict={}
         ),
     )
 
@@ -199,7 +197,7 @@ def test_execute_solid_with_failed_input_expectation_non_throwing():
         throw_on_error=False,
     )
 
-    assert isinstance(solid_execution_result, DagsterExecutionResult)
+    assert isinstance(solid_execution_result, SolidExecutionResult)
     assert solid_execution_result.success is False
     assert solid_execution_result.reason == DagsterExecutionFailureReason.EXPECTATION_FAILURE
 
@@ -229,7 +227,7 @@ def test_execute_solid_with_failed_input_expectation_throwing():
 def create_input_failing_solid():
     test_output = {}
 
-    def failing_expectation_fn(_some_input):
+    def failing_expectation_fn(_context, _info, _some_input):
         return ExpectationResult(success=False)
 
     failing_expect = ExpectationDefinition(name='failing', expectation_fn=failing_expectation_fn)
@@ -254,7 +252,7 @@ def test_execute_solid_with_failed_output_expectation_non_throwing():
         throw_on_error=False
     )
 
-    assert isinstance(solid_execution_result, DagsterExecutionResult)
+    assert isinstance(solid_execution_result, SolidExecutionResult)
     assert solid_execution_result.success is False
     assert solid_execution_result.reason == DagsterExecutionFailureReason.EXPECTATION_FAILURE
 
@@ -305,7 +303,7 @@ def test_execute_solid_with_no_inputs():
 def create_output_failing_solid():
     test_output = {}
 
-    def failing_expectation_fn(_output):
+    def failing_expectation_fn(_context, _info, _output):
         return ExpectationResult(success=False)
 
     output_expectation = ExpectationDefinition(

--- a/python_modules/dagster/dagster/core/core_tests/test_output_expectations.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_output_expectations.py
@@ -1,5 +1,6 @@
 import pytest
 
+import dagster
 from dagster.core.definitions import (
     ExpectationDefinition,
     ExpectationResult,
@@ -13,15 +14,28 @@ def create_test_context():
     return ExecutionContext()
 
 
+def create_dummy_output_info(expect_def):
+    return dagster.OutputExpectationInfo(
+        solid=dagster.SolidDefinition(
+            name='dummy',
+            inputs=[],
+            transform_fn=lambda _context, _args: None,
+            output=dagster.OutputDefinition(expectations=[expect_def])
+        ),
+        expectation_def=expect_def
+    )
+
+
 def test_basic_failing_output_expectation():
-    def failing(_output):
+    def failing(_context, _info, _output):
         return ExpectationResult(
             success=False,
             message='some message',
         )
 
     result = _execute_output_expectation(
-        create_test_context(), ExpectationDefinition('failing', failing), 'not used'
+        create_test_context(), create_dummy_output_info(ExpectationDefinition('failing', failing)),
+        'not used'
     )
 
     assert isinstance(result, ExpectationResult)
@@ -30,14 +44,18 @@ def test_basic_failing_output_expectation():
 
 
 def test_basic_passing_output_expectation():
-    def success(_output):
+    def success(_context, _info, _output):
         return ExpectationResult(
             success=True,
             message='yay',
         )
 
     expectation = ExpectationDefinition('success', success)
-    result = _execute_output_expectation(create_test_context(), expectation, 'not used')
+    result = _execute_output_expectation(
+        create_test_context(),
+        create_dummy_output_info(expectation),
+        'not used',
+    )
 
     assert isinstance(result, ExpectationResult)
     assert result.success
@@ -50,5 +68,6 @@ def test_output_expectation_user_error():
 
     with pytest.raises(DagsterUserCodeExecutionError):
         _execute_output_expectation(
-            create_test_context(), ExpectationDefinition('throwing', throwing), 'not used'
+            create_test_context(),
+            create_dummy_output_info(ExpectationDefinition('throwing', throwing)), 'not used'
         )

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -14,7 +14,7 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
     execute_pipeline_iterator_in_memory,
     ExecutionContext,
-    DagsterExecutionResult,
+    SolidExecutionResult,
 )
 
 # protected members
@@ -234,8 +234,8 @@ def transform_called(name):
 
 
 def assert_equivalent_results(left, right):
-    check.inst_param(left, 'left', DagsterExecutionResult)
-    check.inst_param(right, 'right', DagsterExecutionResult)
+    check.inst_param(left, 'left', SolidExecutionResult)
+    check.inst_param(right, 'right', SolidExecutionResult)
 
     assert left.success == right.success
     assert left.name == right.name
@@ -244,8 +244,8 @@ def assert_equivalent_results(left, right):
 
 
 def assert_all_results_equivalent(expected_results, result_results):
-    check.list_param(expected_results, 'expected_results', of_type=DagsterExecutionResult)
-    check.list_param(result_results, 'result_results', of_type=DagsterExecutionResult)
+    check.list_param(expected_results, 'expected_results', of_type=SolidExecutionResult)
+    check.list_param(result_results, 'result_results', of_type=SolidExecutionResult)
     assert len(expected_results) == len(result_results)
     for expected, result in zip(expected_results, result_results):
         assert_equivalent_results(expected, result)
@@ -288,7 +288,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
     assert results[0].transformed_value == [input_set('A_input'), transform_called('A')]
 
     expected_results = [
-        DagsterExecutionResult(
+        SolidExecutionResult(
             success=True,
             solid=pipeline.solid_named('A'),
             transformed_value=[
@@ -297,7 +297,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
             ],
             exception=None,
         ),
-        DagsterExecutionResult(
+        SolidExecutionResult(
             success=True,
             solid=pipeline.solid_named('B'),
             transformed_value=[
@@ -307,7 +307,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
             ],
             exception=None,
         ),
-        DagsterExecutionResult(
+        SolidExecutionResult(
             success=True,
             solid=pipeline.solid_named('C'),
             transformed_value=[
@@ -318,7 +318,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
             ],
             exception=None,
         ),
-        DagsterExecutionResult(
+        SolidExecutionResult(
             success=True,
             solid=pipeline.solid_named('D'),
             transformed_value=[

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -2,8 +2,6 @@ from enum import Enum
 
 from dagster import check
 
-import dagster.core.definitions
-
 
 class DagsterExecutionFailureReason(Enum):
     USER_CODE_ERROR = 'USER_CODE_ERROR'
@@ -53,11 +51,14 @@ class DagsterUserCodeExecutionError(DagsterUserError):
 class DagsterExpectationFailedError(DagsterError):
     '''Thrown with pipeline configured to throw on expectation failure'''
 
-    def __init__(self, *args, failed_expectation_results, **kwargs):
+    def __init__(self, execution_result, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.failed_results = check.list_param(
-            failed_expectation_results,
-            'failed_expectation_results',
-            # fully qualified name prevents circular reference
-            dagster.core.definitions.ExpectationResult
+        # FIXME: need to reorganize to fix this circular dep
+        # Probable fix is to move all "execution result" objects
+        # to definitions
+        import dagster.core.execution
+        self.execution_result = check.inst_param(
+            execution_result,
+            'execution_result',
+            dagster.core.execution.SolidExecutionResult,
         )

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
@@ -68,7 +68,7 @@ def create_table_output():
     )
 
 
-def _table_name_read_fn(context, arg_dict):
+def _table_name_read_fn(_context, arg_dict):
     check.dict_param(arg_dict, 'arg_dict')
 
     table_name = check.str_elem(arg_dict, 'table_name')

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -9,6 +9,7 @@ if sys.version_info[0] < 3:
 else:
     import builtins
 
+
 def long_description():
     here = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(here, 'README.rst'), 'r') as fh:
@@ -52,7 +53,7 @@ setup(
 
         # sqlalchemy kernel
         'sqlalchemy>=1.2.7',
-        'jinja2>=2.10',
+        'jinja2>=2.8',
 
         # examples
         # unused and very, very heavy


### PR DESCRIPTION
This PR "productionizes" expectations execution. Namely it makes it
configurable. (Currently you can just totally turn this off or no.
Undoubtedly this will have to become more granular and sophisticated)

Also this instigated a substantial refactor of execution.py, which was
quite pleasing.