### PR TITLE
Rendered sql

### DIFF
--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -47,7 +47,6 @@ class DagsterType(object):
     def iterate_types(self):
         yield self
 
-    # If python had final methods, these would be final
     def serialize_value(self, output_dir, value):
         type_value = self.create_serializable_type_value(self.evaluate_value(value), output_dir)
         output_path = os.path.join(output_dir, 'type_value')
@@ -61,7 +60,6 @@ class DagsterType(object):
             )
         return type_value
 
-    # If python had final methods, these would be final
     def deserialize_value(self, output_dir):
         with open(os.path.join(output_dir, 'type_value'), 'r') as ff:
             type_value_dict = json.load(ff)
@@ -180,7 +178,7 @@ class PythonObjectType(UncoercedTypeMixin, DagsterType):
             return pickle.load(pf)
 
 
-class _DagsterStringType(DagsterScalarType):
+class DagsterStringType(DagsterScalarType):
     def is_python_valid_value(self, value):
         return nullable_isinstance(value, string_types)
 
@@ -353,8 +351,8 @@ def process_incoming_composite_value(dagster_composite_type, incoming_value, cto
     return ctor(fields_to_pass)
 
 
-String = _DagsterStringType(name='String', description='A string.')
-Path = _DagsterStringType(
+String = DagsterStringType(name='String', description='A string.')
+Path = DagsterStringType(
     name='Path',
     description='''
 A string the represents a path. It is very useful for some tooling

--- a/python_modules/dagster/dagster/sqlalchemy/common.py
+++ b/python_modules/dagster/dagster/sqlalchemy/common.py
@@ -35,13 +35,13 @@ def check_supports_sql_alchemy_resource(context):
 def create_sql_alchemy_context_from_sa_resource(sa_resource, *args, **kwargs):
     check.inst_param(sa_resource, 'sa_resource', SqlAlchemyResource)
     resources = DefaultSqlAlchemyResources(sa_resource)
-    context = ExecutionContext(resources=resources, *args, **kwargs)
+    context = ExecutionContext.for_run(resources=resources, *args, **kwargs)
     return check_supports_sql_alchemy_resource(context)
 
 
 def create_sql_alchemy_context_from_engine(engine, *args, **kwargs):
     resources = DefaultSqlAlchemyResources(SqlAlchemyResource(engine))
-    context = ExecutionContext(resources=resources, *args, **kwargs)
+    context = ExecutionContext.for_run(resources=resources, *args, **kwargs)
     return check_supports_sql_alchemy_resource(context)
 
 

--- a/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_isolated_templated_sql_tests.py
@@ -32,12 +32,9 @@ def pipeline_test_def(solids, context, dependencies=None):
     )
 
 
-def test_single_templated_sql_solid_single_table_with_api():
-
+def define_sum_table_pipeline():
     sql = '''CREATE TABLE {{sum_table}} AS
     SELECT num1, num2, num1 + num2 as sum FROM num_table'''
-
-    sum_table_arg = 'specific_sum_table'
 
     sum_table_transform = create_templated_sql_transform_solid(
         name='sum_table_transform',
@@ -46,6 +43,13 @@ def test_single_templated_sql_solid_single_table_with_api():
     )
 
     pipeline = pipeline_test_def(solids=[sum_table_transform], context=in_mem_context())
+    return pipeline
+
+
+def test_single_templated_sql_solid_single_table_with_api():
+    pipeline = define_sum_table_pipeline()
+
+    sum_table_arg = 'specific_sum_table'
 
     environment = config.Environment(
         solids={'sum_table_transform': config.Solid({
@@ -57,6 +61,25 @@ def test_single_templated_sql_solid_single_table_with_api():
     assert result.success
 
     assert _load_table(result.context, sum_table_arg) == [(1, 2, 3), (3, 4, 7)]
+
+
+def test_single_templated_sql_solid_single_table_with_api_serialize_intermediates():
+    pipeline = define_sum_table_pipeline()
+
+    sum_table_arg = 'specific_sum_table'
+
+    environment = config.Environment(
+        solids={'sum_table_transform': config.Solid({
+            'sum_table': sum_table_arg
+        })},
+        execution=config.Execution(serialize_intermediates=True),
+    )
+
+    result = execute_pipeline(pipeline, environment=environment)
+    assert result.success
+
+    print("RUN_ID")
+    print(result.run_id)
 
 
 def test_single_templated_sql_solid_double_table_raw_api():
@@ -118,6 +141,11 @@ def test_single_templated_sql_solid_double_table_with_api():
 
     assert _load_table(result.context, sum_table_arg) == [(1, 2, 3), (3, 4, 7)]
 
+    assert result.result_for_solid('sum_solid').transformed_value(
+        'sql_text'
+    ) == '''CREATE TABLE specific_sum_table AS
+    SELECT num1, num2, num1 + num2 as sum FROM specific_num_table'''
+
 
 def test_templated_sql_solid_pipeline():
     sum_sql_template = '''CREATE TABLE {{sum_table}} AS
@@ -164,12 +192,6 @@ def test_templated_sql_solid_pipeline():
                 'sum_table': first_sum_table,
                 'sum_sq_table': first_sum_sq_table,
             }),
-            #  {
-            #     'sum_table': table_name_source(first_sum_table)
-            # },
-            # 'sum_sq_table': {
-            #     'sum_sq_table': table_name_source(first_sum_sq_table)
-            # },
         }
     )
     first_result = execute_pipeline(pipeline, environment=environment_one)

--- a/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_isolated_templated_sql_tests.py
@@ -78,8 +78,12 @@ def test_single_templated_sql_solid_single_table_with_api_serialize_intermediate
     result = execute_pipeline(pipeline, environment=environment)
     assert result.success
 
-    print("RUN_ID")
-    print(result.run_id)
+    sql_output = '/tmp/dagster/runs/{run_id}/sum_table_transform/outputs/sql_text/sql'.format(
+        run_id=result.run_id,
+    )
+
+    assert open(sql_output).read() == '''CREATE TABLE specific_sum_table AS
+    SELECT num1, num2, num1 + num2 as sum FROM num_table'''
 
 
 def test_single_templated_sql_solid_double_table_raw_api():

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -38,6 +38,9 @@ class DagsterSqlTextType(types.DagsterStringType):
             sf.write(value)
 
 
+SqlTextType = DagsterSqlTextType()
+
+
 def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_solids=None):
     check.str_param(name, 'name')
     check.str_param(sql, 'sql')
@@ -58,7 +61,7 @@ def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_s
         transform_fn=_create_templated_sql_transform_with_output(sql),
         outputs=[
             OutputDefinition(name='result', dagster_type=types.Any),
-            OutputDefinition(name='sql_text', dagster_type=DagsterSqlTextType()),
+            OutputDefinition(name='sql_text', dagster_type=SqlTextType),
         ],
     )
 

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -1,4 +1,6 @@
 import jinja2
+import json
+import os
 
 from dagster import (
     ConfigDefinition,
@@ -12,9 +14,6 @@ from dagster import (
 )
 
 from .common import execute_sql_text_on_context
-
-import json
-import os
 
 
 class DagsterSqlTextType(types.DagsterStringType):

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -1,6 +1,7 @@
-import jinja2
 import json
 import os
+
+import jinja2
 
 from dagster import (
     ConfigDefinition,
@@ -18,9 +19,11 @@ from .common import execute_sql_text_on_context
 
 class DagsterSqlTextType(types.DagsterStringType):
     def __init__(self):
-        super(DagsterSqlTextType, self).__init__(name='SqlText')
+        super(DagsterSqlTextType, self).__init__(
+            name='SqlText',
+            description='A string of SQL text that is directly executable.',
+        )
 
-    # If python had final methods, these would be final
     def serialize_value(self, output_dir, value):
         type_value = self.create_serializable_type_value(self.evaluate_value(value), output_dir)
         output_path = os.path.join(output_dir, 'type_value')


### PR DESCRIPTION
For the templated sql solid, create a new output type that is the rendered sql. When serialize_intermediates is on, it creates a file that contains the executable sql