### PR TITLE
Cleanup config value stuff

### DIFF
--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -16,7 +16,7 @@ from .definitions import (
     ResourceDefinition,
 )
 
-from .evaluator import throwing_evaluate_config_value
+from .evaluator import hard_create_config_value
 
 from .types import (
     Bool,
@@ -42,7 +42,7 @@ def define_maybe_optional_selector_field(dagster_type):
     return Field(
         dagster_type,
         is_optional=is_optional,
-        default_value=lambda: throwing_evaluate_config_value(dagster_type, None),
+        default_value=lambda: hard_create_config_value(dagster_type, None),
     ) if is_optional else Field(dagster_type)
 
 

--- a/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_config_type_system.py
@@ -18,10 +18,10 @@ from dagster import (
 
 from dagster.core.evaluator import (
     evaluate_config_value,
-    throwing_evaluate_config_value,
     DagsterEvaluationErrorReason,
 )
 
+from dagster.core.test_utils import throwing_evaluate_config_value
 
 def test_noop_config():
     assert Field(types.Any)

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -22,11 +22,9 @@ from dagster.core.config_types import (
     SpecificContextConfig,
 )
 
-from dagster.core.evaluator import (
-    evaluate_config_value,
-    throwing_evaluate_config_value,
-)
+from dagster.core.evaluator import evaluate_config_value
 
+from dagster.core.test_utils import throwing_evaluate_config_value
 
 def test_context_config_any():
     context_defs = {

--- a/python_modules/dagster/dagster/core/evaluator.py
+++ b/python_modules/dagster/dagster/core/evaluator.py
@@ -249,14 +249,9 @@ def stack_with_list_index(stack, list_index):
     )
 
 
-def throwing_evaluate_config_value(dagster_type, config_value):
-    check.inst_param(dagster_type, 'dagster_type', DagsterType)
+def hard_create_config_value(dagster_type, config_value):
     result = evaluate_config_value(dagster_type, config_value)
-    if not result.success:
-        raise DagsterEvaluateConfigValueError(
-            result.errors[0].stack,
-            result.errors[0].message,
-        )
+    check.invariant(result.success)
     return result.value
 
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -56,7 +56,6 @@ from .evaluator import (
     EvaluationError,
     evaluate_config_value,
     friendly_string_for_error,
-    throwing_evaluate_config_value,
 )
 
 from .events import construct_event_logger
@@ -258,25 +257,6 @@ def create_execution_plan(pipeline, environment=None):
     with yield_context(pipeline, environment) as context:
         return create_execution_plan_core(
             ExecutionPlanInfo(context, execution_graph, environment),
-        )
-
-
-def create_config_value(config_type, config_input):
-    if isinstance(config_input, config.Environment):
-        return config_input
-
-    try:
-        # TODO: we should bubble up multiple errors from here
-        return throwing_evaluate_config_value(config_type, config_input)
-    except DagsterEvaluateConfigValueError as e:
-        raise DagsterTypeError(
-            'Invalid config value on type {dagster_type}: {error_msg}. Value received {value}'.
-            format(
-                value=json.dumps(config_input, indent=2)
-                if isinstance(config_input, dict) else config_input,
-                dagster_type=config_type.name,
-                error_msg=','.join(e.args),
-            )
         )
 
 

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -1,4 +1,5 @@
 from dagster import (
+    DagsterEvaluateConfigValueError,
     DagsterInvariantViolationError,
     PipelineDefinition,
     PipelineContextDefinition,
@@ -8,7 +9,11 @@ from dagster import (
     execute_pipeline,
 )
 
+from dagster.core.evaluator import evaluate_config_value
+
 from dagster.core.execution_context import ExecutionContext
+
+from dagster.core.types import DagsterType
 
 
 def execute_single_solid_in_isolation(
@@ -95,3 +100,14 @@ def single_output_transform(name, inputs, transform_fn, output, description=None
         outputs=[output],
         description=description,
     )
+
+
+def throwing_evaluate_config_value(dagster_type, config_value):
+    check.inst_param(dagster_type, 'dagster_type', DagsterType)
+    result = evaluate_config_value(dagster_type, config_value)
+    if not result.success:
+        raise DagsterEvaluateConfigValueError(
+            result.errors[0].stack,
+            result.errors[0].message,
+        )
+    return result.value

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -287,8 +287,8 @@ class Field:
         if is_optional == INFER_OPTIONAL_COMPOSITE_FIELD:
             is_optional = all_optional_type(dagster_type)
             if is_optional is True:
-                from .evaluator import throwing_evaluate_config_value
-                self._default_value = lambda: throwing_evaluate_config_value(dagster_type, None)
+                from .evaluator import hard_create_config_value
+                self._default_value = lambda: hard_create_config_value(dagster_type, None)
             else:
                 self._default_value = default_value
         else:
@@ -366,8 +366,7 @@ class DagsterCompositeTypeBase(DagsterType):
         )
 
     def coerce_runtime_value(self, value):
-        from .evaluator import throwing_evaluate_config_value
-        return throwing_evaluate_config_value(self, value)
+        return value
 
     def iterate_types(self):
         for field_type in self.field_dict.values():
@@ -492,11 +491,7 @@ class _Dict(DagsterCompositeType):
         )
 
     def coerce_runtime_value(self, value):
-        if value is not None and not isinstance(value, dict):
-            raise DagsterRuntimeCoercionError('Incoming value for composite must be dict')
-        ## TODO make this return value
-        from .evaluator import throwing_evaluate_config_value
-        return throwing_evaluate_config_value(self, value)
+        return value
 
 
 String = DagsterStringType(name='String', description='A string.')


### PR DESCRIPTION
@mgasner is going to embark on some changes to the type system this week. In prep for this, this diff eliminates some pure technical debt that just confuses this system. We were actually running config values through the evaluation machinery twice in a lot of cases.