### PR TITLE
Improve error messaging and document behavior in tests

### DIFF
--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -1,5 +1,7 @@
 import pytest
 
+import dagster.check as check
+
 from dagster import (
     DagsterInvalidDefinitionError,
     Field,
@@ -11,6 +13,10 @@ from dagster import (
     solid,
     types,
 )
+
+from dagster.core.utility_solids import define_stub_solid
+
+from .test_pipeline_execution import create_solid_with_deps
 
 
 def solid_a_b_list():
@@ -31,8 +37,36 @@ def solid_a_b_list():
 
 
 def test_no_dep_specified():
-    with pytest.raises(DagsterInvalidDefinitionError, match='Dependency must be specified'):
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=
+        'Solid B is passed to list of pipeline solids, but is not used in pipeline. You must define its dependencies:'
+    ):
         PipelineDefinition(solids=solid_a_b_list(), dependencies={})
+
+
+def test_missing_inputs():
+    bar_solid = define_stub_solid('bar', [{'baz': 'bip'}])
+    foo_solid = create_solid_with_deps('foo', bar_solid)
+    baz_solid = create_solid_with_deps('baz', foo_solid)
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match='Dependency must be specified for solid foo input bar'
+    ):
+        PipelineDefinition(
+            solids=[baz_solid, foo_solid],
+            dependencies={'baz': {
+                'foo': DependencyDefinition('foo')
+            }},
+        )
+
+
+def test_create_pipeline_with_bad_solids_list():
+    stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
+    with pytest.raises(check.ParameterCheckError, match='Param "solids" is not a list.'):
+        PipelineDefinition(
+            solids=stub_solid,
+            dependencies={},
+        )
 
 
 def test_circular_dep():

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -299,26 +299,17 @@ def test_create_single_solid_pipeline_with_alias():
     assert result.result_for_solid('aliased').transformed_value() == expected
 
 
-def test_create_pipeline_with_bad_solids_list():
-    stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
-    with pytest.raises(check.ParameterCheckError) as exc_info:
-        single_solid_pipeline = PipelineDefinition(
-            solids=stub_solid,
-            dependencies={},
-        )
-
-    assert 'Param "solids" is not a list.' in str(exc_info.value)
-
-
 def test_create_pipeline_with_empty_solids_list():
-    stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
     single_solid_pipeline = PipelineDefinition(
         solids=[],
         dependencies={},
     )
 
+    result = execute_pipeline(single_solid_pipeline)
+    assert result.success
 
-def test_create_singleton_pipeline():
+
+def test_singleton_pipeline():
     stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
     single_solid_pipeline = PipelineDefinition(
         solids=[stub_solid],
@@ -329,17 +320,28 @@ def test_create_singleton_pipeline():
     assert result.success
 
 
-def test_unused_solid_pipeline():
+def test_two_root_solid_pipeline_with_empty_dependency_definition():
     stub_solid_a = define_stub_solid('stub_a', [{'a key': 'a value'}])
     stub_solid_b = define_stub_solid('stub_b', [{'a key': 'a value'}])
-    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
-        single_solid_pipeline = PipelineDefinition(
-            solids=[stub_solid_a, stub_solid_b],
-            dependencies={'stub_a': {}},
-        )
+    single_solid_pipeline = PipelineDefinition(
+        solids=[stub_solid_a, stub_solid_b],
+        dependencies={},
+    )
 
-    assert 'Solid stub_b is passed to list of pipeline solids, but is not used in pipeline.' in \
-        str(exc_info.value)
+    result = execute_pipeline(single_solid_pipeline)
+    assert result.success
+
+
+def test_two_root_solid_pipeline_with_partial_dependency_definition():
+    stub_solid_a = define_stub_solid('stub_a', [{'a key': 'a value'}])
+    stub_solid_b = define_stub_solid('stub_b', [{'a key': 'a value'}])
+    single_solid_pipeline = PipelineDefinition(
+        solids=[stub_solid_a, stub_solid_b],
+        dependencies={'stub_a': {}},
+    )
+
+    result = execute_pipeline(single_solid_pipeline)
+    assert result.success
 
 
 def _do_test(pipeline, do_execute_pipeline_iter):

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -1,3 +1,7 @@
+import pytest
+
+import dagster.check as check
+
 from dagster import (
     DependencyDefinition,
     InputDefinition,
@@ -16,6 +20,8 @@ from dagster.core.definitions import (
     _create_adjacency_lists,
     Solid,
 )
+
+from dagster.core.errors import DagsterInvalidDefinitionError
 
 from dagster.core.execution import (
     SolidExecutionResult,
@@ -291,6 +297,49 @@ def test_create_single_solid_pipeline_with_alias():
 
     expected = [{'a_key': 'stubbed_thing'}, {'A': 'transform_called'}]
     assert result.result_for_solid('aliased').transformed_value() == expected
+
+
+def test_create_pipeline_with_bad_solids_list():
+    stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
+    with pytest.raises(check.ParameterCheckError) as exc_info:
+        single_solid_pipeline = PipelineDefinition(
+            solids=stub_solid,
+            dependencies={},
+        )
+
+    assert 'Param "solids" is not a list.' in str(exc_info.value)
+
+
+def test_create_pipeline_with_empty_solids_list():
+    stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
+    single_solid_pipeline = PipelineDefinition(
+        solids=[],
+        dependencies={},
+    )
+
+
+def test_create_singleton_pipeline():
+    stub_solid = define_stub_solid('stub', [{'a key': 'a value'}])
+    single_solid_pipeline = PipelineDefinition(
+        solids=[stub_solid],
+        dependencies={},
+    )
+
+    result = execute_pipeline(single_solid_pipeline)
+    assert result.success
+
+
+def test_unused_solid_pipeline():
+    stub_solid_a = define_stub_solid('stub_a', [{'a key': 'a value'}])
+    stub_solid_b = define_stub_solid('stub_b', [{'a key': 'a value'}])
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        single_solid_pipeline = PipelineDefinition(
+            solids=[stub_solid_a, stub_solid_b],
+            dependencies={'stub_a': {}},
+        )
+
+    assert 'Solid stub_b is passed to list of pipeline solids, but is not used in pipeline.' in \
+        str(exc_info.value)
 
 
 def _do_test(pipeline, do_execute_pipeline_iter):


### PR DESCRIPTION
This improves error handling slightly. Note the maybe inconsistent behavior now documented by `test_create_singleton_pipeline` and `test_unused_solid_pipeline`, caused by the automatic shim at https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/core/definitions.py#L429.