### PR TITLE
Default ConfigDefinitino to take no input

### DIFF
--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -54,14 +54,14 @@ class Pipeline(graphene.ObjectType):
 class PipelineContext(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
-    config = graphene.NonNull(lambda: Config)
+    config = graphene.Field(lambda: Config)
 
     def __init__(self, name, context):
         super(PipelineContext, self).__init__(name=name, description=context.description)
         self._context = check.inst_param(context, 'context', dagster.PipelineContextDefinition)
 
     def resolve_config(self, _info):
-        return Config(self._context.config_def)
+        return Config(self._context.config_def) if self._context.config_def else None
 
 
 class Solid(graphene.ObjectType):
@@ -155,7 +155,7 @@ class SolidDefinition(graphene.ObjectType):
     description = graphene.String()
     input_definitions = graphene.NonNull(graphene.List(lambda: graphene.NonNull(InputDefinition)))
     output_definitions = graphene.NonNull(graphene.List(lambda: graphene.NonNull(OutputDefinition)))
-    config_definition = graphene.NonNull(lambda: Config)
+    config_definition = graphene.Field(lambda: Config)
 
     # solids - ?
 
@@ -179,7 +179,7 @@ class SolidDefinition(graphene.ObjectType):
         ]
 
     def resolve_config_definition(self, _info):
-        return Config(self._solid_def.config_def)
+        return Config(self._solid_def.config_def) if self._solid_def.config_def else None
 
 
 class InputDefinition(graphene.ObjectType):
@@ -258,7 +258,7 @@ class Config(graphene.ObjectType):
 
     def __init__(self, config_def):
         super(Config, self).__init__()
-        self._config_def = check.inst_param(config_def, 'config_def', dagster.ConfigDefinition)
+        self._config_def = check.opt_inst_param(config_def, 'config_def', dagster.ConfigDefinition)
 
     def resolve_type(self, _info):
         return Type.from_dagster_type(dagster_type=self._config_def.config_type)

--- a/python_modules/dagit/dagit/webapp/src/Config.tsx
+++ b/python_modules/dagit/dagit/webapp/src/Config.tsx
@@ -61,13 +61,17 @@ export default class Config extends React.Component<ConfigProps, {}> {
   }
 
   public render() {
-    return (
-      <ConfigCard elevation={3}>
-        <H6>Config</H6>
-        <TypeWithTooltip type={this.props.config.type} />
-        {this.renderFields()}
-      </ConfigCard>
-    );
+    if (this.props.config) {
+      return (
+        <ConfigCard elevation={3}>
+          <H6>Config</H6>
+          <TypeWithTooltip type={this.props.config.type} />
+          {this.renderFields()}
+        </ConfigCard>
+      );
+    } else {
+      return null;
+    }
   }
 }
 

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -627,6 +627,18 @@ def create_config_value(execution_info, pipeline_solid):
     solid_configs = execution_info.environment.solids
     config_input = solid_configs[name].config if name in solid_configs else None
 
+    if solid_def.config_def is None:
+        if config_input is not None:
+            raise DagsterInvariantViolationError(
+                (
+                    'Solid {solid} was provided {config_input} but does not take config'.format(
+                        solid=solid_def.name,
+                        config_input=repr(config_input)
+                    )
+                )
+            )
+        return None
+
     try:
         return solid_def.config_def.config_type.evaluate_value(config_input)
     except DagsterEvaluateValueError as eval_error:

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -90,3 +90,30 @@ def test_solid_not_found():
                 }),
             }),
         )
+
+
+def test_config_for_no_config():
+    def _t_fn(*_args):
+        raise Exception('should not reach')
+
+    solid_def = SolidDefinition(
+        name='no_config_solid',
+        inputs=[],
+        outputs=[],
+        transform_fn=_t_fn,
+    )
+
+    pipeline = PipelineDefinition(solids=[solid_def])
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Solid no_config_solid was provided {'some_config': 1} but does not take config",
+    ):
+        execute_pipeline(
+            pipeline,
+            config.Environment(solids={
+                'no_config_solid': config.Solid({
+                    'some_config': 1,
+                }),
+            }),
+        )

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1038,7 +1038,6 @@ class SolidDefinition(object):
             config_def,
             'config_def',
             ConfigDefinition,
-            ConfigDefinition(types.Any),
         )
         self.metadata = check.opt_dict_param(metadata, 'metadata', key_type=str)
         self._input_dict = {inp.name: inp for inp in inputs}

--- a/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_four.py
+++ b/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_four.py
@@ -2,7 +2,7 @@
 from dagster import *
 
 
-@solid
+@solid(config_def=ConfigDefinition(types.String))
 def hello_world(info):
     print(info.config)
     return info.config

--- a/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
+++ b/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
@@ -4,7 +4,9 @@ from collections import defaultdict
 from dagster import *
 
 
-@solid
+@solid(
+    config_def=ConfigDefinition(types.Any),
+)
 def double_the_word(info):
     return info.config['word'] * 2
 

--- a/python_modules/dagster/docs/intro_tutorial/part_four.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_four.rst
@@ -20,7 +20,7 @@ minimal API. ``solid`` is more complicated, and has more capabilities:
 
     from dagster import *
 
-    @solid
+    @solid(config_def=ConfigDefinition(types.String))
     def hello_world(info):
         print(info.config)
         return conf

--- a/python_modules/dagster/docs/intro_tutorial/part_seven.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_seven.rst
@@ -11,7 +11,7 @@ and a yaml file so that the CLI tool can know about the repository.
 
     from dagster import *
 
-    @solid
+    @solid(config_def=ConfigDefinition(types.Any))
     def double_the_word(info):
         return info.config['word'] * 2
 


### PR DESCRIPTION
Before ConfigDefinition defaulted to a config that takes anything
if unspecified. Instead, this changes it to default to taking nothing.
This is specified by having ConfigDefinition be nullable.