### PR TITLE
Add links to "depends on" solids in the sidebar, addresses #273

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { H6, Text, Code, UL } from "@blueprintjs/core";
 import { pluginForMetadata } from "./plugins";
+import { DEFAULT_RESULT_NAME } from "./Util";
 
 import SolidTypeSignature from "./SolidTypeSignature";
 import TypeWithTooltip from "./TypeWithTooltip";
@@ -84,34 +85,38 @@ export default class SidebarSolidInfo extends React.Component<
   };
 
   renderInputs() {
-    return this.props.solid.inputs.map((input, i: number) => (
-      <SectionItemContainer key={i}>
-        <SectionItemHeader>{input.definition.name}</SectionItemHeader>
-        <TypeWrapper>
-          <TypeWithTooltip type={input.definition.type} />
-        </TypeWrapper>
-        <Description description={input.definition.description} />
-        {input.dependsOn && (
-          <Text>
-            Depends on{" "}
-            <Link to={`./${input.dependsOn.definition.name}`}>
-              <Code>{input.dependsOn.definition.name}</Code>
-            </Link>
-          </Text>
-        )}
-        {input.definition.expectations.length > 0 ? (
-          <H6>Expectations</H6>
-        ) : null}
-        <UL>
-          {input.definition.expectations.map((expectation, i) => (
-            <li key={i}>
-              {expectation.name}
-              <Description description={expectation.description} />
-            </li>
-          ))}
-        </UL>
-      </SectionItemContainer>
-    ));
+    return this.props.solid.inputs.map(
+      ({ definition, dependsOn }, i: number) => (
+        <SectionItemContainer key={i}>
+          <SectionItemHeader>{definition.name}</SectionItemHeader>
+          <TypeWrapper>
+            <TypeWithTooltip type={definition.type} />
+          </TypeWrapper>
+          <Description description={definition.description} />
+          {dependsOn && (
+            <Text>
+              Depends on{" "}
+              <Link to={`./${dependsOn.solid.name}`}>
+                <Code>
+                  {dependsOn.definition.name !== DEFAULT_RESULT_NAME
+                    ? `${dependsOn.solid.name}:${dependsOn.definition.name}`
+                    : dependsOn.solid.name}
+                </Code>
+              </Link>
+            </Text>
+          )}
+          {definition.expectations.length > 0 ? <H6>Expectations</H6> : null}
+          <UL>
+            {definition.expectations.map((expectation, i) => (
+              <li key={i}>
+                {expectation.name}
+                <Description description={expectation.description} />
+              </li>
+            ))}
+          </UL>
+        </SectionItemContainer>
+      )
+    );
   }
 
   renderOutputs() {

--- a/python_modules/dagit/dagit/webapp/src/Util.tsx
+++ b/python_modules/dagit/dagit/webapp/src/Util.tsx
@@ -1,0 +1,1 @@
+export const DEFAULT_RESULT_NAME = "result";

--- a/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/graph/SolidNode.tsx
@@ -16,6 +16,7 @@ import {
 
 import SolidTags from "./SolidTags";
 import SolidConfigPort from "./SolidConfigPort";
+import { DEFAULT_RESULT_NAME } from "../Util";
 
 interface ISolidNodeProps {
   layout: IFullSolidLayout;
@@ -101,12 +102,16 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
   renderIO(
     colorKey: string,
     items: Array<SolidNodeFragment_inputs | SolidNodeFragment_outputs>,
-    layout: { [inputName: string]: { layout: ILayout } }
+    layout: { [ioName: string]: { layout: ILayout } }
   ) {
     return Object.keys(layout).map((key, i) => {
       const { x, y, width, height } = layout[key].layout;
-      const input = items.find(o => o.definition.name === key);
+
+      const item = items.find(o => o.definition.name === key);
+      if (!item) return <g key={i} />;
+
       const showText = width == 0 && !this.props.minified;
+      const { name, type } = item.definition;
 
       return (
         <g key={i}>
@@ -128,29 +133,22 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
               stroke="white"
               strokeWidth={1.5}
             />
-            {showText && (
-              <SVGMonospaceText
-                text={`${input!.definition.name}:`}
-                fill="#FFF"
-                size={14}
-              />
-            )}
+            {showText &&
+              name !== DEFAULT_RESULT_NAME && (
+                <SVGMonospaceText text={`${name}:`} fill="#FFF" size={14} />
+              )}
             {showText && (
               <SVGFlowLayoutRect
                 rx={4}
                 ry={4}
+                fill="#d6ecff"
                 stroke="#2491eb"
                 strokeWidth={1}
                 height={27}
                 spacing={0}
                 padding={4}
-                fill="#d6ecff"
               >
-                <SVGMonospaceText
-                  text={input!.definition.type.name}
-                  size={14}
-                  fill="#222"
-                />
+                <SVGMonospaceText text={type.name} size={14} fill="#222" />
               </SVGFlowLayoutRect>
             )}
           </SVGFlowLayoutRect>


### PR DESCRIPTION
This PR updates the sidebar to correctly link to solids the current solid depends on, and also omits the default output name ("result") on the DAG and in the sidebar. 