### PR TITLE
List Error Reporting

### DIFF
--- a/python_modules/airline-demo/airline_demo/solids.py
+++ b/python_modules/airline-demo/airline_demo/solids.py
@@ -35,8 +35,8 @@ def mkdir_p(newdir, mode=0o777):
     try:
         os.makedirs(newdir, mode)
     except OSError as err:
-        # Reraise the error unless it's about an already existing directory 
-        if err.errno != errno.EEXIST or not os.path.isdir(newdir): 
+        # Reraise the error unless it's about an already existing directory
+        if err.errno != errno.EEXIST or not os.path.isdir(newdir):
             raise
 
 

--- a/python_modules/airline-demo/setup.py
+++ b/python_modules/airline-demo/setup.py
@@ -8,7 +8,6 @@ if sys.version_info[0] < 3:
 else:
     import builtins
 
-
 version = {}
 with open("airline_demo/version.py") as fp:
     exec(fp.read(), version)  # pylint: disable=W0122
@@ -28,9 +27,7 @@ setup(
         'Operating System :: OS Independent',
     ),
     packages=find_packages(exclude=['test']),
-    install_requires=[
-        'dagster'
-    ],
+    install_requires=['dagster'],
     dependency_links=[
         'git+ssh://git@github.com:dagster-io/dagster.git',
     ]

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -75,6 +75,7 @@ def define_pipeline_two():
         },
     )
 
+
 def define_pipeline_with_list():
     return PipelineDefinition(
         name='pipeline_with_list',
@@ -88,6 +89,7 @@ def define_pipeline_with_list():
             ),
         ],
     )
+
 
 def define_more_complicated_config():
     return PipelineDefinition(
@@ -201,6 +203,7 @@ def test_basic_valid_config():
     assert result.data['isPipelineConfigValid']['__typename'] == 'PipelineConfigValidationValid'
     assert result.data['isPipelineConfigValid']['pipeline']['name'] == 'pandas_hello_world'
 
+
 def test_root_field_not_defined():
     result = execute_config_graphql(
         pipeline_name='pandas_hello_world',
@@ -212,7 +215,7 @@ def test_root_field_not_defined():
                     },
                 },
             },
-            'nope' : {},
+            'nope': {},
         },
     )
 
@@ -226,6 +229,7 @@ def test_root_field_not_defined():
     assert error['__typename'] == 'FieldNotDefinedConfigError'
     assert error['fieldName'] == 'nope'
     assert not error['stack']['entries']
+
 
 def test_root_wrong_type():
     result = execute_config_graphql(
@@ -242,10 +246,10 @@ def test_root_wrong_type():
     assert error['reason'] == 'RUNTIME_TYPE_MISMATCH'
     assert not error['stack']['entries']
 
+
 def field_stack(error_data):
     return [
-        entry['field']['name']
-        for entry in error_data['stack']['entries']
+        entry['field']['name'] for entry in error_data['stack']['entries']
         if entry['__typename'] == 'EvaluationStackPathEntry'
     ]
 
@@ -576,16 +580,15 @@ def test_more_complicated_multiple_errors():
 
     # TODO: two more errors
 
+
 def test_config_list():
     result = execute_config_graphql(
         pipeline_name='pipeline_with_list',
-        config={
-            'solids' : {
-                'solid_with_list' : {
-                    'config' : [1, 2]
-                }
+        config={'solids': {
+            'solid_with_list': {
+                'config': [1, 2]
             }
-        }
+        }}
     )
 
     assert not result.errors
@@ -594,16 +597,15 @@ def test_config_list():
     assert valid_data['__typename'] == 'PipelineConfigValidationValid'
     assert valid_data['pipeline']['name'] == 'pipeline_with_list'
 
+
 def test_config_list_invalid():
     result = execute_config_graphql(
         pipeline_name='pipeline_with_list',
-        config={
-            'solids' : {
-                'solid_with_list' : {
-                    'config' : 'foo'
-                }
+        config={'solids': {
+            'solid_with_list': {
+                'config': 'foo'
             }
-        }
+        }}
     )
 
     assert not result.errors
@@ -614,16 +616,15 @@ def test_config_list_invalid():
     assert len(valid_data['errors']) == 1
     assert ['solids', 'solid_with_list', 'config'] == field_stack(valid_data['errors'][0])
 
+
 def test_config_list_item_invalid():
     result = execute_config_graphql(
         pipeline_name='pipeline_with_list',
-        config={
-            'solids' : {
-                'solid_with_list' : {
-                    'config' : [1, 'foo'],
-                }
+        config={'solids': {
+            'solid_with_list': {
+                'config': [1, 'foo'],
             }
-        }
+        }}
     )
 
     assert not result.errors

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -584,11 +584,13 @@ def test_more_complicated_multiple_errors():
 def test_config_list():
     result = execute_config_graphql(
         pipeline_name='pipeline_with_list',
-        config={'solids': {
-            'solid_with_list': {
-                'config': [1, 2]
-            }
-        }}
+        config={
+            'solids': {
+                'solid_with_list': {
+                    'config': [1, 2],
+                },
+            },
+        },
     )
 
     assert not result.errors
@@ -601,11 +603,13 @@ def test_config_list():
 def test_config_list_invalid():
     result = execute_config_graphql(
         pipeline_name='pipeline_with_list',
-        config={'solids': {
-            'solid_with_list': {
-                'config': 'foo'
-            }
-        }}
+        config={
+            'solids': {
+                'solid_with_list': {
+                    'config': 'foo',
+                },
+            },
+        },
     )
 
     assert not result.errors
@@ -620,11 +624,13 @@ def test_config_list_invalid():
 def test_config_list_item_invalid():
     result = execute_config_graphql(
         pipeline_name='pipeline_with_list',
-        config={'solids': {
-            'solid_with_list': {
-                'config': [1, 'foo'],
-            }
-        }}
+        config={
+            'solids': {
+                'solid_with_list': {
+                    'config': [1, 'foo'],
+                },
+            },
+        },
     )
 
     assert not result.errors

--- a/python_modules/dagster/dagster/core/core_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_evaluator.py
@@ -4,6 +4,8 @@ from dagster.core.definitions import build_config_dict_type
 
 from dagster.core.evaluator import (
     DagsterEvaluationErrorReason,
+    EvaluationStackListItemEntry,
+    EvaluationStackPathEntry,
     EvaluateValueResult,
     evaluate_config_value,
 )
@@ -469,11 +471,14 @@ def test_config_list_in_dict_error():
     assert len(result.errors) == 1
     error = result.errors[0]
     assert error.reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
-    assert len(error.stack.entries) == 1
+    assert len(error.stack.entries) == 2
     stack_entry = error.stack.entries[0]
+    assert isinstance(stack_entry, EvaluationStackPathEntry)
     assert stack_entry.field_name == 'nested_list'
     assert stack_entry.field_def.dagster_type.name == 'List.Int'
-
+    list_entry = error.stack.entries[1]
+    assert isinstance(list_entry, EvaluationStackListItemEntry)
+    assert list_entry.list_index == 1
 
 def test_config_double_list():
     nested_lists = types.ConfigDictionary(

--- a/python_modules/dagster/dagster/core/core_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_evaluator.py
@@ -480,6 +480,7 @@ def test_config_list_in_dict_error():
     assert isinstance(list_entry, EvaluationStackListItemEntry)
     assert list_entry.list_index == 1
 
+
 def test_config_double_list():
     nested_lists = types.ConfigDictionary(
         name='NestedLists',

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -77,11 +77,6 @@ class EvaluationStack(namedtuple('_EvaluationStack', 'entries')):
     def levels(self):
         return [entry.field_name for entry in self.entries]
 
-    @property
-    def top(self):
-        check.invariant(self.entries, 'entries must have at least one value')
-        return self.entries[len(self.entries) - 1]
-
 
 class EvaluationStackEntry:  # marker interface
     pass

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -99,8 +99,8 @@ class EvaluationStackListItemEntry(
     EvaluationStackEntry,
 ):
     def __new__(cls, list_index):
-        check.opt_int_param(list_index, 'list_index')
-        check.param_invariant(list_index is None or list_index >= 0, 'list_index')
+        check.int_param(list_index, 'list_index')
+        check.param_invariant(list_index >= 0, 'list_index')
         return super(EvaluationStackListItemEntry, cls).__new__(
             cls,
             list_index,
@@ -348,10 +348,6 @@ def evaluate_list_value(dagster_list_type, config_value, collector, stack):
 
     output_list = []
     for index, item in enumerate(config_value):
-        # TODO: how to represent list element in the stack
-        # should be pushing something
-        # Should consult with mikhail/ben to see about what info is best
-        # to expose in dagit. Probably just a list index in the stack
         output_list.append(
             _evaluate_config_value(
                 dagster_list_type.inner_type,


### PR DESCRIPTION
This is a proposal for new error reporting for invalid list items. I'm looking for feedback here. This isn't my favorite, but it is very very explicit. It complicates the query and schema by adding another union type and therefore another layer of fragment spreads. (You can see this in the PR in test_graphql.py)

Other approaches would be to keep a single "StackEntry" type but to add a nullable list index field. The field definition would *also* have to become nullable to handle the case where the root element is a list (e.g. there is no field) and an error occurs in the list item.