### PR TITLE
Factor out dependency construction out of PipelineDefinition.__init__

### DIFF
--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -648,6 +648,7 @@ def create_config_value(execution_info, pipeline_solid):
 # and one wants to be able to attach to the logical output of a solid during execution
 ComputeNodeBuilderState = namedtuple('ComputeNodeBuilderState', 'compute_nodes cn_output_node_map')
 
+
 def create_compute_node_inputs(info, state, pipeline_solid):
     check.inst_param(info, 'info', ComputeNodeExecutionInfo)
     check.inst_param(state, 'state', ComputeNodeBuilderState)
@@ -663,9 +664,7 @@ def create_compute_node_inputs(info, state, pipeline_solid):
 
         check.invariant(
             dependency_structure.has_dep(input_handle),
-            '{input_handle} not found in dependency structure'.format(
-                input_handle=input_handle
-            ),
+            '{input_handle} not found in dependency structure'.format(input_handle=input_handle),
         )
 
         solid_output_handle = dependency_structure.get_dep(input_handle)
@@ -688,6 +687,7 @@ def create_compute_node_inputs(info, state, pipeline_solid):
         )
 
     return cn_inputs
+
 
 def create_compute_node_graph(execution_info):
     check.inst_param(execution_info, 'execution_info', ComputeNodeExecutionInfo)

--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -92,3 +92,11 @@ def test_to_solid_output_not_there():
                 'b_input': DependencyDefinition('A', output='NOTTHERE')
             }},
         )
+
+
+def test_invalid_item_in_solid_list():
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Invalid item in solid list: 'not_a_solid'",
+    ):
+        PipelineDefinition(solids=['not_a_solid'])

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -83,9 +83,9 @@ def create_root_solid(name):
 
 
 def _do_construct(solids, dependencies):
-    solids = [Solid(name=solid.name, definition=solid) for solid in solids]
+    solids = {s.name: Solid(name=s.name, definition=s) for s in solids}
     dependency_structure = DependencyStructure.from_definitions(solids, dependencies)
-    return _create_adjacency_lists(solids, dependency_structure)
+    return _create_adjacency_lists(list(solids.values()), dependency_structure)
 
 
 def test_empty_adjaceny_lists():


### PR DESCRIPTION
PipelineDefinition.__init__ as getting unwieldly so factored out
dependency construction and validation out of the __init__ method