### PR TITLE
Expose GraphQL Interface for Config Errors

### DIFF
--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -679,9 +679,13 @@ class MissingFieldErrorData(graphene.ObjectType):
     field = graphene.NonNull(TypeField)
 
 
+class FieldNotDefinedErrorData(graphene.ObjectType):
+    field_name = graphene.NonNull(graphene.String)
+
+
 class ConfigErrorData(graphene.Union):
     class Meta:
-        types = (RuntimeMismatchErrorData, MissingFieldErrorData)
+        types = (RuntimeMismatchErrorData, MissingFieldErrorData, FieldNotDefinedErrorData)
 
 
 class PipelineConfigValidationError(graphene.ObjectType):
@@ -706,9 +710,15 @@ class PipelineConfigValidationError(graphene.ObjectType):
                 value_rep=error_data.value_rep,
             )
         elif isinstance(error_data, dagster.core.evaluator.MissingFieldErrorData):
-            pass
+            return MissingFieldErrorData(
+                field=TypeField(name=error_data.field_name, field=error_data.field_def)
+            )
+        elif isinstance(error_data, dagster.core.evaluator.FieldNotDefinedErrorData):
+            return FieldNotDefinedErrorData(field_name=error_data.field_name)
         else:
-            pass
+            check.failed(
+                'Error type not supported {error_data}'.format(error_data=repr(error_data))
+            )
 
 
 def create_schema():

--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -54,33 +54,38 @@ def non_null_list(ttype):
 def create_graphql_error(error):
     check.inst_param(error, 'error', dagster.core.evaluator.EvaluationError)
 
-    common_args = dict(
-        message=error.message,
-        path=[],  # TODO: remove
-        stack=error.stack,
-        reason=error.reason,
-    )
-
     if isinstance(error.error_data, dagster.core.evaluator.RuntimeMismatchErrorData):
         return RuntimeMismatchConfigError(
+            message=error.message,
+            path=[],  # TODO: remove
+            stack=error.stack,
+            reason=error.reason,
             type=error.error_data.dagster_type,
             value_rep=error.error_data.value_rep,
-            **common_args,
         )
     elif isinstance(error.error_data, dagster.core.evaluator.MissingFieldErrorData):
         return MissingFieldConfigError(
+            message=error.message,
+            path=[],  # TODO: remove
+            stack=error.stack,
+            reason=error.reason,
             field=TypeField(name=error.error_data.field_name, field=error.error_data.field_def),
-            **common_args,
         )
     elif isinstance(error.error_data, dagster.core.evaluator.FieldNotDefinedErrorData):
         return FieldNotDefinedConfigError(
+            message=error.message,
+            path=[],  # TODO: remove
+            stack=error.stack,
+            reason=error.reason,
             field_name=error.error_data.field_name,
-            **common_args,
         )
     elif isinstance(error.error_data, dagster.core.evaluator.SelectorTypeErrorData):
         return SelectorTypeConfigError(
+            message=error.message,
+            path=[],  # TODO: remove
+            stack=error.stack,
+            reason=error.reason,
             incoming_fields=error.error_data.incoming_fields,
-            **common_args,
         )
     else:
         check.failed(

--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -8,6 +8,7 @@ from graphene.types.generic import GenericScalar
 import dagster
 import dagster.core.definitions
 import dagster.core.config_types
+import dagster.core.evaluator
 import dagster.core.errors
 
 from dagster import check
@@ -15,7 +16,7 @@ from dagster import check
 from dagster.core.types import DagsterCompositeType
 
 from dagster.core.evaluator import evaluate_config_value
-from dagster.core.execution import create_execution_plan, create_config_value
+from dagster.core.execution import create_execution_plan
 
 
 def resolve_pipelines_implementation(_root_obj, info):
@@ -683,9 +684,6 @@ class ConfigErrorData(graphene.Union):
         types = (RuntimeMismatchErrorData, MissingFieldErrorData)
 
 
-import dagster.core.evaluator
-
-
 class PipelineConfigValidationError(graphene.ObjectType):
     message = graphene.NonNull(graphene.String)
     path = non_null_list(graphene.String)
@@ -694,9 +692,12 @@ class PipelineConfigValidationError(graphene.ObjectType):
     error_data = graphene.NonNull(ConfigErrorData)
 
     def resolve_error_data(self, _info):
-        print('resolve_error_data')
-        print(self)
-        print(self.error_data)
+        # false positives on this because self is weird in graphene
+        # the field assignments above end up masking the actual
+        # value of the field at runtime from pylint's perspective
+
+        # pylint: disable=E1101
+
         error_data = self.error_data
 
         if isinstance(error_data, dagster.core.evaluator.RuntimeMismatchErrorData):

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -307,21 +307,25 @@ def define_more_complicated_nested_config():
         ],
     )
 
+
 def define_context_config_pipeline():
     return PipelineDefinition(
         name='context_config_pipeline',
         solids=[],
         context_definitions={
-            'context_one' : PipelineContextDefinition(
+            'context_one':
+            PipelineContextDefinition(
                 context_fn=lambda *args, **kwargs: None,
                 config_def=ConfigDefinition(types.String),
             ),
-            'context_two' : PipelineContextDefinition(
+            'context_two':
+            PipelineContextDefinition(
                 context_fn=lambda *args, **kwargs: None,
                 config_def=ConfigDefinition(types.Int),
             ),
         }
     )
+
 
 def test_context_config_works():
     result = execute_dagster_graphql(
@@ -331,8 +335,8 @@ def test_context_config_works():
             'pipelineName': 'context_config_pipeline',
             'config': {
                 'context': {
-                    'context_one' : {
-                        'config' : 'kj23k4j3'
+                    'context_one': {
+                        'config': 'kj23k4j3'
                     },
                 },
             },
@@ -342,8 +346,7 @@ def test_context_config_works():
     assert not result.errors
     assert result.data
     assert result.data['isPipelineConfigValid']['__typename'] == 'PipelineConfigValidationValid'
-    assert result.data['isPipelineConfigValid']['pipeline']['name'
-                                                            ] == 'context_config_pipeline'
+    assert result.data['isPipelineConfigValid']['pipeline']['name'] == 'context_config_pipeline'
 
     result = execute_dagster_graphql(
         define_repo(),
@@ -352,8 +355,8 @@ def test_context_config_works():
             'pipelineName': 'context_config_pipeline',
             'config': {
                 'context': {
-                    'context_two' : {
-                        'config' : 38934
+                    'context_two': {
+                        'config': 38934
                     },
                 },
             },
@@ -363,8 +366,7 @@ def test_context_config_works():
     assert not result.errors
     assert result.data
     assert result.data['isPipelineConfigValid']['__typename'] == 'PipelineConfigValidationValid'
-    assert result.data['isPipelineConfigValid']['pipeline']['name'
-                                                            ] == 'context_config_pipeline'
+    assert result.data['isPipelineConfigValid']['pipeline']['name'] == 'context_config_pipeline'
 
 
 def test_context_config_selector_error():
@@ -386,6 +388,7 @@ def test_context_config_selector_error():
     assert error_data['reason'] == 'SELECTOR_FIELD_ERROR'
     assert error_data['incomingFields'] == []
 
+
 def test_context_config_wrong_selector():
     result = execute_dagster_graphql(
         define_repo(),
@@ -393,7 +396,9 @@ def test_context_config_wrong_selector():
         {
             'pipelineName': 'context_config_pipeline',
             'config': {
-                'context': {'not_defined': {}},
+                'context': {
+                    'not_defined': {}
+                },
             },
         },
     )
@@ -405,6 +410,7 @@ def test_context_config_wrong_selector():
     assert error_data['reason'] == 'FIELD_NOT_DEFINED'
     assert error_data['fieldName'] == 'not_defined'
 
+
 def test_context_config_multiple_selectors():
     result = execute_dagster_graphql(
         define_repo(),
@@ -414,10 +420,10 @@ def test_context_config_multiple_selectors():
             'config': {
                 'context': {
                     'context_one': {
-                        'config' : 'kdjfd'
+                        'config': 'kdjfd'
                     },
                     'context_two': {
-                        'config' : 123,
+                        'config': 123,
                     },
                 },
             },

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -369,35 +369,44 @@ def test_more_complicated_multiple_errors():
     assert len(result.data['isPipelineConfigValid']['errors']) == 4
 
     missing_error_one = find_error(
-        result, ['solids', 'a_solid_with_config', 'config'], 'MISSING_REQUIRED_FIELD',
+        result,
+        ['solids', 'a_solid_with_config', 'config'],
+        'MISSING_REQUIRED_FIELD',
     )
     assert ['solids', 'a_solid_with_config', 'config'] == field_stack(missing_error_one)
     assert missing_error_one['reason'] == 'MISSING_REQUIRED_FIELD'
     assert missing_error_one['errorData']['field']['name'] == 'field_one'
 
     not_defined_one = find_error(
-        result, ['solids', 'a_solid_with_config', 'config'], 'FIELD_NOT_DEFINED',
+        result,
+        ['solids', 'a_solid_with_config', 'config'],
+        'FIELD_NOT_DEFINED',
     )
     assert ['solids', 'a_solid_with_config', 'config'] == field_stack(not_defined_one)
     assert not_defined_one['reason'] == 'FIELD_NOT_DEFINED'
     assert not_defined_one['errorData']['fieldName'] == 'extra_one'
 
     runtime_type_error = find_error(
-        result, ['solids', 'a_solid_with_config', 'config', 'nested_field', 'field_four_str'], 'RUNTIME_TYPE_MISMATCH',
+        result,
+        ['solids', 'a_solid_with_config', 'config', 'nested_field', 'field_four_str'],
+        'RUNTIME_TYPE_MISMATCH',
     )
-    assert ['solids', 'a_solid_with_config', 'config', 'nested_field', 'field_four_str'] == field_stack(runtime_type_error)
+    assert ['solids', 'a_solid_with_config', 'config', 'nested_field',
+            'field_four_str'] == field_stack(runtime_type_error)
     assert runtime_type_error['reason'] == 'RUNTIME_TYPE_MISMATCH'
     assert runtime_type_error['errorData']['valueRep'] == '23434'
     assert runtime_type_error['errorData']['type']['name'] == 'String'
 
     not_defined_two = find_error(
-        result, ['solids', 'a_solid_with_config', 'config', 'nested_field'], 'FIELD_NOT_DEFINED',
+        result,
+        ['solids', 'a_solid_with_config', 'config', 'nested_field'],
+        'FIELD_NOT_DEFINED',
     )
 
-    assert ['solids', 'a_solid_with_config', 'config', 'nested_field'] == field_stack(not_defined_two)
+    assert ['solids', 'a_solid_with_config', 'config',
+            'nested_field'] == field_stack(not_defined_two)
     assert not_defined_two['reason'] == 'FIELD_NOT_DEFINED'
     assert not_defined_two['errorData']['fieldName'] == 'extra_two'
-
 
     # TODO: two more errors
 

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -21,6 +21,7 @@ from .evaluator import throwing_evaluate_config_value
 from .types import (
     Bool,
     DagsterCompositeType,
+    DagsterSelectorType,
     DagsterType,
     DagsterTypeAttributes,
 )
@@ -94,7 +95,7 @@ def single_item(ddict):
     return list(ddict.items())[0]
 
 
-class ContextConfigType(DagsterCompositeType):
+class ContextConfigType(DagsterSelectorType):
     def __init__(self, pipeline_name, context_definitions):
         check.str_param(pipeline_name, 'pipeline_name')
         check.dict_param(
@@ -129,8 +130,6 @@ class ContextConfigType(DagsterCompositeType):
         )
 
     def construct_from_config_value(self, config_value):
-        if not config_value:
-            return None
         context_name, context_value = single_item(config_value)
         return Context(name=context_name, config=context_value['config'])
 

--- a/python_modules/dagster/dagster/core/core_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_evaluator.py
@@ -8,6 +8,7 @@ from dagster.core.evaluator import (
     evaluate_config_value,
 )
 
+
 def assert_success(result, expected_value):
     assert result.success
     assert result.value == expected_value

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -213,8 +213,7 @@ def test_errors():
 
     result = evaluate_config_value(context_config_type, invalid_value)
     assert not result.success
-    # two field not defined. one field missing
-    assert len(result.errors) == 3
+    assert len(result.errors) == 1
 
 
 def test_select_context():
@@ -733,45 +732,6 @@ def test_optional_and_required_context():
 
     assert env_obj.context.name == 'optional_field_context'
     assert env_obj.context.config == {'optional_field': 'foobar'}
-
-
-def test_default_optional_and_required_context():
-    pipeline_def = PipelineDefinition(
-        name='some_pipeline',
-        solids=[],
-        context_definitions={
-            'default':
-            PipelineContextDefinition(
-                context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
-                        name='some_optional_context_config',
-                        fields={
-                            'optional_field': types.Field(types.String, is_optional=True),
-                        },
-                    ),
-                ),
-            ),
-            'required_field_context':
-            PipelineContextDefinition(
-                context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
-                        name='some_required_context_config',
-                        fields={
-                            'required_field': types.Field(types.String),
-                        },
-                    ),
-                ),
-            ),
-        },
-    )
-
-    env_type = EnvironmentConfigType(pipeline_def)
-    assert env_type.field_dict['context'].is_optional
-    env_obj = throwing_evaluate_config_value(env_type, {})
-    assert env_obj.context.name == 'default'
-    assert env_obj.context.config is None
 
 
 def test_default_optional_with_default_value_and_required_context():

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -394,6 +394,7 @@ def create_missing_required_field_error(dagster_type, stack, defined_fields, exp
             defined=repr(defined_fields),
         ),
         error_data=MissingFieldErrorData(
-            field_name=expected_field, field_def=dagster_type.field_named(expected_field),
+            field_name=expected_field,
+            field_def=dagster_type.field_named(expected_field),
         ),
     )

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -137,8 +137,9 @@ def stack_with_field(stack, field_name, field_def):
     return EvaluationStack(entries=stack.entries + [EvaluationStackEntry(field_name, field_def)])
 
 
-def throwing_evaluate_config_value(dagster_type, value):
-    result = evaluate_config_value(dagster_type, value)
+def throwing_evaluate_config_value(dagster_type, config_value):
+    check.inst_param(dagster_type, 'dagster_type', DagsterType)
+    result = evaluate_config_value(dagster_type, config_value)
     if not result.success:
         raise DagsterEvaluateConfigValueError(
             result.errors[0].stack,
@@ -147,10 +148,15 @@ def throwing_evaluate_config_value(dagster_type, value):
     return result.value
 
 
-def evaluate_config_value(dagster_type, value):
+def evaluate_config_value(dagster_type, config_value):
     check.inst_param(dagster_type, 'dagster_type', DagsterType)
     collector = ErrorCollector()
-    value = _evaluate_config_value(dagster_type, value, EvaluationStack(entries=[]), collector)
+    value = _evaluate_config_value(
+        dagster_type,
+        config_value,
+        EvaluationStack(entries=[]),
+        collector,
+    )
     if collector.errors:
         return EvaluateValueResult(success=False, value=None, errors=collector.errors)
     else:
@@ -163,30 +169,30 @@ def single_item(ddict):
     return list(ddict.items())[0]
 
 
-def evaluate_selector_input_value(dagster_type, incoming_value, collector, stack):
+def evaluate_selector_config_value(dagster_type, config_value, collector, stack):
     check.inst_param(dagster_type, 'dagster_type', DagsterSelectorType)
     check.inst_param(collector, 'collector', ErrorCollector)
     check.inst_param(stack, 'stack', EvaluationStack)
 
-    if incoming_value and not isinstance(incoming_value, dict):
+    if config_value and not isinstance(config_value, dict):
         collector.add_error(
             EvaluationError(
                 stack=stack,
                 reason=DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH,
                 message='Value for selector type {type_name} must be a dict got {value}'.format(
                     type_name=dagster_type.name,
-                    value=incoming_value,
+                    value=config_value,
                 ),
                 error_data=RuntimeMismatchErrorData(
                     dagster_type=dagster_type,
-                    value_rep=repr(incoming_value),
+                    value_rep=repr(config_value),
                 ),
             )
         )
         return None
 
-    if incoming_value and len(incoming_value) > 1:
-        incoming_fields = sorted(list(incoming_value.keys()))
+    if config_value and len(config_value) > 1:
+        incoming_fields = sorted(list(config_value.keys()))
         defined_fields = sorted(list(dagster_type.field_dict.keys()))
         collector.add_error(
             EvaluationError(
@@ -203,7 +209,7 @@ def evaluate_selector_input_value(dagster_type, incoming_value, collector, stack
             )
         )
         return None
-    elif not incoming_value:
+    elif not config_value:
         defined_fields = sorted(list(dagster_type.field_dict.keys()))
         if len(dagster_type.field_dict) > 1:
             collector.add_error(
@@ -222,9 +228,9 @@ def evaluate_selector_input_value(dagster_type, incoming_value, collector, stack
         field_name, field_def = single_item(dagster_type.field_dict)
         incoming_field_value = field_def.default_value if field_def.default_provided else None
     else:
-        check.invariant(incoming_value and len(incoming_value) == 1)
+        check.invariant(config_value and len(config_value) == 1)
 
-        field_name, incoming_field_value = single_item(incoming_value)
+        field_name, incoming_field_value = single_item(config_value)
         if field_name not in dagster_type.field_dict:
             collector.add_error(
                 create_field_not_defined_error(
@@ -250,70 +256,70 @@ def evaluate_selector_input_value(dagster_type, incoming_value, collector, stack
     return dagster_type.construct_from_config_value({field_name: field_value})
 
 
-def _evaluate_config_value(dagster_type, value, stack, collector):
+def _evaluate_config_value(dagster_type, config_value, stack, collector):
     check.inst_param(dagster_type, 'dagster_type', DagsterType)
     check.inst_param(stack, 'stack', EvaluationStack)
     check.inst_param(collector, 'collector', ErrorCollector)
 
     if isinstance(dagster_type, DagsterScalarType):
-        if dagster_type.is_python_valid_value(value):
-            return dagster_type.coerce_runtime_value(value)
+        if dagster_type.is_python_valid_value(config_value):
+            return config_value
         else:
             collector.add_error(
                 EvaluationError(
                     stack=stack,
                     reason=DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH,
                     message='Value {value} is not valid for type {type_name}'.format(
-                        value=value,
+                        value=config_value,
                         type_name=dagster_type.name,
                     ),
                     error_data=RuntimeMismatchErrorData(
                         dagster_type=dagster_type,
-                        value_rep=repr(value),
+                        value_rep=repr(config_value),
                     ),
                 )
             )
             return None
     elif isinstance(dagster_type, DagsterSelectorType):
-        return evaluate_selector_input_value(dagster_type, value, collector, stack)
+        return evaluate_selector_config_value(dagster_type, config_value, collector, stack)
     elif isinstance(dagster_type, DagsterCompositeType):
-        return evaluate_composite_input_value(dagster_type, value, collector, stack)
+        return evaluate_composite_config_value(dagster_type, config_value, collector, stack)
     elif isinstance(dagster_type, PythonObjectType):
         check.failed('PythonObjectType should not be used in a config hierarchy')
     elif dagster_type == Any:
-        return value
+        return config_value
     else:
         check.failed('Unknown type {name}'.format(name=dagster_type.name))
 
 
-def evaluate_composite_input_value(dagster_composite_type, incoming_value, collector, stack):
+def evaluate_composite_config_value(dagster_composite_type, config_value, collector, stack):
     check.inst_param(dagster_composite_type, 'dagster_composite_type', DagsterCompositeType)
     check.inst_param(collector, 'collector', ErrorCollector)
     check.inst_param(stack, 'stack', EvaluationStack)
 
-    if incoming_value and not isinstance(incoming_value, dict):
+    if config_value and not isinstance(config_value, dict):
         collector.add_error(
             EvaluationError(
                 stack=stack,
                 reason=DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH,
                 message='Value for composite type {type_name} must be a dict got {value}'.format(
                     type_name=dagster_composite_type.name,
-                    value=incoming_value,
+                    value=config_value,
                 ),
                 error_data=RuntimeMismatchErrorData(
                     dagster_type=dagster_composite_type,
-                    value_rep=repr(incoming_value),
+                    value_rep=repr(config_value),
                 ),
             )
         )
         return None
 
-    incoming_value = check.opt_dict_param(incoming_value, 'incoming_value', key_type=str)
+    config_value = check.opt_dict_param(config_value, 'incoming_value', key_type=str)
 
     field_dict = dagster_composite_type.field_dict
 
     defined_fields = set(field_dict.keys())
-    incoming_fields = set(incoming_value.keys())
+    incoming_fields = set(config_value.keys())
 
     local_errors = []
 
@@ -350,7 +356,7 @@ def evaluate_composite_input_value(dagster_composite_type, incoming_value, colle
         if expected_field in incoming_fields:
             evaluated_value = _evaluate_config_value(
                 field_def.dagster_type,
-                incoming_value[expected_field],
+                config_value[expected_field],
                 stack_with_field(stack, expected_field, field_def),
                 collector,
             )

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -31,11 +31,12 @@ class FieldNotDefinedErrorData(namedtuple('_FieldNotDefinedErrorData', 'field_na
         )
 
 
-class MissingFieldErrorData(namedtuple('_MissingFieldErrorData', 'field_name')):
-    def __new__(cls, field_name):
+class MissingFieldErrorData(namedtuple('_MissingFieldErrorData', 'field_name field_def')):
+    def __new__(cls, field_name, field_def):
         return super(MissingFieldErrorData, cls).__new__(
             cls,
             check.str_param(field_name, 'field_name'),
+            check.inst_param(field_def, 'field_def', Field),
         )
 
 
@@ -392,5 +393,7 @@ def create_missing_required_field_error(dagster_type, stack, defined_fields, exp
             type_name=dagster_type.name,
             defined=repr(defined_fields),
         ),
-        error_data=MissingFieldErrorData(field_name=expected_field),
+        error_data=MissingFieldErrorData(
+            field_name=expected_field, field_def=dagster_type.field_named(expected_field),
+        ),
     )

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -20,7 +20,7 @@ class DagsterEvaluationErrorReason(Enum):
     RUNTIME_TYPE_MISMATCH = 'RUNTIME_TYPE_MISMATCH'
     MISSING_REQUIRED_FIELD = 'MISSING_REQUIRED_FIELD'
     FIELD_NOT_DEFINED = 'FIELD_NOT_DEFINED'
-    SELECTOR_FIELD_ERROR = 'MULTIPLE_FIELDS_DEFINED'
+    SELECTOR_FIELD_ERROR = 'SELECTOR_FIELD_ERROR'
 
 
 class FieldNotDefinedErrorData(namedtuple('_FieldNotDefinedErrorData', 'field_name')):

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -52,6 +52,8 @@ class DagsterType(object):
         check.not_implemented('Must implement in subclass')
 
     def construct_from_config_value(self, config_value):
+        '''This function is called *after* the config value has been processed
+        (error-checked and default values applied)'''
         return config_value
 
     def iterate_types(self):

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -349,6 +349,10 @@ class DagsterCompositeType(DagsterType):
     def field_name_set(self):
         return set(self.field_dict.keys())
 
+    def field_named(self, name):
+        check.str_param(name, 'name')
+        return self.field_dict[name]
+
 
 class DagsterSelectorType(DagsterCompositeType):
     '''This subclass "marks" a composite type as one where only

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
@@ -59,7 +59,7 @@ def test_sql_create_tables():
 
     pipeline = create_mem_sql_pipeline_context_tuple(solids=[create_all_tables_solids])
 
-    pipeline_result = execute_pipeline(pipeline)
+    pipeline_result = execute_pipeline(pipeline, {'context': {'default': {}}})
     assert pipeline_result.success
 
     assert set(pipeline_engine(pipeline_result).table_names()) == set(
@@ -83,7 +83,7 @@ def test_sql_populate_tables():
         }
     )
 
-    pipeline_result = execute_pipeline(pipeline)
+    pipeline_result = execute_pipeline(pipeline, {'context': {'default': {}}})
 
     assert pipeline_result.success
 
@@ -134,7 +134,7 @@ def create_full_pipeline():
 def test_full_in_memory_pipeline():
 
     pipeline = create_full_pipeline()
-    pipeline_result = execute_pipeline(pipeline)
+    pipeline_result = execute_pipeline(pipeline, {'context': {'default': {}}})
     assert pipeline_result.success
 
     engine = pipeline_engine(pipeline_result)


### PR DESCRIPTION
We now have a GraphQL interface for getting all the errors for the config file. I still need to write a unit test for the selector error, but I wanted to get this PR out so that @freiksenet could build on it if the mood struck.