### PR TITLE
Add descriptions to config in sidebar, improve styling

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/Config.tsx
+++ b/python_modules/dagit/dagit/webapp/src/Config.tsx
@@ -20,8 +20,13 @@ function renderTypeRecursive(
     return (
       <>
         {`{`}
-        {type.fields.map((fieldData: any) => (
+        {type.fields.map(fieldData => (
           <DictEntry key={fieldData.name}>
+            {fieldData.description && (
+              <DictComment>{`${innerIndent}/* ${
+                fieldData.description
+              } */`}</DictComment>
+            )}
             {innerIndent}
             <DictKey>{fieldData.name}</DictKey>
             {fieldData.isOptional && Optional}
@@ -60,6 +65,7 @@ export default class Config extends React.Component<ConfigProps, {}> {
     ConfigFragment: gql`
       fragment TypeInfoFragment on Type {
         name
+        description
         isDict
         isList
         isNullable
@@ -69,6 +75,7 @@ export default class Config extends React.Component<ConfigProps, {}> {
         ... on CompositeType {
           fields {
             name
+            description
             type {
               name
             }
@@ -107,19 +114,24 @@ export default class Config extends React.Component<ConfigProps, {}> {
 }
 
 const ConfigWrapper = styled.code`
-  margin-top: 10px;
-  margin-bottom: 10px;
   color: ${Colors.GRAY3};
   display: block;
   white-space: pre-wrap;
   font-size: smaller;
-  line-height: 20px;
+  line-height: 18px;
 `;
 
 const DictEntry = styled.div``;
 
 const DictKey = styled.span`
   color: ${Colors.BLACK};
+`;
+
+const DictComment = styled.div`
+  /* This allows long comments to wrap as nice indented blocks, while
+     copy/pasting as a single line with space-based indentation. */
+  text-indent: -3em;
+  padding-left: 3em;
 `;
 
 const Optional = (

--- a/python_modules/dagit/dagit/webapp/src/Description.tsx
+++ b/python_modules/dagit/dagit/webapp/src/Description.tsx
@@ -92,6 +92,9 @@ const Container = styled.div`
   overflow: hidden;
   font-size: 0.8rem;
   position: relative;
+  p:last-child {
+    margin-bottom: 5px;
+  }
 `;
 
 const Mask = styled.div`

--- a/python_modules/dagit/dagit/webapp/src/SidebarComponents.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarComponents.tsx
@@ -55,7 +55,8 @@ export const SidebarTitle = styled.h3`
 
 export const SectionItemHeader = styled.h4`
   font-family: "Source Code Pro", monospace;
-  margin: 8px 0;
+  font-size: 15px;
+  margin: 6px 0;
 `;
 
 export const SidebarSubhead = styled.div`
@@ -65,7 +66,14 @@ export const SidebarSubhead = styled.div`
   margin-top: 14px;
 `;
 export const SectionItemContainer = styled.div`
-  margin-bottom: 10px;
+  border-bottom: 1px solid ${Colors.LIGHT_GRAY2};
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 5px;
+  }
 `;
 
 // Internal

--- a/python_modules/dagit/dagit/webapp/src/SidebarPipelineInfo.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarPipelineInfo.tsx
@@ -14,10 +14,6 @@ import Config from "./Config";
 import { SidebarPipelineInfoFragment } from "./types/SidebarPipelineInfoFragment";
 import { IconNames } from "@blueprintjs/icons";
 
-// TODO (schrockn/bengotow)
-// For pipelines with multiple resources this was a tad aggressive,
-// so commenting it out for now.
-// const NO_DESCRIPTION = "No description provided.";
 const NO_DESCRIPTION = "";
 
 interface ISidebarPipelineInfoProps {
@@ -66,7 +62,7 @@ export default class SidebarPipelineInfo extends React.Component<
         </SidebarSection>
         <SidebarSection title={"Contexts"}>
           {pipeline.contexts.map(context => (
-            <ContextContainer key={context.name}>
+            <SectionItemContainer key={context.name}>
               <SectionItemHeader>{context.name}</SectionItemHeader>
               <Description
                 description={context.description || NO_DESCRIPTION}
@@ -74,9 +70,15 @@ export default class SidebarPipelineInfo extends React.Component<
               {context.config && <Config config={context.config} />}
               {context.resources.map(resource => (
                 <ContextResourceContainer key={resource.name}>
-                  <Icon icon={IconNames.LAYERS} color={Colors.DARK_GRAY2} />
+                  <Icon
+                    iconSize={14}
+                    icon={IconNames.LAYERS}
+                    color={Colors.DARK_GRAY2}
+                  />
                   <div>
-                    <SectionItemHeader>{resource.name}</SectionItemHeader>
+                    <ContextResourceHeader>
+                      {resource.name}
+                    </ContextResourceHeader>
                     <Description
                       description={resource.description || NO_DESCRIPTION}
                     />
@@ -84,7 +86,7 @@ export default class SidebarPipelineInfo extends React.Component<
                   </div>
                 </ContextResourceContainer>
               ))}
-            </ContextContainer>
+            </SectionItemContainer>
           ))}
         </SidebarSection>
       </div>
@@ -92,13 +94,8 @@ export default class SidebarPipelineInfo extends React.Component<
   }
 }
 
-const ContextContainer = styled(SectionItemContainer)`
-  border-bottom: 1px solid ${Colors.LIGHT_GRAY2};
-  margin-bottom: 20px;
-  padding-bottom: 20px;
-  &:last-child {
-    border-bottom: none;
-  }
+const ContextResourceHeader = styled(SectionItemHeader)`
+  font-size: 13px;
 `;
 
 const ContextResourceContainer = styled.div`
@@ -106,7 +103,7 @@ const ContextResourceContainer = styled.div`
   align-items: flex-start;
   padding-top: 15px;
   & .bp3-icon {
-    padding-top: 10px;
+    padding-top: 7px;
     padding-right: 10px;
   }
 `;

--- a/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
+++ b/python_modules/dagit/dagit/webapp/src/SidebarSolidInfo.tsx
@@ -106,14 +106,16 @@ export default class SidebarSolidInfo extends React.Component<
             </Text>
           )}
           {definition.expectations.length > 0 ? <H6>Expectations</H6> : null}
-          <UL>
-            {definition.expectations.map((expectation, i) => (
-              <li key={i}>
-                {expectation.name}
-                <Description description={expectation.description} />
-              </li>
-            ))}
-          </UL>
+          {definition.expectations.length > 0 ? (
+            <UL>
+              {definition.expectations.map((expectation, i) => (
+                <li key={i}>
+                  {expectation.name}
+                  <Description description={expectation.description} />
+                </li>
+              ))}
+            </UL>
+          ) : null}
         </SectionItemContainer>
       )
     );

--- a/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -24,7 +24,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-frDJqD fufUhH"
+        className="sc-kvZOFW YGnhO"
       >
         <span
           className="bp3-popover-wrapper"
@@ -75,11 +75,11 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-kvZOFW gchTTx"
+          className="sc-hqyNC cNpWOq"
         >
           <a
             active={true}
-            className="sc-hqyNC juXOEG"
+            className="sc-jbKcbu fWwXBu"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
@@ -87,7 +87,7 @@ Array [
           </a>
           <a
             active={false}
-            className="sc-hqyNC kZJHpv"
+            className="sc-jbKcbu eIUbjt"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
@@ -98,10 +98,10 @@ Array [
     </div>
   </div>,
   <div
-    className="sc-jWBwVP jXDqsr"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-brqgnP ccjrfS"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
           "width": "70vw",
@@ -109,7 +109,7 @@ Array [
       }
     >
       <div
-        className="sc-jAaTju gauvsM"
+        className="sc-jDwBTQ bSCVyv"
       >
         <span
           className="bp3-popover-wrapper"
@@ -157,7 +157,7 @@ Array [
           </span>
         </span>
         <input
-          className="sc-jDwBTQ iSYPrz"
+          className="sc-gPEVay ldPQtW"
           onChange={[Function]}
           placeholder="Filter..."
           type="text"
@@ -492,7 +492,7 @@ Array [
       />
     </div>
     <div
-      className="sc-cMljjf ergilj"
+      className="sc-jAaTju cVRbSZ"
       style={
         Object {
           "width": "30vw",
@@ -500,14 +500,14 @@ Array [
       }
     >
       <div
-        className="sc-eHgmQL cExWIO"
+        className="sc-cvbbAY eJUIRn"
       >
         <a
           href="/pandas_hello_world/load_num_csv"
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY khgIJN"
+            className="sc-jWBwVP jjMzhC"
           >
             <span
               className="bp3-icon bp3-icon-diagram-tree"
@@ -541,7 +541,7 @@ Array [
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY jFgLi"
+            className="sc-jWBwVP hPUXXS"
           >
             <span
               className="bp3-icon bp3-icon-manual"
@@ -637,7 +637,7 @@ Array [
                 className="sc-dxgOiQ dPbrCh"
               >
                 <div
-                  className="sc-jTzLTM FbleH"
+                  className="sc-jTzLTM hukIzI"
                   onClick={[Function]}
                   style={
                     Object {
@@ -745,7 +745,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-frDJqD fufUhH"
+        className="sc-kvZOFW YGnhO"
       >
         <span
           className="bp3-popover-wrapper"
@@ -834,7 +834,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-frDJqD fufUhH"
+        className="sc-kvZOFW YGnhO"
       >
         <span
           className="bp3-popover-wrapper"
@@ -885,11 +885,11 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-kvZOFW gchTTx"
+          className="sc-hqyNC cNpWOq"
         >
           <a
             active={true}
-            className="sc-hqyNC juXOEG"
+            className="sc-jbKcbu fWwXBu"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
@@ -897,7 +897,7 @@ Array [
           </a>
           <a
             active={false}
-            className="sc-hqyNC kZJHpv"
+            className="sc-jbKcbu eIUbjt"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
@@ -908,10 +908,10 @@ Array [
     </div>
   </div>,
   <div
-    className="sc-jWBwVP jXDqsr"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-brqgnP ccjrfS"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
           "width": "70vw",
@@ -919,7 +919,7 @@ Array [
       }
     >
       <div
-        className="sc-jAaTju gauvsM"
+        className="sc-jDwBTQ bSCVyv"
       >
         <span
           className="bp3-popover-wrapper"
@@ -967,7 +967,7 @@ Array [
           </span>
         </span>
         <input
-          className="sc-jDwBTQ iSYPrz"
+          className="sc-gPEVay ldPQtW"
           onChange={[Function]}
           placeholder="Filter..."
           type="text"
@@ -1302,7 +1302,7 @@ Array [
       />
     </div>
     <div
-      className="sc-cMljjf ergilj"
+      className="sc-jAaTju cVRbSZ"
       style={
         Object {
           "width": "30vw",
@@ -1310,14 +1310,14 @@ Array [
       }
     >
       <div
-        className="sc-eHgmQL cExWIO"
+        className="sc-cvbbAY eJUIRn"
       >
         <a
           href="/pandas_hello_world"
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY jFgLi"
+            className="sc-jWBwVP hPUXXS"
           >
             <span
               className="bp3-icon bp3-icon-diagram-tree"
@@ -1351,7 +1351,7 @@ Array [
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY khgIJN"
+            className="sc-jWBwVP jjMzhC"
           >
             <span
               className="bp3-icon bp3-icon-manual"
@@ -1494,15 +1494,15 @@ Array [
                 className="sc-dxgOiQ dPbrCh"
               >
                 <div
-                  className="sc-kEYyzF lnALwk sc-kGXeez fDgYil"
+                  className="sc-kGXeez eAvgrC"
                 >
                   <h4
-                    className="sc-chPdSV jUtMzA"
+                    className="sc-chPdSV bzfSHL"
                   >
                     default
                   </h4>
                   <code
-                    className="sc-jKJlTe iEmlwG"
+                    className="sc-jKJlTe rcQGl"
                   >
                     {
                     <div
@@ -1573,7 +1573,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-frDJqD fufUhH"
+        className="sc-kvZOFW YGnhO"
       >
         <span
           className="bp3-popover-wrapper"
@@ -1624,11 +1624,11 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-kvZOFW gchTTx"
+          className="sc-hqyNC cNpWOq"
         >
           <a
             active={true}
-            className="sc-hqyNC juXOEG"
+            className="sc-jbKcbu fWwXBu"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
@@ -1636,7 +1636,7 @@ Array [
           </a>
           <a
             active={false}
-            className="sc-hqyNC kZJHpv"
+            className="sc-jbKcbu eIUbjt"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
@@ -1647,10 +1647,10 @@ Array [
     </div>
   </div>,
   <div
-    className="sc-jWBwVP jXDqsr"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-brqgnP ccjrfS"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
           "width": "70vw",
@@ -1658,7 +1658,7 @@ Array [
       }
     >
       <div
-        className="sc-jAaTju gauvsM"
+        className="sc-jDwBTQ bSCVyv"
       >
         <span
           className="bp3-popover-wrapper"
@@ -1706,7 +1706,7 @@ Array [
           </span>
         </span>
         <input
-          className="sc-jDwBTQ iSYPrz"
+          className="sc-gPEVay ldPQtW"
           onChange={[Function]}
           placeholder="Filter..."
           type="text"
@@ -2041,7 +2041,7 @@ Array [
       />
     </div>
     <div
-      className="sc-cMljjf ergilj"
+      className="sc-jAaTju cVRbSZ"
       style={
         Object {
           "width": "30vw",
@@ -2049,14 +2049,14 @@ Array [
       }
     >
       <div
-        className="sc-eHgmQL cExWIO"
+        className="sc-cvbbAY eJUIRn"
       >
         <a
           href="/pandas_hello_world/load_num_csv"
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY jFgLi"
+            className="sc-jWBwVP hPUXXS"
           >
             <span
               className="bp3-icon bp3-icon-diagram-tree"
@@ -2090,7 +2090,7 @@ Array [
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY khgIJN"
+            className="sc-jWBwVP jjMzhC"
           >
             <span
               className="bp3-icon bp3-icon-manual"
@@ -2233,15 +2233,15 @@ Array [
                 className="sc-dxgOiQ dPbrCh"
               >
                 <div
-                  className="sc-kEYyzF lnALwk sc-kGXeez fDgYil"
+                  className="sc-kGXeez eAvgrC"
                 >
                   <h4
-                    className="sc-chPdSV jUtMzA"
+                    className="sc-chPdSV bzfSHL"
                   >
                     default
                   </h4>
                   <code
-                    className="sc-jKJlTe iEmlwG"
+                    className="sc-jKJlTe rcQGl"
                   >
                     {
                     <div
@@ -2312,7 +2312,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-frDJqD fufUhH"
+        className="sc-kvZOFW YGnhO"
       >
         <span
           className="bp3-popover-wrapper"
@@ -2363,11 +2363,11 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-kvZOFW gchTTx"
+          className="sc-hqyNC cNpWOq"
         >
           <a
             active={true}
-            className="sc-hqyNC juXOEG"
+            className="sc-jbKcbu fWwXBu"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
@@ -2375,7 +2375,7 @@ Array [
           </a>
           <a
             active={false}
-            className="sc-hqyNC kZJHpv"
+            className="sc-jbKcbu eIUbjt"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
@@ -2386,10 +2386,10 @@ Array [
     </div>
   </div>,
   <div
-    className="sc-jWBwVP jXDqsr"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-brqgnP ccjrfS"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
           "width": "70vw",
@@ -2397,7 +2397,7 @@ Array [
       }
     >
       <div
-        className="sc-jAaTju gauvsM"
+        className="sc-jDwBTQ bSCVyv"
       >
         <span
           className="bp3-popover-wrapper"
@@ -2445,7 +2445,7 @@ Array [
           </span>
         </span>
         <input
-          className="sc-jDwBTQ iSYPrz"
+          className="sc-gPEVay ldPQtW"
           onChange={[Function]}
           placeholder="Filter..."
           type="text"
@@ -2780,7 +2780,7 @@ Array [
       />
     </div>
     <div
-      className="sc-cMljjf ergilj"
+      className="sc-jAaTju cVRbSZ"
       style={
         Object {
           "width": "30vw",
@@ -2788,14 +2788,14 @@ Array [
       }
     >
       <div
-        className="sc-eHgmQL cExWIO"
+        className="sc-cvbbAY eJUIRn"
       >
         <a
           href="/pandas_hello_world/load_num_csv"
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY khgIJN"
+            className="sc-jWBwVP jjMzhC"
           >
             <span
               className="bp3-icon bp3-icon-diagram-tree"
@@ -2829,7 +2829,7 @@ Array [
           onClick={[Function]}
         >
           <div
-            className="sc-cvbbAY jFgLi"
+            className="sc-jWBwVP hPUXXS"
           >
             <span
               className="bp3-icon bp3-icon-manual"
@@ -3066,7 +3066,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-frDJqD fufUhH"
+        className="sc-kvZOFW YGnhO"
       >
         <span
           className="bp3-popover-wrapper"

--- a/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/Config.test.tsx.snap
+++ b/python_modules/dagit/dagit/webapp/src/__tests__/__snapshots__/Config.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders given a basic type 1`] = `
 <code
-  className="sc-bwzfXH jdjHtP"
+  className="sc-bwzfXH kJdBIT"
 >
   <a
     href="/?typeExplorer=Int"
@@ -19,7 +19,7 @@ exports[`renders given a basic type 1`] = `
 
 exports[`renders given a complex type 1`] = `
 <code
-  className="sc-bwzfXH jdjHtP"
+  className="sc-bwzfXH kJdBIT"
 >
   {
   <div

--- a/python_modules/dagit/dagit/webapp/src/__tests__/mockData.tsx
+++ b/python_modules/dagit/dagit/webapp/src/__tests__/mockData.tsx
@@ -6,173 +6,309 @@ import { CONFIG_CODE_EDITOR_CONTAINER_QUERY } from "../configeditor/ConfigCodeEd
 const MOCKS = [
   {
     request: {
-      operationName: "TypeListContainerQuery",
-      queryVariableName: "TYPE_LIST_CONTAINER_QUERY",
-      query: TYPE_LIST_CONTAINER_QUERY,
-      variables: { pipelineName: "pandas_hello_world" }
+      operationName: "PipelineseContainerQuery",
+      queryVariableName: "APP_QUERY",
+      query: APP_QUERY,
+      variables: undefined
     },
     result: {
       data: {
-        pipelineOrError: {
-          __typename: "Pipeline",
-          types: [
+        pipelinesOrError: {
+          __typename: "PipelineConnection",
+          nodes: [
             {
-              name: "Bool",
-              typeAttributes: {
-                isBuiltin: true,
-                isSystemConfig: false,
-                __typename: "TypeAttributes",
-                isNamed: true
+              name: "pandas_hello_world",
+              runs: [],
+              environmentType: {
+                name: "PandasHelloWorld.Environment",
+                __typename: "CompositeType"
               },
+              __typename: "Pipeline",
               description: null,
-              __typename: "RegularType"
-            },
-            {
-              name: "Dict.1",
-              typeAttributes: {
-                isBuiltin: true,
-                isSystemConfig: false,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: "A configuration dictionary with typed fields",
-              __typename: "CompositeType"
-            },
-            {
-              name: "Dict.2",
-              typeAttributes: {
-                isBuiltin: true,
-                isSystemConfig: false,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: "A configuration dictionary with typed fields",
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasDataFrame",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: false,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description:
-                "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-              __typename: "RegularType"
-            },
-            {
-              name: "PandasHelloWorld.ContextConfig",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: "A configuration dictionary with typed fields",
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasHelloWorld.ContextDefinitionConfig.Default",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name:
-                "PandasHelloWorld.ContextDefinitionConfig.Default.Resources",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasHelloWorld.Environment",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasHelloWorld.ExecutionConfig",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasHelloWorld.ExpectationsConfig",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasHelloWorld.SolidConfig.LoadNumCsv",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name: "PandasHelloWorld.SolidsConfigDictionary",
-              typeAttributes: {
-                isBuiltin: false,
-                isSystemConfig: true,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "CompositeType"
-            },
-            {
-              name: "Path",
-              typeAttributes: {
-                isBuiltin: true,
-                isSystemConfig: false,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "RegularType"
-            },
-            {
-              name: "String",
-              typeAttributes: {
-                isBuiltin: true,
-                isSystemConfig: false,
-                __typename: "TypeAttributes",
-                isNamed: true
-              },
-              description: null,
-              __typename: "RegularType"
+              contexts: [
+                {
+                  name: "default",
+                  description: null,
+                  __typename: "PipelineContext",
+                  config: {
+                    type: {
+                      name: "Dict.2",
+                      description:
+                        "A configuration dictionary with typed fields",
+                      isDict: true,
+                      isList: false,
+                      isNullable: false,
+                      innerTypes: [
+                        {
+                          name: "String",
+                          __typename: "RegularType",
+                          description: null,
+                          isDict: false,
+                          isList: false,
+                          isNullable: false,
+                          innerTypes: [],
+                          typeAttributes: {
+                            isNamed: true,
+                            __typename: "TypeAttributes"
+                          }
+                        }
+                      ],
+                      fields: [
+                        {
+                          name: "log_level",
+                          description: null,
+                          type: { name: "String", __typename: "RegularType" },
+                          isOptional: true,
+                          __typename: "TypeField"
+                        }
+                      ],
+                      __typename: "CompositeType",
+                      typeAttributes: {
+                        isNamed: true,
+                        __typename: "TypeAttributes"
+                      }
+                    },
+                    __typename: "Config"
+                  },
+                  resources: []
+                }
+              ],
+              solids: [
+                {
+                  name: "sum_sq_solid",
+                  definition: {
+                    metadata: [],
+                    configDefinition: null,
+                    __typename: "SolidDefinition",
+                    description: null
+                  },
+                  inputs: [
+                    {
+                      definition: {
+                        name: "sum_df",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularType",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+                          typeAttributes: {
+                            isNamed: true,
+                            __typename: "TypeAttributes"
+                          }
+                        },
+                        __typename: "InputDefinition",
+                        description: null,
+                        expectations: []
+                      },
+                      dependsOn: {
+                        definition: {
+                          name: "result",
+                          __typename: "OutputDefinition"
+                        },
+                        solid: { name: "sum_solid", __typename: "Solid" },
+                        __typename: "Output"
+                      },
+                      __typename: "Input"
+                    }
+                  ],
+                  outputs: [
+                    {
+                      definition: {
+                        name: "result",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularType",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+                          typeAttributes: {
+                            isNamed: true,
+                            __typename: "TypeAttributes"
+                          }
+                        },
+                        expectations: [],
+                        __typename: "OutputDefinition",
+                        description: null
+                      },
+                      dependedBy: [],
+                      __typename: "Output"
+                    }
+                  ],
+                  __typename: "Solid"
+                },
+                {
+                  name: "load_num_csv",
+                  definition: {
+                    metadata: [],
+                    configDefinition: {
+                      type: {
+                        description:
+                          "A configuration dictionary with typed fields",
+                        __typename: "CompositeType",
+                        name: "Dict.1",
+                        isDict: true,
+                        isList: false,
+                        isNullable: false,
+                        innerTypes: [
+                          {
+                            name: "Path",
+                            __typename: "RegularType",
+                            description: null,
+                            isDict: false,
+                            isList: false,
+                            isNullable: false,
+                            innerTypes: [],
+                            typeAttributes: {
+                              isNamed: true,
+                              __typename: "TypeAttributes"
+                            }
+                          }
+                        ],
+                        fields: [
+                          {
+                            name: "path",
+                            description: null,
+                            type: { name: "Path", __typename: "RegularType" },
+                            isOptional: false,
+                            __typename: "TypeField"
+                          }
+                        ],
+                        typeAttributes: {
+                          isNamed: true,
+                          __typename: "TypeAttributes"
+                        }
+                      },
+                      __typename: "Config"
+                    },
+                    __typename: "SolidDefinition",
+                    description: null
+                  },
+                  inputs: [],
+                  outputs: [
+                    {
+                      definition: {
+                        name: "result",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularType",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+                          typeAttributes: {
+                            isNamed: true,
+                            __typename: "TypeAttributes"
+                          }
+                        },
+                        expectations: [],
+                        __typename: "OutputDefinition",
+                        description: null
+                      },
+                      dependedBy: [
+                        {
+                          solid: { name: "sum_solid", __typename: "Solid" },
+                          __typename: "Input"
+                        }
+                      ],
+                      __typename: "Output"
+                    }
+                  ],
+                  __typename: "Solid"
+                },
+                {
+                  name: "sum_solid",
+                  definition: {
+                    metadata: [],
+                    configDefinition: null,
+                    __typename: "SolidDefinition",
+                    description: null
+                  },
+                  inputs: [
+                    {
+                      definition: {
+                        name: "num",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularType",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+                          typeAttributes: {
+                            isNamed: true,
+                            __typename: "TypeAttributes"
+                          }
+                        },
+                        __typename: "InputDefinition",
+                        description: null,
+                        expectations: []
+                      },
+                      dependsOn: {
+                        definition: {
+                          name: "result",
+                          __typename: "OutputDefinition"
+                        },
+                        solid: { name: "load_num_csv", __typename: "Solid" },
+                        __typename: "Output"
+                      },
+                      __typename: "Input"
+                    }
+                  ],
+                  outputs: [
+                    {
+                      definition: {
+                        name: "result",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularType",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+                          typeAttributes: {
+                            isNamed: true,
+                            __typename: "TypeAttributes"
+                          }
+                        },
+                        expectations: [],
+                        __typename: "OutputDefinition",
+                        description: null
+                      },
+                      dependedBy: [
+                        {
+                          solid: { name: "sum_sq_solid", __typename: "Solid" },
+                          __typename: "Input"
+                        }
+                      ],
+                      __typename: "Output"
+                    }
+                  ],
+                  __typename: "Solid"
+                }
+              ]
             }
           ]
+        }
+      }
+    }
+  },
+
+  {
+    request: {
+      operationName: "TypeExplorerContainerQuery",
+      queryVariableName: "TYPE_EXPLORER_CONTAINER_QUERY",
+      query: TYPE_EXPLORER_CONTAINER_QUERY,
+      variables: {
+        pipelineName: "pandas_hello_world",
+        typeName: "PandasDataFrame"
+      }
+    },
+    result: {
+      data: {
+        type: {
+          __typename: "RegularType",
+          name: "PandasDataFrame",
+          description:
+            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+          typeAttributes: {
+            isBuiltin: false,
+            isSystemConfig: false,
+            __typename: "TypeAttributes",
+            isNamed: true
+          }
         }
       }
     }
@@ -349,644 +485,171 @@ const MOCKS = [
 
   {
     request: {
-      operationName: "TypeExplorerContainerQuery",
-      queryVariableName: "TYPE_EXPLORER_CONTAINER_QUERY",
-      query: TYPE_EXPLORER_CONTAINER_QUERY,
-      variables: {
-        pipelineName: "pandas_hello_world",
-        typeName: "PandasDataFrame"
-      }
+      operationName: "TypeListContainerQuery",
+      queryVariableName: "TYPE_LIST_CONTAINER_QUERY",
+      query: TYPE_LIST_CONTAINER_QUERY,
+      variables: { pipelineName: "pandas_hello_world" }
     },
     result: {
       data: {
-        type: {
-          __typename: "RegularType",
-          name: "PandasDataFrame",
-          description:
-            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-          typeAttributes: {
-            isBuiltin: false,
-            isSystemConfig: false,
-            __typename: "TypeAttributes",
-            isNamed: true
-          }
-        }
-      }
-    }
-  },
-
-  {
-    request: {
-      operationName: "PipelineseContainerQuery",
-      queryVariableName: "APP_QUERY",
-      query: APP_QUERY,
-      variables: undefined
-    },
-    result: {
-      data: {
-        pipelinesOrError: {
-          __typename: "PipelineConnection",
-          nodes: [
+        pipelineOrError: {
+          __typename: "Pipeline",
+          types: [
             {
-              name: "pandas_hello_world",
-              runs: [
-                {
-                  runId: "d359c04d-8c4a-4851-ae62-bc24028e1468",
-                  status: "SUCCESS",
-                  logs: {
-                    nodes: [
-                      {
-                        message:
-                          "Beginning execution of pipeline pandas_hello_world",
-                        timestamp: "1544860601216",
-                        level: "INFO",
-                        __typename: "PipelineStartEvent"
-                      },
-                      {
-                        message:
-                          "About to execute the compute node graph in the following order ['load_num_csv.transform', 'sum_solid.transform', 'sum_sq_solid.transform']",
-                        timestamp: "1544860601218",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Entering execute_steps loop. Order: ['load_num_csv.transform', 'sum_solid.transform', 'sum_sq_solid.transform']",
-                        timestamp: "1544860601220",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Beginning execution of load_num_csv.transform",
-                        timestamp: "1544860601221",
-                        level: "INFO",
-                        __typename: "ExecutionStepStartEvent",
-                        step: {
-                          name: "load_num_csv.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Executing core transform for solid load_num_csv.",
-                        timestamp: "1544860601221",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          'Solid load_num_csv emitted output "result" value    num1  num2\n0     1     2\n1     3     4',
-                        timestamp: "1544860601301",
-                        level: "INFO",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Execution of load_num_csv.transform succeeded in 80.23190498352051",
-                        timestamp: "1544860601302",
-                        level: "INFO",
-                        __typename: "ExecutionStepSuccessEvent",
-                        step: {
-                          name: "load_num_csv.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message: "Beginning execution of sum_solid.transform",
-                        timestamp: "1544860601303",
-                        level: "INFO",
-                        __typename: "ExecutionStepStartEvent",
-                        step: {
-                          name: "sum_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Executing core transform for solid sum_solid.",
-                        timestamp: "1544860601303",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          'Solid sum_solid emitted output "result" value    num1  num2  sum\n0     1     2    3\n1     3     4    7',
-                        timestamp: "1544860601318",
-                        level: "INFO",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Execution of sum_solid.transform succeeded in 15.486955642700195",
-                        timestamp: "1544860601319",
-                        level: "INFO",
-                        __typename: "ExecutionStepSuccessEvent",
-                        step: {
-                          name: "sum_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Beginning execution of sum_sq_solid.transform",
-                        timestamp: "1544860601321",
-                        level: "INFO",
-                        __typename: "ExecutionStepStartEvent",
-                        step: {
-                          name: "sum_sq_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Executing core transform for solid sum_sq_solid.",
-                        timestamp: "1544860601321",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          'Solid sum_sq_solid emitted output "result" value    num1  num2  sum  sum_sq\n0     1     2    3       9\n1     3     4    7      49',
-                        timestamp: "1544860601330",
-                        level: "INFO",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Execution of sum_sq_solid.transform succeeded in 9.60993766784668",
-                        timestamp: "1544860601331",
-                        level: "INFO",
-                        __typename: "ExecutionStepSuccessEvent",
-                        step: {
-                          name: "sum_sq_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Completing successful execution of pipeline pandas_hello_world",
-                        timestamp: "1544860601332",
-                        level: "INFO",
-                        __typename: "PipelineSuccessEvent"
-                      }
-                    ],
-                    __typename: "LogMessageConnection",
-                    pageInfo: { lastCursor: "15", __typename: "PageInfo" }
-                  },
-                  executionPlan: {
-                    steps: [
-                      {
-                        name: "load_num_csv.transform",
-                        solid: { name: "load_num_csv", __typename: "Solid" },
-                        tag: "TRANSFORM",
-                        __typename: "ExecutionStep"
-                      },
-                      {
-                        name: "sum_solid.transform",
-                        solid: { name: "sum_solid", __typename: "Solid" },
-                        tag: "TRANSFORM",
-                        __typename: "ExecutionStep"
-                      },
-                      {
-                        name: "sum_sq_solid.transform",
-                        solid: { name: "sum_sq_solid", __typename: "Solid" },
-                        tag: "TRANSFORM",
-                        __typename: "ExecutionStep"
-                      }
-                    ],
-                    __typename: "ExecutionPlan"
-                  },
-                  __typename: "PipelineRun"
-                },
-                {
-                  runId: "1cf3859c-2e71-4448-8db6-176aca626cc8",
-                  status: "SUCCESS",
-                  logs: {
-                    nodes: [
-                      {
-                        message:
-                          "Beginning execution of pipeline pandas_hello_world",
-                        timestamp: "1544860606343",
-                        level: "INFO",
-                        __typename: "PipelineStartEvent"
-                      },
-                      {
-                        message:
-                          "About to execute the compute node graph in the following order ['load_num_csv.transform', 'sum_solid.transform', 'sum_sq_solid.transform']",
-                        timestamp: "1544860606345",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Entering execute_steps loop. Order: ['load_num_csv.transform', 'sum_solid.transform', 'sum_sq_solid.transform']",
-                        timestamp: "1544860606348",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Beginning execution of load_num_csv.transform",
-                        timestamp: "1544860606350",
-                        level: "INFO",
-                        __typename: "ExecutionStepStartEvent",
-                        step: {
-                          name: "load_num_csv.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Executing core transform for solid load_num_csv.",
-                        timestamp: "1544860606351",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          'Solid load_num_csv emitted output "result" value    num1  num2\n0     1     2\n1     3     4',
-                        timestamp: "1544860606396",
-                        level: "INFO",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Execution of load_num_csv.transform succeeded in 46.205997467041016",
-                        timestamp: "1544860606398",
-                        level: "INFO",
-                        __typename: "ExecutionStepSuccessEvent",
-                        step: {
-                          name: "load_num_csv.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message: "Beginning execution of sum_solid.transform",
-                        timestamp: "1544860606399",
-                        level: "INFO",
-                        __typename: "ExecutionStepStartEvent",
-                        step: {
-                          name: "sum_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Executing core transform for solid sum_solid.",
-                        timestamp: "1544860606399",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          'Solid sum_solid emitted output "result" value    num1  num2  sum\n0     1     2    3\n1     3     4    7',
-                        timestamp: "1544860606415",
-                        level: "INFO",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Execution of sum_solid.transform succeeded in 15.848875045776367",
-                        timestamp: "1544860606416",
-                        level: "INFO",
-                        __typename: "ExecutionStepSuccessEvent",
-                        step: {
-                          name: "sum_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Beginning execution of sum_sq_solid.transform",
-                        timestamp: "1544860606417",
-                        level: "INFO",
-                        __typename: "ExecutionStepStartEvent",
-                        step: {
-                          name: "sum_sq_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Executing core transform for solid sum_sq_solid.",
-                        timestamp: "1544860606417",
-                        level: "DEBUG",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          'Solid sum_sq_solid emitted output "result" value    num1  num2  sum  sum_sq\n0     1     2    3       9\n1     3     4    7      49',
-                        timestamp: "1544860606429",
-                        level: "INFO",
-                        __typename: "LogMessageEvent"
-                      },
-                      {
-                        message:
-                          "Execution of sum_sq_solid.transform succeeded in 12.370824813842773",
-                        timestamp: "1544860606430",
-                        level: "INFO",
-                        __typename: "ExecutionStepSuccessEvent",
-                        step: {
-                          name: "sum_sq_solid.transform",
-                          __typename: "ExecutionStep"
-                        }
-                      },
-                      {
-                        message:
-                          "Completing successful execution of pipeline pandas_hello_world",
-                        timestamp: "1544860606430",
-                        level: "INFO",
-                        __typename: "PipelineSuccessEvent"
-                      }
-                    ],
-                    __typename: "LogMessageConnection",
-                    pageInfo: { lastCursor: "15", __typename: "PageInfo" }
-                  },
-                  executionPlan: {
-                    steps: [
-                      {
-                        name: "load_num_csv.transform",
-                        solid: { name: "load_num_csv", __typename: "Solid" },
-                        tag: "TRANSFORM",
-                        __typename: "ExecutionStep"
-                      },
-                      {
-                        name: "sum_solid.transform",
-                        solid: { name: "sum_solid", __typename: "Solid" },
-                        tag: "TRANSFORM",
-                        __typename: "ExecutionStep"
-                      },
-                      {
-                        name: "sum_sq_solid.transform",
-                        solid: { name: "sum_sq_solid", __typename: "Solid" },
-                        tag: "TRANSFORM",
-                        __typename: "ExecutionStep"
-                      }
-                    ],
-                    __typename: "ExecutionPlan"
-                  },
-                  __typename: "PipelineRun"
-                }
-              ],
-              environmentType: {
-                name: "PandasHelloWorld.Environment",
-                __typename: "CompositeType"
+              name: "Bool",
+              typeAttributes: {
+                isBuiltin: true,
+                isSystemConfig: false,
+                __typename: "TypeAttributes",
+                isNamed: true
               },
-              __typename: "Pipeline",
               description: null,
-              contexts: [
-                {
-                  name: "default",
-                  description: null,
-                  __typename: "PipelineContext",
-                  config: {
-                    type: {
-                      name: "Dict.2",
-                      isDict: true,
-                      isList: false,
-                      isNullable: false,
-                      innerTypes: [
-                        {
-                          name: "String",
-                          __typename: "RegularType",
-                          isDict: false,
-                          isList: false,
-                          isNullable: false,
-                          innerTypes: [],
-                          description: null,
-                          typeAttributes: {
-                            isNamed: true,
-                            __typename: "TypeAttributes"
-                          }
-                        }
-                      ],
-                      fields: [
-                        {
-                          name: "log_level",
-                          type: { name: "String", __typename: "RegularType" },
-                          isOptional: true,
-                          __typename: "TypeField"
-                        }
-                      ],
-                      __typename: "CompositeType",
-                      description:
-                        "A configuration dictionary with typed fields",
-                      typeAttributes: {
-                        isNamed: true,
-                        __typename: "TypeAttributes"
-                      }
-                    },
-                    __typename: "Config"
-                  },
-                  resources: []
-                }
-              ],
-              solids: [
-                {
-                  name: "sum_sq_solid",
-                  definition: {
-                    metadata: [],
-                    configDefinition: null,
-                    __typename: "SolidDefinition",
-                    description: null
-                  },
-                  inputs: [
-                    {
-                      definition: {
-                        name: "sum_df",
-                        type: {
-                          name: "PandasDataFrame",
-                          __typename: "RegularType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-                          typeAttributes: {
-                            isNamed: true,
-                            __typename: "TypeAttributes"
-                          }
-                        },
-                        __typename: "InputDefinition",
-                        description: null,
-                        expectations: []
-                      },
-                      dependsOn: {
-                        definition: {
-                          name: "result",
-                          __typename: "OutputDefinition"
-                        },
-                        solid: { name: "sum_solid", __typename: "Solid" },
-                        __typename: "Output"
-                      },
-                      __typename: "Input"
-                    }
-                  ],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          name: "PandasDataFrame",
-                          __typename: "RegularType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-                          typeAttributes: {
-                            isNamed: true,
-                            __typename: "TypeAttributes"
-                          }
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                },
-                {
-                  name: "load_num_csv",
-                  definition: {
-                    metadata: [],
-                    configDefinition: {
-                      type: {
-                        description:
-                          "A configuration dictionary with typed fields",
-                        __typename: "CompositeType",
-                        name: "Dict.1",
-                        isDict: true,
-                        isList: false,
-                        isNullable: false,
-                        innerTypes: [
-                          {
-                            name: "Path",
-                            __typename: "RegularType",
-                            isDict: false,
-                            isList: false,
-                            isNullable: false,
-                            innerTypes: [],
-                            description: null,
-                            typeAttributes: {
-                              isNamed: true,
-                              __typename: "TypeAttributes"
-                            }
-                          }
-                        ],
-                        fields: [
-                          {
-                            name: "path",
-                            type: { name: "Path", __typename: "RegularType" },
-                            isOptional: false,
-                            __typename: "TypeField"
-                          }
-                        ],
-                        typeAttributes: {
-                          isNamed: true,
-                          __typename: "TypeAttributes"
-                        }
-                      },
-                      __typename: "Config"
-                    },
-                    __typename: "SolidDefinition",
-                    description: null
-                  },
-                  inputs: [],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          name: "PandasDataFrame",
-                          __typename: "RegularType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-                          typeAttributes: {
-                            isNamed: true,
-                            __typename: "TypeAttributes"
-                          }
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [
-                        {
-                          solid: { name: "sum_solid", __typename: "Solid" },
-                          __typename: "Input"
-                        }
-                      ],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                },
-                {
-                  name: "sum_solid",
-                  definition: {
-                    metadata: [],
-                    configDefinition: null,
-                    __typename: "SolidDefinition",
-                    description: null
-                  },
-                  inputs: [
-                    {
-                      definition: {
-                        name: "num",
-                        type: {
-                          name: "PandasDataFrame",
-                          __typename: "RegularType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-                          typeAttributes: {
-                            isNamed: true,
-                            __typename: "TypeAttributes"
-                          }
-                        },
-                        __typename: "InputDefinition",
-                        description: null,
-                        expectations: []
-                      },
-                      dependsOn: {
-                        definition: {
-                          name: "result",
-                          __typename: "OutputDefinition"
-                        },
-                        solid: { name: "load_num_csv", __typename: "Solid" },
-                        __typename: "Output"
-                      },
-                      __typename: "Input"
-                    }
-                  ],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          name: "PandasDataFrame",
-                          __typename: "RegularType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
-                          typeAttributes: {
-                            isNamed: true,
-                            __typename: "TypeAttributes"
-                          }
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [
-                        {
-                          solid: { name: "sum_sq_solid", __typename: "Solid" },
-                          __typename: "Input"
-                        }
-                      ],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                }
-              ]
+              __typename: "RegularType"
+            },
+            {
+              name: "Dict.1",
+              typeAttributes: {
+                isBuiltin: true,
+                isSystemConfig: false,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: "A configuration dictionary with typed fields",
+              __typename: "CompositeType"
+            },
+            {
+              name: "Dict.2",
+              typeAttributes: {
+                isBuiltin: true,
+                isSystemConfig: false,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: "A configuration dictionary with typed fields",
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasDataFrame",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: false,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description:
+                "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/",
+              __typename: "RegularType"
+            },
+            {
+              name: "PandasHelloWorld.ContextConfig",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: "A configuration dictionary with typed fields",
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasHelloWorld.ContextDefinitionConfig.Default",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name:
+                "PandasHelloWorld.ContextDefinitionConfig.Default.Resources",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasHelloWorld.Environment",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasHelloWorld.ExecutionConfig",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasHelloWorld.ExpectationsConfig",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasHelloWorld.SolidConfig.LoadNumCsv",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name: "PandasHelloWorld.SolidsConfigDictionary",
+              typeAttributes: {
+                isBuiltin: false,
+                isSystemConfig: true,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "CompositeType"
+            },
+            {
+              name: "Path",
+              typeAttributes: {
+                isBuiltin: true,
+                isSystemConfig: false,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "RegularType"
+            },
+            {
+              name: "String",
+              typeAttributes: {
+                isBuiltin: true,
+                isSystemConfig: false,
+                __typename: "TypeAttributes",
+                isNamed: true
+              },
+              description: null,
+              __typename: "RegularType"
             }
           ]
         }

--- a/python_modules/dagit/dagit/webapp/src/configeditor/types/ConfigExplorerFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/configeditor/types/ConfigExplorerFragment.ts
@@ -17,11 +17,11 @@ export interface ConfigExplorerFragment_contexts_config_type_RegularType_innerTy
 
 export interface ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -39,17 +39,18 @@ export interface ConfigExplorerFragment_contexts_config_type_RegularType_innerTy
 
 export interface ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -62,11 +63,11 @@ export interface ConfigExplorerFragment_contexts_config_type_RegularType_typeAtt
 
 export interface ConfigExplorerFragment_contexts_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_contexts_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_contexts_config_type_RegularType_typeAttributes;
 }
 
@@ -80,11 +81,11 @@ export interface ConfigExplorerFragment_contexts_config_type_CompositeType_inner
 
 export interface ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -102,17 +103,18 @@ export interface ConfigExplorerFragment_contexts_config_type_CompositeType_inner
 
 export interface ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -129,17 +131,18 @@ export interface ConfigExplorerFragment_contexts_config_type_CompositeType_field
 
 export interface ConfigExplorerFragment_contexts_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigExplorerFragment_contexts_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigExplorerFragment_contexts_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_contexts_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_contexts_config_type_CompositeType_typeAttributes;
   fields: ConfigExplorerFragment_contexts_config_type_CompositeType_fields[];
 }
@@ -166,11 +169,11 @@ export interface ConfigExplorerFragment_solids_definition_configDefinition_type_
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -188,17 +191,18 @@ export interface ConfigExplorerFragment_solids_definition_configDefinition_type_
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -211,11 +215,11 @@ export interface ConfigExplorerFragment_solids_definition_configDefinition_type_
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_solids_definition_configDefinition_type_RegularType_typeAttributes;
 }
 
@@ -229,11 +233,11 @@ export interface ConfigExplorerFragment_solids_definition_configDefinition_type_
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -251,17 +255,18 @@ export interface ConfigExplorerFragment_solids_definition_configDefinition_type_
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -278,17 +283,18 @@ export interface ConfigExplorerFragment_solids_definition_configDefinition_type_
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_typeAttributes;
   fields: ConfigExplorerFragment_solids_definition_configDefinition_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/AppQuery.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/AppQuery.ts
@@ -96,11 +96,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_con
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -118,17 +118,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_con
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -141,11 +142,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_con
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_RegularType_typeAttributes;
 }
 
@@ -159,11 +160,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_con
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -181,17 +182,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_con
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -208,17 +210,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_con
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_type_CompositeType_fields[];
 }
@@ -239,11 +242,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_res
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -261,17 +264,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_res
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -284,11 +288,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_res
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_RegularType_typeAttributes;
 }
 
@@ -302,11 +306,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_res
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -324,17 +328,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_res
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -351,17 +356,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_res
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_fields[];
 }
@@ -400,11 +406,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_defin
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -422,17 +428,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_defin
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -463,11 +470,11 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_defin
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -485,17 +492,18 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_defin
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -512,6 +520,7 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_defin
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_fields_type;
   isOptional: boolean;
 }

--- a/python_modules/dagit/dagit/webapp/src/types/ConfigFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/ConfigFragment.ts
@@ -17,11 +17,11 @@ export interface ConfigFragment_type_RegularType_innerTypes_RegularType_typeAttr
 
 export interface ConfigFragment_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigFragment_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigFragment_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -39,17 +39,18 @@ export interface ConfigFragment_type_RegularType_innerTypes_CompositeType_fields
 
 export interface ConfigFragment_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigFragment_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigFragment_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigFragment_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigFragment_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: ConfigFragment_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -62,11 +63,11 @@ export interface ConfigFragment_type_RegularType_typeAttributes {
 
 export interface ConfigFragment_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigFragment_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigFragment_type_RegularType_typeAttributes;
 }
 
@@ -80,11 +81,11 @@ export interface ConfigFragment_type_CompositeType_innerTypes_RegularType_typeAt
 
 export interface ConfigFragment_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigFragment_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigFragment_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -102,17 +103,18 @@ export interface ConfigFragment_type_CompositeType_innerTypes_CompositeType_fiel
 
 export interface ConfigFragment_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigFragment_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigFragment_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigFragment_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigFragment_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: ConfigFragment_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -129,17 +131,18 @@ export interface ConfigFragment_type_CompositeType_fields_type {
 
 export interface ConfigFragment_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: ConfigFragment_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface ConfigFragment_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: ConfigFragment_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: ConfigFragment_type_CompositeType_typeAttributes;
   fields: ConfigFragment_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/PipelineExplorerFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/PipelineExplorerFragment.ts
@@ -17,11 +17,11 @@ export interface PipelineExplorerFragment_contexts_config_type_RegularType_inner
 
 export interface PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -39,17 +39,18 @@ export interface PipelineExplorerFragment_contexts_config_type_RegularType_inner
 
 export interface PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -62,11 +63,11 @@ export interface PipelineExplorerFragment_contexts_config_type_RegularType_typeA
 
 export interface PipelineExplorerFragment_contexts_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_config_type_RegularType_typeAttributes;
 }
 
@@ -80,11 +81,11 @@ export interface PipelineExplorerFragment_contexts_config_type_CompositeType_inn
 
 export interface PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -102,17 +103,18 @@ export interface PipelineExplorerFragment_contexts_config_type_CompositeType_inn
 
 export interface PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -129,17 +131,18 @@ export interface PipelineExplorerFragment_contexts_config_type_CompositeType_fie
 
 export interface PipelineExplorerFragment_contexts_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerFragment_contexts_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerFragment_contexts_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_config_type_CompositeType_typeAttributes;
   fields: PipelineExplorerFragment_contexts_config_type_CompositeType_fields[];
 }
@@ -160,11 +163,11 @@ export interface PipelineExplorerFragment_contexts_resources_config_type_Regular
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -182,17 +185,18 @@ export interface PipelineExplorerFragment_contexts_resources_config_type_Regular
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -205,11 +209,11 @@ export interface PipelineExplorerFragment_contexts_resources_config_type_Regular
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_resources_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_resources_config_type_RegularType_typeAttributes;
 }
 
@@ -223,11 +227,11 @@ export interface PipelineExplorerFragment_contexts_resources_config_type_Composi
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -245,17 +249,18 @@ export interface PipelineExplorerFragment_contexts_resources_config_type_Composi
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -272,17 +277,18 @@ export interface PipelineExplorerFragment_contexts_resources_config_type_Composi
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerFragment_contexts_resources_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_typeAttributes;
   fields: PipelineExplorerFragment_contexts_resources_config_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/PipelineExplorerSolidFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/PipelineExplorerSolidFragment.ts
@@ -22,11 +22,11 @@ export interface PipelineExplorerSolidFragment_definition_configDefinition_type_
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -44,17 +44,18 @@ export interface PipelineExplorerSolidFragment_definition_configDefinition_type_
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: PipelineExplorerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -85,11 +86,11 @@ export interface PipelineExplorerSolidFragment_definition_configDefinition_type_
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -107,17 +108,18 @@ export interface PipelineExplorerSolidFragment_definition_configDefinition_type_
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -134,6 +136,7 @@ export interface PipelineExplorerSolidFragment_definition_configDefinition_type_
 
 export interface PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelineExplorerSolidFragment_definition_configDefinition_type_CompositeType_fields_type;
   isOptional: boolean;
 }

--- a/python_modules/dagit/dagit/webapp/src/types/PipelinePageFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/PipelinePageFragment.ts
@@ -96,11 +96,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_t
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -118,17 +118,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_t
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -141,11 +142,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_t
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_RegularType_typeAttributes;
 }
 
@@ -159,11 +160,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_t
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -181,17 +182,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_t
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -208,17 +210,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_t
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_contexts_config_type_CompositeType_fields[];
 }
@@ -239,11 +242,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resource
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -261,17 +264,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resource
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -284,11 +288,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resource
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_RegularType_typeAttributes;
 }
 
@@ -302,11 +306,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resource
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -324,17 +328,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resource
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -351,17 +356,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resource
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_contexts_resources_config_type_CompositeType_fields[];
 }
@@ -400,11 +406,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -422,17 +428,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -463,11 +470,11 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -485,17 +492,18 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -512,6 +520,7 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: PipelinePageFragment_PipelineConnection_nodes_solids_definition_configDefinition_type_CompositeType_fields_type;
   isOptional: boolean;
 }

--- a/python_modules/dagit/dagit/webapp/src/types/SidebarPipelineInfoFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/SidebarPipelineInfoFragment.ts
@@ -17,11 +17,11 @@ export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType_in
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -39,17 +39,18 @@ export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType_in
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -62,11 +63,11 @@ export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType_ty
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_config_type_RegularType_typeAttributes;
 }
 
@@ -80,11 +81,11 @@ export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -102,17 +103,18 @@ export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -129,17 +131,18 @@ export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarPipelineInfoFragment_contexts_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_typeAttributes;
   fields: SidebarPipelineInfoFragment_contexts_config_type_CompositeType_fields[];
 }
@@ -160,11 +163,11 @@ export interface SidebarPipelineInfoFragment_contexts_resources_config_type_Regu
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -182,17 +185,18 @@ export interface SidebarPipelineInfoFragment_contexts_resources_config_type_Regu
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -205,11 +209,11 @@ export interface SidebarPipelineInfoFragment_contexts_resources_config_type_Regu
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_resources_config_type_RegularType_typeAttributes;
 }
 
@@ -223,11 +227,11 @@ export interface SidebarPipelineInfoFragment_contexts_resources_config_type_Comp
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -245,17 +249,18 @@ export interface SidebarPipelineInfoFragment_contexts_resources_config_type_Comp
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -272,17 +277,18 @@ export interface SidebarPipelineInfoFragment_contexts_resources_config_type_Comp
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_typeAttributes;
   fields: SidebarPipelineInfoFragment_contexts_resources_config_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/SidebarSolidInfoFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/SidebarSolidInfoFragment.ts
@@ -88,11 +88,11 @@ export interface SidebarSolidInfoFragment_definition_configDefinition_type_Regul
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -110,17 +110,18 @@ export interface SidebarSolidInfoFragment_definition_configDefinition_type_Regul
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -133,11 +134,11 @@ export interface SidebarSolidInfoFragment_definition_configDefinition_type_Regul
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarSolidInfoFragment_definition_configDefinition_type_RegularType_typeAttributes;
 }
 
@@ -151,11 +152,11 @@ export interface SidebarSolidInfoFragment_definition_configDefinition_type_Compo
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -173,17 +174,18 @@ export interface SidebarSolidInfoFragment_definition_configDefinition_type_Compo
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -200,17 +202,18 @@ export interface SidebarSolidInfoFragment_definition_configDefinition_type_Compo
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_typeAttributes;
   fields: SidebarSolidInfoFragment_definition_configDefinition_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/SidebarTabbedContainerPipelineFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/SidebarTabbedContainerPipelineFragment.ts
@@ -21,11 +21,11 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_Reg
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -43,17 +43,18 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_Reg
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -66,11 +67,11 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_Reg
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_config_type_RegularType_typeAttributes;
 }
 
@@ -84,11 +85,11 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_Com
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -106,17 +107,18 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_Com
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -133,17 +135,18 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_Com
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerPipelineFragment_contexts_config_type_CompositeType_fields[];
 }
@@ -164,11 +167,11 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_resources_confi
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -186,17 +189,18 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_resources_confi
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -209,11 +213,11 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_resources_confi
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_RegularType_typeAttributes;
 }
 
@@ -227,11 +231,11 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_resources_confi
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -249,17 +253,18 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_resources_confi
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -276,17 +281,18 @@ export interface SidebarTabbedContainerPipelineFragment_contexts_resources_confi
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerPipelineFragment_contexts_resources_config_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/SidebarTabbedContainerSolidFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/SidebarTabbedContainerSolidFragment.ts
@@ -88,11 +88,11 @@ export interface SidebarTabbedContainerSolidFragment_definition_configDefinition
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -110,17 +110,18 @@ export interface SidebarTabbedContainerSolidFragment_definition_configDefinition
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes_CompositeType_fields[];
 }
@@ -133,11 +134,11 @@ export interface SidebarTabbedContainerSolidFragment_definition_configDefinition
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_RegularType_typeAttributes;
 }
 
@@ -151,11 +152,11 @@ export interface SidebarTabbedContainerSolidFragment_definition_configDefinition
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_RegularType_typeAttributes;
 }
 
@@ -173,17 +174,18 @@ export interface SidebarTabbedContainerSolidFragment_definition_configDefinition
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes_CompositeType_fields[];
 }
@@ -200,17 +202,18 @@ export interface SidebarTabbedContainerSolidFragment_definition_configDefinition
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_fields {
   name: string;
+  description: string | null;
   type: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_fields_type;
   isOptional: boolean;
 }
 
 export interface SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_innerTypes[];
-  description: string | null;
   typeAttributes: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_typeAttributes;
   fields: SidebarTabbedContainerSolidFragment_definition_configDefinition_type_CompositeType_fields[];
 }

--- a/python_modules/dagit/dagit/webapp/src/types/TypeInfoFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/types/TypeInfoFragment.ts
@@ -17,11 +17,11 @@ export interface TypeInfoFragment_RegularType_typeAttributes {
 
 export interface TypeInfoFragment_RegularType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: TypeInfoFragment_RegularType_innerTypes[];
-  description: string | null;
   typeAttributes: TypeInfoFragment_RegularType_typeAttributes;
 }
 
@@ -35,6 +35,7 @@ export interface TypeInfoFragment_CompositeType_fields_type {
 
 export interface TypeInfoFragment_CompositeType_fields {
   name: string;
+  description: string | null;
   type: TypeInfoFragment_CompositeType_fields_type;
   isOptional: boolean;
 }
@@ -45,12 +46,12 @@ export interface TypeInfoFragment_CompositeType_typeAttributes {
 
 export interface TypeInfoFragment_CompositeType {
   name: string;
+  description: string | null;
   isDict: boolean;
   isList: boolean;
   isNullable: boolean;
   innerTypes: TypeInfoFragment_CompositeType_innerTypes[];
   fields: TypeInfoFragment_CompositeType_fields[];
-  description: string | null;
   typeAttributes: TypeInfoFragment_CompositeType_typeAttributes;
 }
 


### PR DESCRIPTION
This PR adjusts the CSS of the sidebar to better support pipelines with many resources. The resource titles are a bit smaller to indicate they are nested within the context header and the information is less spread out. Config dictionaries now print field descriptions as block comments. 

<img width="485" alt="image" src="https://user-images.githubusercontent.com/1037212/50047584-f5187700-006c-11e9-9a24-65ce2fb6e69b.png">

This PR also updates the solid sidebar a bit to use the same dividers and slightly more compact spacing:

<img width="463" alt="image" src="https://user-images.githubusercontent.com/1037212/50047606-73751900-006d-11e9-8aeb-8537628812c5.png">
