### PR TITLE
Refactor execution_plan_create

### DIFF
--- a/python_modules/dagit/dagit/pipeline_execution_manager.py
+++ b/python_modules/dagit/dagit/pipeline_execution_manager.py
@@ -9,6 +9,7 @@ import gevent
 
 from dagster import (check, ReentrantInfo, PipelineDefinition)
 from dagster.core.execution import (
+    create_typed_environment,
     execute_reentrant_pipeline,
 )
 from dagster.core.evaluator import evaluate_config_value
@@ -86,7 +87,7 @@ class SynchronousExecutionManager(PipelineExecutionManager):
         try:
             return execute_reentrant_pipeline(
                 pipeline,
-                pipeline_run.typed_environment,
+                create_typed_environment(pipeline, pipeline_run.config),
                 throw_on_error=False,
                 reentrant_info=ReentrantInfo(
                     pipeline_run.run_id,

--- a/python_modules/dagit/dagit/pipeline_run_storage.py
+++ b/python_modules/dagit/dagit/pipeline_run_storage.py
@@ -60,8 +60,7 @@ class PipelineRun(object):
         self,
         run_id,
         pipeline_name,
-        typed_environment,
-        environment_config,
+        env_config,
         execution_plan,
     ):
         self.__subscribers = []
@@ -70,15 +69,10 @@ class PipelineRun(object):
         self._status = PipelineRunStatus.NOT_STARTED
         self._run_id = check.str_param(run_id, 'run_id')
         self._pipeline_name = check.str_param(pipeline_name, 'pipeline_name')
-        self._environment_config = check.dict_param(
-            environment_config,
+        self._env_config = check.dict_param(
+            env_config,
             'environment_config',
             key_type=str,
-        )
-        self._typed_environment = check.inst_param(
-            typed_environment,
-            'typed_environment',
-            config.Environment,
         )
         self._execution_plan = check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
 
@@ -95,12 +89,8 @@ class PipelineRun(object):
         return self._pipeline_name
 
     @property
-    def typed_environment(self):
-        return self._typed_environment
-
-    @property
     def config(self):
-        return self._environment_config
+        return self._env_config
 
     @property
     def execution_plan(self):

--- a/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_pandas_solids.py
+++ b/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_pandas_solids.py
@@ -22,6 +22,8 @@ from dagster.core.execution import (
     execute_pipeline,
 )
 
+from dagster.core.test_utils import single_output_transform
+
 from dagster.utils import script_relative_path
 
 from dagster.utils.test import (
@@ -34,8 +36,6 @@ from dagster_contrib.pandas import (
     to_csv_solid,
     to_parquet_solid,
 )
-
-from dagster.core.test_utils import single_output_transform
 
 
 def load_csv_solid(name):

--- a/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_compute_nodes.py
@@ -11,7 +11,6 @@ from dagster import (
 
 from dagster.core.execution import (
     create_execution_plan,
-    create_typed_environment,
 )
 
 from dagster.core.execution_plan.create import (
@@ -70,7 +69,7 @@ def test_compute_noop_node():
         noop,
     ])
 
-    plan = create_execution_plan(pipeline, create_typed_environment(pipeline))
+    plan = create_execution_plan(pipeline)
 
     assert len(plan.steps) == 1
     outputs = list(execute_step(plan.steps[0], create_test_runtime_execution_context(), {}))

--- a/python_modules/dagster/dagster/core/core_tests/test_output_materialization.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_output_materialization.py
@@ -27,7 +27,7 @@ from dagster.core.config_types import (
 
 from dagster.core.execution import (
     create_typed_environment,
-    create_execution_plan_new_api,
+    create_execution_plan,
 )
 
 from dagster.core.execution_plan.objects import StepOutputHandle
@@ -219,7 +219,7 @@ def test_no_outputs_one_input_config_schema():
 
 
 def test_basic_int_execution_plan():
-    execution_plan = create_execution_plan_new_api(
+    execution_plan = create_execution_plan(
         single_int_output_pipeline(),
         {
             'solids': {
@@ -309,7 +309,7 @@ def test_basic_string_json_materialization():
 
 def test_basic_int_and_string_execution_plan():
     pipeline = multiple_output_pipeline()
-    execution_plan = create_execution_plan_new_api(
+    execution_plan = create_execution_plan(
         pipeline,
         {
             'solids': {
@@ -428,7 +428,7 @@ def read_file_contents(path):
 
 def test_basic_int_and_string_json_multiple_materialization_execution_plan():
     pipeline = multiple_output_pipeline()
-    execution_plan = create_execution_plan_new_api(
+    execution_plan = create_execution_plan(
         pipeline,
         {
             'solids': {
@@ -566,7 +566,7 @@ def assert_plan_topological_level(steps, step_nums, step_keys):
 
 
 def test_basic_int_multiple_serializations_execution_plan():
-    execution_plan = create_execution_plan_new_api(
+    execution_plan = create_execution_plan(
         single_int_output_pipeline(),
         {
             'solids': {

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -244,16 +244,15 @@ class SolidExecutionResult(object):
                 return result.failure_data.dagster_error
 
 
-# TODO: make this new top-level api in subsequent PR
-def create_execution_plan_new_api(pipeline, env_config=None):
+def create_execution_plan(pipeline, env_config=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.opt_dict_param(env_config, 'env_config', key_type=str)
 
     typed_environment = create_typed_environment(pipeline, env_config)
-    return create_execution_plan(pipeline, typed_environment)
+    return create_execution_plan_with_typed_environment(pipeline, typed_environment)
 
 
-def create_execution_plan(pipeline, typed_environment):
+def create_execution_plan_with_typed_environment(pipeline, typed_environment):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(typed_environment, 'environment', config.Environment)
 

--- a/python_modules/dagster/dagster/core/execution_plan/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/execution_plan_tests/test_execution_plan_subset.py
@@ -45,7 +45,7 @@ def define_two_int_pipeline():
 
 def test_execution_plan_simple_two_steps():
     pipeline_def = define_two_int_pipeline()
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
 
     assert isinstance(execution_plan.steps, list)
     assert len(execution_plan.steps) == 2
@@ -68,7 +68,7 @@ def test_execution_plan_simple_two_steps():
 def test_create_subplan_source_step():
     pipeline_def = define_two_int_pipeline()
     typed_environment = create_typed_environment(pipeline_def, None)
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
     with yield_context(pipeline_def, typed_environment) as context:
         subplan = create_subplan(
             ExecutionPlanInfo(
@@ -90,7 +90,7 @@ def test_create_subplan_source_step():
 def test_create_subplan_middle_step():
     pipeline_def = define_two_int_pipeline()
     typed_environment = create_typed_environment(pipeline_def, None)
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
     with yield_context(pipeline_def, typed_environment) as context:
         subplan = create_subplan(
             ExecutionPlanInfo(
@@ -129,7 +129,7 @@ def test_create_subplan_middle_step():
 
 def test_execution_plan_source_step():
     pipeline_def = define_two_int_pipeline()
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
     step_results = execute_plan(
         pipeline_def,
         execution_plan,
@@ -142,7 +142,7 @@ def test_execution_plan_source_step():
 
 def test_execution_plan_middle_step():
     pipeline_def = define_two_int_pipeline()
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
     step_results = execute_plan(
         pipeline_def,
         execution_plan,
@@ -168,7 +168,7 @@ def test_execution_plan_two_outputs():
 
     pipeline_def = PipelineDefinition(name='return_one_two_pipeline', solids=[return_one_two])
 
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
 
     step_results = execute_plan(pipeline_def, execution_plan)
 
@@ -191,7 +191,7 @@ def test_reentrant_execute_plan():
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='has_context_value_pipeline', solids=[has_context_value])
-    execution_plan = create_execution_plan(pipeline_def, create_typed_environment(pipeline_def))
+    execution_plan = create_execution_plan(pipeline_def)
 
     step_results = execute_plan(
         pipeline_def,


### PR DESCRIPTION
Make execution_plan_create take a bare dictionary instead of a typed_environment. Eliminates boilerplate at most callsites.