### PR TITLE
Improve error messages

### DIFF
--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -11,6 +11,7 @@ from .definitions import (
     SolidDefinition,
     check,
 )
+from .errors import DagsterInvariantViolationError
 
 if hasattr(inspect, 'signature'):
     funcsigs = inspect
@@ -331,7 +332,7 @@ def _create_solid_transform_wrapper(fn, input_defs, output_defs):
             elif len(output_defs) == 1:
                 yield Result(value=result, output_name=output_defs[0].name)
             elif result is not None:
-                raise Exception(
+                raise DagsterInvariantViolationError(
                     'Solid unexpectedly returned output {result} of type {type_}. Should be a '
                     'MultipleResults object, or a generator, containing or yielding {n_results} '
                     'results: {{{expected_results}}}.'.format(

--- a/python_modules/dagster/dagster/core/decorators.py
+++ b/python_modules/dagster/dagster/core/decorators.py
@@ -331,8 +331,23 @@ def _create_solid_transform_wrapper(fn, input_defs, output_defs):
             elif len(output_defs) == 1:
                 yield Result(value=result, output_name=output_defs[0].name)
             elif result is not None:
-                # XXX(freiksenet)
-                raise Exception('Output for a solid without an output.')
+                raise Exception(
+                    'Solid unexpectedly returned output {result} of type {type_}. Should be a '
+                    'MultipleResults object, or a generator, containing or yielding {n_results} '
+                    'results: {{{expected_results}}}.'.format(
+                        result=result,
+                        type_=type(result),
+                        n_results=len(output_defs),
+                        expected_results=', '.join(
+                            [
+                                '\'{result_name}\': {dagster_type}'.format(
+                                    result_name=output_def.name,
+                                    dagster_type=output_def.dagster_type
+                                ) for output_def in output_defs
+                            ]
+                        )
+                    )
+                )
 
     return transform
 

--- a/python_modules/dagster/dagster/dagster_examples/log_spew/pipeline.py
+++ b/python_modules/dagster/dagster/dagster_examples/log_spew/pipeline.py
@@ -1,6 +1,7 @@
 from dagster import (
     DependencyDefinition,
     InputDefinition,
+    MultipleResults,
     OutputDefinition,
     PipelineDefinition,
     solid,
@@ -30,7 +31,7 @@ def nonce_solid(name, n_inputs, n_outputs):
                 info.context.info('Info message seq={i} from solid {name}'.format(i=i, name=name))
             else:
                 info.context.debug('Debug message seq={i} from solid {name}'.format(i=i, name=name))
-        return ['foo' for i in range(n_outputs)]
+        return MultipleResults.from_dict({'output_{}'.format(i): 'foo' for i in range(n_outputs)})
 
     return solid_fn
 


### PR DESCRIPTION
@freiksenet this picks up your TODO at https://github.com/dagster-io/dagster/compare/improve-error-messages?expand=1#diff-d6cafa96061ca741ccbf66bbec542549L334

Our status quo behavior is a little suspect, as documented by the new test `test_solid_with_implicit_single_output_injected`.