### PR TITLE
fix typeahead regression

### DIFF
--- a/python_modules/dagster/dagster/core/configurable.py
+++ b/python_modules/dagster/dagster/core/configurable.py
@@ -115,6 +115,15 @@ class ConfigurableFromDict(Configurable):
         check.str_param(name, 'name')
         return self.field_dict[name]
 
+    def iterate_types(self):
+        for field_type in self.field_dict.values():
+            for inner_type in field_type.dagster_type.iterate_types():
+                yield inner_type
+
+        # FIXME: is_named needs to be moved into Configurable
+        if self.is_named:  # pylint: disable=E1101
+            yield self
+
 
 class ConfigurableObjectFromDict(ConfigurableFromDict):
     pass

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -111,6 +111,40 @@ def test_default_context_config():
     assert 'default' in context_dict
 
 
+def test_all_types_provided():
+    pipeline_def = PipelineDefinition(
+        name='pipeline',
+        solids=[],
+        context_definitions={
+            'some_context':
+            PipelineContextDefinition(
+                config_field=types.Field(
+                    types.NamedDict(
+                        'SomeContextNamedDict',
+                        {
+                            'with_default_int':
+                            Field(
+                                types.Int,
+                                is_optional=True,
+                                default_value=23434,
+                            ),
+                        },
+                    )
+                ),
+                context_fn=lambda *args: None
+            )
+        },
+    )
+
+
+    all_types = list(pipeline_def.all_types())
+    type_names = set(t.name for t in all_types)
+    assert 'SomeContextNamedDict' in type_names
+    assert 'Pipeline.ContextDefinitionConfig.SomeContext' in type_names
+    assert 'Pipeline.ContextDefinitionConfig.SomeContext.Resources' in type_names
+
+
+
 def test_provided_default_config():
     pipeline_def = PipelineDefinition(
         context_definitions={

--- a/python_modules/dagster/dagster/core/types.py
+++ b/python_modules/dagster/dagster/core/types.py
@@ -354,14 +354,6 @@ class _Dict(ConfigurableObjectFromDict, DagsterType):
     def coerce_runtime_value(self, value):
         return value
 
-    def iterate_types(self):
-        for field_type in self.field_dict.values():
-            for inner_type in field_type.dagster_type.iterate_types():
-                yield inner_type
-
-        if self.is_named:
-            yield self
-
 
 String = DagsterStringType(name='String', description='A string.')
 Path = DagsterStringType(


### PR DESCRIPTION
Type system refactor broke the typeahead. All the types in a pipeline were not being found. This is a hacky fix, but it is tested.