### PR TITLE
Attribute types

### DIFF
--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -401,8 +401,6 @@ class RegularType(graphene.ObjectType):
             Type,
         ]
 
-    type_attributes = graphene.NonNull(TypeAttributes)
-
     def __init__(self, dagster_type):
         super(RegularType, self).__init__(
             name=dagster_type.name,
@@ -416,7 +414,6 @@ class RegularType(graphene.ObjectType):
 
 class CompositeType(graphene.ObjectType):
     fields = graphene.NonNull(graphene.List(graphene.NonNull(lambda: TypeField)))
-    type_attributes = graphene.NonNull(TypeAttributes)
 
     class Meta:
         interfaces = [

--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -365,8 +365,21 @@ class Config(graphene.ObjectType):
 
 
 class TypeAttributes(graphene.ObjectType):
-    is_builtin = graphene.NonNull(graphene.Boolean)
-    is_system_config = graphene.NonNull(graphene.Boolean)
+    is_builtin = graphene.NonNull(
+        graphene.Boolean,
+        description='''
+True if the system defines it and it is the same type across pipelines.
+Examples include "Int" and "String."''',
+    )
+    is_system_config = graphene.NonNull(
+        graphene.Boolean,
+        description='''
+Dagster generates types for base elements of the config system (e.g. the solids and
+context field of the base environment). These types are always present
+and are typically not relevant to an end user. This flag allows tool authors to
+filter out those types by default.
+''',
+    )
 
 
 class Type(graphene.Interface):

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -272,6 +272,10 @@ fragment SolidFragment on Solid {
 fragment TypeWithTooltipFragment on Type {
   name
   description
+  typeAttributes {
+    isBuiltin
+    isSystemConfig
+  }
   __typename
 }
 

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -21,6 +21,7 @@ from .types import (
     DagsterCompositeType,
     DagsterEvaluateValueError,
     DagsterType,
+    DagsterTypeAttributes,
     process_incoming_composite_value,
 )
 
@@ -61,7 +62,11 @@ class SpecificContextConfig(DagsterCompositeType, HasUserConfig):
     def __init__(self, name, config_type):
         check.str_param(name, 'name')
         config_field = define_possibly_optional_field(config_type, all_optional_type(config_type))
-        super(SpecificContextConfig, self).__init__(name, {'config': config_field})
+        super(SpecificContextConfig, self).__init__(
+            name,
+            {'config': config_field},
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
+        )
 
     def evaluate_value(self, value):
         config_output = process_incoming_composite_value(self, value, lambda val: val)
@@ -121,6 +126,7 @@ class ContextConfigType(DagsterCompositeType):
             full_type_name,
             field_dict,
             'A configuration dictionary with typed fields',
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
         )
 
     def evaluate_value(self, value):
@@ -193,6 +199,7 @@ class SolidConfigType(DagsterCompositeType, HasUserConfig):
                     all_optional_type(config_type),
                 ),
             },
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
         )
 
     def evaluate_value(self, value):
@@ -266,6 +273,7 @@ class EnvironmentConfigType(DagsterCompositeType):
                 'expectations': expectations_field,
                 'execution': execution_field,
             },
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
         )
 
     def evaluate_value(self, value):
@@ -284,6 +292,7 @@ class ExpectationsConfigType(DagsterCompositeType):
         super(ExpectationsConfigType, self).__init__(
             name,
             {'evaluate': Field(Bool, is_optional=True, default_value=True)},
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
         )
 
     def evaluate_value(self, value):
@@ -328,7 +337,11 @@ class SolidDictionaryType(DagsterCompositeType):
                     all_optional_user_config(solid_config_type),
                 )
 
-        super(SolidDictionaryType, self).__init__(name, field_dict)
+        super(SolidDictionaryType, self).__init__(
+            name,
+            field_dict,
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
+        )
 
     def evaluate_value(self, value):
         return process_incoming_composite_value(self, value, lambda val: val)
@@ -342,6 +355,7 @@ class ExecutionConfigType(DagsterCompositeType):
             {
                 'serialize_intermediates': Field(Bool, is_optional=True, default_value=False),
             },
+            type_attributes=DagsterTypeAttributes(is_system_config=True),
         )
 
     def evaluate_value(self, value):

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -94,6 +94,7 @@ def test_default_execution():
     assert execution_config_type.evaluate_value(None).serialize_intermediates is False
     assert execution_config_type.type_attributes.is_system_config
 
+
 def test_default_context_config():
     pipeline_def = PipelineDefinition(
         solids=[
@@ -333,6 +334,7 @@ def test_solid_dictionary_type():
         assert specific_solid_config_type.type_attributes.is_system_config
         user_config_field = specific_solid_config_field.dagster_type.field_dict['config']
         assert user_config_field.dagster_type.type_attributes.is_system_config is False
+
 
 def define_test_solids_config_pipeline():
     return PipelineDefinition(

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -35,6 +35,9 @@ def test_context_config_any():
     }
 
     context_config_type = ContextConfigType('something', context_defs)
+
+    assert context_config_type.type_attributes.is_system_config
+
     output = context_config_type.evaluate_value({'test': {'config': 1}})
     assert output.name == 'test'
     assert output.config == 1
@@ -89,7 +92,7 @@ def test_default_execution():
     execution_config_type = ExecutionConfigType('some_name')
     assert execution_config_type.evaluate_value({}).serialize_intermediates is False
     assert execution_config_type.evaluate_value(None).serialize_intermediates is False
-
+    assert execution_config_type.type_attributes.is_system_config
 
 def test_default_context_config():
     pipeline_def = PipelineDefinition(
@@ -151,6 +154,7 @@ def test_provided_default_config():
     env_type = EnvironmentConfigType(pipeline_def)
     env_obj = env_type.evaluate_value({})
     assert env_obj.context.name == 'some_context'
+    assert env_type.type_attributes.is_system_config
 
 
 def test_default_environment():
@@ -285,6 +289,7 @@ def test_solid_config():
     solid_inst = solid_config_type.evaluate_value({'config': 1})
     assert isinstance(solid_inst, config.Solid)
     assert solid_inst.config == 1
+    assert solid_config_type.type_attributes.is_system_config
 
 
 def test_expectations_config():
@@ -321,6 +326,13 @@ def test_solid_dictionary_type():
         'string_config_solid': config.Solid('bar'),
     }
 
+    assert solid_dict_type.type_attributes.is_system_config
+
+    for specific_solid_config_field in solid_dict_type.field_dict.values():
+        specific_solid_config_type = specific_solid_config_field.dagster_type
+        assert specific_solid_config_type.type_attributes.is_system_config
+        user_config_field = specific_solid_config_field.dagster_type.field_dict['config']
+        assert user_config_field.dagster_type.type_attributes.is_system_config is False
 
 def define_test_solids_config_pipeline():
     return PipelineDefinition(

--- a/python_modules/dagster/dagster/core/core_tests/test_types.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_types.py
@@ -11,7 +11,7 @@ from dagster.core.types import (
 
 
 def test_desc():
-    type_foo = DagsterType(name='Foo', type_attributes=DagsterTypeAttributes(), description='A foo')
+    type_foo = DagsterType(name='Foo', description='A foo')
     assert type_foo.name == 'Foo'
     assert type_foo.description == 'A foo'
     assert type_foo.type_attributes.is_builtin is False

--- a/python_modules/dagster/dagster/core/core_tests/test_types.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_types.py
@@ -1,6 +1,9 @@
 import pytest
 
+from dagster import types
+
 from dagster.core.types import (
+    DagsterTypeAttributes,
     DagsterEvaluateValueError,
     DagsterType,
     PythonObjectType,
@@ -8,9 +11,11 @@ from dagster.core.types import (
 
 
 def test_desc():
-    type_foo = DagsterType(name='Foo', description='A foo')
+    type_foo = DagsterType(name='Foo', type_attributes=DagsterTypeAttributes(), description='A foo')
     assert type_foo.name == 'Foo'
     assert type_foo.description == 'A foo'
+    assert type_foo.type_attributes.is_builtin is False
+    assert type_foo.type_attributes.is_system_config is False
 
 
 def test_python_object_type():
@@ -23,5 +28,13 @@ def test_python_object_type():
     assert type_bar.description == 'A bar.'
     assert type_bar.evaluate_value(Bar())
     assert type_bar.evaluate_value(None) is None  # allow nulls
+    assert type_bar.type_attributes.is_builtin is False
+    assert type_bar.type_attributes.is_system_config is False
     with pytest.raises(DagsterEvaluateValueError):
         type_bar.evaluate_value('not_a_bar')
+
+
+def test_builtin_scalars():
+    for builtin_scalar in [types.String, types.Int, types.Dict, types.Any, types.Bool, types.Path]:
+        assert builtin_scalar.type_attributes.is_builtin is True
+        assert builtin_scalar.type_attributes.is_system_config is False

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -131,10 +131,6 @@ class DagsterScalarType(UncoercedTypeMixin, DagsterType):
 
       description (str): Description of the type
     '''
-    pass
-    # def __init__(self, *args, **kwargs):
-    # def __init__(self, name, type_attributes, description):
-    #     super(DagsterScalarType, self).__init__(*args, **kwargs)
 
 
 class DagsterBuiltinScalarType(DagsterScalarType):

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -33,7 +33,7 @@ class DagsterType(object):
       description (str): Description of the type
     '''
 
-    def __init__(self, name, type_attributes, description):
+    def __init__(self, name, type_attributes=DEFAULT_TYPE_ATTRIBUTES, description=None):
         self.name = check.str_param(name, 'name')
         self.description = check.opt_str_param(description, 'description')
         self.type_attributes = check.inst_param(


### PR DESCRIPTION
Add the formalized notion of "type attributes" to the dagster type
system. The short term need is the need for the browser to distinguish
between builtin, system config, and normal types. However we will need
more of these attributes (having is_scalar and is_composite in here would
probably make sense, for example).

Added to both the internal type system and the graphql schema.