### PR TITLE
Consolidate execution paths (stacked on #452; do not merge to master)

### DIFF
--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -103,7 +103,7 @@ def execute_solids(
     existing = [pipeline_def.solid_named(solid_name).definition for solid_name in solid_names]
 
     isolated_pipeline = PipelineDefinition(
-        name=pipeline_def.name + '_isolated',  # TODO: lame
+        name=pipeline_def.name + '_isolated',
         solids=existing + injected_solids,
         context_definitions=pipeline_def.context_definitions,
         dependencies=deps,


### PR DESCRIPTION
There was always an annoying dual code path in the executor iterative and non-iterative versions of the execution pipeline. This diff consolidates those and eliminates the now-pointless inner "graph" functions.