### PR TITLE
Add dagster_type decorator

### DIFF
--- a/python_modules/airline-demo/airline_demo/types.py
+++ b/python_modules/airline-demo/airline_demo/types.py
@@ -8,6 +8,7 @@ import sqlalchemy
 
 from pyspark.sql import DataFrame
 
+from dagster import dagster_type, make_dagster_type
 from dagster.core.types.runtime import PythonObjectType, Stringish
 
 AirlineDemoResources = namedtuple(
@@ -16,18 +17,15 @@ AirlineDemoResources = namedtuple(
 )
 
 
-class SparkDataFrameType(PythonObjectType):
-    def __init__(self):
-        super(SparkDataFrameType, self).__init__(
-            python_type=DataFrame, description='A Pyspark data frame.'
-        )
+SparkDataFrameType = make_dagster_type(
+    DataFrame, name='SparkDataFrameType', description='A Pyspark data frame.'
+)
 
-
-class SqlAlchemyEngineType(PythonObjectType):
-    def __init__(self):
-        super(SqlAlchemyEngineType, self).__init__(
-            python_type=sqlalchemy.engine.Connectable, description='A SqlAlchemy Connectable'
-        )
+SqlAlchemyEngineType = make_dagster_type(
+    sqlalchemy.engine.Connectable,
+    name='SqlAlchemyEngineType',
+    description='A SqlAlchemy Connectable',
+)
 
 
 class SqlTableName(Stringish):

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -57,6 +57,8 @@ from dagster.core.types import (
     PythonObjectType,
     String,
 )
+
+from dagster.core.types.decorator import dagster_type
 from dagster.core.types.config import ConfigType
 from dagster.core.types.evaluator import DagsterEvaluateConfigValueError
 from dagster.core.types.runtime import RuntimeType

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -58,7 +58,7 @@ from dagster.core.types import (
     String,
 )
 
-from dagster.core.types.decorator import dagster_type
+from dagster.core.types.decorator import dagster_type, make_dagster_type
 from dagster.core.types.config import ConfigType
 from dagster.core.types.evaluator import DagsterEvaluateConfigValueError
 from dagster.core.types.runtime import RuntimeType

--- a/python_modules/dagster/dagster/core/definitions/definitions_tests/test_decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/definitions_tests/test_decorators.py
@@ -2,9 +2,11 @@
 import pytest
 
 from dagster import (
+    Any,
     DagsterInvalidDefinitionError,
     DependencyDefinition,
     ExecutionContext,
+    Field,
     InputDefinition,
     MultipleResults,
     OutputDefinition,
@@ -13,8 +15,6 @@ from dagster import (
     execute_pipeline,
     lambda_solid,
     solid,
-    Field,
-    Any,
 )
 
 from dagster.core.errors import DagsterInvariantViolationError

--- a/python_modules/dagster/dagster/core/types/__init__.py
+++ b/python_modules/dagster/dagster/core/types/__init__.py
@@ -1,5 +1,5 @@
 from .builtin_enum import BuiltinEnum
-from .dagster_type import Nullable, List
+from .wrapping import Nullable, List
 from .field import Dict, Field, NamedDict
 from .runtime import PythonObjectType
 

--- a/python_modules/dagster/dagster/core/types/config.py
+++ b/python_modules/dagster/dagster/core/types/config.py
@@ -235,8 +235,6 @@ def List(inner_type):
 def resolve_to_config_list(list_type):
     check.inst_param(list_type, 'list_type', WrappingListType)
     return List(resolve_config_type(list_type.inner_type))
-    # config_list_type = define_config_list_type(inner_type)
-    # return list_type(resolve_config_type(list_type.inner_type))
 
 
 def resolve_to_config_nullable(nullable_type):
@@ -245,8 +243,6 @@ def resolve_to_config_nullable(nullable_type):
 
 
 def resolve_config_type(dagster_type):
-    # check_dagster_type_param(dagster_type, 'dagster_type', ConfigType)
-
     if dagster_type is None:
         return ConfigAny.inst()
     if isinstance(dagster_type, BuiltinEnum):

--- a/python_modules/dagster/dagster/core/types/config.py
+++ b/python_modules/dagster/dagster/core/types/config.py
@@ -5,7 +5,9 @@ import six
 from dagster import check
 
 from .builtin_enum import BuiltinEnum
-from .dagster_type import WrappingListType, WrappingNullableType, check_dagster_type_param
+
+# from .dagster_type import check_dagster_type_param
+from .wrapping import WrappingListType, WrappingNullableType
 
 
 class ConfigTypeAttributes(
@@ -243,7 +245,7 @@ def resolve_to_config_nullable(nullable_type):
 
 
 def resolve_config_type(dagster_type):
-    check_dagster_type_param(dagster_type, 'dagster_type', ConfigType)
+    # check_dagster_type_param(dagster_type, 'dagster_type', ConfigType)
 
     if dagster_type is None:
         return ConfigAny.inst()

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -1,37 +1,26 @@
 from dagster import check
 
 from .builtin_enum import BuiltinEnum
+from .wrapping import WrappingType
+
+MAGIC_RUNTIME_TYPE_NAME = '__runtime_type'
 
 
-class WrappingType(object):
-    def __init__(self, inner_type):
-        # Cannot check inner_type because of circular references and no fwd declarations
-        self.inner_type = inner_type
-
-
-def List(inner_type):
-    return WrappingListType(inner_type)
-
-
-class WrappingListType(WrappingType):
-    pass
-
-
-def Nullable(inner_type):
-    return WrappingNullableType(inner_type)
-
-
-class WrappingNullableType(WrappingType):
-    pass
+def is_runtime_type_decorated_klass(klass):
+    check.type_param(klass, 'klass')
+    return hasattr(klass, MAGIC_RUNTIME_TYPE_NAME)
 
 
 def check_dagster_type_param(dagster_type, param_name, base_type):
+
     # Cannot check base_type because of circular references and no fwd declarations
     if dagster_type is None:
         return dagster_type
     if isinstance(dagster_type, BuiltinEnum):
         return dagster_type
     if isinstance(dagster_type, WrappingType):
+        return dagster_type
+    if is_runtime_type_decorated_klass(dagster_type):
         return dagster_type
 
     check.param_invariant(

--- a/python_modules/dagster/dagster/core/types/decorator.py
+++ b/python_modules/dagster/dagster/core/types/decorator.py
@@ -1,0 +1,49 @@
+from dagster import check
+from .runtime import PythonObjectType, RuntimeType
+
+
+def create_inner_class(bare_cls, name, description):
+    class _ObjectType(PythonObjectType):
+        def __init__(self):
+            super(_ObjectType, self).__init__(
+                name=name, description=description, python_type=bare_cls
+            )
+
+    type_inst = _ObjectType.inst()
+
+    make_klass_runtime_type_decorated_klass(bare_cls, type_inst)
+    return bare_cls
+
+
+def dagster_type(name=None, description=None):
+    def _with_args(bare_cls):
+        check.type_param(bare_cls, 'bare_cls')
+        return create_inner_class(
+            bare_cls=bare_cls, name=name if name else bare_cls.__name__, description=description
+        )
+
+    # check for no args, no parens case
+    if callable(name):
+        klass = name
+        return create_inner_class(bare_cls=klass, name=klass.__name__, description=None)
+
+    return _with_args
+
+
+MAGIC_RUNTIME_TYPE_NAME = '__runtime_type'
+
+
+def is_runtime_type_decorated_klass(klass):
+    check.type_param(klass, 'klass')
+    return hasattr(klass, MAGIC_RUNTIME_TYPE_NAME)
+
+
+def get_runtime_type_on_decorated_klass(klass):
+    check.type_param(klass, 'klass')
+    return getattr(klass, MAGIC_RUNTIME_TYPE_NAME)
+
+
+def make_klass_runtime_type_decorated_klass(klass, runtime_type):
+    check.type_param(klass, 'klass')
+    check.inst_param(runtime_type, 'runtime_type', RuntimeType)
+    setattr(klass, MAGIC_RUNTIME_TYPE_NAME, runtime_type)

--- a/python_modules/dagster/dagster/core/types/decorator.py
+++ b/python_modules/dagster/dagster/core/types/decorator.py
@@ -47,3 +47,14 @@ def make_klass_runtime_type_decorated_klass(klass, runtime_type):
     check.type_param(klass, 'klass')
     check.inst_param(runtime_type, 'runtime_type', RuntimeType)
     setattr(klass, MAGIC_RUNTIME_TYPE_NAME, runtime_type)
+
+
+def make_dagster_type(existing_type, name=None, description=None):
+    check.type_param(existing_type, 'existing_type')
+    check.opt_str_param(name, 'name')
+    check.opt_str_param(description, 'description')
+    return create_inner_class(
+        existing_type,
+        name=existing_type.__name__ if name is None else name,
+        description=description,
+    )

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -13,7 +13,7 @@ from .config import ConfigType
 from .config import List as ConfigList
 from .config import Nullable as ConfigNullable
 from .config import resolve_config_type
-from .dagster_type import WrappingListType, WrappingNullableType, check_dagster_type_param
+from .wrapping import WrappingListType, WrappingNullableType
 
 
 def check_opt_config_cls_param(config_cls, param_name):
@@ -237,6 +237,9 @@ _RUNTIME_MAP = {
     BuiltinEnum.PATH: Path.inst(),
 }
 
+from .dagster_type import check_dagster_type_param
+from .decorator import is_runtime_type_decorated_klass, get_runtime_type_on_decorated_klass
+
 
 def resolve_runtime_type(dagster_type):
     check_dagster_type_param(dagster_type, 'dagster_type', RuntimeType)
@@ -249,6 +252,8 @@ def resolve_runtime_type(dagster_type):
         return resolve_to_runtime_list(dagster_type)
     if isinstance(dagster_type, WrappingNullableType):
         return resolve_to_runtime_nullable(dagster_type)
+    if is_runtime_type_decorated_klass(dagster_type):
+        return get_runtime_type_on_decorated_klass(dagster_type)
     if issubclass(dagster_type, RuntimeType):
         return dagster_type.inst()
 

--- a/python_modules/dagster/dagster/core/types/types_tests/test_dagster_type_decorator.py
+++ b/python_modules/dagster/dagster/core/types/types_tests/test_dagster_type_decorator.py
@@ -1,4 +1,9 @@
-from dagster.core.types.decorator import dagster_type, get_runtime_type_on_decorated_klass
+from collections import namedtuple
+from dagster.core.types.decorator import (
+    dagster_type,
+    get_runtime_type_on_decorated_klass,
+    make_dagster_type,
+)
 
 
 def test_dagster_type_decorator():
@@ -17,3 +22,27 @@ def test_dagster_type_decorator():
     assert get_runtime_type_on_decorated_klass(Foo).name == 'Foo'
     assert get_runtime_type_on_decorated_klass(Bar).name == 'Bar'
     assert get_runtime_type_on_decorated_klass(Baaz).name == 'Baaz'
+
+
+def test_dagster_type_decorator_name_desc():
+    @dagster_type(name='DifferentName', description='desc')
+    class Something(object):
+        pass
+
+    runtime_type = get_runtime_type_on_decorated_klass(Something)
+    assert runtime_type.name == 'DifferentName'
+    assert runtime_type.description == 'desc'
+
+
+def test_make_dagster_type():
+    OverwriteNameTuple = make_dagster_type(namedtuple('SomeNamedTuple', 'prop'))
+    runtime_type = get_runtime_type_on_decorated_klass(OverwriteNameTuple)
+    assert runtime_type.name == 'SomeNamedTuple'
+    assert OverwriteNameTuple(prop='foo').prop == 'foo'
+
+    OverwriteNameTuple = make_dagster_type(
+        namedtuple('SomeNamedTuple', 'prop'), name='OverwriteName'
+    )
+    runtime_type = get_runtime_type_on_decorated_klass(OverwriteNameTuple)
+    assert runtime_type.name == 'OverwriteName'
+    assert OverwriteNameTuple(prop='foo').prop == 'foo'

--- a/python_modules/dagster/dagster/core/types/types_tests/test_dagster_type_decorator.py
+++ b/python_modules/dagster/dagster/core/types/types_tests/test_dagster_type_decorator.py
@@ -1,0 +1,19 @@
+from dagster.core.types.decorator import dagster_type, get_runtime_type_on_decorated_klass
+
+
+def test_dagster_type_decorator():
+    @dagster_type(name=None)
+    class Foo(object):
+        pass
+
+    @dagster_type()
+    class Bar(object):
+        pass
+
+    @dagster_type
+    class Baaz(object):
+        pass
+
+    assert get_runtime_type_on_decorated_klass(Foo).name == 'Foo'
+    assert get_runtime_type_on_decorated_klass(Bar).name == 'Bar'
+    assert get_runtime_type_on_decorated_klass(Baaz).name == 'Baaz'

--- a/python_modules/dagster/dagster/core/types/wrapping.py
+++ b/python_modules/dagster/dagster/core/types/wrapping.py
@@ -1,0 +1,20 @@
+class WrappingType(object):
+    def __init__(self, inner_type):
+        # Cannot check inner_type because of circular references and no fwd declarations
+        self.inner_type = inner_type
+
+
+def List(inner_type):
+    return WrappingListType(inner_type)
+
+
+class WrappingListType(WrappingType):
+    pass
+
+
+def Nullable(inner_type):
+    return WrappingNullableType(inner_type)
+
+
+class WrappingNullableType(WrappingType):
+    pass

--- a/python_modules/dagster/dagster/core/types/wrapping.py
+++ b/python_modules/dagster/dagster/core/types/wrapping.py
@@ -13,6 +13,7 @@ class WrappingListType(WrappingType):
 
 
 def Nullable(inner_type):
+    # Cannot check inner_type because of circular references and no fwd declarations
     return WrappingNullableType(inner_type)
 
 

--- a/python_modules/dagster/dagster/tutorials/test_intro_tutorial_part_twelve.py
+++ b/python_modules/dagster/dagster/tutorials/test_intro_tutorial_part_twelve.py
@@ -16,18 +16,12 @@ from dagster import (
     execute_pipeline,
     lambda_solid,
     solid,
+    make_dagster_type,
 )
 
 from dagster.core.types.runtime import RuntimeType
 
-StringTuple = namedtuple('StringTuple', 'str_one str_two')
-
-
-class StringTupleType(PythonObjectType):
-    def __init__(self):
-        super(StringTupleType, self).__init__(
-            name='StringTuple', python_type=StringTuple, description=''
-        )
+StringTuple = make_dagster_type(namedtuple('StringTuple', 'str_one str_two'))
 
 
 class SSNString(str):
@@ -55,7 +49,7 @@ class SSNStringTypeClass(RuntimeType):
         return SSNString(value)
 
 
-@lambda_solid(output=OutputDefinition(StringTupleType))
+@lambda_solid(output=OutputDefinition(StringTuple))
 def produce_valid_value():
     return StringTuple(str_one='value_one', str_two='value_two')
 
@@ -65,7 +59,7 @@ def produce_invalid_value():
     return 'not_a_tuple'
 
 
-@solid(inputs=[InputDefinition('string_tuple', StringTupleType)])
+@solid(inputs=[InputDefinition('string_tuple', StringTuple)])
 def consume_string_tuple(info, string_tuple):
     info.context.info('Logging value {string_tuple}'.format(string_tuple=string_tuple))
 

--- a/python_modules/dagster/dagster/tutorials/test_intro_tutorial_part_twelve.py
+++ b/python_modules/dagster/dagster/tutorials/test_intro_tutorial_part_twelve.py
@@ -12,11 +12,10 @@ from dagster import (
     InputDefinition,
     OutputDefinition,
     PipelineDefinition,
-    PythonObjectType,
     execute_pipeline,
     lambda_solid,
-    solid,
     make_dagster_type,
+    solid,
 )
 
 from dagster.core.types.runtime import RuntimeType


### PR DESCRIPTION
This adds two methods of creating dagster_types. One is the dagster_type decorator. This is used for new classes. The other is "make_dagster_type" which can help out with existing classes that one cannot modify. I decided to go with a monkeypatching approach. The other option would be to have a cache of classes for the whole program. I thought this was the better option all things consider because I like to avoid these type of global caches when possible.