### PR TITLE
lambda_solid and solid

### DIFF
--- a/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
+++ b/python_modules/dagster-ge/dagster_ge_tests/test_pandas_ge.py
@@ -9,7 +9,7 @@ from dagster import (
     PipelineDefinition,
     config,
     execute_pipeline,
-    solid,
+    lambda_solid,
 )
 from dagster.core.errors import DagsterExpectationFailedError
 from dagster.core.utility_solids import define_stub_solid
@@ -29,7 +29,7 @@ def col_exists(name, col_name):
     return dagster_ge.ge_expectation(name, lambda ge_df: ge_df.expect_column_to_exist(col_name))
 
 
-@solid(
+@lambda_solid(
     inputs=[
         InputDefinition(
             'num_df', dagster_pd.DataFrame, expectations=[col_exists('num1_exists', 'num1')]
@@ -37,11 +37,11 @@ def col_exists(name, col_name):
     ],
     output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
-def sum_solid(_context, _conf, num_df):
+def sum_solid(num_df):
     return _sum_solid_impl(num_df)
 
 
-@solid(
+@lambda_solid(
     inputs=[
         InputDefinition(
             'num_df',
@@ -51,11 +51,11 @@ def sum_solid(_context, _conf, num_df):
     ],
     output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
-def sum_solid_fails_input_expectation(_context, _conf, num_df):
+def sum_solid_fails_input_expectation(num_df):
     return _sum_solid_impl(num_df)
 
 
-@solid(
+@lambda_solid(
     inputs=[
         InputDefinition(
             'num_df',
@@ -69,7 +69,7 @@ def sum_solid_fails_input_expectation(_context, _conf, num_df):
     ],
     output=OutputDefinition(dagster_type=dagster_pd.DataFrame)
 )
-def sum_solid_expectations_config(_context, _conf, num_df):
+def sum_solid_expectations_config(num_df):
     return _sum_solid_impl(num_df)
 
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -27,6 +27,7 @@ from dagster.core.definitions import (
 
 from dagster.core.decorators import (
     MultipleResults,
+    lambda_solid,
     solid,
 )
 
@@ -55,6 +56,7 @@ __all__ = [
     'Result',
 
     # Decorators
+    'lambda_solid',
     'solid',
     'MultipleResults',
 

--- a/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
@@ -1,11 +1,9 @@
 from dagster import (
-    ConfigDefinition,
     ExecutionContext,
-    OutputDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
     config,
-    solid,
+    lambda_solid,
 )
 
 from dagster.core.execution import (
@@ -25,8 +23,8 @@ def silencing_default_context():
     }
 
 
-@solid(name='noop', inputs=[], outputs=[OutputDefinition()])
-def noop_solid(_context, _conf):
+@lambda_solid
+def noop():
     return 'foo'
 
 
@@ -36,7 +34,7 @@ def silencing_pipeline(solids):
 
 def test_compute_noop_node():
     pipeline = silencing_pipeline(solids=[
-        noop_solid,
+        noop,
     ])
 
     environment = config.Environment()

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -9,6 +9,7 @@ from dagster import (
     PipelineContextDefinition,
     config,
     execute_pipeline,
+    lambda_solid,
     solid,
     types,
 )
@@ -20,11 +21,8 @@ from dagster.utils.logging import (INFO, ERROR)
 
 
 def test_default_context():
-    @solid(
-        inputs=[],
-        outputs=[OutputDefinition()],
-    )
-    def default_context_transform(context, _conf):
+    @solid(inputs=[], outputs=[OutputDefinition()])
+    def default_context_transform(context, _):
         for logger in context._logger.loggers:
             assert logger.level == ERROR
 
@@ -35,11 +33,8 @@ def test_default_context():
 
 
 def test_default_context_with_log_level():
-    @solid(
-        inputs=[],
-        outputs=[OutputDefinition()],
-    )
-    def default_context_transform(context, _conf):
+    @solid(inputs=[], outputs=[OutputDefinition()])
+    def default_context_transform(context, _):
         for logger in context._logger.loggers:
             assert logger.level == INFO
 
@@ -58,11 +53,8 @@ def test_default_context_with_log_level():
 
 def test_default_value():
     def _get_config_test_solid(config_key, config_value):
-        @solid(
-            inputs=[],
-            outputs=[OutputDefinition()],
-        )
-        def config_test(context, _conf):
+        @solid(inputs=[], outputs=[OutputDefinition()])
+        def config_test(context, _):
             assert context.resources == {config_key: config_value}
 
         return config_test
@@ -93,11 +85,8 @@ def test_default_value():
 
 
 def test_custom_contexts():
-    @solid(
-        inputs=[],
-        outputs=[OutputDefinition()],
-    )
-    def custom_context_transform(context, _conf):
+    @solid(inputs=[], outputs=[OutputDefinition()])
+    def custom_context_transform(context, _):
         assert context.resources == {'field_one': 'value_two'}
 
     pipeline = PipelineDefinition(
@@ -140,11 +129,8 @@ def test_custom_contexts():
 def test_yield_context():
     events = []
 
-    @solid(
-        inputs=[],
-        outputs=[OutputDefinition()],
-    )
-    def custom_context_transform(context, _conf):
+    @solid(inputs=[], outputs=[OutputDefinition()])
+    def custom_context_transform(context, _):
         assert context.resources == {'field_one': 'value_two'}
         assert context._context_dict['foo'] == 'bar'  # pylint: disable=W0212
         events.append('during')
@@ -183,10 +169,7 @@ def test_yield_context():
 # TODO: reenable pending the ability to specific optional arguments
 # https://github.com/dagster-io/dagster/issues/56
 def test_invalid_context():
-    @solid(
-        inputs=[],
-        outputs=[OutputDefinition()],
-    )
+    @lambda_solid
     def never_transform():
         raise Exception('should never execute')
 

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -12,8 +12,6 @@ from .definitions import (
     check,
 )
 
-from .types import Any
-
 if hasattr(inspect, 'signature'):
     funcsigs = inspect
 else:
@@ -38,10 +36,10 @@ class MultipleResults(namedtuple('_MultipleResults', 'results')):
             OutputDefinition(name='bar'),
         ])
         def my_solid():
-            return MultipleResults([
+            return MultipleResults(
                 Result('Barb', 'foo'),
                 Result('Glarb', 'bar'),
-            ])
+            )
 
 
         @solid(outputs=[
@@ -72,24 +70,48 @@ class MultipleResults(namedtuple('_MultipleResults', 'results')):
         return MultipleResults(*results)
 
 
+class _LambdaSolid(object):
+    def __init__(
+        self,
+        name=None,
+        inputs=None,
+        output=None,
+        description=None,
+    ):
+        self.name = check.opt_str_param(name, 'name')
+        self.input_defs = check.opt_list_param(inputs, 'inputs', InputDefinition)
+        self.output_def = check.inst_param(output, 'output', OutputDefinition)
+        self.description = check.opt_str_param(description, 'description')
+
+    def __call__(self, fn):
+        check.callable_param(fn, 'fn')
+
+        if not self.name:
+            self.name = fn.__name__
+
+        _validate_transform_fn(self.name, fn, self.input_defs)
+        transform_fn = _create_lambda_solid_transform_wrapper(fn, self.input_defs, self.output_def)
+        return SolidDefinition(
+            name=self.name,
+            inputs=self.input_defs,
+            outputs=[self.output_def],
+            transform_fn=transform_fn,
+            description=self.description,
+        )
+
+
 class _Solid(object):
     def __init__(
         self,
         name=None,
         inputs=None,
         outputs=None,
-        output=None,
         description=None,
         config_def=None,
     ):
         self.name = check.opt_str_param(name, 'name')
         self.input_defs = check.opt_list_param(inputs, 'inputs', InputDefinition)
-
-        if output is not None and outputs is None:
-            self.outputs = [check.opt_inst_param(output, 'output', OutputDefinition)]
-        else:
-            self.outputs = check.opt_list_param(outputs, 'outputs', OutputDefinition)
-
+        self.outputs = check.opt_list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
         self.config_def = check.opt_inst_param(config_def, 'config_def', ConfigDefinition)
 
@@ -99,8 +121,8 @@ class _Solid(object):
         if not self.name:
             self.name = fn.__name__
 
-        _validate_transform_fn(self.name, fn, self.input_defs)
-        transform_fn = _create_transform_wrapper(fn, self.input_defs, self.outputs)
+        _validate_transform_fn(self.name, fn, self.input_defs, ['context', 'conf'])
+        transform_fn = _create_solid_transform_wrapper(fn, self.input_defs, self.outputs)
         return SolidDefinition(
             name=self.name,
             inputs=self.input_defs,
@@ -111,12 +133,64 @@ class _Solid(object):
         )
 
 
-def solid(name=None, inputs=None, output=None, outputs=None, config_def=None, description=None):
+def lambda_solid(
+    name=None,
+    inputs=None,
+    output=None,
+    description=None,
+):
+    '''(decorator) Create a simple solid
+
+    This shortcut allows the creation of simple solids that do not require
+    configuration and whose implementations do not require a context.
+
+    Lambda solids take inputs an and produce an output. The body of the function
+    should return a single value.
+
+    Args:
+        name (str): Name of solid
+        inputs (List[InputDefinition]): List of inputs
+        output (OutputDefinition): The output of the solid. Defaults to OutputDefinition()
+        description (str): Solid description
+
+    .. code-block:: python
+
+        @lambda_solid
+        def hello_world():
+            return 'hello'
+
+        @lambda_solid(inputs=[InputDefinition(name="foo")])
+        def hello_world(foo):
+            return foo
+
+    '''
+    output = output or OutputDefinition()
+
+    if callable(name):
+        check.invariant(inputs is None)
+        check.invariant(description is None)
+        return _LambdaSolid(output=output)(name)
+
+    return _LambdaSolid(
+        name=name,
+        inputs=inputs,
+        output=output,
+        description=description,
+    )
+
+
+def solid(
+    name=None,
+    inputs=None,
+    outputs=None,
+    config_def=None,
+    description=None,
+):
     '''(decorator) Create a solid with specified parameters.
 
     This shortcut simplifies core solid API by exploding arguments into kwargs of the
     transform function and omitting additional parameters when they are not needed.
-    Parameters are otherwise as per :py:class:`SolidDefinition`. 
+    Parameters are otherwise as per :py:class:`SolidDefinition`.
 
     Decorated function is the transform function itself. Instead of having to yield
     result objects, transform support multiple simpler output types.
@@ -126,6 +200,14 @@ def solid(name=None, inputs=None, output=None, outputs=None, config_def=None, de
     3. Return a :py:class:`MultipleResults`. Works like yielding several results for
        multiple outputs. Useful for solids that have multiple outputs.
     4. Yield :py:class:`Result`. Same as default transform behaviour.
+
+    Args:
+        name (str): Name of solid
+        inputs (List[InputDefinition]): List of inputs
+        outputs (List[OutputDefinition]): List of outputs
+        config_def (ConfigDefinition):
+            The configuration for this solid.
+        description (str): Description of this solid.
 
     Examples:
 
@@ -143,11 +225,11 @@ def solid(name=None, inputs=None, output=None, outputs=None, config_def=None, de
         def hello_world(context, conf):
             return {'foo': 'bar'}
 
-        @solid(output=OutputDefinition())
+        @solid(outputs=[OutputDefinition()])
         def hello_world(context, conf):
             return Result(value={'foo': 'bar'})
 
-        @solid(output=OutputDefinition())
+        @solid(outputs=[OutputDefinition()])
         def hello_world(context, conf):
             yield Result(value={'foo': 'bar'})
 
@@ -162,16 +244,32 @@ def solid(name=None, inputs=None, output=None, outputs=None, config_def=None, de
             })
 
         @solid(
-            inputs=[InputDefinition(name="foo_to_foo")],
+            inputs=[InputDefinition(name="foo")],
             outputs=[OutputDefinition()]
         )
-        def hello_world(context, conf, foo_to_foo):
-            return foo_to_foo
+        def hello_world(context, conf, foo):
+            return foo
+
+        @solid(
+            inputs=[InputDefinition(name="foo")],
+            outputs=[OutputDefinition()],
+        )
+        def hello_world(context, conf, foo):
+            context.info('log something')
+            return foo
+
+        @solid(
+            inputs=[InputDefinition(name="foo")],
+            outputs=[OutputDefinition()],
+            config_def=ConfigDefinition(types.ConfigDictionary({'str_value' : Field(types.String)})),
+        )
+        def hello_world(context, conf, foo):
+            # conf is a dictionary with 'str_value' key
+            return foo
 
     '''
     if callable(name):
         check.invariant(inputs is None)
-        check.invariant(output is None)
         check.invariant(outputs is None)
         check.invariant(description is None)
         check.invariant(config_def is None)
@@ -180,17 +278,37 @@ def solid(name=None, inputs=None, output=None, outputs=None, config_def=None, de
     return _Solid(
         name=name,
         inputs=inputs,
-        output=output,
         outputs=outputs,
         config_def=config_def,
         description=description,
     )
 
 
-# TODO change names and check types
-def _create_transform_wrapper(fn, inputs, outputs):
+def _create_lambda_solid_transform_wrapper(fn, input_defs, output_def):
     check.callable_param(fn, 'fn')
-    input_names = [input.name for input in inputs]
+    check.list_param(input_defs, 'input_defs', of_type=InputDefinition)
+    check.inst_param(output_def, 'output_def', OutputDefinition)
+
+    input_names = [input_def.name for input_def in input_defs]
+
+    @wraps(fn)
+    def transform(_context, inputs, _conf):
+        kwargs = {}
+        for input_name in input_names:
+            kwargs[input_name] = inputs[input_name]
+
+        result = fn(**kwargs)
+        yield Result(value=result, output_name=output_def.name)
+
+    return transform
+
+
+def _create_solid_transform_wrapper(fn, input_defs, output_defs):
+    check.callable_param(fn, 'fn')
+    check.list_param(input_defs, 'input_defs', of_type=InputDefinition)
+    check.list_param(output_defs, 'output_defs', of_type=OutputDefinition)
+
+    input_names = [input_def.name for input_def in input_defs]
 
     @wraps(fn)
     def transform(context, args, conf):
@@ -209,8 +327,8 @@ def _create_transform_wrapper(fn, inputs, outputs):
             elif isinstance(result, MultipleResults):
                 for item in result.results:
                     yield item
-            elif len(outputs) == 1:
-                yield Result(value=result, output_name=outputs[0].name)
+            elif len(output_defs) == 1:
+                yield Result(value=result, output_name=output_defs[0].name)
             elif result is not None:
                 # XXX(freiksenet)
                 raise Exception('Output for a solid without an output.')
@@ -233,10 +351,18 @@ class FunctionValidationError(Exception):
         self.missing_names = missing_names
 
 
-def _validate_transform_fn(solid_name, transform_fn, inputs):
+def _validate_transform_fn(solid_name, transform_fn, inputs, expected_positionals=None):
+    check.str_param(solid_name, 'solid_name')
+    check.callable_param(transform_fn, 'transform_fn')
+    check.list_param(inputs, 'inputs', of_type=InputDefinition)
+    expected_positionals = check.opt_list_param(
+        expected_positionals,
+        'expected_positionals',
+        of_type=str,
+    )
+
     names = set(inp.name for inp in inputs)
     # Currently being super strict about naming. Might be a good idea to relax. Starting strict.
-    expected_positionals = ('context', 'conf')
     try:
         _validate_decorated_fn(transform_fn, names, expected_positionals)
     except FunctionValidationError as e:
@@ -277,8 +403,10 @@ def _validate_decorated_fn(fn, names, expected_positionals):
 
     for expected, actual in zip(expected_positionals, expected_positional_params):
         possible_names = [
-            expected, '_{expected}'.format(expected=expected),
-            '{expected}_'.format(expected=expected)
+            '_',
+            expected,
+            '_{expected}'.format(expected=expected),
+            '{expected}_'.format(expected=expected),
         ]
         if (
             actual.kind not in [

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -344,7 +344,7 @@ class PipelineDefinition(object):
                 raise DagsterInvalidDefinitionError(
                     '''You have passed a lambda or function {func} into
                 a pipeline that is not a solid. You have likely forgetten to annotate this function
-                with an @solid decorator located in dagster.core.decorators
+                with an @solid or @lambda_solid decorator located in dagster.core.decorators
                 '''.format(func=solid.__name__)
                 )
 

--- a/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/pandas_hello_world/pipeline.py
@@ -4,36 +4,36 @@ from dagster import (
     InputDefinition,
     OutputDefinition,
     PipelineDefinition,
-    solid,
+    lambda_solid,
 )
 import dagster.pandas as dagster_pd
 
 
-@solid(
+@lambda_solid(
     inputs=[InputDefinition('num', dagster_pd.DataFrame)],
-    outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
-def sum_solid(_context, _conf, num):
+def sum_solid(num):
     sum_df = num.copy()
     sum_df['sum'] = sum_df['num1'] + sum_df['num2']
     return sum_df
 
 
-@solid(
+@lambda_solid(
     inputs=[InputDefinition('sum_df', dagster_pd.DataFrame)],
-    outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
-def sum_sq_solid(_context, _conf, sum_df):
+def sum_sq_solid(sum_df):
     sum_sq_df = sum_df.copy()
     sum_sq_df['sum_sq'] = sum_df['sum']**2
     return sum_sq_df
 
 
-@solid(
+@lambda_solid(
     inputs=[InputDefinition('sum_sq_solid', dagster_pd.DataFrame)],
-    outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
-def always_fails_solid(_context, _conf, **_kwargs):
+def always_fails_solid(**_kwargs):
     raise Exception('I am a programmer and I make error')
 
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
@@ -8,9 +8,9 @@ from dagster import (
     SolidDefinition,
     config,
     execute_pipeline,
+    lambda_solid,
 )
 
-from dagster.core.decorators import solid
 from dagster.utils import script_relative_path
 from dagster.utils.test import get_temp_file_name
 
@@ -122,11 +122,11 @@ def create_definition_based_solid():
 
 
 def create_decorator_based_solid():
-    @solid(
+    @lambda_solid(
         inputs=[InputDefinition('num_csv', dagster_pd.DataFrame)],
-        outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)],
+        output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
     )
-    def hello_world(_context, _conf, num_csv):
+    def hello_world(num_csv):
         num_csv['sum'] = num_csv['num1'] + num_csv['num2']
         return num_csv
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_solids.py
@@ -11,7 +11,7 @@ from dagster import (
     SolidDefinition,
     check,
     config,
-    solid,
+    lambda_solid,
 )
 
 from dagster.core.execution import (
@@ -176,30 +176,30 @@ def create_sum_table():
     )
 
 
-@solid(
+@lambda_solid(
     inputs=[InputDefinition('num_csv', dagster_pd.DataFrame)],
-    outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)],
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
-def sum_table(_context, _conf, num_csv):
+def sum_table(num_csv):
     check.inst_param(num_csv, 'num_csv', pd.DataFrame)
     num_csv['sum'] = num_csv['num1'] + num_csv['num2']
     return num_csv
 
 
-@solid(
+@lambda_solid(
     inputs=[InputDefinition('sum_df', dagster_pd.DataFrame)],
-    outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)],
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
-def sum_sq_table(_context, _conf, sum_df):
+def sum_sq_table(sum_df):
     sum_df['sum_squared'] = sum_df['sum'] * sum_df['sum']
     return sum_df
 
 
-@solid(
+@lambda_solid(
     inputs=[InputDefinition('sum_table_renamed', dagster_pd.DataFrame)],
-    outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)],
+    output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
 )
-def sum_sq_table_renamed_input(_context, _conf, sum_table_renamed):
+def sum_sq_table_renamed_input(sum_table_renamed):
     sum_table_renamed['sum_squared'] = sum_table_renamed['sum'] * sum_table_renamed['sum']
     return sum_table_renamed
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_user_error.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_user_error.py
@@ -13,7 +13,7 @@ from dagster import (
     SolidDefinition,
     config,
     execute_pipeline,
-    solid,
+    lambda_solid,
 )
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.utility_solids import define_stub_solid
@@ -31,12 +31,12 @@ def _dataframe_solid(name, inputs, transform_fn):
 def test_wrong_output_value():
     csv_input = InputDefinition('num_csv', dagster_pd.DataFrame)
 
-    @solid(
+    @lambda_solid(
         name="test_wrong_output",
         inputs=[csv_input],
-        outputs=[OutputDefinition(dagster_type=dagster_pd.DataFrame)]
+        output=OutputDefinition(dagster_type=dagster_pd.DataFrame),
     )
-    def df_solid(_context, _conf, num_csv):
+    def df_solid(num_csv):
         return 'not a dataframe'
 
     pass_solid = define_stub_solid('pass_solid', pd.DataFrame())
@@ -56,12 +56,11 @@ def test_wrong_output_value():
 
 
 def test_wrong_input_value():
-    @solid(
+    @lambda_solid(
         name="test_wrong_input",
         inputs=[InputDefinition('foo', dagster_pd.DataFrame)],
-        outputs=[OutputDefinition()],
     )
-    def df_solid(_context, _conf, foo):
+    def df_solid(foo):
         return foo
 
     pass_solid = define_stub_solid('pass_solid', 'not a dataframe')

--- a/python_modules/dagster/docs/apidocs/decorators.rst
+++ b/python_modules/dagster/docs/apidocs/decorators.rst
@@ -5,6 +5,8 @@ Decorators
 
 A more concise way to define solids.
 
+.. autofunction:: lambda_solid
+
 .. autofunction:: solid
 
 .. autoclass:: MultipleResults

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -18,7 +18,7 @@ def long_description():
 
 setup(
     name='dagster',
-    version='0.2.0.dev5',
+    version='0.2.0.dev8',
     author='Elementl',
     author_email='schrockn@elementl.com',
     license='Apache-2.0',


### PR DESCRIPTION
There are now two flavors of decorator.

1) `lambda_solid`. Takes inputs. No config or context. Produces a single output. Only
return naked value out of the transform.

2) `solid`. Takes inputs, produces outputs. Accepts context and config.
The transform can return a naked value, a Result, or a generator that
yields a sequence of Results.

This satisfies the need/desire for "simple" and introductory use cases
for solids (in the form of a lambda_solid) relatively elegantly but then
has a decorator-style solid that can cover nearly all use cases.