### PR TITLE
Better rules around what you need to specify for context configs

### DIFF
--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -15,11 +15,8 @@ from .definitions import (
     PipelineDefinition,
 )
 
-from .errors import DagsterTypeError
-
 from .types import (
     Bool,
-    ConfigDictionary,
     DagsterCompositeType,
     DagsterEvaluateValueError,
     DagsterType,

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -62,10 +62,7 @@ def define_possibly_optional_field(config_type, is_optional):
 class SpecificContextConfig(DagsterCompositeType, HasUserConfig):
     def __init__(self, name, config_type):
         check.str_param(name, 'name')
-        is_optional = all_optional_type(config_type)
-
         config_field = define_possibly_optional_field(config_type, all_optional_type(config_type))
-
         super(SpecificContextConfig, self).__init__(name, {'config': config_field})
 
     def evaluate_value(self, value):
@@ -190,12 +187,7 @@ class SolidConfigType(DagsterCompositeType, HasUserConfig):
 
 def define_environment_field(field_type):
     check.inst_param(field_type, 'field_type', DagsterType)
-
-    return Field(
-        field_type,
-        is_optional=True,
-        default_value=lambda: field_type.evaluate_value({}),
-    )
+    return define_possibly_optional_field(field_type, all_optional_type(field_type))
 
 
 class EnvironmentConfigType(DagsterCompositeType):

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -25,8 +25,6 @@ from dagster.core.config_types import (
     camelcase,
 )
 
-from dagster.core.definitions import DefaultContextConfigDict
-
 
 def test_camelcase():
     assert camelcase('foo') == 'Foo'
@@ -617,7 +615,8 @@ def test_required_context_with_required_subfield():
         name='some_pipeline',
         solids=[],
         context_definitions={
-            'some_context': PipelineContextDefinition(
+            'some_context':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
@@ -646,7 +645,8 @@ def test_all_optional_field_on_single_context_dict():
         name='some_pipeline',
         solids=[],
         context_definitions={
-            'some_context': PipelineContextDefinition(
+            'some_context':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
@@ -666,13 +666,14 @@ def test_all_optional_field_on_single_context_dict():
     assert env_type.field_dict['execution'].is_optional
     assert env_type.field_dict['expectations'].is_optional
 
+
 def test_optional_and_required_context():
     pipeline_def = PipelineDefinition(
         name='some_pipeline',
         solids=[],
         context_definitions={
-            'optional_field_context': PipelineContextDefinition(
-
+            'optional_field_context':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
@@ -683,8 +684,8 @@ def test_optional_and_required_context():
                     ),
                 ),
             ),
-            'required_field_context': PipelineContextDefinition(
-
+            'required_field_context':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
@@ -721,14 +722,17 @@ def test_optional_and_required_context():
         },
     )
 
+    assert env_obj.context.name == 'optional_field_context'
+    assert env_obj.context.config == {'optional_field': 'foobar'}
+
 
 def test_default_optional_and_required_context():
     pipeline_def = PipelineDefinition(
         name='some_pipeline',
         solids=[],
         context_definitions={
-            'default': PipelineContextDefinition(
-
+            'default':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
@@ -739,8 +743,8 @@ def test_default_optional_and_required_context():
                     ),
                 ),
             ),
-            'required_field_context': PipelineContextDefinition(
-
+            'required_field_context':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
@@ -761,19 +765,21 @@ def test_default_optional_and_required_context():
     assert env_obj.context.name == 'default'
     assert env_obj.context.config == {}
 
+
 def test_default_optional_with_default_value_and_required_context():
     pipeline_def = PipelineDefinition(
         name='some_pipeline',
         solids=[],
         context_definitions={
-            'default': PipelineContextDefinition(
-
+            'default':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
-                            'optional_field': types.Field(
+                            'optional_field':
+                            types.Field(
                                 types.String,
                                 is_optional=True,
                                 default_value='foobar',
@@ -782,8 +788,8 @@ def test_default_optional_with_default_value_and_required_context():
                     ),
                 ),
             ),
-            'required_field_context': PipelineContextDefinition(
-
+            'required_field_context':
+            PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
                     config_type=types.ConfigDictionary(

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
@@ -16,7 +16,6 @@ from dagster import (
     PipelineContextDefinition,
     PipelineDefinition,
     RepositoryDefinition,
-    config,
     execute_pipeline,
     lambda_solid,
     solid,
@@ -229,11 +228,11 @@ def define_part_nine_repo():
     )
 
 
-
 def test_intro_tutorial_part_nine_step_one():
     result = execute_pipeline(
         define_part_nine_step_one_pipeline(),
-        yaml.load('''
+        yaml.load(
+            '''
 solids:
     injest_a:
         config: 2
@@ -253,9 +252,10 @@ context:
     assert result.result_for_solid('add_ints').transformed_value() == 5
     assert result.result_for_solid('mult_ints').transformed_value() == 6
 
+
 def test_intro_tutorial_part_nine_step_one_with_various_defaults():
     yaml_variants = [
-       '''
+        '''
 solids:
     injest_a:
         config: 2
@@ -289,7 +289,6 @@ solids:
     injest_b:
         config: 3
 ''',
-
     ]
     for yaml_variant in yaml_variants:
 
@@ -308,7 +307,8 @@ solids:
 def test_intro_tutorial_part_nine_final_local_success():
     result = execute_pipeline(
         define_part_nine_final_pipeline(),
-        yaml.load('''
+        yaml.load(
+            '''
 context:
     local:
 
@@ -317,7 +317,8 @@ solids:
         config: 2
     injest_b:
         config: 3
-'''),
+'''
+        ),
     )
 
     assert result.success
@@ -337,7 +338,8 @@ solids:
 def test_intro_tutorial_part_nine_final_cloud_success():
     result = execute_pipeline(
         define_part_nine_final_pipeline(),
-        yaml.load('''
+        yaml.load(
+            '''
 context:
     cloud:
         config:
@@ -350,9 +352,9 @@ solids:
         config: 2
     injest_b:
         config: 3
-'''),
-
-   )
+'''
+        ),
+    )
 
     assert result.success
 
@@ -361,7 +363,8 @@ def test_intro_tutorial_part_nine_final_error():
     with pytest.raises(DagsterTypeError, match='Field username not found'):
         execute_pipeline(
             define_part_nine_final_pipeline(),
-            yaml.load('''
+            yaml.load(
+                '''
 context:
     cloud:
         config:
@@ -374,5 +377,6 @@ solids:
         config: 2
     injest_b:
         config: 3
-'''),
+'''
+            ),
         )


### PR DESCRIPTION
Context configuration is complicated. The current system config schema is working around the lack of something like tagged union. Only one of the contexts can be specified, and 'default' is treated specially. (The default thing might definitely be a mistake, but we can address that later).

I expect this to change as we explore the config editor.

