### PR TITLE
Run id and context reentrantcy

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -134,7 +134,7 @@ def test_yield_context():
     @solid(inputs=[], outputs=[OutputDefinition()])
     def custom_context_transform(info):
         assert info.context.resources == {'field_one': 'value_two'}
-        assert info.context._context_dict['foo'] == 'bar'  # pylint: disable=W0212
+        assert info.context._context_stack['foo'] == 'bar'  # pylint: disable=W0212
         events.append('during')
 
     def _yield_context(info):

--- a/python_modules/dagster/dagster/core/core_tests/test_execution_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execution_context.py
@@ -1,0 +1,31 @@
+from collections import OrderedDict
+import uuid
+
+from dagster.core.execution_context import (
+    ExecutionContext,
+    ReentrantContextInfo,
+)
+
+# pylint: disable=W0212
+
+
+def test_noarg_ctor():
+    context = ExecutionContext()
+    assert context._context_stack == OrderedDict()
+
+
+def test_for_run_ctor():
+    context = ExecutionContext.for_run()
+    assert uuid.UUID(context.get_context_value('run_id'))
+    assert uuid.UUID(context.run_id)
+
+
+def test_reentrant_info():
+    context = ExecutionContext(reentrant_info=ReentrantContextInfo(OrderedDict()))
+    assert context._context_stack == OrderedDict()
+
+
+def test_reentrant_info_with_values():
+    context = ExecutionContext(reentrant_info=ReentrantContextInfo(OrderedDict({'foo': 'bar'})))
+    assert context._context_stack == OrderedDict({'foo': 'bar'})
+    assert context.get_context_value('foo') == 'bar'

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -149,7 +149,7 @@ DefaultContextConfigDict = ConfigDictionary(
 def _default_pipeline_context_definitions():
     def _default_context_fn(info):
         log_level = level_from_string(info.config['log_level'])
-        context = ExecutionContext(
+        context = ExecutionContext.for_run(
             loggers=[define_colored_console_logger('dagster', level=log_level)]
         )
         return context
@@ -1462,10 +1462,20 @@ class ContextCreationExecutionInfo(
         )
 
 
-ExpectationExecutionInfo = namedtuple(
-    'ExpectationExecutionInfo',
-    'context inout_def solid_def expectation_def',
-)
+class ExpectationExecutionInfo(
+    namedtuple(
+        '_ExpectationExecutionInfo',
+        'context inout_def solid expectation_def',
+    )
+):
+    def __new__(cls, context, inout_def, solid, expectation_def):
+        return super(ExpectationExecutionInfo, cls).__new__(
+            cls,
+            check.inst_param(context, 'context', ExecutionContext),
+            check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition)),
+            check.inst_param(solid, 'solid', Solid),
+            check.inst_param(expectation_def, 'expectation_def', ExpectationDefinition),
+        )
 
 
 class TransformExecutionInfo(namedtuple('_TransformExecutionInfo', 'context config solid_def')):

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -66,8 +66,7 @@ class DagsterExpectationFailedError(DagsterError):
     def __repr__(self):
         inout_def = self.info.inout_def
         return (
-            'DagsterExpectationFailedError(' +
-            'solid={name}, '.format(name=self.info.solid_def.name) +
+            'DagsterExpectationFailedError(' + 'solid={name}, '.format(name=self.info.solid.name) +
             '{key}={name}, '.format(key=inout_def.descriptive_key, name=inout_def.name) +
             'expectation={name}'.format(name=self.info.expectation_def.name
                                         ) + 'value={value}'.format(value=repr(self.value)) + ')'


### PR DESCRIPTION
This is the beginning of a series of changes to allow a single
pipeline to be executed across multiple process. This PR adds a run_id
concept to the ExecutionContext as well as creates a new style of
"re-entrant" construction that will allow a user to seed a
ExecutionContext with a pre-existing context stack (that could include a
run id).

This will eventually be able to be driven by config, and we will be able
to restart execution of a subset of a pipeline with a prefilled context
stack.