### PR TITLE
Config type optional behavior

### DIFF
--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -71,9 +71,11 @@ yarn
 yarn build</pre>'''
         return text, 500
 
+
 import nbformat
 from traitlets.config import Config
 from nbconvert import HTMLExporter
+
 
 def notebook_view(_path):
     # This currently provides open access to your file system - the very least we can

--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -183,6 +183,7 @@ class SolidMetadataItemDefinition(graphene.ObjectType):
     key = graphene.String()
     value = graphene.String()
 
+
 class SolidDefinition(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -220,9 +220,6 @@ class EnvironmentConfigType(DagsterCompositeType):
         )
 
     def evaluate_value(self, value):
-        # if value is None:
-        #     return Environment()
-
         if isinstance(value, Environment):
             return value
 

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -382,4 +382,3 @@ def test_custom_composite_type():
             'foo': 'some_string',
             'bar': 'not_an_int',
         })
-

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 import pytest
+
 from dagster import (
     ConfigDefinition,
     types,
@@ -381,3 +382,4 @@ def test_custom_composite_type():
             'foo': 'some_string',
             'bar': 'not_an_int',
         })
+

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -258,7 +258,6 @@ def _validate_environment(environment, pipeline):
 
 
 def _create_config_value(config_type, config_input):
-    print(f'CREATE_CONFIG_VALUE name {config_type.name} input {config_input}')
     try:
         return config_type.evaluate_value(config_input)
     except DagsterEvaluateValueError as e:
@@ -276,15 +275,11 @@ def yield_context(pipeline, environment):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(environment, 'environment', config.Environment)
 
-    print(f'INCOMING ENVIRONMENT {environment}')
-
     _validate_environment(environment, pipeline)
 
     context_name = environment.context.name
     context_definition = pipeline.context_definitions[context_name]
     config_type = context_definition.config_def.config_type
-
-    print('About to create config value out of ' + str(environment.context))
 
     config_value = _create_config_value(config_type, environment.context.config)
 
@@ -310,7 +305,6 @@ def execute_pipeline_iterator(pipeline, environment):
 
     pipeline_env_type = EnvironmentConfigType(pipeline)
 
-    print(f'RIGHT BEFORE _create_config_value {environment}')
     environment = _create_config_value(pipeline_env_type, environment)
 
     check.inst_param(environment, 'enviroment', config.Environment)
@@ -398,7 +392,6 @@ def execute_pipeline(
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
 
     pipeline_env_type = EnvironmentConfigType(pipeline)
-    print(f'Right before in execute_pipeline {environment}')
     environment = _create_config_value(pipeline_env_type, environment)
 
     execution_graph = ExecutionGraph.from_pipeline(pipeline)
@@ -416,7 +409,6 @@ def _execute_graph(
 
     display_name = execution_graph.pipeline.display_name
     results = []
-    print(f'Right before in execute graph {environment}')
     with yield_context(execution_graph.pipeline, environment) as context:
         with context.value('pipeline', execution_graph.pipeline.display_name):
             context.info('Beginning execution of pipeline {pipeline}'.format(pipeline=display_name))

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/repository.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/repository.py
@@ -1,9 +1,9 @@
 from dagster import (RepositoryDefinition)
 from dagstermill.dagstermill_tests.test_basic_dagstermill_solids import (
-    define_test_notebook_dag_pipeline,
-    define_hello_world_config_pipeline,
+    define_test_notebook_dag_pipeline, define_hello_world_config_pipeline,
     define_hello_world_inputs_pipeline
 )
+
 
 def define_example_repository():
     return RepositoryDefinition(


### PR DESCRIPTION
This PR pushes more of the behavior to determine defaults in the system config type system. This makes it so that one does not have to specify config values if all the values down in the tree are optional and defaults are filled in properly. This increases the usability of the config system.