### PR TITLE
Do some renames and definition changes

### DIFF
--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -81,7 +81,7 @@ class Solid(graphene.ObjectType):
 
         if depended_by:
             self._depended_by = {
-                output_handle.output.name: input_handles
+                output_handle.output_def.name: input_handles
                 for output_handle, input_handles in depended_by.items()
             }
         else:
@@ -90,19 +90,19 @@ class Solid(graphene.ObjectType):
     def resolve_inputs(self, info):
         return [
             Input(input_definition, self, self._depends_on.get(input_definition.name))
-            for input_definition in self._solid.inputs
+            for input_definition in self._solid.input_defs
         ]
 
     def resolve_outputs(self, info):
         return [
             Output(output_definition, self, self._depended_by.get(output_definition.name, []))
-            for output_definition in self._solid.outputs
+            for output_definition in self._solid.output_defs
         ]
 
     def resolve_config(self, info):
         return [
             Argument(name=name, argument=argument)
-            for name, argument in self._solid.config_dict_def.items()
+            for name, argument in self._solid.config_def.argument_def_dict.items()
         ]
 
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -6,6 +6,7 @@ from dagster.core.execution_context import ExecutionContext
 
 from dagster.core.definitions import (
     ArgumentDefinition,
+    ConfigDefinition,
     DependencyDefinition,
     ExpectationDefinition,
     ExpectationResult,

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -126,13 +126,13 @@ def print_solid(printer, solid):
 
         printer.line('Outputs:')
 
-        for output in solid.outputs:
-            print(output.name)
+        for output_def in solid.output_defs:
+            print(output_def.name)
 
 
 def print_inputs(printer, solid):
     printer.line('Inputs:')
-    for input_def in solid.inputs:
+    for input_def in solid.input_defs:
         with printer.with_indent():
             printer.line('Input: {name}'.format(name=input_def.name))
 
@@ -231,7 +231,7 @@ def print_metrics_to_console(results, printer):
 
         printer('Metrics for {name}'.format(name=result.name))
 
-        for input_def in result.solid.inputs:
+        for input_def in result.solid.input_defs:
             metrics_for_input = list(
                 context.metrics_covering_context({
                     'solid': result.name,

--- a/python_modules/dagster/dagster/core/argument_handling.py
+++ b/python_modules/dagster/dagster/core/argument_handling.py
@@ -1,10 +1,11 @@
 from dagster import check
+
+from .definitions import ArgumentDefinitionDictionary
 from .errors import DagsterTypeError
-from .definitions import check_argument_def_dict
 
 
 def validate_args(argument_def_dict, arg_dict, error_context_str):
-    check_argument_def_dict(argument_def_dict)
+    check.inst_param(argument_def_dict, 'argument_def_dict', ArgumentDefinitionDictionary)
     check.dict_param(arg_dict, 'arg_dict', key_type=str)
     check.str_param(error_context_str, 'error_context_str')
 

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -36,13 +36,6 @@ from .graph import ExecutionGraph
 
 from .types import DagsterType
 
-
-def get_single_solid_output(solid):
-    check.inst_param(solid, 'solid', SolidDefinition)
-    check.invariant(len(solid.outputs) == 1)
-    return solid.outputs[0]
-
-
 class ComputeNodeOutputHandle(namedtuple('_ComputeNodeOutputHandle', 'compute_node output_name')):
     def __new__(cls, compute_node, output_name):
         return super(ComputeNodeOutputHandle, cls).__new__(
@@ -282,7 +275,7 @@ class ComputeNode:
                     raise DagsterInvariantViolationError(
                         f'''Core transform for {self.solid.name} returned an output
                         {result.output_name} that does not exist. The available
-                        outputs are {list([output.name for output in self.solid.outputs])}'''
+                        outputs are {list([output_def.name for output_def in self.solid.output_defs])}'''
                     )
 
                 if result.output_name in seen_outputs:
@@ -504,7 +497,7 @@ def create_compute_node_graph_from_env(execution_graph, env):
     for topo_solid in execution_graph.topological_solids:
         cn_inputs = []
 
-        for input_def in topo_solid.inputs:
+        for input_def in topo_solid.input_defs:
             prev_cn_output_handle = _prev_node_handle(
                 dependency_structure,
                 topo_solid,
@@ -536,7 +529,7 @@ def create_compute_node_graph_from_env(execution_graph, env):
             )
 
         validated_config_args = validate_args(
-            topo_solid.config_dict_def,
+            topo_solid.config_def.argument_def_dict,
             env.config_dict_for_solid(topo_solid.name),
             'config for solid {solid_name}'.format(solid_name=topo_solid.name),
         )
@@ -547,7 +540,7 @@ def create_compute_node_graph_from_env(execution_graph, env):
             validated_config_args,
         )
 
-        for output_def in topo_solid.outputs:
+        for output_def in topo_solid.output_defs:
             output_handle = topo_solid.output_handle(output_def.name)
             if env.evaluate_expectations and output_def.expectations:
                 expectations_graph = create_expectations_cn_graph(
@@ -648,8 +641,8 @@ def create_compute_node_from_solid_transform(solid, node_inputs, config_args):
         friendly_name=f'{solid.name}.transform',
         node_inputs=node_inputs,
         node_outputs=[
-            ComputeNodeOutput(name=output.name, dagster_type=output.dagster_type)
-            for output in solid.outputs
+            ComputeNodeOutput(name=output_def.name, dagster_type=output_def.dagster_type)
+            for output_def in solid.output_defs
         ],
         arg_dict={},
         compute_fn=lambda context, inputs: _execute_core_transform(

--- a/python_modules/dagster/dagster/core/core_tests/test_argument_handling.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_argument_handling.py
@@ -1,12 +1,16 @@
 import pytest
 
-from dagster import (ArgumentDefinition, types)
+from dagster import (
+    ArgumentDefinition,
+    types,
+)
 from dagster.core.argument_handling import validate_args
+from dagster.core.definitions import ArgumentDefinitionDictionary
 from dagster.core.errors import DagsterTypeError
 
 
 def _validate(argument_def_dict, arg_dict):
-    return validate_args(argument_def_dict, arg_dict, 'dummy')
+    return validate_args(ArgumentDefinitionDictionary(argument_def_dict), arg_dict, 'dummy')
 
 
 def _single_required_string_arg_def_dict():

--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -17,14 +17,12 @@ def solid_a_b_list():
             inputs=[],
             outputs=[OutputDefinition()],
             transform_fn=lambda context, inputs, config: None,
-            config_def={},
         ),
         SolidDefinition(
             name='B',
             inputs=[InputDefinition('b_input')],
             outputs=[],
             transform_fn=lambda context, inputs, config: None,
-            config_def={},
         )
     ]
 

--- a/python_modules/dagster/dagster/core/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_multiple_outputs.py
@@ -25,7 +25,6 @@ def test_multiple_outputs():
             OutputDefinition(name='output_one'),
             OutputDefinition(name='output_two'),
         ],
-        config_def={},
         transform_fn=_t_fn,
     )
 
@@ -76,7 +75,6 @@ def test_multiple_outputs_expectations():
                 ],
             ),
         ],
-        config_def={},
         transform_fn=_transform_fn,
     )
 
@@ -99,7 +97,6 @@ def test_wrong_multiple_output():
         outputs=[
             OutputDefinition(name='output_one'),
         ],
-        config_def={},
         transform_fn=_t_fn,
     )
 
@@ -122,7 +119,6 @@ def test_multiple_outputs_of_same_name_disallowed():
         outputs=[
             OutputDefinition(name='output_one'),
         ],
-        config_def={},
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -2,6 +2,7 @@ import dagster
 
 from dagster import (
     ArgumentDefinition,
+    ConfigDefinition,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
@@ -27,7 +28,9 @@ def define_pass_value_solid(name, description=None):
         description=description,
         inputs=[],
         outputs=[OutputDefinition(dagster_type=types.String)],
-        config_def={'value': ArgumentDefinition(types.String)},
+        config_def=ConfigDefinition({
+            'value': ArgumentDefinition(types.String)
+        }),
         transform_fn=_value_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -2,6 +2,7 @@ import pytest
 
 from dagster import (
     ArgumentDefinition,
+    ConfigDefinition,
     PipelineDefinition,
     SolidDefinition,
     config,
@@ -22,7 +23,9 @@ def test_basic_solid_with_config():
         name='with_context',
         inputs=[],
         outputs=[],
-        config_def={'some_config': ArgumentDefinition(types.String)},
+        config_def=ConfigDefinition({
+            'some_config': ArgumentDefinition(types.String)
+        }),
         transform_fn=_t_fn,
     )
 
@@ -47,7 +50,9 @@ def test_config_arg_mismatch():
         name='with_context',
         inputs=[],
         outputs=[],
-        config_def={'some_config': ArgumentDefinition(types.String)},
+        config_def=ConfigDefinition({
+            'some_config': ArgumentDefinition(types.String)
+        }),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -45,18 +45,23 @@ def check_valid_name(name):
     return name
 
 
-def check_argument_def_dict(config_def_dict):
-    return check.dict_param(
-        config_def_dict,
-        'config_def_dict',
-        key_type=str,
-        value_type=ArgumentDefinition,
-    )
+# We wrap the passed in dictionary of str : ArgumentDefinition to
+# 1) enforce typing
+# 2) enforce immutability
+# 3) make type checks throughout execution cheaper
+class ArgumentDefinitionDictionary(dict):
+    def __init__(self, ddict):
+        super().__init__(
+            check.dict_param(ddict, 'ddict', key_type=str, value_type=ArgumentDefinition)
+        )
+
+    def __setitem__(self, _key, _value):
+        check.failed('This dictionary is readonly')
 
 
 class PipelineContextDefinition:
     def __init__(self, *, argument_def_dict, context_fn, description=None):
-        self.argument_def_dict = check_argument_def_dict(argument_def_dict)
+        self.argument_def_dict = ArgumentDefinitionDictionary(argument_def_dict)
         self.context_fn = check.callable_param(context_fn, 'context_fn')
         self.description = description
 
@@ -260,7 +265,7 @@ class PipelineDefinition:
 
                 if not self._solid_dict[from_solid].has_input(from_input):
                     input_list = [
-                        input_def.name for input_def in self._solid_dict[from_solid].inputs
+                        input_def.name for input_def in self._solid_dict[from_solid].input_defs
                     ]
                     raise DagsterInvalidDefinitionError(
                         f'Solid {from_solid} does not have input {from_input}. ' + \
@@ -280,7 +285,7 @@ class PipelineDefinition:
         self.dependency_structure = DependencyStructure.from_definitions(solids, dependencies)
 
         for solid in solids:
-            for input_def in solid.inputs:
+            for input_def in solid.input_defs:
                 if not self.dependency_structure.has_dep(solid.input_handle(input_def.name)):
                     if name:
                         raise DagsterInvalidDefinitionError(
@@ -402,25 +407,25 @@ class SolidInputHandle(namedtuple('_SolidInputHandle', 'solid input_def')):
         return self.solid.name == other.solid.name and self.input_def.name == other.input_def.name
 
 
-class SolidOutputHandle(namedtuple('_SolidOutputHandle', 'solid output')):
-    def __new__(cls, solid, output):
+class SolidOutputHandle(namedtuple('_SolidOutputHandle', 'solid output_def')):
+    def __new__(cls, solid, output_def):
         return super(SolidOutputHandle, cls).__new__(
             cls,
             check.inst_param(solid, 'solid', SolidDefinition),
-            check.inst_param(output, 'output', OutputDefinition),
+            check.inst_param(output_def, 'output_def', OutputDefinition),
         )
 
     def __str__(self):
-        return f'SolidOutputHandle(solid="{self.solid.name}", output.name="{self.output.name}")'
+        return f'SolidOutputHandle(solid="{self.solid.name}", output.name="{self.output_def.name}")'
 
     def __repr__(self):
-        return f'SolidOutputHandle(solid="{self.solid.name}", output.name="{self.output.name}")'
+        return f'SolidOutputHandle(solid="{self.solid.name}", output.name="{self.output_def.name}")'
 
     def __hash__(self):
-        return hash((self.solid.name, self.output.name))
+        return hash((self.solid.name, self.output_def.name))
 
     def __eq__(self, other):
-        return self.solid.name == other.solid.name and self.output.name == other.output.name
+        return self.solid.name == other.solid.name and self.output_def.name == other.output_def.name
 
 
 class Result(namedtuple('_Result', 'value output_name')):
@@ -432,28 +437,42 @@ class Result(namedtuple('_Result', 'value output_name')):
         )
 
 
+class ConfigDefinition:
+    def __init__(self, argument_def_dict):
+        self.argument_def_dict = ArgumentDefinitionDictionary(argument_def_dict)
+
+
 class SolidDefinition:
-    def __init__(self, *, name, inputs, transform_fn, outputs, config_def, description=None):
+    def __init__(self, *, name, inputs, transform_fn, outputs, config_def=None, description=None):
         self.name = check_valid_name(name)
-        self.inputs = check.list_param(inputs, 'inputs', InputDefinition)
+        self.input_defs = check.list_param(inputs, 'inputs', InputDefinition)
         self.transform_fn = check.callable_param(transform_fn, 'transform_fn')
-        self.outputs = check.list_param(outputs, 'outputs', OutputDefinition)
+        self.output_defs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
-        self.config_dict_def = check_argument_def_dict(config_def)
+        self.config_def = check.opt_inst_param(
+            config_def,
+            'config_def',
+            ConfigDefinition,
+            ConfigDefinition({}),
+        )
 
         input_handles = {}
-        for inp in self.inputs:
-            input_handles[inp.name] = SolidInputHandle(self, inp)
+        for input_def in self.input_defs:
+            input_handles[input_def.name] = SolidInputHandle(self, input_def)
 
-        self.input_handles = input_handles
+        self._input_handles = input_handles
 
         output_handles = {}
-        for output in outputs:
-            output_handles[output.name] = SolidOutputHandle(self, output)
+        for output_def in self.output_defs:
+            output_handles[output_def.name] = SolidOutputHandle(self, output_def)
 
-        self.output_handles = output_handles
+        self._output_handles = output_handles
         self._input_dict = _build_named_dict(inputs)
         self._output_dict = _build_named_dict(outputs)
+
+    @property
+    def outputs(self):
+        return self.output_defs
 
     @staticmethod
     def single_output_transform(
@@ -468,21 +487,17 @@ class SolidDefinition:
             inputs=inputs,
             transform_fn=_new_transform_fn,
             outputs=[output],
-            config_def=check.opt_dict_param(config_def, 'config_def'),
+            config_def=config_def,
             description=description,
         )
 
     def input_handle(self, name):
         check.str_param(name, 'name')
-        return self.input_handles[name]
+        return self._input_handles[name]
 
     def output_handle(self, name):
         check.str_param(name, 'name')
-        return self.output_handles[name]
-
-    @property
-    def input_names(self):
-        return [inp.name for inp in self.inputs]
+        return self._output_handles[name]
 
     def has_input(self, name):
         check.str_param(name, 'name')

--- a/python_modules/dagster/dagster/core/graph.py
+++ b/python_modules/dagster/dagster/core/graph.py
@@ -47,7 +47,7 @@ def _dependency_structure_to_dep_dict(dependency_structure):
     for input_handle, output_handle in dependency_structure.items():
         dep_dict[input_handle.solid.name][input_handle.input_def.name] = DependencyDefinition(
             solid=output_handle.solid.name,
-            output=output_handle.output.name,
+            output=output_handle.output_def.name,
         )
     return dep_dict
 
@@ -143,8 +143,8 @@ class ExecutionGraph:
 
         trans_deps = set()
         solid = self._solid_dict[solid_name]
-        for inp in solid.inputs:
-            input_handle = solid.input_handle(inp.name)
+        for input_def in solid.input_defs:
+            input_handle = solid.input_handle(input_def.name)
             if self.dependency_structure.has_dep(input_handle):
                 output_handle = self.dependency_structure.get_dep(input_handle)
                 trans_deps.add(output_handle.solid.name)
@@ -171,7 +171,7 @@ class ExecutionGraph:
         handle_dict = InputToOutputHandleDict()
 
         for solid in involved_solids:
-            for input_def in solid.inputs:
+            for input_def in solid.input_defs:
                 input_handle = solid.input_handle(input_def.name)
                 if self.dependency_structure.has_dep(input_handle):
                     handle_dict[input_handle] = self.dependency_structure.get_dep(input_handle)
@@ -188,7 +188,7 @@ class ExecutionGraph:
 
             involved_solid_set.add(solid.name)
 
-            for input_def in solid.inputs:
+            for input_def in solid.input_defs:
                 input_handle = solid.input_handle(input_def.name)
                 if not self.dependency_structure.has_dep(input_handle):
                     continue
@@ -220,7 +220,7 @@ def _all_depended_on_solids(execution_graph):
     dependency_structure = execution_graph.dependency_structure
 
     for solid in execution_graph.solids:
-        for input_def in solid.inputs:
+        for input_def in solid.input_defs:
             input_handle = solid.input_handle(input_def.name)
             if dependency_structure.has_dep(input_handle):
                 output_handle = dependency_structure.get_dep(input_handle)

--- a/python_modules/dagster/dagster/core/utility_solids.py
+++ b/python_modules/dagster/dagster/core/utility_solids.py
@@ -18,6 +18,5 @@ def define_stub_solid(name, value):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_def={},
         transform_fn=_value_t_fn,
     )

--- a/python_modules/dagster/dagster/graphviz.py
+++ b/python_modules/dagster/dagster/graphviz.py
@@ -14,12 +14,12 @@ def build_graphviz_graph(pipeline):
     graphviz_graph.attr('node', color='grey', shape='box')
 
     for solid in pipeline.solids:
-        for input_def in solid.inputs:
+        for input_def in solid.input_defs:
             scoped_name = solid.name + '.' + input_def.name
             graphviz_graph.node(scoped_name)
 
     for solid in pipeline.solids:
-        for input_def in solid.inputs:
+        for input_def in solid.input_defs:
             scoped_name = solid.name + '.' + input_def.name
             graphviz_graph.edge(scoped_name, solid.name)
 

--- a/python_modules/dagster/dagster/pandas_kernel/__init__.py
+++ b/python_modules/dagster/dagster/pandas_kernel/__init__.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from dagster import (
     ArgumentDefinition,
+    ConfigDefinition,
     ExecutionContext,
     InputDefinition,
     OutputDefinition,
@@ -40,9 +41,9 @@ def load_csv_solid(name):
         inputs=[],
         outputs=[OutputDefinition(dagster_type=DataFrame)],
         transform_fn=_t_fn,
-        config_def={
+        config_def=ConfigDefinition({
             'path': ArgumentDefinition(types.Path),
-        }
+        }),
     )
 
 
@@ -54,7 +55,9 @@ def to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def={'path': ArgumentDefinition(types.Path)},
+        config_def=ConfigDefinition({
+            'path': ArgumentDefinition(types.Path)
+        }),
         transform_fn=_t_fn,
     )
 
@@ -67,6 +70,8 @@ def to_parquet_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def={'path': ArgumentDefinition(types.Path)},
+        config_def=ConfigDefinition({
+            'path': ArgumentDefinition(types.Path)
+        }),
         transform_fn=_t_fn,
     )

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_library_slide.py
@@ -30,7 +30,7 @@ def test_hello_world_with_dataframe_fns():
 
 
 def run_hello_world(hello_world):
-    assert len(hello_world.inputs) == 1
+    assert len(hello_world.input_defs) == 1
 
     pipeline = PipelineDefinition(
         solids=[

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_hello_world_no_library_slide.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from dagster import (
     ArgumentDefinition,
+    ConfigDefinition,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
@@ -24,7 +25,9 @@ def define_read_csv_solid(name):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_def={'path': ArgumentDefinition(types.Path)},
+        config_def=ConfigDefinition({
+            'path': ArgumentDefinition(types.Path)
+        }),
         transform_fn=_t_fn
     )
 
@@ -37,7 +40,9 @@ def define_to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df')],
         outputs=[],
-        config_def={'path': ArgumentDefinition(types.Path)},
+        config_def=ConfigDefinition({
+            'path': ArgumentDefinition(types.Path)
+        }),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas_kernel/pandas_kernel_tests/test_pandas_solids.py
@@ -36,7 +36,7 @@ def get_solid_transformed_value(_context, solid_inst, environment):
         solids=[dagster_pd.load_csv_solid('load_csv'), solid_inst],
         dependencies={
             solid_inst.name: {
-                solid_inst.inputs[0].name: DependencyDefinition('load_csv'),
+                solid_inst.input_defs[0].name: DependencyDefinition('load_csv'),
             }
         }
     )
@@ -128,7 +128,7 @@ def execute_transform_in_temp_csv_files(solid_inst):
         solids=[load_csv_solid, solid_inst, to_csv_solid],
         dependencies={
             solid_inst.name: {
-                solid_inst.inputs[0].name: DependencyDefinition('load_csv'),
+                solid_inst.input_defs[0].name: DependencyDefinition('load_csv'),
             },
             'to_csv': {
                 'df': DependencyDefinition(solid_inst.name),

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/subquery_builder_experimental.py
@@ -2,6 +2,7 @@ import os
 
 from dagster import (
     ArgumentDefinition,
+    ConfigDefinition,
     InputDefinition,
     OutputDefinition,
     SolidDefinition,
@@ -61,9 +62,9 @@ def define_create_table_solid(name):
         inputs=[InputDefinition('expr')],
         outputs=[],
         transform_fn=_materialization_fn,
-        config_def={
+        config_def=ConfigDefinition({
             'table_name': ArgumentDefinition(types.String),
-        }
+        }),
     )
 
 

--- a/python_modules/dagster/dagster/sqlalchemy_kernel/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/templated.py
@@ -2,6 +2,7 @@ import jinja2
 
 from dagster import (
     ArgumentDefinition,
+    ConfigDefinition,
     InputDefinition,
     OutputDefinition,
     Result,
@@ -22,14 +23,14 @@ def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_s
         dependant_solids, 'dependant_solids', of_type=SolidDefinition
     )
 
-    config_def = {}
+    argument_def_dict = {}
     for table in table_arguments:
-        config_def[table] = ArgumentDefinition(types.String)
+        argument_def_dict[table] = ArgumentDefinition(types.String)
 
     return SolidDefinition(
         name=name,
         inputs=[InputDefinition(solid.name) for solid in dependant_solids],
-        config_def=config_def,
+        config_def=ConfigDefinition(argument_def_dict),
         transform_fn=_create_templated_sql_transform_with_output(sql),
         outputs=[OutputDefinition()],
     )


### PR DESCRIPTION
1) Add ConfigDefinition

This is to future proof this API a bit. Currently it only contains the
argument definition dictionary, but I suspect that will change. This
will make that easier to manage.

2) Add ArgumentDefinitionDictionary class for internal use

3) Consistent naming output_def, input_def in SolidDefinition and handle
classes