### PR TITLE
Add context value for solid and solid_definition

### DIFF
--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -249,7 +249,7 @@ def _execute_core_transform(context, compute_node, conf, inputs):
 
     solid = compute_node.solid
 
-    with context.value('solid', solid.name):
+    with context.values({'solid': solid.name, 'solid_definition': solid.definition.name}):
         context.debug('Executing core transform for solid {solid}.'.format(solid=solid.name))
 
         with time_execution_scope() as timer_result, \

--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -84,6 +84,13 @@ def test_context_value():
     assert 'message="some message"' in logger.messages[0].msg
 
 
+def test_get_context_value():
+    context = ExecutionContext()
+
+    with context.value('some_key', 'some_value'):
+        assert context.get_context_value('some_key') == 'some_value'
+
+
 def test_log_message_id():
     logger = LoggerForTest()
     context = ExecutionContext(loggers=[logger])

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -140,6 +140,10 @@ class ExecutionContext(object):
         See debug()'''
         return self._log('critical', msg, kwargs)
 
+    def get_context_value(self, key):
+        check.str_param(key, 'key')
+        return self._context_dict[key]
+
     # FIXME: Actually make this work
     # def exception(self, e):
     #     check.inst_param(e, 'e', Exception)


### PR DESCRIPTION
In order to help debugging the solid name and the solid definition
should be in the context stack, not just the solid name.