### PR TITLE
Dagster supports multiple outputs now

### DIFF
--- a/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
+++ b/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
@@ -27,7 +27,7 @@ def col_exists(name, col_name):
             'num_df', dagster_pd.DataFrame, expectations=[col_exists('num1_exists', 'num1')]
         )
     ],
-    output=OutputDefinition(dagster_pd.DataFrame)
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
 def sum_solid(num_df):
     return _sum_solid_impl(num_df)
@@ -41,7 +41,7 @@ def sum_solid(num_df):
             expectations=[col_exists('failing', 'not_a_column')],
         )
     ],
-    output=OutputDefinition(dagster_pd.DataFrame)
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
 def sum_solid_fails_input_expectation(num_df):
     return _sum_solid_impl(num_df)
@@ -59,7 +59,7 @@ def sum_solid_fails_input_expectation(num_df):
             ],
         ),
     ],
-    output=OutputDefinition(dagster_pd.DataFrame)
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
 def sum_solid_expectations_config(num_df):
     return _sum_solid_impl(num_df)

--- a/python_modules/dagster/README.rst
+++ b/python_modules/dagster/README.rst
@@ -353,7 +353,7 @@ pandas kernel. (Note: the "kernel" terminology is not settled)
         num_df['sum'] = num_df['num1'] + num_df['num2']
         return num_df
 
-    sum_solid = SolidDefinition(
+    sum_solid = SolidDefinition.single_output_transform(
         name='sum',
         description='This computes the sum of two numbers.'
         inputs=[dagster_pd.dataframe_csv_input(name='num_df')],
@@ -448,7 +448,7 @@ and squared that value. (Fancy!)
         depends_on=sum_solid,
     )
 
-    sum_sq_solid = SolidDefinition(
+    sum_sq_solid = SolidDefinition.single_output_transform(
         name='sum_sq',
         inputs=[sum_sq_input],
         transform_fn=sum_sq_transform,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -14,6 +14,7 @@ from dagster.core.definitions import (
     OutputDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
+    Result,
     SolidDefinition,
     SourceDefinition,
 )

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -123,18 +123,19 @@ def print_solid(printer, solid):
     with printer.with_indent():
         print_inputs(printer, solid)
 
-        printer.line('Output:')
+        printer.line('Outputs:')
 
-        if solid.output.materializations:
-            printer.line('Materializations:')
-            for materialization_def in solid.output.materializations:
-                arg_list = format_argument_dict(materialization_def.argument_def_dict)
-                with printer.with_indent():
-                    printer.line(
-                        '{name}({arg_list})'.format(
-                            name=materialization_def.name, arg_list=arg_list
+        for output in solid.outputs:
+            if output.materializations:
+                printer.line('Materializations:')
+                for materialization_def in output.materializations:
+                    arg_list = format_argument_dict(materialization_def.argument_def_dict)
+                    with printer.with_indent():
+                        printer.line(
+                            '{name}({arg_list})'.format(
+                                name=materialization_def.name, arg_list=arg_list
+                            )
                         )
-                    )
 
 
 def print_inputs(printer, solid):

--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -41,9 +41,15 @@ class Environment(
     namedtuple('EnvironmentData', 'context sources materializations expectations, execution')
 ):
     def __new__(
-        cls, sources, *, context=None, materializations=None, expectations=None, execution=None
+        cls,
+        sources=None,
+        *,
+        context=None,
+        materializations=None,
+        expectations=None,
+        execution=None
     ):
-        check.dict_param(sources, 'sources', key_type=str, value_type=dict)
+        sources = check.opt_dict_param(sources, 'sources', key_type=str, value_type=dict)
         for _solid_name, source_dict in sources.items():
             check.dict_param(source_dict, 'source_dict', key_type=str, value_type=Source)
 

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -21,6 +21,7 @@ from .definitions import (
     MaterializationDefinition,
     OutputDefinition,
     PipelineDefinition,
+    Result,
     SolidDefinition,
     SolidInputHandle,
     SolidOutputHandle,
@@ -42,13 +43,10 @@ from .types import (
 )
 
 
-class ComputeResult(namedtuple('_ComputeResult', 'output_name value')):
-    def __new__(cls, output_name, value):
-        return super(ComputeResult, cls).__new__(
-            cls,
-            check.str_param(output_name, 'output_name'),
-            value,
-        )
+def get_single_solid_output(solid):
+    check.inst_param(solid, 'solid', SolidDefinition)
+    check.invariant(len(solid.outputs) == 1)
+    return solid.outputs[0]
 
 
 class ComputeNodeOutputHandle(namedtuple('_ComputeNodeOutputHandle', 'compute_node output_name')):
@@ -125,6 +123,7 @@ class ComputeNodeResult(
 LOG_LEVEL = 'ERROR'
 logger = define_logger('dagster-compute-nodes', LOG_LEVEL)
 
+
 @contextmanager
 def _user_code_error_boundary(context, msg, **kwargs):
     '''
@@ -163,6 +162,7 @@ JOIN_OUTPUT = 'join_output'
 MATERIALIZATION_INPUT = 'mat_input'
 EXPECTATION_INPUT = 'expectation_input'
 
+
 def _execute_core_transform(context, solid_transform_fn, values_dict):
     '''
     Execute the user-specified transform for the solid. Wrap in an error boundary and do
@@ -175,12 +175,10 @@ def _execute_core_transform(context, solid_transform_fn, values_dict):
     error_str = 'Error occured during core transform'
     with _user_code_error_boundary(context, error_str):
         with time_execution_scope() as timer_result:
-            transformed_value = solid_transform_fn(context, values_dict)
+            for result in solid_transform_fn(context, values_dict):
+                yield result
 
         context.metric('core_transform_time_ms', timer_result.millis)
-
-        return transformed_value
-
 
 
 class ComputeNodeInput:
@@ -220,18 +218,22 @@ class ComputeNode:
         self.tag = check.inst_param(tag, 'tag', ComputeNodeTag)
         self.solid = check.inst_param(solid, 'solid', SolidDefinition)
 
-    def _create_compute_node_result(self, compute_result):
-        check.inst_param(compute_result, 'compute_result', ComputeResult)
+    def node_named(self, name):
+        check.str_param(name, 'name')
+        for node_output in self.node_outputs:
+            if node_output.name == name:
+                return node_output
 
-        value = compute_result.value
+        check.failed('not found')
 
-        check.invariant(len(self.node_outputs) == 1)
-        node_output = self.node_outputs[0]
+    def _create_compute_node_result(self, result):
+        check.inst_param(result, 'result', Result)
 
+        node_output = self.node_named(result.output_name)
 
-        if not node_output.dagster_type.is_python_valid_value(value):
+        if not node_output.dagster_type.is_python_valid_value(result.value):
             raise DagsterInvariantViolationError(
-                f'''Solid {self.solid.name} output {value}
+                f'''Solid {self.solid.name} output {result.value}
                 which does not match the type for Dagster Type
                 {node_output.dagster_type.name}'''
             )
@@ -240,16 +242,14 @@ class ComputeNode:
             compute_node=self,
             tag=self.tag,
             success_data=ComputeNodeSuccessData(
-                output_name=compute_result.output_name,
-                value=compute_result.value,
+                output_name=result.output_name,
+                value=result.value,
             ),
         )
 
     def execute(self, context, inputs):
         check.inst_param(context, 'context', ExecutionContext)
         check.dict_param(inputs, 'inputs', key_type=str)
-
-        check.invariant(len(self.solid.outputs) == 1)
 
         logger.debug(f'Entering execution for {self.friendly_name}')
 
@@ -267,13 +267,13 @@ class ComputeNode:
 
         try:
             with _user_code_error_boundary(context, error_str):
-                compute_results = list(self.compute_fn(context, inputs))
+                results = list(self.compute_fn(context, inputs))
 
                 if not self.node_outputs:
                     return
 
-                for compute_result in compute_results:
-                    yield self._create_compute_node_result(compute_result)
+                for result in results:
+                    yield self._create_compute_node_result(result)
 
         except DagsterUserCodeExecutionError as dagster_user_exception:
             yield ComputeNodeResult.failure_result(
@@ -285,8 +285,6 @@ class ComputeNode:
             )
             return
 
-
-
     def output_named(self, name):
         check.str_param(name, 'name')
 
@@ -295,8 +293,6 @@ class ComputeNode:
                 return node_output
 
         check.failed(f'output {name} not found')
-
-
 
 
 def execute_compute_nodes(context, compute_nodes):
@@ -326,12 +322,13 @@ def execute_compute_nodes(context, compute_nodes):
 def _yieldify(sync_compute_fn):
     def _wrap(context, inputs):
         yield sync_compute_fn(context, inputs)
+
     return _wrap
+
 
 class SingleSyncOutputComputeNode(ComputeNode):
     def __init__(self, *, sync_compute_fn, **kwargs):
         super().__init__(compute_fn=_yieldify(sync_compute_fn), **kwargs)
-
 
 
 def create_compute_node_from_source_config(solid, input_name, source_config):
@@ -360,13 +357,15 @@ def create_compute_node_from_source_config(solid, input_name, source_config):
             ),
         ],
         arg_dict=arg_dict,
-        sync_compute_fn=lambda context, _inputs: ComputeResult(
+        sync_compute_fn=lambda context, _inputs: Result(
             output_name=SOURCE_OUTPUT,
             value=source_def.source_fn(context, arg_dict)
         ),
         tag=ComputeNodeTag.SOURCE,
         solid=solid,
     )
+
+
 def create_source_compute_node_dict_from_environment(pipeline, environment):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(environment, 'environment', config.Environment)
@@ -381,9 +380,11 @@ def create_source_compute_node_dict_from_environment(pipeline, environment):
 
 
 def get_lambda(output_name, value):
-    return lambda _context, _args: ComputeResult(output_name, value)
+    return lambda _context, _args: Result(output_name, value)
+
 
 SOURCE_OUTPUT = 'source_output'
+
 
 def create_source_compute_node_dict_from_input_values(pipeline, input_values):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
@@ -485,26 +486,24 @@ def create_compute_node_graph_from_environment(pipeline, environment):
     )
 
 
-
 def create_expectation_cn(solid, expectation_def, friendly_name, tag, prev_node_output_handle):
     check.inst_param(solid, 'solid', SolidDefinition)
     check.inst_param(expectation_def, 'input_expct_def', ExpectationDefinition)
     check.inst_param(prev_node_output_handle, 'prev_node_output_handle', ComputeNodeOutputHandle)
+
+    output = get_single_solid_output(solid)
 
     return SingleSyncOutputComputeNode(
         friendly_name=friendly_name,
         node_inputs=[
             ComputeNodeInput(
                 name=EXPECTATION_INPUT,
-                dagster_type=solid.output.dagster_type,
+                dagster_type=output.dagster_type,
                 prev_output_handle=prev_node_output_handle,
             )
         ],
         node_outputs=[
-            ComputeNodeOutput(
-                name=EXPECTATION_VALUE_OUTPUT,
-                dagster_type=solid.output.dagster_type
-            ),
+            ComputeNodeOutput(name=EXPECTATION_VALUE_OUTPUT, dagster_type=output.dagster_type),
         ],
         arg_dict={},
         sync_compute_fn=_create_expectation_lambda(
@@ -550,6 +549,7 @@ def create_expectations_cn_graph(solid, inout_def, prev_node_output_handle, tag)
         create_cn_output_handle(join_cn, output_name),
     )
 
+
 def _prev_node_handle(dep_structure, solid, input_def, source_cn_dict, logical_output_mapper):
     check.inst_param(dep_structure, 'dep_structure', DependencyStructure)
     check.inst_param(solid, 'solid', SolidDefinition)
@@ -575,6 +575,7 @@ def _prev_node_handle(dep_structure, solid, input_def, source_cn_dict, logical_o
 
         solid_output_handle = dep_structure.get_dep(input_handle)
         return logical_output_mapper.get_cn_output_handle(solid_output_handle)
+
 
 def create_cn_output_handle(compute_node, cn_output_name):
     check.inst_param(compute_node, 'compute_node', ComputeNode)
@@ -666,15 +667,13 @@ def create_compute_node_graph_from_source_dict(
                 cn_output_handle = prev_cn_output_handle
 
             cn_inputs.append(
-                ComputeNodeInput(
-                    input_def.name, input_def.dagster_type, cn_output_handle
-                )
+                ComputeNodeInput(input_def.name, input_def.dagster_type, cn_output_handle)
             )
 
         solid_transform_cn = create_compute_node_from_solid_transform(topo_solid, cn_inputs)
 
         for output_def in topo_solid.outputs:
-            if evaluate_expectations and topo_solid.output.expectations:
+            if evaluate_expectations and output_def.expectations:
                 expectations_graph = create_expectations_cn_graph(
                     topo_solid,
                     output_def,
@@ -691,7 +690,6 @@ def create_compute_node_graph_from_source_dict(
                     topo_solid.output_handle(output_def.name),
                     create_cn_output_handle(solid_transform_cn, output_def.name),
                 )
-
 
         compute_nodes.append(solid_transform_cn)
 
@@ -755,8 +753,10 @@ def _create_join_node(solid, prev_nodes, prev_output_name):
 
 ExpectationExecutionInfo = namedtuple('ExpectationExecutionInfo', 'solid expectation_def')
 
+
 def _create_join_lambda(_context, inputs):
-    return ComputeResult(output_name=JOIN_OUTPUT, value=list(inputs.values())[0])
+    return Result(output_name=JOIN_OUTPUT, value=list(inputs.values())[0])
+
 
 def _create_expectation_lambda(solid, expectation_def, output_name):
     check.inst_param(solid, 'solid', SolidDefinition)
@@ -770,7 +770,7 @@ def _create_expectation_lambda(solid, expectation_def, output_name):
             inputs[EXPECTATION_INPUT],
         )
         if expt_result.success:
-            return ComputeResult(output_name=output_name, value=inputs[EXPECTATION_INPUT])
+            return Result(output_name=output_name, value=inputs[EXPECTATION_INPUT])
 
         raise DagsterExpectationFailedError(None)  # for now
 
@@ -783,7 +783,8 @@ def _construct_materialization_cn(pipeline, materialization, prev_output_handle)
     check.inst_param(prev_output_handle, 'prev_output_handle', ComputeNodeOutputHandle)
 
     solid = pipeline.solid_named(materialization.solid)
-    mat_def = solid.output.materialization_of_type(materialization.name)
+    output = get_single_solid_output(solid)
+    mat_def = output.materialization_of_type(materialization.name)
 
     error_context_str = 'source type {mat}'.format(mat=mat_def.name)
 
@@ -798,7 +799,7 @@ def _construct_materialization_cn(pipeline, materialization, prev_output_handle)
         node_inputs=[
             ComputeNodeInput(
                 name=MATERIALIZATION_INPUT,
-                dagster_type=solid.output.dagster_type,
+                dagster_type=output.dagster_type,
                 prev_output_handle=prev_output_handle,
             )
         ],
@@ -815,7 +816,7 @@ def _create_materialization_lambda(mat_def, materialization, output_name):
     check.inst_param(materialization, 'materialization', config.Materialization)
     check.str_param(output_name, 'output_name')
 
-    return lambda context, inputs: ComputeResult(
+    return lambda context, inputs: Result(
         output_name=output_name,
         value=mat_def.materialization_fn(
             context,
@@ -824,14 +825,12 @@ def _create_materialization_lambda(mat_def, materialization, output_name):
         ),
     )
 
+
 def create_compute_node_from_solid_transform(solid, node_inputs):
     check.inst_param(solid, 'solid', SolidDefinition)
     check.list_param(node_inputs, 'node_inputs', of_type=ComputeNodeInput)
-    check.invariant(len(solid.outputs) == 1)
 
-    output_name = solid.outputs[0].name
-
-    return SingleSyncOutputComputeNode(
+    return ComputeNode(
         friendly_name=f'{solid.name}.transform',
         node_inputs=node_inputs,
         node_outputs=[
@@ -839,13 +838,10 @@ def create_compute_node_from_solid_transform(solid, node_inputs):
             for output in solid.outputs
         ],
         arg_dict={},
-        sync_compute_fn=lambda context, inputs: ComputeResult(
-            output_name=output_name,
-            value=_execute_core_transform(
-                context,
-                solid.transform_fn,
-                inputs,
-            ),
+        compute_fn=lambda context, inputs: _execute_core_transform(
+            context,
+            solid.transform_fn,
+            inputs,
         ),
         tag=ComputeNodeTag.TRANSFORM,
         solid=solid,

--- a/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execute_solid.py
@@ -13,7 +13,7 @@ from dagster.core.definitions import (
 
 from dagster.core.execution import (
     output_single_solid,
-    ExecutionResultBase,
+    ExecutionStepResult,
     DagsterExecutionFailureReason,
     ExecutionContext,
     execute_single_solid,
@@ -61,7 +61,7 @@ def test_execute_solid_no_args():
         argument_def_dict={},
     )
 
-    single_solid = SolidDefinition(
+    single_solid = SolidDefinition.single_output_transform(
         name='some_node',
         inputs=[some_input],
         transform_fn=tranform_fn_inst,
@@ -118,7 +118,7 @@ def test_hello_world():
         assert arg_dict == {}
         output_events['called'] = True
 
-    hello_world = SolidDefinition(
+    hello_world = SolidDefinition.single_output_transform(
         name='hello_world',
         inputs=[
             create_custom_source_input(
@@ -161,7 +161,7 @@ def test_hello_world():
 def test_execute_solid_with_args():
     test_output = {}
 
-    single_solid = SolidDefinition(
+    single_solid = SolidDefinition.single_output_transform(
         name='some_node',
         inputs=[create_single_dict_input()],
         transform_fn=lambda context, args: args['some_input'],
@@ -193,7 +193,7 @@ def test_execute_solid_with_failed_input_expectation_non_throwing():
         throw_on_error=False,
     )
 
-    assert isinstance(solid_execution_result, ExecutionResultBase)
+    assert isinstance(solid_execution_result, ExecutionStepResult)
     assert solid_execution_result.success is False
     # assert solid_execution_result.reason == DagsterExecutionFailureReason.EXPECTATION_FAILURE
 
@@ -228,7 +228,7 @@ def create_input_failing_solid():
 
     failing_expect = ExpectationDefinition(name='failing', expectation_fn=failing_expectation_fn)
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name='some_node',
         inputs=[create_single_dict_input(expectations=[failing_expect])],
         transform_fn=lambda context, args: args['some_input'],
@@ -248,7 +248,7 @@ def test_execute_solid_with_failed_output_expectation_non_throwing():
         throw_on_error=False
     )
 
-    assert isinstance(solid_execution_result, ExecutionResultBase)
+    assert isinstance(solid_execution_result, ExecutionStepResult)
     assert solid_execution_result.success is False
     # assert solid_execution_result.reason == DagsterExecutionFailureReason.EXPECTATION_FAILURE
 
@@ -281,7 +281,7 @@ def _set_key_value(ddict, key, value):
 
 def test_execute_solid_with_no_inputs():
     did_run_dict = {}
-    no_args_solid = SolidDefinition(
+    no_args_solid = SolidDefinition.single_output_transform(
         name='no_args_solid',
         inputs=[],
         transform_fn=lambda context, args: _set_key_value(did_run_dict, 'did_run', True),
@@ -306,7 +306,7 @@ def create_output_failing_solid():
         name='output_failure', expectation_fn=failing_expectation_fn
     )
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name='some_node',
         inputs=[create_single_dict_input()],
         transform_fn=lambda context, args: args['some_input'],

--- a/python_modules/dagster/dagster/core/core_tests/test_iterator_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_iterator_execution.py
@@ -36,7 +36,7 @@ def test_iterator_solid():
         argument_def_dict={},
     )
 
-    iterable_solid = SolidDefinition(
+    iterable_solid = SolidDefinition.single_output_transform(
         name='some_node',
         inputs=[some_input],
         transform_fn=transform_fn,

--- a/python_modules/dagster/dagster/core/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_multiple_outputs.py
@@ -1,0 +1,36 @@
+from dagster import (
+    OutputDefinition,
+    PipelineDefinition,
+    Result,
+    SolidDefinition,
+    config,
+    execute_pipeline,
+)
+
+
+def test_multiple_outputs():
+    def _t_fn(_context, _inputs):
+        yield Result('output_one', 'foo')
+        yield Result('output_two', 'bar')
+
+    solid = SolidDefinition(
+        name='multiple_outputs',
+        inputs=[],
+        outputs=[
+            OutputDefinition(name='output_one'),
+            OutputDefinition(name='output_two'),
+        ],
+        transform_fn=_t_fn,
+    )
+
+    pipeline = PipelineDefinition(solids=[solid])
+
+    result = execute_pipeline(pipeline, config.Environment(sources={}))
+
+    assert result.result_list[0].name == 'multiple_outputs'
+    assert result.result_list[0].output_name == 'output_one'
+    assert result.result_list[0].transformed_value == 'foo'
+
+    assert result.result_list[1].name == 'multiple_outputs'
+    assert result.result_list[1].output_name == 'output_two'
+    assert result.result_list[1].transformed_value == 'bar'

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -15,7 +15,7 @@ from dagster.core import types
 
 
 def test_execute_solid_with_input_same_name():
-    solid = SolidDefinition(
+    solid = SolidDefinition.single_output_transform(
         'a_thing',
         inputs=[
             InputDefinition(
@@ -61,14 +61,14 @@ def test_execute_two_solids_with_same_input_name():
         ],
     )
 
-    solid_one = SolidDefinition(
+    solid_one = SolidDefinition.single_output_transform(
         'solid_one',
         inputs=[input_def],
         transform_fn=lambda context, args: args['a_thing'] + args['a_thing'],
         output=dagster.OutputDefinition(),
     )
 
-    solid_two = SolidDefinition(
+    solid_two = SolidDefinition.single_output_transform(
         'solid_two',
         inputs=[input_def],
         transform_fn=lambda context, args: args['a_thing'] + args['a_thing'],
@@ -98,7 +98,7 @@ def test_execute_two_solids_with_same_input_name():
 
 
 def test_execute_dep_solid_different_input_name():
-    first_solid = SolidDefinition(
+    first_solid = SolidDefinition.single_output_transform(
         'first_solid',
         inputs=[
             InputDefinition(
@@ -116,7 +116,7 @@ def test_execute_dep_solid_different_input_name():
         output=dagster.OutputDefinition(),
     )
 
-    second_solid = SolidDefinition(
+    second_solid = SolidDefinition.single_output_transform(
         'second_solid',
         inputs=[
             InputDefinition(
@@ -166,7 +166,7 @@ def test_execute_dep_solid_same_input_name():
         's2_t2_source': False,
     }
 
-    table_one = SolidDefinition(
+    table_one = SolidDefinition.single_output_transform(
         'table_one',
         inputs=[
             InputDefinition(
@@ -185,7 +185,7 @@ def test_execute_dep_solid_same_input_name():
         output=dagster.OutputDefinition(),
     )
 
-    table_two = SolidDefinition(
+    table_two = SolidDefinition.single_output_transform(
         'table_two',
         inputs=[
             InputDefinition(

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -64,7 +64,7 @@ def create_root_success_solid(name):
         passed_rows.append({name: 'transform_called'})
         return passed_rows
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=[create_input_set_input_def(input_name)],
         transform_fn=root_transform,
@@ -83,7 +83,7 @@ def create_root_transform_failure_solid(name):
     def failed_transform(**_kwargs):
         raise Exception('Transform failed')
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=[inp],
         transform_fn=failed_transform,
@@ -102,7 +102,7 @@ def create_root_input_failure_solid(name):
         argument_def_dict={},
     )
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=[inp],
         transform_fn=lambda **_kwargs: {},
@@ -118,7 +118,7 @@ def create_root_output_failure_solid(name):
         passed_rows.append({name: 'transform_called'})
         return passed_rows
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=[create_input_set_input_def(input_name)],
         transform_fn=root_transform,
@@ -194,7 +194,7 @@ def test_failure_midstream():
         check.failed('user error')
         return [args['A'], args['B'], {'C': 'transform_called'}]
 
-    solid_c = SolidDefinition(
+    solid_c = SolidDefinition.single_output_transform(
         name='C',
         inputs=[InputDefinition(name='A'), InputDefinition(name='B')],
         transform_fn=transform_fn,

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -16,7 +16,7 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
     execute_pipeline_iterator_in_memory,
     ExecutionContext,
-    ExecutionResultBase,
+    ExecutionStepResult,
 )
 
 from dagster.utils.compatability import create_custom_source_input
@@ -56,7 +56,7 @@ def create_solid_with_deps(name, *solid_deps):
         #return copy.deepcopy(passed_rows)
         return passed_rows
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=inputs,
         transform_fn=dep_transform,
@@ -78,7 +78,7 @@ def create_root_solid(name):
         #return copy.deepcopy(passed_rows)
         return passed_rows
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=[inp],
         transform_fn=root_transform,
@@ -285,8 +285,8 @@ def transform_called(name):
 
 
 def assert_equivalent_results(left, right):
-    check.inst_param(left, 'left', ExecutionResultBase)
-    check.inst_param(right, 'right', ExecutionResultBase)
+    check.inst_param(left, 'left', ExecutionStepResult)
+    check.inst_param(right, 'right', ExecutionStepResult)
 
     assert left.success == right.success
     assert left.name == right.name
@@ -295,8 +295,8 @@ def assert_equivalent_results(left, right):
 
 
 def assert_all_results_equivalent(expected_results, result_results):
-    check.list_param(expected_results, 'expected_results', of_type=ExecutionResultBase)
-    check.list_param(result_results, 'result_results', of_type=ExecutionResultBase)
+    check.list_param(expected_results, 'expected_results', of_type=ExecutionStepResult)
+    check.list_param(result_results, 'result_results', of_type=ExecutionStepResult)
     assert len(expected_results) == len(result_results)
     for expected, result in zip(expected_results, result_results):
         assert_equivalent_results(expected, result)

--- a/python_modules/dagster/dagster/core/core_tests/test_transform_only_pipeline.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_transform_only_pipeline.py
@@ -19,7 +19,7 @@ def _set_key_value(ddict, key, value):
 def test_execute_solid_with_dep_only_inputs_no_api():
     did_run_dict = {}
 
-    step_one_solid = SolidDefinition(
+    step_one_solid = SolidDefinition.single_output_transform(
         name='step_one_solid',
         inputs=[],
         transform_fn=lambda context, args: _set_key_value(did_run_dict, 'step_one', True),
@@ -32,7 +32,7 @@ def test_execute_solid_with_dep_only_inputs_no_api():
         argument_def_dict={},
     )
 
-    step_two_solid = SolidDefinition(
+    step_two_solid = SolidDefinition.single_output_transform(
         name='step_two_solid',
         inputs=[only_dep_input],
         transform_fn=lambda context, args: _set_key_value(did_run_dict, 'step_two', True),
@@ -64,14 +64,14 @@ def test_execute_solid_with_dep_only_inputs_no_api():
 def test_execute_solid_with_dep_only_inputs_with_api():
     did_run_dict = {}
 
-    step_one_solid = SolidDefinition(
+    step_one_solid = SolidDefinition.single_output_transform(
         name='step_one_solid',
         inputs=[],
         transform_fn=lambda context, args: _set_key_value(did_run_dict, 'step_one', True),
         output=OutputDefinition(),
     )
 
-    step_two_solid = SolidDefinition(
+    step_two_solid = SolidDefinition.single_output_transform(
         name='step_two_solid',
         transform_fn=lambda context, args: _set_key_value(did_run_dict, 'step_two', True),
         inputs=[InputDefinition(step_one_solid.name)],

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -50,7 +50,7 @@ class _Solid:
 
         _validate_transform_fn(self.name, fn, self.inputs, expect_context)
         transform_fn = _create_transform_wrapper(fn, self.inputs, expect_context)
-        return SolidDefinition(
+        return SolidDefinition.single_output_transform(
             name=self.name,
             inputs=self.inputs,
             output=self.output,

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -334,14 +334,14 @@ class OutputDefinition:
     # runtime type info
     def __init__(
         self,
-        # name=None,
+        name=None,
         dagster_type=None,
         materializations=None,
         expectations=None,
         output_callback=None,
         description=None
     ):
-        self.name = DEFAULT_OUTPUT
+        self.name = check.opt_str_param(name, 'name', DEFAULT_OUTPUT)
 
         self.dagster_type = check.opt_inst_param(
             dagster_type, 'dagster_type', types.DagsterType, types.Any
@@ -404,11 +404,20 @@ class SolidOutputHandle(namedtuple('_SolidOutputHandle', 'solid output')):
         return self.solid.name == other.solid.name and self.output.name == other.output.name
 
 
+class Result(namedtuple('_Result', 'output_name value')):
+    def __new__(cls, output_name, value):
+        return super(Result, cls).__new__(
+            cls,
+            check.str_param(output_name, 'output_name'),
+            value,
+        )
+
+
 # One or more inputs
 # The core computation in the native kernel abstraction
 # The output
 class SolidDefinition:
-    def __init__(self, name, inputs, transform_fn, output, description=None):
+    def __init__(self, name, inputs, transform_fn, outputs, description=None):
         # if output:
         #     check.invariant(outputs is None)
         #     self.outputs = [output]
@@ -419,10 +428,8 @@ class SolidDefinition:
         self.name = check_valid_name(name)
         self.inputs = check.list_param(inputs, 'inputs', InputDefinition)
         self.transform_fn = check.callable_param(transform_fn, 'transform')
-        self.output = check.inst_param(output, 'output', OutputDefinition)
+        self.outputs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
-
-        self.outputs = [output]
 
         input_handles = {}
         for inp in self.inputs:
@@ -430,7 +437,19 @@ class SolidDefinition:
 
         self.input_handles = input_handles
 
-        self.output_handles = {output.name: SolidOutputHandle(self, output)}
+        output_handles = {}
+        for output in outputs:
+            output_handles[output.name] = SolidOutputHandle(self, output)
+
+        self.output_handles = output_handles
+
+    @staticmethod
+    def single_output_transform(name, inputs, transform_fn, output, description=None):
+        def _new_transform_fn(context, inputs):
+            value = transform_fn(context, inputs)
+            yield Result(DEFAULT_OUTPUT, value)
+
+        return SolidDefinition(name, inputs, _new_transform_fn, [output], description)
 
     # Notes to self
 

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -60,5 +60,5 @@ class DagsterExpectationFailedError(DagsterError):
         self.execution_result = check.opt_inst_param(
             execution_result,
             'execution_result',
-            dagster.core.execution.ExecutionResultBase,
+            dagster.core.execution.ExecutionStepResult,
         )

--- a/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/pipeline.py
@@ -11,7 +11,7 @@ import dagster.pandas_kernel as dagster_pd
 
 @solid(
     inputs=[InputDefinition('num', dagster_pd.DataFrame)],
-    output=OutputDefinition(dagster_pd.DataFrame)
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
 def sum_solid(num):
     sum_df = num.copy()
@@ -21,7 +21,7 @@ def sum_solid(num):
 
 @solid(
     inputs=[InputDefinition('sum_df', dagster_pd.DataFrame)],
-    output=OutputDefinition(dagster_pd.DataFrame)
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
 def sum_sq_solid(sum_df):
     sum_sq_df = sum_df.copy()
@@ -31,7 +31,7 @@ def sum_sq_solid(sum_df):
 
 @solid(
     inputs=[InputDefinition('sum_sq_solid', dagster_pd.DataFrame)],
-    output=OutputDefinition(dagster_pd.DataFrame)
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
 def always_fails_solid(**_kwargs):
     raise Exception('I am a programmer and I make error')

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
@@ -66,11 +66,11 @@ def create_definition_based_solid():
         return num_csv
 
     # supports CSV and PARQUET by default
-    hello_world = dagster.SolidDefinition(
+    hello_world = dagster.SolidDefinition.single_output_transform(
         name='hello_world',
         inputs=[table_input],
         transform_fn=transform_fn,
-        output=dagster.OutputDefinition(dagster_pd.DataFrame)
+        output=dagster.OutputDefinition(dagster_type=dagster_pd.DataFrame)
     )
     return hello_world
 
@@ -78,7 +78,7 @@ def create_definition_based_solid():
 def create_decorator_based_solid():
     @solid(
         inputs=[dagster.InputDefinition('num_csv', dagster_pd.DataFrame)],
-        output=dagster.OutputDefinition(dagster_pd.DataFrame),
+        output=dagster.OutputDefinition(dagster_type=dagster_pd.DataFrame),
     )
     def hello_world(num_csv):
         num_csv['sum'] = num_csv['num1'] + num_csv['num2']

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
@@ -43,7 +43,7 @@ def create_hello_world_solid_no_api():
         argument_def_dict={'path': ArgumentDefinition(types.Path)}
     )
 
-    hello_world = SolidDefinition(
+    hello_world = SolidDefinition.single_output_transform(
         name='hello_world',
         inputs=[csv_input],
         transform_fn=hello_world_transform_fn,
@@ -110,7 +110,7 @@ def create_hello_world_solid_composed_api():
         num_df['sum'] = num_df['num1'] + num_df['num2']
         return num_df
 
-    hello_world = SolidDefinition(
+    hello_world = SolidDefinition.single_output_transform(
         name='hello_world',
         inputs=[create_dataframe_input(name='num_df')],
         transform_fn=transform_fn,
@@ -149,7 +149,7 @@ def test_pipeline():
         num_df['sum'] = num_df['num1'] + num_df['num2']
         return num_df
 
-    solid_one = SolidDefinition(
+    solid_one = SolidDefinition.single_output_transform(
         name='solid_one',
         inputs=[create_dataframe_input(name='num_df')],
         transform_fn=solid_one_transform,
@@ -161,7 +161,7 @@ def test_pipeline():
         sum_df['sum_sq'] = sum_df['sum'] * sum_df['sum']
         return sum_df
 
-    solid_two = SolidDefinition(
+    solid_two = SolidDefinition.single_output_transform(
         name='solid_two',
         inputs=[create_dataframe_input(name='sum_df')],
         transform_fn=solid_two_transform,

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
@@ -30,11 +30,11 @@ from dagster.utils.test import (get_temp_file_name, get_temp_file_names, script_
 
 
 def _dataframe_solid(name, inputs, transform_fn):
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=inputs,
         transform_fn=transform_fn,
-        output=OutputDefinition(dagster_pd.DataFrame),
+        output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
     )
 
 
@@ -86,7 +86,7 @@ def test_pandas_solid():
         argument_def_dict={},
     )
 
-    single_solid = SolidDefinition(
+    single_solid = SolidDefinition.single_output_transform(
         name='sum_table',
         inputs=[csv_input],
         transform_fn=transform,
@@ -125,7 +125,7 @@ def test_pandas_csv_to_csv():
         argument_def_dict={'path': ArgumentDefinition(types.Path)}
     )
 
-    solid_def = SolidDefinition(
+    solid_def = SolidDefinition.single_output_transform(
         name='sum_table',
         inputs=[csv_input],
         transform_fn=transform,
@@ -169,7 +169,7 @@ def create_sum_table():
 
 @solid(
     inputs=[InputDefinition('num_csv', dagster_pd.DataFrame)],
-    output=OutputDefinition(dagster_pd.DataFrame),
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
 def sum_table(num_csv):
     check.inst_param(num_csv, 'num_csv', pd.DataFrame)
@@ -179,7 +179,7 @@ def sum_table(num_csv):
 
 @solid(
     inputs=[InputDefinition('sum_df', dagster_pd.DataFrame)],
-    output=OutputDefinition(dagster_pd.DataFrame),
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
 def sum_sq_table(sum_df):
     sum_df['sum_squared'] = sum_df['sum'] * sum_df['sum']
@@ -190,7 +190,7 @@ def sum_sq_table(sum_df):
     inputs=[
         InputDefinition('sum_table_renamed', dagster_pd.DataFrame)
     ],
-    output=OutputDefinition(dagster_pd.DataFrame),
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
 def sum_sq_table_renamed_input(sum_table_renamed):
     sum_table_renamed['sum_squared'] = sum_table_renamed['sum'] * sum_table_renamed['sum']

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_user_error.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_user_error.py
@@ -12,11 +12,11 @@ from dagster.utils.test import script_relative_path
 
 
 def _dataframe_solid(name, inputs, transform_fn):
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=inputs,
         transform_fn=transform_fn,
-        output=OutputDefinition(dagster_pd.DataFrame),
+        output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
     )
 
 
@@ -24,7 +24,9 @@ def test_wrong_output_value():
     csv_input = InputDefinition('num_csv', dagster_pd.DataFrame)
 
     @solid(
-        name="test_wrong_output", inputs=[csv_input], output=OutputDefinition(dagster_pd.DataFrame)
+        name="test_wrong_output",
+        inputs=[csv_input],
+        output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
     )
     def df_solid(num_csv):
         return 'not a dataframe'

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
@@ -64,7 +64,7 @@ def test_single_templated_sql_solid_single_table_raw_api():
         ]
     )
 
-    sum_table_transform_solid = SolidDefinition(
+    sum_table_transform_solid = SolidDefinition.single_output_transform(
         name='sum_table_transform',
         inputs=[sum_table_input],
         transform_fn=_create_templated_sql_transform_with_output(sql, 'sum_table'),
@@ -155,7 +155,7 @@ def test_single_templated_sql_solid_double_table_raw_api():
         ]
     )
 
-    sum_solid = SolidDefinition(
+    sum_solid = SolidDefinition.single_output_transform(
         name='sum_solid',
         inputs=[sum_table_input, num_table_input],
         transform_fn=_create_templated_sql_transform_with_output(

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
@@ -106,7 +106,7 @@ def create_sql_solid(name, inputs, sql_text):
     check.list_param(inputs, 'inputs', of_type=InputDefinition)
     check.str_param(sql_text, 'sql_text')
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name,
         inputs=inputs,
         transform_fn=create_sql_transform(sql_text),
@@ -131,7 +131,7 @@ def create_sql_statement_solid(name, sql_text, inputs=None):
     if inputs is None:
         inputs = []
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         transform_fn=_create_sql_alchemy_transform_fn(sql_text),
         inputs=inputs,

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/templated.py
@@ -109,7 +109,7 @@ def create_templated_sql_transform_solid(
     dep_inputs = [_create_table_input(dep.name) for dep in table_deps]
     table_inputs = [_create_table_input(table) for table in table_arguments]
 
-    return SolidDefinition(
+    return SolidDefinition.single_output_transform(
         name=name,
         inputs=table_inputs + dep_inputs + extra_inputs,
         transform_fn=_create_templated_sql_transform_with_output(sql, output),


### PR DESCRIPTION
Now the contract for the transform is that you yield a sequence of
Result objects. Added single_output_transform helper for SolidDefinition
to handle all legacy callers.