### PR TITLE
Rename @solid to @transform

### DIFF
--- a/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
+++ b/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
@@ -9,7 +9,7 @@ from dagster import (
     PipelineDefinition,
     config,
     execute_pipeline,
-    solid,
+    transform,
 )
 from dagster.core.errors import DagsterExpectationFailedError
 from dagster.core.utility_solids import define_stub_solid
@@ -29,7 +29,7 @@ def col_exists(name, col_name):
     return dagster_ge.ge_expectation(name, lambda ge_df: ge_df.expect_column_to_exist(col_name))
 
 
-@solid(
+@transform(
     inputs=[
         InputDefinition(
             'num_df', dagster_pd.DataFrame, expectations=[col_exists('num1_exists', 'num1')]
@@ -41,7 +41,7 @@ def sum_solid(num_df):
     return _sum_solid_impl(num_df)
 
 
-@solid(
+@transform(
     inputs=[
         InputDefinition(
             'num_df',
@@ -55,7 +55,7 @@ def sum_solid_fails_input_expectation(num_df):
     return _sum_solid_impl(num_df)
 
 
-@solid(
+@transform(
     inputs=[
         InputDefinition(
             'num_df',

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,7 +1,13 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 from builtins import *  # pylint: disable=W0622,W0401
 
-from dagster.core.execution import execute_pipeline_iterator, execute_pipeline, PipelineExecutionResult, SolidExecutionResult
+from dagster.core.execution import (
+    PipelineExecutionResult,
+    SolidExecutionResult,
+    execute_pipeline,
+    execute_pipeline_iterator,
+)
+
 from dagster.core.execution_context import ExecutionContext
 
 from dagster.core.definitions import (
@@ -22,6 +28,7 @@ from dagster.core.definitions import (
 from dagster.core.decorators import (
     MultipleResults,
     solid,
+    transform,
     with_context,
 )
 
@@ -51,6 +58,7 @@ __all__ = [
 
     # Decorators
     'solid',
+    'transform',
     'with_context',
     'MultipleResults',
 

--- a/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
@@ -1,11 +1,10 @@
 from dagster import (
-    ConfigDefinition,
     ExecutionContext,
     OutputDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
     config,
-    solid,
+    transform,
 )
 
 from dagster.core.execution import (
@@ -25,7 +24,7 @@ def silencing_default_context():
     }
 
 
-@solid(name='noop', inputs=[], outputs=[OutputDefinition()])
+@transform(name='noop', inputs=[], outputs=[OutputDefinition()])
 def noop_solid():
     return 'foo'
 

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -9,7 +9,7 @@ from dagster import (
     PipelineContextDefinition,
     config,
     execute_pipeline,
-    solid,
+    transform,
     types,
     with_context,
 )
@@ -21,7 +21,7 @@ from dagster.utils.logging import (INFO, ERROR)
 
 
 def test_default_context():
-    @solid(
+    @transform(
         inputs=[],
         outputs=[OutputDefinition()],
     )
@@ -37,7 +37,7 @@ def test_default_context():
 
 
 def test_default_context_with_log_level():
-    @solid(
+    @transform(
         inputs=[],
         outputs=[OutputDefinition()],
     )
@@ -61,7 +61,7 @@ def test_default_context_with_log_level():
 
 def test_default_value():
     def _get_config_test_solid(config_key, config_value):
-        @solid(
+        @transform(
             inputs=[],
             outputs=[OutputDefinition()],
         )
@@ -97,7 +97,7 @@ def test_default_value():
 
 
 def test_custom_contexts():
-    @solid(
+    @transform(
         inputs=[],
         outputs=[OutputDefinition()],
     )
@@ -145,7 +145,7 @@ def test_custom_contexts():
 def test_yield_context():
     events = []
 
-    @solid(
+    @transform(
         inputs=[],
         outputs=[OutputDefinition()],
     )
@@ -189,7 +189,7 @@ def test_yield_context():
 # TODO: reenable pending the ability to specific optional arguments
 # https://github.com/dagster-io/dagster/issues/56
 def test_invalid_context():
-    @solid(
+    @transform(
         inputs=[],
         outputs=[OutputDefinition()],
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_decorator.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_decorator.py
@@ -1,0 +1,163 @@
+import pytest
+
+from dagster import (
+    ConfigDefinition,
+    DagsterTypeError,
+    ExecutionContext,
+    Field,
+    OutputDefinition,
+    Result,
+    config,
+    solid,
+    types,
+)
+
+from dagster.core.test_utils import execute_single_solid
+
+
+def _execute_empty(solid_inst):
+    execute_single_solid(
+        ExecutionContext(),
+        solid_inst,
+        config.Environment(),
+    )
+
+
+def test_solid_no_parens():
+    called = {}
+
+    @solid
+    def hello_world(_context, _inputs, _conf):
+        called['yep'] = True
+
+    pipeline_result = execute_single_solid(
+        ExecutionContext(),
+        hello_world,
+        config.Environment(),
+    )
+
+    assert pipeline_result.success
+    assert called['yep']
+
+
+def test_solid_no_args():
+    called = {}
+
+    @solid()
+    def hello_world(_context, _inputs, _conf):
+        called['yep'] = True
+
+    pipeline_result = execute_single_solid(
+        ExecutionContext(),
+        hello_world,
+        config.Environment(),
+    )
+
+    assert pipeline_result.success
+    assert called['yep']
+
+
+def test_solid():
+    @solid(outputs=[OutputDefinition()])
+    def hello_world(_context, _inputs, _conf):
+        return {'foo': 'bar'}
+
+    pipeline_result = execute_single_solid(
+        ExecutionContext(),
+        hello_world,
+        config.Environment(),
+    )
+
+    assert pipeline_result.success
+    assert len(pipeline_result.result_list) == 1
+    result = pipeline_result.result_for_solid('hello_world')
+    assert result.transformed_value()['foo'] == 'bar'
+
+
+def test_solid_yield():
+    @solid(output=OutputDefinition())
+    def hello_world(_context, _inputs, _conf):
+        yield Result(value={'foo': 'bar'})
+
+    pipeline_result = execute_single_solid(
+        ExecutionContext(),
+        hello_world,
+        config.Environment(),
+    )
+
+    assert pipeline_result.success
+    assert len(pipeline_result.result_list) == 1
+    result = pipeline_result.result_for_solid('hello_world')
+    assert result.transformed_value()['foo'] == 'bar'
+
+
+def test_solid_context():
+    test_context = ExecutionContext()
+
+    called = {}
+
+    @solid
+    def hello_world(context, _inputs, _conf):
+        called['yep'] = True
+        assert context == test_context
+
+    pipeline_result = execute_single_solid(
+        test_context,
+        hello_world,
+        config.Environment(),
+    )
+
+    assert called['yep']
+
+    assert pipeline_result.success
+
+
+def test_solid_with_any_config():
+    config_value = {'sdjkfd': 'ksjdkfdj'}
+    called = {}
+
+    @solid
+    def hello_world(_context, _inputs, conf):
+        called['yep'] = True
+        assert conf == config_value
+
+    pipeline_result = execute_single_solid(
+        ExecutionContext(),
+        hello_world,
+        config.Environment(solids={'hello_world': config.Solid(config_value)})
+    )
+
+    assert pipeline_result.success
+
+
+def test_solid_with_defined_config():
+    config_value = {'config_key': 'config_value'}
+    called = {}
+
+    @solid(config_def=ConfigDefinition(types.ConfigDictionary({'config_key': Field(types.String)})))
+    def hello_world(_context, _inputs, conf):
+        called['yep'] = True
+        assert conf == config_value
+
+    pipeline_result = execute_single_solid(
+        ExecutionContext(),
+        hello_world,
+        config.Environment(solids={'hello_world': config.Solid(config_value)})
+    )
+
+    assert pipeline_result.success
+
+
+def test_solid_with_defined_config_error():
+    @solid(config_def=ConfigDefinition(types.ConfigDictionary({'config_key': Field(types.String)})))
+    def hello_world(_context, _inputs, _conf):
+        pass
+
+    with pytest.raises(DagsterTypeError):
+        execute_single_solid(
+            ExecutionContext(),
+            hello_world,
+            config.Environment(solids={'hello_world': config.Solid({
+                'kdjfkdjkfd': 'foo'
+            })})
+        )

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -343,7 +343,7 @@ class PipelineDefinition(object):
                 raise DagsterInvalidDefinitionError(
                     '''You have passed a lambda or function {func} into
                 a pipeline that is not a solid. You have likely forgetten to annotate this function
-                with an @solid decorator located in dagster.core.decorators
+                with an @transform or similar decorator located in dagster.core.decorators.
                 '''.format(func=solid.__name__)
                 )
 

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -18,6 +18,8 @@ def execute_single_solid(context, solid, environment, throw_on_error=True):
     single_solid_environment = config.Environment(
         expectations=environment.expectations,
         context=environment.context,
+        solids={solid.name: environment.solids[solid.name]}
+        if solid.name in environment.solids else None
     )
 
     pipeline_result = execute_pipeline(

--- a/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/pipeline.py
@@ -4,12 +4,12 @@ from dagster import (
     InputDefinition,
     OutputDefinition,
     PipelineDefinition,
-    solid,
+    transform,
 )
 import dagster.pandas as dagster_pd
 
 
-@solid(
+@transform(
     inputs=[InputDefinition('num', dagster_pd.DataFrame)],
     outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
 )
@@ -19,7 +19,7 @@ def sum_solid(num):
     return sum_df
 
 
-@solid(
+@transform(
     inputs=[InputDefinition('sum_df', dagster_pd.DataFrame)],
     outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
 )
@@ -29,7 +29,7 @@ def sum_sq_solid(sum_df):
     return sum_sq_df
 
 
-@solid(
+@transform(
     inputs=[InputDefinition('sum_sq_solid', dagster_pd.DataFrame)],
     outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
 )

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
@@ -10,7 +10,7 @@ from dagster import (
     execute_pipeline,
 )
 
-from dagster.core.decorators import solid
+from dagster.core.decorators import transform
 from dagster.utils import script_relative_path
 from dagster.utils.test import get_temp_file_name
 
@@ -122,7 +122,7 @@ def create_definition_based_solid():
 
 
 def create_decorator_based_solid():
-    @solid(
+    @transform(
         inputs=[InputDefinition('num_csv', dagster_pd.DataFrame)],
         outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)],
     )

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_user_error.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_user_error.py
@@ -13,7 +13,7 @@ from dagster import (
     SolidDefinition,
     config,
     execute_pipeline,
-    solid,
+    transform,
 )
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.utility_solids import define_stub_solid
@@ -31,7 +31,7 @@ def _dataframe_solid(name, inputs, transform_fn):
 def test_wrong_output_value():
     csv_input = InputDefinition('num_csv', dagster_pd.DataFrame)
 
-    @solid(
+    @transform(
         name="test_wrong_output",
         inputs=[csv_input],
         outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
@@ -56,7 +56,7 @@ def test_wrong_output_value():
 
 
 def test_wrong_input_value():
-    @solid(
+    @transform(
         name="test_wrong_input",
         inputs=[InputDefinition('foo', dagster_pd.DataFrame)],
         outputs=[OutputDefinition()],

--- a/python_modules/dagster/docs/apidocs/decorators.rst
+++ b/python_modules/dagster/docs/apidocs/decorators.rst
@@ -5,7 +5,7 @@ Decorators
 
 A more concise way to define solids.
 
-.. autofunction:: solid
+.. autofunction:: transform
 
 .. autofunction:: with_context
 


### PR DESCRIPTION
- Rename @solid to @Transform
- Add new @solid transform which lightly wraps SolidDefinition.
Transform_fn does not change function signature
- Both @solid and @Transform now work with a decorator with no parens