### PR TITLE
Fix pytest breakage

### DIFF
--- a/python_modules/airline-demo/tox.ini
+++ b/python_modules/airline-demo/tox.ini
@@ -4,11 +4,8 @@ envlist = py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN TOXENV
 deps =
-  pytest
-  pytest-cov
-  pytest-dependency
-  pytest-runner
   -e ../dagster
+  -r ../dagster/dev-requirements.txt
   -e ../dagstermill
 commands =
   coverage erase

--- a/python_modules/dagit/dev-requirements.txt
+++ b/python_modules/dagit/dev-requirements.txt
@@ -2,6 +2,8 @@ pylint==2.2.2; python_version >= '3.6'
 pre-commit==1.10.1
 pytest==4.0.2
 pytest-cov==2.6.0
+pytest-dependency==0.4.0
+pytest-runner==4.2
 recommonmark==0.4.0
 rope==0.11.0
 snapshottest==0.5.0

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -5,8 +5,7 @@ envlist = py37,py36,py35,py27
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
   -e ../dagster
-  -r ../dagster/dev-requirements.txt
-  -r dev-requirements.txt
+  -r ./dev-requirements.txt
   -e ../dagstermill
   -e ../dagster-contrib
 commands =

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -4,15 +4,13 @@ envlist = py37,py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  pytest
-  pytest-cov
-  pytest-runner
+  -e ../dagster
+  -r ../dagster/dev-requirements.txt
+  -r dev-requirements.txt
+  -e ../dagstermill
+  -e ../dagster-contrib
 commands =
   coverage erase
-  pip install -r dev-requirements.txt
-  pip install -e ../dagster
-  pip install -e ../dagstermill
-  pip install -e ../dagster-contrib
   pytest -v --cov=dagit --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagma/dev-requirements.txt
+++ b/python_modules/dagma/dev-requirements.txt
@@ -1,4 +1,4 @@
 pylint==1.9.2
-pytest==3.6.1
+pytest==4.0.2
 pytest-cov==2.6.0
 yapf==0.22.0

--- a/python_modules/dagma/tox.ini
+++ b/python_modules/dagma/tox.ini
@@ -4,10 +4,8 @@ envlist = py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 deps =
-  pytest
-  pytest-cov
-  pytest-runner
   -e ../dagster
+  -r ../dagster/dev-requirements.txt
 commands =
   coverage erase
   pip install -e ../dagma

--- a/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_dagstermill_pandas_solids.py
@@ -21,6 +21,9 @@ from dagster.utils import script_relative_path
 from dagster_contrib.pandas import DataFrame
 
 
+# dummy commnet
+
+
 def nb_test_path(name):
     return script_relative_path('notebooks/{name}.ipynb'.format(name=name))
 

--- a/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagster-contrib/dagster_contrib/pandas/pandas_tests/test_dagstermill_pandas_solids.py
@@ -21,9 +21,6 @@ from dagster.utils import script_relative_path
 from dagster_contrib.pandas import DataFrame
 
 
-# dummy commnet
-
-
 def nb_test_path(name):
     return script_relative_path('notebooks/{name}.ipynb'.format(name=name))
 

--- a/python_modules/dagster-contrib/tox.ini
+++ b/python_modules/dagster-contrib/tox.ini
@@ -4,10 +4,8 @@ envlist = py37,py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  pytest
-  pytest-cov
-  pytest-runner
   -e ../dagster
+  -r ../dagster/dev-requirements.txt
   -e ../dagstermill
 commands =
   pip install -e .[pandas]

--- a/python_modules/dagster/dev-requirements.txt
+++ b/python_modules/dagster/dev-requirements.txt
@@ -2,6 +2,8 @@ black==18.9b0; python_version >= '3.6'
 pylint==2.2.2; python_version >= '3.6'
 pytest==4.0.2
 pytest-cov==2.6.0
+pytest-dependency==0.4.0
+pytest-runner==4.2
 recommonmark==0.4.0
 rope==0.11
 Sphinx==1.7.5

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -4,13 +4,10 @@ envlist = py37,py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  pytest
-  pytest-cov
-  pytest-runner
+  -e .
+  -r dev-requirements.txt
 commands =
   coverage erase
-  pip install -e ../dagster
-  pip install -r dev-requirements.txt
   pytest -v --cov=dagster --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagstermill/tox.ini
+++ b/python_modules/dagstermill/tox.ini
@@ -4,11 +4,9 @@ envlist = py36,py35,py27
 [testenv]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST COVERALLS_REPO_TOKEN
 deps =
-  pytest
-  pytest-cov
-  pytest-runner
+  -e ../dagster
+  -r ../dagster/dev-requirements.txt
 commands =
-  pip install -e ../dagster
   pytest -v --cov=dagstermill --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tgox/*,**/test_*.py'


### PR DESCRIPTION
A new version of pytest was released which broke our tests. Our tox files were install the latest version of pytest and not the pegged version in our various dev-requirements files.