### PR TITLE
Enable common editor shortcuts in config editor

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/ConfigCodeEditor.tsx
@@ -63,6 +63,7 @@ export default class ConfigCodeEditor extends React.Component<
               closeOnUnfocus: false,
               typeConfig: this.props.typeConfig
             },
+            keyMap: "sublime",
             extraKeys: {
               "Cmd-Space": (editor: any) =>
                 editor.showHint({


### PR DESCRIPTION
We were importing the sublime keymappings but not turning them on