### PR TITLE
Move execution plan to top level query (stacked on #288)

### DIFF
--- a/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
+++ b/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
@@ -8,83 +8,81 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots['test_query_execution_plan_snapshot 1'] = {
-    'pipeline': {
-        'executionPlan': {
-            'pipeline': {
-                'name': 'pandas_hello_world'
-            },
-            'steps': [
-                {
-                    'inputs': [
-                    ],
-                    'name': 'load_num_csv.transform',
-                    'outputs': [
-                        {
-                            'name': 'result',
-                            'type': {
-                                'name': 'PandasDataFrame'
-                            }
-                        }
-                    ],
-                    'solid': {
-                        'name': 'load_num_csv'
-                    },
-                    'tag': 'TRANSFORM'
-                },
-                {
-                    'inputs': [
-                        {
-                            'dependsOn': {
-                                'name': 'load_num_csv.transform'
-                            },
-                            'name': 'num',
-                            'type': {
-                                'name': 'PandasDataFrame'
-                            }
-                        }
-                    ],
-                    'name': 'sum_solid.transform',
-                    'outputs': [
-                        {
-                            'name': 'result',
-                            'type': {
-                                'name': 'PandasDataFrame'
-                            }
-                        }
-                    ],
-                    'solid': {
-                        'name': 'sum_solid'
-                    },
-                    'tag': 'TRANSFORM'
-                },
-                {
-                    'inputs': [
-                        {
-                            'dependsOn': {
-                                'name': 'sum_solid.transform'
-                            },
-                            'name': 'sum_df',
-                            'type': {
-                                'name': 'PandasDataFrame'
-                            }
-                        }
-                    ],
-                    'name': 'sum_sq_solid.transform',
-                    'outputs': [
-                        {
-                            'name': 'result',
-                            'type': {
-                                'name': 'PandasDataFrame'
-                            }
-                        }
-                    ],
-                    'solid': {
-                        'name': 'sum_sq_solid'
-                    },
-                    'tag': 'TRANSFORM'
-                }
-            ]
+    'executionPlan': {
+        '__typename': 'ExecutionPlan',
+        'pipeline': {
+            'name': 'pandas_hello_world'
         },
-        'name': 'pandas_hello_world'
+        'steps': [
+            {
+                'inputs': [
+                ],
+                'name': 'load_num_csv.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'load_num_csv'
+                },
+                'tag': 'TRANSFORM'
+            },
+            {
+                'inputs': [
+                    {
+                        'dependsOn': {
+                            'name': 'load_num_csv.transform'
+                        },
+                        'name': 'num',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'name': 'sum_solid.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_solid'
+                },
+                'tag': 'TRANSFORM'
+            },
+            {
+                'inputs': [
+                    {
+                        'dependsOn': {
+                            'name': 'sum_solid.transform'
+                        },
+                        'name': 'sum_df',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'name': 'sum_sq_solid.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_sq_solid'
+                },
+                'tag': 'TRANSFORM'
+            }
+        ]
     }
 }

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -144,6 +144,9 @@ query PipelineQuery($executionParams: PipelineExecutionParams!)
                 }
             }
         }
+        ... on PipelineNotFoundError {
+            pipelineName
+        }
     }
 }
 '''
@@ -159,6 +162,18 @@ def execute_config_graphql(pipeline_name, config):
             },
         },
     )
+
+def test_pipeline_not_found():
+    result = execute_config_graphql(
+        pipeline_name='nope',
+        config={},
+    )
+
+    assert not result.errors
+    assert result.data
+    assert result.data['isPipelineConfigValid']['__typename'] == 'PipelineNotFoundError'
+    assert result.data['isPipelineConfigValid']['pipelineName'] == 'nope'
+
 
 def test_basic_valid_config():
     result = execute_config_graphql(
@@ -577,58 +592,91 @@ def test_pipeline_by_name():
     assert not result.errors
     assert result.data['pipeline']['name'] == 'pandas_hello_world_two'
 
-
-COMPUTE_NODE_QUERY = '''
-query PipelineQuery($config: GenericScalar)
-{
-  pipeline(name:"pandas_hello_world") {
-    name
-    executionPlan(config:$config) {
-      pipeline {
-        name
-      }
+EXECUTION_PLAN_QUERY = '''
+query PipelineQuery($executionParams: PipelineExecutionParams!) {
+  executionPlan(executionParams: $executionParams) {
+    __typename
+    ... on ExecutionPlan {
+      pipeline { name }
       steps {
         name
         solid {
-            name
+          name
         }
         tag
         inputs {
-           name
-           type {
-               name
-           }
-           dependsOn {
-               name
-           }
+          name
+          type {
+            name
+          }
+          dependsOn {
+            name
+          }
         }
         outputs {
+          name
+          type {
             name
-            type {
-                name
-            }
+          }
         }
       }
+    }
+    ... on PipelineNotFoundError {
+        pipelineName
     }
   }
 }
 '''
 
+def test_query_execution_plan_errors():
+    result = execute_dagster_graphql(
+        define_repo(),
+        EXECUTION_PLAN_QUERY,
+        {
+            'executionParams' : {
+                'pipelineName' : 'pandas_hello_world',
+                'config' : 2334893,
+            }
+        }
+    )
+
+    assert result.data
+    assert not result.errors
+    assert result.data['executionPlan']['__typename'] == 'PipelineConfigValidationInvalid'
+
+    result = execute_dagster_graphql(
+        define_repo(),
+        EXECUTION_PLAN_QUERY,
+        {
+            'executionParams' : {
+                'pipelineName' : 'nope',
+                'config' : 2334893,
+            }
+        }
+    )
+
+    assert result.data
+    assert not result.errors
+    assert result.data['executionPlan']['__typename'] == 'PipelineNotFoundError'
+    assert result.data['executionPlan']['pipelineName'] == 'nope'
 
 def test_query_execution_plan_snapshot(snapshot):
     result = execute_dagster_graphql(
         define_repo(),
-        COMPUTE_NODE_QUERY,
+        EXECUTION_PLAN_QUERY,
         {
-            'config': {
-                'solids': {
-                    'load_num_csv': {
-                        'config': {
-                            'path': 'pandas_hello_world/num.csv',
+            'executionParams' : {
+                'pipelineName' : 'pandas_hello_world',
+                'config': {
+                    'solids': {
+                        'load_num_csv': {
+                            'config': {
+                                'path': 'pandas_hello_world/num.csv',
+                            },
                         },
                     },
                 },
-            },
+            }
         },
     )
 
@@ -641,17 +689,20 @@ def test_query_execution_plan_snapshot(snapshot):
 def test_query_execution_plan():
     result = execute_dagster_graphql(
         define_repo(),
-        COMPUTE_NODE_QUERY,
+        EXECUTION_PLAN_QUERY,
         {
-            'config': {
-                'solids': {
-                    'load_num_csv': {
-                        'config': {
-                            'path': 'pandas_hello_world/num.csv',
+            'executionParams' : {
+                'pipelineName' : 'pandas_hello_world',
+                'config': {
+                    'solids': {
+                        'load_num_csv': {
+                            'config': {
+                                'path': 'pandas_hello_world/num.csv',
+                            },
                         },
                     },
                 },
-            },
+            }
         },
     )
 
@@ -661,14 +712,14 @@ def test_query_execution_plan():
     assert result.data
     assert not result.errors
 
-    plan_data = result.data['pipeline']['executionPlan']
+    plan_data = result.data['executionPlan']
 
     names = get_nameset(plan_data['steps'])
     assert len(names) == 3
 
     assert names == set(['load_num_csv.transform', 'sum_solid.transform', 'sum_sq_solid.transform'])
 
-    assert result.data['pipeline']['executionPlan']['pipeline']['name'] == 'pandas_hello_world'
+    assert result.data['executionPlan']['pipeline']['name'] == 'pandas_hello_world'
 
     cn = get_named_thing(plan_data['steps'], 'sum_solid.transform')
 

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1603,6 +1603,10 @@ class RepositoryDefinition(object):
 
         self._pipeline_cache = {}
 
+    def has_pipeline(self, name):
+        check.str_param(name, 'name')
+        return name in self.pipeline_dict
+
     def get_pipeline(self, name):
         '''Get a pipeline by name. Only constructs that pipeline and caches it.
 
@@ -1612,6 +1616,8 @@ class RepositoryDefinition(object):
         Returns:
             PipelineDefinition: Instance of PipelineDefinition with that name.
 '''
+        check.str_param(name, 'name')
+
         if name in self._pipeline_cache:
             return self._pipeline_cache[name]
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -45,8 +45,9 @@ from .errors import (
 )
 
 from .evaluator import (
-    throwing_evaluate_config_value,
     DagsterEvaluateConfigValueError,
+    evaluate_config_value,
+    throwing_evaluate_config_value,
 )
 
 from .execution_plan import (
@@ -266,13 +267,14 @@ def _validate_environment(environment, pipeline):
             )
 
 
-def create_execution_plan(pipeline, config_dict=None):
+def create_execution_plan(pipeline, environment=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
-    config_dict = check.opt_dict_param(config_dict, 'config_dict')
+    check.opt_inst_param(environment, 'environment', config.Environment)
 
-    pipeline_env_type = EnvironmentConfigType(pipeline)
+    pipeline_env_type = pipeline.environment_type
 
-    environment = create_config_value(pipeline_env_type, config_dict)
+    if environment is None:
+        environment = evaluate_config_value(pipeline_env_type, None).value
 
     check.inst(environment, config.Environment)
 


### PR DESCRIPTION
This also improves the error handling story. One thing to note is that we added a PipelineNotFoundError to these top level fields. There's an argument to say that both the config checking and the execution plan generation should be embedded within the pipeline type so that we can do erroring at that level. 