### PR TITLE
Execution Plan Key

### DIFF
--- a/python_modules/dagit/dagit/schema.py
+++ b/python_modules/dagit/dagit/schema.py
@@ -689,6 +689,7 @@ an intermediate value if the pipeline is configured to do that.'''
 
 
 class ExecutionStep(graphene.ObjectType):
+    # TODO: rename to key post mikhail merge
     name = graphene.NonNull(graphene.String)
     inputs = non_null_list(lambda: ExecutionStepInput)
     outputs = non_null_list(lambda: ExecutionStepOutput)
@@ -710,7 +711,7 @@ class ExecutionStep(graphene.ObjectType):
         return [ExecutionStepOutput(out) for out in self.execution_step.step_outputs]
 
     def resolve_name(self, _info):
-        return self.execution_step.friendly_name
+        return self.execution_step.key
 
     def resolve_solid(self, _info):
         return Solid(self.execution_step.solid)

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -51,30 +51,30 @@ class ExecutionEvents:
             event_type=EventType.PIPELINE_FAILURE.value,
         )
 
-    def execution_plan_step_start(self, friendly_name):
-        check.str_param(friendly_name, 'friendly_name')
+    def execution_plan_step_start(self, key):
+        check.str_param(key, 'key')
         self.context.info(
-            'Beginning execution of {name}'.format(name=friendly_name),
+            'Beginning execution of {key}'.format(key=key),
             event_type=EventType.EXECUTION_PLAN_STEP_START.value,
         )
 
-    def execution_plan_step_success(self, friendly_name, millis):
-        check.str_param(friendly_name, 'friendly_name')
+    def execution_plan_step_success(self, key, millis):
+        check.str_param(key, 'key')
         check.float_param(millis, 'millis')
 
         self.context.info(
-            'Execution of {name} succeeded in {millis}'.format(
-                name=friendly_name,
+            'Execution of {key} succeeded in {millis}'.format(
+                key=key,
                 millis=millis,
             ),
             event_type=EventType.EXECUTION_PLAN_STEP_SUCCESS.value,
             millis=millis,
         )
 
-    def execution_plan_step_failure(self, friendly_name):
-        check.str_param(friendly_name, 'friendly_name')
+    def execution_plan_step_failure(self, key):
+        check.str_param(key, 'key')
         self.context.info(
-            'Execution of {name} failed'.format(name=friendly_name),
+            'Execution of {key} failed'.format(key=key),
             event_type=EventType.EXECUTION_PLAN_STEP_FAILURE.value,
         )
 
@@ -131,8 +131,8 @@ class PipelineEventRecord(EventRecord):
 
 class ExecutionStepEventRecord(EventRecord):
     @property
-    def friendly_name(self):
-        return self._logger_message.meta['friendly_name']
+    def key(self):
+        return self._logger_message.meta['key']
 
     @property
     def pipeline_name(self):

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -446,7 +446,7 @@ def _execute_graph_iterator(context, execution_graph, environment):
 
     context.debug(
         'About to execute the compute node graph in the following order {order}'.format(
-            order=[cn.friendly_name for cn in steps]
+            order=[step.key for step in steps]
         )
     )
 

--- a/python_modules/dagster/dagster/core/execution_plan.py
+++ b/python_modules/dagster/dagster/core/execution_plan.py
@@ -290,7 +290,6 @@ class StepOutput(object):
 
 class ExecutionStep(object):
     def __init__(self, key, step_inputs, step_outputs, compute_fn, tag, solid):
-        # self.guid = str(uuid.uuid4())
         self.key = check.str_param(key, 'key')
 
         self.step_inputs = check.list_param(step_inputs, 'step_inputs', of_type=StepInput)
@@ -736,10 +735,10 @@ def create_execution_plan_core(execution_info):
             output_handle = pipeline_solid.output_handle(output_def.name)
             state.step_output_map[output_handle] = subgraph.terminal_step_output_handle
 
-    return _create_execution_plan(state.steps)
+    return create_execution_plan_from_steps(state.steps)
 
 
-def _create_execution_plan(steps):
+def create_execution_plan_from_steps(steps):
     check.list_param(steps, 'steps', of_type=ExecutionStep)
 
     step_dict = {step.key: step for step in steps}


### PR DESCRIPTION
This eliminates the notion of a guid id for an execution plan step and instead prefers a human-readable key that the system guarantees is unique-per-key and that is stable in between process invocations. 