### PR TITLE
Add escape hatch for uniqueness to ease upgrade pain

### DIFF
--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -1178,7 +1178,7 @@ class RepositoryDefinition(object):
         if not self.enforce_uniqueness:
             raise DagsterInvariantViolationError(
                 (
-                    'In order fo get_solid_def to have reliable semantics '
+                    'In order for get_solid_def to have reliable semantics '
                     'you must construct the repo with ensure_uniqueness=True'
                 )
             )

--- a/python_modules/dagster/dagster/core/definitions.py
+++ b/python_modules/dagster/dagster/core/definitions.py
@@ -15,7 +15,10 @@ from dagster.utils.logging import (
 
 from .config import DEFAULT_CONTEXT_NAME
 
-from .errors import DagsterInvalidDefinitionError
+from .errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
+)
 
 from .execution_context import (
     RuntimeExecutionContext,
@@ -1070,7 +1073,7 @@ class RepositoryDefinition(object):
 
     '''
 
-    def __init__(self, name, pipeline_dict):
+    def __init__(self, name, pipeline_dict, enforce_uniqueness=True):
         '''
         Args:
             name (str): Name of pipeline.
@@ -1090,6 +1093,8 @@ class RepositoryDefinition(object):
         self.pipeline_dict = pipeline_dict
 
         self._pipeline_cache = {}
+
+        self.enforce_uniqueness = enforce_uniqueness
 
     def has_pipeline(self, name):
         check.str_param(name, 'name')
@@ -1156,7 +1161,7 @@ class RepositoryDefinition(object):
                 if solid_def.name not in solid_defs:
                     solid_defs[solid_def.name] = solid_def
                     solid_to_pipeline[solid_def.name] = pipeline.name
-                else:
+                elif self.enforce_uniqueness:
                     if not solid_defs[solid_def.name] is solid_def:
                         raise DagsterInvalidDefinitionError(
                             'Trying to add duplicate solid def {} in {}, Already saw in {}'.format(
@@ -1169,6 +1174,14 @@ class RepositoryDefinition(object):
 
     def get_solid_def(self, name):
         check.str_param(name, 'name')
+
+        if not self.enforce_uniqueness:
+            raise DagsterInvariantViolationError(
+                (
+                    'In order fo get_solid_def to have reliable semantics '
+                    'you must construct the repo with ensure_uniqueness=True'
+                )
+            )
 
         solid_defs = self._construct_solid_defs(self.get_all_pipelines())
 


### PR DESCRIPTION
This is essentially a clarify-only feature. But we use clarify as a testbed for stress-testing dagit etc so I'm inclined to add this support, at least temporarily. Fixing clarify to have unique solid definition names will be a project given the complexity of the code and solid generation system. 

Made issue https://github.com/dagster-io/dagster/issues/523 since this is not obviously a win. However this PR unblocks viewing things in clarify repo for now.