### PR TITLE
Eliminate log level from ExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -13,7 +13,10 @@ from dagster import (
     with_context,
 )
 from dagster.core.errors import (DagsterTypeError, DagsterInvariantViolationError)
-from dagster.utils.logging import ERROR
+from dagster.utils.logging import (INFO, ERROR)
+
+# protected variable. need to test loggers
+# pylint: disable=W0212
 
 
 def test_default_context():
@@ -23,7 +26,8 @@ def test_default_context():
     )
     @with_context
     def default_context_transform(context):
-        assert context.log_level == ERROR
+        for logger in context._logger.loggers:
+            assert logger.level == ERROR
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
     execute_pipeline(
@@ -38,13 +42,14 @@ def test_default_context_with_log_level():
     )
     @with_context
     def default_context_transform(context):
-        assert context.log_level == ERROR
+        for logger in context._logger.loggers:
+            assert logger.level == INFO
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
     execute_pipeline(
         pipeline,
         environment=config.Environment(
-            sources={}, context=config.Context('default', {'log_level': 'ERROR'})
+            sources={}, context=config.Context('default', {'log_level': 'INFO'})
         )
     )
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -68,7 +68,6 @@ def _default_pipeline_context_definitions():
 
         log_level = level_from_string(args['log_level'])
         context = dagster.core.execution.ExecutionContext(
-            log_level=log_level,
             loggers=[
                 dagster.utils.logging.define_colored_console_logger('dagster', level=log_level)
             ]

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -31,7 +31,7 @@ import six
 
 from dagster import check, config
 
-from dagster.utils.logging import (CompositeLogger, ERROR, get_formatted_stack_trace)
+from dagster.utils.logging import (CompositeLogger, get_formatted_stack_trace)
 from dagster.utils.timing import time_execution_scope
 
 from .definitions import (
@@ -66,11 +66,10 @@ class ExecutionContext:
     a user does not have to subclass ExecutionContext
     '''
 
-    def __init__(self, loggers=None, log_level=ERROR, resources=None):
-        self._logger = CompositeLogger(loggers=loggers, level=log_level)
+    def __init__(self, loggers=None, resources=None):
+        self._logger = CompositeLogger(loggers=loggers)
         self._context_dict = OrderedDict()
         self._metrics = []
-        self.log_level = log_level
         self.resources = resources
 
     def _maybe_quote(self, val):

--- a/python_modules/dagster/dagster/utils/logging.py
+++ b/python_modules/dagster/dagster/utils/logging.py
@@ -23,11 +23,8 @@ def level_from_string(string):
     return LOOKUP[string]
 
 class CompositeLogger:
-    def __init__(self, loggers=None, level=logging.ERROR):
+    def __init__(self, loggers=None):
         self.loggers = check.opt_list_param(loggers, 'loggers', of_type=logging.Logger)
-
-        for logger in self.loggers:
-            logger.setLevel(level)
 
     def __getattr__(self, name):
         def _invoke_logger_method(*args, **kwargs):
@@ -60,8 +57,7 @@ def define_json_file_logger(name, json_path, level):
     check.param_invariant(level in VALID_LEVELS, 'level', f'Must be valid python logging level. Got {level}')
 
     klass = logging.getLoggerClass()
-    logger = klass(name)
-    logger.setLevel(level)
+    logger = klass(name, level=level)
     stream_handler = JsonFileHandler(json_path)
     stream_handler.setFormatter(define_default_formatter())
     logger.addHandler(stream_handler)
@@ -73,7 +69,7 @@ def define_colored_console_logger(name, level=INFO):
     check.param_invariant(level in VALID_LEVELS, 'level', f'Must be valid python logging level. Got {level}')
 
     klass = logging.getLoggerClass()
-    logger = klass(name)
+    logger = klass(name, level=level)
     coloredlogs.install(logger=logger, level=level, fmt=default_format_string())
     return logger
 


### PR DESCRIPTION
We had log level as an argument to both the ExecutionContext and the
loggers. This was confusing. Instead, only have the loggers decide the
logging level.