### PR TITLE
Example: use list type to config parallel pipeline operations

### DIFF
--- a/python_modules/airline-demo/airline_demo/pipelines.py
+++ b/python_modules/airline-demo/airline_demo/pipelines.py
@@ -25,11 +25,8 @@ from .solids import (
     subsample_spark_dataset,
     thunk,
     union_spark_data_frames,
-<<<<<<< HEAD
     unzip_file,
     upload_to_s3,
-=======
->>>>>>> f1cf34e... Example: use list type to config parallel pipeline operations
 )
 from .types import (
     AirlineDemoResources,

--- a/python_modules/airline-demo/airline_demo/pipelines.py
+++ b/python_modules/airline-demo/airline_demo/pipelines.py
@@ -15,7 +15,7 @@ from dagster import (
 from .solids import (
     average_sfo_outbound_avg_delays_by_destination,
     canonicalize_column_names,
-    download_from_s3,
+    download_and_unzip_files_from_s3,
     ingest_csv_to_spark,
     join_spark_data_frames,
     load_data_to_database_from_spark,
@@ -25,8 +25,11 @@ from .solids import (
     subsample_spark_dataset,
     thunk,
     union_spark_data_frames,
+<<<<<<< HEAD
     unzip_file,
     upload_to_s3,
+=======
+>>>>>>> f1cf34e... Example: use list type to config parallel pipeline operations
 )
 from .types import (
     AirlineDemoResources,
@@ -200,60 +203,12 @@ context_definitions = {
 
 def define_airline_demo_download_pipeline():
     solids = [
-        download_from_s3,
-        thunk,
-        unzip_file,
+        download_and_unzip_files_from_s3,
     ]
-    dependencies = {
-        SolidInstance('thunk', alias='april_on_time_data_filename'): {},
-        SolidInstance('thunk', alias='may_on_time_data_filename'): {},
-        SolidInstance('thunk', alias='june_on_time_data_filename'): {},
-        SolidInstance('thunk', alias='q2_coupon_data_filename'): {},
-        SolidInstance('thunk', alias='q2_market_data_filename'): {},
-        SolidInstance('thunk', alias='q2_ticket_data_filename'): {},
-        SolidInstance('thunk', alias='master_cord_data_filename'): {},
-        SolidInstance('download_from_s3', alias='download_april_on_time_data'): {},
-        SolidInstance('download_from_s3', alias='download_may_on_time_data'): {},
-        SolidInstance('download_from_s3', alias='download_june_on_time_data'): {},
-        SolidInstance('download_from_s3', alias='download_q2_coupon_data'): {},
-        SolidInstance('download_from_s3', alias='download_q2_market_data'): {},
-        SolidInstance('download_from_s3', alias='download_q2_ticket_data'): {},
-        SolidInstance('download_from_s3', alias='download_q2_sfo_weather'): {},
-        SolidInstance('download_from_s3', alias='download_master_cord_data'): {},
-        SolidInstance('unzip_file', alias='unzip_april_on_time_data'): {
-            'archive_path': DependencyDefinition('download_april_on_time_data'),
-            'archive_member': DependencyDefinition('april_on_time_data_filename'),
-        },
-        SolidInstance('unzip_file', alias='unzip_may_on_time_data'): {
-            'archive_path': DependencyDefinition('download_may_on_time_data'),
-            'archive_member': DependencyDefinition('may_on_time_data_filename'),
-        },
-        SolidInstance('unzip_file', alias='unzip_june_on_time_data'): {
-            'archive_path': DependencyDefinition('download_june_on_time_data'),
-            'archive_member': DependencyDefinition('june_on_time_data_filename'),
-        },
-        SolidInstance('unzip_file', alias='unzip_q2_coupon_data'): {
-            'archive_path': DependencyDefinition('download_q2_coupon_data'),
-            'archive_member': DependencyDefinition('q2_coupon_data_filename'),
-        },
-        SolidInstance('unzip_file', alias='unzip_q2_market_data'): {
-            'archive_path': DependencyDefinition('download_q2_market_data'),
-            'archive_member': DependencyDefinition('q2_market_data_filename'),
-        },
-        SolidInstance('unzip_file', alias='unzip_q2_ticket_data'): {
-            'archive_path': DependencyDefinition('download_q2_ticket_data'),
-            'archive_member': DependencyDefinition('q2_ticket_data_filename'),
-        },
-        SolidInstance('unzip_file', alias='unzip_master_cord_data'): {
-            'archive_path': DependencyDefinition('download_master_cord_data'),
-            'archive_member': DependencyDefinition('master_cord_data_filename'),
-        },
-    }
     return PipelineDefinition(
         name='airline_demo_download_pipeline',
         context_definitions=context_definitions,
         solids=solids,
-        dependencies=dependencies,
     )
 
 

--- a/python_modules/airline-demo/airline_demo/test/test_pipelines.py
+++ b/python_modules/airline-demo/airline_demo/test/test_pipelines.py
@@ -28,152 +28,101 @@ def test_pipeline_download():
                 }
             },
             'solids': {
-                'april_on_time_data_filename': {
-                    'config':
-                    'On_Time_Reporting_Carrier_On_Time_Performance_(1987_present)_2018_4.csv'
-                },
-                'may_on_time_data_filename': {
-                    'config':
-                    'On_Time_Reporting_Carrier_On_Time_Performance_(1987_present)_2018_5.csv'
-                },
-                'june_on_time_data_filename': {
-                    'config':
-                    'On_Time_Reporting_Carrier_On_Time_Performance_(1987_present)_2018_6.csv'
-                },
-                'q2_coupon_data_filename': {
-                    'config': 'Origin_and_Destination_Survey_DB1BCoupon_2018_2.csv'
-                },
-                'q2_market_data_filename': {
-                    'config': 'Origin_and_Destination_Survey_DB1BMarket_2018_2.csv'
-                },
-                'q2_ticket_data_filename': {
-                    'config': 'Origin_and_Destination_Survey_DB1BTicket_2018_2.csv'
-                },
-                'master_cord_data_filename': {
-                    'config': '954834304_T_MASTER_CORD.csv'
-                },
-                'download_april_on_time_data': {
-                    'config': {
-                        'bucket':
-                        'dagster-airline-demo-source-data',
-                        'key':
-                        'On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_4.zip',
-                        'skip_if_present':
-                        True,
-                        'target_path':
-                        'source_data/On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_4.zip',
-                    }
-                },
-                'download_may_on_time_data': {
-                    'config': {
-                        'bucket':
-                        'dagster-airline-demo-source-data',
-                        'key':
-                        'On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_5.zip',
-                        'skip_if_present':
-                        True,
-                        'target_path':
-                        'source_data/On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_5.zip',
-                    },
-                },
-                'download_june_on_time_data': {
-                    'config': {
-                        'bucket':
-                        'dagster-airline-demo-source-data',
-                        'key':
-                        'On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_6.zip',
-                        'skip_if_present':
-                        True,
-                        'target_path':
-                        'source_data/On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_6.zip',
-                    }
-                },
-                'download_q2_coupon_data': {
-                    'config': {
-                        'bucket':
-                        'dagster-airline-demo-source-data',
-                        'key':
-                        'Origin_and_Destination_Survey_DB1BCoupon_2018_2.zip',
-                        'skip_if_present':
-                        True,
-                        'target_path':
-                        'source_data/Origin_and_Destination_Survey_DB1BCoupon_2018_2.zip',
-                    }
-                },
-                'download_q2_market_data': {
-                    'config': {
-                        'bucket':
-                        'dagster-airline-demo-source-data',
-                        'key':
-                        'Origin_and_Destination_Survey_DB1BMarket_2018_2.zip',
-                        'skip_if_present':
-                        True,
-                        'target_path':
-                        'source_data/Origin_and_Destination_Survey_DB1BMarket_2018_2.zip',
-                    }
-                },
-                'download_q2_ticket_data': {
-                    'config': {
-                        'bucket':
-                        'dagster-airline-demo-source-data',
-                        'key':
-                        'Origin_and_Destination_Survey_DB1BTicket_2018_2.zip',
-                        'skip_if_present':
-                        True,
-                        'target_path':
-                        'source_data/Origin_and_Destination_Survey_DB1BTicket_2018_2.zip',
-                    }
-                },
-                'download_q2_sfo_weather': {
-                    'config': {
-                        'bucket': 'dagster-airline-demo-source-data',
-                        'key': 'sfo_q2_weather.txt',
-                        'skip_if_present': True,
-                        'target_path': 'source_data/sfo_q2_weather.txt',
-                    }
-                },
-                'download_master_cord_data': {
-                    'config': {
-                        'bucket': 'dagster-airline-demo-source-data',
-                        'key': '954834304_T_MASTER_CORD.zip',
-                        'skip_if_present': True,
-                        'target_path': 'source_data/954834304_T_MASTER_CORD.zip',
-                    }
-                },
-                'unzip_april_on_time_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    },
-                },
-                'unzip_may_on_time_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    },
-                },
-                'unzip_june_on_time_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    },
-                },
-                'unzip_q2_coupon_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    },
-                },
-                'unzip_q2_market_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    },
-                },
-                'unzip_q2_ticket_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    },
-                },
-                'unzip_master_cord_data': {
-                    'config': {
-                        'skip_if_present': True,
-                    }
+                'download_and_unzip_files_from_s3': {
+                    'config': [
+                        {
+                            'bucket':
+                            'dagster-airline-demo-source-data',
+                            'key':
+                            'On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_4.zip',
+                            'skip_if_present':
+                            True,
+                            'target_path':
+                            'source_data/On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_4.zip',
+                            'unarchive':
+                            True,
+                            'archive_member':
+                            'On_Time_Reporting_Carrier_On_Time_Performance_(1987_present)_2018_4.csv',
+                        },
+                        {
+                            'bucket':
+                            'dagster-airline-demo-source-data',
+                            'key':
+                            'On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_5.zip',
+                            'skip_if_present':
+                            True,
+                            'target_path':
+                            'source_data/On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_5.zip',
+                            'unarchive':
+                            True,
+                            'archive_member':
+                            'On_Time_Reporting_Carrier_On_Time_Performance_(1987_present)_2018_5.csv',
+                        },
+                        {
+                            'bucket':
+                            'dagster-airline-demo-source-data',
+                            'key':
+                            'On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_6.zip',
+                            'skip_if_present':
+                            True,
+                            'target_path':
+                            'source_data/On_Time_Reporting_Carrier_On_Time_Performance_1987_present_2018_6.zip',
+                            'unarchive':
+                            True,
+                            'archive_member':
+                            'On_Time_Reporting_Carrier_On_Time_Performance_(1987_present)_2018_6.csv',
+                        },
+                        {
+                            'bucket':
+                            'dagster-airline-demo-source-data',
+                            'key':
+                            'Origin_and_Destination_Survey_DB1BCoupon_2018_2.zip',
+                            'skip_if_present':
+                            True,
+                            'target_path':
+                            'source_data/Origin_and_Destination_Survey_DB1BCoupon_2018_2.zip',
+                            'unarchive':
+                            True,
+                            'archive_member':
+                            'Origin_and_Destination_Survey_DB1BCoupon_2018_2.csv',
+                        },
+                        {
+                            'bucket':
+                            'dagster-airline-demo-source-data',
+                            'key':
+                            'Origin_and_Destination_Survey_DB1BMarket_2018_2.zip',
+                            'skip_if_present':
+                            True,
+                            'target_path':
+                            'source_data/Origin_and_Destination_Survey_DB1BMarket_2018_2.zip',
+                            'unarchive':
+                            True,
+                            'archive_member':
+                            'Origin_and_Destination_Survey_DB1BMarket_2018_2.csv',
+                        },
+                        {
+                            'bucket':
+                            'dagster-airline-demo-source-data',
+                            'key':
+                            'Origin_and_Destination_Survey_DB1BTicket_2018_2.zip',
+                            'skip_if_present':
+                            True,
+                            'target_path':
+                            'source_data/Origin_and_Destination_Survey_DB1BTicket_2018_2.zip',
+                            'unarchive':
+                            True,
+                            'archive_member':
+                            'Origin_and_Destination_Survey_DB1BTicket_2018_2.csv',
+                        },
+                        {
+                            'bucket': 'dagster-airline-demo-source-data',
+                            'key': 'sfo_q2_weather.txt',
+                            'skip_if_present': True,
+                            'target_path': 'source_data/sfo_q2_weather.txt',
+                            'unarchive': False,
+                            'archive_member': '',
+                        },
+                    ]
                 }
             }
         }

--- a/python_modules/airline-demo/airline_demo/test/test_solids.py
+++ b/python_modules/airline-demo/airline_demo/test/test_solids.py
@@ -26,11 +26,11 @@ from dagster import (
 from dagster.utils.test import (define_stub_solid, execute_solid)
 
 from airline_demo.solids import (
-    sql_solid,
-    download_from_s3,
+    # download_from_s3,
     ingest_csv_to_spark,
+    sql_solid,
     thunk,
-    unzip_file,
+    # unzip_file,
 )
 from airline_demo.utils import (
     create_s3_session,
@@ -104,67 +104,66 @@ def test_thunk():
     assert result.transformed_value() == 'foo'
 
 
-@pytest.mark.nettest
-def test_download_from_s3():
-    result = execute_solid(
-        PipelineDefinition([download_from_s3], context_definitions=_s3_context()),
-        'download_from_s3',
-        environment={
-            'context': {
-                'test': {}
-            },
-            'solids': {
-                'download_from_s3': {
-                    'config': {
-                        'bucket': 'dagster-airline-demo-source-data',
-                        'key': 'test/test_file'
-                    }
-                }
-            }
-        }
-    )
-    assert result.success
-    assert result.transformed_value() == 'test/test_file'
-    assert os.path.isfile(result.transformed_value())
-    with open(result.transformed_value(), 'r') as fd:
-        assert fd.read() == 'test\n'
+# @pytest.mark.nettest
+# def test_download_from_s3():
+#     result = execute_solid(
+#         PipelineDefinition([download_from_s3], context_definitions=_s3_context()),
+#         'download_from_s3',
+#         environment={
+#             'context': {
+#                 'test': {}
+#             },
+#             'solids': {
+#                 'download_from_s3': {
+#                     'config': {
+#                         'bucket': 'dagster-airline-demo-source-data',
+#                         'key': 'test/test_file'
+#                     }
+#                 }
+#             }
+#         }
+#     )
+#     assert result.success
+#     assert result.transformed_value() == 'test/test_file'
+#     assert os.path.isfile(result.transformed_value())
+#     with open(result.transformed_value(), 'r') as fd:
+#         assert fd.read() == 'test\n'
 
+# def test_unzip_file():
+#     @lambda_solid
+#     def nonce():
+#         return None
 
-def test_unzip_file():
-    @lambda_solid
-    def nonce():
-        return None
-
-    result = execute_solid(
-        PipelineDefinition(
-            solids=[nonce, unzip_file],
-            dependencies={
-                'unzip_file': {
-                    'archive_path': DependencyDefinition('nonce'),
-                    'archive_member': DependencyDefinition('nonce')
-                }
-            }
-        ),
-        'unzip_file',
-        inputs={
-            'archive_path': os.path.join(os.path.dirname(__file__), 'data/test.zip'),
-            'archive_member': 'test/test_file'
-        },
-        environment={'solids': {
-            'unzip_file': {
-                'config': {
-                    'skip_if_present': False
-                }
-            }
-        }}
-    )
-    assert result.success
-    assert result.transformed_value() == os.path.join(
-        os.path.dirname(__file__), 'data', 'test/test_file'
-    )
-    assert os.path.isfile(result.transformed_value())
-    with open(result.transformed_value(), 'r') as fd:
-        assert fd.read() == 'test\n'
+#     result = execute_solid(
+#         PipelineDefinition(
+#             solids=[nonce, unzip_file],
+#             dependencies={
+#                 'unzip_file': {
+#                     'archive_path': DependencyDefinition('nonce'),
+#                     'archive_member': DependencyDefinition('nonce')
+#                 }
+#             }
+#         ),
+#         'unzip_file',
+#         inputs={
+#             'archive_path': os.path.join(os.path.dirname(__file__), 'data/test.zip'),
+#             'archive_member': 'test/test_file'
+#         },
+#         environment={'solids': {
+#             'unzip_file': {
+#                 'config': {
+#                     'skip_if_present': False
+#                 }
+#             }
+#         }}
+#     )
+#     assert result.success
+#     assert result.transformed_value() == os.path.join(
+#         os.path.dirname(__file__), 'data', 'test/test_file'
+#     )
+#     assert os.path.isfile(result.transformed_value())
+#     with open(result.transformed_value(), 'r') as fd:
+#         assert fd.read() == 'test\n'
 
 
 @pytest.mark.spark

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -417,8 +417,8 @@ class _DagsterListType(DagsterType):
             type_attributes=DagsterTypeAttributes(is_builtin=True),
         )
 
-    def coerce_runtime_value(self, _value):
-        check.failed('not implemented')
+    def coerce_runtime_value(self, value):
+        return value
 
     def iterate_types(self):
         yield self.inner_type


### PR DESCRIPTION
This is one approach to the issue we are starting to see with fan-outs / parallel pipeline fragments. In this case, the naïve approach of writing a separate pipeline fragment for each download-and-maybe-unzip step for a number of source files results in an ungainly and duplicative DAG:
<img width="867" alt="screen shot 2018-12-03 at 11 16 41 am" src="https://user-images.githubusercontent.com/427016/49396043-fc469900-f6ec-11e8-9e3f-e649633e8622.png">

The alternative presented here uses the List type in config and reduces these parallel steps to a single node:

<img width="186" alt="screen shot 2018-12-03 at 11 18 50 am" src="https://user-images.githubusercontent.com/427016/49396131-43348e80-f6ed-11e8-9c78-8876be36b2ca.png">

Disadvantages of this pattern:

- Discards the information we have about parallelism, restricts parallel execution
- Encourages tight coupling of disparate operations and solids with lots of flags and logic, discourages writing of small reusable solids
- Variadic inputs lead naturally to variadic outputs -- even if we pass List outputs, it's not clear how downstream solids will select their inputs from the list they're passed. I suspect we will end up with situations where the outputs of solids like this aren't used directly (instead we output something like `done:Bool`), downstream solids declare dependencies on unused inputs just to enforce execution order, and parameters move to config.

Advantages of this pattern:
- Much simpler pipelines with less boilerplate and duplication. In production there might be dozens or hundreds of files being grabbed from an SFTP drop and then unzipped or parsed in a standard way, and it seems crazy to define pipelines with many aliased solids vs. a much more navigable config list. These pipelines will also be much easier to maintain.