### PR TITLE
Change order of arguments to transform function in SolidDefintion

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -16,13 +16,13 @@ def solid_a_b_list():
             name='A',
             inputs=[],
             outputs=[OutputDefinition()],
-            transform_fn=lambda context, inputs, config: None,
+            transform_fn=lambda context, conf, inputs: None,
         ),
         SolidDefinition(
             name='B',
             inputs=[InputDefinition('b_input')],
             outputs=[],
-            transform_fn=lambda context, inputs, config: None,
+            transform_fn=lambda context, conf, inputs: None,
         )
     ]
 

--- a/python_modules/dagster/dagster/core/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_multiple_outputs.py
@@ -16,7 +16,7 @@ from dagster import (
 
 
 def test_multiple_outputs():
-    def _t_fn(_context, _inputs, _config_dict):
+    def _t_fn(*_args):
         yield Result(output_name='output_one', value='foo')
         yield Result(output_name='output_two', value='bar')
 
@@ -87,7 +87,7 @@ def test_multiple_outputs_expectations():
 
 
 def test_wrong_multiple_output():
-    def _t_fn(_context, _inputs, _config_dict):
+    def _t_fn(*args):
         yield Result(output_name='mismatch', value='foo')
 
     solid = SolidDefinition(
@@ -108,7 +108,7 @@ def test_wrong_multiple_output():
 def test_multiple_outputs_of_same_name_disallowed():
     # make this illegal until it is supported
 
-    def _t_fn(_context, _inputs, _config_dict):
+    def _t_fn(*args):
         yield Result(output_name='output_one', value='foo')
         yield Result(output_name='output_one', value='foo')
 
@@ -128,7 +128,7 @@ def test_multiple_outputs_of_same_name_disallowed():
 
 
 def test_multiple_outputs_only_emit_one():
-    def _t_fn(_context, _inputs, _config_dict):
+    def _t_fn(*args):
         yield Result(output_name='output_one', value='foo')
 
     solid = SolidDefinition(

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -20,8 +20,8 @@ def define_pass_value_solid(name, description=None):
     check.str_param(name, 'name')
     check.opt_str_param(description, 'description')
 
-    def _value_t_fn(_context, _inputs, config_dict):
-        yield Result(config_dict['value'])
+    def _value_t_fn(_context, conf, _inputs):
+        yield Result(conf['value'])
 
     return SolidDefinition(
         name=name,
@@ -39,7 +39,7 @@ def test_execute_solid_with_input_same_name():
     a_thing_solid = SolidDefinition.single_output_transform(
         'a_thing',
         inputs=[InputDefinition(name='a_thing')],
-        transform_fn=lambda context, args: args['a_thing'] + args['a_thing'],
+        transform_fn=lambda context, inputs: inputs['a_thing'] + inputs['a_thing'],
         output=dagster.OutputDefinition(),
     )
 
@@ -66,14 +66,14 @@ def test_execute_two_solids_with_same_input_name():
     solid_one = SolidDefinition.single_output_transform(
         'solid_one',
         inputs=[input_def],
-        transform_fn=lambda context, args: args['a_thing'] + args['a_thing'],
+        transform_fn=lambda context, inputs: inputs['a_thing'] + inputs['a_thing'],
         output=dagster.OutputDefinition(),
     )
 
     solid_two = SolidDefinition.single_output_transform(
         'solid_two',
         inputs=[input_def],
-        transform_fn=lambda context, args: args['a_thing'] + args['a_thing'],
+        transform_fn=lambda context, inputs: inputs['a_thing'] + inputs['a_thing'],
         output=dagster.OutputDefinition(),
     )
 
@@ -120,7 +120,7 @@ def test_execute_dep_solid_different_input_name():
     first_solid = SolidDefinition.single_output_transform(
         'first_solid',
         inputs=[InputDefinition(name='a_thing')],
-        transform_fn=lambda context, args: args['a_thing'] + args['a_thing'],
+        transform_fn=lambda context, inputs: inputs['a_thing'] + inputs['a_thing'],
         output=dagster.OutputDefinition(),
     )
 
@@ -129,7 +129,7 @@ def test_execute_dep_solid_different_input_name():
         inputs=[
             InputDefinition(name='an_input'),
         ],
-        transform_fn=lambda context, args: args['an_input'] + args['an_input'],
+        transform_fn=lambda context, inputs: inputs['an_input'] + inputs['an_input'],
         output=dagster.OutputDefinition(),
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -80,9 +80,9 @@ def test_failure_midstream():
     solid_a = create_root_success_solid('A')
     solid_b = create_root_success_solid('B')
 
-    def transform_fn(_context, args):
+    def transform_fn(_context, inputs):
         check.failed('user error')
-        return [args['A'], args['B'], {'C': 'transform_called'}]
+        return [inputs['A'], inputs['B'], {'C': 'transform_called'}]
 
     solid_c = SolidDefinition.single_output_transform(
         name='C',

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -35,10 +35,10 @@ def create_dep_input_fn(name):
 
 
 def make_transform(name):
-    def transform(_context, args):
+    def transform(_context, inputs):
         passed_rows = []
         seen = set()
-        for row in args.values():
+        for row in inputs.values():
             for item in row:
                 key = list(item.keys())[0]
                 if key not in seen:

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -16,8 +16,8 @@ from dagster.core.errors import DagsterTypeError
 def test_basic_solid_with_config():
     did_get = {}
 
-    def _t_fn(_context, _inputs, config_dict):
-        did_get['yep'] = config_dict
+    def _t_fn(_context, conf, _inputs):
+        did_get['yep'] = conf
 
     solid = SolidDefinition(
         name='solid_with_context',
@@ -43,7 +43,7 @@ def test_basic_solid_with_config():
 
 
 def test_config_arg_mismatch():
-    def _t_fn(_context, _inputs, _config_dict):
+    def _t_fn(*args):
         raise Exception('should not reach')
 
     solid = SolidDefinition(

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -292,7 +292,7 @@ def _create_lambda_solid_transform_wrapper(fn, input_defs, output_def):
     input_names = [input_def.name for input_def in input_defs]
 
     @wraps(fn)
-    def transform(_context, inputs, _conf):
+    def transform(_context, _conf, inputs):
         kwargs = {}
         for input_name in input_names:
             kwargs[input_name] = inputs[input_name]
@@ -311,10 +311,10 @@ def _create_solid_transform_wrapper(fn, input_defs, output_defs):
     input_names = [input_def.name for input_def in input_defs]
 
     @wraps(fn)
-    def transform(context, args, conf):
+    def transform(context, conf, inputs):
         kwargs = {}
         for input_name in input_names:
-            kwargs[input_name] = args[input_name]
+            kwargs[input_name] = inputs[input_name]
 
         result = fn(context, conf, **kwargs)
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -880,7 +880,7 @@ class SolidDefinition(object):
 
         '''
 
-        def _new_transform_fn(context, inputs, _config_dict):
+        def _new_transform_fn(context, _conf, inputs):
             value = transform_fn(context, inputs)
             if isinstance(value, Result):
                 raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/core/utility_solids.py
+++ b/python_modules/dagster/dagster/core/utility_solids.py
@@ -9,7 +9,7 @@ from dagster import (
 def define_stub_solid(name, value):
     check.str_param(name, 'name')
 
-    def _value_t_fn(_context, _inputs, _config_dict):
+    def _value_t_fn(*_args):
         yield Result(value)
 
     return SolidDefinition(

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -31,8 +31,8 @@ DataFrame = _create_dataframe_type()
 def load_csv_solid(name):
     check.str_param(name, 'name')
 
-    def _t_fn(_context, _inputs, config_dict):
-        yield Result(pd.read_csv(config_dict['path']))
+    def _t_fn(_context, conf, _inputs):
+        yield Result(pd.read_csv(conf['path']))
 
     return SolidDefinition(
         name=name,
@@ -46,8 +46,8 @@ def load_csv_solid(name):
 
 
 def to_csv_solid(name):
-    def _t_fn(_context, inputs, config_dict):
-        inputs['df'].to_csv(config_dict['path'], index=False)
+    def _t_fn(_context, conf, inputs):
+        inputs['df'].to_csv(conf['path'], index=False)
 
     return SolidDefinition(
         name=name,
@@ -61,8 +61,8 @@ def to_csv_solid(name):
 
 
 def to_parquet_solid(name):
-    def _t_fn(_context, inputs, config_dict):
-        inputs['df'].to_parquet(config_dict['path'])
+    def _t_fn(_context, conf, inputs):
+        inputs['df'].to_parquet(conf['path'])
 
     return SolidDefinition(
         name=name,

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
@@ -106,8 +106,8 @@ def run_hello_world(hello_world):
 def create_definition_based_solid():
     table_input = InputDefinition('num_csv', dagster_pd.DataFrame)
 
-    def transform_fn(_context, args):
-        num_csv = args['num_csv']
+    def transform_fn(_context, inputs):
+        num_csv = inputs['num_csv']
         num_csv['sum'] = num_csv['num1'] + num_csv['num2']
         return num_csv
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -18,8 +18,8 @@ from dagster.utils import script_relative_path
 
 
 def define_read_csv_solid(name):
-    def _t_fn(_context, _inputs, config_dict):
-        yield Result(pd.read_csv(config_dict['path']))
+    def _t_fn(_context, conf, _inputs):
+        yield Result(pd.read_csv(conf['path']))
 
     return SolidDefinition(
         name=name,
@@ -33,8 +33,8 @@ def define_read_csv_solid(name):
 
 
 def define_to_csv_solid(name):
-    def _t_fn(_context, inputs, config_dict):
-        inputs['df'].to_csv(config_dict['path'], index=False)
+    def _t_fn(_context, conf, inputs):
+        inputs['df'].to_csv(conf['path'], index=False)
 
     return SolidDefinition(
         name=name,
@@ -48,8 +48,8 @@ def define_to_csv_solid(name):
 
 
 def test_hello_world_pipeline_no_api():
-    def hello_world_transform_fn(_context, args):
-        num_df = args['num_df']
+    def hello_world_transform_fn(_context, inputs):
+        num_df = inputs['num_df']
         num_df['sum'] = num_df['num1'] + num_df['num2']
         return num_df
 
@@ -94,8 +94,8 @@ def test_hello_world_pipeline_no_api():
 
 
 def create_hello_world_solid_composed_pipeline():
-    def transform_fn(_context, args):
-        num_df = args['num_df']
+    def transform_fn(_context, inputs):
+        num_df = inputs['num_df']
         num_df['sum'] = num_df['num1'] + num_df['num2']
         return num_df
 
@@ -142,8 +142,8 @@ def test_hello_world_composed():
 
 
 def test_pandas_hello_no_library():
-    def solid_one_transform(_context, args):
-        num_df = args['num_df']
+    def solid_one_transform(_context, inputs):
+        num_df = inputs['num_df']
         num_df['sum'] = num_df['num1'] + num_df['num2']
         return num_df
 
@@ -154,8 +154,8 @@ def test_pandas_hello_no_library():
         output=OutputDefinition(),
     )
 
-    def solid_two_transform(_context, args):
-        sum_df = args['sum_df']
+    def solid_two_transform(_context, inputs):
+        sum_df = inputs['sum_df']
         sum_df['sum_sq'] = sum_df['sum'] * sum_df['sum']
         return sum_df
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_solids.py
@@ -70,8 +70,8 @@ def create_test_context():
 def test_basic_pandas_solid():
     csv_input = InputDefinition('num_csv', dagster_pd.DataFrame)
 
-    def transform(_context, args):
-        num_csv = args['num_csv']
+    def transform(_context, inputs):
+        num_csv = inputs['num_csv']
         num_csv['sum'] = num_csv['num1'] + num_csv['num2']
         return num_csv
 
@@ -107,9 +107,9 @@ def test_pandas_csv_to_csv():
     csv_input = InputDefinition('num_csv', dagster_pd.DataFrame)
 
     # just adding a second context arg to test that
-    def transform(context, args):
+    def transform(context, inputs):
         check.inst_param(context, 'context', ExecutionContext)
-        num_csv = args['num_csv']
+        num_csv = inputs['num_csv']
         num_csv['sum'] = num_csv['num1'] + num_csv['num2']
         return num_csv
 
@@ -163,8 +163,8 @@ def execute_transform_in_temp_csv_files(solid_inst):
 
 
 def create_sum_table():
-    def transform(_context, args):
-        num_csv = args['num_csv']
+    def transform(_context, inputs):
+        num_csv = inputs['num_csv']
         check.inst_param(num_csv, 'num_csv', pd.DataFrame)
         num_csv['sum'] = num_csv['num1'] + num_csv['num2']
         return num_csv
@@ -232,9 +232,9 @@ def _sum_only_pipeline():
 
 
 def test_two_input_solid():
-    def transform(_context, args):
-        num_csv1 = args['num_csv1']
-        num_csv2 = args['num_csv2']
+    def transform(_context, inputs):
+        num_csv1 = inputs['num_csv1']
+        num_csv2 = inputs['num_csv2']
         check.inst_param(num_csv1, 'num_csv1', pd.DataFrame)
         check.inst_param(num_csv2, 'num_csv2', pd.DataFrame)
         num_csv1['sum'] = num_csv1['num1'] + num_csv2['num2']
@@ -287,7 +287,7 @@ def test_no_transform_solid():
     num_table = _dataframe_solid(
         name='num_table',
         inputs=[InputDefinition('num_csv', dagster_pd.DataFrame)],
-        transform_fn=lambda _context, args: args['num_csv'],
+        transform_fn=lambda _context, inputs: inputs['num_csv'],
     )
     context = create_test_context()
     df = get_solid_transformed_value(
@@ -329,11 +329,11 @@ def create_diamond_dag():
     num_table_solid = _dataframe_solid(
         name='num_table',
         inputs=[InputDefinition('num_csv', dagster_pd.DataFrame)],
-        transform_fn=lambda _context, args: args['num_csv'],
+        transform_fn=lambda _context, inputs: inputs['num_csv'],
     )
 
-    def sum_transform(_context, args):
-        num_df = args['num_table']
+    def sum_transform(_context, inputs):
+        num_df = inputs['num_table']
         sum_df = num_df.copy()
         sum_df['sum'] = num_df['num1'] + num_df['num2']
         return sum_df
@@ -344,8 +344,8 @@ def create_diamond_dag():
         transform_fn=sum_transform,
     )
 
-    def mult_transform(_context, args):
-        num_table = args['num_table']
+    def mult_transform(_context, inputs):
+        num_table = inputs['num_table']
         mult_table = num_table.copy()
         mult_table['mult'] = num_table['num1'] * num_table['num2']
         return mult_table
@@ -356,9 +356,9 @@ def create_diamond_dag():
         transform_fn=mult_transform,
     )
 
-    def sum_mult_transform(_context, args):
-        sum_df = args['sum_table']
-        mult_df = args['mult_table']
+    def sum_mult_transform(_context, inputs):
+        sum_df = inputs['sum_table']
+        mult_df = inputs['mult_table']
         sum_mult_table = sum_df.copy()
         sum_mult_table['mult'] = mult_df['mult']
         sum_mult_table['sum_mult'] = sum_df['sum'] * mult_df['mult']
@@ -597,8 +597,8 @@ def test_pandas_multiple_inputs():
         },
     )
 
-    def transform_fn(_context, args):
-        return args['num_csv1'] + args['num_csv2']
+    def transform_fn(_context, inputs):
+        return inputs['num_csv1'] + inputs['num_csv2']
 
     double_sum = _dataframe_solid(
         name='double_sum',

--- a/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
@@ -48,10 +48,10 @@ class DagsterSqlTableExpression(DagsterSqlExpression):
 
 
 def define_create_table_solid(name):
-    def _materialization_fn(context, inputs, config_dict):
+    def _materialization_fn(context, conf, inputs):
         sql_expr = inputs['expr']
         check.inst(sql_expr, DagsterSqlExpression)
-        output_table_name = check.str_elem(config_dict, 'table_name')
+        output_table_name = check.str_elem(conf, 'table_name')
         total_sql = '''CREATE TABLE {output_table_name} AS {query_text}'''.format(
             output_table_name=output_table_name, query_text=sql_expr.query_text
         )
@@ -77,9 +77,9 @@ def _table_name_read_fn(_context, arg_dict):
 
 
 def create_sql_transform(sql_text):
-    def transform_fn(_context, args):
+    def transform_fn(_context, inputs):
         sql_texts = {}
-        for name, sql_expr in args.items():
+        for name, sql_expr in inputs.items():
             sql_texts[name] = sql_expr.from_target
 
         return DagsterSqlQueryExpression(sql_text.format(**sql_texts))

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -42,9 +42,9 @@ def _render_template_string(template_text, config_dict):
 
 
 def _create_templated_sql_transform_with_output(sql):
-    def do_transform(context, _inputs, config_dict):
-        rendered_sql = _render_template_string(sql, config_dict)
+    def do_transform(context, conf, _inputs):
+        rendered_sql = _render_template_string(sql, conf)
         execute_sql_text_on_context(context, rendered_sql)
-        yield Result(config_dict)
+        yield Result(conf)
 
     return do_transform

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -18,7 +18,7 @@ def long_description():
 
 setup(
     name='dagster',
-    version='0.2.0.dev8',
+    version='0.2.0.dev9',
     author='Elementl',
     author_email='schrockn@elementl.com',
     license='Apache-2.0',


### PR DESCRIPTION
To be consistent with decorators (and logic generally), now:

context, conf, inputs