### PR TITLE
Changes to support clarify

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/Solid.tsx
+++ b/python_modules/dagit/dagit/webapp/src/Solid.tsx
@@ -112,7 +112,7 @@ export default class Solid extends React.Component<ISolidProps, {}> {
     return this.props.solid.outputs.map((output, i: number) => (
       <SolidPartCard key={i} elevation={3} horizontal={true}>
         <H6>
-          Input <Code>{output.name}</Code>
+          Output <Code>{output.name}</Code>
         </H6>
         <TypeWrapper>
           <TypeWithTooltip type={output.type} />

--- a/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
+++ b/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
@@ -71,13 +71,13 @@ def sum_solid_expectations_config(num_df):
     return _sum_solid_impl(num_df)
 
 
-from dagster.core.utility_solids import define_pass_mem_value
+from dagster.core.utility_solids import define_stub_solid
 
 
 def test_single_node_passing_expectation():
     in_df = pd.DataFrame.from_dict({'num1': [1, 3], 'num2': [2, 4]})
     pipeline = dagster.PipelineDefinition(
-        solids=[define_pass_mem_value('value', in_df), sum_solid],
+        solids=[define_stub_solid('value', in_df), sum_solid],
         dependencies={'sum_solid': {
             'num_df': DependencyDefinition('value')
         }}
@@ -97,7 +97,7 @@ def test_single_node_passing_expectation():
 def test_single_node_passing_json_config_expectations():
     in_df = pd.DataFrame.from_dict({'num1': [1, 3], 'num2': [2, 4]})
     pipeline = dagster.PipelineDefinition(
-        solids=[define_pass_mem_value('value', in_df), sum_solid_expectations_config],
+        solids=[define_stub_solid('value', in_df), sum_solid_expectations_config],
         dependencies={
             sum_solid_expectations_config.name: {
                 'num_df': DependencyDefinition('value')
@@ -119,7 +119,7 @@ def test_single_node_passing_json_config_expectations():
 def test_single_node_failing_expectation():
     in_df = pd.DataFrame.from_dict({'num1': [1, 3], 'num2': [2, 4]})
     pipeline = dagster.PipelineDefinition(
-        solids=[define_pass_mem_value('value', in_df), sum_solid_fails_input_expectation],
+        solids=[define_stub_solid('value', in_df), sum_solid_fails_input_expectation],
         dependencies={
             sum_solid_fails_input_expectation.name: {
                 'num_df': DependencyDefinition('value')

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -289,7 +289,6 @@ class ComputeNode:
 
         check.failed(f'output {name} not found')
 
-
 def execute_compute_nodes(context, compute_nodes):
     check.inst_param(context, 'context', ExecutionContext)
     check.list_param(compute_nodes, 'compute_nodes', of_type=ComputeNode)
@@ -300,9 +299,13 @@ def execute_compute_nodes(context, compute_nodes):
         for node_input in compute_node.node_inputs:
             prev_output_handle = node_input.prev_output_handle
             if prev_output_handle not in intermediate_results:
+
+                target_cn = prev_output_handle.compute_node
+
                 check.failed(
                     f'Could not find handle {prev_output_handle} in results. ' + \
-                    f'current node: {compute_node.friendly_name}'
+                    f'current node: {compute_node.friendly_name}\n' + \
+                    f'target node: {target_cn.friendly_name}'
                 )
             input_value = intermediate_results[prev_output_handle].success_data.value
             input_values[node_input.name] = input_value
@@ -353,24 +356,25 @@ class ComputeNodeGraph:
             yield self.cn_dict[cn_guid]
 
 
-def create_expectation_cn(solid, expectation_def, friendly_name, tag, prev_node_output_handle):
+def create_expectation_cn(solid, expectation_def, friendly_name, tag, prev_node_output_handle, inout_def):
     check.inst_param(solid, 'solid', SolidDefinition)
     check.inst_param(expectation_def, 'input_expct_def', ExpectationDefinition)
     check.inst_param(prev_node_output_handle, 'prev_node_output_handle', ComputeNodeOutputHandle)
+    check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition))
 
-    output = get_single_solid_output(solid)
+    value_type = inout_def.dagster_type
 
     return SingleSyncOutputComputeNode(
         friendly_name=friendly_name,
         node_inputs=[
             ComputeNodeInput(
                 name=EXPECTATION_INPUT,
-                dagster_type=output.dagster_type,
+                dagster_type=value_type,
                 prev_output_handle=prev_node_output_handle,
             )
         ],
         node_outputs=[
-            ComputeNodeOutput(name=EXPECTATION_VALUE_OUTPUT, dagster_type=output.dagster_type),
+            ComputeNodeOutput(name=EXPECTATION_VALUE_OUTPUT, dagster_type=value_type),
         ],
         arg_dict={},
         sync_compute_fn=_create_expectation_lambda(
@@ -404,6 +408,7 @@ def create_expectations_cn_graph(solid, inout_def, prev_node_output_handle, tag)
             friendly_name=f'{solid.name}.{inout_def.name}.expectation.{expectation_def.name}',
             tag=tag,
             prev_node_output_handle=prev_node_output_handle,
+            inout_def=inout_def,
         )
         input_expect_nodes.append(expect_compute_node)
         compute_nodes.append(expect_compute_node)

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -17,7 +17,7 @@ from dagster.core.execution import (
     execute_single_solid,
     ExecutionContext,
 )
-from dagster.core.utility_solids import define_pass_mem_value
+from dagster.core.utility_solids import define_stub_solid
 
 # This file tests a lot of parameter name stuff
 # So these warnings are spurious
@@ -88,7 +88,7 @@ def test_solid_with_input():
         return foo_to_foo
 
     pipeline = PipelineDefinition(
-        solids=[define_pass_mem_value('test_value', {'foo': 'bar'}), hello_world],
+        solids=[define_stub_solid('test_value', {'foo': 'bar'}), hello_world],
         dependencies={'hello_world': {
             'foo_to_foo': DependencyDefinition('test_value'),
         }}

--- a/python_modules/dagster/dagster/core/core_tests/test_definitions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definitions.py
@@ -1,0 +1,9 @@
+from dagster import (DependencyDefinition)
+
+
+def test_deps_equal():
+    assert DependencyDefinition('foo') == DependencyDefinition('foo')
+    assert DependencyDefinition('foo') != DependencyDefinition('bar')
+
+    assert DependencyDefinition('foo', 'bar') == DependencyDefinition('foo', 'bar')
+    assert DependencyDefinition('foo', 'bar') != DependencyDefinition('foo', 'quuz')

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -8,12 +8,28 @@ from dagster import (
     PipelineDefinition,
     Result,
     SolidDefinition,
+    check,
     config,
     execute_pipeline,
     types,
 )
 
-from dagster.core.utility_solids import define_pass_value_solid
+
+def define_pass_value_solid(name, description=None):
+    check.str_param(name, 'name')
+    check.opt_str_param(description, 'description')
+
+    def _value_t_fn(_context, _inputs, config_dict):
+        yield Result(config_dict['value'])
+
+    return SolidDefinition(
+        name=name,
+        description=description,
+        inputs=[],
+        outputs=[OutputDefinition(dagster_type=types.String)],
+        config_def={'value': ArgumentDefinition(types.String)},
+        transform_fn=_value_t_fn,
+    )
 
 
 def test_execute_solid_with_input_same_name():

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -156,11 +156,11 @@ def test_disconnected_graphs_adjaceny_lists():
     assert backwards_edges == {'B': {'A'}, 'A': set(), 'D': {'C'}, 'C': set()}
 
 
-from dagster.core.utility_solids import define_pass_mem_value
+from dagster.core.utility_solids import define_stub_solid
 
 
 def create_diamond_solids():
-    a_source = define_pass_mem_value('A_source', [input_set('A_input')])
+    a_source = define_stub_solid('A_source', [input_set('A_input')])
     node_a = create_root_solid('A')
     node_b = create_solid_with_deps('B', node_a)
     node_c = create_solid_with_deps('C', node_a)

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -45,10 +45,10 @@ def check_valid_name(name):
     return name
 
 
-def check_argument_def_dict(argument_def_dict):
+def check_argument_def_dict(config_def_dict):
     return check.dict_param(
-        argument_def_dict,
-        'argument_def_dict',
+        config_def_dict,
+        'config_def_dict',
         key_type=str,
         value_type=ArgumentDefinition,
     )
@@ -80,11 +80,14 @@ def _default_pipeline_context_definitions():
     return {'default': default_context_def}
 
 
-class DependencyDefinition:
-    def __init__(self, solid, output=DEFAULT_OUTPUT, description=None):
-        self.solid = check.str_param(solid, 'solid')
-        self.output = check.str_param(output, 'output')
-        self.description = check.opt_str_param(description, 'description')
+class DependencyDefinition(namedtuple('_DependencyDefinition', 'solid output description')):
+    def __new__(cls, solid, output=DEFAULT_OUTPUT, description=None):
+        return super(DependencyDefinition, cls).__new__(
+            cls,
+            check.str_param(solid, 'solid'),
+            check.str_param(output, 'output'),
+            check.opt_str_param(description, 'description'),
+        )
 
 
 class InputToOutputHandleDict(dict):
@@ -100,6 +103,13 @@ class InputToOutputHandleDict(dict):
 
 def check_two_dim_str_dict(ddict, param_name, value_type):
     check.dict_param(ddict, param_name, key_type=str, value_type=dict)
+    for sub_dict in ddict.values():
+        check.dict_param(sub_dict, 'sub_dict', key_type=str, value_type=value_type)
+    return ddict
+
+
+def check_opt_two_dim_str_dict(ddict, param_name, value_type):
+    ddict = check.opt_dict_param(ddict, param_name, key_type=str, value_type=dict)
     for sub_dict in ddict.values():
         check.dict_param(sub_dict, 'sub_dict', key_type=str, value_type=value_type)
     return ddict
@@ -177,12 +187,23 @@ def _build_named_dict(things):
 
 class PipelineDefinition:
     @staticmethod
-    def create_pipeline_slice(pipeline, from_solids, through_solids, injected_solids):
+    def create_single_solid_pipeline(pipeline, solid_name, injected_solids=None):
+        return PipelineDefinition.create_sub_pipeline(
+            pipeline,
+            [solid_name],
+            [solid_name],
+            injected_solids,
+        )
+
+    @staticmethod
+    def create_sub_pipeline(pipeline, from_solids, through_solids, injected_solids=None):
         from .graph import ExecutionGraph
         check.inst_param(pipeline, 'pipeline', PipelineDefinition)
         check.list_param(from_solids, 'from_solids', of_type=str)
         check.list_param(through_solids, 'through_solids', of_type=str)
-        check_two_dim_str_dict(injected_solids, 'injected_solids', SolidDefinition)
+        injected_solids = check_opt_two_dim_str_dict(
+            injected_solids, 'injected_solids', SolidDefinition
+        )
 
         subgraph = ExecutionGraph.from_pipeline_subset(
             pipeline,
@@ -435,7 +456,9 @@ class SolidDefinition:
         self._output_dict = _build_named_dict(outputs)
 
     @staticmethod
-    def single_output_transform(name, inputs, transform_fn, output, description=None):
+    def single_output_transform(
+        name, inputs, transform_fn, output, config_def=None, description=None
+    ):
         def _new_transform_fn(context, inputs, _config_dict):
             value = transform_fn(context, inputs)
             yield Result(output_name=DEFAULT_OUTPUT, value=value)
@@ -445,7 +468,7 @@ class SolidDefinition:
             inputs=inputs,
             transform_fn=_new_transform_fn,
             outputs=[output],
-            config_def={},
+            config_def=check.opt_dict_param(config_def, 'config_def'),
             description=description,
         )
 

--- a/python_modules/dagster/dagster/core/utility_solids.py
+++ b/python_modules/dagster/dagster/core/utility_solids.py
@@ -8,24 +8,7 @@ from dagster import (
 )
 
 
-def define_pass_value_solid(name, description=None):
-    check.str_param(name, 'name')
-    check.opt_str_param(description, 'description')
-
-    def _value_t_fn(_context, _inputs, config_dict):
-        yield Result(config_dict['value'])
-
-    return SolidDefinition(
-        name=name,
-        description=description,
-        inputs=[],
-        outputs=[OutputDefinition(dagster_type=types.String)],
-        config_def={'value': ArgumentDefinition(types.String)},
-        transform_fn=_value_t_fn,
-    )
-
-
-def define_pass_mem_value(name, value):
+def define_stub_solid(name, value):
     check.str_param(name, 'name')
 
     def _value_t_fn(_context, _inputs, _config_dict):

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
@@ -506,7 +506,7 @@ def test_pandas_output_intermediate_csv_files():
         }
 
         pipeline_result = execute_pipeline(
-            PipelineDefinition.create_pipeline_slice(
+            PipelineDefinition.create_sub_pipeline(
                 pipeline,
                 ['sum_mult_table'],
                 ['sum_mult_table'],

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_user_error.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_user_error.py
@@ -19,7 +19,7 @@ from dagster import (
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution import execute_single_solid
 from dagster.utils.test import script_relative_path
-from dagster.core.utility_solids import define_pass_mem_value
+from dagster.core.utility_solids import define_stub_solid
 
 
 def _dataframe_solid(name, inputs, transform_fn):
@@ -42,7 +42,7 @@ def test_wrong_output_value():
     def df_solid(num_csv):
         return 'not a dataframe'
 
-    pass_solid = define_pass_mem_value('pass_solid', pd.DataFrame())
+    pass_solid = define_stub_solid('pass_solid', pd.DataFrame())
 
     pipeline = PipelineDefinition(
         solids=[pass_solid, df_solid],
@@ -67,7 +67,7 @@ def test_wrong_input_value():
     def df_solid(foo):
         return foo
 
-    pass_solid = define_pass_mem_value('pass_solid', 'not a dataframe')
+    pass_solid = define_stub_solid('pass_solid', 'not a dataframe')
 
     pipeline = PipelineDefinition(
         solids=[pass_solid, df_solid],

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_basic_solid.py
@@ -10,7 +10,7 @@ from dagster import (
     execute_pipeline,
 )
 
-from dagster.core.utility_solids import define_pass_mem_value
+from dagster.core.utility_solids import define_stub_solid
 
 from dagster.sqlalchemy_kernel.subquery_builder_experimental import (
     create_sql_solid,
@@ -53,7 +53,7 @@ def create_num_table(engine):
 
 
 def test_sql_sum_solid():
-    expr_solid = define_pass_mem_value('expr', DagsterSqlTableExpression('num_table'))
+    expr_solid = define_stub_solid('expr', DagsterSqlTableExpression('num_table'))
 
     sum_table_solid = create_sum_table_solid()
 
@@ -101,7 +101,7 @@ def create_sum_table_solid():
 def create_sum_sq_pipeline(context, expr, extra_solids=None, extra_deps=None):
     check.inst_param(expr, 'expr', DagsterSqlTableExpression)
 
-    expr_solid = define_pass_mem_value('expr', expr)
+    expr_solid = define_stub_solid('expr', expr)
 
     sum_solid = create_sum_table_solid()
 

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/sqlalchemy_kernel_tests/test_isolated_templated_sql_tests.py
@@ -17,7 +17,7 @@ from dagster.sqlalchemy_kernel.templated import (
     create_templated_sql_transform_solid,
 )
 
-from dagster.core.utility_solids import define_pass_value_solid
+from dagster.core.utility_solids import define_stub_solid
 
 from .math_test_db import in_mem_context
 
@@ -202,7 +202,7 @@ def test_templated_sql_solid_pipeline():
     # now execute subdag
 
     pipeline_two = pipeline_test_def(
-        solids=[define_pass_value_solid('pass_value'), sum_sq_solid],
+        solids=[define_stub_solid('pass_value', 'TODO'), sum_sq_solid],
         context=context,
         dependencies={
             sum_sq_solid.name: {
@@ -213,17 +213,13 @@ def test_templated_sql_solid_pipeline():
 
     second_sum_sq_table = 'second_sum_sq_table'
 
+    sum_sq_args = {
+        'sum_table': first_sum_table,
+        'sum_sq_table': second_sum_sq_table,
+    }
     environment_two = config.Environment(
         solids={
-            'pass_value':
-            config.Solid({
-                'value': 'something'
-            }),
-            'sum_sq_table':
-            config.Solid({
-                'sum_table': first_sum_table,
-                'sum_sq_table': second_sum_sq_table,
-            }),
+            'sum_sq_table': config.Solid(sum_sq_args),
         },
     )
 


### PR DESCRIPTION
1) Make expectations work for cases with named outputs
2) Change output UI to render Output instead of Input
3) Equality semantics for DependencyDefinition (nice for testing)
4) Rename create_pipeline_slice to create_sub_pipeline (marginally
better)
5) Add create_single_solid_pipeline