### PR TITLE
Move from_solids and through_solids to config.Environment

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -3,7 +3,6 @@ from builtins import *  # pylint: disable=W0622,W0401
 
 from dagster.core.execution import (
     execute_pipeline,
-    execute_pipeline_through_solid,
     ExecutionContext,
     ExpectationResult,
     InputExpectationInfo,

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -218,28 +218,20 @@ def load_yaml_from_path(path):
     default=get_default_config_for_pipeline,
     help="Path to environment file. Defaults to ./PIPELINE_DIR/env.yml."
 )
-@click.option('--from-solid', type=click.STRING, help="Solid to start execution from", default=None)
-# @click.option('--log-level', type=click.Choice(LOGGING_DICT.keys()), default='INFO')
-# def execute_command(pipeline_config, env, from_solid, log_level):
-def execute_command(pipeline_config, env, from_solid):
-    do_execute_command(pipeline_config.pipeline, env, from_solid, print)
+def execute_command(pipeline_config, env):
+    do_execute_command(pipeline_config.pipeline, env, print)
 
 
-def do_execute_command(pipeline, env, from_solid, printer):
+def do_execute_command(pipeline, env, printer):
     check.inst_param(pipeline, 'pipeline', dagster.PipelineDefinition)
     check.str_param(env, 'env')
-    check.opt_str_param(from_solid, 'from_solid')
     check.callable_param(printer, 'printer')
 
     env_config = load_yaml_from_path(env)
 
     environment = dagster.config.construct_environment(env_config)
 
-    pipeline_iter = execute_pipeline_iterator(
-        pipeline,
-        environment=environment,
-        from_solids=[from_solid] if from_solid else None,
-    )
+    pipeline_iter = execute_pipeline_iterator(pipeline, environment)
 
     process_results_for_console(pipeline_iter, printer)
 

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -20,17 +20,11 @@ def test_execute_pipeline():
             'sum_solid': {
                 'num': config.Source(name='CSV', args={'path': script_relative_path('num.csv')})
             }
-        }
+        },
+        execution=config.Execution(from_solids=['sum_solid'], through_solids=['sum_sq_solid']),
     )
 
-    result = execute_pipeline(
-        pipeline,
-        environment=environment,
-        from_solids=['sum_solid'],
-        through_solids=[
-            'sum_sq_solid',
-        ]
-    )
+    result = execute_pipeline(pipeline, environment=environment)
 
     assert result.success
 
@@ -58,8 +52,9 @@ def test_cli_execute():
         os.chdir(script_relative_path('../..'))
 
         do_execute_command(
-            define_pipeline(), script_relative_path('../../pandas_hello_world/env.yml'), None,
-            lambda *_args, **_kwargs: None
+            define_pipeline(),
+            script_relative_path('../../pandas_hello_world/env.yml'),
+            lambda *_args, **_kwargs: None,
         )
     finally:
         # restore cwd

--- a/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/env.yml
+++ b/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/env.yml
@@ -1,3 +1,7 @@
+execution:
+  from: sum_solid
+  through: sum_sq_solid
+
 context:
   name: default
   args:


### PR DESCRIPTION
Instead of parameterizing separately, from_solids and through_solids is
part of the config system. The contents of a config are totally tied to
the through and from arguments anyways so they should be a part of the
top level object.