### PR TITLE
fixes templating issue with sql alchemy 

### DIFF
--- a/python_modules/dagster/dagster/sqlalchemy_kernel/common.py
+++ b/python_modules/dagster/dagster/sqlalchemy_kernel/common.py
@@ -76,5 +76,5 @@ def execute_sql_text_on_context(context, sql_text):
     else:
         connection = engine.connect()
         transaction = connection.begin()
-        connection.execute(sql_text)
+        connection.execute(sqlalchemy.text(sql_text))
         transaction.commit()


### PR DESCRIPTION
Construct a sql alchemy `TextClause` prior to executing the sql.  This allows for characters like `%` to be used in SQL statement without having to perform extra escaping within the SQL itself.

per: 
* https://stackoverflow.com/questions/3325467/elixir-sqlalchemy-equivalent-to-sql-like-statement
* http://docs.sqlalchemy.org/en/latest/core/sqlelement.html?highlight=sqlalchemy%20text#sqlalchemy.sql.expression.text
