### PR TITLE
Add the ability to scaffold a config

### DIFF
--- a/python_modules/dagster/dagster/cli/cli_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster/cli/cli_tests/test_cli_commands.py
@@ -6,6 +6,7 @@ from dagster.cli.pipeline import (
     execute_print_command,
     execute_list_command,
     execute_execute_command,
+    execute_scaffold_command,
 )
 from dagster.cli.dynamic_loader import InvalidRepositoryLoadingComboError
 
@@ -149,12 +150,27 @@ def test_execute_command():
         execute_execute_command(
             env=None,
             cli_args=cli_args,
-            print_fn=print,
+            print_fn=no_print,
         )
 
     for cli_args in valid_cli_args():
         execute_execute_command(
             env=script_relative_path('env.yml'),
             cli_args=cli_args,
-            print_fn=print,
+            print_fn=no_print,
+        )
+
+
+def test_scaffold_command():
+    for cli_args in valid_cli_args():
+        cli_args['print_only_required'] = True
+        execute_scaffold_command(
+            cli_args=cli_args,
+            print_fn=no_print,
+        )
+
+        cli_args['print_only_required'] = False
+        execute_scaffold_command(
+            cli_args=cli_args,
+            print_fn=no_print,
         )

--- a/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
@@ -1,0 +1,154 @@
+from dagster import (
+    PipelineContextDefinition,
+    PipelineDefinition,
+    SolidDefinition,
+    ConfigDefinition,
+    check,
+    types,
+)
+
+from dagster.core.config_types import EnvironmentConfigType
+
+from dagster.cli.config_scaffolder import (
+    scaffold_pipeline_config,
+    scaffold_type,
+)
+
+
+def fail_me():
+    return check.failed('Should not call')
+
+
+def test_scalars():
+    assert scaffold_type(types.Int) == 0
+    assert scaffold_type(types.String) == ''
+    assert scaffold_type(types.Path) == 'path/to/something'
+    assert scaffold_type(types.Bool) is True
+    assert scaffold_type(types.Dict) == {}
+    assert scaffold_type(types.Any) == 'AnyType'
+
+
+def test_basic_solids_config():
+    pipeline_def = PipelineDefinition(
+        name='BasicSolidsConfigPipeline',
+        solids=[
+            SolidDefinition(
+                name='required_field_solid',
+                inputs=[],
+                outputs=[],
+                config_def=ConfigDefinition(
+                    types.ConfigDictionary(
+                        'RequiredFieldSolidConfigDict',
+                        {'required_int': types.Field(types.Int)},
+                    )
+                ),
+                transform_fn=lambda *_args: fail_me(),
+            )
+        ]
+    )
+
+    env_config_type = EnvironmentConfigType(pipeline_def)
+
+    assert env_config_type.field_dict['solids'].is_optional is False
+    solids_config_type = env_config_type.field_dict['solids'].dagster_type
+    assert solids_config_type.field_dict['required_field_solid'].is_optional is False
+    required_solid_config_type = solids_config_type.field_dict['required_field_solid'].dagster_type
+    assert required_solid_config_type.field_dict['config'].is_optional is False
+
+    context_config_type = env_config_type.field_dict['context'].dagster_type
+
+    assert 'default' in context_config_type.field_dict
+    assert context_config_type.field_dict['default'].is_optional
+
+    default_context_config_type = context_config_type.field_dict['default'].dagster_type
+
+    assert set(default_context_config_type.field_dict.keys()) == set(['config'])
+
+    default_context_user_config_type = default_context_config_type.field_dict['config'].dagster_type
+
+    assert set(default_context_user_config_type.field_dict.keys()) == set(['log_level'])
+
+    assert scaffold_pipeline_config(
+        pipeline_def,
+        skip_optional=False,
+    ) == {
+        'context': {
+            'default': {
+                'config': {
+                    'log_level': '',
+                },
+            },
+        },
+        'solids': {
+            'required_field_solid': {
+                'config': {
+                    'required_int': 0,
+                },
+            },
+        },
+        'execution': {
+            'serialize_intermediates': True,
+        },
+        'expectations': {
+            'evaluate': True,
+        },
+    }
+
+
+def test_two_contexts():
+    pipeline_def = PipelineDefinition(
+        name='TwoContextsPipeline',
+        solids=[],
+        context_definitions={
+            'context_one':
+            PipelineContextDefinition(
+                context_fn=lambda *args: fail_me(),
+                config_def=ConfigDefinition(
+                    types.ConfigDictionary(
+                        'ContextOneConfigDict',
+                        {
+                            'context_one_field': types.Field(types.String),
+                        },
+                    ),
+                ),
+            ),
+            'context_two':
+            PipelineContextDefinition(
+                context_fn=lambda *args: fail_me(),
+                config_def=ConfigDefinition(
+                    types.ConfigDictionary(
+                        'ContextTwoConfigDict',
+                        {
+                            'context_two_field': types.Field(types.Int),
+                        },
+                    ),
+                ),
+            ),
+        },
+    )
+
+    assert scaffold_pipeline_config(pipeline_def) == {'context': {}}
+
+    assert scaffold_pipeline_config(
+        pipeline_def, skip_optional=False
+    ) == {
+        'context': {
+            'context_one': {
+                'config': {
+                    'context_one_field': '',
+                },
+            },
+            'context_two': {
+                'config': {
+                    'context_two_field': 0,
+                },
+            },
+        },
+        'solids': {},
+        'execution': {
+            'serialize_intermediates': True,
+        },
+        'expectations': {
+            'evaluate': True,
+        },
+    }

--- a/python_modules/dagster/dagster/cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/config_scaffolder.py
@@ -1,0 +1,61 @@
+from dagster import (
+    PipelineDefinition,
+    check,
+    types,
+)
+
+from dagster.core.config_types import (
+    EnvironmentConfigType,
+    is_environment_context_field_optional,
+)
+
+
+def scaffold_pipeline_config(pipeline_def, skip_optional=True):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.bool_param(skip_optional, 'skip_optional')
+
+    env_config_type = EnvironmentConfigType(pipeline_def)
+
+    env_dict = {}
+
+    for env_field_name, env_field in env_config_type.field_dict.items():
+        if skip_optional and env_field.is_optional:
+            continue
+
+        # unfortunately we have to treat this special for now
+        if env_field_name == 'context':
+            if skip_optional and is_environment_context_field_optional(pipeline_def):
+                continue
+
+        env_dict[env_field_name] = scaffold_type(env_field.dagster_type, skip_optional)
+
+    return env_dict
+
+
+def scaffold_type(config_type, skip_optional=True):
+    check.inst_param(config_type, 'config_type', types.DagsterType)
+    check.bool_param(skip_optional, 'skip_optional')
+
+    if isinstance(config_type, types.DagsterCompositeType):
+        default_dict = {}
+        for field_name, field in config_type.field_dict.items():
+            if skip_optional and field.is_optional:
+                continue
+
+            default_dict[field_name] = scaffold_type(field.dagster_type, skip_optional)
+        return default_dict
+    elif config_type is types.Dict:
+        return {}
+    elif config_type is types.Any:
+        return 'AnyType'
+    elif isinstance(config_type, types.DagsterScalarType):
+        defaults = {
+            types.String: '',
+            types.Path: 'path/to/something',
+            types.Int: 0,
+            types.Bool: True,
+        }
+
+        return defaults[config_type]
+    else:
+        check.failed('Do not know how to scaffold {type_name}'.format(type_name=config_type.name))


### PR DESCRIPTION
Add a CLI command that can take a pipeline and scaffold a config. There are too variants of this command. One that prints out *every* piece of config, whether it be optional or not. The other skips all required config.