### PR TITLE
Make ConfigDefinition a Field

### DIFF
--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -446,7 +446,7 @@ class Config(graphene.ObjectType):
 
     def __init__(self, config_def):
         super(Config, self).__init__()
-        self._config_def = check.opt_inst_param(config_def, 'config_def', dagster.ConfigDefinition)
+        self._config_def = check.opt_inst_param(config_def, 'config_def', dagster.ConfigField)
 
     def resolve_type(self, _info):
         return Type.from_dagster_type(dagster_type=self._config_def.config_type)

--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -449,7 +449,7 @@ class Config(graphene.ObjectType):
         self._config_def = check.opt_inst_param(config_def, 'config_def', dagster.ConfigField)
 
     def resolve_type(self, _info):
-        return Type.from_dagster_type(dagster_type=self._config_def.config_type)
+        return Type.from_dagster_type(dagster_type=self._config_def.dagster_type)
 
 
 class TypeAttributes(graphene.ObjectType):

--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -237,7 +237,7 @@ class PipelineContext(graphene.ObjectType):
         self._context = check.inst_param(context, 'context', dagster.PipelineContextDefinition)
 
     def resolve_config(self, _info):
-        return Config(self._context.config_def) if self._context.config_def else None
+        return Config(self._context.config_field) if self._context.config_field else None
 
 
 class Solid(graphene.ObjectType):
@@ -367,7 +367,7 @@ class SolidDefinition(graphene.ObjectType):
         ]
 
     def resolve_config_definition(self, _info):
-        return Config(self._solid_def.config_def) if self._solid_def.config_def else None
+        return Config(self._solid_def.config_field) if self._solid_def.config_field else None
 
 
 class InputDefinition(graphene.ObjectType):

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -84,7 +84,7 @@ def define_more_complicated_config():
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *_args: None,
-                config_def=ConfigField.solid_config_dict(
+                config_field=ConfigField.solid_config_dict(
                     'more_complicated_config',
                     'a_solid_with_config',
                     {
@@ -283,7 +283,7 @@ def define_more_complicated_nested_config():
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *_args: None,
-                config_def=ConfigField.solid_config_dict(
+                config_field=ConfigField.solid_config_dict(
                     'more_complicated_nested_config',
                     'a_solid_with_config',
                     {
@@ -316,12 +316,12 @@ def define_context_config_pipeline():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda *args, **kwargs: None,
-                config_def=ConfigField(types.String),
+                config_field=ConfigField(types.String),
             ),
             'context_two':
             PipelineContextDefinition(
                 context_fn=lambda *args, **kwargs: None,
-                config_def=ConfigField(types.Int),
+                config_field=ConfigField(types.Int),
             ),
         }
     )

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -1,7 +1,7 @@
 from graphql import graphql
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
@@ -84,7 +84,7 @@ def define_more_complicated_config():
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *_args: None,
-                config_def=ConfigDefinition.solid_config_dict(
+                config_def=ConfigField.solid_config_dict(
                     'more_complicated_config',
                     'a_solid_with_config',
                     {
@@ -283,7 +283,7 @@ def define_more_complicated_nested_config():
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *_args: None,
-                config_def=ConfigDefinition.solid_config_dict(
+                config_def=ConfigField.solid_config_dict(
                     'more_complicated_nested_config',
                     'a_solid_with_config',
                     {
@@ -316,12 +316,12 @@ def define_context_config_pipeline():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda *args, **kwargs: None,
-                config_def=ConfigDefinition(types.String),
+                config_def=ConfigField(types.String),
             ),
             'context_two':
             PipelineContextDefinition(
                 context_fn=lambda *args, **kwargs: None,
-                config_def=ConfigDefinition(types.Int),
+                config_def=ConfigField(types.Int),
             ),
         }
     )

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -10,7 +10,7 @@ from dagster.core.execution_context import (
 )
 
 from dagster.core.definitions import (
-    ConfigDefinition,
+    ConfigField,
     ContextCreationExecutionInfo,
     DependencyDefinition,
     ExpectationDefinition,
@@ -54,7 +54,7 @@ from .version import __version__
 
 __all__ = [
     # Definition
-    'ConfigDefinition',
+    'ConfigField',
     'DependencyDefinition',
     'ExpectationDefinition',
     'ExpectationResult',

--- a/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
@@ -36,7 +36,7 @@ def test_basic_solids_config():
                 name='required_field_solid',
                 inputs=[],
                 outputs=[],
-                config_def=ConfigField(
+                config_field=ConfigField(
                     types.ConfigDictionary(
                         'RequiredFieldSolidConfigDict',
                         {'required_int': types.Field(types.Int)},
@@ -103,7 +103,7 @@ def test_two_contexts():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda *args: fail_me(),
-                config_def=ConfigField(
+                config_field=ConfigField(
                     types.ConfigDictionary(
                         'ContextOneConfigDict',
                         {
@@ -115,7 +115,7 @@ def test_two_contexts():
             'context_two':
             PipelineContextDefinition(
                 context_fn=lambda *args: fail_me(),
-                config_def=ConfigField(
+                config_field=ConfigField(
                     types.ConfigDictionary(
                         'ContextTwoConfigDict',
                         {

--- a/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
@@ -2,7 +2,7 @@ from dagster import (
     PipelineContextDefinition,
     PipelineDefinition,
     SolidDefinition,
-    ConfigDefinition,
+    ConfigField,
     check,
     types,
 )
@@ -36,7 +36,7 @@ def test_basic_solids_config():
                 name='required_field_solid',
                 inputs=[],
                 outputs=[],
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     types.ConfigDictionary(
                         'RequiredFieldSolidConfigDict',
                         {'required_int': types.Field(types.Int)},
@@ -103,7 +103,7 @@ def test_two_contexts():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda *args: fail_me(),
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     types.ConfigDictionary(
                         'ContextOneConfigDict',
                         {
@@ -115,7 +115,7 @@ def test_two_contexts():
             'context_two':
             PipelineContextDefinition(
                 context_fn=lambda *args: fail_me(),
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     types.ConfigDictionary(
                         'ContextTwoConfigDict',
                         {

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -210,7 +210,7 @@ def print_context_definition(printer, context_name, context_definition):
     print_description(printer, context_definition.description)
 
     printer.line(
-        'Type: {config_type}'.format(config_type=context_definition.config_def.config_type.name)
+        'Type: {dagster_type}'.format(dagster_type=context_definition.config_def.config_type.name)
     )
 
 

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -210,7 +210,9 @@ def print_context_definition(printer, context_name, context_definition):
     print_description(printer, context_definition.description)
 
     printer.line(
-        'Type: {dagster_type}'.format(dagster_type=context_definition.config_field.config_type.name)
+        'Type: {dagster_type}'.format(
+            dagster_type=context_definition.config_field.dagster_type.name
+        )
     )
 
 

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -210,7 +210,7 @@ def print_context_definition(printer, context_name, context_definition):
     print_description(printer, context_definition.description)
 
     printer.line(
-        'Type: {dagster_type}'.format(dagster_type=context_definition.config_def.config_type.name)
+        'Type: {dagster_type}'.format(dagster_type=context_definition.config_field.config_type.name)
     )
 
 

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -80,7 +80,7 @@ def define_specific_context_field(
             pipeline_name=pipeline_name,
             context_name=camelcase(context_name),
         ),
-        context_def.config_def.config_type,
+        context_def.config_field.config_type,
     )
 
     if is_optional and provide_default:
@@ -111,7 +111,7 @@ class ContextConfigType(DagsterSelectorType):
         for context_name, context_definition in context_definitions.items():
 
             is_optional = True if len(context_definitions) > 1 else all_optional_type(
-                context_definition.config_def.config_type,
+                context_definition.config_field.config_type,
             )
 
             field_dict[context_name] = define_specific_context_field(
@@ -164,7 +164,7 @@ def define_environment_field(field_type):
 def has_all_optional_default_context(pipeline_def):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     return 'default' in pipeline_def.context_definitions and all_optional_type(
-        pipeline_def.context_definitions['default'].config_def.config_type
+        pipeline_def.context_definitions['default'].config_field.config_type
     )
 
 
@@ -175,7 +175,7 @@ def is_environment_context_field_optional(pipeline_def):
     else:
         _, single_context_def = single_item(pipeline_def.context_definitions)
 
-        return all_optional_type(single_context_def.config_def.config_type)
+        return all_optional_type(single_context_def.config_field.config_type)
 
 
 class EnvironmentConfigType(DagsterCompositeType):
@@ -250,18 +250,18 @@ class SolidDictionaryType(DagsterCompositeType):
         pipeline_name = camelcase(pipeline_def.name)
         field_dict = {}
         for solid in pipeline_def.solids:
-            if solid.definition.config_def:
+            if solid.definition.config_field:
                 solid_name = camelcase(solid.name)
                 solid_config_type = SolidConfigType(
                     '{pipeline_name}.SolidConfig.{solid_name}'.format(
                         pipeline_name=pipeline_name,
                         solid_name=solid_name,
                     ),
-                    solid.definition.config_def.config_type,
+                    solid.definition.config_field.config_type,
                 )
                 field_dict[solid.name] = define_possibly_optional_field(
                     solid_config_type,
-                    solid.definition.config_def.is_optional,
+                    solid.definition.config_field.is_optional,
                 )
 
         super(SolidDictionaryType, self).__init__(

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -243,12 +243,6 @@ def all_optional_type(dagster_type):
     return True
 
 
-def all_optional_user_config(config_type):
-    check.inst_param(config_type, 'config_type', HasUserConfig)
-    user_config_field = config_type.field_dict['config']
-    return all_optional_type(user_config_field.dagster_type)
-
-
 class SolidDictionaryType(DagsterCompositeType):
     def __init__(self, name, pipeline_def):
         check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
@@ -267,7 +261,7 @@ class SolidDictionaryType(DagsterCompositeType):
                 )
                 field_dict[solid.name] = define_possibly_optional_field(
                     solid_config_type,
-                    all_optional_user_config(solid_config_type),
+                    solid.definition.config_def.is_optional,
                 )
 
         super(SolidDictionaryType, self).__init__(

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -254,7 +254,7 @@ def test_mixed_args_passing():
 
 def _single_nested_config():
     return ConfigDefinition(
-        config_type=types.ConfigDictionary(
+        dagster_type=types.ConfigDictionary(
             'ParentType', {
                 'nested':
                 Field(
@@ -270,7 +270,7 @@ def _single_nested_config():
 
 def _nested_optional_config_with_default():
     return ConfigDefinition(
-        config_type=types.ConfigDictionary(
+        dagster_type=types.ConfigDictionary(
             'ParentType', {
                 'nested':
                 Field(
@@ -299,7 +299,7 @@ def _nested_optional_config_with_no_default():
         },
     )
     return ConfigDefinition(
-        config_type=types.ConfigDictionary(
+        dagster_type=types.ConfigDictionary(
             'ParentType',
             {'nested': Field(dagster_type=nested_type)},
         )

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -39,7 +39,11 @@ def test_int_field():
         },
     )
 
-    assert evaluate_config_value(config_field.dagster_type, {'int_field': 1}).value == {'int_field': 1}
+    assert evaluate_config_value(config_field.dagster_type, {
+        'int_field': 1
+    }).value == {
+        'int_field': 1
+    }
 
 
 def assert_config_value_success(dagster_type, config_value, expected):

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -32,7 +32,7 @@ def test_noop_config():
 
 
 def test_int_field():
-    config_def = ConfigField.config_dict(
+    config_def = ConfigField.config_dict_field(
         'SingleRequiredInt',
         {
             'int_field': Field(types.Int),
@@ -53,7 +53,7 @@ def assert_eval_failure(dagster_type, value):
 
 
 def test_int_fails():
-    config_def = ConfigField.config_dict(
+    config_def = ConfigField.config_dict_field(
         'SingleRequiredInt', {
             'int_field': Field(types.Int),
         }
@@ -64,7 +64,7 @@ def test_int_fails():
 
 
 def test_default_arg():
-    config_def = ConfigField.config_dict(
+    config_def = ConfigField.config_dict_field(
         'TestDefaultArg', {
             'int_field': Field(types.Int, default_value=2, is_optional=True),
         }
@@ -74,13 +74,13 @@ def test_default_arg():
 
 
 def _single_required_string_config_dict():
-    return ConfigField.config_dict(
+    return ConfigField.config_dict_field(
         'SingleRequiredField', {'string_field': Field(types.String)}
     )
 
 
 def _multiple_required_fields_config_dict():
-    return ConfigField.config_dict(
+    return ConfigField.config_dict_field(
         'MultipleRequiredFields', {
             'field_one': Field(types.String),
             'field_two': Field(types.String),
@@ -89,7 +89,7 @@ def _multiple_required_fields_config_dict():
 
 
 def _single_optional_string_config_dict():
-    return ConfigField.config_dict(
+    return ConfigField.config_dict_field(
         'SingleOptionalString', {'optional_field': Field(types.String, is_optional=True)}
     )
 
@@ -100,14 +100,14 @@ def _single_optional_string_field_config_dict_with_default():
         is_optional=True,
         default_value='some_default',
     )
-    return ConfigField.config_dict(
+    return ConfigField.config_dict_field(
         'SingleOptionalStringWithDefault',
         {'optional_field': optional_field_def},
     )
 
 
 def _mixed_required_optional_string_config_dict_with_default():
-    return ConfigField.config_dict(
+    return ConfigField.config_dict_field(
         'MixedRequired', {
             'optional_arg': Field(
                 types.String,

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -538,7 +538,7 @@ def test_wrong_solid_name():
                 name='some_solid',
                 inputs=[],
                 outputs=[],
-                config_def=ConfigField.solid_config_dict(
+                config_field=ConfigField.solid_config_dict(
                     'pipeline_wrong_solid_name',
                     'some_solid',
                     {},
@@ -641,7 +641,7 @@ def test_pipeline_name_mismatch_error():
                     name='some_solid',
                     inputs=[],
                     outputs=[],
-                    config_def=ConfigField.solid_config_dict(
+                    config_field=ConfigField.solid_config_dict(
                         'wrong_pipeline',
                         'some_solid',
                         {},
@@ -659,7 +659,7 @@ def test_pipeline_name_mismatch_error():
                 'some_context':
                 PipelineContextDefinition(
                     context_fn=lambda *_args: None,
-                    config_def=ConfigField.context_config_dict(
+                    config_field=ConfigField.context_config_dict(
                         'not_a_match',
                         'some_context',
                         {},
@@ -678,7 +678,7 @@ def test_solid_name_mismatch():
                     name='dont_match_me',
                     inputs=[],
                     outputs=[],
-                    config_def=ConfigField.solid_config_dict(
+                    config_field=ConfigField.solid_config_dict(
                         'solid_name_mismatch',
                         'nope',
                         {},
@@ -696,7 +696,7 @@ def test_solid_name_mismatch():
                     name='dont_match_me',
                     inputs=[],
                     outputs=[],
-                    config_def=ConfigField.context_config_dict(
+                    config_field=ConfigField.context_config_dict(
                         'solid_name_mismatch',
                         'dont_match_me',
                         {},
@@ -716,7 +716,7 @@ def test_context_name_mismatch():
                 'test':
                 PipelineContextDefinition(
                     context_fn=lambda *_args: None,
-                    config_def=ConfigField.context_config_dict(
+                    config_field=ConfigField.context_config_dict(
                         'context_name_mismatch',
                         'nope',
                         {},
@@ -733,7 +733,7 @@ def test_context_name_mismatch():
                 'test':
                 PipelineContextDefinition(
                     context_fn=lambda *_args: None,
-                    config_def=ConfigField.solid_config_dict(
+                    config_field=ConfigField.solid_config_dict(
                         'context_name_mismatch',
                         'some_solid',
                         {},

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -32,14 +32,14 @@ def test_noop_config():
 
 
 def test_int_field():
-    config_def = ConfigField.config_dict_field(
+    config_field = ConfigField.config_dict_field(
         'SingleRequiredInt',
         {
             'int_field': Field(types.Int),
         },
     )
 
-    assert evaluate_config_value(config_def.config_type, {'int_field': 1}).value == {'int_field': 1}
+    assert evaluate_config_value(config_field.dagster_type, {'int_field': 1}).value == {'int_field': 1}
 
 
 def assert_config_value_success(dagster_type, config_value, expected):
@@ -53,24 +53,24 @@ def assert_eval_failure(dagster_type, value):
 
 
 def test_int_fails():
-    config_def = ConfigField.config_dict_field(
+    config_field = ConfigField.config_dict_field(
         'SingleRequiredInt', {
             'int_field': Field(types.Int),
         }
     )
 
-    assert_eval_failure(config_def.config_type, {'int_field': 'fjkdj'})
-    assert_eval_failure(config_def.config_type, {'int_field': True})
+    assert_eval_failure(config_field.dagster_type, {'int_field': 'fjkdj'})
+    assert_eval_failure(config_field.dagster_type, {'int_field': True})
 
 
 def test_default_arg():
-    config_def = ConfigField.config_dict_field(
+    config_field = ConfigField.config_dict_field(
         'TestDefaultArg', {
             'int_field': Field(types.Int, default_value=2, is_optional=True),
         }
     )
 
-    assert_config_value_success(config_def.config_type, {}, {'int_field': 2})
+    assert_config_value_success(config_field.dagster_type, {}, {'int_field': 2})
 
 
 def _single_required_string_config_dict():
@@ -120,8 +120,8 @@ def _mixed_required_optional_string_config_dict_with_default():
     )
 
 
-def _validate(config_def, value):
-    return throwing_evaluate_config_value(config_def.config_type, value)
+def _validate(config_field, value):
+    return throwing_evaluate_config_value(config_field.config_type, value)
 
 
 def test_single_required_string_field_config_type():
@@ -434,7 +434,7 @@ def test_build_single_nested():
         assert nested_field_type.name == 'PipelineName.Solid.SolidName.NestedDict.ConfigDict'
         assert nested_field_type.field_name_set == set(['bar'])
 
-    old_style_config_def = ConfigField(
+    old_style_config_field = ConfigField(
         types.ConfigDictionary(
             'PipelineName.Solid.SolidName.ConfigDict',
             {
@@ -453,7 +453,7 @@ def test_build_single_nested():
         ),
     )
 
-    _assert_facts(old_style_config_def.config_type)
+    _assert_facts(old_style_config_field.config_type)
 
     single_nested_manual = build_config_dict_type(
         ['PipelineName', 'Solid', 'SolidName'],
@@ -471,7 +471,7 @@ def test_build_single_nested():
 
     _assert_facts(single_nested_manual)
 
-    nested_from_config_def = ConfigField.solid_config_dict(
+    nested_from_config_field = ConfigField.solid_config_dict(
         'pipeline_name',
         'solid_name',
         {
@@ -482,7 +482,7 @@ def test_build_single_nested():
         },
     )
 
-    _assert_facts(nested_from_config_def.config_type)
+    _assert_facts(nested_from_config_field.config_type)
 
 
 def test_build_double_nested():

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -121,7 +121,7 @@ def _mixed_required_optional_string_config_dict_with_default():
 
 
 def _validate(config_field, value):
-    return throwing_evaluate_config_value(config_field.config_type, value)
+    return throwing_evaluate_config_value(config_field.dagster_type, value)
 
 
 def test_single_required_string_field_config_type():
@@ -453,7 +453,7 @@ def test_build_single_nested():
         ),
     )
 
-    _assert_facts(old_style_config_field.config_type)
+    _assert_facts(old_style_config_field.dagster_type)
 
     single_nested_manual = build_config_dict_type(
         ['PipelineName', 'Solid', 'SolidName'],
@@ -482,7 +482,7 @@ def test_build_single_nested():
         },
     )
 
-    _assert_facts(nested_from_config_field.config_type)
+    _assert_facts(nested_from_config_field.dagster_type)
 
 
 def test_build_double_nested():
@@ -496,7 +496,7 @@ def test_build_double_nested():
                 }
             }
         },
-    ).config_type
+    ).dagster_type
 
     assert double_config_type.name == 'SomePipeline.Context.SomeContext.ConfigDict'
 
@@ -524,7 +524,7 @@ def test_build_optionality():
                 'value': types.Field(types.String, is_optional=True),
             }
         },
-    ).config_type
+    ).dagster_type
 
     assert optional_test_type.field_dict['required'].is_optional is False
     assert optional_test_type.field_dict['optional'].is_optional is True

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterEvaluateConfigValueError,
     DagsterInvalidDefinitionError,
     DagsterTypeError,
@@ -28,11 +28,11 @@ from dagster.core.definitions import build_config_dict_type
 
 
 def test_noop_config():
-    assert ConfigDefinition(types.Any)
+    assert ConfigField(types.Any)
 
 
 def test_int_field():
-    config_def = ConfigDefinition.config_dict(
+    config_def = ConfigField.config_dict(
         'SingleRequiredInt',
         {
             'int_field': Field(types.Int),
@@ -53,7 +53,7 @@ def assert_eval_failure(dagster_type, value):
 
 
 def test_int_fails():
-    config_def = ConfigDefinition.config_dict(
+    config_def = ConfigField.config_dict(
         'SingleRequiredInt', {
             'int_field': Field(types.Int),
         }
@@ -64,7 +64,7 @@ def test_int_fails():
 
 
 def test_default_arg():
-    config_def = ConfigDefinition.config_dict(
+    config_def = ConfigField.config_dict(
         'TestDefaultArg', {
             'int_field': Field(types.Int, default_value=2, is_optional=True),
         }
@@ -74,13 +74,13 @@ def test_default_arg():
 
 
 def _single_required_string_config_dict():
-    return ConfigDefinition.config_dict(
+    return ConfigField.config_dict(
         'SingleRequiredField', {'string_field': Field(types.String)}
     )
 
 
 def _multiple_required_fields_config_dict():
-    return ConfigDefinition.config_dict(
+    return ConfigField.config_dict(
         'MultipleRequiredFields', {
             'field_one': Field(types.String),
             'field_two': Field(types.String),
@@ -89,7 +89,7 @@ def _multiple_required_fields_config_dict():
 
 
 def _single_optional_string_config_dict():
-    return ConfigDefinition.config_dict(
+    return ConfigField.config_dict(
         'SingleOptionalString', {'optional_field': Field(types.String, is_optional=True)}
     )
 
@@ -100,14 +100,14 @@ def _single_optional_string_field_config_dict_with_default():
         is_optional=True,
         default_value='some_default',
     )
-    return ConfigDefinition.config_dict(
+    return ConfigField.config_dict(
         'SingleOptionalStringWithDefault',
         {'optional_field': optional_field_def},
     )
 
 
 def _mixed_required_optional_string_config_dict_with_default():
-    return ConfigDefinition.config_dict(
+    return ConfigField.config_dict(
         'MixedRequired', {
             'optional_arg': Field(
                 types.String,
@@ -253,7 +253,7 @@ def test_mixed_args_passing():
 
 
 def _single_nested_config():
-    return ConfigDefinition(
+    return ConfigField(
         dagster_type=types.ConfigDictionary(
             'ParentType', {
                 'nested':
@@ -269,7 +269,7 @@ def _single_nested_config():
 
 
 def _nested_optional_config_with_default():
-    return ConfigDefinition(
+    return ConfigField(
         dagster_type=types.ConfigDictionary(
             'ParentType', {
                 'nested':
@@ -298,7 +298,7 @@ def _nested_optional_config_with_no_default():
             ),
         },
     )
-    return ConfigDefinition(
+    return ConfigField(
         dagster_type=types.ConfigDictionary(
             'ParentType',
             {'nested': Field(dagster_type=nested_type)},
@@ -434,7 +434,7 @@ def test_build_single_nested():
         assert nested_field_type.name == 'PipelineName.Solid.SolidName.NestedDict.ConfigDict'
         assert nested_field_type.field_name_set == set(['bar'])
 
-    old_style_config_def = ConfigDefinition(
+    old_style_config_def = ConfigField(
         types.ConfigDictionary(
             'PipelineName.Solid.SolidName.ConfigDict',
             {
@@ -471,7 +471,7 @@ def test_build_single_nested():
 
     _assert_facts(single_nested_manual)
 
-    nested_from_config_def = ConfigDefinition.solid_config_dict(
+    nested_from_config_def = ConfigField.solid_config_dict(
         'pipeline_name',
         'solid_name',
         {
@@ -486,7 +486,7 @@ def test_build_single_nested():
 
 
 def test_build_double_nested():
-    double_config_type = ConfigDefinition.context_config_dict(
+    double_config_type = ConfigField.context_config_dict(
         'some_pipeline',
         'some_context',
         {
@@ -513,7 +513,7 @@ def test_build_double_nested():
 
 
 def test_build_optionality():
-    optional_test_type = ConfigDefinition.solid_config_dict(
+    optional_test_type = ConfigField.solid_config_dict(
         'some_pipeline',
         'some_solid',
         {
@@ -538,7 +538,7 @@ def test_wrong_solid_name():
                 name='some_solid',
                 inputs=[],
                 outputs=[],
-                config_def=ConfigDefinition.solid_config_dict(
+                config_def=ConfigField.solid_config_dict(
                     'pipeline_wrong_solid_name',
                     'some_solid',
                     {},
@@ -641,7 +641,7 @@ def test_pipeline_name_mismatch_error():
                     name='some_solid',
                     inputs=[],
                     outputs=[],
-                    config_def=ConfigDefinition.solid_config_dict(
+                    config_def=ConfigField.solid_config_dict(
                         'wrong_pipeline',
                         'some_solid',
                         {},
@@ -659,7 +659,7 @@ def test_pipeline_name_mismatch_error():
                 'some_context':
                 PipelineContextDefinition(
                     context_fn=lambda *_args: None,
-                    config_def=ConfigDefinition.context_config_dict(
+                    config_def=ConfigField.context_config_dict(
                         'not_a_match',
                         'some_context',
                         {},
@@ -678,7 +678,7 @@ def test_solid_name_mismatch():
                     name='dont_match_me',
                     inputs=[],
                     outputs=[],
-                    config_def=ConfigDefinition.solid_config_dict(
+                    config_def=ConfigField.solid_config_dict(
                         'solid_name_mismatch',
                         'nope',
                         {},
@@ -696,7 +696,7 @@ def test_solid_name_mismatch():
                     name='dont_match_me',
                     inputs=[],
                     outputs=[],
-                    config_def=ConfigDefinition.context_config_dict(
+                    config_def=ConfigField.context_config_dict(
                         'solid_name_mismatch',
                         'dont_match_me',
                         {},
@@ -716,7 +716,7 @@ def test_context_name_mismatch():
                 'test':
                 PipelineContextDefinition(
                     context_fn=lambda *_args: None,
-                    config_def=ConfigDefinition.context_config_dict(
+                    config_def=ConfigField.context_config_dict(
                         'context_name_mismatch',
                         'nope',
                         {},
@@ -733,7 +733,7 @@ def test_context_name_mismatch():
                 'test':
                 PipelineContextDefinition(
                     context_fn=lambda *_args: None,
-                    config_def=ConfigDefinition.solid_config_dict(
+                    config_def=ConfigField.solid_config_dict(
                         'context_name_mismatch',
                         'some_solid',
                         {},

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     ExecutionContext,
     Field,
     OutputDefinition,
@@ -67,7 +67,7 @@ def test_default_value():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_def=ConfigDefinition.config_dict(
+                config_def=ConfigField.config_dict(
                     'CustomOneDict',
                     {
                         'field_one':
@@ -98,7 +98,7 @@ def test_custom_contexts():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_def=ConfigDefinition.config_dict(
+                config_def=ConfigField.config_dict(
                     'CustomOneDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
@@ -106,7 +106,7 @@ def test_custom_contexts():
             ),
             'custom_two':
             PipelineContextDefinition(
-                config_def=ConfigDefinition.config_dict(
+                config_def=ConfigField.config_dict(
                     'CustomTwoDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
@@ -149,7 +149,7 @@ def test_yield_context():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_def=ConfigDefinition.config_dict(
+                config_def=ConfigField.config_dict(
                     'CustomOneDict', {'field_one': Field(dagster_type=types.String)}
                 ),
                 context_fn=_yield_context,
@@ -200,7 +200,7 @@ def test_invalid_context():
         context_definitions={
             'default':
             PipelineContextDefinition(
-                config_def=ConfigDefinition.config_dict(
+                config_def=ConfigField.config_dict(
                     'SingleStringDict', {'string_field': Field(types.String)}
                 ),
                 context_fn=lambda info: info.config,

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -67,7 +67,7 @@ def test_default_value():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_def=ConfigField.config_dict(
+                config_field=ConfigField.config_dict(
                     'CustomOneDict',
                     {
                         'field_one':
@@ -98,7 +98,7 @@ def test_custom_contexts():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_def=ConfigField.config_dict(
+                config_field=ConfigField.config_dict(
                     'CustomOneDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
@@ -106,7 +106,7 @@ def test_custom_contexts():
             ),
             'custom_two':
             PipelineContextDefinition(
-                config_def=ConfigField.config_dict(
+                config_field=ConfigField.config_dict(
                     'CustomTwoDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
@@ -149,7 +149,7 @@ def test_yield_context():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_def=ConfigField.config_dict(
+                config_field=ConfigField.config_dict(
                     'CustomOneDict', {'field_one': Field(dagster_type=types.String)}
                 ),
                 context_fn=_yield_context,
@@ -200,7 +200,7 @@ def test_invalid_context():
         context_definitions={
             'default':
             PipelineContextDefinition(
-                config_def=ConfigField.config_dict(
+                config_field=ConfigField.config_dict(
                     'SingleStringDict', {'string_field': Field(types.String)}
                 ),
                 context_fn=lambda info: info.config,

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -67,7 +67,7 @@ def test_default_value():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_field=ConfigField.config_dict(
+                config_field=ConfigField.config_dict_field(
                     'CustomOneDict',
                     {
                         'field_one':
@@ -98,7 +98,7 @@ def test_custom_contexts():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_field=ConfigField.config_dict(
+                config_field=ConfigField.config_dict_field(
                     'CustomOneDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
@@ -106,7 +106,7 @@ def test_custom_contexts():
             ),
             'custom_two':
             PipelineContextDefinition(
-                config_field=ConfigField.config_dict(
+                config_field=ConfigField.config_dict_field(
                     'CustomTwoDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
@@ -149,7 +149,7 @@ def test_yield_context():
         context_definitions={
             'custom_one':
             PipelineContextDefinition(
-                config_field=ConfigField.config_dict(
+                config_field=ConfigField.config_dict_field(
                     'CustomOneDict', {'field_one': Field(dagster_type=types.String)}
                 ),
                 context_fn=_yield_context,
@@ -200,7 +200,7 @@ def test_invalid_context():
         context_definitions={
             'default':
             PipelineContextDefinition(
-                config_field=ConfigField.config_dict(
+                config_field=ConfigField.config_dict_field(
                     'SingleStringDict', {'string_field': Field(types.String)}
                 ),
                 context_fn=lambda info: info.config,

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -14,6 +14,7 @@ from dagster import (
     execute_pipeline,
     lambda_solid,
     solid,
+    types,
 )
 
 from dagster.core.test_utils import execute_single_solid
@@ -334,7 +335,7 @@ def test_any_config_definition():
     called = {}
     conf_value = 234
 
-    @solid(config_def=ConfigDefinition())
+    @solid(config_def=ConfigDefinition(types.Any))
     def hello_world(info):
         assert info.config == conf_value
         called['yup'] = True

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -331,7 +331,7 @@ def test_descriptions():
     assert solid_desc.description == 'foo'
 
 
-def test_any_config_definition():
+def test_any_config_field():
     called = {}
     conf_value = 234
 

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -335,7 +335,7 @@ def test_any_config_definition():
     called = {}
     conf_value = 234
 
-    @solid(config_def=ConfigField(types.Any))
+    @solid(config_field=ConfigField(types.Any))
     def hello_world(info):
         assert info.config == conf_value
         called['yup'] = True

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterInvalidDefinitionError,
     DependencyDefinition,
     ExecutionContext,
@@ -335,7 +335,7 @@ def test_any_config_definition():
     called = {}
     conf_value = 234
 
-    @solid(config_def=ConfigDefinition(types.Any))
+    @solid(config_def=ConfigField(types.Any))
     def hello_world(info):
         assert info.config == conf_value
         called['yup'] = True

--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -108,7 +108,7 @@ def test_invalid_item_in_solid_list():
 
 def test_double_type():
     @solid(
-        config_def=ConfigField(
+        config_field=ConfigField(
             types.ConfigDictionary(
                 'SomeTypeName',
                 {'some_field': Field(types.String)},
@@ -119,7 +119,7 @@ def test_double_type():
         raise Exception('should not execute')
 
     @solid(
-        config_def=ConfigField(
+        config_field=ConfigField(
             types.ConfigDictionary(
                 'SomeTypeName',
                 {'some_field': Field(types.String)},

--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterInvalidDefinitionError,
     Field,
     DependencyDefinition,
@@ -108,7 +108,7 @@ def test_invalid_item_in_solid_list():
 
 def test_double_type():
     @solid(
-        config_def=ConfigDefinition(
+        config_def=ConfigField(
             types.ConfigDictionary(
                 'SomeTypeName',
                 {'some_field': Field(types.String)},
@@ -119,7 +119,7 @@ def test_double_type():
         raise Exception('should not execute')
 
     @solid(
-        config_def=ConfigDefinition(
+        config_def=ConfigField(
             types.ConfigDictionary(
                 'SomeTypeName',
                 {'some_field': Field(types.String)},

--- a/python_modules/dagster/dagster/core/core_tests/test_definitions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definitions.py
@@ -42,7 +42,7 @@ def test_pipeline_types():
     @solid(
         inputs=[InputDefinition('input_one', types.String)],
         outputs=[OutputDefinition(types.Any)],
-        config_def=ConfigField(SolidOneConfigDict),
+        config_field=ConfigField(SolidOneConfigDict),
     )
     def solid_one(_info, input_one):
         raise Exception('should not execute')
@@ -56,7 +56,7 @@ def test_pipeline_types():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda: None,
-                config_def=ConfigField(ContextOneConfigDict),
+                config_field=ConfigField(ContextOneConfigDict),
             )
         }
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_definitions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definitions.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     Field,
     PipelineContextDefinition,
@@ -42,7 +42,7 @@ def test_pipeline_types():
     @solid(
         inputs=[InputDefinition('input_one', types.String)],
         outputs=[OutputDefinition(types.Any)],
-        config_def=ConfigDefinition(SolidOneConfigDict),
+        config_def=ConfigField(SolidOneConfigDict),
     )
     def solid_one(_info, input_one):
         raise Exception('should not execute')
@@ -56,7 +56,7 @@ def test_pipeline_types():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda: None,
-                config_def=ConfigDefinition(ContextOneConfigDict),
+                config_def=ConfigField(ContextOneConfigDict),
             )
         }
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -32,7 +32,7 @@ def define_pass_value_solid(name, description=None):
         description=description,
         inputs=[],
         outputs=[OutputDefinition(types.String)],
-        config_def=ConfigField(SingleValueDict),
+        config_field=ConfigField(SingleValueDict),
         transform_fn=_value_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -1,7 +1,7 @@
 import dagster
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     Field,
     InputDefinition,
@@ -32,7 +32,7 @@ def define_pass_value_solid(name, description=None):
         description=description,
         inputs=[],
         outputs=[OutputDefinition(types.String)],
-        config_def=ConfigDefinition(SingleValueDict),
+        config_def=ConfigField(SingleValueDict),
         transform_fn=_value_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_aliases.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_aliases.py
@@ -72,7 +72,7 @@ def test_only_aliased_solids():
 def test_aliased_configs():
     @solid(
         inputs=[],
-        config_def=ConfigField(types.Int),
+        config_field=ConfigField(types.Int),
     )
     def load_constant(info):
         return info.config

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_aliases.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_aliases.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     InputDefinition,
     PipelineDefinition,
@@ -72,7 +72,7 @@ def test_only_aliased_solids():
 def test_aliased_configs():
     @solid(
         inputs=[],
-        config_def=ConfigDefinition(types.Int),
+        config_def=ConfigField(types.Int),
     )
     def load_constant(info):
         return info.config

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -25,7 +25,7 @@ def test_basic_solid_with_config():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_def=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
+        config_field=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 
@@ -50,7 +50,7 @@ def test_config_arg_mismatch():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_def=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
+        config_field=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -25,7 +25,7 @@ def test_basic_solid_with_config():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_field=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
+        config_field=ConfigField.config_dict_field('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 
@@ -50,7 +50,7 @@ def test_config_arg_mismatch():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_field=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
+        config_field=ConfigField.config_dict_field('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -25,7 +25,9 @@ def test_basic_solid_with_config():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_field=ConfigField.config_dict_field('SomeConfig', {'some_config': Field(types.String)}),
+        config_field=ConfigField.config_dict_field(
+            'SomeConfig', {'some_config': Field(types.String)}
+        ),
         transform_fn=_t_fn,
     )
 
@@ -50,7 +52,9 @@ def test_config_arg_mismatch():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_field=ConfigField.config_dict_field('SomeConfig', {'some_config': Field(types.String)}),
+        config_field=ConfigField.config_dict_field(
+            'SomeConfig', {'some_config': Field(types.String)}
+        ),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_with_config.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterInvariantViolationError,
     DagsterTypeError,
     Field,
@@ -25,7 +25,7 @@ def test_basic_solid_with_config():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_def=ConfigDefinition.config_dict('SomeConfig', {'some_config': Field(types.String)}),
+        config_def=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 
@@ -50,7 +50,7 @@ def test_config_arg_mismatch():
         name='solid_with_context',
         inputs=[],
         outputs=[],
-        config_def=ConfigDefinition.config_dict('SomeConfig', {'some_config': Field(types.String)}),
+        config_def=ConfigField.config_dict('SomeConfig', {'some_config': Field(types.String)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -33,7 +33,7 @@ def test_context_config_any():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigField(types.Any),
+            config_field=ConfigField(types.Any),
             context_fn=lambda *args: ExecutionContext(),
         )
     }
@@ -51,7 +51,7 @@ def test_context_config():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigField(
+            config_field=ConfigField(
                 dagster_type=types.
                 ConfigDictionary('TestConfigDict', {
                     'some_str': Field(types.String),
@@ -121,7 +121,7 @@ def test_provided_default_config():
         context_definitions={
             'some_context':
             PipelineContextDefinition(
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         'ksjdkfjd', {
                             'with_default_int':
@@ -189,7 +189,7 @@ def test_errors():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigField(
+            config_field=ConfigField(
                 types.ConfigDictionary(
                     'something',
                     {
@@ -217,12 +217,12 @@ def test_select_context():
     context_defs = {
         'int_context':
         PipelineContextDefinition(
-            config_def=ConfigField(types.Int),
+            config_field=ConfigField(types.Int),
             context_fn=lambda *args: ExecutionContext(),
         ),
         'string_context':
         PipelineContextDefinition(
-            config_def=ConfigField(types.String),
+            config_field=ConfigField(types.String),
             context_fn=lambda *args: ExecutionContext(),
         ),
     }
@@ -326,14 +326,14 @@ def define_test_solids_config_pipeline():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(types.Int, is_optional=True),
+                config_field=ConfigField(types.Int, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
             ),
             SolidDefinition(
                 name='string_config_solid',
-                config_def=ConfigField(types.String, is_optional=True),
+                config_field=ConfigField(types.String, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -347,7 +347,7 @@ def test_solid_dictionary_some_no_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(types.Int),
+                config_field=ConfigField(types.Int),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -383,14 +383,14 @@ def test_whole_environment():
         context_definitions={
             'test':
             PipelineContextDefinition(
-                config_def=ConfigField(types.Any),
+                config_field=ConfigField(types.Any),
                 context_fn=lambda *args: ExecutionContext(),
             )
         },
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(types.Int),
+                config_field=ConfigField(types.Int),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -468,7 +468,7 @@ def test_optional_solid_with_no_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(types.Int),
+                config_field=ConfigField(types.Int),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda info, _inputs: _assert_config_none(info, 234),
@@ -505,7 +505,7 @@ def test_optional_solid_with_optional_scalar_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(types.Int, is_optional=True),
+                config_field=ConfigField(types.Int, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda info, _inputs: _assert_config_none(info, 234),
@@ -536,7 +536,7 @@ def test_required_solid_with_required_subfield():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(
+                config_field=ConfigField(
                     types.ConfigDictionary(
                         'TestRequiredSolidConfig',
                         {
@@ -593,7 +593,7 @@ def test_optional_solid_with_optional_subfield():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigField(
+                config_field=ConfigField(
                     types.ConfigDictionary(
                         'TestOptionalSolidConfig', {
                             'optional_field': types.Field(types.String, is_optional=True),
@@ -623,7 +623,7 @@ def test_required_context_with_required_subfield():
             'some_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_context_config',
                         fields={
@@ -653,7 +653,7 @@ def test_all_optional_field_on_single_context_dict():
             'some_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_context_config',
                         fields={
@@ -680,7 +680,7 @@ def test_optional_and_required_context():
             'optional_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
@@ -692,7 +692,7 @@ def test_optional_and_required_context():
             'required_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={
@@ -740,7 +740,7 @@ def test_default_optional_with_default_value_and_required_context():
             'default':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
@@ -757,7 +757,7 @@ def test_default_optional_with_default_value_and_required_context():
             'required_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigField(
+                config_field=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterEvaluateConfigValueError,
     ExecutionContext,
     Field,
@@ -33,7 +33,7 @@ def test_context_config_any():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigDefinition(types.Any),
+            config_def=ConfigField(types.Any),
             context_fn=lambda *args: ExecutionContext(),
         )
     }
@@ -51,7 +51,7 @@ def test_context_config():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigDefinition(
+            config_def=ConfigField(
                 dagster_type=types.
                 ConfigDictionary('TestConfigDict', {
                     'some_str': Field(types.String),
@@ -121,7 +121,7 @@ def test_provided_default_config():
         context_definitions={
             'some_context':
             PipelineContextDefinition(
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         'ksjdkfjd', {
                             'with_default_int':
@@ -189,7 +189,7 @@ def test_errors():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigDefinition(
+            config_def=ConfigField(
                 types.ConfigDictionary(
                     'something',
                     {
@@ -217,12 +217,12 @@ def test_select_context():
     context_defs = {
         'int_context':
         PipelineContextDefinition(
-            config_def=ConfigDefinition(types.Int),
+            config_def=ConfigField(types.Int),
             context_fn=lambda *args: ExecutionContext(),
         ),
         'string_context':
         PipelineContextDefinition(
-            config_def=ConfigDefinition(types.String),
+            config_def=ConfigField(types.String),
             context_fn=lambda *args: ExecutionContext(),
         ),
     }
@@ -326,14 +326,14 @@ def define_test_solids_config_pipeline():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int, is_optional=True),
+                config_def=ConfigField(types.Int, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
             ),
             SolidDefinition(
                 name='string_config_solid',
-                config_def=ConfigDefinition(types.String, is_optional=True),
+                config_def=ConfigField(types.String, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -347,7 +347,7 @@ def test_solid_dictionary_some_no_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int),
+                config_def=ConfigField(types.Int),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -383,14 +383,14 @@ def test_whole_environment():
         context_definitions={
             'test':
             PipelineContextDefinition(
-                config_def=ConfigDefinition(types.Any),
+                config_def=ConfigField(types.Any),
                 context_fn=lambda *args: ExecutionContext(),
             )
         },
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int),
+                config_def=ConfigField(types.Int),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -468,7 +468,7 @@ def test_optional_solid_with_no_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int),
+                config_def=ConfigField(types.Int),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda info, _inputs: _assert_config_none(info, 234),
@@ -505,7 +505,7 @@ def test_optional_solid_with_optional_scalar_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int, is_optional=True),
+                config_def=ConfigField(types.Int, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda info, _inputs: _assert_config_none(info, 234),
@@ -536,7 +536,7 @@ def test_required_solid_with_required_subfield():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     types.ConfigDictionary(
                         'TestRequiredSolidConfig',
                         {
@@ -593,7 +593,7 @@ def test_optional_solid_with_optional_subfield():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     types.ConfigDictionary(
                         'TestOptionalSolidConfig', {
                             'optional_field': types.Field(types.String, is_optional=True),
@@ -623,7 +623,7 @@ def test_required_context_with_required_subfield():
             'some_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_context_config',
                         fields={
@@ -653,7 +653,7 @@ def test_all_optional_field_on_single_context_dict():
             'some_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_context_config',
                         fields={
@@ -680,7 +680,7 @@ def test_optional_and_required_context():
             'optional_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
@@ -692,7 +692,7 @@ def test_optional_and_required_context():
             'required_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={
@@ -740,7 +740,7 @@ def test_default_optional_with_default_value_and_required_context():
             'default':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
@@ -757,7 +757,7 @@ def test_default_optional_with_default_value_and_required_context():
             'required_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_def=ConfigDefinition(
+                config_def=ConfigField(
                     dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -21,7 +21,6 @@ from dagster.core.config_types import (
     SolidConfigType,
     SolidDictionaryType,
     SpecificContextConfig,
-    all_optional_user_config,
 )
 
 from dagster.core.evaluator import (
@@ -111,8 +110,6 @@ def test_default_context_config():
 
     assert isinstance(default_context_config_type, SpecificContextConfig)
     assert 'config' in default_context_config_type.field_dict
-
-    assert all_optional_user_config(default_context_config_type)
 
     context_dict = throwing_evaluate_config_value(context_config_type, {})
 
@@ -329,14 +326,14 @@ def define_test_solids_config_pipeline():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int),
+                config_def=ConfigDefinition(types.Int, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
             ),
             SolidDefinition(
                 name='string_config_solid',
-                config_def=ConfigDefinition(types.String),
+                config_def=ConfigDefinition(types.String, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda *args: None,
@@ -508,7 +505,7 @@ def test_optional_solid_with_optional_scalar_config():
         solids=[
             SolidDefinition(
                 name='int_config_solid',
-                config_def=ConfigDefinition(types.Int),
+                config_def=ConfigDefinition(types.Int, is_optional=True),
                 inputs=[],
                 outputs=[],
                 transform_fn=lambda info, _inputs: _assert_config_none(info, 234),
@@ -601,7 +598,8 @@ def test_optional_solid_with_optional_subfield():
                         'TestOptionalSolidConfig', {
                             'optional_field': types.Field(types.String, is_optional=True),
                         }
-                    )
+                    ),
+                    is_optional=True,
                 ),
                 inputs=[],
                 outputs=[],

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -34,7 +34,7 @@ def test_context_config_any():
     context_defs = {
         'test':
         PipelineContextDefinition(
-            config_def=ConfigDefinition(),
+            config_def=ConfigDefinition(types.Any),
             context_fn=lambda *args: ExecutionContext(),
         )
     }
@@ -53,7 +53,7 @@ def test_context_config():
         'test':
         PipelineContextDefinition(
             config_def=ConfigDefinition(
-                config_type=types.
+                dagster_type=types.
                 ConfigDictionary('TestConfigDict', {
                     'some_str': Field(types.String),
                 })
@@ -125,7 +125,7 @@ def test_provided_default_config():
             'some_context':
             PipelineContextDefinition(
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         'ksjdkfjd', {
                             'with_default_int':
                             Field(
@@ -386,7 +386,7 @@ def test_whole_environment():
         context_definitions={
             'test':
             PipelineContextDefinition(
-                config_def=ConfigDefinition(),
+                config_def=ConfigDefinition(types.Any),
                 context_fn=lambda *args: ExecutionContext(),
             )
         },
@@ -626,7 +626,7 @@ def test_required_context_with_required_subfield():
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         name='some_context_config',
                         fields={
                             'required_field': types.Field(types.String),
@@ -656,7 +656,7 @@ def test_all_optional_field_on_single_context_dict():
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         name='some_context_config',
                         fields={
                             'optional_field': types.Field(types.String, is_optional=True),
@@ -683,7 +683,7 @@ def test_optional_and_required_context():
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
                             'optional_field': types.Field(types.String, is_optional=True),
@@ -695,7 +695,7 @@ def test_optional_and_required_context():
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={
                             'required_field': types.Field(types.String),
@@ -743,7 +743,7 @@ def test_default_optional_with_default_value_and_required_context():
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
                             'optional_field':
@@ -760,7 +760,7 @@ def test_default_optional_with_default_value_and_required_context():
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary(
+                    dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={
                             'required_field': types.Field(types.String),

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 import inspect
 
 from .definitions import (
-    ConfigDefinition,
+    ConfigField,
     DagsterInvalidDefinitionError,
     InputDefinition,
     OutputDefinition,
@@ -114,7 +114,7 @@ class _Solid(object):
         outputs = outputs or [OutputDefinition()]
         self.outputs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
-        self.config_def = check.opt_inst_param(config_def, 'config_def', ConfigDefinition)
+        self.config_def = check.opt_inst_param(config_def, 'config_def', ConfigField)
 
     def __call__(self, fn):
         check.callable_param(fn, 'fn')

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -107,14 +107,14 @@ class _Solid(object):
         inputs=None,
         outputs=None,
         description=None,
-        config_def=None,
+        config_field=None,
     ):
         self.name = check.opt_str_param(name, 'name')
         self.input_defs = check.opt_list_param(inputs, 'inputs', InputDefinition)
         outputs = outputs or [OutputDefinition()]
         self.outputs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
-        self.config_def = check.opt_inst_param(config_def, 'config_def', ConfigField)
+        self.config_field = check.opt_inst_param(config_field, 'config_field', ConfigField)
 
     def __call__(self, fn):
         check.callable_param(fn, 'fn')
@@ -129,7 +129,7 @@ class _Solid(object):
             inputs=self.input_defs,
             outputs=self.outputs,
             transform_fn=transform_fn,
-            config_def=self.config_def,
+            config_field=self.config_field,
             description=self.description,
         )
 
@@ -184,7 +184,7 @@ def solid(
     name=None,
     inputs=None,
     outputs=None,
-    config_def=None,
+    config_field=None,
     description=None,
 ):
     '''(decorator) Create a solid with specified parameters.
@@ -262,7 +262,7 @@ def solid(
         @solid(
             inputs=[InputDefinition(name="foo")],
             outputs=[OutputDefinition()],
-            config_def=ConfigDefinition(types.ConfigDictionary({'str_value' : Field(types.String)})),
+            config_field=ConfigDefinition(types.ConfigDictionary({'str_value' : Field(types.String)})),
         )
         def hello_world(info, foo):
             # info.config is a dictionary with 'str_value' key
@@ -273,14 +273,14 @@ def solid(
         check.invariant(inputs is None)
         check.invariant(outputs is None)
         check.invariant(description is None)
-        check.invariant(config_def is None)
+        check.invariant(config_field is None)
         return _Solid()(name)
 
     return _Solid(
         name=name,
         inputs=inputs,
         outputs=outputs,
-        config_def=config_def,
+        config_field=config_field,
         description=description,
     )
 

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -206,7 +206,7 @@ def solid(
         name (str): Name of solid
         inputs (List[InputDefinition]): List of inputs
         outputs (List[OutputDefinition]): List of outputs
-        config_def (ConfigDefinition):
+        config_field (ConfigField):
             The configuration for this solid.
         description (str): Description of this solid.
 
@@ -262,7 +262,7 @@ def solid(
         @solid(
             inputs=[InputDefinition(name="foo")],
             outputs=[OutputDefinition()],
-            config_field=ConfigDefinition(types.ConfigDictionary({'str_value' : Field(types.String)})),
+            config_field=ConfigField(types.ConfigDictionary({'str_value' : Field(types.String)})),
         )
         def hello_world(info, foo):
             # info.config is a dictionary with 'str_value' key

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -132,8 +132,8 @@ class PipelineContextDefinition(object):
         self.config_def = check.opt_inst_param(
             config_def,
             'config_def',
-            ConfigDefinition,
-            ConfigDefinition(types.Any),
+            ConfigField,
+            ConfigField(types.Any),
         )
         self.context_fn = check.callable_param(context_fn, 'context_fn')
         self.description = description
@@ -160,7 +160,7 @@ def _default_pipeline_context_definitions():
         return context
 
     default_context_def = PipelineContextDefinition(
-        config_def=ConfigDefinition(DefaultContextConfigDict),
+        config_def=ConfigField(DefaultContextConfigDict),
         context_fn=_default_context_fn,
     )
     return {DEFAULT_CONTEXT_NAME: default_context_def}
@@ -1088,7 +1088,7 @@ def build_config_dict_type(name_stack, fields, scoped_config_info=None):
     return ConfigDictionary('.'.join(name_stack + ['ConfigDict']), field_dict, scoped_config_info)
 
 
-class ConfigDefinition(Field):
+class ConfigField(Field):
     '''Represents the configuration of an entity in Dagster
 
     Broadly defined, configs determine how computations within dagster interact with
@@ -1136,7 +1136,7 @@ class ConfigDefinition(Field):
         check.str_param(context_name, 'context_name')
         check.dict_param(fields, 'fields', key_type=str)
 
-        return ConfigDefinition(
+        return ConfigField(
             build_config_dict_type(
                 [
                     camelcase(pipeline_name),
@@ -1163,7 +1163,7 @@ class ConfigDefinition(Field):
         check.str_param(solid_name, 'solid_name')
         check.dict_param(fields, 'fields', key_type=str)
 
-        return ConfigDefinition(
+        return ConfigField(
             build_config_dict_type(
                 [
                     camelcase(pipeline_name),
@@ -1197,7 +1197,7 @@ class ConfigDefinition(Field):
              })
 
         '''
-        return ConfigDefinition(types.ConfigDictionary(name, field_dict))
+        return ConfigField(types.ConfigDictionary(name, field_dict))
 
     @property
     def config_type(self):
@@ -1273,7 +1273,7 @@ class SolidDefinition(object):
         self.config_def = check.opt_inst_param(
             config_def,
             'config_def',
-            ConfigDefinition,
+            ConfigField,
         )
         self.metadata = check.opt_dict_param(metadata, 'metadata', key_type=str)
         self._input_dict = {inp.name: inp for inp in inputs}

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1199,6 +1199,7 @@ class ConfigField(Field):
                 default_value=lambda: throwing_evaluate_config_value(config_dict_type, None),
             )
 
+
 def all_fields_optional(field_dict):
     for field in field_dict.values():
         if not field.is_optional:

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -544,7 +544,7 @@ def _gather_all_types(solids, context_definitions, environment_type):
 
     for context_definition in context_definitions.values():
         if context_definition.config_field:
-            for dagster_type in context_definition.config_field.config_type.iterate_types():
+            for dagster_type in context_definition.config_field.dagster_type.iterate_types():
                 yield dagster_type
 
     for dagster_type in environment_type.iterate_types():
@@ -679,7 +679,7 @@ class PipelineDefinition(object):
             if not context_def.config_field:
                 continue
 
-            for in_def_type in context_def.config_field.config_type.iterate_types():
+            for in_def_type in context_def.config_field.dagster_type.iterate_types():
                 if not isinstance(in_def_type, IsScopedConfigType):
                     continue
                 if not in_def_type.scoped_config_info:
@@ -1085,17 +1085,6 @@ def build_config_dict_type(name_stack, fields, scoped_config_info=None):
 
 
 class ConfigField(Field):
-    '''Represents the configuration of an entity in Dagster
-
-    Broadly defined, configs determine how computations within dagster interact with
-    the external world. Example values that would end up in configs would be file paths,
-    database table names, and so forth.
-
-    Attributes:
-
-        config_type (DagsterType): Type of the config.
-    '''
-
     @staticmethod
     def context_config_dict(pipeline_name, context_name, fields):
         '''
@@ -1194,10 +1183,6 @@ class ConfigField(Field):
 
         '''
         return ConfigField(types.ConfigDictionary(name, field_dict))
-
-    @property
-    def config_type(self):
-        return self.dagster_type
 
 
 class SolidDefinition(object):

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -21,6 +21,7 @@ from .errors import DagsterInvalidDefinitionError
 from .execution_context import ExecutionContext
 
 from .types import (
+    FIELD_NO_DEFAULT_PROVIDED,
     ConfigDictionary,
     IsScopedConfigType,
     ScopedConfigInfo,
@@ -1087,7 +1088,7 @@ def build_config_dict_type(name_stack, fields, scoped_config_info=None):
     return ConfigDictionary('.'.join(name_stack + ['ConfigDict']), field_dict, scoped_config_info)
 
 
-class ConfigDefinition(object):
+class ConfigDefinition(Field):
     '''Represents the configuration of an entity in Dagster
 
     Broadly defined, configs determine how computations within dagster interact with
@@ -1198,11 +1199,26 @@ class ConfigDefinition(object):
         '''
         return ConfigDefinition(types.ConfigDictionary(name, field_dict))
 
-    def __init__(self, config_type=types.Any, description=None):
+    def __init__(
+        self,
+        config_type=types.Any,
+        default_value=FIELD_NO_DEFAULT_PROVIDED,
+        is_optional=False,
+        description=None,
+    ):
+
         '''Construct a ConfigDefinition
 
         Args:
             config_type (DagsterType): Type the determines shape and values of config'''
+
+        super(ConfigDefinition, self).__init__(
+            config_type,
+            default_value=default_value,
+            is_optional=is_optional,
+            description=description,
+        )
+
         self.config_type = check.inst_param(config_type, 'config_type', DagsterType)
         self.description = check.opt_str_param(description, 'description')
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -133,7 +133,9 @@ context_fn (callable):
             config_field,
             'config_field',
             ConfigField,
-            # TODO: Do not check this in
+            # For now we are defaulting to allowing any config for a
+            # pipeline context definition. This should instead default
+            # to having no config like a SolidDefinition
             ConfigField(types.Any, is_optional=True, default_value=None),
         )
         self.context_fn = check.callable_param(context_fn, 'context_fn')

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1199,28 +1199,9 @@ class ConfigDefinition(Field):
         '''
         return ConfigDefinition(types.ConfigDictionary(name, field_dict))
 
-    def __init__(
-        self,
-        config_type=types.Any,
-        default_value=FIELD_NO_DEFAULT_PROVIDED,
-        is_optional=False,
-        description=None,
-    ):
-
-        '''Construct a ConfigDefinition
-
-        Args:
-            config_type (DagsterType): Type the determines shape and values of config'''
-
-        super(ConfigDefinition, self).__init__(
-            config_type,
-            default_value=default_value,
-            is_optional=is_optional,
-            description=description,
-        )
-
-        self.config_type = check.inst_param(config_type, 'config_type', DagsterType)
-        self.description = check.opt_str_param(description, 'description')
+    @property
+    def config_type(self):
+        return self.dagster_type
 
 
 class SolidDefinition(object):

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1175,7 +1175,7 @@ class ConfigField(Field):
         )
 
     @staticmethod
-    def config_dict(name, field_dict):
+    def config_dict_field(name, field_dict):
         '''Shortcut to create a dictionary based config definition.
 
 
@@ -1187,7 +1187,7 @@ class ConfigField(Field):
 
         .. code-block:: python
 
-            ConfigField.config_dict({
+            ConfigField.config_dict_field({
                 'int_field': Field(types.Int),
                 'string_field': Field(types.String),
              })

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -311,7 +311,7 @@ def yield_context(pipeline, environment):
 
     context_name = environment.context.name
     context_definition = pipeline.context_definitions[context_name]
-    config_type = context_definition.config_def.config_type
+    config_type = context_definition.config_field.config_type
 
     config_value = create_config_value(config_type, environment.context.config)
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -292,11 +292,11 @@ def create_config_value(config_type, config_input):
         return throwing_evaluate_config_value(config_type, config_input)
     except DagsterEvaluateConfigValueError as e:
         raise DagsterTypeError(
-            'Invalid config value on type {config_type}: {error_msg}. Value received {value}'.
+            'Invalid config value on type {dagster_type}: {error_msg}. Value received {value}'.
             format(
                 value=json.dumps(config_input, indent=2)
                 if isinstance(config_input, dict) else config_input,
-                config_type=config_type.name,
+                dagster_type=config_type.name,
                 error_msg=','.join(e.args),
             )
         )

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -311,7 +311,7 @@ def yield_context(pipeline, environment):
 
     context_name = environment.context.name
     context_definition = pipeline.context_definitions[context_name]
-    config_type = context_definition.config_field.config_type
+    config_type = context_definition.config_field.dagster_type
 
     config_value = create_config_value(config_type, environment.context.config)
 

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -637,7 +637,7 @@ def create_config_value(execution_info, pipeline_solid):
         return None
 
     try:
-        return throwing_evaluate_config_value(solid_def.config_field.config_type, config_input)
+        return throwing_evaluate_config_value(solid_def.config_field.dagster_type, config_input)
     except DagsterEvaluateConfigValueError as eval_error:
         raise_from(
             DagsterTypeError(

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -624,7 +624,7 @@ def create_config_value(execution_info, pipeline_solid):
     solid_configs = execution_info.environment.solids
     config_input = solid_configs[name].config if name in solid_configs else None
 
-    if solid_def.config_def is None:
+    if solid_def.config_field is None:
         if config_input is not None:
             raise DagsterInvariantViolationError(
                 (
@@ -637,7 +637,7 @@ def create_config_value(execution_info, pipeline_solid):
         return None
 
     try:
-        return throwing_evaluate_config_value(solid_def.config_def.config_type, config_input)
+        return throwing_evaluate_config_value(solid_def.config_field.config_type, config_input)
     except DagsterEvaluateConfigValueError as eval_error:
         raise_from(
             DagsterTypeError(

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
@@ -29,13 +29,13 @@ fields = {'word': Field(types.String)}
 WordConfig = types.ConfigDictionary(name=name, fields=fields)
 
 
-@solid(config_def=ConfigField(WordConfig))
+@solid(config_field=ConfigField(WordConfig))
 def double_the_word_with_typed_config(info):
     return info.config['word'] * 2
 
 
 @solid(
-    config_def=ConfigField(WordConfig),
+    config_field=ConfigField(WordConfig),
     outputs=[OutputDefinition(types.String)],
 )
 def typed_double_word(info):
@@ -43,7 +43,7 @@ def typed_double_word(info):
 
 
 @solid(
-    config_def=ConfigField(WordConfig),
+    config_field=ConfigField(WordConfig),
     outputs=[OutputDefinition(types.Int)],
 )
 def typed_double_word_mismatch(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterInvariantViolationError,
     DagsterTypeError,
     DependencyDefinition,
@@ -29,13 +29,13 @@ fields = {'word': Field(types.String)}
 WordConfig = types.ConfigDictionary(name=name, fields=fields)
 
 
-@solid(config_def=ConfigDefinition(WordConfig))
+@solid(config_def=ConfigField(WordConfig))
 def double_the_word_with_typed_config(info):
     return info.config['word'] * 2
 
 
 @solid(
-    config_def=ConfigDefinition(WordConfig),
+    config_def=ConfigField(WordConfig),
     outputs=[OutputDefinition(types.String)],
 )
 def typed_double_word(info):
@@ -43,7 +43,7 @@ def typed_double_word(info):
 
 
 @solid(
-    config_def=ConfigDefinition(WordConfig),
+    config_def=ConfigField(WordConfig),
     outputs=[OutputDefinition(types.Int)],
 )
 def typed_double_word_mismatch(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eleven.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eleven.py
@@ -2,7 +2,7 @@
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterInvariantViolationError,
     DependencyDefinition,
     InputDefinition,
@@ -42,7 +42,7 @@ def return_dict_results(_info):
 
 
 @solid(
-    config_def=ConfigDefinition(types.String, description='Should be either out_one or out_two'),
+    config_def=ConfigField(types.String, description='Should be either out_one or out_two'),
     outputs=[
         OutputDefinition(dagster_type=types.Int, name='out_one'),
         OutputDefinition(dagster_type=types.Int, name='out_two'),

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eleven.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eleven.py
@@ -42,7 +42,7 @@ def return_dict_results(_info):
 
 
 @solid(
-    config_def=ConfigField(types.String, description='Should be either out_one or out_two'),
+    config_field=ConfigField(types.String, description='Should be either out_one or out_two'),
     outputs=[
         OutputDefinition(dagster_type=types.Int, name='out_one'),
         OutputDefinition(dagster_type=types.Int, name='out_two'),

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_four.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_four.py
@@ -9,7 +9,7 @@ from dagster import (
 )
 
 
-@solid(config_def=ConfigField(types.String))
+@solid(config_field=ConfigField(types.String))
 def hello_world(info):
     print(info.config)
     return info.config

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_four.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_four.py
@@ -1,6 +1,6 @@
 # pylint: disable=W0622,W0614,W0401
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     PipelineDefinition,
     config,
     execute_pipeline,
@@ -9,7 +9,7 @@ from dagster import (
 )
 
 
-@solid(config_def=ConfigDefinition(types.String))
+@solid(config_def=ConfigField(types.String))
 def hello_world(info):
     print(info.config)
     return info.config

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_fourteen.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_fourteen.py
@@ -14,7 +14,7 @@ from dagster import (
 
 
 @solid(
-    config_def=ConfigField(types.Int),
+    config_field=ConfigField(types.Int),
     outputs=[OutputDefinition(types.Int)],
 )
 def load_number(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_fourteen.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_fourteen.py
@@ -1,5 +1,5 @@
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
@@ -14,7 +14,7 @@ from dagster import (
 
 
 @solid(
-    config_def=ConfigDefinition(types.Int),
+    config_def=ConfigField(types.Int),
     outputs=[OutputDefinition(types.Int)],
 )
 def load_number(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
@@ -203,7 +203,7 @@ def define_part_nine_final_pipeline():
                 context_fn=lambda info: ExecutionContext.console_logging(
                     resources=PartNineResources(PublicCloudStore(info.config['credentials']))
                 ),
-                config_def=ConfigDefinition(config_type=types.ConfigDictionary(
+                config_def=ConfigDefinition(dagster_type=types.ConfigDictionary(
                     name='CloudConfigDict',
                     fields={
                     'credentials': Field(types.ConfigDictionary(

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
@@ -6,7 +6,7 @@ import yaml
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterTypeError,
     DependencyDefinition,
     ExecutionContext,
@@ -57,14 +57,14 @@ PartNineResources = namedtuple('PartNineResources', 'store')
 
 def define_contextless_solids():
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_def=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_a(info):
         return info.config
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_def=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_b(info):
@@ -91,7 +91,7 @@ def define_contextless_solids():
 
 def define_contextful_solids():
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_def=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_a(info):
@@ -99,7 +99,7 @@ def define_contextful_solids():
         return info.config
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_def=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_b(info):
@@ -203,7 +203,7 @@ def define_part_nine_final_pipeline():
                 context_fn=lambda info: ExecutionContext.console_logging(
                     resources=PartNineResources(PublicCloudStore(info.config['credentials']))
                 ),
-                config_def=ConfigDefinition(dagster_type=types.ConfigDictionary(
+                config_def=ConfigField(dagster_type=types.ConfigDictionary(
                     name='CloudConfigDict',
                     fields={
                     'credentials': Field(types.ConfigDictionary(

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
@@ -57,14 +57,14 @@ PartNineResources = namedtuple('PartNineResources', 'store')
 
 def define_contextless_solids():
     @solid(
-        config_def=ConfigField(types.Int),
+        config_field=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_a(info):
         return info.config
 
     @solid(
-        config_def=ConfigField(types.Int),
+        config_field=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_b(info):
@@ -91,7 +91,7 @@ def define_contextless_solids():
 
 def define_contextful_solids():
     @solid(
-        config_def=ConfigField(types.Int),
+        config_field=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_a(info):
@@ -99,7 +99,7 @@ def define_contextful_solids():
         return info.config
 
     @solid(
-        config_def=ConfigField(types.Int),
+        config_field=ConfigField(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def injest_b(info):
@@ -203,7 +203,7 @@ def define_part_nine_final_pipeline():
                 context_fn=lambda info: ExecutionContext.console_logging(
                     resources=PartNineResources(PublicCloudStore(info.config['credentials']))
                 ),
-                config_def=ConfigField(dagster_type=types.ConfigDictionary(
+                config_field=ConfigField(dagster_type=types.ConfigDictionary(
                     name='CloudConfigDict',
                     fields={
                     'credentials': Field(types.ConfigDictionary(

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
@@ -16,7 +16,7 @@ from dagster import (
 
 
 @solid(
-    config_def=ConfigField(types.Any),
+    config_field=ConfigField(types.Any),
 )
 def double_the_word(info):
     return info.config['word'] * 2

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     InputDefinition,
     PipelineDefinition,
@@ -16,7 +16,7 @@ from dagster import (
 
 
 @solid(
-    config_def=ConfigDefinition(types.Any),
+    config_def=ConfigField(types.Any),
 )
 def double_the_word(info):
     return info.config['word'] * 2

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_ten.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_ten.py
@@ -4,7 +4,7 @@ from logging import DEBUG
 import pytest
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DagsterExpectationFailedError,
     DependencyDefinition,
     ExpectationDefinition,
@@ -21,7 +21,7 @@ from dagster import (
 
 
 @solid(
-    config_def=ConfigDefinition(types.Int),
+    config_def=ConfigField(types.Int),
     outputs=[
         OutputDefinition(
             types.Int,
@@ -39,7 +39,7 @@ def injest_a(info):
 
 
 @solid(
-    config_def=ConfigDefinition(types.Int),
+    config_def=ConfigField(types.Int),
     outputs=[OutputDefinition(types.Int)],
 )
 def injest_b(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_ten.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_ten.py
@@ -21,7 +21,7 @@ from dagster import (
 
 
 @solid(
-    config_def=ConfigField(types.Int),
+    config_field=ConfigField(types.Int),
     outputs=[
         OutputDefinition(
             types.Int,
@@ -39,7 +39,7 @@ def injest_a(info):
 
 
 @solid(
-    config_def=ConfigField(types.Int),
+    config_field=ConfigField(types.Int),
     outputs=[OutputDefinition(types.Int)],
 )
 def injest_b(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_thirteen.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_thirteen.py
@@ -13,12 +13,12 @@ from dagster import (
 )
 
 
-@solid(config_def=ConfigField(types.Int), outputs=[OutputDefinition(types.Int)])
+@solid(config_field=ConfigField(types.Int), outputs=[OutputDefinition(types.Int)])
 def load_a(info):
     return info.config
 
 
-@solid(config_def=ConfigField(types.Int), outputs=[OutputDefinition(types.Int)])
+@solid(config_field=ConfigField(types.Int), outputs=[OutputDefinition(types.Int)])
 def load_b(info):
     return info.config
 
@@ -68,7 +68,7 @@ def test_part_thirteen_step_one():
 
 
 @solid(
-    config_def=ConfigField(types.Int),
+    config_field=ConfigField(types.Int),
     outputs=[OutputDefinition(types.Int)],
 )
 def load_number(info):

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_thirteen.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_thirteen.py
@@ -1,5 +1,5 @@
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
@@ -13,12 +13,12 @@ from dagster import (
 )
 
 
-@solid(config_def=ConfigDefinition(types.Int), outputs=[OutputDefinition(types.Int)])
+@solid(config_def=ConfigField(types.Int), outputs=[OutputDefinition(types.Int)])
 def load_a(info):
     return info.config
 
 
-@solid(config_def=ConfigDefinition(types.Int), outputs=[OutputDefinition(types.Int)])
+@solid(config_def=ConfigField(types.Int), outputs=[OutputDefinition(types.Int)])
 def load_b(info):
     return info.config
 
@@ -68,7 +68,7 @@ def test_part_thirteen_step_one():
 
 
 @solid(
-    config_def=ConfigDefinition(types.Int),
+    config_def=ConfigField(types.Int),
     outputs=[OutputDefinition(types.Int)],
 )
 def load_number(info):

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -78,7 +78,7 @@ def load_csv_solid(name):
         inputs=[],
         outputs=[OutputDefinition(DataFrame)],
         transform_fn=_t_fn,
-        config_def=ConfigField(LoadDataFrameConfigDict),
+        config_field=ConfigField(LoadDataFrameConfigDict),
     )
 
 
@@ -90,7 +90,7 @@ def to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def=ConfigField(WriteDataFrameConfigDict),
+        config_field=ConfigField(WriteDataFrameConfigDict),
         transform_fn=_t_fn,
     )
 
@@ -103,6 +103,6 @@ def to_parquet_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def=ConfigField(WriteDataFrameConfigDict),
+        config_field=ConfigField(WriteDataFrameConfigDict),
         transform_fn=_t_fn,
     )

--- a/python_modules/dagster/dagster/pandas/__init__.py
+++ b/python_modules/dagster/dagster/pandas/__init__.py
@@ -6,7 +6,7 @@ import tempfile
 import pandas as pd
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     Field,
     ExecutionContext,
     InputDefinition,
@@ -78,7 +78,7 @@ def load_csv_solid(name):
         inputs=[],
         outputs=[OutputDefinition(DataFrame)],
         transform_fn=_t_fn,
-        config_def=ConfigDefinition(LoadDataFrameConfigDict),
+        config_def=ConfigField(LoadDataFrameConfigDict),
     )
 
 
@@ -90,7 +90,7 @@ def to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def=ConfigDefinition(WriteDataFrameConfigDict),
+        config_def=ConfigField(WriteDataFrameConfigDict),
         transform_fn=_t_fn,
     )
 
@@ -103,6 +103,6 @@ def to_parquet_solid(name):
         name=name,
         inputs=[InputDefinition('df', DataFrame)],
         outputs=[],
-        config_def=ConfigDefinition(WriteDataFrameConfigDict),
+        config_def=ConfigField(WriteDataFrameConfigDict),
         transform_fn=_t_fn,
     )

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     Field,
     InputDefinition,
@@ -27,7 +27,7 @@ def define_read_csv_solid(name):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_def=ConfigDefinition.config_dict('ReadCsvConfigDict', {'path': Field(types.Path)}),
+        config_def=ConfigField.config_dict('ReadCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn
     )
 
@@ -40,7 +40,7 @@ def define_to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df')],
         outputs=[],
-        config_def=ConfigDefinition.config_dict('ToCsvConfigDict', {'path': Field(types.Path)}),
+        config_def=ConfigField.config_dict('ToCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -27,7 +27,9 @@ def define_read_csv_solid(name):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_field=ConfigField.config_dict_field('ReadCsvConfigDict', {'path': Field(types.Path)}),
+        config_field=ConfigField.config_dict_field(
+            'ReadCsvConfigDict', {'path': Field(types.Path)}
+        ),
         transform_fn=_t_fn
     )
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -27,7 +27,7 @@ def define_read_csv_solid(name):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_field=ConfigField.config_dict('ReadCsvConfigDict', {'path': Field(types.Path)}),
+        config_field=ConfigField.config_dict_field('ReadCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn
     )
 
@@ -40,7 +40,7 @@ def define_to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df')],
         outputs=[],
-        config_field=ConfigField.config_dict('ToCsvConfigDict', {'path': Field(types.Path)}),
+        config_field=ConfigField.config_dict_field('ToCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -27,7 +27,7 @@ def define_read_csv_solid(name):
         name=name,
         inputs=[],
         outputs=[OutputDefinition()],
-        config_def=ConfigField.config_dict('ReadCsvConfigDict', {'path': Field(types.Path)}),
+        config_field=ConfigField.config_dict('ReadCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn
     )
 
@@ -40,7 +40,7 @@ def define_to_csv_solid(name):
         name=name,
         inputs=[InputDefinition('df')],
         outputs=[],
-        config_def=ConfigField.config_dict('ToCsvConfigDict', {'path': Field(types.Path)}),
+        config_field=ConfigField.config_dict('ToCsvConfigDict', {'path': Field(types.Path)}),
         transform_fn=_t_fn,
     )
 

--- a/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
@@ -1,7 +1,7 @@
 import os
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     Field,
     InputDefinition,
     OutputDefinition,
@@ -71,7 +71,7 @@ def define_create_table_solid(name):
         inputs=[InputDefinition('expr')],
         outputs=[],
         transform_fn=_materialization_fn,
-        config_def=ConfigDefinition(CreateTableConfigDict),
+        config_def=ConfigField(CreateTableConfigDict),
     )
 
 

--- a/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster/dagster/sqlalchemy/subquery_builder_experimental.py
@@ -71,7 +71,7 @@ def define_create_table_solid(name):
         inputs=[InputDefinition('expr')],
         outputs=[],
         transform_fn=_materialization_fn,
-        config_def=ConfigField(CreateTableConfigDict),
+        config_field=ConfigField(CreateTableConfigDict),
     )
 
 

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -62,7 +62,7 @@ def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_s
     return SolidDefinition(
         name=name,
         inputs=[InputDefinition(solid.name) for solid in dependant_solids],
-        config_field=ConfigField.config_dict('{name}_Type'.format(name=name), field_dict),
+        config_field=ConfigField.config_dict_field('{name}_Type'.format(name=name), field_dict),
         transform_fn=_create_templated_sql_transform_with_output(sql),
         outputs=[
             OutputDefinition(name='result', dagster_type=types.Any),

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -4,7 +4,7 @@ import os
 import jinja2
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     Field,
     InputDefinition,
     OutputDefinition,
@@ -62,7 +62,7 @@ def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_s
     return SolidDefinition(
         name=name,
         inputs=[InputDefinition(solid.name) for solid in dependant_solids],
-        config_def=ConfigDefinition.config_dict('{name}_Type'.format(name=name), field_dict),
+        config_def=ConfigField.config_dict('{name}_Type'.format(name=name), field_dict),
         transform_fn=_create_templated_sql_transform_with_output(sql),
         outputs=[
             OutputDefinition(name='result', dagster_type=types.Any),

--- a/python_modules/dagster/dagster/sqlalchemy/templated.py
+++ b/python_modules/dagster/dagster/sqlalchemy/templated.py
@@ -62,7 +62,7 @@ def create_templated_sql_transform_solid(name, sql, table_arguments, dependant_s
     return SolidDefinition(
         name=name,
         inputs=[InputDefinition(solid.name) for solid in dependant_solids],
-        config_def=ConfigField.config_dict('{name}_Type'.format(name=name), field_dict),
+        config_field=ConfigField.config_dict('{name}_Type'.format(name=name), field_dict),
         transform_fn=_create_templated_sql_transform_with_output(sql),
         outputs=[
             OutputDefinition(name='result', dagster_type=types.Any),

--- a/python_modules/dagster/docs/intro_tutorial/part_eight.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_eight.rst
@@ -25,7 +25,7 @@ documentation.
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(
+        config_field=ConfigDefinition(
             types.ConfigDictionary({'word': Field(types.String)})
         )
     )
@@ -99,7 +99,7 @@ specified, it defaults to the Any type.
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(
+        config_field=ConfigDefinition(
             types.ConfigDictionary({'word': Field(types.String)})
         ),
         outputs=[OutputDefinition(types.String)],
@@ -118,7 +118,7 @@ So imagine we made a coding error (mistyped the output) such as:
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(
+        config_field=ConfigDefinition(
             types.ConfigDictionary({'word': Field(types.String)})
         ),
         outputs=[OutputDefinition(types.Int)],

--- a/python_modules/dagster/docs/intro_tutorial/part_eleven.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_eleven.rst
@@ -138,7 +138,7 @@ and then execute that pipeline.
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.String, description='Should be either out_one or out_two'),
+        config_field=ConfigDefinition(types.String, description='Should be either out_one or out_two'),
         outputs=[
             OutputDefinition(dagster_type=types.Int, name='out_one'),
             OutputDefinition(dagster_type=types.Int, name='out_two'),

--- a/python_modules/dagster/docs/intro_tutorial/part_four.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_four.rst
@@ -26,7 +26,7 @@ minimal API. ``solid`` is more complicated, and has more capabilities:
         types,
     )
 
-    @solid(config_def=ConfigDefinition(types.String))
+    @solid(config_field=ConfigDefinition(types.String))
     def hello_world(info):
         print(info.config)
 

--- a/python_modules/dagster/docs/intro_tutorial/part_fourteen.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_fourteen.rst
@@ -15,7 +15,7 @@ We have the following pipeline:
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def load_number(info):

--- a/python_modules/dagster/docs/intro_tutorial/part_nine.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_nine.rst
@@ -357,7 +357,7 @@ version of that store.
                     )
                 ),
                 config_def=ConfigDefinition(
-                    config_type=types.ConfigDictionary('CloudConfig', {
+                    dagster_type=types.ConfigDictionary('CloudConfig', {
                         'credentials': Field(types.ConfigDictionary('CloudCredentials', {
                             'user' : Field(types.String),
                             'pass' : Field(types.String),

--- a/python_modules/dagster/docs/intro_tutorial/part_nine.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_nine.rst
@@ -27,7 +27,7 @@ and then two downstream solids add and multiple those numbers, respectively.
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_a(info):
@@ -35,7 +35,7 @@ and then two downstream solids add and multiple those numbers, respectively.
 
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_b(info):
@@ -124,7 +124,7 @@ Naively let's add this to one of our transforms:
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_a(info):
@@ -153,7 +153,7 @@ this:
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_a(info):
@@ -239,7 +239,7 @@ which is attached the resources property of the context.
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_a(info):
@@ -247,7 +247,7 @@ which is attached the resources property of the context.
         return conf
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_b(info):
@@ -356,7 +356,7 @@ version of that store.
                         )
                     )
                 ),
-                config_def=ConfigDefinition(
+                config_field=ConfigDefinition(
                     dagster_type=types.ConfigDictionary('CloudConfig', {
                         'credentials': Field(types.ConfigDictionary('CloudCredentials', {
                             'user' : Field(types.String),

--- a/python_modules/dagster/docs/intro_tutorial/part_seven.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_seven.rst
@@ -6,7 +6,7 @@ and a yaml file so that the CLI tool can know about the repository.
 
 .. code-block:: python
 
-    @solid(config_def=ConfigDefinition(types.Any))
+    @solid(config_field=ConfigDefinition(types.Any))
     def double_the_word(info):
         return info.config['word'] * 2
 

--- a/python_modules/dagster/docs/intro_tutorial/part_ten.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_ten.rst
@@ -21,7 +21,7 @@ Let us return to a slightly simplified version of the data pipeline from part ni
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_a(info):
@@ -29,7 +29,7 @@ Let us return to a slightly simplified version of the data pipeline from part ni
 
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def ingest_b(info):
@@ -64,7 +64,7 @@ in clear terms. We'll add an expectation in order to do this.
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[
             OutputDefinition(
                 types.Int,

--- a/python_modules/dagster/docs/intro_tutorial/part_thirteen.rst
+++ b/python_modules/dagster/docs/intro_tutorial/part_thirteen.rst
@@ -9,12 +9,12 @@ Now imagine we a pipeline like the following:
 
 .. code-block:: python
 
-    @solid(config_def=ConfigDefinition(types.Int), outputs=[OutputDefinition(types.Int)])
+    @solid(config_field=ConfigDefinition(types.Int), outputs=[OutputDefinition(types.Int)])
     def load_a(info):
         return info.config
 
 
-    @solid(config_def=ConfigDefinition(types.Int), outputs=[OutputDefinition(types.Int)])
+    @solid(config_field=ConfigDefinition(types.Int), outputs=[OutputDefinition(types.Int)])
     def load_b(info):
         return info.config
 
@@ -72,7 +72,7 @@ graph:
 .. code-block:: python
 
     @solid(
-        config_def=ConfigDefinition(types.Int),
+        config_field=ConfigDefinition(types.Int),
         outputs=[OutputDefinition(types.Int)],
     )
     def load_number(info):

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -167,7 +167,9 @@ class Manager:
             return InMemoryConfig(value)
 
         try:
-            return InMemoryConfig(self.solid_def.config_field.config_type.coerce_runtime_value(value))
+            return InMemoryConfig(
+                self.solid_def.config_field.dagster_type.coerce_runtime_value(value)
+            )
         except DagsterRuntimeCoercionError as de:
             raise_from(
                 DagstermillError(
@@ -298,7 +300,7 @@ def define_dagstermill_solid(
         inputs=inputs,
         transform_fn=_dm_solid_transform(name, notebook_path),
         outputs=outputs,
-        config_field=config_def,
+        config_field=config_field,
         description='This solid is backed by the notebook at {path}'.format(path=notebook_path),
         metadata={
             'notebook_path': notebook_path,

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -167,7 +167,7 @@ class Manager:
             return InMemoryConfig(value)
 
         try:
-            return InMemoryConfig(self.solid_def.config_def.config_type.coerce_runtime_value(value))
+            return InMemoryConfig(self.solid_def.config_field.config_type.coerce_runtime_value(value))
         except DagsterRuntimeCoercionError as de:
             raise_from(
                 DagstermillError(
@@ -286,7 +286,7 @@ def define_dagstermill_solid(
     notebook_path,
     inputs=None,
     outputs=None,
-    config_def=None,
+    config_field=None,
 ):
     check.str_param(name, 'name')
     check.str_param(notebook_path, 'notebook_path')
@@ -298,7 +298,7 @@ def define_dagstermill_solid(
         inputs=inputs,
         transform_fn=_dm_solid_transform(name, notebook_path),
         outputs=outputs,
-        config_def=config_def,
+        config_field=config_def,
         description='This solid is backed by the notebook at {path}'.format(path=notebook_path),
         metadata={
             'notebook_path': notebook_path,

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -127,7 +127,7 @@ def define_hello_world_config_pipeline():
         nb_test_path('hello_world_with_config'),
         [],
         [OutputDefinition()],
-        config_def=ConfigField(types.String),
+        config_field=ConfigField(types.String),
     )
     return PipelineDefinition(name='test_config_dag', solids=[with_config_solid])
 
@@ -146,7 +146,7 @@ def test_hello_world_config():
 
 @solid(
     inputs=[],
-    config_def=ConfigField(types.Int),
+    config_field=ConfigField(types.Int),
 )
 def load_constant(info):
     return info.config

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -5,7 +5,7 @@ import pytest
 import dagstermill as dm
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
@@ -127,7 +127,7 @@ def define_hello_world_config_pipeline():
         nb_test_path('hello_world_with_config'),
         [],
         [OutputDefinition()],
-        config_def=ConfigDefinition(types.String),
+        config_def=ConfigField(types.String),
     )
     return PipelineDefinition(name='test_config_dag', solids=[with_config_solid])
 
@@ -146,7 +146,7 @@ def test_hello_world_config():
 
 @solid(
     inputs=[],
-    config_def=ConfigDefinition(types.Int),
+    config_def=ConfigField(types.Int),
 )
 def load_constant(info):
     return info.config

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -8,7 +8,7 @@ from dagster import (
     SolidDefinition,
     InputDefinition,
     OutputDefinition,
-    ConfigDefinition,
+    ConfigField,
     check,
     types,
 )
@@ -69,7 +69,7 @@ def define_solid_with_stuff():
         name='stuff',
         inputs=[InputDefinition('foo', types.Int)],
         outputs=[OutputDefinition(name='bar', dagster_type=types.Int)],
-        config_def=ConfigDefinition(types.Int),
+        config_def=ConfigField(types.Int),
         transform_fn=lambda *args, **kwargs: check.failed('do not execute'),
         metadata={
             'notebook_path': 'unused.ipynb',

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_manager.py
@@ -69,7 +69,7 @@ def define_solid_with_stuff():
         name='stuff',
         inputs=[InputDefinition('foo', types.Int)],
         outputs=[OutputDefinition(name='bar', dagster_type=types.Int)],
-        config_def=ConfigField(types.Int),
+        config_field=ConfigField(types.Int),
         transform_fn=lambda *args, **kwargs: check.failed('do not execute'),
         metadata={
             'notebook_path': 'unused.ipynb',

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
@@ -6,7 +6,7 @@ import pytest
 import dagstermill as dm
 
 from dagster import (
-    ConfigDefinition,
+    ConfigField,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
@@ -57,7 +57,7 @@ def define_pandas_source_test_solid():
         notebook_path=nb_test_path('pandas_source_test'),
         inputs=[],
         outputs=[OutputDefinition(DataFrame)],
-        config_def=ConfigDefinition(types.String),
+        config_def=ConfigField(types.String),
     )
 
 

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
@@ -57,7 +57,7 @@ def define_pandas_source_test_solid():
         notebook_path=nb_test_path('pandas_source_test'),
         inputs=[],
         outputs=[OutputDefinition(DataFrame)],
-        config_def=ConfigField(types.String),
+        config_field=ConfigField(types.String),
     )
 
 


### PR DESCRIPTION
After discussion with @Aylr, we decided that the top-level ConfigDefinition should have the features of fields. E.g. you should be able to declare it optional, with a default value, etc.

So this PR does that. ConfigDefinition is renamed to ConfigField and becomes a field, for all intents and purposes.