### PR TITLE
config dict builder

### DIFF
--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -1,6 +1,8 @@
 import re
 from dagster import check
 
+from dagster.utils import camelcase
+
 from .config import (
     Context,
     Environment,
@@ -347,15 +349,3 @@ class ExecutionConfigType(DagsterCompositeType):
 
     def evaluate_value(self, value):
         return process_incoming_composite_value(self, value, lambda val: Execution(**val))
-
-
-# Adapted from https://github.com/okunishinishi/python-stringcase/blob/master/stringcase.py
-def camelcase(string):
-    string = re.sub(r'^[\-_\.]', '', str(string))
-    if not string:
-        return string
-    return str(string[0]).upper() + re.sub(
-        r'[\-_\.\s]([a-z])',
-        lambda matched: str(matched.group(1)).upper(),
-        string[1:],
-    )

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -1,4 +1,3 @@
-import re
 from dagster import check
 
 from dagster.utils import camelcase
@@ -298,9 +297,7 @@ def all_optional_type(dagster_type):
     check.inst_param(dagster_type, 'dagster_type', DagsterType)
 
     if isinstance(dagster_type, DagsterCompositeType):
-        for field in dagster_type.field_dict.values():
-            if not field.is_optional:
-                return False
+        return dagster_type.all_fields_optional
     return True
 
 

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -317,7 +317,7 @@ class SolidDictionaryType(DagsterCompositeType):
             if solid.definition.config_def:
                 solid_name = camelcase(solid.name)
                 solid_config_type = SolidConfigType(
-                    '{pipeline_name}.{solid_name}.SolidConfig'.format(
+                    '{pipeline_name}.SolidConfig.{solid_name}'.format(
                         pipeline_name=pipeline_name,
                         solid_name=solid_name,
                     ),

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -521,6 +521,7 @@ def test_build_optionality():
     assert optional_test_type.field_dict['required'].is_optional is False
     assert optional_test_type.field_dict['optional'].is_optional is True
 
+
 def test_pipeline_name_mismatch_error():
     with pytest.raises(DagsterInvalidDefinitionError, match='wrong pipeline name'):
         PipelineDefinition(
@@ -540,13 +541,13 @@ def test_pipeline_name_mismatch_error():
             ],
         )
 
-
     with pytest.raises(DagsterInvalidDefinitionError, match='wrong pipeline name'):
         PipelineDefinition(
             name='pipeline_mismatch_test',
             solids=[],
             context_definitions={
-                'some_context' : PipelineContextDefinition(
+                'some_context':
+                PipelineContextDefinition(
                     context_fn=lambda *_args: None,
                     config_def=ConfigDefinition.context_config_dict(
                         'not_a_match',
@@ -556,6 +557,7 @@ def test_pipeline_name_mismatch_error():
                 )
             }
         )
+
 
 def test_solid_name_mismatch():
     with pytest.raises(DagsterInvalidDefinitionError, match='wrong solid name'):
@@ -601,7 +603,8 @@ def test_context_name_mismatch():
             name='context_name_mismatch',
             solids=[],
             context_definitions={
-                'test' : PipelineContextDefinition(
+                'test':
+                PipelineContextDefinition(
                     context_fn=lambda *_args: None,
                     config_def=ConfigDefinition.context_config_dict(
                         'context_name_mismatch',
@@ -617,7 +620,8 @@ def test_context_name_mismatch():
             name='context_name_mismatch',
             solids=[],
             context_definitions={
-                'test' : PipelineContextDefinition(
+                'test':
+                PipelineContextDefinition(
                     context_fn=lambda *_args: None,
                     config_def=ConfigDefinition.solid_config_dict(
                         'context_name_mismatch',

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -412,6 +412,25 @@ def test_build_single_nested():
         assert nested_field_type.name == 'PipelineName.Solid.SolidName.NestedDict.ConfigDict'
         assert nested_field_type.field_name_set == set(['bar'])
 
+    old_style_config_def = ConfigDefinition(
+        types.ConfigDictionary(
+            'PipelineName.Solid.SolidName.ConfigDict',
+            {
+                'foo' : types.Field(types.String),
+                'nested_dict' : types.Field(
+                    types.ConfigDictionary(
+                        'PipelineName.Solid.SolidName.NestedDict.ConfigDict',
+                        {
+                            'bar' : types.Field(types.String),
+                        },
+                    ),
+                ),
+            },
+        ),
+    )
+
+    _assert_facts(old_style_config_def.config_type)
+
     single_nested_manual = build_config_dict_type(
         ['PipelineName', 'Solid', 'SolidName'],
         {

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -409,7 +409,7 @@ def test_whole_environment():
     solids_type = environment_type.field_dict['solids'].dagster_type
     assert solids_type.name == 'SomePipeline.SolidsConfigDictionary'
     assert solids_type.field_dict['int_config_solid'
-                                  ].dagster_type.name == 'SomePipeline.IntConfigSolid.SolidConfig'
+                                  ].dagster_type.name == 'SomePipeline.SolidConfig.IntConfigSolid'
     assert environment_type.field_dict['expectations'
                                        ].dagster_type.name == 'SomePipeline.ExpectationsConfig'
 

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -25,7 +25,6 @@ from dagster.core.config_types import (
 )
 
 
-
 def test_context_config_any():
     context_defs = {
         'test':

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -22,15 +22,8 @@ from dagster.core.config_types import (
     SolidDictionaryType,
     SpecificContextConfig,
     all_optional_user_config,
-    camelcase,
 )
 
-
-def test_camelcase():
-    assert camelcase('foo') == 'Foo'
-    assert camelcase('foo_bar') == 'FooBar'
-    assert camelcase('foo.bar') == 'FooBar'
-    assert camelcase('foo-bar') == 'FooBar'
 
 
 def test_context_config_any():

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1044,7 +1044,6 @@ class Result(namedtuple('_Result', 'value output_name')):
         )
 
 
-# PipelineName.Context.ContextName.ConfigDict
 def build_config_dict_type(name_stack, fields, scoped_config_info):
     check.list_param(name_stack, 'name_stack', of_type=str)
     check.dict_param(fields, 'fields', key_type=str, value_type=(Field, dict))

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -692,7 +692,6 @@ class PipelineDefinition(object):
                         ).format(type_name=in_def_type.name, context_name=context_name)
                     )
 
-
     @staticmethod
     def create_single_solid_pipeline(pipeline, solid_name, injected_solids=None):
         '''
@@ -1314,6 +1313,7 @@ class SolidDefinition(object):
         if self.config_def:
             for dagster_type in self.config_def.config_type.iterate_types():
                 yield dagster_type
+
 
 def _create_adjacency_lists(solids, dep_structure):
     check.list_param(solids, 'solids', Solid)

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1040,6 +1040,36 @@ class ConfigDefinition(object):
 
     @staticmethod
     def context_config_def_dict(pipeline_name, context_name, fields):
+        '''
+        Method to create a ConfigDefinition for a PipelineContextDefinition
+
+        e.g.
+
+        PipelineContextDefinition(
+            context_fn=_some_fn,
+            config_def=ConfigDefinition.context_config_def_dict(
+                'pipeline_name',
+                'context_name',
+                { # creates type PipelineName.Context.ContextName.ConfigDict
+                    'dict_field_one' : { # creates type named
+                                         # PipelineName.Context.ContextName.DictFieldOne.ConfigDict
+                        'sub_field' : types.Field(types.String),
+                    },
+                    'field_two' : types.Field(types.Int),
+                },
+            ),
+        )
+
+        Args:
+            pipeline_name (str): The name of the pipeline this resides within
+            contexts_name (str): The name of the context this resides within
+            fields (FieldsDict = Dict[str, Field | FieldsDict]): Dictionary that represents
+                the structure of the config. The key name at every level is the field name.
+                If the value is a field then it is just a field. If the value is a dictionary
+                then another config dictionary is constructed (recursively) and set to that
+                types. Essentially a new type is created at every non-leaf node of this tree.
+
+        '''
         check.str_param(pipeline_name, 'pipeline_name')
         check.str_param(context_name, 'context_name')
         check.dict_param(fields, 'fields', key_type=str)
@@ -1057,6 +1087,12 @@ class ConfigDefinition(object):
 
     @staticmethod
     def solid_config_def_dict(pipeline_name, solid_name, fields):
+        '''
+            See description of context_config_def_dict.
+
+            The only difference between these two is that this method constructs
+            types starting with the name '<<PipelineName>>.Solid.<<SolidName>>'
+        '''
         check.str_param(pipeline_name, 'pipeline_name')
         check.str_param(solid_name, 'solid_name')
         check.dict_param(fields, 'fields', key_type=str)

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1014,6 +1014,14 @@ class ConfigDefinition(object):
     '''
 
     @staticmethod
+    def solid_config_def_dict(pipeline_name, solid_name, fields):
+        pass
+
+    @staticmethod
+    def context_config_def_dict(pipeline_name, solid_name, fields):
+        pass
+
+    @staticmethod
     def config_dict(name, field_dict):
         '''Shortcut to create a dictionary based config definition.
 

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -288,6 +288,17 @@ class DagsterCompositeType(DagsterType):
                 yield inner_type
         yield self
 
+    @property
+    def all_fields_optional(self):
+        for field in self.field_dict.values():
+            if not field.is_optional:
+                return False
+        return True
+
+    @property
+    def field_name_set(self):
+        return set(self.field_dict.keys())
+
 
 class ConfigDictionary(DagsterCompositeType):
     '''Configuration dictionary.

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import re
 import yaml
 
 from dagster import check
@@ -23,3 +24,14 @@ def load_yaml_from_path(path):
     check.str_param(path, 'path')
     with open(path, 'r') as ff:
         return yaml.load(ff)
+
+# Adapted from https://github.com/okunishinishi/python-stringcase/blob/master/stringcase.py
+def camelcase(string):
+    string = re.sub(r'^[\-_\.]', '', str(string))
+    if not string:
+        return string
+    return str(string[0]).upper() + re.sub(
+        r'[\-_\.\s]([a-z])',
+        lambda matched: str(matched.group(1)).upper(),
+        string[1:],
+    )

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -25,6 +25,7 @@ def load_yaml_from_path(path):
     with open(path, 'r') as ff:
         return yaml.load(ff)
 
+
 # Adapted from https://github.com/okunishinishi/python-stringcase/blob/master/stringcase.py
 def camelcase(string):
     string = re.sub(r'^[\-_\.]', '', str(string))

--- a/python_modules/dagster/dagster/utils/utils_tests/test_camelcase.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_camelcase.py
@@ -1,0 +1,8 @@
+from dagster.utils import camelcase
+
+
+def test_camelcase():
+    assert camelcase('foo') == 'Foo'
+    assert camelcase('foo_bar') == 'FooBar'
+    assert camelcase('foo.bar') == 'FooBar'
+    assert camelcase('foo-bar') == 'FooBar'


### PR DESCRIPTION
Right now, constructing nested dictionaries for configurations on solids
and contexts is a big pain. The user must make up a throwaway name for
type and then do multiple layers of nesting, coming up with more
arbitrary names a long the way. The syntax is also verbose.

This PR address that issue.

What was before:

```
   ConfigDefinition(
        types.ConfigDictionary(
            'PipelineName.Solid.SolidName.ConfigDict',
            {
                'foo' : types.Field(types.String),
                'nested_dict' : types.Field(
                    types.ConfigDictionary(
                        'PipelineName.Solid.SolidName.NestedDict.ConfigDict',
                        {
                            'bar' : types.Field(types.String),
                        },
                    ),
                ),
            },
        ),
    )
```

becomes

```
    ConfigDefinition.solid_config_def_dict(
        'pipeline_name',
        'solid_name',
        {
            'foo': types.Field(types.String),
            'nested_dict': {
                'bar': types.Field(types.String),
            },
        },
    )
```

This should make it far less painful to construct configuration types
that are custom to a context or solid, reducing lots of boilerplate.