### PR TITLE
Initial stab at structured logging

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -7,7 +7,7 @@ from dagster.core.execution_context import DAGSTER_META_KEY
 from dagster.utils.logging import (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
 
-class LogMessage(namedtuple('LogMessage', 'msg extra level')):
+class LogMessageForTest(namedtuple('LogMessageForTest', 'msg extra level')):
     @property
     def dagster_meta(self):
         return self.extra[DAGSTER_META_KEY]
@@ -25,30 +25,30 @@ class LoggerForTest(logging.Logger):
 
     def debug(self, msg, *args, **kwargs):
         extra = kwargs.pop('extra', None)
-        self.messages.append(LogMessage(msg=msg, level=DEBUG, extra=extra))
+        self.messages.append(LogMessageForTest(msg=msg, level=DEBUG, extra=extra))
 
     def info(self, msg, *args, **kwargs):
         extra = kwargs.pop('extra', None)
-        self.messages.append(LogMessage(msg=msg, level=INFO, extra=extra))
+        self.messages.append(LogMessageForTest(msg=msg, level=INFO, extra=extra))
 
     def warning(self, msg, *args, **kwargs):
         extra = kwargs.pop('extra', None)
-        self.messages.append(LogMessage(msg=msg, level=WARNING, extra=extra))
+        self.messages.append(LogMessageForTest(msg=msg, level=WARNING, extra=extra))
 
     def error(self, msg, *args, **kwargs):
         extra = kwargs.pop('extra', None)
-        self.messages.append(LogMessage(msg=msg, level=ERROR, extra=extra))
+        self.messages.append(LogMessageForTest(msg=msg, level=ERROR, extra=extra))
 
     def critical(self, msg, *args, **kwargs):
         extra = kwargs.pop('extra', None)
-        self.messages.append(LogMessage(msg=msg, level=CRITICAL, extra=extra))
+        self.messages.append(LogMessageForTest(msg=msg, level=CRITICAL, extra=extra))
 
 
 def test_test_logger():
     logger = LoggerForTest()
     logger.debug('fog')
     assert len(logger.messages) == 1
-    assert logger.messages[0] == LogMessage(msg='fog', level=DEBUG, extra=None)
+    assert logger.messages[0] == LogMessageForTest(msg='fog', level=DEBUG, extra=None)
 
 
 def orig_message(message):

--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -46,7 +46,7 @@ def test_test_logger():
 
 
 def orig_message(message):
-    return message.extra['orig_message']
+    return message.extra['dagster_meta']['orig_message']
 
 
 def test_context_logging():
@@ -79,7 +79,7 @@ def test_context_value():
     with context.value('some_key', 'some_value'):
         context.info('some message')
 
-    assert logger.messages[0].extra['some_key'] == 'some_value'
+    assert logger.messages[0].extra['dagster_meta']['some_key'] == 'some_value'
     assert 'some_key="some_value"' in logger.messages[0].msg
     assert 'message="some message"' in logger.messages[0].msg
 
@@ -96,7 +96,9 @@ def test_log_message_id():
     context = ExecutionContext(loggers=[logger])
     context.info('something')
 
-    assert isinstance(uuid.UUID(logger.messages[0].extra['log_message_id']), uuid.UUID)
+    assert isinstance(
+        uuid.UUID(logger.messages[0].extra['dagster_meta']['log_message_id']), uuid.UUID
+    )
 
 
 def test_interleaved_context_value():
@@ -109,14 +111,14 @@ def test_interleaved_context_value():
             context.info('message two')
 
     message_one = logger.messages[0]
-    assert message_one.extra['key_one'] == 'value_one'
+    assert message_one.extra['dagster_meta']['key_one'] == 'value_one'
     assert 'key_two' not in message_one.extra
     assert 'key_one="value_one"' in message_one.msg
     assert 'key_two' not in message_one.msg
 
     message_two = logger.messages[1]
-    assert message_two.extra['key_one'] == 'value_one'
-    assert message_two.extra['key_two'] == 'value_two'
+    assert message_two.extra['dagster_meta']['key_one'] == 'value_one'
+    assert message_two.extra['dagster_meta']['key_two'] == 'value_two'
     assert 'key_one="value_one"' in message_two.msg
     assert 'key_two="value_two"' in message_two.msg
 
@@ -128,10 +130,10 @@ def test_message_specific_logging():
         context.info('message one', key_two='value_two')
 
     message_one = logger.messages[0]
-    assert message_one.extra['key_one'] == 'value_one'
-    assert message_one.extra['key_two'] == 'value_two'
+    assert message_one.extra['dagster_meta']['key_one'] == 'value_one'
+    assert message_one.extra['dagster_meta']['key_two'] == 'value_two'
 
-    assert set(message_one.extra.keys()) == set(
+    assert set(message_one.extra['dagster_meta'].keys()) == set(
         ['key_one', 'key_two', 'log_message_id', 'orig_message']
     )
 
@@ -146,7 +148,7 @@ def test_multicontext_value():
         context.info('message one')
 
     message_two = logger.messages[0]
-    assert message_two.extra['key_one'] == 'value_one'
-    assert message_two.extra['key_two'] == 'value_two'
+    assert message_two.extra['dagster_meta']['key_one'] == 'value_one'
+    assert message_two.extra['dagster_meta']['key_two'] == 'value_two'
     assert 'key_one="value_one"' in message_two.msg
     assert 'key_two="value_two"' in message_two.msg

--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -3,9 +3,15 @@ import logging
 import uuid
 
 from dagster.core.execution import ExecutionContext
+from dagster.core.execution_context import DAGSTER_META_KEY
 from dagster.utils.logging import (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
-LogMessage = namedtuple('LogMessage', 'msg extra level')
+
+class LogMessage(namedtuple('LogMessage', 'msg extra level')):
+    @property
+    def dagster_meta(self):
+        return self.extra[DAGSTER_META_KEY]
+
 
 # eliminate complaint about overriding methods imprecisely
 # pylint: disable=W0221
@@ -46,7 +52,7 @@ def test_test_logger():
 
 
 def orig_message(message):
-    return message.extra['dagster_meta']['orig_message']
+    return message.dagster_meta['orig_message']
 
 
 def test_context_logging():
@@ -79,7 +85,7 @@ def test_context_value():
     with context.value('some_key', 'some_value'):
         context.info('some message')
 
-    assert logger.messages[0].extra['dagster_meta']['some_key'] == 'some_value'
+    assert logger.messages[0].dagster_meta['some_key'] == 'some_value'
     assert 'some_key="some_value"' in logger.messages[0].msg
     assert 'message="some message"' in logger.messages[0].msg
 
@@ -96,9 +102,7 @@ def test_log_message_id():
     context = ExecutionContext(loggers=[logger])
     context.info('something')
 
-    assert isinstance(
-        uuid.UUID(logger.messages[0].extra['dagster_meta']['log_message_id']), uuid.UUID
-    )
+    assert isinstance(uuid.UUID(logger.messages[0].dagster_meta['log_message_id']), uuid.UUID)
 
 
 def test_interleaved_context_value():
@@ -111,14 +115,14 @@ def test_interleaved_context_value():
             context.info('message two')
 
     message_one = logger.messages[0]
-    assert message_one.extra['dagster_meta']['key_one'] == 'value_one'
+    assert message_one.dagster_meta['key_one'] == 'value_one'
     assert 'key_two' not in message_one.extra
     assert 'key_one="value_one"' in message_one.msg
     assert 'key_two' not in message_one.msg
 
     message_two = logger.messages[1]
-    assert message_two.extra['dagster_meta']['key_one'] == 'value_one'
-    assert message_two.extra['dagster_meta']['key_two'] == 'value_two'
+    assert message_two.dagster_meta['key_one'] == 'value_one'
+    assert message_two.dagster_meta['key_two'] == 'value_two'
     assert 'key_one="value_one"' in message_two.msg
     assert 'key_two="value_two"' in message_two.msg
 
@@ -130,10 +134,10 @@ def test_message_specific_logging():
         context.info('message one', key_two='value_two')
 
     message_one = logger.messages[0]
-    assert message_one.extra['dagster_meta']['key_one'] == 'value_one'
-    assert message_one.extra['dagster_meta']['key_two'] == 'value_two'
+    assert message_one.dagster_meta['key_one'] == 'value_one'
+    assert message_one.dagster_meta['key_two'] == 'value_two'
 
-    assert set(message_one.extra['dagster_meta'].keys()) == set(
+    assert set(message_one.dagster_meta.keys()) == set(
         ['key_one', 'key_two', 'log_message_id', 'orig_message']
     )
 
@@ -148,7 +152,7 @@ def test_multicontext_value():
         context.info('message one')
 
     message_two = logger.messages[0]
-    assert message_two.extra['dagster_meta']['key_one'] == 'value_one'
-    assert message_two.extra['dagster_meta']['key_two'] == 'value_two'
+    assert message_two.dagster_meta['key_one'] == 'value_one'
+    assert message_two.dagster_meta['key_two'] == 'value_two'
     assert 'key_one="value_one"' in message_two.msg
     assert 'key_two="value_two"' in message_two.msg

--- a/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
@@ -1,0 +1,48 @@
+from collections import defaultdict
+
+from dagster import (
+    ExecutionContext,
+    PipelineDefinition,
+    PipelineContextDefinition,
+    execute_pipeline,
+)
+
+from dagster.core.events import (
+    construct_event_logger,
+    EventRecord,
+    EventType,
+)
+
+
+def single_event(events, event_type):
+    assert event_type in events
+    assert len(events[event_type]) == 1
+    return events[event_type][0]
+
+
+def test_empty_pipeline():
+    events = defaultdict(list)
+
+    def _event_callback(record):
+        assert isinstance(record, EventRecord)
+
+        events[record.event_type].append(record)
+
+    pipeline_def = PipelineDefinition(
+        name='empty_pipeline',
+        solids=[],
+        context_definitions={
+            'default':
+            PipelineContextDefinition(
+                context_fn=
+                lambda info: ExecutionContext(loggers=[construct_event_logger(_event_callback)])
+            )
+        }
+    )
+
+    result = execute_pipeline(pipeline_def)
+    assert result.success
+    assert events
+
+    assert single_event(events, EventType.PIPELINE_START).pipeline_name == 'empty_pipeline'
+    assert single_event(events, EventType.PIPELINE_SUCCESS).pipeline_name == 'empty_pipeline'

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -6,7 +6,7 @@ from dagster.utils.logging import (
     DEBUG,
     StructuredLoggerHandler,
     StructuredLoggerMessage,
-    construct_logger,
+    construct_single_handler_logger,
 )
 
 
@@ -122,7 +122,7 @@ def construct_event_logger(event_record_callback):
     '''
     check.callable_param(event_record_callback, 'event_record_callback')
 
-    return construct_logger(
+    return construct_single_handler_logger(
         'event-logger', DEBUG,
         StructuredLoggerHandler(
             lambda logger_message: event_record_callback(construct_event_record(logger_message))

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -1,0 +1,49 @@
+from enum import Enum
+
+from dagster import check
+
+
+class EventType(Enum):
+    PIPELINE_START = 'PIPELINE_START'
+    PIPELINE_SUCCESS = 'PIPELINE_SUCCESS'
+    PIPELINE_FAILURE = 'PIPELINE_FAILURE'
+    UNCATEGORIZED = 'UNCATEGORIZED'
+
+
+class ExecutionEvents:
+    def __init__(self, context):
+        self.context = context
+
+    def pipeline_start(self):
+        self.check_pipeline_in_context()
+        self.context.info(
+            'Beginning execution of pipeline {pipeline}'.format(pipeline=self.pipeline_name()),
+            event_type=EventType.PIPELINE_START.value,
+        )
+
+    def pipeline_success(self):
+        self.check_pipeline_in_context()
+        self.context.info(
+            'Completing successful execution of pipeline {pipeline}'.format(
+                pipeline=self.pipeline_name(),
+            ),
+            event_type=EventType.PIPELINE_SUCCESS.value,
+        )
+
+    def pipeline_failure(self):
+        self.check_pipeline_in_context()
+        self.context.info(
+            'Completing failing execution of pipeline {pipeline}'.format(
+                pipeline=self.pipeline_name()
+            ),
+            event_type=EventType.PIPELINE_FAILURE.value,
+        )
+
+    def pipeline_name(self):
+        return self.context.get_context_value('pipeline')
+
+    def check_pipeline_in_context(self):
+        check.invariant(
+            self.context.has_context_value('pipeline'),
+            'Must have pipeline context value',
+        )

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -505,11 +505,10 @@ def _execute_graph(
     check.inst_param(environment, 'environment', config.Environment)
     check.bool_param(throw_on_error, 'throw_on_error')
 
-    display_name = execution_graph.pipeline.display_name
     results = []
     with yield_context(execution_graph.pipeline, environment) as context:
         with context.value('pipeline', execution_graph.pipeline.display_name):
-            context.info('Beginning execution of pipeline {pipeline}'.format(pipeline=display_name))
+            context.events.pipeline_start()
 
             for result in _execute_graph_iterator(context, execution_graph, environment):
                 if throw_on_error and not result.success:
@@ -519,16 +518,8 @@ def _execute_graph(
 
             pipeline_result = PipelineExecutionResult(execution_graph.pipeline, context, results)
             if pipeline_result.success:
-                context.info(
-                    'Completing successful execution of pipeline {pipeline}'.format(
-                        pipeline=display_name
-                    )
-                )
+                context.events.pipeline_success()
             else:
-                context.info(
-                    'Completing failing execution of pipeline {pipeline}'.format(
-                        pipeline=display_name
-                    )
-                )
+                context.events.pipeline_failure()
 
             return pipeline_result

--- a/python_modules/dagster/dagster/utils/logging.py
+++ b/python_modules/dagster/dagster/utils/logging.py
@@ -75,7 +75,6 @@ class JsonFileHandler(logging.Handler):
 class StructuredLoggerMessage(
     namedtuple('StructuredLoggerMessage', 'name message level meta record')
 ):
-
     def __new__(cls, name, message, level, meta, record):
         return super(StructuredLoggerMessage, cls).__new__(
             cls,
@@ -85,6 +84,7 @@ class StructuredLoggerMessage(
             check.dict_param(meta, 'meta'),
             check.inst_param(record, 'record', logging.LogRecord),
         )
+
 
 class StructuredLoggerHandler(logging.Handler):
     def __init__(self, callback):
@@ -107,6 +107,7 @@ class StructuredLoggerHandler(logging.Handler):
             logging.critical('Error during logging!')
             logging.exception(str(e))
 
+
 def check_valid_level_param(level):
     check.param_invariant(
         level in VALID_LEVELS,
@@ -115,7 +116,8 @@ def check_valid_level_param(level):
     )
     return level
 
-def construct_logger(name, level, handler):
+
+def construct_single_handler_logger(name, level, handler):
     check.str_param(name, 'name')
     check_valid_level_param(level)
     check.inst_param(handler, 'handler', logging.Handler)
@@ -131,8 +133,7 @@ def define_structured_logger(name, callback, level):
     check.callable_param(callback, 'callback')
     check_valid_level_param(level)
 
-    return construct_logger(name, level, StructuredLoggerHandler(callback))
-
+    return construct_single_handler_logger(name, level, StructuredLoggerHandler(callback))
 
 
 def define_json_file_logger(name, json_path, level):
@@ -142,7 +143,7 @@ def define_json_file_logger(name, json_path, level):
 
     stream_handler = JsonFileHandler(json_path)
     stream_handler.setFormatter(define_default_formatter())
-    return construct_logger(name, level, stream_handler)
+    return construct_single_handler_logger(name, level, stream_handler)
 
 
 def define_colored_console_logger(name, level=INFO):

--- a/python_modules/dagster/dagster/utils/logging.py
+++ b/python_modules/dagster/dagster/utils/logging.py
@@ -73,7 +73,7 @@ class JsonFileHandler(logging.Handler):
 
 
 class StructuredLoggerMessage(
-    namedtuple('StructuredLoggerMessage', 'name message level meta record')
+    namedtuple('_StructuredLoggerMessage', 'name message level meta record')
 ):
     def __new__(cls, name, message, level, meta, record):
         return super(StructuredLoggerMessage, cls).__new__(

--- a/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
@@ -1,5 +1,7 @@
 import json
 
+from dagster.core.execution_context import ExecutionContext
+
 from dagster.utils.test import get_temp_file_name
 from dagster.utils.logging import (
     define_json_file_logger,
@@ -59,3 +61,18 @@ def test_no_double_write_same_names():
         assert len(data) == 1
         assert data[0]['name'] == 'foo'
         assert data[0]['msg'] == 'logger one message'
+
+
+# This test ensures the behavior that the clarify project relies upon
+# See extended comment in JsonFileHandler::emit
+def test_write_dagster_meta():
+    with get_temp_file_name() as tf_name:
+        logger = define_json_file_logger('foo', tf_name, DEBUG)
+        execution_context = ExecutionContext(loggers=[logger])
+        execution_context.debug('some_debug_message', context_key='context_value')
+        data = list(parse_json_lines(tf_name))
+        assert len(data) == 1
+        print(data[0])
+        assert data[0]['name'] == 'foo'
+        assert data[0]['orig_message'] == 'some_debug_message'
+        assert data[0]['context_key'] == 'context_value'

--- a/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
@@ -1,7 +1,11 @@
 import json
 
 from dagster.utils.test import get_temp_file_name
-from dagster.utils.logging import (define_json_file_logger, DEBUG, INFO)
+from dagster.utils.logging import (
+    define_json_file_logger,
+    DEBUG,
+    INFO,
+)
 
 
 def test_basic_logging():

--- a/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
@@ -72,7 +72,6 @@ def test_write_dagster_meta():
         execution_context.debug('some_debug_message', context_key='context_value')
         data = list(parse_json_lines(tf_name))
         assert len(data) == 1
-        print(data[0])
         assert data[0]['name'] == 'foo'
         assert data[0]['orig_message'] == 'some_debug_message'
         assert data[0]['context_key'] == 'context_value'

--- a/python_modules/dagster/dagster/utils/utils_tests/test_structured_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_structured_logging.py
@@ -1,0 +1,99 @@
+from dagster.utils.logging import (
+    define_structured_logger,
+    DEBUG,
+)
+
+from dagster import ExecutionContext
+from dagster.core.events import EventType
+
+
+def test_structured_logger_in_context():
+    messages = []
+
+    def _append_message(logger_message):
+        messages.append(logger_message)
+
+    logger = define_structured_logger('some_name', _append_message, level=DEBUG)
+    context = ExecutionContext(loggers=[logger])
+    context.debug('from_context', foo=2)
+    assert len(messages) == 1
+    message = messages[0]
+    assert message.name == 'some_name'
+    assert message.level == 'DEBUG'
+    assert message.meta['foo'] == 2
+    assert message.meta['orig_message'] == 'from_context'
+
+
+from collections import namedtuple
+
+
+class LogRecord:
+    def __init__(self, logger_message):
+        self._logger_message = logger_message
+
+    @property
+    def message(self):
+        return self._logger_message.message
+
+    @property
+    def level(self):
+        return self._logger_message.level
+
+    @property
+    def original_message(self):
+        return self._logger_message.meta['orig_message']
+
+    @property
+    def event_type(self):
+        event_type = self._logger_message.meta.get('event_type')
+        return EventType(event_type) if event_type else EventType.UNCATEGORIZED
+
+
+class PipelineEventRecord(LogRecord):
+    @property
+    def pipeline_name(self):
+        return self._logger_message.meta['pipeline']
+
+
+class UncategorizedLogRecord(LogRecord):
+    pass
+
+
+EVENT_CLS_LOOKUP = {
+    EventType.PIPELINE_START: PipelineEventRecord,
+    EventType.PIPELINE_SUCCESS: PipelineEventRecord,
+    EventType.PIPELINE_FAILURE: PipelineEventRecord,
+}
+
+
+def construct_typed_message(logger_message):
+    event_type = logger_message.meta.get('event_type')
+    if event_type:
+        log_record_cls = EVENT_CLS_LOOKUP.get(EventType(event_type), UncategorizedLogRecord)
+    else:
+        log_record_cls = UncategorizedLogRecord
+
+    return log_record_cls(logger_message)
+
+
+def test_construct_typed_log_messages():
+    messages = []
+
+    def _append_message(logger_message):
+        messages.append(construct_typed_message(logger_message))
+
+    logger = define_structured_logger('some_name', _append_message, level=DEBUG)
+    context = ExecutionContext(loggers=[logger])
+    context.info('random message')
+
+    assert len(messages) == 1
+    message = messages[0]
+    assert isinstance(message, UncategorizedLogRecord)
+
+    with context.value('pipeline', 'some_pipeline'):
+        context.events.pipeline_start()
+
+    assert len(messages) == 2
+    pipeline_start = messages[1]
+    assert isinstance(pipeline_start, PipelineEventRecord)
+    assert pipeline_start.event_type == EventType.PIPELINE_START


### PR DESCRIPTION
I'm not totally happy with this, but it's a start. In particular I think naming could be substantially better.

A few changes here.

1. For all dagster integrations with the python logging framework, we now stash all the dagster-domain metadata (e.g. the context stack) in a special property in the logging.LogRecord object. Previously (I didn't really understand this) all of those properties were unconditionally monkeypatched on the LogRecord object within the python logging module (yeah seriously) so this was risky and confusing. This change also required a horrible hack to be applied to the JsonFileHandler in order to maintain backward compatibility. Superconductive projects currently have a dependency on this.
2. There is a new base level logger handler which just passes through all the logging information we have to a provided callback. This is the StructuredLoggerHandler.
3. The Structured logger handler is used to create a logger that will emit a stream of typed, structured "Event Records" so a callback. This is what the graphql subscriptions would hook into. These would be directly translated to graphql types. It uses the "event_type" property set on the log message to decide what structured event to create. We have no formal schema to manage this process really.
4. There is a new "events" api on the context. This is mostly for organizational purposes.

This structure makes it so that these events appear as normal log messages in, for example, the console logging use case, but if you add a structured event logger you can also hook into the stream of typed log messages.

I've only added the pipeline start, success, and failure events as an example. There will be a lot more once we agree on an API.

