### PR TITLE
Improve coverage reporting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@ integration, and so on -- but in essence they all describe the same activity: Pe
 computations structured as a DAG (directed, acyclic graph) that end up producing data assets,
 whether those assets be tables, files, machine-learning models, etc.
 
+[![Coverage Status](https://coveralls.io/repos/github/dagster-io/dagster/badge.svg)](https://coveralls.io/github/dagster-io/dagster)
+
 There are a few tools in this repo:
 
 - **Dagster**: The core programming model and abstraction stack; a stateless single-node and -process execution engine; and a CLI tool for driving that engine.

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -4,7 +4,6 @@ envlist = py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  coveralls
   pytest
   pytest-cov
   pytest-runner
@@ -16,4 +15,3 @@ commands =
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'
-  coveralls

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -4,7 +4,6 @@ envlist = py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  coveralls
   pytest
   pytest-cov
   pytest-runner
@@ -15,4 +14,3 @@ commands =
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'
-  coveralls

--- a/python_modules/dagstermill/tox.ini
+++ b/python_modules/dagstermill/tox.ini
@@ -4,7 +4,6 @@ envlist = py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  coveralls
   pytest
   pytest-cov
   pytest-runner
@@ -12,6 +11,5 @@ commands =
   pip install -e ../dagster
   pytest -v --cov=dagstermill --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
-  coverage html --omit='.tox/*,**/test_*.py'
+  coverage html --omit='.tgox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'
-  coveralls


### PR DESCRIPTION
This is a quick fix to avoid reporting individual jobs back to coveralls -- which is producing artificial check failures in the GitHub interface (since the aggregate coverage of the entire repo is <= the project with the highest coverage, the final check run on Circle shows a factitious "decrease" in coverage).