### PR TITLE
Continuing work on dagstermill

### DIFF
--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -978,9 +978,21 @@ class SolidDefinition(object):
         outputs (List[OutputDefinition]): Outputs of the solid.
         config_def (ConfigDefinition): How the solid configured.
         description (str): Description of the solid.
+        metadata (dict):
+            Arbitrary metadata for the solid. Some frameworks expect and require
+            certain metadata to be attached to a solid.
     '''
 
-    def __init__(self, name, inputs, transform_fn, outputs, config_def=None, description=None):
+    def __init__(
+        self,
+        name,
+        inputs,
+        transform_fn,
+        outputs,
+        config_def=None,
+        description=None,
+        metadata=None,
+    ):
         self.name = check_valid_name(name)
         self.input_defs = check.list_param(inputs, 'inputs', InputDefinition)
         self.transform_fn = check.callable_param(transform_fn, 'transform_fn')
@@ -992,6 +1004,7 @@ class SolidDefinition(object):
             ConfigDefinition,
             ConfigDefinition(types.Any),
         )
+        self.metadata = check.opt_dict_param(metadata, 'metadata', key_type=str)
         self._input_dict = _build_named_dict(inputs)
         self._output_dict = _build_named_dict(outputs)
 

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/notebooks/pandas_input_transform_test.ipynb
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/notebooks/pandas_input_transform_test.ipynb
@@ -6,39 +6,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import os\n",
-    "# import sys\n",
-    "# module_path = os.path.abspath(os.path.join('..'))\n",
-    "# if module_path not in sys.path:\n",
-    "#     sys.path.append(module_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import dagstermill as dm\n",
-    "manager = dm.define_manager()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import pandas as pd\n",
     "\n",
-    "from dagstermill.dagstermill_tests.test_basic_dagstermill_solids import return_one"
+    "from dagstermill.dagstermill_tests.test_dagstermill_pandas_solids import define_pandas_input_transform_test_solid\n",
+    "manager = dm.define_manager(define_pandas_input_transform_test_solid())\n",
+    "\n",
+    "\n",
+    "df = pd.read_csv(manager.get_path('num_test_data.csv'))\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "inputs = manager.define_inputs(df=df)"
+   ]
   },
   {
    "cell_type": "code",
@@ -46,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "list(return_one.transform_fn(None, None))[0].value\n"
+    "df = manager.get_input(inputs, 'df')"
    ]
   },
   {
@@ -55,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "manager.yield_result(1)"
+    "df"
    ]
   },
   {
@@ -63,7 +53,37 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "df = df + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = df['num'].sum()\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manager.yield_result(int(result))"
+   ]
   },
   {
    "cell_type": "code",
@@ -74,6 +94,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/notebooks/pandas_source_test.ipynb
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/notebooks/pandas_source_test.ipynb
@@ -6,47 +6,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import os\n",
-    "# import sys\n",
-    "# module_path = os.path.abspath(os.path.join('..'))\n",
-    "# if module_path not in sys.path:\n",
-    "#     sys.path.append(module_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import dagstermill as dm\n",
-    "manager = dm.define_manager()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import pandas as pd\n",
     "\n",
-    "from dagstermill.dagstermill_tests.test_basic_dagstermill_solids import return_one"
+    "from dagstermill.dagstermill_tests.test_dagstermill_pandas_solids import define_pandas_source_test_solid\n",
+    "manager = dm.define_manager(define_pandas_source_test_solid())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
    "outputs": [],
    "source": [
-    "list(return_one.transform_fn(None, None))[0].value\n"
+    "config = manager.define_config('num_test_data.csv')"
    ]
   },
   {
@@ -55,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "manager.yield_result(1)"
+    "config = manager.get_config(config)"
    ]
   },
   {
@@ -63,7 +40,28 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(config)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manager.yield_result(df)"
+   ]
   },
   {
    "cell_type": "code",
@@ -74,6 +72,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -1,5 +1,8 @@
 import sys
+
 import pytest
+
+import dagstermill as dm
 
 from dagster import (
     ConfigDefinition,
@@ -16,57 +19,6 @@ from dagster import (
 )
 
 from dagster.utils import script_relative_path
-
-import dagstermill as dm
-
-
-def test_basic_get_in_memory_input():
-    manager = dm.define_manager()
-    inputs = manager.define_inputs(a=1)
-    assert manager.get_input(inputs, 'a') == 1
-
-
-def test_basic_get_in_memory_inputs():
-    manager = dm.define_manager()
-    inputs = manager.define_inputs(a=1, b=2)
-    assert manager.get_input(inputs, 'a') == 1
-    assert manager.get_input(inputs, 'b') == 2
-
-    a, b = manager.get_inputs(inputs, 'a', 'b')
-
-    assert a == 1
-    assert b == 2
-
-
-def test_basic_get_serialized_inputs():
-    manager = dm.define_manager()
-    inputs = dm.serialize_dm_object(dict(a=1, b=2))
-    assert manager.get_input(inputs, 'a') == 1
-    assert manager.get_input(inputs, 'b') == 2
-
-    a, b = manager.get_inputs(inputs, 'a', 'b')
-
-    assert a == 1
-    assert b == 2
-
-
-def test_basic_in_memory_config():
-    manager = dm.define_manager()
-    value = {'path': 'some_path.csv'}
-    config_ = manager.define_config(value)
-    assert manager.get_config(config_) == value
-
-
-def test_basic_serialized_config():
-    manager = dm.define_manager()
-    value = {'path': 'some_path.csv'}
-    config_ = dm.serialize_dm_object(value)
-    assert manager.get_config(config_) == value
-
-
-def test_serialize_unserialize():
-    value = {'a': 1, 'b': 2}
-    assert dm.deserialize_dm_object(dm.serialize_dm_object(value)) == value
 
 
 def nb_test_path(name):

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -1,0 +1,116 @@
+import pytest
+
+import dagstermill as dm
+
+from dagster import (
+    SolidDefinition,
+    InputDefinition,
+    OutputDefinition,
+    ConfigDefinition,
+    check,
+    types,
+)
+
+
+def test_basic_get_in_memory_input():
+    manager = dm.define_manager()
+    inputs = manager.define_inputs(a=1)
+    assert manager.get_input(inputs, 'a') == 1
+
+
+def test_basic_get_in_memory_inputs():
+    manager = dm.define_manager()
+    inputs = manager.define_inputs(a=1, b=2)
+    assert manager.get_input(inputs, 'a') == 1
+    assert manager.get_input(inputs, 'b') == 2
+
+    a, b = manager.get_inputs(inputs, 'a', 'b')
+
+    assert a == 1
+    assert b == 2
+
+
+def test_basic_get_serialized_inputs():
+    manager = dm.define_manager()
+    inputs = dm.serialize_dm_object(dict(a=1, b=2))
+    assert manager.get_input(inputs, 'a') == 1
+    assert manager.get_input(inputs, 'b') == 2
+
+    a, b = manager.get_inputs(inputs, 'a', 'b')
+
+    assert a == 1
+    assert b == 2
+
+
+def test_basic_in_memory_config():
+    manager = dm.define_manager()
+    value = {'path': 'some_path.csv'}
+    config_ = manager.define_config(value)
+    assert manager.get_config(config_) == value
+
+
+def test_basic_serialized_config():
+    manager = dm.define_manager()
+    value = {'path': 'some_path.csv'}
+    config_ = dm.serialize_dm_object(value)
+    assert manager.get_config(config_) == value
+
+
+def test_serialize_unserialize():
+    value = {'a': 1, 'b': 2}
+    assert dm.deserialize_dm_object(dm.serialize_dm_object(value)) == value
+
+
+def define_solid_with_stuff():
+    return SolidDefinition(
+        name='stuff',
+        inputs=[InputDefinition('foo', types.Int)],
+        outputs=[OutputDefinition(name='bar', dagster_type=types.Int)],
+        config_def=ConfigDefinition(types.Int),
+        transform_fn=lambda *args, **kwargs: check.failed('do not execute'),
+        metadata={'notebook_path': 'unused.ipynb'},
+    )
+
+
+def test_input_names():
+    manager = dm.define_manager(define_solid_with_stuff())
+    manager.define_inputs(foo=2)
+
+    with pytest.raises(dm.DagstermillError, match='Solid stuff does not have input baaz'):
+        manager.define_inputs(baaz=2)
+
+
+def test_input_typecheck():
+    manager = dm.define_manager(define_solid_with_stuff())
+    manager.define_inputs(foo=2)
+
+    with pytest.raises(dm.DagstermillError, match='Input foo failed type check'):
+        manager.define_inputs(foo='ndokfjdkf')
+
+
+def test_output_name():
+    manager = dm.define_manager(define_solid_with_stuff())
+
+    with pytest.raises(dm.DagstermillError, match='Solid stuff does not have output named nope'):
+        manager.yield_result(234, output_name='nope')
+
+    with pytest.raises(dm.DagstermillError, match='Solid stuff does not have output named result'):
+        manager.yield_result(234)
+
+
+def test_output_typemismatch():
+    manager = dm.define_manager(define_solid_with_stuff())
+
+    with pytest.raises(
+        dm.DagstermillError,
+        match='Solid stuff output bar output_type Int failed type check',
+    ):
+        manager.yield_result('not_a_string', output_name='bar')
+
+
+def test_config_typecheck():
+    manager = dm.define_manager(define_solid_with_stuff())
+    manager.define_config(2)
+
+    with pytest.raises(dm.DagstermillError, match='Config for solid stuff failed type check'):
+        manager.define_config('2k3j4k3')

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
@@ -16,9 +16,8 @@ from dagster import (
     types,
 )
 
-from dagster.utils import script_relative_path
-
 from dagster.pandas import DataFrame
+from dagster.utils import script_relative_path
 
 from .test_basic_dagstermill_solids import (
     nb_test_path,

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
@@ -1,0 +1,105 @@
+import os
+
+import pandas as pd
+
+import dagstermill as dm
+
+from dagster import (
+    ConfigDefinition,
+    DependencyDefinition,
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    config,
+    define_stub_solid,
+    execute_pipeline,
+    types,
+)
+
+from dagster.utils import script_relative_path
+
+from dagster.pandas import DataFrame
+
+from .test_basic_dagstermill_solids import (
+    nb_test_path,
+    notebook_test,
+)
+
+
+def define_pandas_input_transform_test_solid():
+    return dm.define_dagstermill_solid(
+        name='pandas_input_transform_test',
+        notebook_path=nb_test_path('pandas_input_transform_test'),
+        inputs=[InputDefinition('df', DataFrame)],
+        outputs=[OutputDefinition(types.Int)],
+    )
+
+
+def define_pandas_input_transform_test_pipeline():
+    in_df = pd.DataFrame({'num': [3, 5, 7]})
+    return PipelineDefinition(
+        name='input_transform_test_pipeline',
+        solids=[
+            define_stub_solid('load_df', in_df),
+            define_pandas_input_transform_test_solid(),
+        ],
+        dependencies={
+            'pandas_input_transform_test': {
+                'df': DependencyDefinition('load_df'),
+            },
+        },
+    )
+
+
+def define_pandas_source_test_solid():
+    return dm.define_dagstermill_solid(
+        name='pandas_source_test',
+        notebook_path=nb_test_path('pandas_source_test'),
+        inputs=[],
+        outputs=[OutputDefinition(DataFrame)],
+        config_def=ConfigDefinition(types.String),
+    )
+
+
+def define_pandas_source_test_pipeline():
+    return PipelineDefinition(
+        name='input_transform_test_pipeline',
+        solids=[define_pandas_source_test_solid()],
+    )
+
+
+@notebook_test
+def test_pandas_input_transform_test_pipeline():
+    pipeline = define_pandas_input_transform_test_pipeline()
+    pipeline_result = execute_pipeline(pipeline)
+    in_df = pd.DataFrame({'num': [3, 5, 7]})
+    solid_result = pipeline_result.result_for_solid('pandas_input_transform_test')
+    expected_sum_result = ((in_df + 1)['num']).sum()
+    sum_result = solid_result.transformed_value()
+    assert sum_result == expected_sum_result
+
+
+@notebook_test
+def test_pandas_source_test_pipeline():
+    pipeline = define_pandas_source_test_pipeline()
+    pipeline_result = execute_pipeline(
+        pipeline,
+        config.Environment(
+            solids={
+                'pandas_source_test': config.Solid(script_relative_path('num.csv')),
+            },
+        ),
+    )
+    assert pipeline_result.success
+    solid_result = pipeline_result.result_for_solid('pandas_source_test')
+    expected = pd.read_csv(script_relative_path('num.csv'))
+    assert solid_result.transformed_value().equals(expected)
+
+
+def test_manager_path():
+    rooted_manager = dm.define_manager(define_pandas_input_transform_test_solid())
+    dirname = os.path.dirname(os.path.abspath(nb_test_path('pandas_input_transform_test')))
+    assert rooted_manager.get_path('foo') == os.path.join(dirname, 'foo')
+
+    unrooted_manager = dm.define_manager()
+    assert unrooted_manager.get_path('foo') == 'foo'


### PR DESCRIPTION
This adds tests that deal with pandas dataframe

1) dagstermill.Manager now optionally takes it's own solid definition as
an argument.
2) It currently only uses this to know where the notebook is executing.
This allows for path resolution within the notebook.
3) Added a metadata field to the SolidDefinition to allow for this type
of thing. This will be useful for tools like dagit so that they can
query the solid and get access to the notebookpath.
4) Outputs are now serialized and de-serialized just like inputs.