### PR TITLE
Allow sub_pipeline definition with aliases

### DIFF
--- a/python_modules/.vscode/settings.json
+++ b/python_modules/.vscode/settings.json
@@ -11,7 +11,7 @@
     "dagster/dagster/dagster_examples/dagster_examples_tests",
     "dagster-ge/dagster_ge_tests",
     "dagit/dagit_tests",
-    "dagstermill/dagstermill_tests"
+    "dagstermill/dagstermill/dagstermill_tests"
   ],
   "python.unitTest.pyTestEnabled": true,
   "python.pythonPath": "/Users/schrockn/code/venvs/dagster/bin/python",

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -9,6 +9,7 @@ from dagster import (
     OutputDefinition,
     PipelineDefinition,
     Result,
+    check,
     config,
     execute_pipeline,
     lambda_solid,

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -426,8 +426,8 @@ class PipelineDefinition(object):
             context_definitions (Dict[str, PipelineContextDefinition]): See class description.
             dependencies: (Dict[str, Dict[str, DependencyDefinition]]): See class description.
         '''
-        self.description = check.opt_str_param(description, 'description')
         self.name = check.opt_str_param(name, 'name', '<<unnamed>>')
+        self.description = check.opt_str_param(description, 'description')
 
         if context_definitions is None:
             context_definitions = _default_pipeline_context_definitions()
@@ -1043,7 +1043,8 @@ def _create_adjacency_lists(solids, dep_structure):
 def _dependency_structure_to_dep_dict(dependency_structure):
     dep_dict = defaultdict(dict)
     for input_handle, output_handle in dependency_structure.items():
-        dep_dict[input_handle.solid.name][input_handle.input_def.name] = DependencyDefinition(
+        solid_instance = SolidInstance(input_handle.solid.definition.name, input_handle.solid.name)
+        dep_dict[solid_instance][input_handle.input_def.name] = DependencyDefinition(
             solid=output_handle.solid.name,
             output=output_handle.output_def.name,
         )


### PR DESCRIPTION
We should be able to unit test pipelines with aliases