### PR TITLE
Group types in the sidebar into built-ins, generated types, custom types

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/SidebarComponents.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarComponents.tsx
@@ -1,9 +1,11 @@
 import * as React from "react";
 import styled from "styled-components";
-import { Colors, Collapse } from "@blueprintjs/core";
+import { Icon, Colors, Collapse } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
 
 interface ISidebarSectionProps {
   title: string;
+  collapsedByDefault?: boolean;
 }
 
 interface ISidebarSectionState {
@@ -15,24 +17,32 @@ export class SidebarSection extends React.Component<
   ISidebarSectionState
 > {
   state = {
-    isOpen: true
+    isOpen: this.props.collapsedByDefault === true ? false : true
   };
 
   render() {
+    const { isOpen } = this.state;
+
     return (
       <div>
-        <SectionHeader
-          onClick={() => this.setState({ isOpen: !this.state.isOpen })}
-        >
+        <SectionHeader onClick={() => this.setState({ isOpen: !isOpen })}>
           {this.props.title}
+          <DisclosureIcon
+            icon={isOpen ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_UP}
+          />
         </SectionHeader>
-        <Collapse isOpen={this.state.isOpen}>
+        <Collapse isOpen={isOpen}>
           <SectionInner>{this.props.children}</SectionInner>
         </Collapse>
       </div>
     );
   }
 }
+
+export const DisclosureIcon = styled(Icon)`
+  float: right;
+  opacity: 0.5;
+`;
 
 export const SidebarTitle = styled.h3`
   font-family: "Source Code Pro", monospace;

--- a/python_modules/dagit/dagit/webapp/src/configeditor/TypeExplorer.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/TypeExplorer.tsx
@@ -25,6 +25,7 @@ export default class TypeExplorer extends React.Component<
         __typename
         name
         description
+        builtin
         ... on CompositeType {
           fields {
             name

--- a/python_modules/dagit/dagit/webapp/src/configeditor/TypeExplorer.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/TypeExplorer.tsx
@@ -25,7 +25,10 @@ export default class TypeExplorer extends React.Component<
         __typename
         name
         description
-        builtin
+        typeAttributes {
+          isBuiltin
+          isSystemConfig
+        }
         ... on CompositeType {
           fields {
             name

--- a/python_modules/dagit/dagit/webapp/src/configeditor/TypeList.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/TypeList.tsx
@@ -14,16 +14,16 @@ interface ITypeListProps {
   types: Array<TypeListFragment>;
 }
 
-function groupTypes(types: TypeListFragment[]) {
+function groupTypes(types: Array<TypeListFragment>) {
   const groups = {
     Custom: Array<TypeListFragment>(),
     Generated: Array<TypeListFragment>(),
     "Built-in": Array<TypeListFragment>()
   };
   types.forEach(type => {
-    if (type.builtin) {
+    if (type.typeAttributes.isBuiltin) {
       groups["Built-in"].push(type);
-    } else if (type.name.includes(".")) {
+    } else if (type.typeAttributes.isSystemConfig) {
       groups["Generated"].push(type);
     } else {
       groups["Custom"].push(type);
@@ -37,7 +37,10 @@ export default class TypeList extends React.Component<ITypeListProps, {}> {
     TypeListFragment: gql`
       fragment TypeListFragment on Type {
         name
-        builtin
+        typeAttributes {
+          isBuiltin
+          isSystemConfig
+        }
         ...TypeWithTooltipFragment
       }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/TypeList.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/TypeList.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import gql from "graphql-tag";
+import styled from "styled-components";
 import { H3, UL } from "@blueprintjs/core";
 import TypeWithTooltip from "../TypeWithTooltip";
 import { TypeListFragment } from "./types/TypeListFragment";
@@ -13,12 +14,30 @@ interface ITypeListProps {
   types: Array<TypeListFragment>;
 }
 
+function groupTypes(types: TypeListFragment[]) {
+  const groups = {
+    Custom: Array<TypeListFragment>(),
+    Generated: Array<TypeListFragment>(),
+    "Built-in": Array<TypeListFragment>()
+  };
+  types.forEach(type => {
+    if (type.builtin) {
+      groups["Built-in"].push(type);
+    } else if (type.name.includes(".")) {
+      groups["Generated"].push(type);
+    } else {
+      groups["Custom"].push(type);
+    }
+  });
+  return groups;
+}
+
 export default class TypeList extends React.Component<ITypeListProps, {}> {
   static fragments = {
     TypeListFragment: gql`
       fragment TypeListFragment on Type {
         name
-
+        builtin
         ...TypeWithTooltipFragment
       }
 
@@ -26,24 +45,33 @@ export default class TypeList extends React.Component<ITypeListProps, {}> {
     `
   };
 
-  renderTypes() {
-    return this.props.types.map((type, i) => (
-      <li key={i}>
+  renderTypes(types: TypeListFragment[]) {
+    return types.map((type, i) => (
+      <TypeLI key={i}>
         <TypeWithTooltip type={type} />
-      </li>
+      </TypeLI>
     ));
   }
 
   render() {
+    const groups = groupTypes(this.props.types);
+
     return (
       <div>
         <SidebarSubhead />
         <SidebarTitle>Pipeline Types</SidebarTitle>
-        <SidebarSection title={"Fields"}>
-          <UL>{this.renderTypes()}</UL>
-        </SidebarSection>
+        {Object.keys(groups).map((title, idx) => (
+          <SidebarSection title={title} collapsedByDefault={idx !== 0}>
+            <UL>{this.renderTypes(groups[title])}</UL>
+          </SidebarSection>
+        ))}
         <H3 />
       </div>
     );
   }
 }
+
+const TypeLI = styled.li`
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+`;

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerContainerQuery.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerContainerQuery.ts
@@ -7,11 +7,47 @@
 // GraphQL query operation: TypeExplorerContainerQuery
 // ====================================================
 
+export interface TypeExplorerContainerQuery_type_RegularType_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
+}
+
 export interface TypeExplorerContainerQuery_type_RegularType {
   __typename: "RegularType";
   name: string;
   description: string | null;
-  builtin: boolean;
+  typeAttributes: TypeExplorerContainerQuery_type_RegularType_typeAttributes;
+}
+
+export interface TypeExplorerContainerQuery_type_CompositeType_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
 }
 
 export interface TypeExplorerContainerQuery_type_CompositeType_fields_type {
@@ -31,7 +67,7 @@ export interface TypeExplorerContainerQuery_type_CompositeType {
   __typename: "CompositeType";
   name: string;
   description: string | null;
-  builtin: boolean;
+  typeAttributes: TypeExplorerContainerQuery_type_CompositeType_typeAttributes;
   fields: TypeExplorerContainerQuery_type_CompositeType_fields[];
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerContainerQuery.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerContainerQuery.ts
@@ -11,6 +11,7 @@ export interface TypeExplorerContainerQuery_type_RegularType {
   __typename: "RegularType";
   name: string;
   description: string | null;
+  builtin: boolean;
 }
 
 export interface TypeExplorerContainerQuery_type_CompositeType_fields_type {
@@ -30,6 +31,7 @@ export interface TypeExplorerContainerQuery_type_CompositeType {
   __typename: "CompositeType";
   name: string;
   description: string | null;
+  builtin: boolean;
   fields: TypeExplorerContainerQuery_type_CompositeType_fields[];
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerFragment.ts
@@ -11,6 +11,7 @@ export interface TypeExplorerFragment_RegularType {
   __typename: "RegularType";
   name: string;
   description: string | null;
+  builtin: boolean;
 }
 
 export interface TypeExplorerFragment_CompositeType_fields_type {
@@ -30,6 +31,7 @@ export interface TypeExplorerFragment_CompositeType {
   __typename: "CompositeType";
   name: string;
   description: string | null;
+  builtin: boolean;
   fields: TypeExplorerFragment_CompositeType_fields[];
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeExplorerFragment.ts
@@ -7,11 +7,47 @@
 // GraphQL fragment: TypeExplorerFragment
 // ====================================================
 
+export interface TypeExplorerFragment_RegularType_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
+}
+
 export interface TypeExplorerFragment_RegularType {
   __typename: "RegularType";
   name: string;
   description: string | null;
-  builtin: boolean;
+  typeAttributes: TypeExplorerFragment_RegularType_typeAttributes;
+}
+
+export interface TypeExplorerFragment_CompositeType_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
 }
 
 export interface TypeExplorerFragment_CompositeType_fields_type {
@@ -31,7 +67,7 @@ export interface TypeExplorerFragment_CompositeType {
   __typename: "CompositeType";
   name: string;
   description: string | null;
-  builtin: boolean;
+  typeAttributes: TypeExplorerFragment_CompositeType_typeAttributes;
   fields: TypeExplorerFragment_CompositeType_fields[];
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListContainerQuery.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListContainerQuery.ts
@@ -9,6 +9,7 @@
 
 export interface TypeListContainerQuery_types {
   name: string;
+  builtin: boolean;
   description: string | null;
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListContainerQuery.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListContainerQuery.ts
@@ -7,9 +7,27 @@
 // GraphQL query operation: TypeListContainerQuery
 // ====================================================
 
+export interface TypeListContainerQuery_types_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
+}
+
 export interface TypeListContainerQuery_types {
   name: string;
-  builtin: boolean;
+  typeAttributes: TypeListContainerQuery_types_typeAttributes;
   description: string | null;
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListFragment.ts
@@ -9,6 +9,7 @@
 
 export interface TypeListFragment {
   name: string;
+  builtin: boolean;
   description: string | null;
 }
 

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/TypeListFragment.ts
@@ -7,9 +7,27 @@
 // GraphQL fragment: TypeListFragment
 // ====================================================
 
+export interface TypeListFragment_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
+}
+
 export interface TypeListFragment {
   name: string;
-  builtin: boolean;
+  typeAttributes: TypeListFragment_typeAttributes;
   description: string | null;
 }
 


### PR DESCRIPTION
This is a pretty small PR that groups the items in the type explorer so it's a bit easier to navigate. The "Generated" and "Built-in" types are collapsed by default.

I didn't want to hardcode `String`, `Bool`, etc. in to the client so I added a "builtin" attribute to the typescript schema that checks to see if the type is one of the standard ones exported from `types.py`. I'm not sure this is the best way to do this—if it'd be better, it'd also be easy to hardcode the list in JS.

For generated types, we decided to just detect the presence of a `.` for now and introduce a more formal classification later after things have evolved a bit.