### PR TITLE
Config system improvements (including better path information)

### DIFF
--- a/python_modules/Makefile
+++ b/python_modules/Makefile
@@ -26,3 +26,5 @@ reinstall:
 rebuild_dagit:
 	cd dagit/dagit/webapp; yarn install && yarn build
 
+dagster_yapf:
+	find dagster -name "*.py" | grep -v ".tox" | grep -v ".vscode" | grep -v "snapshots" | xargs yapf -i

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -122,6 +122,7 @@ def start_pipeline_execution(context, pipelineName, config):
                 execute_reentrant_pipeline,
                 pipeline.get_dagster_pipeline(),
                 config.value,
+                throw_on_error=False,
                 reentrant_info=ReentrantInfo(
                     new_run_id,
                     event_callback=run.handle_new_event,

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -7,7 +7,11 @@ from dagster import (
     check,
 )
 from dagster.core.evaluator import evaluate_config_value
-from dagster.core.execution import create_execution_plan
+
+from dagster.core.execution import (
+    create_execution_plan,
+    execute_reentrant_pipeline,
+)
 
 from . import pipelines, execution, errors, runs
 from .utils import non_null_list, EitherValue, EitherError
@@ -113,8 +117,9 @@ def start_pipeline_execution(context, pipelineName, config):
         def start_execution(config):
             new_run_id = str(uuid.uuid4())
             run = pipeline_run_storage.add_run(new_run_id, pipelineName, config)
+            # TODO: If this throws an error what do we do?
             gevent.spawn(
-                execute_pipeline,
+                execute_reentrant_pipeline,
                 pipeline.get_dagster_pipeline(),
                 config.value,
                 reentrant_info=ReentrantInfo(

--- a/python_modules/dagit/dagit_tests/test_smoke.py
+++ b/python_modules/dagit/dagit_tests/test_smoke.py
@@ -1,7 +1,6 @@
 import json
 from dagit import app
 from dagit.pipeline_run_storage import PipelineRunStorage
-from dagster.cli.dynamic_loader import DynamicObject
 from dagster.dagster_examples.repository import define_example_repository
 
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,4 +1,5 @@
 from dagster.core.execution import (
+    PipelineConfigEvaluationError,
     PipelineExecutionResult,
     ReentrantInfo,
     SolidExecutionResult,

--- a/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/cli_tests/test_config_scaffolder.py
@@ -103,7 +103,7 @@ def test_two_contexts():
             'context_one':
             PipelineContextDefinition(
                 context_fn=lambda *args: fail_me(),
-                config_field=Field(
+                config_field=Field.composite_field(
                     types.ConfigDictionary(
                         'ContextOneConfigDict',
                         {
@@ -115,7 +115,7 @@ def test_two_contexts():
             'context_two':
             PipelineContextDefinition(
                 context_fn=lambda *args: fail_me(),
-                config_field=Field(
+                config_field=Field.composite_field(
                     types.ConfigDictionary(
                         'ContextTwoConfigDict',
                         {

--- a/python_modules/dagster/dagster/cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/config_scaffolder.py
@@ -4,17 +4,17 @@ from dagster import (
     types,
 )
 
-from dagster.core.config_types import (
-    EnvironmentConfigType,
-    is_environment_context_field_optional,
-)
+
+def is_environment_context_field_optional(pipeline_def):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    return pipeline_def.environment_type.field_dict['context'].is_optional
 
 
 def scaffold_pipeline_config(pipeline_def, skip_optional=True):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.bool_param(skip_optional, 'skip_optional')
 
-    env_config_type = EnvironmentConfigType(pipeline_def)
+    env_config_type = pipeline_def.environment_type
 
     env_dict = {}
 
@@ -36,7 +36,9 @@ def scaffold_type(config_type, skip_optional=True):
     check.inst_param(config_type, 'config_type', types.DagsterType)
     check.bool_param(skip_optional, 'skip_optional')
 
-    if isinstance(config_type, types.DagsterCompositeType):
+    # Right now selectors and composites have the same
+    # scaffolding logic, which might not be wise.
+    if isinstance(config_type, types.DagsterCompositeTypeBase):
         default_dict = {}
         for field_name, field in config_type.field_dict.items():
             if skip_optional and field.is_optional:

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -9,7 +9,6 @@ import click
 from dagster import (
     PipelineDefinition,
     check,
-    config,
 )
 
 from dagster.core.definitions import ExecutionGraph, Solid

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -11,7 +11,6 @@ from .config import (
 )
 
 from .definitions import (
-    Field,
     PipelineContextDefinition,
     PipelineDefinition,
 )
@@ -22,18 +21,30 @@ from .types import (
     Bool,
     DagsterCompositeType,
     DagsterSelectorType,
-    DagsterType,
     DagsterTypeAttributes,
+    Field,
 )
 
 
-def define_possibly_optional_field(dagster_type, is_optional):
-    check.inst_param(dagster_type, 'dagster_type', DagsterType)
-    check.bool_param(is_optional, 'is_optional')
+def define_maybe_optional_composite_field(dagster_type):
+    return Field.composite_field(dagster_type)
+
+
+def _is_selector_field_optional(dagster_type):
+    if len(dagster_type.field_dict) > 1:
+        return False
+    else:
+        _name, field = single_item(dagster_type.field_dict)
+        return field.is_optional
+
+
+def define_maybe_optional_selector_field(dagster_type):
+    check.inst_param(dagster_type, 'dagster_type', DagsterSelectorType)
+    is_optional = _is_selector_field_optional(dagster_type)
 
     return Field(
         dagster_type,
-        is_optional=True,
+        is_optional=is_optional,
         default_value=lambda: throwing_evaluate_config_value(dagster_type, None),
     ) if is_optional else Field(dagster_type)
 
@@ -49,33 +60,6 @@ class SpecificContextConfig(DagsterCompositeType):
             },
             type_attributes=DagsterTypeAttributes(is_system_config=True),
         )
-
-
-def define_specific_context_field(
-    pipeline_name,
-    context_name,
-    context_def,
-    is_optional,
-    provide_default=False,
-):
-    check.str_param(pipeline_name, 'pipeline_name')
-    check.str_param(context_name, 'context_name')
-    check.inst_param(context_def, 'context_def', PipelineContextDefinition)
-    check.bool_param(is_optional, 'is_optional')
-    check.bool_param(provide_default, 'provide_default')
-
-    specific_context_config_type = SpecificContextConfig(
-        '{pipeline_name}.ContextDefinitionConfig.{context_name}'.format(
-            pipeline_name=pipeline_name,
-            context_name=camelcase(context_name),
-        ),
-        context_def.config_field,
-    )
-
-    if is_optional and provide_default:
-        return define_possibly_optional_field(specific_context_config_type, is_optional)
-
-    return Field(specific_context_config_type, is_optional=is_optional)
 
 
 def single_item(ddict):
@@ -97,19 +81,25 @@ class ContextConfigType(DagsterSelectorType):
         full_type_name = '{pipeline_name}.ContextConfig'.format(pipeline_name=pipeline_name)
 
         field_dict = {}
-        for context_name, context_definition in context_definitions.items():
-
-            is_optional = True if len(
-                context_definitions
-            ) > 1 else context_definition.config_field.is_optional
-
-            field_dict[context_name] = define_specific_context_field(
-                pipeline_name,
-                context_name,
-                context_definition,
-                is_optional=is_optional,
-                provide_default=is_optional and len(context_definitions) == 1,
+        if len(context_definitions) == 1:
+            context_name, context_definition = single_item(context_definitions)
+            field_dict[context_name] = define_maybe_optional_composite_field(
+                create_specific_context_type(
+                    pipeline_name,
+                    context_name,
+                    context_definition,
+                ),
             )
+        else:
+            for context_name, context_definition in context_definitions.items():
+                field_dict[context_name] = Field(
+                    create_specific_context_type(
+                        pipeline_name,
+                        context_name,
+                        context_definition,
+                    ),
+                    is_optional=True,
+                )
 
         super(ContextConfigType, self).__init__(
             full_type_name,
@@ -121,6 +111,17 @@ class ContextConfigType(DagsterSelectorType):
     def construct_from_config_value(self, config_value):
         context_name, context_value = single_item(config_value)
         return Context(name=context_name, config=context_value['config'])
+
+
+def create_specific_context_type(pipeline_name, context_name, context_definition):
+    specific_context_config_type = SpecificContextConfig(
+        '{pipeline_name}.ContextDefinitionConfig.{context_name}'.format(
+            pipeline_name=pipeline_name,
+            context_name=camelcase(context_name),
+        ),
+        context_definition.config_field,
+    )
+    return specific_context_config_type
 
 
 class SolidConfigType(DagsterCompositeType):
@@ -139,46 +140,30 @@ class SolidConfigType(DagsterCompositeType):
         return Solid(config=config_value.get('config'))
 
 
-def define_environment_field(field_type):
-    check.inst_param(field_type, 'field_type', DagsterType)
-    return define_possibly_optional_field(field_type, all_optional_type(field_type))
-
-
-def is_environment_context_field_optional(pipeline_def):
-    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
-    if len(pipeline_def.context_definitions) > 1:
-        return False
-    else:
-        _, single_context_def = single_item(pipeline_def.context_definitions)
-
-        return single_context_def.config_field.is_optional
-
-
 class EnvironmentConfigType(DagsterCompositeType):
     def __init__(self, pipeline_def):
         check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
 
         pipeline_name = camelcase(pipeline_def.name)
 
-        context_field = define_possibly_optional_field(
+        context_field = define_maybe_optional_selector_field(
             ContextConfigType(pipeline_name, pipeline_def.context_definitions),
-            is_environment_context_field_optional(pipeline_def),
         )
 
-        solids_field = define_environment_field(
+        solids_field = define_maybe_optional_composite_field(
             SolidDictionaryType(
                 '{pipeline_name}.SolidsConfigDictionary'.format(pipeline_name=pipeline_name),
                 pipeline_def,
             )
         )
 
-        expectations_field = define_environment_field(
+        expectations_field = define_maybe_optional_composite_field(
             ExpectationsConfigType(
                 '{pipeline_name}.ExpectationsConfig'.format(pipeline_name=pipeline_name)
             )
         )
 
-        execution_field = define_environment_field(
+        execution_field = define_maybe_optional_composite_field(
             ExecutionConfigType(
                 '{pipeline_name}.ExecutionConfig'.format(pipeline_name=pipeline_name)
             )
@@ -211,14 +196,6 @@ class ExpectationsConfigType(DagsterCompositeType):
         return Expectations(**config_value)
 
 
-def all_optional_type(dagster_type):
-    check.inst_param(dagster_type, 'dagster_type', DagsterType)
-
-    if isinstance(dagster_type, DagsterCompositeType):
-        return dagster_type.all_fields_optional
-    return True
-
-
 class SolidDictionaryType(DagsterCompositeType):
     def __init__(self, name, pipeline_def):
         check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
@@ -235,10 +212,7 @@ class SolidDictionaryType(DagsterCompositeType):
                     ),
                     solid.definition.config_field,
                 )
-                field_dict[solid.name] = define_possibly_optional_field(
-                    solid_config_type,
-                    solid.definition.config_field.is_optional,
-                )
+                field_dict[solid.name] = define_maybe_optional_composite_field(solid_config_type)
 
         super(SolidDictionaryType, self).__init__(
             name,

--- a/python_modules/dagster/dagster/core/core_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_decorators.py
@@ -10,7 +10,6 @@ from dagster import (
     OutputDefinition,
     PipelineDefinition,
     Result,
-    config,
     execute_pipeline,
     lambda_solid,
     solid,
@@ -28,10 +27,6 @@ from dagster.core.utility_solids import define_stub_solid
 
 def create_test_context():
     return ExecutionContext()
-
-
-def create_empty_test_env():
-    return config.Environment()
 
 
 def test_multiple_single_result():
@@ -62,7 +57,6 @@ def test_no_parens_solid():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert called['yup']
@@ -78,7 +72,6 @@ def test_empty_solid():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert called['yup']
@@ -92,7 +85,6 @@ def test_solid():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -108,7 +100,6 @@ def test_solid_one_output():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -124,7 +115,6 @@ def test_solid_yield():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -140,7 +130,6 @@ def test_solid_result_return():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -159,7 +148,6 @@ def test_solid_multiple_outputs():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -184,7 +172,6 @@ def test_dict_multiple_outputs():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -202,7 +189,6 @@ def test_lambda_solid_with_name():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -218,7 +204,6 @@ def test_solid_with_name():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=create_empty_test_env(),
     )
 
     assert result.success
@@ -343,7 +328,13 @@ def test_any_config_field():
     result = execute_single_solid_in_isolation(
         create_test_context(),
         hello_world,
-        environment=config.Environment(solids={'hello_world': config.Solid(conf_value)})
+        environment={
+            'solids': {
+                'hello_world': {
+                    'config': conf_value,
+                },
+            },
+        },
     )
 
     assert called['yup']

--- a/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_naming_collisions.py
@@ -9,7 +9,6 @@ from dagster import (
     Result,
     SolidDefinition,
     check,
-    config,
     execute_pipeline,
     types,
 )
@@ -53,9 +52,15 @@ def test_execute_solid_with_input_same_name():
 
     result = execute_pipeline(
         pipeline,
-        config.Environment(solids={'pass_value': config.Solid({
-            'value': 'foo'
-        })}),
+        environment={
+            'solids': {
+                'pass_value': {
+                    'config': {
+                        'value': 'foo',
+                    },
+                },
+            },
+        },
     )
 
     assert result.result_for_solid('a_thing').transformed_value() == 'foofoo'
@@ -97,16 +102,20 @@ def test_execute_two_solids_with_same_input_name():
 
     result = execute_pipeline(
         pipeline,
-        environment=config.Environment(
-            solids={
-                'pass_to_one': config.Solid({
-                    'value': 'foo'
-                }),
-                'pass_to_two': config.Solid({
-                    'value': 'bar'
-                }),
-            }
-        )
+        environment={
+            'solids': {
+                'pass_to_one': {
+                    'config': {
+                        'value': 'foo',
+                    },
+                },
+                'pass_to_two': {
+                    'config': {
+                        'value': 'bar',
+                    },
+                },
+            },
+        },
     )
 
     assert result.success
@@ -148,9 +157,15 @@ def test_execute_dep_solid_different_input_name():
 
     result = dagster.execute_pipeline(
         pipeline,
-        environment=config.Environment(solids={'pass_to_first': config.Solid({
-            'value': 'bar'
-        })})
+        environment={
+            'solids': {
+                'pass_to_first': {
+                    'config': {
+                        'value': 'bar',
+                    },
+                },
+            },
+        },
     )
 
     assert result.success

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -1,11 +1,9 @@
 from dagster import (
     DependencyDefinition,
-    ExecutionContext,
     InputDefinition,
     OutputDefinition,
     PipelineDefinition,
     check,
-    config,
     execute_pipeline,
     execute_pipeline_iterator,
     SolidInstance,
@@ -249,11 +247,7 @@ def assert_all_results_equivalent(expected_results, result_results):
 
 def test_pipeline_execution_graph_diamond():
     pipeline = PipelineDefinition(solids=create_diamond_solids(), dependencies=diamond_deps())
-    environment = config.Environment()
-    return _do_test(pipeline, lambda: execute_pipeline_iterator(
-        pipeline,
-        environment=environment,
-    ))
+    return _do_test(pipeline, lambda: execute_pipeline_iterator(pipeline))
 
 
 def test_create_single_solid_pipeline():

--- a/python_modules/dagster/dagster/core/core_tests/test_solid_aliases.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_solid_aliases.py
@@ -6,7 +6,6 @@ from dagster import (
     InputDefinition,
     PipelineDefinition,
     SolidInstance,
-    config,
     execute_pipeline,
     lambda_solid,
     solid,
@@ -87,10 +86,16 @@ def test_aliased_configs():
 
     result = execute_pipeline(
         pipeline,
-        config.Environment(solids={
-            'load_a': config.Solid(2),
-            'load_b': config.Solid(3),
-        })
+        {
+            'solids': {
+                'load_a': {
+                    'config': 2,
+                },
+                'load_b': {
+                    'config': 3,
+                },
+            },
+        },
     )
 
     assert result.success

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -354,7 +354,8 @@ def test_solid_configs_defaults():
     int_solid_field = solids_field.dagster_type.field_named('int_config_solid')
 
     assert int_solid_field.is_optional
-    assert int_solid_field.default_provided  # TODO: this is the test case the exposes the default dodginess
+    # TODO: this is the test case the exposes the default dodginess
+    assert int_solid_field.default_provided
 
     assert_has_fields(int_solid_field.dagster_type, 'config')
 
@@ -505,18 +506,16 @@ def test_optional_solid_with_no_config():
         ]
     )
 
-    env_type = EnvironmentConfigType(pipeline_def)
-    env_obj = throwing_evaluate_config_value(
-        env_type, {'solids': {
-            'int_config_solid': {
-                'config': 234
-            }
-        }}
-    )
-
-    assert env_obj.solids['int_config_solid'].config == 234
-
-    assert execute_pipeline(pipeline_def, env_obj).success
+    assert execute_pipeline(
+        pipeline_def,
+        {
+            'solids': {
+                'int_config_solid': {
+                    'config': 234,
+                },
+            },
+        },
+    ).success
 
 
 def test_optional_solid_with_optional_scalar_config():
@@ -744,7 +743,7 @@ def test_optional_and_required_context():
             'optional_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_field=Field(
+                config_field=Field.composite_field(
                     dagster_type=types.ConfigDictionary(
                         name='some_optional_context_config',
                         fields={
@@ -756,7 +755,7 @@ def test_optional_and_required_context():
             'required_field_context':
             PipelineContextDefinition(
                 context_fn=lambda *args: None,
-                config_field=Field(
+                config_field=Field.composite_field(
                     dagster_type=types.ConfigDictionary(
                         name='some_required_context_config',
                         fields={

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -489,8 +489,10 @@ def _validate_dependencies(dependencies, solid_dict, alias_lookup):
                     )
                 else:
                     raise DagsterInvalidDefinitionError(
-                        'Solid {aliased_solid} (aliased by {from_solid} in dependency dictionary) not found in solid list'.
-                        format(
+                        (
+                            'Solid {aliased_solid} (aliased by {from_solid} in dependency '
+                            'dictionary) not found in solid list'
+                        ).format(
                             aliased_solid=aliased_solid,
                             from_solid=from_solid,
                         ),

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -522,10 +522,15 @@ def execute_pipeline(
 
     typed_environment = get_typed_environment(pipeline, environment)
 
-    return execute_reentrant_pipeline(pipeline, typed_environment, reentrant_info)
+    return execute_reentrant_pipeline(pipeline, typed_environment, throw_on_error, reentrant_info)
 
 
-def execute_reentrant_pipeline(pipeline, typed_environment, reentrant_info):
+def execute_reentrant_pipeline(
+    pipeline,
+    typed_environment,
+    throw_on_error,
+    reentrant_info,
+):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(typed_environment, 'typed_environment', config.Environment)
     check.opt_inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
@@ -534,7 +539,7 @@ def execute_reentrant_pipeline(pipeline, typed_environment, reentrant_info):
     return _execute_graph(
         execution_graph,
         typed_environment,
-        throw_on_error=False,
+        throw_on_error=throw_on_error,
         reentrant_info=reentrant_info,
     )
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -522,19 +522,18 @@ def execute_pipeline(
 
     typed_environment = get_typed_environment(pipeline, environment)
 
-    execution_graph = ExecutionGraph.from_pipeline(pipeline)
-    return _execute_graph(execution_graph, typed_environment, throw_on_error, reentrant_info)
+    return execute_reentrant_pipeline(pipeline, typed_environment, reentrant_info)
 
 
-def execute_reentrant_pipeline(pipeline, environment, reentrant_info):
+def execute_reentrant_pipeline(pipeline, typed_environment, reentrant_info):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
-    check.inst_param(environment, 'environment', config.Environment)
-    check.inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
+    check.inst_param(typed_environment, 'typed_environment', config.Environment)
+    check.opt_inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
 
     execution_graph = ExecutionGraph.from_pipeline(pipeline)
     return _execute_graph(
         execution_graph,
-        environment,
+        typed_environment,
         throw_on_error=False,
         reentrant_info=reentrant_info,
     )

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -5,7 +5,6 @@ from dagster import (
     Result,
     SolidDefinition,
     check,
-    config,
     execute_pipeline,
 )
 
@@ -27,20 +26,16 @@ def execute_single_solid_in_isolation(
     '''
     check.inst_param(context_params, 'context_params', ExecutionContext)
     check.inst_param(solid_def, 'solid_def', SolidDefinition)
-    environment = check.opt_inst_param(
-        environment,
-        'environment',
-        config.Environment,
-        config.Environment(),
-    )
+    environment = check.opt_dict_param(environment, 'environment')
     check.bool_param(throw_on_error, 'throw_on_error')
 
-    single_solid_environment = config.Environment(
-        expectations=environment.expectations,
-        context=environment.context,
-        solids={solid_def.name: environment.solids[solid_def.name]}
-        if solid_def.name in environment.solids else None
-    )
+    single_solid_environment = {
+        'expectations': environment.get('expectations'),
+        'context': environment.get('context'),
+        'solids': {
+            solid_def.name: environment['solids'][solid_def.name]
+        } if solid_def.name in environment.get('solids', {}) else None
+    }
 
     pipeline_result = execute_pipeline(
         PipelineDefinition(

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 
-from dagster import config
 from dagster.core.execution import execute_pipeline
 from dagster.utils import script_relative_path
 from dagster.cli.pipeline import (
@@ -22,11 +21,15 @@ def test_pipeline_include():
 
 def test_execute_pipeline():
     pipeline = define_success_pipeline()
-    environment = config.Environment(
-        solids={'load_num_csv': config.Solid({
-            'path': script_relative_path('num.csv')
-        })},
-    )
+    environment = {
+        'solids': {
+            'load_num_csv': {
+                'config': {
+                    'path': script_relative_path('num.csv'),
+                },
+            },
+        },
+    }
 
     result = execute_pipeline(pipeline, environment=environment)
 

--- a/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/dagster_examples_tests/sql_project_example/test_sql_project_pipeline.py
@@ -8,7 +8,6 @@ from dagster import (
     execute_pipeline,
 )
 
-import dagster.sqlalchemy as dagster_sa
 import dagster.sqlalchemy.common
 from dagster.utils import script_relative_path
 
@@ -144,14 +143,3 @@ def test_full_in_memory_pipeline():
     assert engine.execute('SELECT * FROM num_table').fetchall() == [(1, 2), (3, 4)]
     assert engine.execute('SELECT * FROM sum_table').fetchall() == [(1, 2, 3), (3, 4, 7)]
     assert engine.execute('SELECT * FROM sum_sq_table').fetchall() == [(1, 2, 3, 9), (3, 4, 7, 49)]
-
-
-# Commmenting out for now because it takes two seconds
-# def test_full_persisted_pipeline():
-#     pipeline = create_full_pipeline()
-#     pipeline_result = execute_pipeline(
-#         pipeline,
-#         environment=config.Environment(context=config.Context(name='persisted')),
-#     )
-
-#     assert pipeline_result.success

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_eight/test_intro_tutorial_part_eight.py
@@ -4,11 +4,11 @@ import pytest
 
 from dagster import (
     DagsterInvariantViolationError,
-    DagsterTypeError,
     DependencyDefinition,
     Field,
     InputDefinition,
     OutputDefinition,
+    PipelineConfigEvaluationError,
     PipelineDefinition,
     RepositoryDefinition,
     execute_pipeline,
@@ -120,14 +120,17 @@ def test_part_eight_repo_step_one():
 
 def test_part_eight_repo_step_one_wrong_env():
     environment = load_yaml_from_path(script_relative_path('env_step_one_type_error.yml'))
-    with pytest.raises(DagsterTypeError, match='is not valid for type String'):
+    with pytest.raises(
+        PipelineConfigEvaluationError,
+        match='Type failure at path "root:solids:double_the_word_with_typed_config:config:word"',
+    ):
         execute_pipeline(define_part_eight_step_one_pipeline(), environment)
 
 
 def test_part_eight_repo_step_one_wrong_field():
     environment = load_yaml_from_path(script_relative_path('env_step_one_field_error.yml'))
 
-    with pytest.raises(DagsterTypeError, match='Field "wrong_word" is not defined'):
+    with pytest.raises(PipelineConfigEvaluationError, match='Undefined field "wrong_word"'):
         execute_pipeline(define_part_eight_step_one_pipeline(), environment)
 
 

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_five.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_five.py
@@ -2,7 +2,6 @@
 
 from dagster import (
     PipelineDefinition,
-    config,
     execute_pipeline,
     solid,
 )
@@ -47,7 +46,15 @@ def define_step_three_pipeline():
 def test_tutorial_part_five_sample_three():
     pipeline_result = execute_pipeline(
         define_step_two_pipeline(),
-        config.Environment(context=config.Context(config={'log_level': 'DEBUG'}))
+        {
+            'context': {
+                'default': {
+                    'config': {
+                        'log_level': 'DEBUG',
+                    },
+                },
+            },
+        },
     )
 
     assert pipeline_result.success

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_nine/test_intro_tutorial_part_nine.py
@@ -6,12 +6,12 @@ import yaml
 import pytest
 
 from dagster import (
-    DagsterTypeError,
     DependencyDefinition,
     ExecutionContext,
     Field,
     InputDefinition,
     OutputDefinition,
+    PipelineConfigEvaluationError,
     PipelineContextDefinition,
     PipelineDefinition,
     RepositoryDefinition,
@@ -359,7 +359,7 @@ solids:
 
 
 def test_intro_tutorial_part_nine_final_error():
-    with pytest.raises(DagsterTypeError, match='Field "username" is not defined'):
+    with pytest.raises(PipelineConfigEvaluationError) as pe_info:
         execute_pipeline(
             define_part_nine_final_pipeline(),
             yaml.load(
@@ -379,3 +379,5 @@ solids:
 '''
             ),
         )
+
+    assert len(pe_info.value.errors) == 2

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_seven/test_intro_tutorial_part_seven.py
@@ -7,7 +7,6 @@ from dagster import (
     InputDefinition,
     PipelineDefinition,
     RepositoryDefinition,
-    config,
     execute_pipeline,
     lambda_solid,
     solid,
@@ -51,11 +50,15 @@ def define_part_seven_repo():
 
 
 def test_part_seven_repo():
-    environment = config.Environment(
-        solids={
-            'double_the_word': config.Solid(config={'word': 'bar'}),
-        }
-    )
+    environment = {
+        'solids': {
+            'double_the_word': {
+                'config': {
+                    'word': 'bar',
+                },
+            },
+        },
+    }
 
     pipeline_result = execute_pipeline(define_part_seven_pipeline(), environment)
 

--- a/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_thirteen.py
+++ b/python_modules/dagster/dagster/dagster_examples/tutorials/test_intro_tutorial_part_thirteen.py
@@ -5,7 +5,6 @@ from dagster import (
     OutputDefinition,
     PipelineDefinition,
     SolidInstance,
-    config,
     execute_pipeline,
     lambda_solid,
     solid,
@@ -162,15 +161,22 @@ def define_part_thirteen_step_three_pipeline():
 def test_run_whole_pipeline():
     pipeline = define_part_thirteen_step_three_pipeline()
     pipeline_result = execute_pipeline(
-        pipeline,
-        config.Environment(
-            solids={
-                'a': config.Solid(2),
-                'b': config.Solid(6),
-                'c': config.Solid(4),
-                'd': config.Solid(8),
-            }
-        )
+        pipeline, {
+            'solids': {
+                'a': {
+                    'config': 2,
+                },
+                'b': {
+                    'config': 6,
+                },
+                'c': {
+                    'config': 4,
+                },
+                'd': {
+                    'config': 8,
+                },
+            },
+        }
     )
 
     assert pipeline_result.success

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_library_slide.py
@@ -4,7 +4,6 @@ from dagster import (
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
-    config,
     execute_pipeline,
     lambda_solid,
     PipelineDefinition,
@@ -19,11 +18,15 @@ import dagster.pandas as dagster_pd
 
 
 def create_num_csv_environment():
-    return config.Environment(
-        solids={'load_csv': config.Solid({
-            'path': script_relative_path('num.csv')
-        })},
-    )
+    return {
+        'solids': {
+            'load_csv': {
+                'config': {
+                    'path': script_relative_path('num.csv'),
+                },
+            },
+        },
+    }
 
 
 def test_hello_world_with_dataframe_fns():
@@ -78,16 +81,21 @@ def run_hello_world(hello_world):
     )
 
     with get_temp_file_name() as temp_file_name:
-        environment = config.Environment(
-            solids={
-                'load_csv': config.Solid({
-                    'path': script_relative_path('num.csv'),
-                }),
-                'to_csv': config.Solid({
-                    'path': temp_file_name,
-                })
+        environment = {
+            'solids': {
+                'load_csv': {
+                    'config': {
+                        'path': script_relative_path('num.csv'),
+                    },
+                },
+                'to_csv': {
+                    'config': {
+                        'path': temp_file_name,
+                    },
+                },
             },
-        )
+        }
+
         pipeline_result = execute_pipeline(
             pipeline_two,
             environment,

--- a/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
+++ b/python_modules/dagster/dagster/pandas/pandas_tests/test_pandas_hello_world_no_library_slide.py
@@ -9,7 +9,6 @@ from dagster import (
     PipelineDefinition,
     Result,
     SolidDefinition,
-    config,
     execute_pipeline,
     types,
 )
@@ -72,14 +71,15 @@ def test_hello_world_pipeline_no_api():
     )
 
     pipeline_result = execute_pipeline(
-        pipeline,
-        config.Environment(
-            solids={
-                'read_csv_solid': config.Solid({
-                    'path': script_relative_path('num.csv'),
-                }),
+        pipeline, {
+            'solids': {
+                'read_csv_solid': {
+                    'config': {
+                        'path': script_relative_path('num.csv'),
+                    },
+                },
             },
-        ),
+        }
     )
 
     assert pipeline_result.success
@@ -119,13 +119,15 @@ def test_hello_world_composed():
 
     pipeline_result = execute_pipeline(
         pipeline,
-        environment=config.Environment(
-            solids={
-                'read_hello_world': config.Solid({
-                    'path': script_relative_path('num.csv')
-                }),
+        environment={
+            'solids': {
+                'read_hello_world': {
+                    'config': {
+                        'path': script_relative_path('num.csv'),
+                    },
+                },
             },
-        ),
+        }
     )
 
     assert pipeline_result.success
@@ -178,13 +180,15 @@ def test_pandas_hello_no_library():
         }
     )
 
-    environment = config.Environment(
-        solids={
-            'read_one': config.Solid({
-                'path': script_relative_path('num.csv')
-            }),
-        }
-    )
+    environment = {
+        'solids': {
+            'read_one': {
+                'config': {
+                    'path': script_relative_path('num.csv')
+                },
+            },
+        },
+    }
 
     execute_pipeline_result = execute_pipeline(
         pipeline,
@@ -205,14 +209,19 @@ def test_pandas_hello_no_library():
         os.remove(sum_sq_out_path)
 
     sum_sq_path_args = {'path': '/tmp/sum_sq.csv'}
-    environment_two = config.Environment(
-        solids={
-            'read_one': config.Solid({
-                'path': script_relative_path('num.csv')
-            }),
-            'write_two': config.Solid(sum_sq_path_args),
+
+    environment_two = {
+        'solids': {
+            'read_one': {
+                'config': {
+                    'path': script_relative_path('num.csv'),
+                },
+            },
+            'write_two': {
+                'config': sum_sq_path_args
+            },
         },
-    )
+    }
 
     pipeline_two = PipelineDefinition(
         solids=[

--- a/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_basic_solid.py
+++ b/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_basic_solid.py
@@ -6,7 +6,6 @@ from dagster import (
     PipelineContextDefinition,
     PipelineDefinition,
     check,
-    config,
     execute_pipeline,
 )
 
@@ -55,11 +54,15 @@ def test_sql_sum_solid():
 
     create_sum_table = define_create_table_solid('create_sum_table_solid')
 
-    environment = config.Environment(
-        solids={create_sum_table.name: config.Solid({
-            'table_name': 'sum_table',
-        })}
-    )
+    environment = {
+        'solids': {
+            create_sum_table.name: {
+                'config': {
+                    'table_name': 'sum_table',
+                },
+            },
+        },
+    }
 
     pipeline = pipeline_test_def(
         solids=[expr_solid, sum_table_solid, create_sum_table],
@@ -154,11 +157,15 @@ def test_output_sql_sum_sq_solid():
         }}
     )
 
-    environment = config.Environment(
-        solids={'create_sum_sq_table': config.Solid({
-            'table_name': 'sum_sq_table'
-        })},
-    )
+    environment = {
+        'solids': {
+            create_sum_sq_table.name: {
+                'config': {
+                    'table_name': 'sum_sq_table',
+                },
+            },
+        },
+    }
 
     pipeline_result = execute_pipeline(pipeline=pipeline, environment=environment)
 

--- a/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster/dagster/sqlalchemy/sqlalchemy_tests/test_isolated_templated_sql_tests.py
@@ -2,7 +2,6 @@ from dagster import (
     DependencyDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
-    config,
     execute_pipeline,
 )
 
@@ -53,11 +52,15 @@ def test_single_templated_sql_solid_single_table_with_api():
 
     sum_table_arg = 'specific_sum_table'
 
-    environment = config.Environment(
-        solids={'sum_table_transform': config.Solid({
-            'sum_table': sum_table_arg
-        })}
-    )
+    environment = {
+        'solids': {
+            'sum_table_transform': {
+                'config': {
+                    'sum_table': sum_table_arg,
+                },
+            },
+        },
+    }
 
     result = execute_pipeline(pipeline, environment=environment)
     assert result.success
@@ -70,12 +73,18 @@ def test_single_templated_sql_solid_single_table_with_api_serialize_intermediate
 
     sum_table_arg = 'specific_sum_table'
 
-    environment = config.Environment(
-        solids={'sum_table_transform': config.Solid({
-            'sum_table': sum_table_arg
-        })},
-        execution=config.Execution(serialize_intermediates=True),
-    )
+    environment = {
+        'solids': {
+            'sum_table_transform': {
+                'config': {
+                    'sum_table': sum_table_arg,
+                },
+            },
+        },
+        'execution': {
+            'serialize_intermediates': True,
+        },
+    }
 
     result = execute_pipeline(pipeline, environment=environment)
     assert result.success
@@ -105,14 +114,16 @@ def test_single_templated_sql_solid_double_table_raw_api():
         solids=[sum_solid], context_params=in_mem_context_params(num_table_arg)
     )
 
-    environment = config.Environment(
-        solids={
-            'sum_solid': config.Solid({
-                'sum_table': sum_table_arg,
-                'num_table': num_table_arg,
-            })
-        }
-    )
+    environment = {
+        'solids': {
+            'sum_solid': {
+                'config': {
+                    'sum_table': sum_table_arg,
+                    'num_table': num_table_arg,
+                },
+            },
+        },
+    }
 
     result = execute_pipeline(pipeline, environment=environment)
     assert result.success
@@ -137,14 +148,16 @@ def test_single_templated_sql_solid_double_table_with_api():
         solids=[sum_solid], context_params=in_mem_context_params(num_table_arg)
     )
 
-    environment = config.Environment(
-        solids={
-            'sum_solid': config.Solid({
-                'sum_table': sum_table_arg,
-                'num_table': num_table_arg,
-            })
-        }
-    )
+    environment = {
+        'solids': {
+            'sum_solid': {
+                'config': {
+                    'sum_table': sum_table_arg,
+                    'num_table': num_table_arg,
+                },
+            },
+        },
+    }
 
     result = execute_pipeline(pipeline, environment=environment)
     assert result.success
@@ -191,19 +204,22 @@ def test_templated_sql_solid_pipeline():
     first_sum_table = 'first_sum_table'
     first_sum_sq_table = 'first_sum_sq_table'
 
-    environment_one = config.Environment(
-        solids={
-            'sum_table':
-            config.Solid({
-                'sum_table': first_sum_table
-            }),
-            'sum_sq_table':
-            config.Solid({
-                'sum_table': first_sum_table,
-                'sum_sq_table': first_sum_sq_table,
-            }),
-        }
-    )
+    environment_one = {
+        'solids': {
+            'sum_table': {
+                'config': {
+                    'sum_table': first_sum_table,
+                },
+            },
+            'sum_sq_table': {
+                'config': {
+                    'sum_table': first_sum_table,
+                    'sum_sq_table': first_sum_sq_table,
+                },
+            },
+        },
+    }
+
     first_result = execute_pipeline(pipeline, environment=environment_one)
     assert first_result.success
 
@@ -236,11 +252,14 @@ def test_templated_sql_solid_pipeline():
         'sum_table': first_sum_table,
         'sum_sq_table': second_sum_sq_table,
     }
-    environment_two = config.Environment(
-        solids={
-            'sum_sq_table': config.Solid(sum_sq_args),
-        },
-    )
+
+    environment_two = {
+        'solids': {
+            'sum_sq_table': {
+                'config': sum_sq_args,
+            }
+        }
+    }
 
     second_result = execute_pipeline(
         pipeline_two,
@@ -264,11 +283,17 @@ def test_templated_sql_solid_with_api():
     pipeline = pipeline_test_def(solids=[sum_solid], context_params=in_mem_context_params())
 
     sum_table_arg = 'specific_sum_table'
-    environment = config.Environment(
-        solids={'sum_solid': config.Solid({
-            'sum_table': sum_table_arg
-        })},
-    )
+
+    environment = {
+        'solids': {
+            'sum_solid': {
+                'config': {
+                    'sum_table': sum_table_arg,
+                },
+            },
+        },
+    }
+
     result = execute_pipeline(pipeline, environment=environment)
     assert result.success
 
@@ -282,26 +307,27 @@ def test_with_from_through_specifying_all_solids():
     first_mult_table = 'first_mult_table'
     first_sum_mult_table = 'first_sum_mult_table'
 
-    environment = config.Environment(
-        solids={
-            'sum_table':
-            config.Solid({
-                'sum_table': first_sum_table,
-            }),
-            'mult_table':
-            config.Solid({
-                'mult_table': first_mult_table,
-            }),
-            'sum_mult_table':
-            config.Solid(
-                {
+    environment = {
+        'solids': {
+            'sum_table': {
+                'config': {
+                    'sum_table': first_sum_table,
+                },
+            },
+            'mult_table': {
+                'config': {
+                    'mult_table': first_mult_table,
+                },
+            },
+            'sum_mult_table': {
+                'config': {
                     'sum_table': first_sum_table,
                     'mult_table': first_mult_table,
                     'sum_mult_table': first_sum_mult_table,
-                }
-            ),
+                },
+            },
         },
-    )
+    }
 
     pipeline_result = execute_pipeline(pipeline, environment=environment)
     assert len(pipeline_result.result_list) == 3
@@ -317,26 +343,27 @@ def test_multi_input_partial_execution():
     first_mult_table = 'first_mult_table'
     first_sum_mult_table = 'first_sum_mult_table'
 
-    environment = config.Environment(
-        solids={
-            'sum_table':
-            config.Solid({
-                'sum_table': first_sum_table
-            }),
-            'mult_table':
-            config.Solid({
-                'mult_table': first_mult_table,
-            }),
-            'sum_mult_table':
-            config.Solid(
-                {
+    environment = {
+        'solids': {
+            'sum_table': {
+                'config': {
+                    'sum_table': first_sum_table,
+                },
+            },
+            'mult_table': {
+                'config': {
+                    'mult_table': first_mult_table,
+                },
+            },
+            'sum_mult_table': {
+                'config': {
                     'sum_table': first_sum_table,
                     'mult_table': first_mult_table,
                     'sum_mult_table': first_sum_mult_table,
-                }
-            ),
+                },
+            },
         },
-    )
+    }
 
     first_pipeline_result = execute_pipeline(pipeline, environment=environment)
 
@@ -346,27 +373,6 @@ def test_multi_input_partial_execution():
     assert _load_table(first_pipeline_result.context, first_mult_table) == [(1, 2, 2), (3, 4, 12)]
     assert _load_table(first_pipeline_result.context,
                        first_sum_mult_table) == [(1, 3, 2), (3, 7, 12)]
-
-    return
-    # FIXME: need better API for partial pipeline execution
-
-    # second_sum_mult_table = 'second_sum_mult_table'
-
-    # environment_two = config.Environment(
-    #     sources={
-    #         'sum_mult_table': {
-    #             'sum_table': table_name_source(first_sum_table),
-    #             'mult_table': table_name_source(first_mult_table),
-    #             'sum_mult_table': table_name_source(second_sum_mult_table)
-    #         },
-    #     },
-    #     execution=config.Execution.single_solid('sum_mult_table')
-    # )
-
-    # assert second_pipeline_result.success
-    # assert len(second_pipeline_result.result_list) == 1
-    # assert _load_table(second_pipeline_result.context,
-    #                    second_sum_mult_table) == [(1, 3, 2), (3, 7, 12)]
 
 
 def create_multi_input_pipeline():

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -11,7 +11,6 @@ from dagster import (
     OutputDefinition,
     PipelineDefinition,
     SolidInstance,
-    config,
     execute_pipeline,
     lambda_solid,
     solid,
@@ -137,7 +136,13 @@ def test_hello_world_config():
     pipeline = define_hello_world_config_pipeline()
     pipeline_result = execute_pipeline(
         pipeline,
-        config.Environment(solids={'with_config': config.Solid(script_relative_path('num.csv'))}),
+        {
+            'solids': {
+                'with_config': {
+                    'config': script_relative_path('num.csv'),
+                },
+            },
+        },
     )
 
     assert pipeline_result.success
@@ -179,12 +184,16 @@ def define_test_notebook_dag_pipeline():
 def test_notebook_dag():
     pipeline_result = execute_pipeline(
         define_test_notebook_dag_pipeline(),
-        environment=config.Environment(
-            solids={
-                'load_a': config.Solid(1),
-                'load_b': config.Solid(2),
-            }
-        )
+        environment={
+            'solids': {
+                'load_a': {
+                    'config': 1,
+                },
+                'load_b': {
+                    'config': 2,
+                },
+            },
+        },
     )
     assert pipeline_result.success
     assert pipeline_result.result_for_solid('add_two').transformed_value() == 3

--- a/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagstermill/dagstermill/dagstermill_tests/test_dagstermill_pandas_solids.py
@@ -11,7 +11,6 @@ from dagster import (
     InputDefinition,
     OutputDefinition,
     PipelineDefinition,
-    config,
     define_stub_solid,
     execute_pipeline,
     types,
@@ -85,11 +84,13 @@ def test_pandas_source_test_pipeline():
     pipeline = define_pandas_source_test_pipeline()
     pipeline_result = execute_pipeline(
         pipeline,
-        config.Environment(
-            solids={
-                'pandas_source_test': config.Solid(script_relative_path('num.csv')),
+        {
+            'solids': {
+                'pandas_source_test': {
+                    'config': script_relative_path('num.csv'),
+                },
             },
-        ),
+        },
     )
     assert pipeline_result.success
     solid_result = pipeline_result.result_for_solid('pandas_source_test')


### PR DESCRIPTION
This turned into a much bigger PR than I would have liked. However it takes care of some issues which have been plaguing the system for a bit.

1.	execute_pipeline only takes a dict, not a config.Environment. This is the reason for most of the churn here, as a *ton* of unit tests needed updated. However this allows for more clear error messages, simplified code, and unit tests more in line with how we want all client code to be written.
2.	Internal refactoring of the type system. A lot of the internal mechanisms of the config type system were rewritten to be more generic.
3.	Much better error messages. We now print out good path information for errors . E.g. “Missing required field "config" at path root:solids:good_error_handling”

This isn't *quite* where I want it to be but this is a good incremental stopping point. It may be worth shipping down these error messages down to the dagit as well. 
