### PR TITLE
Show whitespace using a small dot background

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
@@ -126,6 +126,10 @@ injectGlobal`
       width: 100%;
     }
   }
+  .cm-whitespace {
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAFJJREFUOBFjYBgFAx8CjLiccPnyZXFmZmY9kPzfv38v6erqvsSmlgmbIEgMpJmRkZEDhGEGYVOL0wBsirGJ4TQA5Oz/////AGEQG5vmUbHBEgIA9y0YCFtvw70AAAAASUVORK5CYII=') center left repeat-x;
+    background-size: 8.4px 8.4px;
+  }
   .CodeMirror-linenumber {
 
   }

--- a/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
@@ -127,10 +127,13 @@ injectGlobal`
     }
   }
   .cm-whitespace {
+    /*
+      Note: background is a 16x16px PNG containing a semi-transparent gray dot. 8.4px
+      is the exact width of a character in Codemirror's monospace font. It's consistent
+      in Firefox and Chrome and doesn't change on zoom in / out, but may need to be
+      modified if we change the Codemirror font.
+    */
     background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAFJJREFUOBFjYBgFAx8CjLiccPnyZXFmZmY9kPzfv38v6erqvsSmlgmbIEgMpJmRkZEDhGEGYVOL0wBsirGJ4TQA5Oz/////AGEQG5vmUbHBEgIA9y0YCFtvw70AAAAASUVORK5CYII=') center left repeat-x;
     background-size: 8.4px 8.4px;
-  }
-  .CodeMirror-linenumber {
-
   }
 `;


### PR DESCRIPTION
This is a bit of a hack, but Codemirror doesn't create a separate span/element for each space (though it does for tabs). The value 8.4px is the exact width of a character in Codemirror's monospace font. It's consistent on Firefox and Chrome and doesn't break on zoom in / zoom out, but I imagine it'd break if we changed the font or size :-/ 

<img width="251" alt="image" src="https://user-images.githubusercontent.com/1037212/49614757-1b009600-f960-11e8-865f-f22f2d955aea.png">
