### PR TITLE
Fixes a TypeError when drilling down on nodes without expectations

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
@@ -99,16 +99,19 @@ export default class SidebarSolidInfo extends React.Component<
             </Link>
           </Text>
         )}
-        {input.definition.expectations.length > 0 ? (
+        {(input.definition.expectations &&
+          input.definition.expectations.length) > 0 ? (
           <H6>Expectations</H6>
         ) : null}
         <UL>
-          {input.definition.expectations.map((expectation, i) => (
-            <li key={i}>
-              {expectation.name}
-              <Description description={expectation.description} />
-            </li>
-          ))}
+          {(input.definition.expectations &&
+            input.definition.expectations.length > 0) ? 
+            input.definition.expectations.map((expectation, i) => (
+              <li key={i}>
+                {expectation.name}
+                <Description description={expectation.description} />
+              </li>
+          )) : null }
         </UL>
       </SectionItemContainer>
     ));
@@ -122,16 +125,19 @@ export default class SidebarSolidInfo extends React.Component<
           <TypeWithTooltip type={output.definition.type} />
         </TypeWrapper>
         <Description description={output.definition.description} />
-        {output.definition.expectations.length > 0 ? (
+        {(output.definition.expectations &&
+          output.definition.expectations.length > 0) ? (
           <H6>Expectations</H6>
         ) : null}
         <UL>
-          {output.definition.expectations.map((expectation, i) => (
-            <li key={i}>
-              {expectation.name}
-              <Description description={expectation.description} />
-            </li>
-          ))}
+          {(output.definition.expectations &&
+            output.definition.expectations.length > 0) ?
+            output.definition.expectations.map((expectation, i) => (
+              <li key={i}>
+                {expectation.name}
+                <Description description={expectation.description} />
+              </li>
+          )): null}
         </UL>
       </SectionItemContainer>
     ));


### PR DESCRIPTION
Previously, clicking on a node without expectations in the dagit display, for instance of the first few tutorial DAGs, would throw a TypeError when we attempted to check `input.expectations.length`, since `input.expectations` was undefined.

I am opening a PR without a test because I am six months to a year behind best practices and the most recent React/TS/GraphQL tooling and I'm looking for guidance on how we'd like to write tests for something like this. My expectation is that we would roughly follow the pattern in the App test and do:

```
const tree = TestRenderer.create(
  <MockedProvider mocks={mocks}><SidebarSolidInfo /></MockedProvider>
).toJSON();
expect(tree).toMatchSnapshot();
```

My biggest question is about the best way to generate mocks that are appropriate for a particular component's query fragments in a particular state -- I would love to be able to pull these out of GraphiQL or directly from the browser if possible. 
