### PR TITLE
Avoid infinite loops in type iterate

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/pipeline_creation.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_creation.py
@@ -149,16 +149,18 @@ def _gather_all_types(solids, context_definitions, environment_type):
 
     check.inst_param(environment_type, 'environment_type', types.DagsterType)
 
+    seen = set()
+
     for solid in solids:
-        for dagster_type in solid.iterate_types():
+        for dagster_type in solid.iterate_types(seen):
             yield dagster_type
 
     for context_definition in context_definitions.values():
         if context_definition.config_field:
-            for dagster_type in context_definition.config_field.dagster_type.iterate_types():
+            for dagster_type in context_definition.config_field.dagster_type.iterate_types(seen):
                 yield dagster_type
 
-    for dagster_type in environment_type.iterate_types():
+    for dagster_type in environment_type.iterate_types(seen):
         yield dagster_type
 
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_creation.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_creation.py
@@ -149,18 +149,20 @@ def _gather_all_types(solids, context_definitions, environment_type):
 
     check.inst_param(environment_type, 'environment_type', types.DagsterType)
 
-    seen = set()
+    seen_config_schemas = set()
 
     for solid in solids:
-        for dagster_type in solid.iterate_types(seen):
+        for dagster_type in solid.iterate_types(seen_config_schemas):
             yield dagster_type
 
     for context_definition in context_definitions.values():
         if context_definition.config_field:
-            for dagster_type in context_definition.config_field.dagster_type.iterate_types(seen):
+            for dagster_type in context_definition.config_field.dagster_type.iterate_types(
+                seen_config_schemas
+            ):
                 yield dagster_type
 
-    for dagster_type in environment_type.iterate_types(seen):
+    for dagster_type in environment_type.iterate_types(seen_config_schemas):
         yield dagster_type
 
 

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -96,15 +96,15 @@ class SolidDefinition(object):
         check.str_param(name, 'name')
         return self._output_dict[name]
 
-    def iterate_types(self):
+    def iterate_types(self, seen):
         for input_def in self.input_defs:
-            for dagster_type in input_def.dagster_type.iterate_types():
+            for dagster_type in input_def.dagster_type.iterate_types(seen):
                 yield dagster_type
 
         for output_def in self.output_defs:
-            for dagster_type in output_def.dagster_type.iterate_types():
+            for dagster_type in output_def.dagster_type.iterate_types(seen):
                 yield dagster_type
 
         if self.config_field:
-            for dagster_type in self.config_field.dagster_type.iterate_types():
+            for dagster_type in self.config_field.dagster_type.iterate_types(seen):
                 yield dagster_type

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -96,15 +96,15 @@ class SolidDefinition(object):
         check.str_param(name, 'name')
         return self._output_dict[name]
 
-    def iterate_types(self, seen):
+    def iterate_types(self, seen_config_schemas):
         for input_def in self.input_defs:
-            for dagster_type in input_def.dagster_type.iterate_types(seen):
+            for dagster_type in input_def.dagster_type.iterate_types(seen_config_schemas):
                 yield dagster_type
 
         for output_def in self.output_defs:
-            for dagster_type in output_def.dagster_type.iterate_types(seen):
+            for dagster_type in output_def.dagster_type.iterate_types(seen_config_schemas):
                 yield dagster_type
 
         if self.config_field:
-            for dagster_type in self.config_field.dagster_type.iterate_types(seen):
+            for dagster_type in self.config_field.dagster_type.iterate_types(seen_config_schemas):
                 yield dagster_type

--- a/python_modules/dagster/dagster/core/types/base.py
+++ b/python_modules/dagster/dagster/core/types/base.py
@@ -19,8 +19,6 @@ from .configurable import (
     Field,
 )
 
-from .materializable import (MaterializeableBuiltinScalar, Materializeable)
-
 SerializedTypeValue = namedtuple('SerializedTypeValue', 'name value')
 
 
@@ -106,11 +104,8 @@ class DagsterType(object):
     def coerce_runtime_value(self, _value):
         check.not_implemented('Must implement in subclass')
 
-    def iterate_types(self):
+    def iterate_types(self, _seen):
         yield self
-        if isinstance(self, Materializeable):
-            # Guaranteed to work after isinstance check
-            yield self.define_materialization_config_schema()  # pylint: disable=E1101
 
     def serialize_value(self, output_dir, value):
         type_value = self.create_serializable_type_value(

--- a/python_modules/dagster/dagster/core/types/builtins.py
+++ b/python_modules/dagster/dagster/core/types/builtins.py
@@ -71,7 +71,6 @@ class MaterializeableBuiltinScalarConfigSchema(ConfigurableSelectorFromDict, Dag
         )
 
     def iterate_types(self, seen_config_schemas):
-        # return []
         yield self
 
         for field_type in self.field_dict.values():

--- a/python_modules/dagster/dagster/core/types/builtins.py
+++ b/python_modules/dagster/dagster/core/types/builtins.py
@@ -17,14 +17,72 @@ from .base import (
 )
 
 from .configurable import (
+    ConfigurableSelectorFromDict,
     ConfigurableObjectFromDict,
     ConfigurableFromScalar,
     ConfigurableFromAny,
     ConfigurableFromNullable,
     ConfigurableFromList,
+    Field,
 )
 
-from .materializable import MaterializeableBuiltinScalar
+from .materializable import Materializeable
+
+
+class MaterializeableBuiltinScalar(Materializeable):
+    def __init__(self, *args, **kwargs):
+        super(MaterializeableBuiltinScalar, self).__init__(*args, **kwargs)
+        self.config_schema = None
+
+    def define_materialization_config_schema(self):
+        if self.config_schema is None:
+            # This has to be applied to a dagster type so name is available
+            # pylint: disable=E1101
+            self.config_schema = MaterializeableBuiltinScalarConfigSchema(
+                '{name}.MaterializationSchema'.format(name=self.name)
+            )
+        return self.config_schema
+
+    def materialize_runtime_value(self, config_spec, runtime_value):
+        check.dict_param(config_spec, 'config_spec')
+        selector_key, selector_value = list(config_spec.items())[0]
+
+        if selector_key == 'json':
+            json_file_path = selector_value['path']
+            json_value = json.dumps({'value': runtime_value})
+            with open(json_file_path, 'w') as ff:
+                ff.write(json_value)
+        else:
+            check.failed(
+                'Unsupported selector key: {selector_key}'.format(selector_key=selector_key)
+            )
+
+
+def define_path_dict_field():
+    return Field(Dict({'path': Field(Path)}))
+
+
+class MaterializeableBuiltinScalarConfigSchema(ConfigurableSelectorFromDict, DagsterType):
+    def __init__(self, name):
+        super(MaterializeableBuiltinScalarConfigSchema, self).__init__(
+            name=name,
+            description='Materialization schema for scalar ' + name,
+            fields={'json': define_path_dict_field()},
+        )
+        # # TODO: add pickle
+        # super(
+        #     MaterializeableBuiltinScalarConfigSchema,
+        #     self,
+        # ).__init__(fields={'json': define_path_dict_field()})
+
+    def iterate_types(self, seen):
+        # return []
+        yield self
+
+        for field_type in self.field_dict.values():
+            for inner_type in field_type.dagster_type.iterate_types(seen):
+                if not isinstance(inner_type, DagsterBuiltinScalarType):
+                    yield inner_type
 
 
 # All builtins are configurable
@@ -39,6 +97,27 @@ class DagsterBuiltinScalarType(
             type_attributes=DagsterTypeAttributes(is_builtin=True),
             description=description,
         )
+
+    def iterate_types(self, seen):
+        # HACK HACK HACK
+        # This is quite terrible and stems from the confusion between
+        # the runtime and config type systems. The problem here is that
+        # materialization config schemas can themselves contain scalars
+        # and without some kind of check we get into an infinite recursion
+        # situation. The real fix will be to separate config and runtime types
+        # in which case the config "Int" and the runtime "Int" will actually be
+        # separate concepts
+        if isinstance(self, Materializeable):
+            # Guaranteed to work after isinstance check
+            # pylint: disable=E1101
+            config_schema = self.define_materialization_config_schema()
+            if not config_schema in seen:
+                seen.add(config_schema)
+                yield config_schema
+                for inner_type in config_schema.iterate_types(seen):
+                    yield inner_type
+
+        yield self
 
 
 class _DagsterAnyType(ConfigurableFromAny, UncoercedTypeMixin, DagsterType):
@@ -148,7 +227,7 @@ class _DagsterNullableType(ConfigurableFromNullable, DagsterType):
     def coerce_runtime_value(self, value):
         return None if value is None else self.inner_type.coerce_runtime_value(value)
 
-    def iterate_types(self):
+    def iterate_types(self, _seen):
         yield self.inner_type
 
 
@@ -172,7 +251,7 @@ class _DagsterListType(ConfigurableFromList, DagsterType):
 
         return list(map(self.inner_type.coerce_runtime_value, value))
 
-    def iterate_types(self):
+    def iterate_types(self, _seen):
         yield self.inner_type
 
 

--- a/python_modules/dagster/dagster/core/types/configurable.py
+++ b/python_modules/dagster/dagster/core/types/configurable.py
@@ -113,9 +113,9 @@ class ConfigurableFromDict(Configurable):
         check.str_param(name, 'name')
         return self.field_dict[name]
 
-    def iterate_types(self):
+    def iterate_types(self, seen):
         for field_type in self.field_dict.values():
-            for inner_type in field_type.dagster_type.iterate_types():
+            for inner_type in field_type.dagster_type.iterate_types(seen):
                 yield inner_type
 
         # FIXME: is_named needs to be moved into Configurable

--- a/python_modules/dagster/dagster/core/types/configurable.py
+++ b/python_modules/dagster/dagster/core/types/configurable.py
@@ -113,9 +113,9 @@ class ConfigurableFromDict(Configurable):
         check.str_param(name, 'name')
         return self.field_dict[name]
 
-    def iterate_types(self, seen):
+    def iterate_types(self, seen_config_schemas):
         for field_type in self.field_dict.values():
-            for inner_type in field_type.dagster_type.iterate_types(seen):
+            for inner_type in field_type.dagster_type.iterate_types(seen_config_schemas):
                 yield inner_type
 
         # FIXME: is_named needs to be moved into Configurable

--- a/python_modules/dagster/dagster/core/types/materializable.py
+++ b/python_modules/dagster/dagster/core/types/materializable.py
@@ -1,16 +1,4 @@
-import json
-
 from dagster import check
-
-from .configurable import (
-    ConfigurableSelectorFromDict,
-    Field,
-)
-
-
-def define_path_dict_field():
-    from . import Dict, Path
-    return Field(Dict({'path': Field(Path)}))
 
 
 class Materializeable(object):
@@ -19,49 +7,6 @@ class Materializeable(object):
 
     def materialize_runtime_value(self, _config_spec, _runtime_value):
         check.failed('must implement')
-
-
-class MaterializeableBuiltinScalarConfigSchema(ConfigurableSelectorFromDict):
-    def __init__(self, name):
-        # TODO: add pickle
-        super(
-            MaterializeableBuiltinScalarConfigSchema,
-            self,
-        ).__init__(fields={'json': define_path_dict_field()})
-        self.name = name
-        self.description = 'Materialization schema for scalar ' + name
-
-    def iterate_types(self):
-        yield self
-
-
-class MaterializeableBuiltinScalar(Materializeable):
-    def __init__(self, *args, **kwargs):
-        super(MaterializeableBuiltinScalar, self).__init__(*args, **kwargs)
-        self.config_schema = None
-
-    def define_materialization_config_schema(self):
-        if self.config_schema is None:
-            # This has to be applied to a dagster type so name is available
-            # pylint: disable=E1101
-            self.config_schema = MaterializeableBuiltinScalarConfigSchema(
-                '{name}.MaterializationSchema'.format(name=self.name)
-            )
-        return self.config_schema
-
-    def materialize_runtime_value(self, config_spec, runtime_value):
-        check.dict_param(config_spec, 'config_spec')
-        selector_key, selector_value = list(config_spec.items())[0]
-
-        if selector_key == 'json':
-            json_file_path = selector_value['path']
-            json_value = json.dumps({'value': runtime_value})
-            with open(json_file_path, 'w') as ff:
-                ff.write(json_value)
-        else:
-            check.failed(
-                'Unsupported selector key: {selector_key}'.format(selector_key=selector_key)
-            )
 
 
 class FileMarshalable:

--- a/python_modules/dagster/dagster/core/types/types_tests/test_materialization_schema.py
+++ b/python_modules/dagster/dagster/core/types/types_tests/test_materialization_schema.py
@@ -1,0 +1,23 @@
+from dagster import (
+    PipelineDefinition,
+    OutputDefinition,
+    lambda_solid,
+    types,
+)
+
+
+def test_materialization_schema_types():
+    @lambda_solid(output=OutputDefinition(types.Int))
+    def return_one():
+        return 1
+
+    pipeline_def = PipelineDefinition(name='test_materialization_schema_types', solids=[return_one])
+
+    string_mat_schema = pipeline_def.type_named('String.MaterializationSchema')
+
+    string_json_mat_schema = string_mat_schema.field_dict['json'].dagster_type
+
+    print(string_json_mat_schema.name)
+    print(string_json_mat_schema.field_dict)
+
+    assert pipeline_def.type_named(string_json_mat_schema.name)

--- a/python_modules/dagster/dagster/core/types/types_tests/test_materialization_schema.py
+++ b/python_modules/dagster/dagster/core/types/types_tests/test_materialization_schema.py
@@ -17,7 +17,4 @@ def test_materialization_schema_types():
 
     string_json_mat_schema = string_mat_schema.field_dict['json'].dagster_type
 
-    print(string_json_mat_schema.name)
-    print(string_json_mat_schema.field_dict)
-
     assert pipeline_def.type_named(string_json_mat_schema.name)

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -26,10 +26,8 @@ from dagster import (
 
 from dagster.core.types.configurable import ConfigurableFromScalar
 from dagster.core.definitions import TransformExecutionInfo
-from dagster.core.types.materializable import (
-    MaterializeableBuiltinScalar,
-    FileMarshalable,
-)
+from dagster.core.types.builtins import MaterializeableBuiltinScalar
+from dagster.core.types.materializable import FileMarshalable
 
 # magic incantation for syncing up notebooks to enclosing virtual environment.
 # I don't claim to understand it.


### PR DESCRIPTION
Well we finally are paying a real price for the confusion between the two type systems. This definitely demonstrates that we need a separate notion of scalars for both the config and runtime systems. The builtin-scalars contain a materialization schema which contain types that contain those scalars. We have to cut short the recursion at some point, and to do that we pass down a set of seen config schemas so we don't iterate over them twice.