### PR TITLE
Enforce inputs in config schema instead of runtime

### DIFF
--- a/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_config_driven_df.py
+++ b/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_config_driven_df.py
@@ -213,7 +213,9 @@ def test_dataframe_csv_missing_input_collision():
             },
         )
 
-    assert 'Error 1: Undefined field "inputs" at path root:solids:df_as_input' in str(exc_info.value)
+    assert 'Error 1: Undefined field "inputs" at path root:solids:df_as_input' in str(
+        exc_info.value
+    )
 
     assert 'yup' not in called
 

--- a/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_config_driven_df.py
+++ b/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_config_driven_df.py
@@ -5,9 +5,9 @@ import pytest
 import pandas as pd
 
 from dagster import (
-    DagsterInvariantViolationError,
     DependencyDefinition,
     InputDefinition,
+    PipelineConfigEvaluationError,
     PipelineDefinition,
     OutputDefinition,
     execute_pipeline,
@@ -167,10 +167,10 @@ def test_dataframe_csv_missing_inputs():
         called['yup'] = True
 
     pipeline = PipelineDefinition(name='missing_inputs', solids=[df_as_input])
-    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+    with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(pipeline)
 
-    assert 'In pipeline missing_inputs solid df_as_input, input df' in str(exc_info.value)
+    assert 'Error 1: Missing required field "solids" at document config root' in str(exc_info.value)
 
     assert 'yup' not in called
 
@@ -195,7 +195,7 @@ def test_dataframe_csv_missing_input_collision():
             },
         },
     )
-    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+    with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             pipeline,
             {
@@ -213,8 +213,7 @@ def test_dataframe_csv_missing_input_collision():
             },
         )
 
-    assert 'In pipeline overlapping solid df_as_input, input df' in str(exc_info.value)
-    assert 'while also specifying' in str(exc_info.value)
+    assert 'Error 1: Undefined field "inputs" at path root:solids:df_as_input' in str(exc_info.value)
 
     assert 'yup' not in called
 

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -17,6 +17,7 @@ from .definitions import (
     ResourceDefinition,
     SolidDefinition,
     Solid,
+    SolidInputHandle,
 )
 
 from .evaluator import hard_create_config_value
@@ -298,9 +299,14 @@ def get_inputs_field(pipeline_def, solid):
 
     inputs_field_fields = {}
     for inp in [inp for inp in solid.definition.input_defs if inp.dagster_type.is_configurable]:
-        # TODO: consider making this a method on configurable and defining
-        # a default in configurable.py
-        inputs_field_fields[inp.name] = Field(inp.dagster_type, is_optional=True)
+        inp_handle = SolidInputHandle(solid, inp)
+        # If this input is not satisfied by a dependency you must
+        # provide it via config
+        if not pipeline_def.dependency_structure.has_dep(inp_handle):
+            inputs_field_fields[inp.name] = Field(inp.dagster_type)
+
+    if not inputs_field_fields:
+        return None
 
     return Field(
         NamedDict(
@@ -310,7 +316,6 @@ def get_inputs_field(pipeline_def, solid):
             ),
             inputs_field_fields,
         ),
-        is_optional=True,
     )
 
 
@@ -355,14 +360,15 @@ class SolidDictionaryType(SystemConfigObject):
         field_dict = {}
         for solid in pipeline_def.solids:
             if solid_has_config_entry(solid.definition):
+
                 solid_config_type = SolidConfigType(
                     '{pipeline_name}.SolidConfig.{solid_name}'.format(
                         pipeline_name=camelcase(pipeline_def.name),
                         solid_name=camelcase(solid.name),
                     ),
                     solid.definition.config_field,
-                    get_inputs_field(pipeline_def, solid),
-                    get_outputs_field(pipeline_def, solid),
+                    inputs_field=get_inputs_field(pipeline_def, solid),
+                    outputs_field=get_outputs_field(pipeline_def, solid),
                 )
 
                 field_dict[solid.name] = Field(solid_config_type)

--- a/python_modules/dagster/dagster/core/config_types.py
+++ b/python_modules/dagster/dagster/core/config_types.py
@@ -15,8 +15,8 @@ from .definitions import (
     PipelineContextDefinition,
     PipelineDefinition,
     ResourceDefinition,
-    SolidDefinition,
     Solid,
+    SolidDefinition,
     SolidInputHandle,
 )
 

--- a/python_modules/dagster/dagster/core/configurable.py
+++ b/python_modules/dagster/dagster/core/configurable.py
@@ -228,6 +228,10 @@ class Field:
         self.is_optional = is_optional
 
     @property
+    def is_required(self):
+        return not self.is_optional
+
+    @property
     def default_provided(self):
         '''Was a default value provided
 

--- a/python_modules/dagster/dagster/core/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_input_injection.py
@@ -5,6 +5,7 @@ from dagster import (
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,
+    PipelineConfigEvaluationError,
     PipelineDefinition,
     SolidInstance,
     execute_pipeline,
@@ -80,13 +81,12 @@ def test_string_missing_inputs():
         called['yup'] = True
 
     pipeline = PipelineDefinition(name='missing_inputs', solids=[str_as_input])
-    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+    with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(pipeline)
 
-    assert 'In pipeline missing_inputs solid str_as_input, input string_input' in str(
+    assert 'Error 1: Missing required field "solids" at document config root.' in str(
         exc_info.value
     )
-
     assert 'yup' not in called
 
 
@@ -110,7 +110,7 @@ def test_string_missing_input_collision():
             },
         },
     )
-    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+    with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             pipeline,
             {
@@ -124,7 +124,10 @@ def test_string_missing_input_collision():
             },
         )
 
-    assert 'In pipeline overlapping solid str_as_input, input string_input' in str(exc_info.value)
-    assert 'while also specifying' in str(exc_info.value)
+    assert 'Error 1: Undefined field "inputs" at path root:solids:str_as_input' in str(
+        exc_info.value
+    )
+    # assert 'In pipeline overlapping solid str_as_input, input string_input' in str(exc_info.value)
+    # assert 'while also specifying' in str(exc_info.value)
 
     assert 'yup' not in called

--- a/python_modules/dagster/dagster/core/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_input_injection.py
@@ -1,7 +1,6 @@
 import pytest
 
 from dagster import (
-    DagsterInvariantViolationError,
     DependencyDefinition,
     InputDefinition,
     OutputDefinition,

--- a/python_modules/dagster/dagster/core/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_input_injection.py
@@ -127,7 +127,5 @@ def test_string_missing_input_collision():
     assert 'Error 1: Undefined field "inputs" at path root:solids:str_as_input' in str(
         exc_info.value
     )
-    # assert 'In pipeline overlapping solid str_as_input, input string_input' in str(exc_info.value)
-    # assert 'while also specifying' in str(exc_info.value)
 
     assert 'yup' not in called

--- a/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_pipeline_execution.py
@@ -24,7 +24,6 @@ from dagster.core.definitions import (
 from dagster.core.execution import (
     PipelineExecutionResult,
     SolidExecutionResult,
-    execute_reentrant_pipeline,
 )
 
 from dagster.core.utility_solids import define_stub_solid

--- a/python_modules/dagster/dagster/core/core_tests/test_system_config.py
+++ b/python_modules/dagster/dagster/core/core_tests/test_system_config.py
@@ -2,14 +2,19 @@ import pytest
 
 from dagster import (
     DagsterEvaluateConfigValueError,
+    DependencyDefinition,
     ExecutionContext,
     Field,
+    InputDefinition,
+    OutputDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
     SolidDefinition,
+    SolidInstance,
     config,
-    types,
     execute_pipeline,
+    lambda_solid,
+    types,
 )
 
 from dagster.core.config_types import (
@@ -803,3 +808,37 @@ def test_optional_and_required_context():
 
     assert env_obj.context.name == 'optional_field_context'
     assert env_obj.context.config == {'optional_field': 'foobar'}
+
+
+def test_required_inputs():
+    @lambda_solid(inputs=[InputDefinition('num', types.Int)], output=OutputDefinition(types.Int))
+    def add_one(num):
+        return num + 1
+
+    pipeline_def = PipelineDefinition(
+        name='required_int_input',
+        solids=[add_one],
+        dependencies={
+            SolidInstance('add_one', 'first_add'): {},
+            SolidInstance('add_one', 'second_add'): {
+                'num': DependencyDefinition('first_add')
+            },
+        },
+    )
+
+    env_type = pipeline_def.environment_type
+
+    solids_type = env_type.field_dict['solids'].dagster_type
+
+    first_add_fields = solids_type.field_dict['first_add'].dagster_type.field_dict
+
+    assert 'inputs'in first_add_fields
+
+    inputs_field = first_add_fields['inputs']
+
+    assert inputs_field.is_required
+
+    assert inputs_field.dagster_type.field_dict['num'].is_required
+
+    # second_add has a dependency so the input is not available
+    assert 'inputs' not in solids_type.field_dict['second_add'].dagster_type.field_dict


### PR DESCRIPTION
We actually have enough information in the pipeline definition to enforce which inputs are needed (those without a dependency) and those which are not.

Notice the test cases that change exception type