### PR TITLE
Fix hot reloading not working due to instanceof failure

### DIFF
--- a/python_modules/dagster/dagster/cli/dynamic_loader.py
+++ b/python_modules/dagster/dagster/cli/dynamic_loader.py
@@ -23,10 +23,16 @@ if sys.version_info[0] >= 3:
     # pipeline code, not dagster imports, installed packages, or parts of the python
     # install. Some of these things (like numpy) actually cannot be reloaded.
     #
+    # Note: We cannot hot-reload Dagster itself. Re-loading RepositoryDefinition, etc.
+    # in user code causes `instanceof` checks to fail since this code still references
+    # the original copies of RespositoryDefinition, etc.
+    #
     _reload = reloader._reload
 
     def conditional_reload(m, visited):
         if "/usr/local" in m.__file__ or "site-packages" in m.__file__:
+            return
+        if m.__name__.startswith("dagster.core") or m.__name__.startswith("dagster.utils"):
             return
         _reload(m, visited)
 


### PR DESCRIPTION
Turns out two of the last edits to the hot-reloading PR broke it. This was actually super interesting to track down. When we allow the `reloader` module to reload the Dagster source, it causes `RepositoryDefinition`, etc to be reloaded, but only in the user’s pipeline code. Instances of these new copies of the classes do not pass instanceof checks against the old versions of the classes, causing the Dagster CLI (which is doing the hot reloading and was not reloaded) to think that you’re providing the wrong object types.