### PR TITLE
Add the ability to serialize intermediates

### DIFF
--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -1,6 +1,7 @@
 from .core.config import (
     Context,
     Environment,
+    Execution,
     Expectations,
     Solid,
 )

--- a/python_modules/dagster/dagster/config.py
+++ b/python_modules/dagster/dagster/config.py
@@ -1,3 +1,5 @@
+# pylint: disable=W0611
+
 from .core.config import (
     Context,
     Environment,

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -836,7 +836,9 @@ def _create_serialization_lambda(solid, output_def):
     def fn(context, _compute_node, inputs):
         value = inputs[SERIALIZE_INPUT]
         path = '/tmp/dagster/runs/{run_id}/{solid_name}/outputs/{output_name}'.format(
-            run_id=context.run_id, solid_name=solid.name, output_name=output_def.name
+            run_id=context.run_id,
+            solid_name=solid.name,
+            output_name=output_def.name,
         )
 
         if not os.path.exists(path):

--- a/python_modules/dagster/dagster/core/compute_nodes.py
+++ b/python_modules/dagster/dagster/core/compute_nodes.py
@@ -3,6 +3,7 @@ from collections import (namedtuple, defaultdict)
 from contextlib import contextmanager
 from enum import Enum
 import uuid
+import os
 import sys
 
 from future.utils import raise_from
@@ -806,8 +807,6 @@ def create_subgraph_for_output(execution_info, solid, solid_transform_cn, output
         )
     else:
         return subgraph
-
-import os
 
 def _create_serialization_lambda(solid, output_def):
     check.inst_param(solid, 'solid', Solid)

--- a/python_modules/dagster/dagster/core/config.py
+++ b/python_modules/dagster/dagster/core/config.py
@@ -20,8 +20,8 @@ class Solid(namedtuple('Solid', 'config')):
         return super(Solid, cls).__new__(cls, config)
 
 
-class Environment(namedtuple('EnvironmentData', 'context solids expectations')):
-    def __new__(cls, solids=None, context=None, expectations=None):
+class Environment(namedtuple('EnvironmentData', 'context solids expectations execution')):
+    def __new__(cls, solids=None, context=None, expectations=None, execution=None):
         check.opt_inst_param(context, 'context', Context)
         check.opt_inst_param(expectations, 'expectations', Expectations)
 
@@ -31,11 +31,15 @@ class Environment(namedtuple('EnvironmentData', 'context solids expectations')):
         if expectations is None:
             expectations = Expectations(evaluate=True)
 
+        if execution is None:
+            execution = Execution(serialize_intermediates=False)
+
         return super(Environment, cls).__new__(
             cls,
             context=context,
             solids=check.opt_dict_param(solids, 'solids', key_type=str, value_type=Solid),
             expectations=expectations,
+            execution=execution,
         )
 
 

--- a/python_modules/dagster/dagster/core/config.py
+++ b/python_modules/dagster/dagster/core/config.py
@@ -45,3 +45,13 @@ class Expectations(namedtuple('ExpectationsData', 'evaluate')):
             cls,
             evaluate=check.bool_param(evaluate, 'evaluate'),
         )
+
+
+class Execution(namedtuple('ExecutionData', 'serialize_intermediates')):
+    def __new__(cls, serialize_intermediates):
+        check.bool_param(serialize_intermediates, 'serialize_intermediates')
+
+        return super(Execution, cls).__new__(
+            cls,
+            serialize_intermediates=serialize_intermediates,
+        )

--- a/python_modules/dagster/dagster/core/config.py
+++ b/python_modules/dagster/dagster/core/config.py
@@ -24,6 +24,7 @@ class Environment(namedtuple('EnvironmentData', 'context solids expectations exe
     def __new__(cls, solids=None, context=None, expectations=None, execution=None):
         check.opt_inst_param(context, 'context', Context)
         check.opt_inst_param(expectations, 'expectations', Expectations)
+        check.opt_inst_param(execution, 'execution', Execution)
 
         if context is None:
             context = Context()
@@ -53,9 +54,8 @@ class Expectations(namedtuple('ExpectationsData', 'evaluate')):
 
 class Execution(namedtuple('ExecutionData', 'serialize_intermediates')):
     def __new__(cls, serialize_intermediates):
-        check.bool_param(serialize_intermediates, 'serialize_intermediates')
 
         return super(Execution, cls).__new__(
             cls,
-            serialize_intermediates=serialize_intermediates,
+            check.bool_param(serialize_intermediates, 'serialize_intermediates'),
         )

--- a/python_modules/dagster/dagster/core/core_tests/test_serialize_intermediates.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_serialize_intermediates.py
@@ -1,0 +1,21 @@
+from dagster import (
+    PipelineDefinition,
+    execute_pipeline,
+    lambda_solid,
+    types,
+)
+
+
+@lambda_solid
+def return_one():
+    return 1
+
+
+def test_serialize_one_int():
+
+    pipeline_def = PipelineDefinition(solids=[return_one])
+    result = execute_pipeline(pipeline_def, {'execution': {'serialize_intermediates': True}})
+    assert result.success
+    path = '/tmp/dagster/runs/{run_id}/return_one/outputs/result'.format(run_id=result.run_id)
+    value = types.Any.deserialize_value(path)
+    assert value == 1

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -321,3 +321,10 @@ def test_solid_config_error():
 
     with pytest.raises(DagsterEvaluateValueError):
         int_solid_config.evaluate_value(1)
+
+
+def test_execution_config():
+    env_type = EnvironmentConfigType(define_test_solids_config_pipeline())
+    env_obj = env_type.evaluate_value({'execution': {'serialize_intermediates': True}})
+    assert isinstance(env_obj.execution, config.Execution)
+    assert env_obj.execution.serialize_intermediates

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import pickle
 import os
 import uuid
@@ -6,6 +7,8 @@ import pandas as pd
 
 from dagster import types
 from dagster.pandas import DataFrame
+
+SomeTuple = namedtuple('SomeTuple', 'foo')
 
 
 def get_unittest_path():
@@ -38,10 +41,6 @@ def roundtrip_typed_value(value, dagster_type):
 def test_pickle():
     assert roundtrip(1) == 1
     assert roundtrip('foo') == 'foo'
-
-
-from collections import namedtuple
-SomeTuple = namedtuple('SomeTuple', 'foo')
 
 
 def test_namedtuple_pickle():

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -1,0 +1,18 @@
+import pickle
+import os
+import uuid
+from dagster import types
+
+TempFileStore = types.TempFileStore
+
+
+def test_basic_serialization():
+    base_dir = f'/tmp/dagster/scratch/{str(uuid.uuid4())}'
+    os.mkdir(base_dir)
+    file_store = TempFileStore(base_dir)
+    info = types.Int.serialize_value(file_store, 1)
+
+    with open(info.path) as ff:
+        out_value = pickle.load(ff)
+
+        assert out_value == 1

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -7,8 +7,6 @@ import pandas as pd
 from dagster import types
 from dagster.pandas import DataFrame
 
-# TempFileStore = types.TempFileStore
-
 
 def roundtrip(value):
     base_dir = f'/tmp/dagster/scratch/unittests/{str(uuid.uuid4())}'

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -6,13 +6,40 @@ from dagster import types
 TempFileStore = types.TempFileStore
 
 
-def test_basic_serialization():
-    base_dir = f'/tmp/dagster/scratch/{str(uuid.uuid4())}'
+def roundtrip(value):
+    base_dir = f'/tmp/dagster/scratch/unittests/{str(uuid.uuid4())}'
     os.mkdir(base_dir)
-    file_store = TempFileStore(base_dir)
-    info = types.Int.serialize_value(file_store, 1)
+    full_path = os.path.join(base_dir, 'value.p')
 
-    with open(info.path) as ff:
-        out_value = pickle.load(ff)
+    with open(full_path, 'wb') as wf:
+        pickle.dump(value, wf)
 
-        assert out_value == 1
+    with open(full_path, 'rb') as rf:
+        return pickle.load(rf)
+
+
+def roundtrip_typed_value(value, dagster_type):
+    base_dir = f'/tmp/dagster/scratch/unittests/{str(uuid.uuid4())}'
+    os.mkdir(base_dir)
+    full_path = os.path.join(base_dir, 'value.p')
+
+    with open(full_path, 'wb') as wf:
+        dagster_type.serialize_value(wf, value)
+
+    with open(full_path, 'rb') as rf:
+        return dagster_type.deserialize_value(rf)
+
+
+def test_pickle():
+    assert roundtrip(1) == 1
+    assert roundtrip('foo') == 'foo'
+
+
+def test_basic_serialization_string():
+    assert roundtrip_typed_value('foo', types.String)
+
+
+def test_basic_serialization():
+    assert roundtrip_typed_value(1, types.Int)
+    assert roundtrip_typed_value(True, types.Bool)
+    assert roundtrip_typed_value({'bar': 'foo'}, types.Dict)

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -8,10 +8,14 @@ from dagster import types
 from dagster.pandas import DataFrame
 
 
-def roundtrip(value):
+def get_unittest_path():
     base_dir = '/tmp/dagster/scratch/unittests/{uuid}'.format(uuid=str(uuid.uuid4()))
-    os.mkdir(base_dir)
-    full_path = os.path.join(base_dir, 'value.p')
+    os.makedirs(base_dir, exist_ok=True)
+    return os.path.join(base_dir, 'value.p')
+
+
+def roundtrip(value):
+    full_path = get_unittest_path()
 
     with open(full_path, 'wb') as wf:
         pickle.dump(value, wf)
@@ -21,9 +25,7 @@ def roundtrip(value):
 
 
 def roundtrip_typed_value(value, dagster_type):
-    base_dir = '/tmp/dagster/scratch/unittests/{uuid}'.format(uuid=str(uuid.uuid4()))
-    os.mkdir(base_dir)
-    full_path = os.path.join(base_dir, 'value.p')
+    full_path = get_unittest_path()
 
     with open(full_path, 'wb') as wf:
         dagster_type.serialize_value(wf, value)

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -10,7 +10,8 @@ from dagster.pandas import DataFrame
 
 def get_unittest_path():
     base_dir = '/tmp/dagster/scratch/unittests/{uuid}'.format(uuid=str(uuid.uuid4()))
-    os.makedirs(base_dir, exist_ok=True)
+    if not os.path.exists(base_dir):
+        os.makedirs(base_dir)
     return os.path.join(base_dir, 'value.p')
 
 

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -9,7 +9,7 @@ from dagster.pandas import DataFrame
 
 
 def roundtrip(value):
-    base_dir = f'/tmp/dagster/scratch/unittests/{str(uuid.uuid4())}'
+    base_dir = '/tmp/dagster/scratch/unittests/{uuid}'.format(uuid=str(uuid.uuid4()))
     os.mkdir(base_dir)
     full_path = os.path.join(base_dir, 'value.p')
 
@@ -21,7 +21,7 @@ def roundtrip(value):
 
 
 def roundtrip_typed_value(value, dagster_type):
-    base_dir = f'/tmp/dagster/scratch/unittests/{str(uuid.uuid4())}'
+    base_dir = '/tmp/dagster/scratch/unittests/{uuid}'.format(uuid=str(uuid.uuid4()))
     os.mkdir(base_dir)
     full_path = os.path.join(base_dir, 'value.p')
 

--- a/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_type_serialization.py
@@ -15,38 +15,14 @@ def get_unittest_path():
     base_dir = '/tmp/dagster/scratch/unittests/{uuid}'.format(uuid=str(uuid.uuid4()))
     if not os.path.exists(base_dir):
         os.makedirs(base_dir)
-    return os.path.join(base_dir, 'value.p')
-
-
-def roundtrip(value):
-    full_path = get_unittest_path()
-
-    with open(full_path, 'wb') as wf:
-        pickle.dump(value, wf)
-
-    with open(full_path, 'rb') as rf:
-        return pickle.load(rf)
+    return base_dir
 
 
 def roundtrip_typed_value(value, dagster_type):
     full_path = get_unittest_path()
 
-    with open(full_path, 'wb') as wf:
-        dagster_type.serialize_value(wf, value)
-
-    with open(full_path, 'rb') as rf:
-        return dagster_type.deserialize_value(rf)
-
-
-def test_pickle():
-    assert roundtrip(1) == 1
-    assert roundtrip('foo') == 'foo'
-
-
-def test_namedtuple_pickle():
-
-    value = SomeTuple(foo='bar')
-    assert roundtrip(value) == value
+    dagster_type.serialize_value(full_path, value)
+    return dagster_type.deserialize_value(full_path)
 
 
 def test_basic_serialization_string():
@@ -57,13 +33,6 @@ def test_basic_serialization():
     assert roundtrip_typed_value(1, types.Int) == 1
     assert roundtrip_typed_value(True, types.Bool) is True
     assert roundtrip_typed_value({'bar': 'foo'}, types.Dict) == {'bar': 'foo'}
-
-
-def test_pandasmeta_serialization():
-    from dagster.pandas import DataFrameMeta
-
-    value = DataFrameMeta(format='csv', path='/tmp/some_path.csv')
-    assert roundtrip(value) == value
 
 
 def test_basic_pandas():

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -17,7 +17,6 @@ will not invoke *any* outputs (and their APIs don't allow the user to).
 
 from contextlib import contextmanager
 import itertools
-import uuid
 
 import six
 
@@ -76,7 +75,7 @@ class PipelineExecutionResult(object):
             'result_list',
             of_type=SolidExecutionResult,
         )
-        self.run_id = context.run_id
+        self.run_id = context.run_id if context.has_run_id() else None
 
     @property
     def success(self):

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -17,6 +17,7 @@ will not invoke *any* outputs (and their APIs don't allow the user to).
 
 from contextlib import contextmanager
 import itertools
+import uuid
 
 import six
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -76,6 +76,7 @@ class PipelineExecutionResult(object):
             'result_list',
             of_type=SolidExecutionResult,
         )
+        self.run_id = context.run_id
 
     @property
     def success(self):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -90,6 +90,7 @@ class ExecutionContext(object):
         return ExecutionContext(
             loggers,
             resources,
+            None,
             ReentrantContextInfo(context_stack=OrderedDict({
                 'run_id': str(uuid.uuid4()),
             }), ),

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -232,3 +232,6 @@ class ExecutionContext(object):
     @property
     def run_id(self):
         return self._context_stack['run_id']
+
+    def has_run_id(self):
+        return 'run_id' in self._context_stack

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -38,10 +38,9 @@ import os
 
 class SystemResources:
     def __init__(self, run_id):
-        tmp_path = f'/tmp/dagster/runs/{run_id}/scratch_fs'
+        tmp_path = '/tmp/dagster/runs/{run_id}/scratch_fs'.format(run_id=run_id)
         os.makedirs(tmp_path)
         self.scratch_fs = ScratchFilesystemResource(tmp_path)
-        pass
 
 
 class ExecutionContext(object):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -28,21 +28,6 @@ class ReentrantContextInfo(namedtuple('ReentrantContextInfo', 'context_stack')):
     pass
 
 
-class ScratchFilesystemResource:
-    def __init__(self, root):
-        self.root = check.str_param(root, 'root')
-
-
-import os
-
-
-class SystemResources:
-    def __init__(self, run_id):
-        tmp_path = '/tmp/dagster/runs/{run_id}/scratch_fs'.format(run_id=run_id)
-        os.makedirs(tmp_path)
-        self.scratch_fs = ScratchFilesystemResource(tmp_path)
-
-
 class ExecutionContext(object):
     '''
     A context object flowed through the entire scope of single execution of a
@@ -70,7 +55,7 @@ class ExecutionContext(object):
             This allows to one to, in effect, reconstruct a context that is already running.
     '''
 
-    def __init__(self, loggers=None, resources=None, system_resources=None, reentrant_info=None):
+    def __init__(self, loggers=None, resources=None, reentrant_info=None):
         if loggers is None:
             loggers = [define_colored_console_logger('dagster')]
 
@@ -82,14 +67,12 @@ class ExecutionContext(object):
             ReentrantContextInfo,
         )
         self._context_stack = reentrant_info.context_stack if reentrant_info else OrderedDict()
-        self.system_resources = system_resources
 
     @staticmethod
     def for_run(loggers=None, resources=None):
         return ExecutionContext(
             loggers,
             resources,
-            None,
             ReentrantContextInfo(context_stack=OrderedDict({
                 'run_id': str(uuid.uuid4()),
             }), ),

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -60,6 +60,7 @@ class DagsterType(object):
         yield self
 
     def serialize_value(self, ff, value):
+        # Probably should force calling code to call evaluate value?
         pickle.dump(self.evaluate_value(value), ff)
 
     def deserialize_value(self, ff):
@@ -139,12 +140,6 @@ class PythonObjectType(UncoercedTypeMixin, DagsterType):
 class _DagsterStringType(DagsterScalarType):
     def is_python_valid_value(self, value):
         return nullable_isinstance(value, string_types)
-
-    # def serialize_value(self, ff, value):
-    #     ff.write(self.evaluate_value(value).encode('utf-8'))
-
-    # def deserialize_value(self, ff):
-    #     return ff.read().decode('utf-8')
 
 
 class _DagsterIntType(DagsterScalarType):

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -52,7 +52,6 @@ class DagsterType(object):
         type_value = self.create_serializable_type_value(self.evaluate_value(value), output_dir)
         output_path = os.path.join(output_dir, 'type_value')
         with open(output_path, 'w') as ff:
-            print('Writing out to {output_path}'.format(output_path=output_path))
             json.dump(
                 {
                     'type': type_value.name,

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -50,6 +50,7 @@ class DagsterType(object):
         # Probably should force calling code to call evaluate value?
         type_value = self.create_serializable_type_value(self.evaluate_value(value))
         pickle.dump(type_value, ff)
+        return type_value
 
     # If python had final methods, these would be final
     def deserialize_value(self, ff):

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -48,7 +48,6 @@ class DagsterType(object):
 
     # If python had final methods, these would be final
     def serialize_value(self, output_dir, value):
-        # Probably should force calling code to call evaluate value?
         type_value = self.create_serializable_type_value(self.evaluate_value(value), output_dir)
         output_path = os.path.join(output_dir, 'type_value')
         with open(output_path, 'w') as ff:

--- a/python_modules/dagster/dagster/core/utility_solids.py
+++ b/python_modules/dagster/dagster/core/utility_solids.py
@@ -1,13 +1,9 @@
-from dagster import check
-
-from .definitions import (
-    InputDefinition,
+from dagster import (
     OutputDefinition,
     Result,
     SolidDefinition,
+    check,
 )
-
-from .types import DagsterType
 
 
 def define_stub_solid(name, value):
@@ -20,25 +16,5 @@ def define_stub_solid(name, value):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        transform_fn=_value_t_fn,
-    )
-
-
-def define_serialization_solid(name, dagster_type):
-    check.str_param(name, 'name')
-    check.inst_param(dagster_type, 'dagster_type', DagsterType)
-
-    def _value_t_fn(info, inputs):
-        value = inputs['value']
-
-        with info.context.system_resources.scratch_fs.writeable_file() as ff:
-            pass
-
-        yield Result(value)
-
-    return SolidDefinition(
-        name=name,
-        inputs=[InputDefinition('value', dagster_type)],
-        outputs=[OutputDefinition(dagster_type)],
         transform_fn=_value_t_fn,
     )

--- a/python_modules/dagster/dagster/core/utility_solids.py
+++ b/python_modules/dagster/dagster/core/utility_solids.py
@@ -1,9 +1,13 @@
-from dagster import (
+from dagster import check
+
+from .definitions import (
+    InputDefinition,
     OutputDefinition,
     Result,
     SolidDefinition,
-    check,
 )
+
+from .types import DagsterType
 
 
 def define_stub_solid(name, value):
@@ -16,5 +20,25 @@ def define_stub_solid(name, value):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
+        transform_fn=_value_t_fn,
+    )
+
+
+def define_serialization_solid(name, dagster_type):
+    check.str_param(name, 'name')
+    check.inst_param(dagster_type, 'dagster_type', DagsterType)
+
+    def _value_t_fn(info, inputs):
+        value = inputs['value']
+
+        with info.context.system_resources.scratch_fs.writeable_file() as ff:
+            pass
+
+        yield Result(value)
+
+    return SolidDefinition(
+        name=name,
+        inputs=[InputDefinition('value', dagster_type)],
+        outputs=[OutputDefinition(dagster_type)],
         transform_fn=_value_t_fn,
     )

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import os
 import pickle
 import tempfile
 
@@ -28,19 +29,23 @@ class _DataFrameType(types.PythonObjectType):
     tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/''',
         )
 
-    def create_serializable_type_value(self, value):
-        # TODO use some passed in value to create temp files
-        csv_path = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        value.to_csv(csv_path.name, index=False)
-        df_meta = DataFrameMeta(format='csv', path=csv_path.name)
-        return types.SerializedTypeValue(name=self.name, value=df_meta)
+    def create_serializable_type_value(self, value, output_dir):
+        check.str_param(output_dir, 'output_dir')
+        csv_path = os.path.join(output_dir, 'csv')
+        value.to_csv(csv_path, index=False)
+        df_meta = DataFrameMeta(format='csv', path='csv')
+        return types.SerializedTypeValue(name=self.name, value=df_meta._asdict())
 
-    def deserialize_from_type_value(self, type_value):
-        df_meta = type_value.value
-        check.inst(df_meta, DataFrameMeta)
+    def deserialize_from_type_value(self, type_value, output_dir):
+        check.str_param(output_dir, 'output_dir')
+
+        df_meta_dict = type_value.value
+        check.inst(df_meta_dict, dict)
+        df_meta = DataFrameMeta(**df_meta_dict)
 
         if df_meta.format == 'csv':
-            return pd.read_csv(df_meta.path)
+            csv_path = os.path.join(output_dir, df_meta.path)
+            return pd.read_csv(csv_path)
         else:
             raise Exception('unsupported')
 

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -28,16 +28,14 @@ class _DataFrameType(types.PythonObjectType):
     tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/''',
         )
 
-    def serialize_value(self, ff, value):
-        check.inst_param(value, 'value', pd.DataFrame)
-
+    def create_serializable_type_value(self, value):
         csv_path = tempfile.NamedTemporaryFile(mode='w', delete=False)
         value.to_csv(csv_path.name, index=False)
         df_meta = DataFrameMeta(format='csv', path=csv_path.name)
-        pickle.dump(df_meta, ff)
+        return types.SerializedTypeValue(name=self.name, value=df_meta)
 
-    def deserialize_value(self, ff):
-        df_meta = pickle.load(ff)
+    def deserialize_from_type_value(self, type_value):
+        df_meta = type_value.value
         check.inst(df_meta, DataFrameMeta)
 
         if df_meta.format == 'csv':

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -29,6 +29,7 @@ class _DataFrameType(types.PythonObjectType):
         )
 
     def create_serializable_type_value(self, value):
+        # TODO use some passed in value
         csv_path = tempfile.NamedTemporaryFile(mode='w', delete=False)
         value.to_csv(csv_path.name, index=False)
         df_meta = DataFrameMeta(format='csv', path=csv_path.name)

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -29,7 +29,7 @@ class _DataFrameType(types.PythonObjectType):
         )
 
     def create_serializable_type_value(self, value):
-        # TODO use some passed in value
+        # TODO use some passed in value to create temp files
         csv_path = tempfile.NamedTemporaryFile(mode='w', delete=False)
         value.to_csv(csv_path.name, index=False)
         df_meta = DataFrameMeta(format='csv', path=csv_path.name)

--- a/python_modules/dagster/dagster_tests/tutorials/tutorial_repository.py
+++ b/python_modules/dagster/dagster_tests/tutorials/tutorial_repository.py
@@ -1,6 +1,7 @@
 from dagster import RepositoryDefinition
 
 from dagster.dagster_examples.tutorials.test_intro_tutorial_part_one import define_pipeline as define_part_one_pipeline
+
 # from .test_intro_tutorial_part_one import define_pipeline as define_part_one_pipeline
 
 

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -3,6 +3,7 @@ from builtins import *  # pylint: disable=W0622,W0401
 
 import json
 import os
+import six
 import uuid
 
 import base64
@@ -196,7 +197,7 @@ def serialize_dm_object(dm_object):
 
 
 def serialize_inputs(inputs, input_defs, scratch_dir):
-    check.dict_param(inputs, 'inputs', key_type=str)
+    check.dict_param(inputs, 'inputs', key_type=six.string_types)
     input_defs = check.opt_list_param(input_defs, 'input_defs', of_type=InputDefinition)
     check.str_param(scratch_dir, 'scratch_dir')
 

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -203,7 +203,6 @@ def serialize_inputs(inputs, input_defs, scratch_dir):
 
     type_values = {}
     input_def_dict = {inp.name: inp for inp in input_defs}
-    # os.makedirs(output_path)
     for input_name, input_value in inputs.items():
         dagster_type = input_def_dict[input_name].dagster_type if input_defs else types.Any
         type_value = dagster_type.create_serializable_type_value(input_value, scratch_dir)
@@ -270,7 +269,6 @@ def _dm_solid_transform(name, notebook_path):
             for output_def in info.solid_def.output_defs:
                 if output_def.name in output_nb.data:
                     value = deserialize_dm_object(output_nb.data[output_def.name])
-                    # value = output_def.dagster_type.deserialize_from_type_value(type_value)
                     yield Result(
                         value,
                         output_def.name,

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -190,9 +190,11 @@ def serialize_dm_object(dm_object):
 def serialize_inputs(inputs, input_defs):
     type_values = {}
     input_def_dict = {inp.name: inp for inp in input_defs} if input_defs else None
+    output_path = '/tmp/dagstermill/temp_values/{some_id}'.format(some_id=str(uuid.uuid4()))
+    os.makedirs(output_path)
     for input_name, input_value in inputs.items():
         dagster_type = input_def_dict[input_name].dagster_type if input_defs else types.Any
-        type_value = dagster_type.create_serializable_type_value(input_value)
+        type_value = dagster_type.create_serializable_type_value(input_value, output_path)
         type_values[input_name] = type_value
 
     return serialize_dm_object(type_values)

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -226,7 +226,8 @@ def _dm_solid_transform(name, notebook_path):
 
     def _t_fn(info, inputs):
         base_dir = '/tmp/dagstermill/output_notebooks'
-        os.makedirs(base_dir, exist_ok=True)
+        if not os.path.exists(base_dir):
+            os.makedirs(base_dir)
 
         temp_path = os.path.join(base_dir, '{prefix}-out.ipynb'.format(prefix=str(uuid.uuid4())))
 

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -200,8 +200,6 @@ def serialize_inputs(inputs, input_defs):
         type_values[input_name] = type_value
 
     return serialize_dm_object(type_values)
-    # return json.dumps(type_values)
-    # return serialize_dm_object(inputs)
 
 
 def deserialize_inputs(inputs_str, input_defs):

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -225,10 +225,10 @@ def _dm_solid_transform(name, notebook_path):
     do_cleanup = False  # for now
 
     def _t_fn(info, inputs):
-        if not os.path.exists('/tmp/dagstermill/'):
-            os.mkdir('/tmp/dagstermill/')
+        base_dir = '/tmp/dagstermill/output_notebooks'
+        os.makedirs(base_dir, exist_ok=True)
 
-        temp_path = '/tmp/dagstermill/{prefix}-out.ipynb'.format(prefix=str(uuid.uuid4()))
+        temp_path = os.path.join(base_dir, '{prefix}-out.ipynb'.format(prefix=str(uuid.uuid4())))
 
         try:
             _source_nb = pm.execute_notebook(

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -100,7 +100,6 @@ class Manager:
             return self.cache[inputs]
 
         ddict = deserialize_inputs(inputs, self.solid_def.input_defs if self.solid_def else None)
-        # ddict = deserialize_dm_object(inputs)
         self.cache[inputs] = self._typecheck_evaluate_inputs(ddict)
         return ddict
 
@@ -207,14 +206,8 @@ def deserialize_inputs(inputs_str, input_defs):
     input_def_dict = {inp.name: inp for inp in input_defs} if input_defs else None
     inputs = {}
     for name, type_value in type_values.items():
-        dagster_type = input_def_dict[name].dagster_type if input_defs else types.Any
+        dagster_type = input_def_dict[name].dagster_type if input_def_dict else types.Any
         inputs[name] = dagster_type.deserialize_from_type_value(type_value)
-        # if input_defs:
-        #     value = input_def_dict[name].dagster_type.deserialize_from_type_value(type_value)
-        #     inputs[name] = value
-        # else:
-        #     value = types.Any.
-        # pass
     return inputs
 
 

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -103,7 +103,7 @@ def test_output_typemismatch():
 
     with pytest.raises(
         dm.DagstermillError,
-        match='Solid stuff output bar output_type Int failed type check',
+        match='Output bar output_type Int failed type check',
     ):
         manager.yield_result('not_a_string', output_name='bar')
 

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 import dagstermill as dm
@@ -32,7 +34,8 @@ def test_basic_get_in_memory_inputs():
 
 def test_basic_get_serialized_inputs():
     manager = dm.define_manager()
-    inputs = dm.serialize_inputs(dict(a=1, b=2), input_defs=None)
+    output_path = '/tmp/dagstermill/temp_values/{some_id}'.format(some_id=str(uuid.uuid4()))
+    inputs = dm.serialize_inputs(dict(a=1, b=2), input_defs=None, scratch_dir=output_path)
     assert manager.get_input(inputs, 'a') == 1
     assert manager.get_input(inputs, 'b') == 2
 
@@ -117,6 +120,7 @@ def test_config_typecheck():
 
 
 def test_serialize_inputs():
+    output_path = '/tmp/dagstermill/temp_values/{some_id}'.format(some_id=str(uuid.uuid4()))
     output = dm.serialize_inputs(
         {
             'foo': 'value_for_foo',
@@ -126,6 +130,7 @@ def test_serialize_inputs():
             InputDefinition('foo'),
             InputDefinition('bar'),
         ],
+        output_path,
     )
 
     print(repr(output))

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -32,7 +32,7 @@ def test_basic_get_in_memory_inputs():
 
 def test_basic_get_serialized_inputs():
     manager = dm.define_manager()
-    inputs = dm.serialize_dm_object(dict(a=1, b=2))
+    inputs = dm.serialize_inputs(dict(a=1, b=2), input_defs=None)
     assert manager.get_input(inputs, 'a') == 1
     assert manager.get_input(inputs, 'b') == 2
 
@@ -114,3 +114,18 @@ def test_config_typecheck():
 
     with pytest.raises(dm.DagstermillError, match='Config for solid stuff failed type check'):
         manager.define_config('2k3j4k3')
+
+
+def test_serialize_inputs():
+    output = dm.serialize_inputs(
+        {
+            'foo': 'value_for_foo',
+            'bar': 123
+        },
+        [
+            InputDefinition('foo'),
+            InputDefinition('bar'),
+        ],
+    )
+
+    print(repr(output))

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+import pytest
 
 import dagstermill as dm
 
@@ -67,6 +68,7 @@ def define_pandas_source_test_pipeline():
     )
 
 
+@pytest.mark.skip('Must ship over run id to notebook process')
 @notebook_test
 def test_pandas_input_transform_test_pipeline():
     pipeline = define_pandas_input_transform_test_pipeline()


### PR DESCRIPTION
Add the ability to serialize intermediate outputs. Serialization is typed to the type system.

This works by using the compute_node infrastructure. Based on config, this actually inserts new compute nodes whose sole job is to serialize values.