### PR TITLE
Execution plan rendering improvements

### DIFF
--- a/python_modules/dagit/dagit/webapp/src/execution/StepMetadataProvider.tsx
+++ b/python_modules/dagit/dagit/webapp/src/execution/StepMetadataProvider.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import produce from "immer";
+import gql from "graphql-tag";
+
+import { StepMetadataProviderMessageFragment } from "./types/StepMetadataProviderMessageFragment";
+
+export enum IStepState {
+  WAITING = "waiting",
+  RUNNING = "running",
+  SUCCEEDED = "succeeded",
+  FAILED = "failed"
+}
+
+export interface IStepMetadata {
+  state: IStepState;
+  start?: number;
+  elapsed?: number;
+  transitionedAt: number;
+}
+
+export interface IStepMetadataDict {
+  [stepName: string]: IStepMetadata;
+}
+
+function extractMetadataFromLogs(
+  logs: StepMetadataProviderMessageFragment[]
+): IStepMetadataDict {
+  const steps = {};
+  logs.forEach(log => {
+    if (log.__typename === "ExecutionStepStartEvent") {
+      steps[log.step.name] = {
+        state: IStepState.RUNNING,
+        start: Number.parseInt(log.timestamp, 10),
+        transitionedAt: log.timestamp
+      };
+    } else if (log.__typename === "ExecutionStepSuccessEvent") {
+      steps[log.step.name] = produce(steps[log.step.name] || {}, step => {
+        step.state = IStepState.SUCCEEDED;
+        if (step.start) {
+          step.transitionedAt = log.timestamp;
+          step.elapsed = Number.parseInt(log.timestamp, 10) - step.start;
+        }
+      });
+    } else if (log.__typename === "ExecutionStepFailureEvent") {
+      steps[log.step.name] = produce(steps[log.step.name] || {}, step => {
+        step.state = IStepState.FAILED;
+        if (step.start) {
+          step.transitionedAt = log.timestamp;
+          step.elapsed = Number.parseInt(log.timestamp, 10) - step.start;
+        }
+      });
+    }
+  });
+  return steps;
+}
+
+interface IStepMetadataProviderProps {
+  logs: StepMetadataProviderMessageFragment[];
+  children: (metadata: IStepMetadataDict) => React.ReactElement<any>;
+}
+
+export default class StepMetadataProvider extends React.Component<
+  IStepMetadataProviderProps
+> {
+  static fragments = {
+    StepMetadataProviderMessageFragment: gql`
+      fragment StepMetadataProviderMessageFragment on PipelineRunEvent {
+        __typename
+        ... on MessageEvent {
+          message
+          timestamp
+        }
+
+        ... on ExecutionStepEvent {
+          step {
+            name
+          }
+        }
+      }
+    `
+  };
+
+  render() {
+    return this.props.children(extractMetadataFromLogs(this.props.logs));
+  }
+}

--- a/python_modules/dagit/dagit/webapp/src/execution/types/StepMetadataProviderMessageFragment.ts
+++ b/python_modules/dagit/dagit/webapp/src/execution/types/StepMetadataProviderMessageFragment.ts
@@ -4,26 +4,27 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL fragment: PipelineRunExecutionPlanFragment
+// GraphQL fragment: StepMetadataProviderMessageFragment
 // ====================================================
 
-export interface PipelineRunExecutionPlanFragment_executionPlan_steps_solid {
+export interface StepMetadataProviderMessageFragment_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent";
+  message: string;
+  timestamp: string;
+}
+
+export interface StepMetadataProviderMessageFragment_ExecutionStepStartEvent_step {
   name: string;
 }
 
-export interface PipelineRunExecutionPlanFragment_executionPlan_steps {
-  name: string;
-  solid: PipelineRunExecutionPlanFragment_executionPlan_steps_solid;
-  tag: StepTag;
+export interface StepMetadataProviderMessageFragment_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent";
+  message: string;
+  timestamp: string;
+  step: StepMetadataProviderMessageFragment_ExecutionStepStartEvent_step;
 }
 
-export interface PipelineRunExecutionPlanFragment_executionPlan {
-  steps: PipelineRunExecutionPlanFragment_executionPlan_steps[];
-}
-
-export interface PipelineRunExecutionPlanFragment {
-  executionPlan: PipelineRunExecutionPlanFragment_executionPlan;
-}
+export type StepMetadataProviderMessageFragment = StepMetadataProviderMessageFragment_LogMessageEvent | StepMetadataProviderMessageFragment_ExecutionStepStartEvent;
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.


### PR DESCRIPTION
This PR makes a few small changes:

- The execution plan boxes render correctly in Firefox. Turns out `background-repeat-x` only works in Chrome.

- The elapsed time is shown in more appropriate units. Previously I thought that millisecond level accuracy would be valuable (I guess for comparing run times) up into the 100's of seconds, but it seems like just showing "4 sec" is fine.

- When nodes in the execution plan are running, the elapsed time counts up in seconds. The value shown in "time since `ExecutionStepStartEvent.timestamp`" and the ticks are scheduled relative to that value, so the transition from 1... 2... 3.. 3.25 (final time) should be smooth and timed correctly.

- I moved the logic that converts log messages into execution plan step metadata into a provider component so that it's not computed on the fly in the ExecutionPlan's render method. This turned out not to be necessary for the final elapsed-time implementation, but I think it'll be necessary if we implement other sorts of effects that require the view to maintain state!