### PR TITLE
Remove constant 700px rest position from execution node animation

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/execution/PipelineRunExecutionPlanBox.tsx
+++ b/python_modules/dagit/dagit/webapp/src/execution/PipelineRunExecutionPlanBox.tsx
@@ -66,7 +66,11 @@ export class ExecutionPlanBox extends React.Component<IExecutionPlanBoxProps> {
             />
           )}
         </ExeuctionStateWrap>
-        <ExecutionPlanBoxName>{name}</ExecutionPlanBoxName>
+        <ExecutionPlanBoxName>
+          {name}
+          {name}
+          {name}
+        </ExecutionPlanBoxName>
         {elapsed && (
           <ExecutionStateLabel>
             {formatExecutionTime(elapsed)}
@@ -124,16 +128,17 @@ const ExecutionFinishedFlash = styled.div<{ success: boolean }>`
   bottom: 0;
   background: linear-gradient(
     111deg,
-    transparent 40%,
+    transparent 30%,
     rgba(255, 255, 255, 0.7) 65%,
     transparent 68%
   );
-  background-size: 200px;
-  background-position-x: ${({ success }) => (success ? 180 : -180)}px;
+  background-size: 150px;
+  background-position-x: ${({ success }) =>
+    success ? `calc(100% + 150px)` : `-150px`};
   background-repeat-x: no-repeat;
   pointer-events: none;
   transition: ${({ success }) =>
-    success ? "300ms background-position-x linear" : ""};
+    success ? "400ms background-position-x linear" : ""};
 `;
 
 const ExecutionPlanBoxContainer = styled.div<{ state: IStepState }>`


### PR DESCRIPTION
This is just a small edit to this animation to accomodate execution nodes of arbitrary length. Using a fixed value is somewhat preferable because it keeps the velocity of the animation constant, but it seems like these could names could get super long so I'd rather `calc` it than just make the constant larger.

This is what it's meant to look like (except at a better-than-gif framerate) - overall goal is to spice up the transition from running -> finished. We could also do a "pop" of some sort but that might be too aggressive. It seems like we're having trouble getting a good enough framerate for this animation when the execution spews lots of log messages. I'm hoping that when we get the stream debounced on the python side this is less of an issue.

![dec-15-2018 13-59-55](https://user-images.githubusercontent.com/1037212/50047808-22b3ef00-0072-11e9-8f2c-586f8c428ce1.gif)
