### PR TITLE
Move database switching logic from solid to context

### DIFF
--- a/python_modules/airline-demo/airline_demo/types.py
+++ b/python_modules/airline-demo/airline_demo/types.py
@@ -11,7 +11,7 @@ from dagster import (
 
 AirlineDemoResources = namedtuple(
     'AirlineDemoResources',
-    ('spark', 's3', 'db_url', 'db_engine', 'db_dialect', 'redshift_s3_temp_dir'),
+    ('spark', 's3', 'db_url', 'db_engine', 'db_dialect', 'redshift_s3_temp_dir', 'db_load'),
 )
 
 SparkDataFrameType = types.PythonObjectType(


### PR DESCRIPTION
This is a rather drastic approach to encapsulating a bunch of nitty logic around loading data to a database from Spark into a resource made available in the context.

This is one example of a general issue pipeline authors are going to face especially when the interfaces to test and production resources (e.g., local Postgres vs. Redshift) differ in ways that aren't already abstracted by the libraries they're using.

Some questions:

- Is it reasonable for resources to have dependencies on each other that aren't made explicit? (https://github.com/dagster-io/dagster/compare/airline-demo...airline-demo-database-loader?expand=1#diff-89b0808a5184d5f708d824a619f62d09R113)
- Should parameters like `db_dialect` (or like `redshift_s3_temp_dir`) be specified at the pipeline (context) level or at the solid (config) level?