### PR TITLE
Subplan execution and ExecutionGraph removal

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -59,7 +59,10 @@ from dagster.core.evaluator import DagsterEvaluateConfigValueError
 
 from dagster.core.utility_solids import define_stub_solid
 
-from dagster.utils.test import execute_solid
+from dagster.utils.test import (
+    execute_solid,
+    execute_solids,
+)
 
 import dagster.core.config as config
 import dagster.core.types as types
@@ -112,6 +115,7 @@ __all__ = [
     # Utilities
     'define_stub_solid',
     'execute_solid',
+    'execute_solids',
 
     # config
     'config',

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -11,7 +11,7 @@ from dagster import (
     check,
 )
 
-from dagster.core.definitions import ExecutionGraph, Solid
+from dagster.core.definitions import Solid
 from dagster.core.execution import execute_pipeline_iterator
 from dagster.graphviz import build_graphviz_graph
 from dagster.utils import load_yaml_from_glob_list
@@ -53,6 +53,9 @@ def list_command(**kwargs):
     return execute_list_command(kwargs, click.echo)
 
 
+from dagster.core.execution_plan.create import solids_in_topological_order
+
+
 def execute_list_command(cli_args, print_fn):
     repository_target_info = load_target_info_from_cli_args(cli_args)
     repository = load_repository_from_target_info(repository_target_info)
@@ -73,8 +76,7 @@ def execute_list_command(cli_args, print_fn):
             print_fn('Description:')
             print_fn(format_description(pipeline.description, indent=' ' * 4))
         print_fn('Solids: (Execution Order)')
-        solid_graph = ExecutionGraph(pipeline, pipeline.solids, pipeline.dependency_structure)
-        for solid in solid_graph.topological_solids:
+        for solid in solids_in_topological_order(pipeline):
             print_fn('    ' + solid.name)
 
 

--- a/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
@@ -9,9 +9,10 @@ from dagster import (
     lambda_solid,
 )
 
-from dagster.core.execution import create_execution_plan
-
-from dagster.core.definitions import ExecutionGraph
+from dagster.core.execution import (
+    create_execution_plan,
+    create_typed_environment,
+)
 
 from dagster.core.execution_plan.create import (
     ExecutionPlanInfo,
@@ -49,11 +50,10 @@ def test_compute_noop_node_core():
 
     environment = config.Environment()
 
-    execution_graph = ExecutionGraph.from_pipeline(pipeline)
     plan = create_execution_plan_core(
         ExecutionPlanInfo(
             create_test_runtime_execution_context(),
-            execution_graph,
+            pipeline,
             environment,
         ),
     )
@@ -70,7 +70,7 @@ def test_compute_noop_node():
         noop,
     ])
 
-    plan = create_execution_plan(pipeline)
+    plan = create_execution_plan(pipeline, create_typed_environment(pipeline))
 
     assert len(plan.steps) == 1
     outputs = list(execute_step(plan.steps[0], create_test_runtime_execution_context(), {}))

--- a/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_definition_errors.py
@@ -80,7 +80,7 @@ def test_from_solid_not_there():
 def test_from_non_existant_input():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Solid B does not have input not_an_input',
+        match='Solid "B" does not have input "not_an_input"',
     ):
         PipelineDefinition(
             solids=solid_a_b_list(),

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -677,10 +677,6 @@ class PipelineDefinition(object):
         '''
         return list(set(self._solid_dict.values()))
 
-    @property
-    def solid_dict(self):
-        return self._solid_dict
-
     def has_solid(self, name):
         '''Return whether or not the solid is in the piepline
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -526,12 +526,12 @@ def execute_plan(pipeline, execution_plan, environment=None, subset_info=None):
     typed_environment = create_typed_environment(pipeline, environment)
 
     with yield_context(pipeline, typed_environment) as context:
-        true_execution_plan = create_subplan(
+        plan_to_execute = create_subplan(
             ExecutionPlanInfo(context=context, pipeline=pipeline, environment=typed_environment),
             execution_plan,
             subset_info,
         ) if subset_info else execution_plan
-        return list(execute_plan_core(context, true_execution_plan))
+        return list(execute_plan_core(context, plan_to_execute))
 
 
 def execute_pipeline(

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -32,7 +32,6 @@ from dagster import (
 from .definitions import (
     DEFAULT_OUTPUT,
     ContextCreationExecutionInfo,
-    ExecutionGraph,
     PipelineDefinition,
     Solid,
 )
@@ -55,17 +54,20 @@ from .evaluator import (
 
 from .events import construct_event_logger
 
-from .execution_plan import (
+from .execution_plan.create import (
     create_execution_plan_core,
-    ExecutionPlanInfo,
+    create_subplan,
 )
 
 from .execution_plan.objects import (
+    ExecutionPlan,
+    ExecutionPlanInfo,
+    ExecutionSubsetInfo,
     StepResult,
     StepTag,
 )
 
-from .execution_plan.simple_engine import execute_plan
+from .execution_plan.simple_engine import execute_plan_core
 
 
 class PipelineExecutionResult(object):
@@ -241,22 +243,12 @@ class SolidExecutionResult(object):
                 return result.failure_data.dagster_error
 
 
-def create_execution_plan(pipeline, environment=None):
+def create_execution_plan(pipeline, typed_environment):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
-    check.opt_inst_param(environment, 'environment', config.Environment)
+    check.inst_param(typed_environment, 'environment', config.Environment)
 
-    pipeline_env_type = pipeline.environment_type
-
-    if environment is None:
-        environment = evaluate_config_value(pipeline_env_type, None).value
-
-    check.inst(environment, config.Environment)
-
-    execution_graph = ExecutionGraph.from_pipeline(pipeline)
-    with yield_context(pipeline, environment) as context:
-        return create_execution_plan_core(
-            ExecutionPlanInfo(context, execution_graph, environment),
-        )
+    with yield_context(pipeline, typed_environment) as context:
+        return create_execution_plan_core(ExecutionPlanInfo(context, pipeline, typed_environment))
 
 
 def get_run_id(reentrant_info):
@@ -435,35 +427,26 @@ def execute_pipeline_iterator(pipeline, environment=None):
       execution (ExecutionContext): execution context of the run
     '''
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
-
-    typed_environment = get_typed_environment(pipeline, environment)
-
-    execution_graph = ExecutionGraph.from_pipeline(pipeline)
+    typed_environment = create_typed_environment(pipeline, environment)
     with yield_context(pipeline, typed_environment) as context:
-        with context.value('pipeline', execution_graph.pipeline.display_name):
-            for result in _execute_graph_iterator(context, execution_graph, typed_environment):
+        with context.value('pipeline', pipeline.display_name):
+            for result in _execute_graph_iterator(context, pipeline, typed_environment):
                 yield result
 
 
-def _execute_graph_iterator(context, execution_graph, environment):
+def _execute_graph_iterator(context, pipeline, environment):
     check.inst_param(context, 'context', RuntimeExecutionContext)
-    check.inst_param(execution_graph, 'execution_graph', ExecutionGraph)
+    check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(environment, 'environent', config.Environment)
 
-    execution_plan = create_execution_plan_core(
-        ExecutionPlanInfo(
-            context,
-            execution_graph,
-            environment,
-        ),
-    )
+    execution_plan = create_execution_plan_core(ExecutionPlanInfo(context, pipeline, environment))
 
     steps = list(execution_plan.topological_steps())
 
     if not steps:
         context.debug(
             'Pipeline {pipeline} has no nodes and no execution will happen'.format(
-                pipeline=execution_graph.pipeline.display_name
+                pipeline=pipeline.display_name
             )
         )
         return
@@ -478,7 +461,7 @@ def _execute_graph_iterator(context, execution_graph, environment):
 
     solid = None
     step_results = []
-    for step_result in execute_plan(context, execution_plan):
+    for step_result in execute_plan_core(context, execution_plan):
         check.inst_param(step_result, 'step_result', StepResult)
 
         step = step_result.step
@@ -534,6 +517,23 @@ class PipelineConfigEvaluationError(Exception):
         super(PipelineConfigEvaluationError, self).__init__(error_msg, *args, **kwargs)
 
 
+def execute_plan(pipeline, execution_plan, environment=None, subset_info=None):
+    check.inst_param(pipeline, 'pipeline', PipelineDefinition)
+    check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
+    check.opt_dict_param(environment, 'environment')
+    check.opt_inst_param(subset_info, 'subset_info', ExecutionSubsetInfo)
+
+    typed_environment = create_typed_environment(pipeline, environment)
+
+    with yield_context(pipeline, typed_environment) as context:
+        true_execution_plan = create_subplan(
+            ExecutionPlanInfo(context=context, pipeline=pipeline, environment=typed_environment),
+            execution_plan,
+            subset_info,
+        ) if subset_info else execution_plan
+        return list(execute_plan_core(context, true_execution_plan))
+
+
 def execute_pipeline(
     pipeline,
     environment=None,
@@ -562,7 +562,7 @@ def execute_pipeline(
     check.bool_param(throw_on_error, 'throw_on_error')
     check.opt_inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
 
-    typed_environment = get_typed_environment(pipeline, environment)
+    typed_environment = create_typed_environment(pipeline, environment)
 
     return execute_reentrant_pipeline(pipeline, typed_environment, throw_on_error, reentrant_info)
 
@@ -577,16 +577,15 @@ def execute_reentrant_pipeline(
     check.inst_param(typed_environment, 'typed_environment', config.Environment)
     check.opt_inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
 
-    execution_graph = ExecutionGraph.from_pipeline(pipeline)
     return _execute_graph(
-        execution_graph,
+        pipeline,
         typed_environment,
         throw_on_error=throw_on_error,
         reentrant_info=reentrant_info,
     )
 
 
-def get_typed_environment(pipeline, environment):
+def create_typed_environment(pipeline, environment=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.opt_dict_param(environment, 'environment')
 
@@ -600,28 +599,28 @@ def get_typed_environment(pipeline, environment):
 
 
 def _execute_graph(
-    execution_graph,
+    pipeline,
     environment,
     throw_on_error=True,
     reentrant_info=None,
 ):
-    check.inst_param(execution_graph, 'execution_graph', ExecutionGraph)
+    check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(environment, 'environment', config.Environment)
     check.bool_param(throw_on_error, 'throw_on_error')
     check.opt_inst_param(reentrant_info, 'reentrant_info', ReentrantInfo)
     results = []
-    with yield_context(execution_graph.pipeline, environment, reentrant_info) as context:
+    with yield_context(pipeline, environment, reentrant_info) as context:
         check.inst(context, RuntimeExecutionContext)
-        with context.value('pipeline', execution_graph.pipeline.display_name):
+        with context.value('pipeline', pipeline.display_name):
             context.events.pipeline_start()
 
-            for result in _execute_graph_iterator(context, execution_graph, environment):
+            for result in _execute_graph_iterator(context, pipeline, environment):
                 if throw_on_error and not result.success:
                     result.reraise_user_error()
 
                 results.append(result)
 
-            pipeline_result = PipelineExecutionResult(execution_graph.pipeline, context, results)
+            pipeline_result = PipelineExecutionResult(pipeline, context, results)
             if pipeline_result.success:
                 context.events.pipeline_success()
             else:

--- a/python_modules/dagster/dagster/core/execution_plan/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/execution_plan_tests/test_execution_plan_subset.py
@@ -1,0 +1,180 @@
+from dagster import (
+    DependencyDefinition,
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    Result,
+    lambda_solid,
+    solid,
+    types,
+)
+
+from dagster.core.execution import (
+    create_subplan,
+    create_execution_plan,
+    execute_plan,
+    create_typed_environment,
+    ExecutionPlanInfo,
+    ExecutionSubsetInfo,
+    yield_context,
+)
+
+from dagster.core.execution_plan.utility import VALUE_OUTPUT
+
+
+def define_two_int_pipeline():
+    @lambda_solid
+    def return_one():
+        return 1
+
+    @lambda_solid(inputs=[InputDefinition('num')])
+    def add_one(num):
+        return num + 1
+
+    return PipelineDefinition(
+        name='pipeline_ints',
+        solids=[return_one, add_one],
+        dependencies={
+            'add_one': {
+                'num': DependencyDefinition('return_one'),
+            },
+        },
+    )
+
+
+def test_execution_plan_simple_two_steps():
+    pipeline_def = define_two_int_pipeline()
+    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+
+    assert isinstance(execution_plan.steps, list)
+    assert len(execution_plan.steps) == 2
+
+    assert execution_plan.get_step_by_key('return_one.transform')
+    assert execution_plan.get_step_by_key('add_one.transform')
+
+    step_results = execute_plan(pipeline_def, execution_plan)
+    assert len(step_results) == 2
+
+    assert step_results[0].step.key == 'return_one.transform'
+    assert step_results[0].success
+    assert step_results[0].success_data.value == 1
+
+    assert step_results[1].step.key == 'add_one.transform'
+    assert step_results[1].success
+    assert step_results[1].success_data.value == 2
+
+
+def test_create_subplan_source_step():
+    pipeline_def = define_two_int_pipeline()
+    typed_environment = create_typed_environment(pipeline_def, None)
+    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    with yield_context(pipeline_def, typed_environment) as context:
+        subplan = create_subplan(
+            ExecutionPlanInfo(
+                context=context,
+                pipeline=pipeline_def,
+                environment=typed_environment,
+            ),
+            execution_plan,
+            ExecutionSubsetInfo(['return_one.transform']),
+        )
+        assert subplan
+        assert len(subplan.steps) == 1
+        assert subplan.steps[0].key == 'return_one.transform'
+        assert not subplan.steps[0].step_inputs
+        assert len(subplan.steps[0].step_outputs) == 1
+        assert len(subplan.topological_steps()) == 1
+
+
+def test_create_subplan_middle_step():
+    pipeline_def = define_two_int_pipeline()
+    typed_environment = create_typed_environment(pipeline_def, None)
+    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    with yield_context(pipeline_def, typed_environment) as context:
+        subplan = create_subplan(
+            ExecutionPlanInfo(
+                context=context,
+                pipeline=pipeline_def,
+                environment=typed_environment,
+            ),
+            execution_plan,
+            ExecutionSubsetInfo(
+                ['add_one.transform'],
+                {
+                    'add_one.transform': {
+                        'num': 2,
+                    },
+                },
+            ),
+        )
+        assert subplan
+        steps = subplan.topological_steps()
+        assert len(steps) == 2
+        assert steps[0].key == 'add_one.transform.input.num.value'
+        assert not steps[0].step_inputs
+        assert len(steps[0].step_outputs) == 1
+        assert steps[1].key == 'add_one.transform'
+        assert len(steps[1].step_inputs) == 1
+        step_input = steps[1].step_inputs[0]
+        assert step_input.prev_output_handle.step.key == 'add_one.transform.input.num.value'
+        assert step_input.prev_output_handle.output_name == VALUE_OUTPUT
+        assert len(steps[1].step_outputs) == 1
+        assert len(subplan.topological_steps()) == 2
+        assert [step.key for step in subplan.topological_steps()] == [
+            'add_one.transform.input.num.value',
+            'add_one.transform',
+        ]
+
+
+def test_execution_plan_source_step():
+    pipeline_def = define_two_int_pipeline()
+    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    step_results = execute_plan(
+        pipeline_def,
+        execution_plan,
+        subset_info=ExecutionSubsetInfo(included_steps=['return_one.transform'])
+    )
+
+    assert len(step_results) == 1
+    assert step_results[0].success_data.value == 1
+
+
+def test_execution_plan_middle_step():
+    pipeline_def = define_two_int_pipeline()
+    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    step_results = execute_plan(
+        pipeline_def,
+        execution_plan,
+        subset_info=ExecutionSubsetInfo(
+            ['add_one.transform'],
+            {
+                'add_one.transform': {
+                    'num': 2,
+                },
+            },
+        ),
+    )
+
+    assert len(step_results) == 2
+    assert step_results[1].success_data.value == 3
+
+
+def test_execution_plan_two_outputs():
+    @solid(outputs=[OutputDefinition(types.Int, 'num_one'), OutputDefinition(types.Int, 'num_two')])
+    def return_one_two(_info):
+        yield Result(1, 'num_one')
+        yield Result(2, 'num_two')
+
+    pipeline_def = PipelineDefinition(name='return_one_two_pipeline', solids=[return_one_two])
+
+    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+
+    step_results = execute_plan(pipeline_def, execution_plan)
+
+    # FIXME: we should change this to be *single* result with two outputs
+    assert step_results[0].step.key == 'return_one_two.transform'
+    assert step_results[0].success_data.value == 1
+    assert step_results[0].success_data.output_name == 'num_one'
+    assert step_results[1].step.key == 'return_one_two.transform'
+    assert step_results[1].success_data.value == 2
+    assert step_results[1].success_data.output_name == 'num_two'

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -41,7 +41,7 @@ def create_input_thunk_execution_step(info, solid, input_def, value):
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
-    dependency_structure = info.execution_graph.dependency_structure
+    dependency_structure = info.pipeline.dependency_structure
     input_handle = solid.input_handle(input_def.name)
 
     if dependency_structure.has_dep(input_handle):
@@ -52,7 +52,7 @@ def create_input_thunk_execution_step(info, solid, input_def, value):
                 'a dependency. Either remove the dependency, specify a subdag '
                 'to execute, or remove the inputs specification in the environment.'
             ).format(
-                pipeline_name=info.execution_graph.pipeline.name,
+                pipeline_name=info.pipeline.name,
                 solid_name=solid.name,
                 input_name=input_def.name,
             )

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -38,7 +38,7 @@ def _all_inputs_covered(step, results):
     return True
 
 
-def execute_plan(context, execution_plan):
+def execute_plan_core(context, execution_plan):
     check.inst_param(context, 'context', RuntimeExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     steps = list(execution_plan.topological_steps())

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -39,7 +39,7 @@ def create_transform_step(solid, step_inputs, conf):
 
 def _yield_transform_results(context, step, conf, inputs):
     gen = step.solid.definition.transform_fn(
-        TransformExecutionInfo(context, conf, step.solid.definition),
+        TransformExecutionInfo(context, conf, step.solid),
         inputs,
     )
 

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -48,3 +48,23 @@ def create_join_step(solid, step_key, prev_steps, prev_output_name):
         tag=StepTag.JOIN,
         solid=solid,
     )
+
+
+VALUE_OUTPUT = 'value_output'
+
+
+def create_value_thunk_step(solid, dagster_type, step_key, value):
+    def _fn(_context, _step, _inputs):
+        yield Result(value, VALUE_OUTPUT)
+
+    return StepOutputHandle(
+        ExecutionStep(
+            key=step_key,
+            step_inputs=[],
+            step_outputs=[StepOutput(VALUE_OUTPUT, dagster_type)],
+            compute_fn=_fn,
+            tag=StepTag.VALUE_THUNK,
+            solid=solid,
+        ),
+        VALUE_OUTPUT,
+    )

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -6,12 +6,16 @@ import tempfile
 import uuid
 
 from dagster import (
-    check,
+    DependencyDefinition,
     PipelineDefinition,
+    SolidInstance,
+    check,
     config,
     define_stub_solid,
     execute_pipeline,
 )
+
+from dagster.core.definitions import SolidInputHandle
 
 from dagster.core.execution_context import RuntimeExecutionContext
 
@@ -54,6 +58,67 @@ def get_temp_file_names(number):
             _unlink_swallow_errors(temp_file_name)
 
 
+def execute_solids(
+    pipeline_def,
+    solid_names,
+    inputs=None,
+    environment=None,
+):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.list_param(solid_names, 'solid_names', of_type=str)
+    inputs = check.opt_dict_param(inputs, 'inputs', key_type=str, value_type=dict)
+    environment = check.opt_dict_param(environment, 'environment')
+
+    injected_solids = []
+    deps = defaultdict(dict)
+
+    for solid_name in solid_names:
+        solid_def = pipeline_def.solid_named(solid_name).definition
+
+        for input_def in solid_def.input_defs:
+            input_name = input_def.name
+            dep_key = SolidInstance(solid_def.name, solid_name)
+            if input_name in inputs.get(solid_name, {}):
+                stub_solid = define_stub_solid(
+                    '{solid_name}_{input_name}'.format(
+                        solid_name=solid_name,
+                        input_name=input_name,
+                    ),
+                    inputs[solid_name][input_name],
+                )
+                injected_solids.append(stub_solid)
+                deps[dep_key][input_name] = DependencyDefinition(stub_solid.name)
+                continue
+
+            inp_handle = SolidInputHandle(pipeline_def.solid_named(solid_name), input_def)
+
+            if pipeline_def.dependency_structure.has_dep(inp_handle):
+                output_handle = pipeline_def.dependency_structure.get_dep(inp_handle)
+                deps[dep_key][input_name] = DependencyDefinition(
+                    solid=output_handle.solid.name,
+                    output=output_handle.output_def.name,
+                )
+                continue
+
+    existing = [pipeline_def.solid_named(solid_name).definition for solid_name in solid_names]
+
+    isolated_pipeline = PipelineDefinition(
+        name=pipeline_def.name + '_isolated',  # TODO: lame
+        solids=existing + injected_solids,
+        context_definitions=pipeline_def.context_definitions,
+        dependencies=deps,
+    )
+
+    result = execute_pipeline(isolated_pipeline, environment)
+
+    if not result.success:
+        for solid_result in result.result_list:
+            if not solid_result.success:
+                solid_result.reraise_user_error()
+
+    return {sr.solid.name: sr for sr in result.result_list}
+
+
 def execute_solid(
     pipeline_def,
     solid_name,
@@ -63,30 +128,11 @@ def execute_solid(
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.str_param(solid_name, 'solid_name')
     inputs = check.opt_dict_param(inputs, 'inputs', key_type=str)
-    environment = check.opt_inst_param(environment, 'environment', (dict, config.Environment))
+    environment = check.opt_dict_param(environment, 'environment')
 
-    injected_solids = defaultdict(dict)
-
-    for input_name, input_value in inputs.items():
-        injected_solids[solid_name][input_name] = define_stub_solid(
-            '{solid_name}_{input_name}'.format(
-                solid_name=solid_name,
-                input_name=input_name,
-            ),
-            input_value,
-        )
-
-    single_solid_pipeline = PipelineDefinition.create_single_solid_pipeline(
+    return execute_solids(
         pipeline_def,
-        solid_name,
-        injected_solids,
-    )
-
-    result = execute_pipeline(single_solid_pipeline, environment)
-
-    solid_result = result.result_for_solid(solid_name)
-
-    if not solid_result.success:
-        solid_result.reraise_user_error()
-
-    return solid_result
+        [solid_name],
+        {solid_name: inputs} if inputs else None,
+        environment,
+    )[solid_name]

--- a/python_modules/dagster/dagster/utils/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster/utils/utils_tests/test_solid_isolation.py
@@ -172,3 +172,17 @@ def test_single_solid_type_checking_output_error():
 
     with pytest.raises(DagsterInvariantViolationError):
         execute_solid(pipeline_def, 'return_string')
+
+
+def test_failing_solid_execute_solid():
+    class ThisException(Exception):
+        pass
+
+    @lambda_solid
+    def throw_an_error():
+        raise ThisException('nope')
+
+    pipeline_def = PipelineDefinition(solids=[throw_an_error])
+
+    with pytest.raises(ThisException):
+        execute_solid(pipeline_def, 'throw_an_error')


### PR DESCRIPTION
Adds the ability to execute arbitrary subsets of *execution plans* rather solid subsets. This will be very useful for doing things like running executions on remote physical execution engines.

This also completely eliminates the old & crufty "ExecutionGraph" abstraction that had long outlived its usefulness. Executing subsets of pipelines at the solid level is now in the execute_solid and execute_solids functions. I'm not totally happy with those APIs but this is a good starting point for now.