### PR TITLE
Enable custom serialization for python object types

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_serialize_intermediates.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_serialize_intermediates.py
@@ -1,4 +1,5 @@
 from dagster import (
+    OutputDefinition,
     PipelineDefinition,
     execute_pipeline,
     lambda_solid,
@@ -11,6 +12,14 @@ def return_one():
     return 1
 
 
+class Some:
+    def __init__(self, value):
+        self.value = value
+
+
+SomeType = types.PythonObjectType('SomeType', Some)
+
+
 def test_serialize_one_int():
 
     pipeline_def = PipelineDefinition(solids=[return_one])
@@ -19,3 +28,18 @@ def test_serialize_one_int():
     path = '/tmp/dagster/runs/{run_id}/return_one/outputs/result'.format(run_id=result.run_id)
     value = types.Any.deserialize_value(path)
     assert value == 1
+
+
+@lambda_solid(output=OutputDefinition(SomeType))
+def return_some_type():
+    return Some('foobar')
+
+
+def test_serialize_custom_type():
+
+    pipeline_def = PipelineDefinition(solids=[return_some_type])
+    result = execute_pipeline(pipeline_def, {'execution': {'serialize_intermediates': True}})
+    assert result.success
+    path = '/tmp/dagster/runs/{run_id}/return_some_type/outputs/result'.format(run_id=result.run_id)
+    some = SomeType.deserialize_value(path)
+    assert some.value == 'foobar'

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import json
 import os
+import pickle
 
 from six import integer_types, string_types
 
@@ -149,6 +150,35 @@ class PythonObjectType(UncoercedTypeMixin, DagsterType):
 
     def is_python_valid_value(self, value):
         return nullable_isinstance(value, self.python_type)
+
+    def serialize_value(self, output_dir, value):
+        type_value = self.create_serializable_type_value(self.evaluate_value(value), output_dir)
+        output_path = os.path.join(output_dir, 'type_value')
+        with open(output_path, 'w') as ff:
+            json.dump(
+                {
+                    'type': type_value.name,
+                    'path': 'pickle'
+                },
+                ff,
+            )
+        pickle_path = os.path.join(output_dir, 'pickle')
+        with open(pickle_path, 'wb') as pf:
+            pickle.dump(value, pf)
+
+        return type_value
+
+    # If python had final methods, these would be final
+    def deserialize_value(self, output_dir):
+        with open(os.path.join(output_dir, 'type_value'), 'r') as ff:
+            type_value_dict = json.load(ff)
+            if type_value_dict['type'] != self.name:
+                raise Exception('type mismatch')
+
+        path = type_value_dict['path']
+        with open(os.path.join(output_dir, path), 'rb') as pf:
+            return pickle.load(pf)
+        # return self.deserialize_from_type_value(type_value, output_dir)
 
 
 class _DagsterStringType(DagsterScalarType):


### PR DESCRIPTION
For arbitrary python types, we default to a pickle-based serialization strategy.