### PR TITLE
Vertical DAG layout, drawn "ports", collapse many inputs/outputs

### DIFF
--- a/python_modules/.vscode/settings.json
+++ b/python_modules/.vscode/settings.json
@@ -25,7 +25,7 @@
     "--no-strict-optional",
     "--allow-subclassing-any"
   ],
-  "files.autoSave": "onFocusChange",
+  // "files.autoSave": "onSave",
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,
@@ -55,7 +55,7 @@
   },
   "python.venvPath": "/Users/schrockn/venvs",
   "editor.formatOnSave": true,
-  "editor.formatOnPaste": true,
+  // "editor.formatOnPaste": true,
   "python.formatting.provider": "yapf",
   "python.formatting.yapfArgs": [
     "--style",

--- a/python_modules/.vscode/settings.json
+++ b/python_modules/.vscode/settings.json
@@ -25,7 +25,7 @@
     "--no-strict-optional",
     "--allow-subclassing-any"
   ],
-  // "files.autoSave": "onSave",
+  "files.autoSave": "onFocusChange",
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,
@@ -55,7 +55,7 @@
   },
   "python.venvPath": "/Users/schrockn/venvs",
   "editor.formatOnSave": true,
-  // "editor.formatOnPaste": true,
+  "editor.formatOnPaste": true,
   "python.formatting.provider": "yapf",
   "python.formatting.yapfArgs": [
     "--style",

--- a/python_modules/dagit/dagit/webapp/src/Pipeline.tsx
+++ b/python_modules/dagit/dagit/webapp/src/Pipeline.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { History } from "history";
 import { Switch, Route, match } from "react-router";
 import { Link } from "react-router-dom";
-import { Card, H3, H5, Text, Code, UL, H6 } from "@blueprintjs/core";
+import { Card, H3, H5, Code } from "@blueprintjs/core";
 import SpacedCard from "./SpacedCard";
 import Config from "./Config";
 import Solid from "./Solid";
@@ -194,7 +194,7 @@ const Section = styled.div`
 `;
 
 const PipelineGraphWrapper = styled(Section)`
-  height: 500px;
+  height: 700px;
   width: 100%;
   display: flex;
 `;

--- a/python_modules/dagit/dagit/webapp/src/TypeWithTooltip.tsx
+++ b/python_modules/dagit/dagit/webapp/src/TypeWithTooltip.tsx
@@ -38,7 +38,7 @@ export default class TypeWithTooltip extends React.Component<
   }
 }
 
-const TypeName = styled.code`
+export const TypeName = styled.code`
   background: #d6ecff;
   border: none;
   padding: 1px 4px;

--- a/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -25,10 +25,10 @@ Array [
     </div>
   </div>,
   <div
-    className="sc-cMljjf fjCaRe"
+    className="sc-csuQGl kSKEbl"
   >
     <div
-      className="bp3-tabs bp3-vertical sc-jAaTju kPqiQR"
+      className="bp3-tabs bp3-vertical sc-Rmtcm bfVNwj"
     >
       <div
         className="bp3-tab-list"

--- a/python_modules/dagit/dagit/webapp/src/graph/PipelineColorScale.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/PipelineColorScale.ts
@@ -6,7 +6,7 @@ const PipelineColorScale = scaleOrdinal({
   range: [
     Colors.TURQUOISE5,
     Colors.TURQUOISE3,
-    Colors.GRAY5,
+    "#DBE6EE",
     Colors.ORANGE3,
     Colors.ORANGE5
   ]

--- a/python_modules/dagit/dagit/webapp/src/graph/PipelineGraph.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/PipelineGraph.tsx
@@ -47,16 +47,7 @@ export default class PipelineGraph extends React.Component<
             height={layout.height}
             onMouseDown={evt => evt.preventDefault()}
           >
-            {pipeline.solids.map(solid => (
-              <SolidNode
-                key={solid.name}
-                solid={solid}
-                onClick={onClickSolid}
-                layout={layout.solids[solid.name]}
-                selected={selectedSolid === solid.name}
-              />
-            ))}
-            <g>
+            <g style={{ opacity: 0.2 }}>
               {layout.connections.map(({ from, to }, i) => (
                 <StyledLink
                   key={i}
@@ -71,6 +62,15 @@ export default class PipelineGraph extends React.Component<
                 />
               ))}
             </g>
+            {pipeline.solids.map(solid => (
+              <SolidNode
+                key={solid.name}
+                solid={solid}
+                onClick={onClickSolid}
+                layout={layout.solids[solid.name]}
+                selected={selectedSolid === solid.name}
+              />
+            ))}
           </SVGContainer>
         </PanAndZoomStyled>
       </GraphWrapper>
@@ -97,8 +97,7 @@ const SVGContainer = styled.svg`
 `;
 
 const StyledLink = styled(Link)`
-  stroke-width: 2;
+  stroke-width: 6;
   stroke: ${Colors.BLACK}
-  strokeOpacity: 0.6;
   fill: none;
 `;

--- a/python_modules/dagit/dagit/webapp/src/graph/PipelineGraph.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/PipelineGraph.tsx
@@ -2,13 +2,10 @@ import * as React from "react";
 import gql from "graphql-tag";
 import styled from "styled-components";
 import { Colors } from "@blueprintjs/core";
-import { LinkHorizontal as Link } from "@vx/shape";
+import { LinkVertical as Link } from "@vx/shape";
 import PanAndZoom from "./PanAndZoom";
 import SolidNode from "./SolidNode";
-import {
-  getDagrePipelineLayout,
-  IFullPipelineLayout
-} from "./getFullSolidLayout";
+import { getDagrePipelineLayout, IPoint } from "./getFullSolidLayout";
 import { PipelineGraphFragment } from "./types/PipelineGraphFragment";
 
 interface IPipelineGraphProps {
@@ -34,74 +31,14 @@ export default class PipelineGraph extends React.Component<
     `
   };
 
-  renderSolids(layout: IFullPipelineLayout) {
-    return this.props.pipeline.solids.map(solid => {
-      const solidLayout = layout.solids[solid.name];
-      return (
-        <SolidNode
-          key={solid.name}
-          solid={solid}
-          layout={solidLayout}
-          onClick={this.props.onClickSolid}
-          selected={this.props.selectedSolid === solid.name}
-        />
-      );
-    });
-  }
-
-  renderConnections(layout: IFullPipelineLayout) {
-    const connections: Array<{
-      from: { solidName: string; outputName: string };
-      to: { solidName: string; inputName: string };
-    }> = [];
-
-    this.props.pipeline.solids.forEach(solid => {
-      solid.inputs.forEach(input => {
-        if (input.dependsOn) {
-          connections.push({
-            from: {
-              solidName: input.dependsOn.solid.name,
-              outputName: input.dependsOn.definition.name
-            },
-            to: {
-              solidName: solid.name,
-              inputName: input.definition.name
-            }
-          });
-        }
-      });
-    });
-
-    const links = connections.map(
-      (
-        {
-          from: { solidName: outputSolidName, outputName },
-          to: { solidName: inputSolidName, inputName }
-        },
-        i
-      ) => (
-        <StyledLink
-          key={i}
-          data={{
-            source: layout.solids[outputSolidName].outputs[outputName].port,
-            target: layout.solids[inputSolidName].inputs[inputName].port
-          }}
-          x={(d: { x: number; y: number }) => d.x}
-          y={(d: { x: number; y: number }) => d.y}
-        />
-      )
-    );
-
-    return <g>{links}</g>;
-  }
-
   render() {
+    const { pipeline, onClickSolid, selectedSolid } = this.props;
     const layout = getDagrePipelineLayout(this.props.pipeline);
 
     return (
       <GraphWrapper>
         <PanAndZoomStyled
-          key={this.props.pipeline.name}
+          key={pipeline.name}
           graphWidth={layout.width}
           graphHeight={layout.height}
         >
@@ -110,8 +47,30 @@ export default class PipelineGraph extends React.Component<
             height={layout.height}
             onMouseDown={evt => evt.preventDefault()}
           >
-            {this.renderConnections(layout)}
-            {this.renderSolids(layout)}
+            {pipeline.solids.map(solid => (
+              <SolidNode
+                key={solid.name}
+                solid={solid}
+                onClick={onClickSolid}
+                layout={layout.solids[solid.name]}
+                selected={selectedSolid === solid.name}
+              />
+            ))}
+            <g>
+              {layout.connections.map(({ from, to }, i) => (
+                <StyledLink
+                  key={i}
+                  x={(d: IPoint) => d.x}
+                  y={(d: IPoint) => d.y}
+                  data={{
+                    // can also use from.point for the "Dagre" closest point on node
+                    source:
+                      layout.solids[from.solidName].outputs[from.edgeName].port,
+                    target: layout.solids[to.solidName].inputs[to.edgeName].port
+                  }}
+                />
+              ))}
+            </g>
           </SVGContainer>
         </PanAndZoomStyled>
       </GraphWrapper>

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
@@ -20,25 +20,31 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
       fragment SolidNodeFragment on Solid {
         name
         inputs {
-          name
-          type {
+          definition {
             name
+            type {
+              name
+            }
           }
           dependsOn {
-            name
+            definition {
+              name
+            }
             solid {
               name
             }
           }
         }
         outputs {
-          name
-          type {
+          definition {
             name
-          }
-          expectations {
-            name
-            description
+            type {
+              name
+            }
+            expectations {
+              name
+              description
+            }
           }
         }
       }
@@ -56,14 +62,14 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     return this.props.solid.inputs.map((input, i) => {
       const {
         layout: { x, y, width, height }
-      } = this.props.layout.inputs[input.name];
+      } = this.props.layout.inputs[input.definition.name];
 
       return (
         <foreignObject key={i} x={x} y={y} height={height}>
           <InputContainer>
             <Port filled={input.dependsOn != null} />
-            <InputOutputName>{input.name}</InputOutputName>
-            <TypeName>{input.type.name} </TypeName>
+            <InputOutputName>{input.definition.name}</InputOutputName>
+            <TypeName>{input.definition.type.name} </TypeName>
           </InputContainer>
         </foreignObject>
       );
@@ -74,14 +80,14 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     return this.props.solid.outputs.map((output, i) => {
       const {
         layout: { x, y, width, height }
-      } = this.props.layout.outputs[output.name];
+      } = this.props.layout.outputs[output.definition.name];
 
       return (
         <foreignObject key={i} x={x} y={y} height={height}>
           <OutputContainer>
             <Port filled={true} />
-            <InputOutputName>{output.name}</InputOutputName>
-            <TypeName>{output.type.name}</TypeName>
+            <InputOutputName>{output.definition.name}</InputOutputName>
+            <TypeName>{output.definition.type.name}</TypeName>
           </OutputContainer>
         </foreignObject>
       );

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
@@ -59,17 +59,20 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
   };
 
   renderInputs() {
-    return this.props.solid.inputs.map((input, i) => {
-      const {
-        layout: { x, y, width, height }
-      } = this.props.layout.inputs[input.definition.name];
+    return Object.keys(this.props.layout.inputs).map((key, i) => {
+      const { x, y, width, height } = this.props.layout.inputs[key].layout;
 
+      const input = this.props.solid.inputs.find(
+        o => o.definition.name === key
+      );
       return (
         <foreignObject key={i} x={x} y={y} height={height}>
           <InputContainer>
-            <Port filled={input.dependsOn != null} />
-            <InputOutputName>{input.definition.name}</InputOutputName>
-            <TypeName>{input.definition.type.name} </TypeName>
+            <Port filled={true} />
+            {width == 0 && (
+              <InputOutputName>{input!.definition.name}</InputOutputName>
+            )}
+            {width == 0 && <TypeName>{input!.definition.type.name}</TypeName>}
           </InputContainer>
         </foreignObject>
       );
@@ -77,17 +80,20 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
   }
 
   renderOutputs() {
-    return this.props.solid.outputs.map((output, i) => {
-      const {
-        layout: { x, y, width, height }
-      } = this.props.layout.outputs[output.definition.name];
+    return Object.keys(this.props.layout.outputs).map((key, i) => {
+      const { x, y, width, height } = this.props.layout.outputs[key].layout;
+      const output = this.props.solid.outputs.find(
+        o => o.definition.name === key
+      );
 
       return (
         <foreignObject key={i} x={x} y={y} height={height}>
           <OutputContainer>
             <Port filled={true} />
-            <InputOutputName>{output.definition.name}</InputOutputName>
-            <TypeName>{output.definition.type.name}</TypeName>
+            {width == 0 && (
+              <InputOutputName>{output!.definition.name}</InputOutputName>
+            )}
+            {width == 0 && <TypeName>{output!.definition.type.name}</TypeName>}
           </OutputContainer>
         </foreignObject>
       );
@@ -179,15 +185,17 @@ const InputOutputName = styled.div`
   font-size: 15px;
   color: white;
   overflow: hidden;
+  padding-left: 7px;
   text-overflow: ellipsis;
   padding-right: 12px;
+  white-space: nowrap;
+  max-width: 300px;
 `;
 
 const Port = styled.div<{ filled: boolean }>`
   display: inline-block;
   width: 14px;
   height: 14px;
-  margin-right: 7px;
   border-radius: 7px;
   border: 2px solid rgba(255, 255, 255, 0.7);
   background: ${props =>

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import gql from "graphql-tag";
 import styled from "styled-components";
-import { Card, H5, Code, Colors } from "@blueprintjs/core";
+import { Colors } from "@blueprintjs/core";
 import PipelineColorScale from "./PipelineColorScale";
 import { SolidNodeFragment } from "./types/SolidNodeFragment";
 import { IFullSolidLayout } from "./getFullSolidLayout";
+import { TypeName } from "../TypeWithTooltip";
 
 interface ISolidNodeProps {
   layout: IFullSolidLayout;
@@ -19,31 +20,25 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
       fragment SolidNodeFragment on Solid {
         name
         inputs {
-          definition {
+          name
+          type {
             name
-            type {
-              name
-            }
           }
           dependsOn {
-            definition {
-              name
-            }
+            name
             solid {
               name
             }
           }
         }
         outputs {
-          definition {
+          name
+          type {
             name
-            type {
-              name
-            }
-            expectations {
-              name
-              description
-            }
+          }
+          expectations {
+            name
+            description
           }
         }
       }
@@ -61,28 +56,15 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     return this.props.solid.inputs.map((input, i) => {
       const {
         layout: { x, y, width, height }
-      } = this.props.layout.inputs[input.definition.name];
+      } = this.props.layout.inputs[input.name];
 
       return (
-        <foreignObject
-          key={i}
-          x={x - this.props.layout.solid.x}
-          y={y - this.props.layout.solid.y}
-          width={width}
-          height={height}
-        >
-          <Card
-            elevation={3}
-            style={{
-              backgroundColor: PipelineColorScale("input"),
-              height: "100%"
-            }}
-          >
-            <H5>
-              <Code>{input.definition.name}</Code> ({input.definition.type.name}
-              )
-            </H5>
-          </Card>
+        <foreignObject key={i} x={x} y={y} height={height}>
+          <InputContainer>
+            <Port filled={input.dependsOn != null} />
+            <InputOutputName>{input.name}</InputOutputName>
+            <TypeName>{input.type.name} </TypeName>
+          </InputContainer>
         </foreignObject>
       );
     });
@@ -92,28 +74,15 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     return this.props.solid.outputs.map((output, i) => {
       const {
         layout: { x, y, width, height }
-      } = this.props.layout.outputs[output.definition.name];
+      } = this.props.layout.outputs[output.name];
 
       return (
-        <foreignObject
-          key={i}
-          x={x - this.props.layout.solid.x}
-          y={y - this.props.layout.solid.y}
-          width={width}
-          height={height}
-        >
-          <Card
-            elevation={3}
-            style={{
-              backgroundColor: PipelineColorScale("output"),
-              height: "100%"
-            }}
-          >
-            <H5>
-              <Code>{output.definition.name}</Code> (
-              {output.definition.type.name})
-            </H5>
-          </Card>
+        <foreignObject key={i} x={x} y={y} height={height}>
+          <OutputContainer>
+            <Port filled={true} />
+            <InputOutputName>{output.name}</InputOutputName>
+            <TypeName>{output.type.name}</TypeName>
+          </OutputContainer>
         </foreignObject>
       );
     });
@@ -121,14 +90,13 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
 
   renderSelectedBox() {
     if (this.props.selected) {
-      const width = this.props.layout.solid.width + 200 * 2 + 20;
-      const height = this.props.layout.solid.height + 20;
+      const { x, y, width, height } = this.props.layout.boundingBox;
       return (
         <rect
-          x={-10 - 200}
-          y={-10}
-          height={height}
-          width={width}
+          x={x - 10}
+          y={y - 10}
+          width={width + 20}
+          height={height + 20}
           fill="transparent"
           stroke={Colors.GRAY3}
           strokeWidth="1"
@@ -140,34 +108,82 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     }
   }
 
+  public renderSolid() {
+    return (
+      <foreignObject {...this.props.layout.solid}>
+        <SolidContainer>
+          <SolidName>{this.props.solid.name}</SolidName>
+        </SolidContainer>
+      </foreignObject>
+    );
+  }
   public render() {
     return (
-      <g
-        onClick={this.handleClick}
-        transform={`translate(${this.props.layout.solid.x}, ${
-          this.props.layout.solid.y
-        })`}
-      >
+      <g onClick={this.handleClick}>
         {this.renderSelectedBox()}
-        <foreignObject
-          width={this.props.layout.solid.width}
-          height={this.props.layout.solid.height}
-        >
-          <Card
-            elevation={2}
-            style={{
-              backgroundColor: PipelineColorScale("solid"),
-              height: "100%"
-            }}
-          >
-            <H5>
-              <Code>{this.props.solid.name}</Code>
-            </H5>
-          </Card>
-        </foreignObject>
+        {this.renderSolid()}
         {this.renderInputs()}
         {this.renderOutputs()}
       </g>
     );
   }
 }
+
+const SolidContainer = styled.div`
+  padding: 12px;
+  border: 1px solid #979797;
+  background-color: ${PipelineColorScale("solid")};
+  height: 100%;
+  margin-top: 0;
+  display: flex;
+  align-items: center;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+`;
+
+const SolidName = styled.div`
+  font-family: "Source Code Pro", monospace;
+  font-weight: 500;
+  font-size: 18px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const IOContainer = styled.div`
+  padding: 7px;
+  height: 100%;
+  position: absolute;
+  display: flex;
+  align-items: center;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+`;
+
+const InputContainer = styled(IOContainer)`
+  border: 1px solid #979797;
+  background-color: ${PipelineColorScale("input")};
+`;
+
+const OutputContainer = styled(IOContainer)`
+  border: 1px solid #979797;
+  background-color: ${PipelineColorScale("output")};
+`;
+
+const InputOutputName = styled.div`
+  font-family: "Source Code Pro", monospace;
+  font-size: 15px;
+  color: white;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 12px;
+`;
+
+const Port = styled.div<{ filled: boolean }>`
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  margin-right: 7px;
+  border-radius: 7px;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  background: ${props =>
+    props.filled ? "rgba(0, 0, 0, 0.3)" : "rgba(255, 255, 255, 0.3)"};
+`;

--- a/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
@@ -44,16 +44,22 @@ export interface ILayoutPipeline {
 interface ILayoutSolid {
   name: string;
   inputs: Array<{
-    name: string;
-    dependsOn: {
+    definition: {
       name: string;
+    };
+    dependsOn: {
+      definition: {
+        name: string;
+      };
       solid: {
         name: string;
       };
     } | null;
   }>;
   outputs: Array<{
-    name: string;
+    definition: {
+      name: string;
+    };
   }>;
 }
 

--- a/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
@@ -91,7 +91,6 @@ export function getDagrePipelineLayout(
   // Define a new top-down, left to right graph layout
   g.setGraph({
     rankdir: "TB",
-    align: "DR",
     marginx: 100,
     marginy: 100
   });
@@ -121,12 +120,12 @@ export function getDagrePipelineLayout(
           from: {
             point: { x: 0, y: 0 },
             solidName: input.dependsOn.solid.name,
-            edgeName: input.dependsOn.name
+            edgeName: input.dependsOn.definition.name
           },
           to: {
             point: { x: 0, y: 0 },
             solidName: solid.name,
-            edgeName: input.name
+            edgeName: input.definition.name
           }
         });
       }
@@ -183,7 +182,7 @@ function layoutSolid(solid: ILayoutSolid, root: IPoint): IFullSolidLayout {
   } = {};
 
   solid.inputs.forEach((input, i) => {
-    inputsLayouts[input.name] = {
+    inputsLayouts[input.definition.name] = {
       port: { x: root.x + PORT_INSET_X, y: accY + PORT_INSET_Y },
       layout: {
         x: root.x,
@@ -212,7 +211,7 @@ function layoutSolid(solid: ILayoutSolid, root: IPoint): IFullSolidLayout {
   } = {};
 
   solid.outputs.forEach((output, i) => {
-    outputLayouts[output.name] = {
+    outputLayouts[output.definition.name] = {
       port: {
         x: root.x + PORT_INSET_X,
         y: accY + OUTPUT_HEIGHT - PORT_INSET_Y

--- a/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
@@ -1,15 +1,28 @@
 import * as dagre from "dagre";
 
+export type ILayoutConnectionMember = {
+  point: IPoint;
+  solidName: string;
+  edgeName: string;
+};
+
+export type ILayoutConnection = {
+  from: ILayoutConnectionMember;
+  to: ILayoutConnectionMember;
+};
+
 export type IFullPipelineLayout = {
   solids: {
     [solidName: string]: IFullSolidLayout;
   };
+  connections: Array<ILayoutConnection>;
   width: number;
   height: number;
 };
 
 export interface IFullSolidLayout {
   solid: ILayout;
+  boundingBox: ILayout;
   inputs: {
     [inputName: string]: {
       layout: ILayout;
@@ -31,23 +44,16 @@ export interface ILayoutPipeline {
 interface ILayoutSolid {
   name: string;
   inputs: Array<{
-    definition: {
-      name: string;
-    };
+    name: string;
     dependsOn: {
-      definition: {
-        name: string;
-      };
-
+      name: string;
       solid: {
         name: string;
       };
     } | null;
   }>;
   outputs: Array<{
-    definition: {
-      name: string;
-    };
+    name: string;
   }>;
 }
 
@@ -63,23 +69,23 @@ export interface IPoint {
   y: number;
 }
 
-const SOLID_WIDTH = 250;
+const SOLID_WIDTH = 350;
 const SOLID_BASE_HEIGHT = 60;
-const SOLID_GAP = 100;
-const INPUT_WIDTH = 200;
-const INPUT_HEIGHT = 80;
-const INPUT_GAP = 20;
-const OUTPUT_WIDTH = 200;
-const OUTPUT_HEIGHT = 80;
-const INPUT_OUTPUT_INSET = 10;
+const INPUT_HEIGHT = 36;
+const OUTPUT_HEIGHT = 36;
+const INPUT_OUTPUT_INSET = 6;
+const PORT_INSET_X = 15;
+const PORT_INSET_Y = OUTPUT_HEIGHT / 2;
 
 export function getDagrePipelineLayout(
   pipeline: ILayoutPipeline
 ): IFullPipelineLayout {
   const g = new dagre.graphlib.Graph();
+
+  // Define a new top-down, left to right graph layout
   g.setGraph({
-    rankdir: "LR",
-    align: "UL",
+    rankdir: "TB",
+    align: "DR",
     marginx: 100,
     marginy: 100
   });
@@ -87,16 +93,36 @@ export function getDagrePipelineLayout(
     return {};
   });
 
+  const connections: Array<ILayoutConnection> = [];
+
   pipeline.solids.forEach(solid => {
-    const layout = layoutSolid({ solid, x: 0, y: 0 });
+    // Lay out each solid individually to get it's width and height based on it's
+    // inputs and outputs, and then attach it to the graph. Dagre will give us it's
+    // x,y position.
+    const layout = layoutSolid(solid, { x: 0, y: 0 });
     g.setNode(solid.name, {
-      height: layout.solid.height,
-      width: layout.solid.width + INPUT_WIDTH * 2 - INPUT_OUTPUT_INSET * 2
+      width: layout.boundingBox.width,
+      height: layout.boundingBox.height
     });
 
+    // Give Dagre the dependency edges and build a flat set of them so we
+    // can reference them in a single pass later
     solid.inputs.forEach(input => {
       if (input.dependsOn) {
         g.setEdge(input.dependsOn.solid.name, solid.name);
+
+        connections.push({
+          from: {
+            point: { x: 0, y: 0 },
+            solidName: input.dependsOn.solid.name,
+            edgeName: input.dependsOn.name
+          },
+          to: {
+            point: { x: 0, y: 0 },
+            solidName: solid.name,
+            edgeName: input.name
+          }
+        });
       }
     });
   });
@@ -106,97 +132,99 @@ export function getDagrePipelineLayout(
   const solids: {
     [solidName: string]: IFullSolidLayout;
   } = {};
+
+  // Read the Dagre layout and map "nodes" back to our solids, but with
+  // X,Y coordinates this time.
   g.nodes().forEach(function(solidName) {
     const node = g.node(solidName);
     const solid = pipeline.solids.find(({ name }) => name === solidName);
     if (solid) {
-      solids[solidName] = layoutSolid({
-        solid: solid,
-        x: node.x,
-        y: node.y
+      solids[solidName] = layoutSolid(solid, {
+        x: node.x - node.width / 2, // Dagre's x/y is the center, we want top left
+        y: node.y - node.height / 2
       });
     }
   });
-  // g.edges().forEach(function(e) {
-  //   console.log(
-  //     "Edge " + e.v + " -> " + e.w + ": " + JSON.stringify(g.edge(e))
-  //   );
-  // });
+
+  // Read the Dagre layout and map "edges" back to our data model. We don't
+  // currently use the "closest points on the node" Dagre suggests (but we could).
+  g.edges().forEach(function(e) {
+    const conn = connections.find(
+      c => c.from.solidName === e.v && c.to.solidName === e.w
+    );
+    const points = g.edge(e).points;
+    if (conn) {
+      conn.from.point = points[0];
+      conn.to.point = points[points.length - 1];
+    }
+  });
 
   return {
     solids,
+    connections,
     width: g.graph().width as number,
     height: g.graph().height as number
   };
 }
 
-function layoutSolid({
-  solid,
-  x: solidX,
-  y: solidY
-}: {
-  solid: ILayoutSolid;
-  x: number;
-  y: number;
-}): IFullSolidLayout {
-  const solidLayout: ILayout = {
-    x: solidX,
-    y: solidY,
-    width: SOLID_WIDTH,
-    height:
-      SOLID_BASE_HEIGHT +
-      (INPUT_HEIGHT + INPUT_GAP) *
-        Math.max(solid.inputs.length, solid.outputs.length)
-  };
-  const inputs: {
-    [inputName: string]: {
-      layout: ILayout;
-      port: IPoint;
-    };
+function layoutSolid(solid: ILayoutSolid, root: IPoint): IFullSolidLayout {
+  // Starting at the root (top left) X,Y, return the layout information for a solid with
+  // input blocks, then the main block, then output blocks (arranged vertically)
+  let accY = root.y;
+
+  const inputsLayouts: {
+    [inputName: string]: { layout: ILayout; port: IPoint };
   } = {};
+
   solid.inputs.forEach((input, i) => {
-    const inputX = solidX + INPUT_OUTPUT_INSET - INPUT_WIDTH;
-    const inputY = solidY + INPUT_GAP + (INPUT_HEIGHT + INPUT_GAP) * i;
-    inputs[input.definition.name] = {
+    inputsLayouts[input.name] = {
+      port: { x: root.x + PORT_INSET_X, y: accY + PORT_INSET_Y },
       layout: {
-        x: inputX,
-        y: inputY,
-        width: INPUT_WIDTH,
+        x: root.x,
+        y: accY,
+        width: 0,
         height: INPUT_HEIGHT
-      },
-      port: {
-        x: inputX,
-        y: inputY + INPUT_HEIGHT / 2
       }
     };
+    accY += INPUT_HEIGHT;
   });
 
-  const outputs: {
+  const solidLayout: ILayout = {
+    x: root.x,
+    y: Math.max(root.y, accY - INPUT_OUTPUT_INSET),
+    width: SOLID_WIDTH,
+    height: SOLID_BASE_HEIGHT + INPUT_OUTPUT_INSET * 2
+  };
+
+  accY += SOLID_BASE_HEIGHT;
+
+  const outputLayouts: {
     [outputName: string]: {
       layout: ILayout;
       port: IPoint;
     };
   } = {};
+
   solid.outputs.forEach((output, i) => {
-    const outputX = solidX + SOLID_WIDTH - INPUT_OUTPUT_INSET;
-    const outputY = solidY + INPUT_GAP + (OUTPUT_HEIGHT + INPUT_GAP) * i;
-    outputs[output.definition.name] = {
-      layout: {
-        x: outputX,
-        y: outputY,
-        width: OUTPUT_WIDTH,
-        height: OUTPUT_HEIGHT
-      },
+    outputLayouts[output.name] = {
       port: {
-        x: outputX,
-        y: outputY + OUTPUT_HEIGHT / 2
-      }
+        x: root.x + PORT_INSET_X,
+        y: accY + OUTPUT_HEIGHT - PORT_INSET_Y
+      },
+      layout: { x: root.x, y: accY, width: 0, height: OUTPUT_HEIGHT }
     };
+    accY += OUTPUT_HEIGHT;
   });
 
   return {
+    boundingBox: {
+      x: root.x,
+      y: root.y,
+      width: SOLID_WIDTH,
+      height: accY - root.y
+    },
     solid: solidLayout,
-    inputs,
-    outputs
+    inputs: inputsLayouts,
+    outputs: outputLayouts
   };
 }

--- a/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/getFullSolidLayout.ts
@@ -182,14 +182,16 @@ function layoutSolid(solid: ILayoutSolid, root: IPoint): IFullSolidLayout {
     [inputName: string]: { layout: ILayout; port: IPoint };
   } = {};
 
-  const buildIOSmallLayout = (idx: number) => {
+  const buildIOSmallLayout = (idx: number, count: number) => {
+    const centeringOffsetX = (SOLID_WIDTH - IO_MINI_WIDTH * count) / 2;
+    const x = root.x + IO_MINI_WIDTH * idx + centeringOffsetX;
     return {
       port: {
-        x: root.x + PORT_INSET_X + IO_MINI_WIDTH * idx,
+        x: x + PORT_INSET_X,
         y: accY + PORT_INSET_Y
       },
       layout: {
-        x: root.x + IO_MINI_WIDTH * idx,
+        x: x,
         y: accY,
         width: IO_MINI_WIDTH,
         height: IO_HEIGHT
@@ -214,7 +216,7 @@ function layoutSolid(solid: ILayoutSolid, root: IPoint): IFullSolidLayout {
   solid.inputs.forEach((input, idx) => {
     inputsLayouts[input.definition.name] =
       solid.inputs.length > IO_THRESHOLD_FOR_MINI
-        ? buildIOSmallLayout(idx)
+        ? buildIOSmallLayout(idx, solid.inputs.length)
         : buildIOLayout();
   });
   if (solid.inputs.length > IO_THRESHOLD_FOR_MINI) {
@@ -240,7 +242,7 @@ function layoutSolid(solid: ILayoutSolid, root: IPoint): IFullSolidLayout {
   solid.outputs.forEach((output, idx) => {
     outputLayouts[output.definition.name] =
       solid.outputs.length > IO_THRESHOLD_FOR_MINI
-        ? buildIOSmallLayout(idx)
+        ? buildIOSmallLayout(idx, solid.outputs.length)
         : buildIOLayout();
   });
   if (solid.outputs.length > IO_THRESHOLD_FOR_MINI) {


### PR DESCRIPTION
This PR makes a handful of changes to the DAG drawing:
- The horizontal layout has been replaced with a centered vertical one, which lends itself better to our purposes because there's more room for text labels, etc.
- The layout includes little "ports" marking inputs / outputs and when more than 4 inputs or outputs are present, their names and types are hidden.
- The layout hides text on inputs / outputs when you zoom out, which makes it a bit easier to see the high level flow of data.

On deck / ToDo:
- I'm working on fixed zoom levels - one for exploring the overall flow, and one for viewing a single node and it's neighbors.
- I'm working on a "jump bar" that will allow to quickly zoom in / out and focus nodes. Coming soon!

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/1037212/45797926-bd13ba80-bc5c-11e8-82c3-61b501fdaace.png">

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/1037212/45798060-3a3f2f80-bc5d-11e8-8a6d-e4ae416e8286.png">
