### PR TITLE
Fix broken YAML syntax highlighting of lists

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { injectGlobal } from "styled-components";
-import * as CodeMirror from "codemirror";
+import "codemirror";
 import "codemirror/lib/codemirror.css";
 import "codemirror/theme/material.css";
 import "codemirror/addon/hint/show-hint";

--- a/python_modules/dagit/dagit/webapp/src/configeditor/codemirror-yaml/mode.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/codemirror-yaml/mode.tsx
@@ -80,7 +80,7 @@ CodeMirror.defineMode("yaml", () => {
         state.inDictValue = true;
         return "meta";
       }
-      
+
       // doc start / end
       if (stream.sol()) {
         state.inDict = false;
@@ -182,7 +182,7 @@ CodeMirror.defineMode("yaml", () => {
           stream.match(/^\s*-?[0-9\.\,]+\s?(?=(,|]))/)
         ) {
           result = "number";
-          return result;  // remain inDictValue until we reach `]`
+          return result; // remain inDictValue until we reach `]`
         }
         /* keywords */
         if (stream.match(keywordRegex)) {


### PR DESCRIPTION
This is a small PR that fixes a couple bugs in our custom YAML tokenizer so that it highlights lists better.

Before:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/1037212/49193642-99dc4a00-f334-11e8-9c3a-231ba3bb104a.png">

After:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/1037212/49193628-892bd400-f334-11e8-8512-e8b25e4d43f6.png">

Sidenote: I think this is still a bit broken. @freiksenet  added `inDict` and `inDictValue` state to the tokenizer but I think they need to be counters and not bools, since dict values within inline pairs (the shorthand dict format) should really be tokenized. Will look in to this separately.

Still broken:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/1037212/49193752-2424ae00-f335-11e8-94cb-3ee09e71ddf2.png">
