### PR TITLE
Log spew

### DIFF
--- a/python_modules/dagster/dagster/dagster_examples/log_spew/env.yml
+++ b/python_modules/dagster/dagster/dagster_examples/log_spew/env.yml
@@ -2,19 +2,3 @@ context:
   default:
     config:
       log_level: DEBUG
-
-solids:
-  solid_A:
-    config:
-  solid_B:
-    config:
-  solid_C:
-    config:
-  solid_D:
-    config:
-  solid_E:
-    config:
-  solid_F:
-    config:
-  solid_G:
-    config:

--- a/python_modules/dagster/dagster/dagster_examples/log_spew/env.yml
+++ b/python_modules/dagster/dagster/dagster_examples/log_spew/env.yml
@@ -1,0 +1,20 @@
+context:
+  default:
+    config:
+      log_level: DEBUG
+
+solids:
+  solid_A:
+    config:
+  solid_B:
+    config:
+  solid_C:
+    config:
+  solid_D:
+    config:
+  solid_E:
+    config:
+  solid_F:
+    config:
+  solid_G:
+    config:

--- a/python_modules/dagster/dagster/dagster_examples/log_spew/pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/log_spew/pipeline.py
@@ -10,7 +10,7 @@ from dagster import (
 
 def nonce_solid(name, n_inputs, n_outputs):
     """Creates a solid with the given number of (meaningless) inputs and outputs.
-    
+
     Config controls the behavior of the nonce solid."""
 
     @solid(
@@ -35,22 +35,16 @@ def nonce_solid(name, n_inputs, n_outputs):
     return solid_fn
 
 
-no_in_two_out = nonce_solid('no_in_two_out', 0, 2)
-one_in_one_out = nonce_solid('one_in_one_out', 1, 1)
-one_in_two_out = nonce_solid('one_in_two_out', 1, 2)
-two_in_one_out = nonce_solid('two_in_one_out', 2, 1)
-one_in_none_out = nonce_solid('one_in_none_out', 1, 0)
-
 
 def define_spew_pipeline():
     return PipelineDefinition(
         name='log_spew',
         solids=[
-            no_in_two_out,
-            one_in_one_out,
-            one_in_two_out,
-            two_in_one_out,
-            one_in_none_out,
+            nonce_solid('no_in_two_out', 0, 2),
+            nonce_solid('one_in_one_out', 1, 1),
+            nonce_solid('one_in_two_out', 1, 2),
+            nonce_solid('two_in_one_out', 2, 1),
+            nonce_solid('one_in_none_out', 1, 0),
         ],
         dependencies={
             SolidInstance('no_in_two_out', alias='solid_a'): {},

--- a/python_modules/dagster/dagster/dagster_examples/log_spew/pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/log_spew/pipeline.py
@@ -1,0 +1,78 @@
+from dagster import (
+    DependencyDefinition,
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    solid,
+    SolidInstance,
+)
+
+
+def nonce_solid(name, n_inputs, n_outputs):
+    """Creates a solid with the given number of (meaningless) inputs and outputs.
+    
+    Config controls the behavior of the nonce solid."""
+
+    @solid(
+        name=name,
+        inputs=[InputDefinition(name='input_{}'.format(i), ) for i in range(n_inputs)],
+        outputs=[OutputDefinition(name='output_{}'.format(i)) for i in range(n_outputs)]
+    )
+    def solid_fn(info, **kwargs):
+        for i in range(100000):
+            if i % 1000 == 0:
+                info.context.error('Error message seq={i} from solid {name}'.format(i=i, name=name))
+            elif i % 100 == 0:
+                info.context.warning(
+                    'Warning message seq={i} from solid {name}'.format(i=i, name=name)
+                )
+            elif i % 10 == 0:
+                info.context.info('Info message seq={i} from solid {name}'.format(i=i, name=name))
+            else:
+                info.context.debug('Debug message seq={i} from solid {name}'.format(i=i, name=name))
+        return ['foo' for i in range(n_outputs)]
+
+    return solid_fn
+
+
+no_in_two_out = nonce_solid('no_in_two_out', 0, 2)
+one_in_one_out = nonce_solid('one_in_one_out', 1, 1)
+one_in_two_out = nonce_solid('one_in_two_out', 1, 2)
+two_in_one_out = nonce_solid('two_in_one_out', 2, 1)
+one_in_none_out = nonce_solid('one_in_none_out', 1, 0)
+
+
+def define_spew_pipeline():
+    return PipelineDefinition(
+        name='log_spew',
+        solids=[
+            no_in_two_out,
+            one_in_one_out,
+            one_in_two_out,
+            two_in_one_out,
+            one_in_none_out,
+        ],
+        dependencies={
+            SolidInstance('no_in_two_out', alias='solid_a'): {},
+            SolidInstance('one_in_one_out', alias='solid_b'): {
+                'input_0': DependencyDefinition('solid_a', 'output_0'),
+            },
+            SolidInstance('one_in_two_out', alias='solid_c'): {
+                'input_0': DependencyDefinition('solid_a', 'output_1'),
+            },
+            SolidInstance('two_in_one_out', alias='solid_d'): {
+                'input_0': DependencyDefinition('solid_b', 'output_0'),
+                'input_1': DependencyDefinition('solid_c', 'output_0'),
+            },
+            SolidInstance('one_in_one_out', alias='solid_e'): {
+                'input_0': DependencyDefinition('solid_c', 'output_0'),
+            },
+            SolidInstance('two_in_one_out', alias='solid_f'): {
+                'input_0': DependencyDefinition('solid_d', 'output_0'),
+                'input_1': DependencyDefinition('solid_e', 'output_0'),
+            },
+            SolidInstance('one_in_none_out', alias='solid_g'): {
+                'input_0': DependencyDefinition('solid_f', 'output_0'),
+            }
+        },
+    )

--- a/python_modules/dagster/dagster/dagster_examples/log_spew/repository.yml
+++ b/python_modules/dagster/dagster/dagster_examples/log_spew/repository.yml
@@ -1,0 +1,3 @@
+repository:
+  file: pipeline.py
+  fn: define_spew_pipeline


### PR DESCRIPTION
Adds a slow example pipeline that spews ~700k log messages as it runs, to support UI dev and test. We may want to extend machinery to do other things to support other test cases, like create solids which fail stochastically or raise particular errors, etc.