### PR TITLE
Add config indicator, clickable "kind" tag to the DAG

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
@@ -31,17 +31,24 @@ class PythonNotebookButton extends React.Component<{ path: string }> {
     open: false
   };
 
+  componentDidMount() {
+    document.addEventListener("show-python-notebook", this.onClick);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("show-python-notebook", this.onClick);
+  }
+
+  onClick = () => {
+    this.setState({
+      open: true
+    });
+  };
+
   render() {
     return (
       <div>
-        <Button
-          icon="duplicate"
-          onClick={() =>
-            this.setState({
-              open: true
-            })
-          }
-        >
+        <Button icon="duplicate" onClick={this.onClick}>
           View Notebook
         </Button>
         <Dialog

--- a/python_modules/dagit/dagit/webapp/src/graph/PipelineColorScale.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/PipelineColorScale.ts
@@ -2,11 +2,19 @@ import { Colors } from "@blueprintjs/core";
 import { scaleOrdinal } from "@vx/scale";
 
 const PipelineColorScale = scaleOrdinal({
-  domain: ["source", "input", "solid", "output", "materializations"],
+  domain: [
+    "source",
+    "input",
+    "solid",
+    "solidDarker",
+    "output",
+    "materializations"
+  ],
   range: [
     Colors.TURQUOISE5,
     Colors.TURQUOISE3,
     "#DBE6EE",
+    "#7D8C97",
     Colors.BLUE3,
     Colors.ORANGE5
   ]

--- a/python_modules/dagit/dagit/webapp/src/graph/SVGComponents.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SVGComponents.tsx
@@ -5,14 +5,19 @@ const PX_TO_UNITS = 0.62;
 interface ISize {
   width: number;
   height: number;
+  compressionPriority?: number;
 }
 
-export interface ISVGEllipseInRectProps {
+export interface ISVGEllipseInRectProps
+  extends React.SVGProps<SVGEllipseElement> {
   x?: number;
   y?: number;
   width: number;
   height: number;
 }
+
+type Element = React.ReactElement<any>;
+type ElementArray = Element[];
 
 /*
 Wraps <ellipse>, but takes a width and height rather than center + radius,
@@ -22,17 +27,16 @@ export class SVGEllipseInRect extends React.PureComponent<
   ISVGEllipseInRectProps
 > {
   render() {
-    const rx = this.props.width / 2;
-    const ry = this.props.height / 2;
+    const { width, height, x, y, ...rest } = this.props;
+    const rx = width / 2;
+    const ry = height / 2;
     return (
       <ellipse
-        cx={(this.props.x || 0) + rx}
-        cy={(this.props.y || 0) + ry}
+        cx={(x || 0) + rx}
+        cy={(y || 0) + ry}
         rx={rx}
         ry={ry}
-        fill="rgba(0, 0, 0, 0.3)"
-        stroke="white"
-        strokeWidth={1.5}
+        {...rest}
       />
     );
   }
@@ -90,6 +94,33 @@ export interface ISVGFlowLayoutRectProps {
   maxWidth?: number;
 }
 
+interface SVGFlowLayoutChildLayout {
+  el: React.ReactElement<any>;
+  width: number;
+  height: number;
+  compressionPriority: number;
+}
+
+function reactChildrenToArray(children: React.ReactNode) {
+  let flattened: React.ReactNodeArray = [];
+
+  const appendChildren = (arr: React.ReactNodeArray) => {
+    arr.forEach(item => {
+      if (!item) {
+        return;
+      }
+      if (item instanceof Array) {
+        appendChildren(item);
+      } else {
+        flattened.push(item);
+      }
+    });
+  };
+
+  appendChildren(children instanceof Array ? children : [children]);
+
+  return flattened;
+}
 /*
 Renders a <rect> and lays out it's children along a horizontal axis using the
 given `padding` and inter-item `spacing`. Children must either have a `width`
@@ -112,32 +143,33 @@ export class SVGFlowLayoutRect extends React.Component<
   ): {
     width: number;
     height: number;
-    childLayouts: Array<{
-      el: React.ReactElement<any>;
-      width: number;
-      height: number;
-      shrinkable: boolean;
-    }>;
+    childLayouts: Array<SVGFlowLayoutChildLayout>;
   } {
     let { children, spacing, padding, height } = props;
 
-    const childLayouts = (children instanceof Array ? children : [children])
-      .filter(c => !!c)
-      .map((el: React.ReactElement<any>, idx) => {
-        if ((el.type as any).intrinsicSizeForProps) {
+    const childLayouts = reactChildrenToArray(children).map(
+      (el: React.ReactElement<any>) => {
+        if (el.type && (el.type as any).intrinsicSizeForProps) {
           return {
             el,
-            shrinkable: true,
+            compressionPriority: 1,
             ...(el.type as any).intrinsicSizeForProps(el.props)
           };
         }
+        if (!el.props || el.props.width === undefined) {
+          console.error(el);
+          throw new Error(
+            `SVGFlowLayoutRect children must have a width prop or implement intrinsicSizeForProps`
+          );
+        }
         return {
           el: el,
-          shrinkable: false,
+          compressionPriority: 0,
           width: el.props.width,
           height: el.props.height
         };
-      });
+      }
+    );
 
     return {
       width:
@@ -150,23 +182,46 @@ export class SVGFlowLayoutRect extends React.Component<
   }
 
   render() {
-    const { x, y, spacing, children, padding, ...rest } = this.props;
+    const { x, y, spacing, children, padding, maxWidth, ...rest } = this.props;
     const layout = SVGFlowLayoutRect.computeLayout(this.props);
 
     // Use the explicit width we're given, fall back to our intrinsic layout width
     const finalWidth = this.props.width
       ? this.props.width
-      : Math.min(this.props.maxWidth || 10000, layout.width);
+      : Math.min(maxWidth || 10000, layout.width);
 
     // If the intrinsic layout width is greater than our final width, we need to
-    // compress the child layouts to fit in available space. For now, compress
-    // anything that defined an intrinsic width and compress them by an even percent.
+    // compress the child layouts to fit in available space. We compress children
+    // with the highest compressionPriority first, distribute compression evenly
+    // among children with that priority, and then work our way down in priority
+    // until we've created enough space.
     if (layout.width > finalWidth) {
-      const shrinkable = [...layout.childLayouts].filter(c => c.shrinkable);
-      const shrinkableWidth = shrinkable.reduce((sum, cl) => sum + cl.width, 0);
-      const ratio =
-        (shrinkableWidth - (layout.width - finalWidth)) / shrinkableWidth;
-      shrinkable.forEach(childLayout => (childLayout.width *= ratio));
+      const grouped: {
+        [priority: string]: [SVGFlowLayoutChildLayout];
+      } = {};
+
+      // Group child layouts by compression priority
+      layout.childLayouts.forEach(l => {
+        const p = `${l.compressionPriority}`;
+        grouped[p] = grouped[p] || [];
+        grouped[p].push(l);
+      });
+
+      // Sort priority values so we shrink the most compressible nodes first
+      const priorities = Object.keys(grouped).sort(
+        (a, b) => parseInt(b) - parseInt(a)
+      );
+
+      for (let i = 0; i < priorities.length; i++) {
+        const passLayouts = grouped[priorities[i]];
+        const passWidth = passLayouts.reduce((sum, cl) => sum + cl.width, 0);
+        const ratio =
+          Math.max(1, passWidth - (layout.width - finalWidth)) / passWidth;
+        if (ratio >= 0.99) break;
+
+        passLayouts.forEach(childLayout => (childLayout.width *= ratio));
+        layout.width -= passWidth * (1 - ratio);
+      }
     }
 
     let acc = padding;
@@ -177,7 +232,8 @@ export class SVGFlowLayoutRect extends React.Component<
       const clone = React.cloneElement(childLayout.el, {
         x: (x || 0) + acc,
         y: (y || 0) + layout.height / 2 - childLayout.height / 2,
-        width: childLayout.width
+        width: childLayout.width,
+        key: idx
       });
 
       acc += childLayout.width;
@@ -195,5 +251,18 @@ export class SVGFlowLayoutRect extends React.Component<
         {...arranged}
       </>
     );
+  }
+}
+
+export class SVGFlowLayoutFiller extends React.Component {
+  static intrinsicSizeForProps(): ISize {
+    return {
+      compressionPriority: 2,
+      width: 1000,
+      height: 1
+    };
+  }
+  render() {
+    return <g />;
   }
 }

--- a/python_modules/dagit/dagit/webapp/src/graph/SVGComponents.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SVGComponents.tsx
@@ -16,9 +16,6 @@ export interface ISVGEllipseInRectProps
   height: number;
 }
 
-type Element = React.ReactElement<any>;
-type ElementArray = Element[];
-
 /*
 Wraps <ellipse>, but takes a width and height rather than center + radius,
 making it compatible with SVGFlowLayoutRect (which inspects it's children's widths.)
@@ -28,6 +25,7 @@ export class SVGEllipseInRect extends React.PureComponent<
 > {
   render() {
     const { width, height, x, y, ...rest } = this.props;
+    console.log(rest);
     const rx = width / 2;
     const ry = height / 2;
     return (
@@ -74,7 +72,10 @@ export class SVGMonospaceText extends React.PureComponent<
     return (
       <text
         {...rest}
-        style={{ font: `${size}px "Source Code Pro", monospace` }}
+        style={{
+          font: `${size}px "Source Code Pro", monospace`,
+          pointerEvents: "none"
+        }}
         width={textClipped.length * size * PX_TO_UNITS}
         dominantBaseline="hanging"
       >

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidConfigPort.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidConfigPort.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Colors } from "@blueprintjs/core";
+import PipelineColorScale from "./PipelineColorScale";
+import { SVGEllipseInRect } from "./SVGComponents";
+
+interface ISolidConfigPortProps {
+  x: number;
+  y: number;
+  minified: boolean;
+}
+
+const SolidConfigPort: React.SFC<ISolidConfigPortProps> = ({
+  x,
+  y,
+  minified
+}) => {
+  return (
+    <>
+      <SVGEllipseInRect
+        x={x}
+        y={y}
+        width={26}
+        height={26}
+        stroke={Colors.GRAY3}
+        fill={PipelineColorScale("solid")}
+        pathLength={100}
+        strokeWidth={1}
+        strokeDasharray={`0 50 0`}
+      />
+      <SVGEllipseInRect
+        x={x + 3}
+        y={y + 3}
+        width={20}
+        height={20}
+        stroke={Colors.WHITE}
+        fill={PipelineColorScale("solidDarker")}
+        pathLength={100}
+        strokeWidth={2}
+      />
+      {!minified && (
+        <text
+          x={x + 8}
+          y={y + 7.5}
+          style={{ font: `14px "Arial", san-serif` }}
+          fill={Colors.WHITE}
+          dominantBaseline="hanging"
+        >
+          C
+        </text>
+      )}
+    </>
+  );
+};
+
+export default SolidConfigPort;

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
@@ -11,6 +11,7 @@ import { IFullSolidLayout, ILayout } from "./getFullSolidLayout";
 import {
   SVGEllipseInRect,
   SVGFlowLayoutRect,
+  SVGFlowLayoutFiller,
   SVGMonospaceText
 } from "./SVGComponents";
 
@@ -23,6 +24,120 @@ interface ISolidNodeProps {
   onClick?: (solid: string) => void;
   onDoubleClick?: (solid: string) => void;
 }
+
+interface ISolidTagsProps {
+  x: number;
+  y: number;
+  width: number;
+  minified: boolean;
+  tags: string[];
+}
+
+function hueForTag(text = "") {
+  return (
+    text
+      .split("")
+      .map(c => c.charCodeAt(0))
+      .reduce((n, a) => n + a) % 360
+  );
+}
+
+const SolidTags: React.SFC<ISolidTagsProps> = ({
+  tags,
+  x,
+  y,
+  width,
+  minified
+}) => {
+  const height = minified ? 32 : 20;
+  const overhang = 6;
+
+  return (
+    <SVGFlowLayoutRect
+      x={x}
+      y={y - (height - overhang)}
+      width={width}
+      height={height}
+      fill={"transparent"}
+      stroke={"transparent"}
+      spacing={minified ? 8 : 4}
+      padding={0}
+    >
+      <SVGFlowLayoutFiller />
+      {tags.map(tag => {
+        const hue = hueForTag(tag);
+        return (
+          <SVGFlowLayoutRect
+            key={tag}
+            rx={0}
+            ry={0}
+            height={height}
+            padding={minified ? 8 : 4}
+            fill={`hsl(${hue}, 10%, 95%)`}
+            stroke={`hsl(${hue}, 55%, 55%)`}
+            strokeWidth={1}
+            spacing={0}
+          >
+            <SVGMonospaceText
+              text={tag}
+              fill={`hsl(${hue}, 55%, 55%)`}
+              size={minified ? 24 : 14}
+            />
+          </SVGFlowLayoutRect>
+        );
+      })}
+    </SVGFlowLayoutRect>
+  );
+};
+
+interface ISolidConfigNubProps {
+  x: number;
+  y: number;
+  minified: boolean;
+}
+
+const SolidConfigNub: React.SFC<ISolidConfigNubProps> = ({
+  x,
+  y,
+  minified
+}) => {
+  return (
+    <>
+      <SVGEllipseInRect
+        x={x}
+        y={y}
+        width={26}
+        height={26}
+        stroke={Colors.GRAY3}
+        fill={PipelineColorScale("solid")}
+        pathLength={100}
+        strokeWidth={1}
+        strokeDasharray={`0 50 0`}
+      />
+      <SVGEllipseInRect
+        x={x + 3}
+        y={y + 3}
+        width={20}
+        height={20}
+        stroke={Colors.WHITE}
+        fill={PipelineColorScale("solidDarker")}
+        pathLength={100}
+        strokeWidth={2}
+      />
+      {!minified && (
+        <text
+          x={x + 8}
+          y={y + 7.5}
+          style={{ font: `14px "Arial", san-serif` }}
+          fill={Colors.WHITE}
+          dominantBaseline="hanging"
+        >
+          C
+        </text>
+      )}
+    </>
+  );
+};
 
 export default class SolidNode extends React.Component<ISolidNodeProps> {
   static fragments = {
@@ -100,7 +215,13 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
             spacing={7}
             height={height}
           >
-            <SVGEllipseInRect width={14} height={14} />
+            <SVGEllipseInRect
+              width={14}
+              height={14}
+              fill="rgba(0, 0, 0, 0.3)"
+              stroke="white"
+              strokeWidth={1.5}
+            />
             {showText && (
               <SVGMonospaceText
                 text={`${input!.definition.name}:`}
@@ -168,18 +289,27 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
   }
 
   public render() {
-    const { solid, layout } = this.props;
+    const { solid, layout, dim, selected, minified } = this.props;
+    const { x, y, width, height } = layout.solid;
 
     return (
       <g
         onClick={this.handleClick}
         onDoubleClick={this.handleDoubleClick}
-        opacity={this.props.dim ? 0.3 : 1}
+        opacity={dim ? 0.3 : 1}
       >
-        {this.props.selected && this.renderSelectedBox()}
+        {selected && this.renderSelectedBox()}
         {this.renderSolid()}
         {this.renderIO("input", solid.inputs, layout.inputs)}
         {this.renderIO("output", solid.outputs, layout.outputs)}
+        <SolidConfigNub minified={minified} x={x + width - 33} y={y - 13} />
+        <SolidTags
+          x={x}
+          y={y + height}
+          width={width + 5}
+          minified={minified}
+          tags={["ipynb", "bla"]}
+        />
       </g>
     );
   }

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidTags.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidTags.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import {
+  SVGFlowLayoutRect,
+  SVGFlowLayoutFiller,
+  SVGMonospaceText
+} from "./SVGComponents";
+
+export interface ISolidTagsProps {
+  x: number;
+  y: number;
+  width: number;
+  minified: boolean;
+  tags: string[];
+  onTagClicked: ((e: React.MouseEvent, tag: string) => void);
+}
+
+function hueForTag(text = "") {
+  if (text === "ipynb") return 26;
+  return (
+    text
+      .split("")
+      .map(c => c.charCodeAt(0))
+      .reduce((n, a) => n + a) % 360
+  );
+}
+
+const SolidTags: React.SFC<ISolidTagsProps> = ({
+  tags,
+  x,
+  y,
+  width,
+  minified,
+  onTagClicked
+}) => {
+  const height = minified ? 32 : 20;
+  const overhang = 6;
+
+  return (
+    <SVGFlowLayoutRect
+      x={x}
+      y={y - (height - overhang)}
+      width={width}
+      height={height}
+      fill={"transparent"}
+      stroke={"transparent"}
+      spacing={minified ? 8 : 4}
+      padding={0}
+    >
+      <SVGFlowLayoutFiller />
+      {tags.map(tag => {
+        const hue = hueForTag(tag);
+        return (
+          <SVGFlowLayoutRect
+            key={tag}
+            rx={0}
+            ry={0}
+            height={height}
+            padding={minified ? 8 : 4}
+            fill={`hsl(${hue}, 10%, 95%)`}
+            stroke={`hsl(${hue}, 75%, 55%)`}
+            onClick={e => onTagClicked(e, tag)}
+            strokeWidth={1}
+            spacing={0}
+          >
+            <SVGMonospaceText
+              text={tag}
+              fill={`hsl(${hue}, 75%, 55%)`}
+              size={minified ? 24 : 14}
+            />
+          </SVGFlowLayoutRect>
+        );
+      })}
+    </SVGFlowLayoutRect>
+  );
+};
+
+export default SolidTags;

--- a/python_modules/dagit/dagit/webapp/src/graph/types/PipelineGraphFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/types/PipelineGraphFragment.ts
@@ -7,6 +7,24 @@
 // GraphQL fragment: PipelineGraphFragment
 // ====================================================
 
+export interface PipelineGraphFragment_solids_definition_metadata {
+  key: string | null;
+  value: string | null;
+}
+
+export interface PipelineGraphFragment_solids_definition_configDefinition_type {
+  description: string | null;
+}
+
+export interface PipelineGraphFragment_solids_definition_configDefinition {
+  type: PipelineGraphFragment_solids_definition_configDefinition_type;
+}
+
+export interface PipelineGraphFragment_solids_definition {
+  metadata: PipelineGraphFragment_solids_definition_metadata[] | null;
+  configDefinition: PipelineGraphFragment_solids_definition_configDefinition | null;
+}
+
 export interface PipelineGraphFragment_solids_inputs_definition_type {
   name: string;
 }
@@ -55,6 +73,7 @@ export interface PipelineGraphFragment_solids_outputs {
 
 export interface PipelineGraphFragment_solids {
   name: string;
+  definition: PipelineGraphFragment_solids_definition;
   inputs: PipelineGraphFragment_solids_inputs[];
   outputs: PipelineGraphFragment_solids_outputs[];
 }

--- a/python_modules/dagit/dagit/webapp/src/graph/types/SolidNodeFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/types/SolidNodeFragment.ts
@@ -7,6 +7,24 @@
 // GraphQL fragment: SolidNodeFragment
 // ====================================================
 
+export interface SolidNodeFragment_definition_metadata {
+  key: string | null;
+  value: string | null;
+}
+
+export interface SolidNodeFragment_definition_configDefinition_type {
+  description: string | null;
+}
+
+export interface SolidNodeFragment_definition_configDefinition {
+  type: SolidNodeFragment_definition_configDefinition_type;
+}
+
+export interface SolidNodeFragment_definition {
+  metadata: SolidNodeFragment_definition_metadata[] | null;
+  configDefinition: SolidNodeFragment_definition_configDefinition | null;
+}
+
 export interface SolidNodeFragment_inputs_definition_type {
   name: string;
 }
@@ -55,6 +73,7 @@ export interface SolidNodeFragment_outputs {
 
 export interface SolidNodeFragment {
   name: string;
+  definition: SolidNodeFragment_definition;
   inputs: SolidNodeFragment_inputs[];
   outputs: SolidNodeFragment_outputs[];
 }

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -302,5 +302,6 @@ def define_dagstermill_solid(
         description='This solid is backed by the notebook at {path}'.format(path=notebook_path),
         metadata={
             'notebook_path': notebook_path,
+            'kind': 'ipynb',
         }
     )

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -71,7 +71,7 @@ def define_solid_with_stuff():
         outputs=[OutputDefinition(name='bar', dagster_type=types.Int)],
         config_def=ConfigDefinition(types.Int),
         transform_fn=lambda *args, **kwargs: check.failed('do not execute'),
-        metadata={'notebook_path': 'unused.ipynb'},
+        metadata={'notebook_path': 'unused.ipynb', 'kind': 'ipynb'},
     )
 
 


### PR DESCRIPTION
This PR adds two new features to the DAG UI: 1) A "nub" that indicates a solid takes configuration and 2) a "kind" label that tells you when a solid is backed by a particular type of resource (SQL, Python Notebook, etc.)

In minified view:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/1037212/47895567-502c3c80-de26-11e8-9546-6fd398a751d7.png">

In maximized view:
<img width="911" alt="image" src="https://user-images.githubusercontent.com/1037212/47895574-57534a80-de26-11e8-90c8-9b02377c953a.png">


The "kind" label is implemented in a generic way, and the rendering supports displaying multiple color-coded "tags" in a row along the bottom right of a solid. The color of the `ipynb` item (and probably other core ones) is hardcoded, but it chooses colors randomly using the text as a seed.

There's some hacky code in this PR that allows you to click the "kind" label and view the Python Notebook representing the solid. (It dispatches a custom event to remotely activate the click handler on the "View Notebook" button.) I expect this will get replaced /very/ soon when we implement a proper plugin system in which "kind" tags can be bound to renderers or additional functionality. 

The "config" mark isn't currently clickable, but the goal is for it to show a popover that elaborates on the config. The DAG doesn't currently provide hover interaction on the input / output types, so I'm planning to add both together in a followup PR.