### PR TITLE
Named types

### DIFF
--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -632,7 +632,8 @@ def create_config_value(execution_info, pipeline_solid):
             raise DagsterInvariantViolationError(
                 (
                     'Solid {solid} was provided {config_input} but does not take config'.format(
-                        solid=solid_def.name, config_input=repr(config_input)
+                        solid=solid_def.name,
+                        config_input=repr(config_input),
                     )
                 )
             )

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -632,8 +632,7 @@ def create_config_value(execution_info, pipeline_solid):
             raise DagsterInvariantViolationError(
                 (
                     'Solid {solid} was provided {config_input} but does not take config'.format(
-                        solid=solid_def.name,
-                        config_input=repr(config_input)
+                        solid=solid_def.name, config_input=repr(config_input)
                     )
                 )
             )

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -14,17 +14,22 @@ def test_noop_config():
 
 
 def test_int_field():
-    config_def = ConfigDefinition.config_dict({
-        'int_field': Field(types.Int),
-    })
+    config_def = ConfigDefinition.config_dict(
+        'SingleRequiredInt',
+        {
+            'int_field': Field(types.Int),
+        },
+    )
 
     assert config_def.config_type.evaluate_value({'int_field': 1}) == {'int_field': 1}
 
 
 def test_int_fails():
-    config_def = ConfigDefinition.config_dict({
-        'int_field': Field(types.Int),
-    })
+    config_def = ConfigDefinition.config_dict(
+        'SingleRequiredInt', {
+            'int_field': Field(types.Int),
+        }
+    )
 
     with pytest.raises(DagsterEvaluateValueError):
         config_def.config_type.evaluate_value({'int_field': 'fjkdj'})
@@ -35,7 +40,7 @@ def test_int_fails():
 
 def test_default_arg():
     config_def = ConfigDefinition.config_dict(
-        {
+        'TestDefaultArg', {
             'int_field': Field(types.Int, default_value=2, is_optional=True),
         }
     )
@@ -44,12 +49,14 @@ def test_default_arg():
 
 
 def _single_required_string_config_dict():
-    return ConfigDefinition.config_dict({'string_field': Field(types.String)})
+    return ConfigDefinition.config_dict(
+        'SingleRequiredField', {'string_field': Field(types.String)}
+    )
 
 
 def _multiple_required_fields_config_dict():
     return ConfigDefinition.config_dict(
-        {
+        'MultipleRequiredFields', {
             'field_one': Field(types.String),
             'field_two': Field(types.String),
         }
@@ -57,7 +64,9 @@ def _multiple_required_fields_config_dict():
 
 
 def _single_optional_string_config_dict():
-    return ConfigDefinition.config_dict({'optional_field': Field(types.String, is_optional=True)})
+    return ConfigDefinition.config_dict(
+        'SingleOptionalString', {'optional_field': Field(types.String, is_optional=True)}
+    )
 
 
 def _single_optional_string_field_config_dict_with_default():
@@ -66,12 +75,15 @@ def _single_optional_string_field_config_dict_with_default():
         is_optional=True,
         default_value='some_default',
     )
-    return ConfigDefinition.config_dict({'optional_field': optional_field_def})
+    return ConfigDefinition.config_dict(
+        'SingleOptionalStringWithDefault',
+        {'optional_field': optional_field_def},
+    )
 
 
 def _mixed_required_optional_string_config_dict_with_default():
     return ConfigDefinition.config_dict(
-        {
+        'MixedRequired', {
             'optional_arg': Field(
                 types.String,
                 is_optional=True,
@@ -218,11 +230,14 @@ def test_mixed_args_passing():
 def _single_nested_config():
     return ConfigDefinition(
         config_type=types.ConfigDictionary(
-            {
+            'ParentType', {
                 'nested':
-                Field(dagster_type=types.ConfigDictionary({
-                    'int_field': Field(types.Int)
-                })),
+                Field(
+                    dagster_type=types.ConfigDictionary(
+                        'NestedType',
+                        {'int_field': Field(types.Int)},
+                    )
+                ),
             }
         )
     )
@@ -231,17 +246,16 @@ def _single_nested_config():
 def _nested_optional_config_with_default():
     return ConfigDefinition(
         config_type=types.ConfigDictionary(
-            {
+            'ParentType', {
                 'nested':
                 Field(
                     dagster_type=types.ConfigDictionary(
-                        {
-                            'int_field': Field(
-                                types.Int,
-                                is_optional=True,
-                                default_value=3,
-                            )
-                        }
+                        'NestedType',
+                        {'int_field': Field(
+                            types.Int,
+                            is_optional=True,
+                            default_value=3,
+                        )}
                     )
                 ),
             }
@@ -250,20 +264,19 @@ def _nested_optional_config_with_default():
 
 
 def _nested_optional_config_with_no_default():
+    nested_type = types.ConfigDictionary(
+        'NestedType',
+        {
+            'int_field': Field(
+                types.Int,
+                is_optional=True,
+            ),
+        },
+    )
     return ConfigDefinition(
         config_type=types.ConfigDictionary(
-            {
-                'nested':
-                Field(
-                    dagster_type=types.
-                    ConfigDictionary({
-                        'int_field': Field(
-                            types.Int,
-                            is_optional=True,
-                        )
-                    })
-                ),
-            }
+            'ParentType',
+            {'nested': Field(dagster_type=nested_type)},
         )
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -68,14 +68,15 @@ def test_default_value():
             'custom_one':
             PipelineContextDefinition(
                 config_def=ConfigDefinition.config_dict(
+                    'CustomOneDict',
                     {
                         'field_one':
                         Field(
                             dagster_type=types.String,
                             is_optional=True,
                             default_value='heyo',
-                        )
-                    }
+                        ),
+                    },
                 ),
                 context_fn=lambda info: ExecutionContext(resources=info.config),
             ),
@@ -98,18 +99,16 @@ def test_custom_contexts():
             'custom_one':
             PipelineContextDefinition(
                 config_def=ConfigDefinition.config_dict(
-                    {
-                        'field_one': Field(dagster_type=types.String)
-                    }
+                    'CustomOneDict',
+                    {'field_one': Field(dagster_type=types.String)},
                 ),
                 context_fn=lambda info: ExecutionContext(resources=info.config),
             ),
             'custom_two':
             PipelineContextDefinition(
                 config_def=ConfigDefinition.config_dict(
-                    {
-                        'field_one': Field(dagster_type=types.String)
-                    }
+                    'CustomTwoDict',
+                    {'field_one': Field(dagster_type=types.String)},
                 ),
                 context_fn=lambda info: ExecutionContext(resources=info.config),
             )
@@ -151,9 +150,7 @@ def test_yield_context():
             'custom_one':
             PipelineContextDefinition(
                 config_def=ConfigDefinition.config_dict(
-                    {
-                        'field_one': Field(dagster_type=types.String)
-                    }
+                    'CustomOneDict', {'field_one': Field(dagster_type=types.String)}
                 ),
                 context_fn=_yield_context,
             ),
@@ -203,9 +200,9 @@ def test_invalid_context():
         context_definitions={
             'default':
             PipelineContextDefinition(
-                config_def=ConfigDefinition.config_dict({
-                    'string_field': Field(types.String)
-                }),
+                config_def=ConfigDefinition.config_dict(
+                    'SingleStringDict', {'string_field': Field(types.String)}
+                ),
                 context_fn=lambda info: info.config,
             )
         }

--- a/python_modules/dagster/dagster/core/core_tests/test_definitions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definitions.py
@@ -1,4 +1,15 @@
-from dagster import (DependencyDefinition)
+from dagster import (
+    ConfigDefinition,
+    DependencyDefinition,
+    Field,
+    PipelineContextDefinition,
+    PipelineDefinition,
+    types,
+    InputDefinition,
+    OutputDefinition,
+    lambda_solid,
+    solid,
+)
 
 
 def test_deps_equal():
@@ -7,3 +18,63 @@ def test_deps_equal():
 
     assert DependencyDefinition('foo', 'bar') == DependencyDefinition('foo', 'bar')
     assert DependencyDefinition('foo', 'bar') != DependencyDefinition('foo', 'quuz')
+
+
+def test_pipeline_types():
+    ContextOneConfigDict = types.ConfigDictionary(
+        'ContextOneConfigDict',
+        {'field_one': Field(types.String)},
+    )
+
+    SolidOneConfigDict = types.ConfigDictionary(
+        'SolidOneConfigDict',
+        {'another_field': Field(types.Int)},
+    )
+
+    @lambda_solid
+    def produce_string():
+        return 'foo'
+
+    @solid(
+        inputs=[InputDefinition('input_one', types.String)],
+        outputs=[OutputDefinition(types.Any)],
+        config_def=ConfigDefinition(SolidOneConfigDict),
+    )
+    def solid_one(_info, input_one):
+        raise Exception('should not execute')
+
+    pipeline_def = PipelineDefinition(
+        solids=[produce_string, solid_one],
+        dependencies={'solid_one': {
+            'input_one': DependencyDefinition('produce_string'),
+        }},
+        context_definitions={
+            'context_one':
+            PipelineContextDefinition(
+                context_fn=lambda: None,
+                config_def=ConfigDefinition(ContextOneConfigDict),
+            )
+        }
+    )
+
+    present_types = [
+        SolidOneConfigDict,
+        ContextOneConfigDict,
+        types.String,
+        types.Any,
+        types.Int,
+    ]
+
+    for present_type in present_types:
+        name = present_type.name
+        assert pipeline_def.has_type(name)
+        assert pipeline_def.type_named(name).name == name
+
+    not_present_types = [
+        types.Bool,
+        types.Dict,
+        types.PythonObjectType('Duisjdfke', dict),
+    ]
+
+    for not_present_type in not_present_types:
+        assert not pipeline_def.has_type(not_present_type.name)

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -30,9 +30,7 @@ def define_pass_value_solid(name, description=None):
         description=description,
         inputs=[],
         outputs=[OutputDefinition(types.String)],
-        config_def=ConfigDefinition.config_dict({
-            'value': Field(types.String)
-        }),
+        config_def=ConfigDefinition.config_dict('SingleValueDict', {'value': Field(types.String)}),
         transform_fn=_value_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -17,6 +17,8 @@ from dagster import (
 
 from dagster.core.test_utils import single_output_transform
 
+SingleValueDict = types.ConfigDictionary('SingleValueDict', {'value': Field(types.String)})
+
 
 def define_pass_value_solid(name, description=None):
     check.str_param(name, 'name')
@@ -30,7 +32,7 @@ def define_pass_value_solid(name, description=None):
         description=description,
         inputs=[],
         outputs=[OutputDefinition(types.String)],
-        config_def=ConfigDefinition.config_dict('SingleValueDict', {'value': Field(types.String)}),
+        config_def=ConfigDefinition(SingleValueDict),
         transform_fn=_value_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -24,9 +24,7 @@ def test_basic_solid_with_config():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_def=ConfigDefinition.config_dict({
-            'some_config': Field(types.String)
-        }),
+        config_def=ConfigDefinition.config_dict('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 
@@ -51,9 +49,7 @@ def test_config_arg_mismatch():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_def=ConfigDefinition.config_dict({
-            'some_config': Field(types.String)
-        }),
+        config_def=ConfigDefinition.config_dict('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -619,7 +619,6 @@ class PipelineDefinition(object):
             value_type=PipelineContextDefinition,
         )
 
-
         dependencies = check_opt_two_dim_dict(
             dependencies,
             'dependencies',
@@ -771,6 +770,14 @@ class PipelineDefinition(object):
         '''
         check.str_param(name, 'name')
         return self._solid_dict[name]
+
+    def has_type(self, name):
+        check.str_param(name, 'name')
+        return name in self._type_dict
+
+    def type_named(self, name):
+        check.str_param(name, 'name')
+        return self._type_dict[name]
 
 
 class ExpectationResult(object):

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -20,6 +20,7 @@ from .errors import DagsterInvalidDefinitionError
 from .execution_context import ExecutionContext
 
 from .types import (
+    ConfigDictionary,
     DagsterType,
     Field,
 )
@@ -133,6 +134,18 @@ class PipelineContextDefinition(object):
         self.description = description
 
 
+DefaultContextConfigDict = ConfigDictionary(
+    'DefaultContextConfigDict',
+    {
+        'log_level': Field(
+            dagster_type=types.String,
+            is_optional=True,
+            default_value='INFO',
+        ),
+    },
+)
+
+
 def _default_pipeline_context_definitions():
     def _default_context_fn(info):
         log_level = level_from_string(info.config['log_level'])
@@ -142,15 +155,7 @@ def _default_pipeline_context_definitions():
         return context
 
     default_context_def = PipelineContextDefinition(
-        config_def=ConfigDefinition.config_dict(
-            {
-                'log_level': Field(
-                    dagster_type=types.String,
-                    is_optional=True,
-                    default_value='INFO',
-                )
-            }
-        ),
+        config_def=ConfigDefinition(DefaultContextConfigDict),
         context_fn=_default_context_fn,
     )
     return {DEFAULT_CONTEXT_NAME: default_context_def}
@@ -940,7 +945,7 @@ class ConfigDefinition(object):
     '''
 
     @staticmethod
-    def config_dict(field_dict):
+    def config_dict(name, field_dict):
         '''Shortcut to create a dictionary based config definition.
 
 
@@ -957,7 +962,7 @@ class ConfigDefinition(object):
              })
 
         '''
-        return ConfigDefinition(types.ConfigDictionary(field_dict))
+        return ConfigDefinition(types.ConfigDictionary(name, field_dict))
 
     def __init__(self, config_type=types.Any, description=None):
         '''Construct a ConfigDefinition

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -211,9 +211,9 @@ class ConfigDictionary(DagsterCompositeType):
     Arguments:
       fields (dict): dictonary of :py:class:`Field` objects keyed by name'''
 
-    def __init__(self, fields):
+    def __init__(self, name, fields):
         super(ConfigDictionary, self).__init__(
-            'ConfigDictionary',
+            name,
             fields,
             lambda val: val,
             self.__doc__,

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -38,6 +38,9 @@ class DagsterType(object):
         '''
         check.not_implemented('Must implement in subclass')
 
+    def iterate_types(self):
+        yield self
+
 
 class UncoercedTypeMixin(object):
     '''This is a helper mixin used when you only want to do a type check
@@ -201,6 +204,12 @@ class DagsterCompositeType(DagsterType):
         if value is not None and not isinstance(value, dict):
             raise DagsterEvaluateValueError('Incoming value for composite must be dict')
         return process_incoming_composite_value(self, value, self.ctor)
+
+    def iterate_types(self):
+        for field_type in self.field_dict.values():
+            for inner_type in field_type.dagster_type.iterate_types():
+                yield inner_type
+        yield self
 
 
 class ConfigDictionary(DagsterCompositeType):

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -27,6 +27,20 @@ tabular data structure with labeled axes (rows and columns). See http://pandas.p
 
 DataFrame = _create_dataframe_type()
 
+LoadDataFrameConfigDict = types.ConfigDictionary(
+    'LoadDataFrameConfigDict',
+    {
+        'path': Field(types.Path),
+    },
+)
+
+WriteDataFrameConfigDict = types.ConfigDictionary(
+    'WriteDataFrameConfigDict',
+    {
+        'path': Field(types.Path),
+    },
+)
+
 
 def load_csv_solid(name):
     check.str_param(name, 'name')
@@ -39,9 +53,7 @@ def load_csv_solid(name):
         inputs=[],
         outputs=[OutputDefinition(DataFrame)],
         transform_fn=_t_fn,
-        config_def=ConfigDefinition.config_dict({
-            'path': Field(types.Path),
-        }),
+        config_def=ConfigDefinition(LoadDataFrameConfigDict),
     )
 
 
@@ -53,9 +65,7 @@ def to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def=ConfigDefinition.config_dict({
-            'path': Field(types.Path)
-        }),
+        config_def=ConfigDefinition(WriteDataFrameConfigDict),
         transform_fn=_t_fn,
     )
 
@@ -68,8 +78,6 @@ def to_parquet_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def=ConfigDefinition.config_dict({
-            'path': Field(types.Path)
-        }),
+        config_def=ConfigDefinition(WriteDataFrameConfigDict),
         transform_fn=_t_fn,
     )

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -27,9 +27,7 @@ def define_read_csv_solid(name):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_def=ConfigDefinition.config_dict({
-            'path': Field(types.Path)
-        }),
+        config_def=ConfigDefinition.config_dict('ReadCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn
     )
 
@@ -42,9 +40,7 @@ def define_to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df')],
         outputs=[],
-        config_def=ConfigDefinition.config_dict({
-            'path': Field(types.Path)
-        }),
+        config_def=ConfigDefinition.config_dict('ToCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
@@ -49,6 +49,13 @@ class DagsterSqlTableExpression(DagsterSqlExpression):
         return self._table_name
 
 
+CreateTableConfigDict = types.ConfigDictionary(
+    'CreateTableConfigDict', {
+        'table_name': Field(types.String),
+    }
+)
+
+
 def define_create_table_solid(name):
     def _materialization_fn(info, inputs):
         sql_expr = inputs['expr']
@@ -64,9 +71,7 @@ def define_create_table_solid(name):
         inputs=[InputDefinition('expr')],
         outputs=[],
         transform_fn=_materialization_fn,
-        config_def=ConfigDefinition.config_dict({
-            'table_name': Field(types.String),
-        }),
+        config_def=ConfigDefinition(CreateTableConfigDict),
     )
 
 

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -30,7 +30,7 @@ def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_s
     return SolidDefinition(
         name=name,
         inputs=[InputDefinition(solid.name) for solid in dependant_solids],
-        config_def=ConfigDefinition.config_dict(field_dict),
+        config_def=ConfigDefinition.config_dict('{name}_Type'.format(name=name), field_dict),
         transform_fn=_create_templated_sql_transform_with_output(sql),
         outputs=[OutputDefinition()],
     )

--- a/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
+++ b/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
@@ -6,16 +6,18 @@ from dagster import *
 
 from dagster.utils import script_relative_path
 
+name = 'WordConfig'
+fields = {'word': Field(types.String)}
+WordConfig = types.ConfigDictionary(name=name, fields=fields)
 
-@solid(config_def=ConfigDefinition(types.ConfigDictionary({'word': Field(types.String)})))
+
+@solid(config_def=ConfigDefinition(WordConfig))
 def double_the_word_with_typed_config(info):
     return info.config['word'] * 2
 
 
 @solid(
-    config_def=ConfigDefinition(types.ConfigDictionary({
-        'word': Field(types.String)
-    })),
+    config_def=ConfigDefinition(WordConfig),
     outputs=[OutputDefinition(types.String)],
 )
 def typed_double_word(info):
@@ -23,9 +25,7 @@ def typed_double_word(info):
 
 
 @solid(
-    config_def=ConfigDefinition(types.ConfigDictionary({
-        'word': Field(types.String)
-    })),
+    config_def=ConfigDefinition(WordConfig),
     outputs=[OutputDefinition(types.Int)],
 )
 def typed_double_word_mismatch(info):

--- a/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
+++ b/python_modules/dagster/dagster_tests/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
@@ -4,7 +4,23 @@ from logging import DEBUG
 
 import pytest
 
-from dagster import *
+from dagster import (
+    ConfigDefinition,
+    DagsterTypeError,
+    DependencyDefinition,
+    ExecutionContext,
+    Field,
+    InputDefinition,
+    OutputDefinition,
+    PipelineContextDefinition,
+    PipelineDefinition,
+    RepositoryDefinition,
+    config,
+    execute_pipeline,
+    lambda_solid,
+    solid,
+    types,
+)
 
 
 class PublicCloudConn:
@@ -187,8 +203,12 @@ def define_part_nine_final():
                 context_fn=lambda info: ExecutionContext.console_logging(
                     resources=PartNineResources(PublicCloudStore(info.config['credentials']))
                 ),
-                config_def=ConfigDefinition(config_type=types.ConfigDictionary({
-                    'credentials': Field(types.ConfigDictionary({
+                config_def=ConfigDefinition(config_type=types.ConfigDictionary(
+                    name='CloudConfigDict',
+                    fields={
+                    'credentials': Field(types.ConfigDictionary(
+                        name='CredentialsConfigDict',
+                        fields={
                         'user' : Field(types.String),
                         'pass' : Field(types.String),
                     })),


### PR DESCRIPTION
This PR adds the requirement for unique type names and a unique object instance per type name per pipeline. This effectively makes a global namespace per pipeline for types.

The biggest changed requirement is that the ConfigDictionary (which is, in effect, an informal parameterized type) must have a name for each of its instances. There might be a bit of "naming fatigue" on these so open to suggestions.