### PR TITLE
Adding Execution Plan Step Logging

### DIFF
--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -164,6 +164,18 @@ def opt_int_param(obj, param_name):
     return obj
 
 
+def float_param(obj, param_name):
+    if not isinstance(obj, float):
+        raise_with_traceback(_param_type_mismatch_exception(obj, float, param_name))
+    return obj
+
+
+def opt_float_param(obj, param_name):
+    if obj is not None and not isinstance(obj, float):
+        raise_with_traceback(_param_type_mismatch_exception(obj, float, param_name))
+    return obj
+
+
 def _is_str(obj):
     return isinstance(obj, string_types)
 

--- a/python_modules/dagster/dagster/check/check_tests/test_check.py
+++ b/python_modules/dagster/dagster/check/check_tests/test_check.py
@@ -28,6 +28,34 @@ def test_opt_int_param():
         check.opt_int_param('s', 'param_name')
 
 
+def test_float_param():
+    assert check.float_param(-1.0, 'param_name') == -1.0
+    assert check.float_param(0.0, 'param_name') == 0.0
+    assert check.float_param(1.1, 'param_name') == 1.1
+
+    with pytest.raises(ParameterCheckError):
+        check.float_param(None, 'param_name')
+
+    with pytest.raises(ParameterCheckError):
+        check.float_param('s', 'param_name')
+
+    with pytest.raises(ParameterCheckError):
+        check.float_param(1, 'param_name')
+
+    with pytest.raises(ParameterCheckError):
+        check.float_param(0, 'param_name')
+
+
+def test_opt_float_param():
+    assert check.opt_float_param(-1.0, 'param_name') == -1.0
+    assert check.opt_float_param(0.0, 'param_name') == 0.0
+    assert check.opt_float_param(1.1, 'param_name') == 1.1
+    assert check.opt_float_param(None, 'param_name') is None
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_float_param('s', 'param_name')
+
+
 def test_list_param():
     assert check.list_param([], 'list_param') == []
 

--- a/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
@@ -67,7 +67,6 @@ def test_single_solid_pipeline():
         return 1
 
     def _event_callback(record):
-        assert isinstance(record, EventRecord)
         events[record.event_type].append(record)
 
     pipeline_def = define_event_logging_pipeline(
@@ -80,5 +79,14 @@ def test_single_solid_pipeline():
     assert result.success
     assert events
 
-    assert single_event(events, EventType.EXECUTION_PLAN_STEP_START)
-    assert single_event(events, EventType.EXECUTION_PLAN_STEP_SUCCESS)
+    start_event = single_event(events, EventType.EXECUTION_PLAN_STEP_START)
+    assert start_event.pipeline_name == 'single_solid_pipeline'
+    assert start_event.solid_name == 'solid_one'
+    assert start_event.solid_definition_name == 'solid_one'
+    success_event = single_event(events, EventType.EXECUTION_PLAN_STEP_SUCCESS)
+    assert success_event.pipeline_name == 'single_solid_pipeline'
+    assert success_event.solid_name == 'solid_one'
+    assert success_event.solid_definition_name == 'solid_one'
+
+    print('META')
+    print(start_event._logger_message.meta)

--- a/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_event_logging.py
@@ -2,9 +2,12 @@ from collections import defaultdict
 
 from dagster import (
     ExecutionContext,
+    ReentrantInfo,
     PipelineDefinition,
     PipelineContextDefinition,
     execute_pipeline,
+    lambda_solid,
+    solid,
 )
 
 from dagster.core.events import (
@@ -20,24 +23,32 @@ def single_event(events, event_type):
     return events[event_type][0]
 
 
+def define_event_logging_pipeline(name, solids, event_callback, deps=None):
+    return PipelineDefinition(
+        name=name,
+        solids=solids,
+        description=deps,
+        context_definitions={
+            'default':
+            PipelineContextDefinition(
+                context_fn=
+                lambda info: ExecutionContext(loggers=[construct_event_logger(event_callback)])
+            )
+        }
+    )
+
+
 def test_empty_pipeline():
     events = defaultdict(list)
 
     def _event_callback(record):
         assert isinstance(record, EventRecord)
-
         events[record.event_type].append(record)
 
-    pipeline_def = PipelineDefinition(
+    pipeline_def = define_event_logging_pipeline(
         name='empty_pipeline',
         solids=[],
-        context_definitions={
-            'default':
-            PipelineContextDefinition(
-                context_fn=
-                lambda info: ExecutionContext(loggers=[construct_event_logger(_event_callback)])
-            )
-        }
+        event_callback=_event_callback,
     )
 
     result = execute_pipeline(pipeline_def)
@@ -46,3 +57,28 @@ def test_empty_pipeline():
 
     assert single_event(events, EventType.PIPELINE_START).pipeline_name == 'empty_pipeline'
     assert single_event(events, EventType.PIPELINE_SUCCESS).pipeline_name == 'empty_pipeline'
+
+
+def test_single_solid_pipeline():
+    events = defaultdict(list)
+
+    @lambda_solid
+    def solid_one():
+        return 1
+
+    def _event_callback(record):
+        assert isinstance(record, EventRecord)
+        events[record.event_type].append(record)
+
+    pipeline_def = define_event_logging_pipeline(
+        name='single_solid_pipeline',
+        solids=[solid_one],
+        event_callback=_event_callback,
+    )
+
+    result = execute_pipeline(pipeline_def)
+    assert result.success
+    assert events
+
+    assert single_event(events, EventType.EXECUTION_PLAN_STEP_START)
+    assert single_event(events, EventType.EXECUTION_PLAN_STEP_SUCCESS)

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -58,15 +58,25 @@ class ExecutionEvents:
             event_type=EventType.EXECUTION_PLAN_STEP_START.value,
         )
 
-    def execution_plan_step_success(self, friendly_name):
+    def execution_plan_step_success(self, friendly_name, millis):
         check.str_param(friendly_name, 'friendly_name')
+        check.float_param(millis, 'millis')
+
         self.context.info(
-            'Beginning execution of {name}'.format(name=friendly_name),
+            'Execution of {name} succeeded in {millis}'.format(
+                name=friendly_name,
+                millis=millis,
+            ),
             event_type=EventType.EXECUTION_PLAN_STEP_SUCCESS.value,
+            millis=millis,
         )
 
-    def execution_plan_step_failure(self):
-        check.failed('TODO')
+    def execution_plan_step_failure(self, friendly_name):
+        check.str_param(friendly_name, 'friendly_name')
+        self.context.info(
+            'Execution of {name} failed'.format(name=friendly_name),
+            event_type=EventType.EXECUTION_PLAN_STEP_FAILURE.value,
+        )
 
     def pipeline_name(self):
         return self.context.get_context_value('pipeline')
@@ -137,6 +147,12 @@ class ExecutionStepEventRecord(EventRecord):
         return self._logger_message.meta['solid_definition']
 
 
+class ExecutionStepSuccessRecord(ExecutionStepEventRecord):
+    @property
+    def millis(self):
+        return self._logger_message.meta['millis']
+
+
 class LogMessageRecord(EventRecord):
     pass
 
@@ -144,7 +160,7 @@ class LogMessageRecord(EventRecord):
 EVENT_CLS_LOOKUP = {
     EventType.EXECUTION_PLAN_STEP_FAILURE: ExecutionStepEventRecord,
     EventType.EXECUTION_PLAN_STEP_START: ExecutionStepEventRecord,
-    EventType.EXECUTION_PLAN_STEP_SUCCESS: ExecutionStepEventRecord,
+    EventType.EXECUTION_PLAN_STEP_SUCCESS: ExecutionStepSuccessRecord,
     EventType.PIPELINE_FAILURE: PipelineEventRecord,
     EventType.PIPELINE_START: PipelineEventRecord,
     EventType.PIPELINE_SUCCESS: PipelineEventRecord,

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -124,6 +124,18 @@ class ExecutionStepEventRecord(EventRecord):
     def friendly_name(self):
         return self._logger_message.meta['friendly_name']
 
+    @property
+    def pipeline_name(self):
+        return self._logger_message.meta['pipeline']
+
+    @property
+    def solid_name(self):
+        return self._logger_message.meta['solid']
+
+    @property
+    def solid_definition_name(self):
+        return self._logger_message.meta['solid_definition']
+
 
 class LogMessageRecord(EventRecord):
     pass

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -14,6 +14,11 @@ class EventType(Enum):
     PIPELINE_START = 'PIPELINE_START'
     PIPELINE_SUCCESS = 'PIPELINE_SUCCESS'
     PIPELINE_FAILURE = 'PIPELINE_FAILURE'
+
+    EXECUTION_PLAN_STEP_SUCCESS = 'EXECUTION_PLAN_STEP_SUCCESS'
+    EXECUTION_PLAN_STEP_START = 'EXECUTION_PLAN_STEP_START'
+    EXECUTION_PLAN_STEP_FAILURE = 'EXECUTION_PLAN_STEP_FAILURE'
+
     UNCATEGORIZED = 'UNCATEGORIZED'
 
 
@@ -45,6 +50,23 @@ class ExecutionEvents:
             ),
             event_type=EventType.PIPELINE_FAILURE.value,
         )
+
+    def execution_plan_step_start(self, friendly_name):
+        check.str_param(friendly_name, 'friendly_name')
+        self.context.info(
+            'Beginning execution of {name}'.format(name=friendly_name),
+            event_type=EventType.EXECUTION_PLAN_STEP_START.value,
+        )
+
+    def execution_plan_step_success(self, friendly_name):
+        check.str_param(friendly_name, 'friendly_name')
+        self.context.info(
+            'Beginning execution of {name}'.format(name=friendly_name),
+            event_type=EventType.EXECUTION_PLAN_STEP_SUCCESS.value,
+        )
+
+    def execution_plan_step_failure(self):
+        check.failed('TODO')
 
     def pipeline_name(self):
         return self.context.get_context_value('pipeline')
@@ -97,15 +119,24 @@ class PipelineEventRecord(EventRecord):
         return self._logger_message.meta['pipeline']
 
 
+class ExecutionStepEventRecord(EventRecord):
+    @property
+    def friendly_name(self):
+        return self._logger_message.meta['friendly_name']
+
+
 class LogMessageRecord(EventRecord):
     pass
 
 
 EVENT_CLS_LOOKUP = {
+    EventType.EXECUTION_PLAN_STEP_FAILURE: ExecutionStepEventRecord,
+    EventType.EXECUTION_PLAN_STEP_START: ExecutionStepEventRecord,
+    EventType.EXECUTION_PLAN_STEP_SUCCESS: ExecutionStepEventRecord,
+    EventType.PIPELINE_FAILURE: PipelineEventRecord,
     EventType.PIPELINE_START: PipelineEventRecord,
     EventType.PIPELINE_SUCCESS: PipelineEventRecord,
-    EventType.PIPELINE_FAILURE: PipelineEventRecord,
-    EventType.UNCATEGORIZED: LogMessageRecord
+    EventType.UNCATEGORIZED: LogMessageRecord,
 }
 
 

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -247,7 +247,6 @@ def _execute_core_transform(context, step, conf, inputs):
 
     solid = step.solid
 
-    # with context.values({'solid': solid.name, 'solid_definition': solid.definition.name}):
     context.debug('Executing core transform for solid {solid}.'.format(solid=solid.name))
 
     with time_execution_scope() as timer_result, \

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -150,7 +150,7 @@ class StepResult(namedtuple(
 
 
 @contextmanager
-def _user_code_error_boundary(context, msg, **kwargs):
+def _execution_step_error_boundary(context, step, msg, **kwargs):
     '''
     Wraps the execution of user-space code in an error boundary. This places a uniform
     policy around an user code invoked by the framework. This ensures that all user
@@ -162,23 +162,30 @@ def _user_code_error_boundary(context, msg, **kwargs):
     check.inst_param(context, 'context', RuntimeExecutionContext)
     check.str_param(msg, 'msg')
 
+    context.events.execution_plan_step_start(step.friendly_name)
     try:
-        yield
-    except DagsterError as de:
-        stack_trace = get_formatted_stack_trace(de)
-        context.error(str(de), stack_trace=stack_trace)
-        raise de
+        with time_execution_scope() as timer_result:
+            yield
+
+        context.events.execution_plan_step_success(step.friendly_name, timer_result.millis)
     except Exception as e:  # pylint: disable=W0703
+        context.events.execution_plan_step_failure(step.friendly_name)
+
         stack_trace = get_formatted_stack_trace(e)
+
         context.error(str(e), stack_trace=stack_trace)
-        raise_from(
-            DagsterUserCodeExecutionError(
-                msg.format(**kwargs),
-                user_exception=e,
-                original_exc_info=sys.exc_info(),
-            ),
-            e,
-        )
+        if isinstance(e, DagsterError):
+            raise e
+        else:
+            context.error(str(e), stack_trace=stack_trace)
+            raise_from(
+                DagsterUserCodeExecutionError(
+                    msg.format(**kwargs),
+                    user_exception=e,
+                    original_exc_info=sys.exc_info(),
+                ),
+                e,
+            )
 
 
 class StepTag(Enum):
@@ -243,16 +250,11 @@ def _execute_core_transform(context, step, conf, inputs):
     check.inst_param(step, 'step', ExecutionStep)
     check.dict_param(inputs, 'inputs', key_type=str)
 
-    error_str = 'Error occured during core transform'
-
     solid = step.solid
 
     context.debug('Executing core transform for solid {solid}.'.format(solid=solid.name))
 
-    with time_execution_scope() as timer_result, \
-        _user_code_error_boundary(context, error_str):
-
-        all_results = list(_yield_transform_results(context, step, conf, inputs))
+    all_results = list(_yield_transform_results(context, step, conf, inputs))
 
     if len(all_results) != len(solid.definition.output_defs):
         emitted_result_names = set([r.output_name for r in all_results])
@@ -267,16 +269,7 @@ def _execute_core_transform(context, step, conf, inputs):
             )
         )
 
-    context.debug(
-        'Finished executing transform for solid {solid}. Time elapsed: {millis:.3f} ms'.format(
-            solid=step.solid.name,
-            millis=timer_result.millis,
-        ),
-        execution_time_ms=timer_result.millis,
-    )
-
-    for result in all_results:
-        yield result
+    return all_results
 
 
 class StepInput(object):
@@ -375,10 +368,7 @@ class ExecutionStep(object):
         def_name = self.solid.definition.name
 
         with context.values({'solid': self.solid.name, 'solid_definition': def_name}):
-            with _user_code_error_boundary(context, error_str):
-
-                context.events.execution_plan_step_start(self.friendly_name)
-
+            with _execution_step_error_boundary(context, self, error_str):
                 gen = self.compute_fn(context, self, evaluated_inputs)
 
                 if gen is None:
@@ -387,7 +377,6 @@ class ExecutionStep(object):
 
                 results = list(gen)
 
-                context.events.execution_plan_step_success(self.friendly_name)
 
             return results
 

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -374,13 +374,20 @@ class ExecutionStep(object):
         )
 
         with _user_code_error_boundary(context, error_str):
+
+            context.events.execution_plan_step_start(self.friendly_name)
+
             gen = self.compute_fn(context, self, evaluated_inputs)
 
             if gen is None:
                 check.invariant(not self.step_outputs)
                 return
 
-            return list(gen)
+            results = list(gen)
+
+            context.events.execution_plan_step_success(self.friendly_name)
+
+            return results
 
     def _error_check_results(self, results):
         seen_outputs = set()

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -172,12 +172,11 @@ def _execution_step_error_boundary(context, step, msg, **kwargs):
         context.events.execution_plan_step_failure(step.friendly_name)
 
         stack_trace = get_formatted_stack_trace(e)
-
         context.error(str(e), stack_trace=stack_trace)
+
         if isinstance(e, DagsterError):
             raise e
         else:
-            context.error(str(e), stack_trace=stack_trace)
             raise_from(
                 DagsterUserCodeExecutionError(
                     msg.format(**kwargs),


### PR DESCRIPTION
We now emit a well-formed event for every step of the execution plan. This is definitely exposing some warts of this subsystem.

1) It's probably too much work to add a typed event message.
2) The context stack makes thing difficult to reason about and test.
3) We need to add a property unique key to every step in the execution plan that is stable between process invocations.