### PR TITLE
Replace stub execution error alert with a nicer one

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/execution/PipelineExecutionContainer.tsx
+++ b/python_modules/dagit/dagit/webapp/src/execution/PipelineExecutionContainer.tsx
@@ -153,12 +153,15 @@ export default class PipelineExecutionContainer extends React.Component<
     proxy: DataProxy,
     result: FetchResult<StartPipelineExecution, StartPipelineExecutionVariables>
   ) => {
-    if (
-      result.data &&
-      result.data.startPipelineExecution.__typename ===
-        "StartPipelineExecutionSuccess"
-    ) {
-      const run = result.data.startPipelineExecution.run;
+    if (!result.data) {
+      alert("No data was returned.");
+      return;
+    }
+
+    const execution = result.data.startPipelineExecution;
+
+    if (execution.__typename === "StartPipelineExecutionSuccess") {
+      const run = execution.run;
       const id = `Pipeline.${this.props.pipeline.name}`;
       const existingData: PipelineExecutionContainerFragment | null = proxy.readFragment(
         {
@@ -183,8 +186,17 @@ export default class PipelineExecutionContainer extends React.Component<
         });
       }
     } else {
-      // XXX(freiksenet): STUB
-      alert("Error in config!");
+      let message = `${
+        this.props.pipeline.name
+      } cannot not be executed with the provided config.`;
+
+      if ("errors" in execution) {
+        message += ` Please fix the following errors:\n\n${execution.errors
+          .map(error => error.message)
+          .join("\n\n")}`;
+      }
+
+      alert(message);
     }
   };
 


### PR DESCRIPTION
This is a small PR that fixes up the execution error alert. I think it's fine that this is a system alert (and convenient that you can dismiss with Enter, etc). Now it includes the actual errors:

<img width="606" alt="image" src="https://user-images.githubusercontent.com/1037212/50047681-488bc480-006f-11e9-8bac-1dbfffa18694.png">
