### PR TITLE
Simplifying ExecutionContext creation API

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
@@ -20,9 +20,7 @@ from dagster.utils.test import create_test_runtime_execution_context
 
 
 def silencing_default_context():
-    return {
-        'default': PipelineContextDefinition(context_fn=lambda *_args: ExecutionContext.create(), )
-    }
+    return {'default': PipelineContextDefinition(context_fn=lambda *_args: ExecutionContext(), )}
 
 
 @lambda_solid

--- a/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
@@ -16,6 +16,8 @@ from dagster.core.definitions import ExecutionGraph
 
 from dagster.core.execution_plan import create_execution_plan_core
 
+from dagster.utils.test import create_test_runtime_execution_context
+
 
 def silencing_default_context():
     return {
@@ -42,7 +44,7 @@ def test_compute_noop_node_core():
     execution_graph = ExecutionGraph.from_pipeline(pipeline)
     plan = create_execution_plan_core(
         ExecutionPlanInfo(
-            ExecutionContext.create_for_test(),
+            create_test_runtime_execution_context(),
             execution_graph,
             environment,
         ),
@@ -50,7 +52,7 @@ def test_compute_noop_node_core():
 
     assert len(plan.steps) == 1
 
-    outputs = list(plan.steps[0].execute(ExecutionContext.create_for_test(), {}))
+    outputs = list(plan.steps[0].execute(create_test_runtime_execution_context(), {}))
 
     assert outputs[0].success_data.value == 'foo'
 
@@ -63,6 +65,6 @@ def test_compute_noop_node():
     plan = create_execution_plan(pipeline)
 
     assert len(plan.steps) == 1
-    outputs = list(plan.steps[0].execute(ExecutionContext.create_for_test(), {}))
+    outputs = list(plan.steps[0].execute(create_test_runtime_execution_context(), {}))
 
     assert outputs[0].success_data.value == 'foo'

--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -4,6 +4,7 @@ import uuid
 
 from dagster.core.execution_context import (ExecutionContext, DAGSTER_META_KEY)
 from dagster.utils.logging import (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+from dagster.utils.test import create_test_runtime_execution_context
 
 
 class LogMessageForTest(namedtuple('LogMessageForTest', 'msg extra level')):
@@ -56,7 +57,7 @@ def orig_message(message):
 
 def test_context_logging():
     logger = LoggerForTest()
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
     context.debug('debug from context')
     context.info('info from context')
     context.warning('warning from context')
@@ -79,7 +80,7 @@ def test_context_logging():
 
 def test_context_value():
     logger = LoggerForTest()
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
 
     with context.value('some_key', 'some_value'):
         context.info('some message')
@@ -90,7 +91,7 @@ def test_context_value():
 
 
 def test_get_context_value():
-    context = ExecutionContext.create_for_test()
+    context = create_test_runtime_execution_context()
 
     with context.value('some_key', 'some_value'):
         assert context.get_context_value('some_key') == 'some_value'
@@ -98,7 +99,7 @@ def test_get_context_value():
 
 def test_log_message_id():
     logger = LoggerForTest()
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
     context.info('something')
 
     assert isinstance(uuid.UUID(logger.messages[0].dagster_meta['log_message_id']), uuid.UUID)
@@ -106,7 +107,7 @@ def test_log_message_id():
 
 def test_interleaved_context_value():
     logger = LoggerForTest()
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
 
     with context.value('key_one', 'value_one'):
         context.info('message one')
@@ -128,7 +129,7 @@ def test_interleaved_context_value():
 
 def test_message_specific_logging():
     logger = LoggerForTest()
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
     with context.value('key_one', 'value_one'):
         context.info('message one', key_two='value_two')
 
@@ -143,7 +144,7 @@ def test_message_specific_logging():
 
 def test_multicontext_value():
     logger = LoggerForTest()
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
     with context.values({
         'key_one': 'value_one',
         'key_two': 'value_two',

--- a/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_context_logging.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import logging
 import uuid
 
-from dagster.core.execution_context import (ExecutionContext, DAGSTER_META_KEY)
+from dagster.core.execution_context import DAGSTER_META_KEY
 from dagster.utils.logging import (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 from dagster.utils.test import create_test_runtime_execution_context
 

--- a/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_custom_context.py
@@ -78,7 +78,7 @@ def test_default_value():
                         ),
                     },
                 ),
-                context_fn=lambda info: ExecutionContext.create(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.config),
             ),
         }
     )
@@ -102,7 +102,7 @@ def test_custom_contexts():
                     'CustomOneDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
-                context_fn=lambda info: ExecutionContext.create(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.config),
             ),
             'custom_two':
             PipelineContextDefinition(
@@ -110,7 +110,7 @@ def test_custom_contexts():
                     'CustomTwoDict',
                     {'field_one': Field(dagster_type=types.String)},
                 ),
-                context_fn=lambda info: ExecutionContext.create(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.config),
             )
         },
     )
@@ -140,7 +140,7 @@ def test_yield_context():
     def _yield_context(info):
         events.append('before')
         context_stack = {'foo': 'bar'}
-        context = ExecutionContext.create(resources=info.config, context_stack=context_stack)
+        context = ExecutionContext(resources=info.config, context_stack=context_stack)
         yield context
         events.append('after')
 

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -27,7 +27,7 @@ from dagster.core.utility_solids import define_stub_solid
 
 
 def create_test_context():
-    return ExecutionContext.create()
+    return ExecutionContext()
 
 
 def create_empty_test_env():

--- a/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
@@ -35,7 +35,7 @@ def test_empty_pipeline():
             'default':
             PipelineContextDefinition(
                 context_fn=
-                lambda info: ExecutionContext.create(loggers=[construct_event_logger(_event_callback)])
+                lambda info: ExecutionContext(loggers=[construct_event_logger(_event_callback)])
             )
         }
     )

--- a/python_modules/dagster/dagster/core/core_tests/test_execution_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_execution_context.py
@@ -1,13 +1,10 @@
-from collections import OrderedDict
 import uuid
 
-from dagster.core.execution_context import (
-    ExecutionContext,
-)
+from dagster.utils.test import create_test_runtime_execution_context
 
 # pylint: disable=W0212
 
 
 def test_noarg_ctor():
-    context = ExecutionContext.create_for_test()
+    context = create_test_runtime_execution_context()
     assert uuid.UUID(context.run_id)

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_errors.py
@@ -23,7 +23,7 @@ from dagster.core.errors import DagsterUserCodeExecutionError
 
 def silencing_default_context():
     return {
-        'default': PipelineContextDefinition(context_fn=lambda *_args: ExecutionContext.create())
+        'default': PipelineContextDefinition(context_fn=lambda *_args: ExecutionContext())
     }
 
 
@@ -123,7 +123,7 @@ def test_do_not_yield_result():
         DagsterInvariantViolationError,
         message='Tranform for solid do_not_yield_result return a Result',
     ):
-        execute_single_solid_in_isolation(ExecutionContext.create(), solid_inst)
+        execute_single_solid_in_isolation(ExecutionContext(), solid_inst)
 
 
 def test_yield_non_result():
@@ -141,7 +141,7 @@ def test_yield_non_result():
         DagsterInvariantViolationError,
         message="Tranform for solid yield_wrong_thing yielded 'foo'",
     ):
-        execute_single_solid_in_isolation(ExecutionContext.create(), solid_inst)
+        execute_single_solid_in_isolation(ExecutionContext(), solid_inst)
 
 
 def test_single_transform_returning_result():
@@ -153,4 +153,4 @@ def test_single_transform_returning_result():
     )
 
     with pytest.raises(DagsterInvariantViolationError):
-        execute_single_solid_in_isolation(ExecutionContext.create(), solid_inst)
+        execute_single_solid_in_isolation(ExecutionContext(), solid_inst)

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -28,6 +28,8 @@ from dagster.core.test_utils import single_output_transform
 
 from dagster.core.utility_solids import define_stub_solid
 
+from dagster.utils.test import (create_test_runtime_execution_context)
+
 # protected members
 # pylint: disable=W0212
 
@@ -304,7 +306,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
     for result in do_execute_pipeline_iter():
         results.append(result)
 
-    result = PipelineExecutionResult(pipeline, ExecutionContext.create_for_test(), results)
+    result = PipelineExecutionResult(pipeline, create_test_runtime_execution_context(), results)
 
     assert result.result_for_solid('A').transformed_value() == [
         input_set('A_input'), transform_called('A')

--- a/python_modules/dagster/dagster/core/core_tests/test_reentrant_context.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_reentrant_context.py
@@ -51,7 +51,7 @@ def test_user_injected_context_stack():
         called['yup'] = True
 
     def _create_context(_info):
-        return ExecutionContext.create(context_stack={'quux': 'baaz'})
+        return ExecutionContext(context_stack={'quux': 'baaz'})
 
     pipeline_def = PipelineDefinition(
         name='injected_run_id',
@@ -78,7 +78,7 @@ def test_user_injected_context_stack_collision():
         called['yup'] = True
 
     def _create_context(_info):
-        return ExecutionContext.create(context_stack={'foo': 'baaz'})
+        return ExecutionContext(context_stack={'foo': 'baaz'})
 
     pipeline_def = PipelineDefinition(
         name='injected_run_id',

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -34,7 +34,7 @@ def test_context_config_any():
         'test':
         PipelineContextDefinition(
             config_field=Field(types.Any),
-            context_fn=lambda *args: ExecutionContext.create(),
+            context_fn=lambda *args: ExecutionContext(),
         )
     }
 
@@ -57,7 +57,7 @@ def test_context_config():
                     'some_str': Field(types.String),
                 })
             ),
-            context_fn=lambda *args: ExecutionContext.create(),
+            context_fn=lambda *args: ExecutionContext(),
         )
     }
 
@@ -195,7 +195,7 @@ def test_errors():
                     },
                 )
             ),
-            context_fn=lambda *args: ExecutionContext.create(),
+            context_fn=lambda *args: ExecutionContext(),
         )
     }
 
@@ -216,12 +216,12 @@ def test_select_context():
         'int_context':
         PipelineContextDefinition(
             config_field=Field(types.Int),
-            context_fn=lambda *args: ExecutionContext.create(),
+            context_fn=lambda *args: ExecutionContext(),
         ),
         'string_context':
         PipelineContextDefinition(
             config_field=Field(types.String),
-            context_fn=lambda *args: ExecutionContext.create(),
+            context_fn=lambda *args: ExecutionContext(),
         ),
     }
 
@@ -406,7 +406,7 @@ def test_whole_environment():
             'test':
             PipelineContextDefinition(
                 config_field=Field(types.Any),
-                context_fn=lambda *args: ExecutionContext.create(),
+                context_fn=lambda *args: ExecutionContext(),
             )
         },
         solids=[

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -23,7 +23,7 @@ from .evaluator import throwing_evaluate_config_value
 from .execution_context import (
     RuntimeExecutionContext,
     ExecutionContext,
-    ExecutionContextUserParams,
+    ExecutionContext,
 )
 
 from .types import (
@@ -106,7 +106,7 @@ context_fn (callable):
             PipelineContextDefinition: The passthrough context definition.
         '''
 
-        check.inst_param(context_params, 'context', ExecutionContextUserParams)
+        check.inst_param(context_params, 'context', ExecutionContext)
         context_definition = PipelineContextDefinition(context_fn=lambda *_args: context_params)
         return {DEFAULT_CONTEXT_NAME: context_definition}
 
@@ -161,7 +161,7 @@ DefaultContextConfigDict = ConfigDictionary(
 def _default_pipeline_context_definitions():
     def _default_context_fn(info):
         log_level = level_from_string(info.config['log_level'])
-        context = ExecutionContext.create(
+        context = ExecutionContext(
             loggers=[define_colored_console_logger('dagster', level=log_level)]
         )
         return context

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -40,7 +40,7 @@ from .definitions import (
 from .config_types import EnvironmentConfigType
 
 from .execution_context import (
-    ExecutionContextUserParams,
+    ExecutionContext,
     RuntimeExecutionContext,
 )
 
@@ -241,11 +241,11 @@ class SolidExecutionResult(object):
 def _wrap_in_yield(context_params_or_gen):
     check.param_invariant(
         inspect.isgenerator(context_params_or_gen)
-        or isinstance(context_params_or_gen, ExecutionContextUserParams),
+        or isinstance(context_params_or_gen, ExecutionContext),
         'context_params_or_gen',
     )
 
-    if isinstance(context_params_or_gen, ExecutionContextUserParams):
+    if isinstance(context_params_or_gen, ExecutionContext):
 
         def _gen_for_context_params():
             yield context_params_or_gen
@@ -331,7 +331,7 @@ def merge_two_dicts(left, right):
 
 
 def get_context_stack(user_context_params, reentrant_info):
-    check.inst(user_context_params, ExecutionContextUserParams)
+    check.inst(user_context_params, ExecutionContext)
     check.opt_inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
 
     if reentrant_info and reentrant_info.context_stack:
@@ -379,7 +379,7 @@ def yield_context(pipeline, environment, reentrant_info=None):
 
     for user_context_params in _wrap_in_yield(context_params_or_gen):
         check.invariant(not called, 'should only yield one thing')
-        check.inst(user_context_params, ExecutionContextUserParams)
+        check.inst(user_context_params, ExecutionContext)
 
         run_id = get_run_id(reentrant_info)
         context_stack = get_context_stack(user_context_params, reentrant_info)

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -44,11 +44,6 @@ class ExecutionContextUserParams(
 
 class ExecutionContext(object):
     @staticmethod
-    def create_for_test(loggers=None, resources=None):
-        run_id = str(uuid.uuid4())
-        return RuntimeExecutionContext(run_id, loggers, resources)
-
-    @staticmethod
     def create(loggers=None, resources=None, context_stack=None):
         return ExecutionContextUserParams(
             loggers=loggers,

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -27,33 +27,18 @@ def _kv_message(all_items):
 DAGSTER_META_KEY = 'dagster_meta'
 
 
-class ExecutionContextUserParams(
-    namedtuple(
-        'ExecutionContextUserParams',
-        'loggers resources context_stack',
-    )
-):
+class ExecutionContext(namedtuple('_ExecutionContext', 'loggers resources context_stack')):
     def __new__(cls, loggers=None, resources=None, context_stack=None):
-        return super(ExecutionContextUserParams, cls).__new__(
+        return super(ExecutionContext, cls).__new__(
             cls,
             loggers=check.opt_list_param(loggers, 'loggers', logging.Logger),
             resources=resources,
             context_stack=check.opt_dict_param(context_stack, 'context_stack'),
         )
 
-
-class ExecutionContext(object):
-    @staticmethod
-    def create(loggers=None, resources=None, context_stack=None):
-        return ExecutionContextUserParams(
-            loggers=loggers,
-            resources=resources,
-            context_stack=context_stack,
-        )
-
     @staticmethod
     def console_logging(log_level=INFO, resources=None):
-        return ExecutionContext.create(
+        return ExecutionContext(
             loggers=[define_colored_console_logger('dagster', log_level)],
             resources=resources,
         )

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -9,7 +9,7 @@ from dagster import (
     execute_pipeline,
 )
 
-from dagster.core.execution_context import ExecutionContextUserParams
+from dagster.core.execution_context import ExecutionContext
 
 
 def execute_single_solid_in_isolation(
@@ -25,7 +25,7 @@ def execute_single_solid_in_isolation(
 
     Prefer execute_solid in dagster.utils.test
     '''
-    check.inst_param(context_params, 'context_params', ExecutionContextUserParams)
+    check.inst_param(context_params, 'context_params', ExecutionContext)
     check.inst_param(solid_def, 'solid_def', SolidDefinition)
     environment = check.opt_inst_param(
         environment,

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_solids.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_solids.py
@@ -65,7 +65,7 @@ def get_num_csv_environment(solids_config):
 
 
 def create_test_context():
-    return ExecutionContext.create()
+    return ExecutionContext()
 
 
 def test_basic_pandas_solid():

--- a/python_modules/dagster/dagster/sqlalchemy/common.py
+++ b/python_modules/dagster/dagster/sqlalchemy/common.py
@@ -6,7 +6,7 @@ from dagster import (
 )
 
 from dagster.core.execution_context import (
-    ExecutionContextUserParams,
+    ExecutionContext,
     RuntimeExecutionContext,
 )
 
@@ -39,7 +39,7 @@ def check_supports_sql_alchemy_resource(context):
 
 def create_sql_alchemy_context_params_from_engine(engine, loggers=None):
     resources = DefaultSqlAlchemyResources(SqlAlchemyResource(engine))
-    return ExecutionContext.create(loggers=loggers, resources=resources)
+    return ExecutionContext(loggers=loggers, resources=resources)
 
 
 def _is_sqlite_context(context):

--- a/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/math_test_db.py
+++ b/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/math_test_db.py
@@ -1,12 +1,13 @@
 import sqlalchemy as sa
-import dagster.sqlalchemy as dagster_sa
-
-from dagster import ExecutionContext
 
 from dagster.sqlalchemy.common import (
-    DefaultSqlAlchemyResources, SqlAlchemyResource, check_supports_sql_alchemy_resource,
-    create_sql_alchemy_context_params_from_engine
+    DefaultSqlAlchemyResources,
+    SqlAlchemyResource,
+    check_supports_sql_alchemy_resource,
+    create_sql_alchemy_context_params_from_engine,
 )
+
+from dagster.utils.test import create_test_runtime_execution_context
 
 
 def create_num_table(engine, num_table_name='num_table'):
@@ -39,7 +40,7 @@ def in_mem_engine(num_table_name='num_table'):
 
 def create_sql_alchemy_context_from_engine(engine, *args, **kwargs):
     resources = DefaultSqlAlchemyResources(SqlAlchemyResource(engine))
-    context = ExecutionContext.create_for_test(resources=resources, *args, **kwargs)
+    context = create_test_runtime_execution_context(resources=resources, *args, **kwargs)
     return check_supports_sql_alchemy_resource(context)
 
 

--- a/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_mocked_context.py
+++ b/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_mocked_context.py
@@ -11,11 +11,13 @@ from dagster.sqlalchemy.common import (
     check_supports_sql_alchemy_resource,
 )
 
+from dagster.utils.test import create_test_runtime_execution_context
+
 
 def create_sql_alchemy_context_from_sa_resource(sa_resource, *args, **kwargs):
     check.inst_param(sa_resource, 'sa_resource', SqlAlchemyResource)
     resources = DefaultSqlAlchemyResources(sa_resource)
-    context = ExecutionContext.create_for_test(resources=resources, *args, **kwargs)
+    context = create_test_runtime_execution_context(resources=resources, *args, **kwargs)
     return check_supports_sql_alchemy_resource(context)
 
 

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import itertools
 import os
 import tempfile
+import uuid
 
 from dagster import (
     check,
@@ -12,6 +13,12 @@ from dagster import (
     execute_pipeline,
 )
 
+from dagster.core.execution_context import RuntimeExecutionContext
+
+
+def create_test_runtime_execution_context(loggers=None, resources=None):
+    run_id = str(uuid.uuid4())
+    return RuntimeExecutionContext(run_id, loggers, resources)
 
 def _unlink_swallow_errors(path):
     check.str_param(path, 'path')

--- a/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_json_logging.py
@@ -2,7 +2,11 @@ import json
 
 from dagster.core.execution_context import ExecutionContext
 
-from dagster.utils.test import get_temp_file_name
+from dagster.utils.test import (
+    create_test_runtime_execution_context,
+    get_temp_file_name,
+)
+
 from dagster.utils.logging import (
     define_json_file_logger,
     DEBUG,
@@ -68,7 +72,7 @@ def test_no_double_write_same_names():
 def test_write_dagster_meta():
     with get_temp_file_name() as tf_name:
         logger = define_json_file_logger('foo', tf_name, DEBUG)
-        execution_context = ExecutionContext.create_for_test(loggers=[logger])
+        execution_context = create_test_runtime_execution_context(loggers=[logger])
         execution_context.debug('some_debug_message', context_key='context_value')
         data = list(parse_json_lines(tf_name))
         assert len(data) == 1

--- a/python_modules/dagster/dagster/utils/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_solid_isolation.py
@@ -123,7 +123,7 @@ def test_single_solid_with_context_config():
             'test_context':
             PipelineContextDefinition(
                 config_field=Field(types.Int, is_optional=True, default_value=2),
-                context_fn=lambda info: ExecutionContext.create(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.config),
             ),
         },
     )

--- a/python_modules/dagster/dagster/utils/utils_tests/test_structured_logging.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_structured_logging.py
@@ -15,6 +15,8 @@ from dagster.core.events import (
     PipelineEventRecord,
 )
 
+from dagster.utils.test import create_test_runtime_execution_context
+
 
 def test_structured_logger_in_context():
     messages = []
@@ -23,7 +25,7 @@ def test_structured_logger_in_context():
         messages.append(logger_message)
 
     logger = define_structured_logger('some_name', _append_message, level=DEBUG)
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
     context.debug('from_context', foo=2)
     assert len(messages) == 1
     message = messages[0]
@@ -40,7 +42,7 @@ def test_construct_event_record():
         messages.append(construct_event_record(logger_message))
 
     logger = define_structured_logger('some_name', _append_message, level=DEBUG)
-    context = ExecutionContext.create_for_test(loggers=[logger])
+    context = create_test_runtime_execution_context(loggers=[logger])
     context.info('random message')
 
     assert len(messages) == 1


### PR DESCRIPTION
This simplifies the ExecutionContext creation API, which eliminates the need for a "UserParams" object which created yet-another-concept.