### PR TITLE
DAG popover support, popovers with type details

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -24,7 +24,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-brqgnP jyxKUE"
+        className="sc-iRbamj gOXIQQ"
       >
         <span
           className="bp3-popover-wrapper"
@@ -69,7 +69,7 @@ Array [
           </span>
         </span>
         <div
-          className="sc-cMljjf bKfJvu"
+          className="sc-jlyJG fUAVrb"
         >
           /
         </div>

--- a/python_modules/dagit/dagit/webapp/src/graph/PanAndZoom.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/PanAndZoom.tsx
@@ -184,14 +184,7 @@ export default class PanAndZoom extends React.Component<
         onKeyDown={onKeyDown}
         tabIndex={-1}
       >
-        <div
-          style={{
-            transformOrigin: `top left`,
-            transform: `matrix(${scale}, 0, 0, ${scale}, ${x}, ${y})`
-          }}
-        >
-          {children(this.state)}
-        </div>
+        {children(this.state)}
       </div>
     );
   }

--- a/python_modules/dagit/dagit/webapp/src/graph/PipelineTypeOverlay.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/PipelineTypeOverlay.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import gql from "graphql-tag";
+import styled from "styled-components";
+import { Colors } from "@blueprintjs/core";
+import { Query, QueryResult } from "react-apollo";
+import { GetTypeDetailsQuery } from "./types/GetTypeDetailsQuery";
+import Loading from "../Loading";
+
+const GET_TYPE_DETAILS = gql`
+  query GetTypeDetailsQuery($pipelineName: String!, $typeName: String!) {
+    type(pipelineName: $pipelineName, typeName: $typeName) {
+      name
+      description
+      typeAttributes {
+        isBuiltin
+        isSystemConfig
+      }
+    }
+  }
+`;
+
+interface IPipelineTypeOverlayProps {
+  root: { x: number; y: number };
+  pipelineName: string;
+  typeName: string;
+}
+
+export default class PipelineTypeOverlay extends React.Component<
+  IPipelineTypeOverlayProps & React.HTMLProps<HTMLDivElement>
+> {
+  render() {
+    const { root, ref, pipelineName, typeName, ...rest } = this.props;
+
+    return (
+      <OverlayContainer
+        {...rest}
+        style={{ left: `${root.x}px`, top: `${root.y}px` }}
+        onWheel={e => e.stopPropagation()}
+        onScroll={e => e.stopPropagation()}
+      >
+        <OverlayContent>
+          <Query
+            query={GET_TYPE_DETAILS}
+            variables={{ pipelineName: pipelineName, typeName: typeName }}
+          >
+            {(queryResult: QueryResult<GetTypeDetailsQuery, any>) => (
+              <Loading queryResult={queryResult}>
+                {data => (
+                  <TypeDescription>
+                    {data.type &&
+                      (
+                        data.type.description || "No description provided."
+                      ).trim()}
+                  </TypeDescription>
+                )}
+              </Loading>
+            )}
+          </Query>
+        </OverlayContent>
+        <OverlayTriangle />
+      </OverlayContainer>
+    );
+  }
+}
+
+const OverlayContainer = styled.div`
+  position: absolute;
+  transform: translate3d(-50%, -100%, 0);
+`;
+
+const OverlayContent = styled.div`
+  padding: 0.5em;
+  background: ${Colors.WHITE};
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  min-width: 240px;
+  max-width: 400px;
+  max-height: 180px;
+  overflow-y: scroll;
+`;
+
+const OverlayTriangle = styled.div`
+  width: 12px;
+  height: 24px;
+  margin: auto;
+  position: relative;
+  z-index: 2;
+  border-top: solid 12px ${Colors.WHITE};
+  border-left: solid 12px transparent;
+  border-right: solid 12px transparent;
+`;
+
+const TypeDescription = styled.div`
+  white-space: pre-line;
+`;

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
@@ -25,6 +25,7 @@ interface ISolidNodeProps {
   dim: boolean;
   onClick?: (solid: string) => void;
   onDoubleClick?: (solid: string) => void;
+  onPreviewType?: (el: SVGElement, type: string | null) => void;
 }
 
 export default class SolidNode extends React.Component<ISolidNodeProps> {
@@ -103,10 +104,12 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     items: Array<SolidNodeFragment_inputs | SolidNodeFragment_outputs>,
     layout: { [inputName: string]: { layout: ILayout } }
   ) {
+    const { minified, onPreviewType } = this.props;
+
     return Object.keys(layout).map((key, i) => {
       const { x, y, width, height } = layout[key].layout;
       const input = items.find(o => o.definition.name === key);
-      const showText = width == 0 && !this.props.minified;
+      const showText = width == 0 && !minified;
 
       return (
         <g key={i}>
@@ -144,6 +147,13 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
                 height={27}
                 spacing={0}
                 padding={4}
+                onMouseOver={e =>
+                  onPreviewType &&
+                  onPreviewType(e.currentTarget, input!.definition.type.name)
+                }
+                onMouseOut={e =>
+                  onPreviewType && onPreviewType(e.currentTarget, null)
+                }
                 fill="#d6ecff"
               >
                 <SVGMonospaceText

--- a/python_modules/dagit/dagit/webapp/src/graph/types/GetTypeDetails.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/types/GetTypeDetails.ts
@@ -1,0 +1,51 @@
+
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetTypeDetails
+// ====================================================
+
+export interface GetTypeDetails_type_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
+}
+
+export interface GetTypeDetails_type {
+  name: string;
+  description: string | null;
+  typeAttributes: GetTypeDetails_type_typeAttributes;
+}
+
+export interface GetTypeDetails {
+  type: GetTypeDetails_type | null;
+}
+
+export interface GetTypeDetailsVariables {
+  typeName: string;
+}
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================

--- a/python_modules/dagit/dagit/webapp/src/graph/types/GetTypeDetailsQuery.ts
+++ b/python_modules/dagit/dagit/webapp/src/graph/types/GetTypeDetailsQuery.ts
@@ -1,0 +1,52 @@
+
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetTypeDetailsQuery
+// ====================================================
+
+export interface GetTypeDetailsQuery_type_typeAttributes {
+  /**
+   * 
+   * True if the system defines it and it is the same type across pipelines.
+   * Examples include "Int" and "String."
+   */
+  isBuiltin: boolean;
+  /**
+   * 
+   * Dagster generates types for base elements of the config system (e.g. the solids and
+   * context field of the base environment). These types are always present
+   * and are typically not relevant to an end user. This flag allows tool authors to
+   * filter out those types by default.
+   * 
+   */
+  isSystemConfig: boolean;
+}
+
+export interface GetTypeDetailsQuery_type {
+  name: string;
+  description: string | null;
+  typeAttributes: GetTypeDetailsQuery_type_typeAttributes;
+}
+
+export interface GetTypeDetailsQuery {
+  type: GetTypeDetailsQuery_type | null;
+}
+
+export interface GetTypeDetailsQueryVariables {
+  pipelineName: string;
+  typeName: string;
+}
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================


### PR DESCRIPTION
Hey! This took me longer than I expected to get working — I originally tried to make Blueprint's official Popover work within our SVG (using `createPortal` to put the contents outside the SVG) and that proved difficult because the `popover.js` module cannot compute the screen location of nodes within the zoomed/panned SVG correctly.

Instead I created a minimal popover implementation that places the overlay and it's DOM into a layer on top of the SVG which uses a screen-space coordinate system that is still transformed as the user moves the document but doesn't zoom.

Right now, the only popover is a simple one that displays the description of the type you mouse over. It's mostly self contained and makes it's own GraphQL query for the info it needs. (We could alternatively bubble this data requirement all the way up but it'd involve a third fragment in a few layers I think - seemed like a good thing to isolate with a separate query / loading spinner, etc.)

I think there are a few follow-up questions here:

- Is this helpful or annoying? Should we make you click the types, or perhaps add a short delay before the popover appears?

- I was planning to add a popover for config as well if we like this concept (showing the config fields.)

<img width="610" alt="image" src="https://user-images.githubusercontent.com/1037212/48231879-958bc500-e364-11e8-9a1e-1ef52dc10ecc.png">
