### PR TITLE
Context config improvements and cleanup

### DIFF
--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -144,8 +144,8 @@ class ContextConfigType(DagsterCompositeType):
             )
 
         if len(value) > 1:
-            specified_contexts = list(value.keys())
-            available_contexts = list(self.field_dict.keys())
+            specified_contexts = sorted(list(value.keys()))
+            available_contexts = sorted(list(self.field_dict.keys()))
             raise DagsterEvaluateValueError(
                 (
                     'You can only specify a single context. You specified {specified_contexts}. '

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from dagster import (
@@ -200,13 +202,18 @@ def test_errors():
 
     context_config_type = ContextConfigType('something', context_defs)
 
-    with pytest.raises(DagsterEvaluateValueError, match='must be dict'):
+    with pytest.raises(DagsterEvaluateValueError, match='must be None or dict'):
         context_config_type.evaluate_value(1)
 
     with pytest.raises(DagsterEvaluateValueError, match='Must specify in config'):
         context_config_type.evaluate_value({})
 
-    with pytest.raises(DagsterEvaluateValueError, match='You can only specify a single context'):
+    expected_message = (
+        "You can only specify a single context. You specified ['context_one', 'context_two']. "
+        "The available contexts are ['test']"
+    )
+
+    with pytest.raises(DagsterEvaluateValueError, match=re.escape(expected_message)):
         context_config_type.evaluate_value({
             'context_one': 1,
             'context_two': 2,
@@ -530,8 +537,8 @@ def test_required_solid_with_required_subfield():
     with pytest.raises(DagsterEvaluateValueError):
         env_type.evaluate_value({'solids': {}})
 
-    # with pytest.raises(DagsterEvaluateValueError):
-    #     env_type.evaluate_value({})
+    with pytest.raises(DagsterEvaluateValueError):
+        env_type.evaluate_value({})
 
 
 def test_all_optional_on_default_context_dict():

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -206,12 +206,33 @@ def test_errors():
     with pytest.raises(DagsterEvaluateValueError, match='Must specify in config'):
         context_config_type.evaluate_value({})
 
-    expected_message = (
-        "You can only specify a single context. You specified ['context_one', 'context_two']. "
-        "The available contexts are ['test']"
-    ).replace('[', r'\[').replace(']', r'\]')
+    # I tried doing some regular expressions here but the rules differ for escaping
+    # between 2.7, 3.5, or 3.6 so gave up and did this hackneyed solution
+    with pytest.raises(DagsterEvaluateValueError, match='You can only specify a single context'):
+        context_config_type.evaluate_value({
+            'context_one': 1,
+            'context_two': 2,
+        })
 
-    with pytest.raises(DagsterEvaluateValueError, match=expected_message):
+    with pytest.raises(DagsterEvaluateValueError, match="You specified"):
+        context_config_type.evaluate_value({
+            'context_one': 1,
+            'context_two': 2,
+        })
+
+    with pytest.raises(DagsterEvaluateValueError, match="'context_one', 'context_two'"):
+        context_config_type.evaluate_value({
+            'context_one': 1,
+            'context_two': 2,
+        })
+
+    with pytest.raises(DagsterEvaluateValueError, match="The available contexts are"):
+        context_config_type.evaluate_value({
+            'context_one': 1,
+            'context_two': 2,
+        })
+
+    with pytest.raises(DagsterEvaluateValueError, match="'test'"):
         context_config_type.evaluate_value({
             'context_one': 1,
             'context_two': 2,

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 
 from dagster import (
@@ -211,9 +209,9 @@ def test_errors():
     expected_message = (
         "You can only specify a single context. You specified ['context_one', 'context_two']. "
         "The available contexts are ['test']"
-    )
+    ).replace('[', r'\[').replace(']', r'\]')
 
-    with pytest.raises(DagsterEvaluateValueError, match=re.escape(expected_message)):
+    with pytest.raises(DagsterEvaluateValueError, match=expected_message):
         context_config_type.evaluate_value({
             'context_one': 1,
             'context_two': 2,

--- a/python_modules/dagster/docs/intro_tutorial/part_nine.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_nine.rst
@@ -80,8 +80,9 @@ Now we configure execution using a env.yml file:
 .. code-block:: yaml
 
     context:
-        config: 
-        log_level: DEBUG
+        default:
+            config:
+                log_level: DEBUG
 
     solids:
         injest_a:
@@ -203,7 +204,7 @@ service, and one that is an in-memory implementation of this.
 Now we need to create one of these stores and put them into the context. The pipeline author must
 create a :py:class:`PipelineContextDefinition`.
 
-It two primrary attributes:
+It two primary attributes:
 
 1) A configuration definition that allows the pipeline author to define what configuration
 is needed to create the ExecutionContext.
@@ -310,7 +311,7 @@ we config it with that name.
 .. code-block:: yaml
 
     context:
-        name: local
+        local:
 
     solids:
         injest_a:
@@ -376,11 +377,11 @@ Now when you invoke this pipeline with the following yaml file:
 .. code-block:: yaml
 
     context:
-        name: cloud
-        config:
-            credentials:
-                user: some_user
-                pass: some_password
+        cloud:
+            config:
+                credentials:
+                    user: some_user
+                    pass: some_password
 
     solids:
         injest_a:


### PR DESCRIPTION
- Fixed part nine tutorial
- Fixed part nine tutorial test cases to be driven by yaml which is higher fidelity to docs
- Improved error message for improperly specified contexts in yaml
- Made context config parsing slightly more permissive when all values in the context config are optional.