### PR TITLE
Consolidate circleci parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
             yarn run check-prettier
 
   airline-demo-py36: &airline-demo-template
-    <<: *dagster-template
+    <<: *dagster-core-modules-template
     docker:
       - image: dagster/cci-test:3.6
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ workflows:
           context: coveralls
       - dagit-webapp:
           context: coveralls
+      - airline-demo-py37:
+          context: coveralls
       - airline-demo-py36:
           context: coveralls
       - airline-demo-py35:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,12 @@ workflows:
   version: 2
   test:
     jobs:
+
+      # Required for merge
+
       - lint
+      - dagit-webapp:
+          context: coveralls
       - dagster-py37:
           context: coveralls
       - dagster-py36:
@@ -19,6 +24,9 @@ workflows:
           context: coveralls
       - dagit-py35:
           context: coveralls
+
+      # Optional steps below
+
       - dagit-py27:
           context: coveralls
       - dagster-aux-modules-py37:
@@ -28,8 +36,6 @@ workflows:
       - dagster-aux-modules-py35:
           context: coveralls
       - dagster-aux-modules-py27:
-          context: coveralls
-      - dagit-webapp:
           context: coveralls
       - airline-demo-py37:
           context: coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,75 +5,79 @@ workflows:
   test:
     jobs:
       - lint
-      - dagster-py37:
+      - dagster-all-modules-py36:
           context: coveralls
-      - dagster-py36:
-          context: coveralls
-      - dagster-py35:
-          context: coveralls
-      - dagster-py27:
-          context: coveralls
-      - dagit-py37:
-          context: coveralls
-      - dagit-py36:
-          context: coveralls
-      - dagit-py35:
-          context: coveralls
-      - dagit-py27:
-          context: coveralls
-      - dagit-webapp:
-          context: coveralls
-      - dagstermill-py37:
-          context: coveralls
-      - dagstermill-py36:
-          context: coveralls
-      - dagstermill-py35:
-          context: coveralls
-      - dagstermill-py27:
-          context: coveralls
-      - airline-demo-py37:
-          context: coveralls
+      # - dagster-py37:
+      #     context: coveralls
+      # - dagster-py36:
+      #     context: coveralls
+      # - dagster-py35:
+      #     context: coveralls
+      # - dagster-py27:
+      #     context: coveralls
+      # - dagit-py37:
+      #     context: coveralls
+      # - dagit-py36:
+      #     context: coveralls
+      # - dagit-py35:
+      #     context: coveralls
+      # - dagit-py27:
+      #     context: coveralls
+      # - dagit-webapp:
+      #     context: coveralls
+      # - dagstermill-py37:
+      #     context: coveralls
+      # - dagstermill-py36:
+      #     context: coveralls
+      # - dagstermill-py35:
+      #     context: coveralls
+      # - dagstermill-py27:
+      #     context: coveralls
+      # - airline-demo-py37:
+      #     context: coveralls
       - airline-demo-py36:
           context: coveralls
       - airline-demo-py35:
           context: coveralls
       - airline-demo-py27:
           context: coveralls
-      - dagster-contrib-py37:
-          context: coveralls
-      - dagster-contrib-py36:
-          context: coveralls
-      - dagster-contrib-py35:
-          context: coveralls
-      - dagster-contrib-py27:
-          context: coveralls
+      # - dagster-contrib-py37:
+      #     context: coveralls
+      # - dagster-contrib-py36:
+      #     context: coveralls
+      # - dagster-contrib-py35:
+      #     context: coveralls
+      # - dagster-contrib-py27:
+      #     context: coveralls
       - dagma-py36:
           context: coveralls
-      - dagma-py35:
-          context: coveralls
-      - dagma-py27:
-          context: coveralls
+      # - dagma-py35:
+      #     context: coveralls
+      # - dagma-py27:
+      #     context: coveralls
 
       - coverage:
           requires:
-            - dagster-py37
-            - dagster-py36
-            - dagster-py35
-            - dagster-py27
-            - dagit-py37
-            - dagit-py36
-            - dagit-py35
-            - dagit-py27
-            - dagstermill-py36
-            - dagstermill-py35
-            - dagstermill-py27
+            - dagster-all-modules-py36
+            # - dagster-py37
+            # - dagster-py36
+            # - dagster-py35
+            # - dagster-py27
+            # - dagit-py37
+            # - dagit-py36
+            # - dagit-py35
+            # - dagit-py27
+            # - dagstermill-py36
+            # - dagstermill-py35
+            # - dagstermill-py27
+            - airline-demo-py37
             - airline-demo-py36
             - airline-demo-py35
             - airline-demo-py27
-            - dagster-contrib-py37
-            - dagster-contrib-py36
-            - dagster-contrib-py35
-            - dagster-contrib-py27
+            # - dagster-contrib-py37
+            # - dagster-contrib-py36
+            # - dagster-contrib-py35
+            # - dagster-contrib-py27
             - dagma-py36
             # - dagma-py35
             # - dagma-py27
@@ -108,6 +112,49 @@ jobs:
 
       # only block warnings for now
       - run: pylint python_modules/dagster/dagster python_modules/dagit/dagit python_modules/dagstermill/dagstermill python_modules/dagster-contrib/dagster_contrib --rcfile=python_modules/.pylintrc --disable=R,C
+
+  dagster-all-modules-py36: &dagster-all-modules-template
+    docker:
+      - image: circleci/python:3.6.6
+    environment:
+      TOXENV: py36
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Dependencies
+          command: |
+            sudo pip install tox
+
+      - run:
+          name: Run Dagster Tests
+          command: |
+            cd python_modules/dagster
+            tox -e $TOXENV
+            cd ..
+            cd python_modules/dagit
+            tox -e $TOXENV
+            cd ..
+            cd python_modules/dagstermill
+            tox -e $TOXENV
+            cd ..
+            cd python_modules/dagster-contrib
+            tox -e $TOXENV
+            cd ..
+
+      - run:
+          command: |
+            mv python_modules/dagster/.coverage python_modules/.coverage.dagster.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagster/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagster/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagster/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
+
+      - persist_to_workspace:
+          root: python_modules/dagster/
+          paths:
+            - .coverage*
 
   dagster-py36: &dagster-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,50 +5,50 @@ workflows:
   test:
     jobs:
       - lint
-      - dagster-py37:
-          context: coveralls
+      # - dagster-py37:
+      #     context: coveralls
       - dagster-py36:
           context: coveralls
-      - dagster-py35:
-          context: coveralls
-      - dagster-py27:
-          context: coveralls
-      - dagit-py37:
-          context: coveralls
-      - dagit-py36:
-          context: coveralls
-      - dagit-py35:
-          context: coveralls
-      - dagit-py27:
-          context: coveralls
-      - dagit-webapp:
-          context: coveralls
-      - dagstermill-py37:
-          context: coveralls
-      - dagstermill-py36:
-          context: coveralls
-      - dagstermill-py35:
-          context: coveralls
-      - dagstermill-py27:
-          context: coveralls
-      - airline-demo-py37:
-          context: coveralls
-      - airline-demo-py36:
-          context: coveralls
-      - airline-demo-py35:
-          context: coveralls
-      - airline-demo-py27:
-          context: coveralls
-      - dagster-contrib-py37:
-          context: coveralls
-      - dagster-contrib-py36:
-          context: coveralls
-      - dagster-contrib-py35:
-          context: coveralls
-      - dagster-contrib-py27:
-          context: coveralls
-      - dagma-py36:
-          context: coveralls
+      # - dagster-py35:
+      #     context: coveralls
+      # - dagster-py27:
+      #     context: coveralls
+      # - dagit-py37:
+      #     context: coveralls
+      # - dagit-py36:
+      #     context: coveralls
+      # - dagit-py35:
+      #     context: coveralls
+      # - dagit-py27:
+      #     context: coveralls
+      # - dagit-webapp:
+      #     context: coveralls
+      # - dagstermill-py37:
+      #     context: coveralls
+      # - dagstermill-py36:
+      #     context: coveralls
+      # - dagstermill-py35:
+      #     context: coveralls
+      # - dagstermill-py27:
+      #     context: coveralls
+      # - airline-demo-py37:
+      #     context: coveralls
+      # - airline-demo-py36:
+      #     context: coveralls
+      # - airline-demo-py35:
+      #     context: coveralls
+      # - airline-demo-py27:
+      #     context: coveralls
+      # - dagster-contrib-py37:
+      #     context: coveralls
+      # - dagster-contrib-py36:
+      #     context: coveralls
+      # - dagster-contrib-py35:
+      #     context: coveralls
+      # - dagster-contrib-py27:
+      #     context: coveralls
+      # - dagma-py36:
+      #     context: coveralls
       # - dagma-py35:
       #     context: coveralls
       # - dagma-py27:
@@ -56,25 +56,25 @@ workflows:
 
       - coverage:
           requires:
-            - dagster-py37
+            # - dagster-py37
             - dagster-py36
-            - dagster-py35
-            - dagster-py27
-            - dagit-py37
-            - dagit-py36
-            - dagit-py35
-            - dagit-py27
-            - dagstermill-py36
-            - dagstermill-py35
-            - dagstermill-py27
-            - airline-demo-py36
-            - airline-demo-py35
-            - airline-demo-py27
-            - dagster-contrib-py37
-            - dagster-contrib-py36
-            - dagster-contrib-py35
-            - dagster-contrib-py27
-            - dagma-py36
+            # - dagster-py35
+            # - dagster-py27
+            # - dagit-py37
+            # - dagit-py36
+            # - dagit-py35
+            # - dagit-py27
+            # - dagstermill-py36
+            # - dagstermill-py35
+            # - dagstermill-py27
+            # - airline-demo-py36
+            # - airline-demo-py35
+            # - airline-demo-py27
+            # - dagster-contrib-py37
+            # - dagster-contrib-py36
+            # - dagster-contrib-py35
+            # - dagster-contrib-py27
+            # - dagma-py36
             # - dagma-py35
             # - dagma-py27
           context: coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,18 +131,18 @@ jobs:
       - run:
           name: Run Dagster Tests
           command: |
-            cd python_modules/dagster
+            pushd python_modules/dagster
             tox -e $TOXENV
-            cd ..
-            cd python_modules/dagit
+            popd
+            pushd python_modules/dagit
             tox -e $TOXENV
-            cd ..
-            cd python_modules/dagstermill
+            popd
+            pushd python_modules/dagstermill
             tox -e $TOXENV
-            cd ..
-            cd python_modules/dagster-contrib
+            popd
+            pushd python_modules/dagster-contrib
             tox -e $TOXENV
-            cd ..
+            popd
 
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,11 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Install Dependencies
-          # command: |
+      # - run:
+      #     name: Install Dependencies
+      #     command: |
+      #       sudo pip install -r python_modules/dagster/dev-requirements.txt
           #   sudo pip install -e python_modules/dagster
-          #   sudo pip install -r python_modules/dagster/dev-requirements.txt
           #   sudo pip install -e python_modules/dagit
           #   sudo pip install -r python_modules/dagit/dev-requirements.txt
           #   sudo pip install -e python_modules/dagstermill

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
           context: coveralls
       - dagster-py35:
           context: coveralls
-      - dagster-py34:
+      - dagster-py27:
           context: coveralls
       - dagit-py37:
           context: coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,21 @@ workflows:
   test:
     jobs:
       - lint
-      - dagster-all-modules-py37:
+      - dagster-core-modules-py37:
           context: coveralls
-      - dagster-all-modules-py36:
+      - dagster-core-modules-py36:
           context: coveralls
-      - dagster-all-modules-py35:
+      - dagster-core-modules-py35:
           context: coveralls
-      - dagster-all-modules-py27:
+      - dagster-core-modules-py27:
+          context: coveralls
+      - dagster-aux-modules-py37:
+          context: coveralls
+      - dagster-aux-modules-py36:
+          context: coveralls
+      - dagster-aux-modules-py35:
+          context: coveralls
+      - dagster-aux-modules-py27:
           context: coveralls
       # - dagster-py37:
       #     context: coveralls
@@ -64,10 +72,14 @@ workflows:
 
       - coverage:
           requires:
-            - dagster-all-modules-py37
-            - dagster-all-modules-py36
-            - dagster-all-modules-py35
-            - dagster-all-modules-py27
+            - dagster-core-modules-py37
+            - dagster-core-modules-py36
+            - dagster-core-modules-py35
+            - dagster-core-modules-py27
+            - dagster-aux-modules-py37
+            - dagster-aux-modules-py36
+            - dagster-aux-modules-py35
+            - dagster-aux-modules-py27
             # - dagster-py37
             # - dagster-py36
             # - dagster-py35
@@ -122,7 +134,7 @@ jobs:
       # only block warnings for now
       - run: pylint python_modules/dagster/dagster python_modules/dagit/dagit python_modules/dagstermill/dagstermill python_modules/dagster-contrib/dagster_contrib --rcfile=python_modules/.pylintrc --disable=R,C
 
-  dagster-all-modules-py36: &dagster-all-modules-template
+  dagster-core-modules-py36: &dagster-core-modules-template
     docker:
       - image: circleci/python:3.6.6
     environment:
@@ -146,19 +158,46 @@ jobs:
             pushd python_modules/dagit
             tox -e $TOXENV
             popd
-            # pushd python_modules/dagstermill
-            # tox -e $TOXENV
-            # popd
-            # pushd python_modules/dagster-contrib
-            # tox -e $TOXENV
-            # popd
 
       - run:
           command: |
             mv python_modules/dagster/.coverage python_modules/.coverage.dagster.${CIRCLE_BUILD_NUM}
             mv python_modules/dagit/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
-            # mv python_modules/dagstermill/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
-            # mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
+
+      - persist_to_workspace:
+          root: python_modules/
+          paths:
+            - .coverage*
+
+  dagster-aux-modules-py36: &dagster-aux-modules-template
+    docker:
+      - image: circleci/python:3.6.6
+    environment:
+      TOXENV: py36
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Dependencies
+          command: |
+            sudo pip install tox
+
+      - run:
+          name: Run Dagster Tests
+          command: |
+            pushd python_modules/dagstermill
+            tox -e $TOXENV
+            popd
+            pushd python_modules/dagster-contrib
+            tox -e $TOXENV
+            popd
+
+      - run:
+          command: |
+            mv python_modules/dagstermill/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
 
       - persist_to_workspace:
           root: python_modules/
@@ -194,22 +233,43 @@ jobs:
           paths:
             - .coverage*
 
-  dagster-all-modules-py37:
-    <<: *dagster-all-modules-template
+  dagster-core-modules-py37:
+    <<: *dagster-core-modules-template
     docker:
       - image: circleci/python:3.7.2
     environment:
       TOXENV: py37
 
-  dagster-all-modules-py35:
-    <<: *dagster-all-modules-template
+  dagster-core-modules-py35:
+    <<: *dagster-core-modules-template
     docker:
       - image: circleci/python:3.5.6
     environment:
       TOXENV: py35
 
-  dagster-all-modules-py27:
-    <<: *dagster-all-modules-template
+  dagster-core-modules-py27:
+    <<: *dagster-core-modules-template
+    docker:
+      - image: circleci/python:2.7.15
+    environment:
+      TOXENV: py27
+
+  dagster-aux-modules-py37:
+    <<: *dagster-aux-modules-template
+    docker:
+      - image: circleci/python:3.7.2
+    environment:
+      TOXENV: py37
+
+  dagster-aux-modules-py35:
+    <<: *dagster-aux-modules-template
+    docker:
+      - image: circleci/python:3.5.6
+    environment:
+      TOXENV: py35
+
+  dagster-aux-modules-py27:
+    <<: *dagster-aux-modules-template
     docker:
       - image: circleci/python:2.7.15
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,17 +77,17 @@ jobs:
     steps:
       - checkout
 
-      # - run:
-      #     name: Install Dependencies
-      #     command: |
-      #       sudo pip install -r python_modules/dagster/dev-requirements.txt
-          #   sudo pip install -e python_modules/dagster
-          #   sudo pip install -e python_modules/dagit
-          #   sudo pip install -r python_modules/dagit/dev-requirements.txt
-          #   sudo pip install -e python_modules/dagstermill
-          #   sudo pip install -e python_modules/dagster-contrib
-          #   sudo pip install -e python_modules/dagster-contrib[pandas]
-          #   sudo pip install -e python_modules/dagster-contrib[sqlalchemy]
+      - run:
+          name: Install Dependencies
+          command: |
+            sudo pip install -r python_modules/dagster/dev-requirements.txt
+            sudo pip install -e python_modules/dagster
+            sudo pip install -e python_modules/dagit
+            sudo pip install -r python_modules/dagit/dev-requirements.txt
+            sudo pip install -e python_modules/dagstermill
+            sudo pip install -e python_modules/dagster-contrib
+            sudo pip install -e python_modules/dagster-contrib[pandas]
+            sudo pip install -e python_modules/dagster-contrib[sqlalchemy]
 
       - attach_workspace:
           at: /tmp/workspace
@@ -223,6 +223,10 @@ jobs:
       - image: circleci/python:3.7.2
     environment:
       TOXENV: py37
+    steps:
+      -run:
+        name: Lint
+        command: pylint python_modules/dagster/dagster --rcfile=python_modules/.pylintrc --disable=R,C
 
   dagster-py35:
     <<: *dagster-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ workflows:
 
       # Required for merge
 
-      - lint
       - dagit-webapp:
           context: coveralls
       - dagster-py37:
@@ -27,6 +26,7 @@ workflows:
 
       # Optional steps below
 
+      - lint
       - dagit-py27:
           context: coveralls
       - dagster-aux-modules-py37:
@@ -223,10 +223,6 @@ jobs:
       - image: circleci/python:3.7.2
     environment:
       TOXENV: py37
-    steps:
-      - run:
-          name: Lint
-          command: pylint python_modules/dagster/dagster --rcfile=python_modules/.pylintrc --disable=R,C
 
   dagster-py35:
     <<: *dagster-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ workflows:
       #     context: coveralls
       # - dagit-py27:
       #     context: coveralls
-      # - dagit-webapp:
-      #     context: coveralls
+      - dagit-webapp:
+          context: coveralls
       # - dagstermill-py37:
       #     context: coveralls
       # - dagstermill-py36:
@@ -146,19 +146,19 @@ jobs:
             pushd python_modules/dagit
             tox -e $TOXENV
             popd
-            pushd python_modules/dagstermill
-            tox -e $TOXENV
-            popd
-            pushd python_modules/dagster-contrib
-            tox -e $TOXENV
-            popd
+            # pushd python_modules/dagstermill
+            # tox -e $TOXENV
+            # popd
+            # pushd python_modules/dagster-contrib
+            # tox -e $TOXENV
+            # popd
 
       - run:
           command: |
             mv python_modules/dagster/.coverage python_modules/.coverage.dagster.${CIRCLE_BUILD_NUM}
             mv python_modules/dagit/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
-            mv python_modules/dagstermill/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
-            mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
+            # mv python_modules/dagstermill/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
+            # mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
 
       - persist_to_workspace:
           root: python_modules/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,55 +21,14 @@ workflows:
           context: coveralls
       - dagster-aux-modules-py27:
           context: coveralls
-      # - dagster-py37:
-      #     context: coveralls
-      # - dagster-py36:
-      #     context: coveralls
-      # - dagster-py35:
-      #     context: coveralls
-      # - dagster-py27:
-      #     context: coveralls
-      # - dagit-py37:
-      #     context: coveralls
-      # - dagit-py36:
-      #     context: coveralls
-      # - dagit-py35:
-      #     context: coveralls
-      # - dagit-py27:
-      #     context: coveralls
       - dagit-webapp:
           context: coveralls
-      # - dagstermill-py37:
-      #     context: coveralls
-      # - dagstermill-py36:
-      #     context: coveralls
-      # - dagstermill-py35:
-      #     context: coveralls
-      # - dagstermill-py27:
-      #     context: coveralls
-      # - airline-demo-py37:
-      #     context: coveralls
       - airline-demo-py36:
           context: coveralls
       - airline-demo-py35:
           context: coveralls
       - airline-demo-py27:
           context: coveralls
-      # - dagster-contrib-py37:
-      #     context: coveralls
-      # - dagster-contrib-py36:
-      #     context: coveralls
-      # - dagster-contrib-py35:
-      #     context: coveralls
-      # - dagster-contrib-py27:
-      #     context: coveralls
-      - dagma-py36:
-          context: coveralls
-      # - dagma-py35:
-      #     context: coveralls
-      # - dagma-py27:
-      #     context: coveralls
-
       - coverage:
           requires:
             - dagster-core-modules-py37
@@ -80,28 +39,10 @@ workflows:
             - dagster-aux-modules-py36
             - dagster-aux-modules-py35
             - dagster-aux-modules-py27
-            # - dagster-py37
-            # - dagster-py36
-            # - dagster-py35
-            # - dagster-py27
-            # - dagit-py37
-            # - dagit-py36
-            # - dagit-py35
-            # - dagit-py27
-            # - dagstermill-py36
-            # - dagstermill-py35
-            # - dagstermill-py27
-            # - airline-demo-py37
+            - airline-demo-py37
             - airline-demo-py36
             - airline-demo-py35
             - airline-demo-py27
-            # - dagster-contrib-py37
-            # - dagster-contrib-py36
-            # - dagster-contrib-py35
-            # - dagster-contrib-py27
-            - dagma-py36
-            # - dagma-py35
-            # - dagma-py27
           context: coveralls
 
 
@@ -193,43 +134,18 @@ jobs:
             pushd python_modules/dagster-contrib
             tox -e $TOXENV
             popd
+            pushd python_modules/dagma
+            tox -e $TOXENV
+            popd
 
       - run:
           command: |
             mv python_modules/dagstermill/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
             mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagma/.coverage python_modules/.coverage.dagma.${CIRCLE_BUILD_NUM}
 
       - persist_to_workspace:
           root: python_modules/
-          paths:
-            - .coverage*
-
-  dagster-py36: &dagster-template
-    docker:
-      - image: circleci/python:3.6.6
-    environment:
-      TOXENV: py36
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo pip install tox
-
-      - run:
-          name: Run Dagster Tests
-          command: |
-            cd python_modules/dagster
-            tox -e $TOXENV
-
-      - run:
-          command: mv python_modules/dagster/.coverage python_modules/dagster/.coverage.dagster.${CIRCLE_BUILD_NUM}
-
-      - persist_to_workspace:
-          root: python_modules/dagster/
           paths:
             - .coverage*
 
@@ -275,110 +191,6 @@ jobs:
     environment:
       TOXENV: py27
 
-  dagit-py36: &dagit-template
-    <<: *dagster-template
-    steps:
-      - checkout
-
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo pip install tox
-
-      - run:
-          name: Run Dagit Tests
-          command: |
-            cd python_modules/dagit
-            tox -e $TOXENV
-
-      - run:
-          command: mv python_modules/dagit/.coverage python_modules/dagit/.coverage.dagit.${CIRCLE_BUILD_NUM}
-
-      - persist_to_workspace:
-          root: python_modules/dagit/
-          paths:
-            - .coverage*
-
-  dagma-py36: &dagma-template
-    <<: *dagster-template
-    steps:
-      - checkout
-
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo pip install tox
-
-      - run:
-          name: Run Dagma Tests
-          command: |
-            cd python_modules/dagma
-            tox -e $TOXENV
-
-      - run:
-          command: mv python_modules/dagma/.coverage python_modules/dagma/.coverage.dagma.${CIRCLE_BUILD_NUM}
-
-      - persist_to_workspace:
-          root: python_modules/dagma/
-          paths:
-            - .coverage*
-
-  dagster-py37:
-    <<: *dagster-template
-    docker:
-      - image: circleci/python:3.7.2
-    environment:
-      TOXENV: py37
-
-  dagster-py35:
-    <<: *dagster-template
-    docker:
-      - image: circleci/python:3.5.6
-    environment:
-      TOXENV: py35
-
-  dagit-py37:
-    <<: *dagit-template
-    docker:
-      - image: circleci/python:3.7.2
-    environment:
-      TOXENV: py37
-
-  dagit-py35:
-    <<: *dagit-template
-    docker:
-      - image: circleci/python:3.5.6
-    environment:
-      TOXENV: py35
-
-  dagma-py35:
-    <<: *dagma-template
-    docker:
-      - image: circleci/python:3.5.6
-    environment:
-      TOXENV: py35
-
-  dagster-py27:
-    <<: *dagster-template
-    docker:
-      - image: circleci/python:2.7.15
-    environment:
-      TOXENV: py27
-
-  dagit-py27:
-    <<: *dagit-template
-    docker:
-      - image: circleci/python:2.7.15
-    environment:
-      TOXENV: py27
-
-  dagma-py27:
-    <<: *dagma-template
-    docker:
-      - image: circleci/python:2.7.15
-    environment:
-      TOXENV: py27
-
   dagit-webapp:
     docker:
       - image: circleci/node:10.6
@@ -409,51 +221,6 @@ jobs:
           command: |
             cd js_modules/dagit
             yarn run check-prettier
-
-  dagstermill-py36: &dagstermill-template
-    <<: *dagster-template
-    steps:
-      - checkout
-
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo pip install tox
-
-      - run:
-          name: Run dagstermill Tests
-          command: |
-            cd python_modules/dagstermill
-            tox -e $TOXENV
-
-      - run:
-          command: mv python_modules/dagstermill/.coverage python_modules/dagstermill/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
-
-      - persist_to_workspace:
-          root: python_modules/dagstermill/
-          paths:
-            - .coverage*
-
-  dagstermill-py37:
-    <<: *dagstermill-template
-    docker:
-      - image: circleci/python:3.7.2
-    environment:
-      TOXENV: py37
-
-  dagstermill-py35:
-    <<: *dagstermill-template
-    docker:
-      - image: circleci/python:3.5.6
-    environment:
-      TOXENV: py35
-
-  dagstermill-py27:
-    <<: *dagstermill-template
-    docker:
-      - image: circleci/python:2.7.15
-    environment:
-      TOXENV: py27
 
   airline-demo-py36: &airline-demo-template
     <<: *dagster-template
@@ -559,53 +326,3 @@ jobs:
           coveralls
 
 
-  dagster-contrib-py36: &dagster-contrib-template
-    <<: *dagster-template
-    docker:
-      - image: dagster/cci-test:3.6
-    environment:
-      TOXENV: py36
-
-    steps:
-      - checkout
-
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo pip install tox
-
-      - run:
-          name: Run dagster-contrib Tests
-          command: |
-            cd python_modules/dagster-contrib
-            tox -e $TOXENV
-
-      - run:
-          command: mv python_modules/dagster-contrib/.coverage python_modules/dagster-contrib/.coverage.airline-demo.${CIRCLE_BUILD_NUM}
-
-      - persist_to_workspace:
-          root: python_modules/dagster-contrib/
-          paths:
-            - .coverage*
-
-  dagster-contrib-py37:
-    <<: *dagster-contrib-template
-    docker:
-      # FIXME: https://github.com/dagster-io/dagster/issues/521 
-      - image: schrockn/cci-test:3.7.2
-    environment:
-      TOXENV: py37
-
-  dagster-contrib-py35:
-    <<: *dagster-contrib-template
-    docker:
-      - image: dagster/cci-test:3.5
-    environment:
-      TOXENV: py35
-
-  dagster-contrib-py27:
-    <<: *dagster-contrib-template
-    docker:
-      - image: dagster/cci-test:2.7
-    environment:
-      TOXENV: py27

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
             mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
 
       - persist_to_workspace:
-          root: python_modules/dagster/
+          root: python_modules/
           paths:
             - .coverage*
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,9 @@ jobs:
     environment:
       TOXENV: py37
     steps:
-      -run:
-        name: Lint
-        command: pylint python_modules/dagster/dagster --rcfile=python_modules/.pylintrc --disable=R,C
+      - run:
+          name: Lint
+          command: pylint python_modules/dagster/dagster --rcfile=python_modules/.pylintrc --disable=R,C
 
   dagster-py35:
     <<: *dagster-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,76 +5,76 @@ workflows:
   test:
     jobs:
       - lint
-      # - dagster-py37:
-      #     context: coveralls
+      - dagster-py37:
+          context: coveralls
       - dagster-py36:
           context: coveralls
-      # - dagster-py35:
-      #     context: coveralls
-      # - dagster-py27:
-      #     context: coveralls
-      # - dagit-py37:
-      #     context: coveralls
-      # - dagit-py36:
-      #     context: coveralls
-      # - dagit-py35:
-      #     context: coveralls
-      # - dagit-py27:
-      #     context: coveralls
-      # - dagit-webapp:
-      #     context: coveralls
-      # - dagstermill-py37:
-      #     context: coveralls
-      # - dagstermill-py36:
-      #     context: coveralls
-      # - dagstermill-py35:
-      #     context: coveralls
-      # - dagstermill-py27:
-      #     context: coveralls
-      # - airline-demo-py37:
-      #     context: coveralls
-      # - airline-demo-py36:
-      #     context: coveralls
-      # - airline-demo-py35:
-      #     context: coveralls
-      # - airline-demo-py27:
-      #     context: coveralls
-      # - dagster-contrib-py37:
-      #     context: coveralls
-      # - dagster-contrib-py36:
-      #     context: coveralls
-      # - dagster-contrib-py35:
-      #     context: coveralls
-      # - dagster-contrib-py27:
-      #     context: coveralls
-      # - dagma-py36:
-      #     context: coveralls
-      # - dagma-py35:
-      #     context: coveralls
-      # - dagma-py27:
-      #     context: coveralls
+      - dagster-py35:
+          context: coveralls
+      - dagster-py27:
+          context: coveralls
+      - dagit-py37:
+          context: coveralls
+      - dagit-py36:
+          context: coveralls
+      - dagit-py35:
+          context: coveralls
+      - dagit-py27:
+          context: coveralls
+      - dagit-webapp:
+          context: coveralls
+      - dagstermill-py37:
+          context: coveralls
+      - dagstermill-py36:
+          context: coveralls
+      - dagstermill-py35:
+          context: coveralls
+      - dagstermill-py27:
+          context: coveralls
+      - airline-demo-py37:
+          context: coveralls
+      - airline-demo-py36:
+          context: coveralls
+      - airline-demo-py35:
+          context: coveralls
+      - airline-demo-py27:
+          context: coveralls
+      - dagster-contrib-py37:
+          context: coveralls
+      - dagster-contrib-py36:
+          context: coveralls
+      - dagster-contrib-py35:
+          context: coveralls
+      - dagster-contrib-py27:
+          context: coveralls
+      - dagma-py36:
+          context: coveralls
+      - dagma-py35:
+          context: coveralls
+      - dagma-py27:
+          context: coveralls
 
       - coverage:
           requires:
-            # - dagster-py37
+            - dagster-py37
             - dagster-py36
-            # - dagster-py35
-            # - dagster-py27
-            # - dagit-py37
-            # - dagit-py36
-            # - dagit-py35
-            # - dagit-py27
-            # - dagstermill-py36
-            # - dagstermill-py35
-            # - dagstermill-py27
-            # - airline-demo-py36
-            # - airline-demo-py35
-            # - airline-demo-py27
-            # - dagster-contrib-py37
-            # - dagster-contrib-py36
-            # - dagster-contrib-py35
-            # - dagster-contrib-py27
-            # - dagma-py36
+            - dagster-py35
+            - dagster-py27
+            - dagit-py37
+            - dagit-py36
+            - dagit-py35
+            - dagit-py27
+            - dagstermill-py36
+            - dagstermill-py35
+            - dagstermill-py27
+            - airline-demo-py36
+            - airline-demo-py35
+            - airline-demo-py27
+            - dagster-contrib-py37
+            - dagster-contrib-py36
+            - dagster-contrib-py35
+            - dagster-contrib-py27
+            - dagma-py36
             # - dagma-py35
             # - dagma-py27
           context: coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,15 +79,15 @@ jobs:
 
       - run:
           name: Install Dependencies
-          command: |
-            sudo pip install -e python_modules/dagster
-            sudo pip install -r python_modules/dagster/dev-requirements.txt
-            sudo pip install -e python_modules/dagit
-            sudo pip install -r python_modules/dagit/dev-requirements.txt
-            sudo pip install -e python_modules/dagstermill
-            sudo pip install -e python_modules/dagster-contrib
-            sudo pip install -e python_modules/dagster-contrib[pandas]
-            sudo pip install -e python_modules/dagster-contrib[sqlalchemy]
+          # command: |
+          #   sudo pip install -e python_modules/dagster
+          #   sudo pip install -r python_modules/dagster/dev-requirements.txt
+          #   sudo pip install -e python_modules/dagit
+          #   sudo pip install -r python_modules/dagit/dev-requirements.txt
+          #   sudo pip install -e python_modules/dagstermill
+          #   sudo pip install -e python_modules/dagster-contrib
+          #   sudo pip install -e python_modules/dagster-contrib[pandas]
+          #   sudo pip install -e python_modules/dagster-contrib[sqlalchemy]
 
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,13 @@ workflows:
   test:
     jobs:
       - lint
+      - dagster-all-modules-py37:
+          context: coveralls
       - dagster-all-modules-py36:
+          context: coveralls
+      - dagster-all-modules-py35:
+          context: coveralls
+      - dagster-all-modules-py27:
           context: coveralls
       # - dagster-py37:
       #     context: coveralls
@@ -58,7 +64,10 @@ workflows:
 
       - coverage:
           requires:
+            - dagster-all-modules-py37
             - dagster-all-modules-py36
+            - dagster-all-modules-py35
+            - dagster-all-modules-py27
             # - dagster-py37
             # - dagster-py36
             # - dagster-py35
@@ -184,6 +193,27 @@ jobs:
           root: python_modules/dagster/
           paths:
             - .coverage*
+
+  dagster-all-modules-py37:
+    <<: *dagster-all-modules-template
+    docker:
+      - image: circleci/python:3.7.2
+    environment:
+      TOXENV: py37
+
+  dagster-all-modules-py35:
+    <<: *dagster-all-modules-template
+    docker:
+      - image: circleci/python:3.5.6
+    environment:
+      TOXENV: py35
+
+  dagster-all-modules-py27:
+    <<: *dagster-all-modules-template
+    docker:
+      - image: circleci/python:2.7.15
+    environment:
+      TOXENV: py27
 
   dagit-py36: &dagit-template
     <<: *dagster-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,9 @@ jobs:
       - run:
           command: |
             mv python_modules/dagster/.coverage python_modules/.coverage.dagster.${CIRCLE_BUILD_NUM}
-            mv python_modules/dagster/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
-            mv python_modules/dagster/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
-            mv python_modules/dagster/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagit/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagstermill/.coverage python_modules/.coverage.dagstermill.${CIRCLE_BUILD_NUM}
+            mv python_modules/dagster-contrib/.coverage python_modules/.coverage.dagster-contrib.${CIRCLE_BUILD_NUM}
 
       - persist_to_workspace:
           root: python_modules/dagster/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,21 @@ workflows:
   test:
     jobs:
       - lint
-      - dagster-core-modules-py37:
+      - dagster-py37:
           context: coveralls
-      - dagster-core-modules-py36:
+      - dagster-py36:
           context: coveralls
-      - dagster-core-modules-py35:
+      - dagster-py35:
           context: coveralls
-      - dagster-core-modules-py27:
+      - dagster-py34:
+          context: coveralls
+      - dagit-py37:
+          context: coveralls
+      - dagit-py36:
+          context: coveralls
+      - dagit-py35:
+          context: coveralls
+      - dagit-py27:
           context: coveralls
       - dagster-aux-modules-py37:
           context: coveralls
@@ -33,10 +41,14 @@ workflows:
           context: coveralls
       - coverage:
           requires:
-            - dagster-core-modules-py37
-            - dagster-core-modules-py36
-            - dagster-core-modules-py35
-            - dagster-core-modules-py27
+            - dagster-py37
+            - dagster-py36
+            - dagster-py35
+            - dagster-py27
+            - dagit-py37
+            - dagit-py36
+            - dagit-py35
+            - dagit-py27
             - dagster-aux-modules-py37
             - dagster-aux-modules-py36
             - dagster-aux-modules-py35
@@ -77,7 +89,38 @@ jobs:
       # only block warnings for now
       - run: pylint python_modules/dagster/dagster python_modules/dagit/dagit python_modules/dagstermill/dagstermill python_modules/dagster-contrib/dagster_contrib --rcfile=python_modules/.pylintrc --disable=R,C
 
-  dagster-core-modules-py36: &dagster-core-modules-template
+  dagit-py36: &dagit-template
+    docker:
+      - image: circleci/python:3.6.6
+    environment:
+      TOXENV: py36
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Dependencies
+          command: |
+            sudo pip install tox
+
+      - run:
+          name: Run Dagster Tests
+          command: |
+            pushd python_modules/dagit
+            tox -e $TOXENV
+            popd
+
+      - run:
+          command: |
+            mv python_modules/dagit/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
+
+      - persist_to_workspace:
+          root: python_modules/
+          paths:
+            - .coverage*
+
+  dagster-py36: &dagster-template
     docker:
       - image: circleci/python:3.6.6
     environment:
@@ -98,14 +141,10 @@ jobs:
             pushd python_modules/dagster
             tox -e $TOXENV
             popd
-            pushd python_modules/dagit
-            tox -e $TOXENV
-            popd
 
       - run:
           command: |
             mv python_modules/dagster/.coverage python_modules/.coverage.dagster.${CIRCLE_BUILD_NUM}
-            mv python_modules/dagit/.coverage python_modules/.coverage.dagit.${CIRCLE_BUILD_NUM}
 
       - persist_to_workspace:
           root: python_modules/
@@ -151,22 +190,43 @@ jobs:
           paths:
             - .coverage*
 
-  dagster-core-modules-py37:
-    <<: *dagster-core-modules-template
+  dagit-py37:
+    <<: *dagit-template
     docker:
       - image: circleci/python:3.7.2
     environment:
       TOXENV: py37
 
-  dagster-core-modules-py35:
-    <<: *dagster-core-modules-template
+  dagit-py35:
+    <<: *dagit-template
     docker:
       - image: circleci/python:3.5.6
     environment:
       TOXENV: py35
 
-  dagster-core-modules-py27:
-    <<: *dagster-core-modules-template
+  dagit-py27:
+    <<: *dagit-template
+    docker:
+      - image: circleci/python:2.7.15
+    environment:
+      TOXENV: py27
+
+  dagster-py37:
+    <<: *dagster-template
+    docker:
+      - image: circleci/python:3.7.2
+    environment:
+      TOXENV: py37
+
+  dagster-py35:
+    <<: *dagster-template
+    docker:
+      - image: circleci/python:3.5.6
+    environment:
+      TOXENV: py35
+
+  dagster-py27:
+    <<: *dagster-template
     docker:
       - image: circleci/python:2.7.15
     environment:
@@ -225,7 +285,7 @@ jobs:
             yarn run check-prettier
 
   airline-demo-py36: &airline-demo-template
-    <<: *dagster-core-modules-template
+    <<: *dagster-template
     docker:
       - image: dagster/cci-test:3.6
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
             # - dagstermill-py36
             # - dagstermill-py35
             # - dagstermill-py27
-            - airline-demo-py37
+            # - airline-demo-py37
             - airline-demo-py36
             - airline-demo-py35
             - airline-demo-py27

--- a/python_modules/dagster-contrib/dagster_contrib/dagster_examples/log_spew/pipeline.py
+++ b/python_modules/dagster-contrib/dagster_contrib/dagster_examples/log_spew/pipeline.py
@@ -14,6 +14,7 @@ from dagster import (
 def nonce_solid(name, n_inputs, n_outputs):
     """Creates a solid with the given number of (meaningless) inputs and outputs.
 
+
     Config controls the behavior of the nonce solid."""
 
     @solid(

--- a/python_modules/dagster-contrib/dagster_contrib/dagster_examples/log_spew/pipeline.py
+++ b/python_modules/dagster-contrib/dagster_contrib/dagster_examples/log_spew/pipeline.py
@@ -14,7 +14,6 @@ from dagster import (
 def nonce_solid(name, n_inputs, n_outputs):
     """Creates a solid with the given number of (meaningless) inputs and outputs.
 
-
     Config controls the behavior of the nonce solid."""
 
     @solid(


### PR DESCRIPTION
This consolidates our test runs a bit to reduce parallelism. This proposes a structure where we have dagster, dagit,  "aux", "airline-demo" per python version. Plus a lint, dagit-webapp,  Core, lint and webapp will be required. Aux (all other python modules) and airline-demo no.