### PR TITLE
Clean up logging and fix double writing.

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -1,0 +1,109 @@
+from collections import namedtuple
+import logging
+import uuid
+
+from dagster.core.execution import ExecutionContext
+from dagster.utils.logging import (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+
+LogMessage = namedtuple('LogMessage', 'msg extra level')
+
+# eliminate complaint about overriding methods imprecisely
+# pylint: disable=W0221
+
+
+# weird name so that pytest ignores
+class LoggerForTest(logging.Logger):
+    def __init__(self, name=None):
+        super().__init__(name if name else str(uuid.uuid4()))
+        self.messages = []
+
+    def debug(self, msg, *args, extra=None, **kwargs):
+        self.messages.append(LogMessage(msg=msg, level=DEBUG, extra=extra))
+
+    def info(self, msg, *args, extra=None, **kwargs):
+        self.messages.append(LogMessage(msg=msg, level=INFO, extra=extra))
+
+    def warning(self, msg, *args, extra=None, **kwargs):
+        self.messages.append(LogMessage(msg=msg, level=WARNING, extra=extra))
+
+    def error(self, msg, *args, extra=None, **kwargs):
+        self.messages.append(LogMessage(msg=msg, level=ERROR, extra=extra))
+
+    def critical(self, msg, *args, extra=None, **kwargs):
+        self.messages.append(LogMessage(msg=msg, level=CRITICAL, extra=extra))
+
+
+def test_test_logger():
+    logger = LoggerForTest()
+    logger.debug('fog')
+    assert len(logger.messages) == 1
+    assert logger.messages[0] == LogMessage(msg='fog', level=DEBUG, extra=None)
+
+
+def orig_message(message):
+    return message.extra['log_message']
+
+
+def test_context_logging():
+    logger = LoggerForTest()
+    context = ExecutionContext(loggers=[logger])
+    context.debug('debug from context')
+    context.info('info from context')
+    context.warning('warning from context')
+    context.error('error from context')
+    context.critical('critical from context')
+
+    assert len(logger.messages) == 5
+
+    assert logger.messages[0].level == DEBUG
+    assert orig_message(logger.messages[0]) == 'debug from context'
+    assert logger.messages[1].level == INFO
+    assert orig_message(logger.messages[1]) == 'info from context'
+    assert logger.messages[2].level == WARNING
+    assert orig_message(logger.messages[2]) == 'warning from context'
+    assert logger.messages[3].level == ERROR
+    assert orig_message(logger.messages[3]) == 'error from context'
+    assert logger.messages[4].level == CRITICAL
+    assert orig_message(logger.messages[4]) == 'critical from context'
+
+
+def test_context_value():
+    logger = LoggerForTest()
+    context = ExecutionContext(loggers=[logger])
+
+    with context.value('some_key', 'some_value'):
+        context.info('some message')
+
+    assert logger.messages[0].extra['some_key'] == 'some_value'
+    assert 'some_key=some_value' in logger.messages[0].msg
+    assert 'message="some message"' in logger.messages[0].msg
+
+
+def test_log_message_id():
+    logger = LoggerForTest()
+    context = ExecutionContext(loggers=[logger])
+    context.info('something')
+
+    assert isinstance(uuid.UUID(logger.messages[0].extra['log_message_id']), uuid.UUID)
+
+
+def test_interleaved_context_value():
+    logger = LoggerForTest()
+    context = ExecutionContext(loggers=[logger])
+
+    with context.value('key_one', 'value_one'):
+        context.info('message one')
+        with context.value('key_two', 'value_two'):
+            context.info('message two')
+
+    message_one = logger.messages[0]
+    assert message_one.extra['key_one'] == 'value_one'
+    assert 'key_two' not in message_one.extra
+    assert 'key_one=value_one' in message_one.msg
+    assert 'key_two' not in message_one.msg
+
+    message_two = logger.messages[1]
+    assert message_two.extra['key_one'] == 'value_one'
+    assert message_two.extra['key_two'] == 'value_two'
+    assert 'key_one=value_one' in message_two.msg
+    assert 'key_two=value_two' in message_two.msg

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -13,6 +13,7 @@ from dagster import (
     with_context,
 )
 from dagster.core.errors import (DagsterTypeError, DagsterInvariantViolationError)
+from dagster.utils.logging import ERROR
 
 
 def test_default_context():
@@ -22,7 +23,7 @@ def test_default_context():
     )
     @with_context
     def default_context_transform(context):
-        assert context.log_level == 'ERROR'
+        assert context.log_level == ERROR
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
     execute_pipeline(
@@ -37,7 +38,7 @@ def test_default_context_with_log_level():
     )
     @with_context
     def default_context_transform(context):
-        assert context.log_level == 'ERROR'
+        assert context.log_level == ERROR
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
     execute_pipeline(

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -4,6 +4,7 @@ import re
 
 from dagster import check
 from dagster.core import types
+from dagster.utils.logging import level_from_string
 
 from .errors import DagsterInvalidDefinitionError
 from .graph import SolidGraph
@@ -65,10 +66,12 @@ def _default_pipeline_context_definitions():
         import dagster.core.execution
         import dagster.utils.logging
 
-        log_level = args['log_level']
+        log_level = level_from_string(args['log_level'])
         context = dagster.core.execution.ExecutionContext(
             log_level=log_level,
-            loggers=[dagster.utils.logging.define_logger('dagster', level=log_level)]
+            loggers=[
+                dagster.utils.logging.define_colored_console_logger('dagster', level=log_level)
+            ]
         )
         return context
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -25,6 +25,7 @@ from collections import (namedtuple, OrderedDict)
 from contextlib import contextmanager
 import copy
 import sys
+import uuid
 
 import six
 
@@ -87,33 +88,42 @@ class ExecutionContext:
             ]
         )
 
-    def _log(self, method, msg, **kwargs):
+    def _log(self, method, msg, kwargs):
         check.str_param(method, 'method')
         check.str_param(msg, 'msg')
+
+        check.invariant('extra' not in kwargs, 'do not allow until explicit support is handled')
+        check.invariant('exc_info' not in kwargs, 'do not allow until explicit support is handled')
+
+        check.invariant('log_message' not in kwargs, 'log_message_id reserved value')
+        check.invariant('log_message_id' not in kwargs, 'log_message_id reserved value')
+
 
         full_message = 'message="{message}" {kv_message}'.format(
             message=msg, kv_message=self._kv_message(kwargs)
         )
 
         log_props = copy.copy(self._context_dict)
+
         log_props['log_message'] = msg
+        log_props['log_message_id'] = str(uuid.uuid4())
 
         getattr(self._logger, method)(full_message, extra={**log_props, **kwargs})
 
     def debug(self, msg, **kwargs):
-        return self._log('debug', msg, **kwargs)
+        return self._log('debug', msg, kwargs)
 
     def info(self, msg, **kwargs):
-        return self._log('info', msg, **kwargs)
+        return self._log('info', msg, kwargs)
 
-    def warn(self, msg, **kwargs):
-        return self._log('warn', msg, **kwargs)
+    def warning(self, msg, **kwargs):
+        return self._log('warning', msg, kwargs)
 
     def error(self, msg, **kwargs):
-        return self._log('error', msg, **kwargs)
+        return self._log('error', msg, kwargs)
 
     def critical(self, msg, **kwargs):
-        return self._log('critical', msg, **kwargs)
+        return self._log('critical', msg, kwargs)
 
     # FIXME: Actually make this work
     # def exception(self, e):

--- a/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
@@ -1,0 +1,57 @@
+import json
+
+from dagster.utils.test import get_temp_file_name
+from dagster.utils.logging import (define_json_file_logger, DEBUG, INFO)
+
+
+def test_basic_logging():
+    with get_temp_file_name() as tf_name:
+        logger = define_json_file_logger('foo', tf_name, DEBUG)
+        logger.debug('bar')
+
+        data = list(parse_json_lines(tf_name))
+
+        assert len(data) == 1
+        assert data[0]['name'] == 'foo'
+        assert data[0]['msg'] == 'bar'
+
+
+def parse_json_lines(tf_name):
+    with open(tf_name) as f:
+        for line in f:
+            yield json.loads(line)
+
+
+def test_no_double_write_diff_names():
+    with get_temp_file_name() as tf_name:
+        foo_logger = define_json_file_logger('foo', tf_name, DEBUG)
+        baaz_logger = define_json_file_logger('baaz', tf_name, DEBUG)
+
+        foo_logger.debug('foo message')
+        baaz_logger.debug('baaz message')
+
+        data = list(parse_json_lines(tf_name))
+
+        assert len(data) == 2
+        assert data[0]['name'] == 'foo'
+        assert data[0]['msg'] == 'foo message'
+        assert data[1]['name'] == 'baaz'
+        assert data[1]['msg'] == 'baaz message'
+
+
+# This demonstrates different, less global, behavior than the typical
+# python logger. Same name does *not* mean the same logger instance
+# here. Hence logger one *retains* debug level while logger_two is
+# a separate instance with info level
+def test_no_double_write_same_names():
+    with get_temp_file_name() as tf_name:
+        foo_logger_one = define_json_file_logger('foo', tf_name, DEBUG)
+        foo_logger_two = define_json_file_logger('foo', tf_name, INFO)
+
+        foo_logger_one.debug('logger one message')
+        foo_logger_two.debug('logger two message')
+
+        data = list(parse_json_lines(tf_name))
+        assert len(data) == 1
+        assert data[0]['name'] == 'foo'
+        assert data[0]['msg'] == 'logger one message'


### PR DESCRIPTION
    There are some concepts, some ideas, that are so repugnant, so vile, so debased,
    that the world, by acclamation, that unite the world with a single voice
    shouting "Never Again." Some things should be tossed into history's unmarked
    grave of discarded lies. To this list I nominate global, mutable variables.
    
    Against my better judgement I used a global set to deal with python's logging
    global-ness. And naturally it is the source of the first real, honest-to-God
    bug in production.

    Now that I'm more confident about the way the context I am just going to
    totally avoid python's horrific global logger registry and just create
    loggers directly. This ends up being a lot easier to think about,
    manage, and test.