### PR TITLE
Fix rounding error causing text truncation on the DAG

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/graph/SVGComponents.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SVGComponents.tsx
@@ -60,7 +60,9 @@ export class SVGMonospaceText extends React.PureComponent<
 
   render() {
     const { width, size, text, ...rest } = this.props;
-    const chars = width ? width / (size * PX_TO_UNITS) : text.length;
+    const chars = width
+      ? Math.round(width / (size * PX_TO_UNITS))
+      : text.length;
 
     let textClipped = text;
     if (textClipped.length > chars) {


### PR DESCRIPTION
This is a small fix—the DAG was truncating the names of solids unnecessarily because it was calculating it had room for `9.99999` characters instead of `10`.