### PR TITLE
Add MultipleResults.from_dict

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -18,6 +18,7 @@ from dagster.core.definitions import (
 )
 
 from dagster.core.decorators import (
+    MultipleResults,
     solid,
     with_context,
 )

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -122,6 +122,33 @@ def test_solid_multiple_outputs():
     assert result.result_list[1].transformed_value['foo'] == 'right'
 
 
+def test_dict_multiple_outputs():
+    @solid(outputs=[
+        OutputDefinition(name="left"),
+        OutputDefinition(name="right"),
+    ])
+    def hello_world():
+        return MultipleResults.from_dict({
+            'left': {
+                'foo': 'left'
+            },
+            'right': {
+                'foo': 'right'
+            },
+        })
+
+    result = execute_single_solid(
+        create_test_context(),
+        hello_world,
+        environment=create_empty_test_env(),
+    )
+
+    assert result.success
+    assert len(result.result_list) == 2
+    assert result.result_list[0].transformed_value['foo'] == 'left'
+    assert result.result_list[1].transformed_value['foo'] == 'right'
+
+
 def test_solid_with_name():
     @solid(name="foobar", outputs=[OutputDefinition()])
     def hello_world():

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -23,6 +23,14 @@ class MultipleResults(namedtuple('_MultipleResults', 'results')):
             check.opt_list_param(list(results), 'results', Result),
         )
 
+    @staticmethod
+    def from_dict(result_dict):
+        check.dict_param(result_dict, 'result_dict', key_type=str)
+        results = []
+        for name, value in result_dict.items():
+            results.append(Result(value, name))
+        return MultipleResults(*results)
+
 
 def with_context(fn):
     """Pass context as a first argument to a transform.


### PR DESCRIPTION
This allows the construction of a MultipleResults object from a
dictionary. I suspect this will actually end up being the most used form
of constructing one of these things.