### PR TITLE
Add makefile entry to recycle installs

### DIFF
--- a/python_modules/Makefile
+++ b/python_modules/Makefile
@@ -17,3 +17,8 @@ yapf:
 	find . -name "*.py" | grep -v ".tox" | grep -v ".vscode" | xargs yapf -i
 		
 
+reinstall:
+	pip uninstall dagit
+	pip uninstall dagster
+	pip install -e dagster
+	pip install -e dagit


### PR DESCRIPTION
Whenever the local version of dagster/dagit changes we need to do
a cycle of uninstall/install for modules with CLI scripts.