### PR TITLE
Input and Output Schema

### DIFF
--- a/python_modules/Makefile
+++ b/python_modules/Makefile
@@ -17,7 +17,7 @@ black:
 	black . --line-length 100 -S --fast
 
 pylint:
-	pylint --disable=R,C dagster/dagster dagit/dagit dagstermill/dagstermill dagster-contrib/dagster_contrib
+	pylint --disable=R,C dagster/dagster dagit/dagit dagstermill/dagstermill dagster-pandas/dagster_pandas dagster-sqlalchemy/dagster_sqlalchemy
 
 reinstall:
 	pip uninstall dagit

--- a/python_modules/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/dagster-pandas/dagster_pandas/data_frame.py
@@ -1,24 +1,9 @@
 from collections import namedtuple
-import pickle
 
 import pandas as pd
 
-from dagster import (
-    Dict,
-    ExecutionContext,
-    Field,
-    InputDefinition,
-    OutputDefinition,
-    Path,
-    Result,
-    Selector,
-    SolidDefinition,
-    String,
-    check,
-    types,
-)
+from dagster import Dict, Field, Path, Selector, String, check, types
 
-from dagster.core.types.field import ConfigSelector
 from dagster.core.types.config_schema import InputSchema, OutputSchema
 
 from dagster.core.types.materializable import FileMarshalable

--- a/python_modules/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/dagster-pandas/dagster_pandas/data_frame.py
@@ -3,9 +3,23 @@ import pickle
 
 import pandas as pd
 
-from dagster import check, Dict, Field, Path, String, types
+from dagster import (
+    Dict,
+    ExecutionContext,
+    Field,
+    InputDefinition,
+    OutputDefinition,
+    Path,
+    Result,
+    Selector,
+    SolidDefinition,
+    String,
+    check,
+    types,
+)
 
 from dagster.core.types.field import ConfigSelector
+from dagster.core.types.config_schema import InputSchema, OutputSchema
 
 from dagster.core.types.materializable import FileMarshalable
 
@@ -22,34 +36,11 @@ def define_csv_dict_field():
     )
 
 
-class PandasDataFrameInputSchema(ConfigSelector):
-    def __init__(self):
-        super(PandasDataFrameInputSchema, self).__init__(
-            fields={
-                'csv': define_csv_dict_field(),
-                'parquet': define_path_dict_field(),
-                'table': define_path_dict_field(),
-            }
-        )
-
-    def construct_from_config_value(self, config_value):
-        file_type, file_options = list(config_value.items())[0]
-        if file_type == 'csv':
-            path = file_options['path']
-            del file_options['path']
-            return pd.read_csv(path, **file_options)
-        elif file_type == 'parquet':
-            return pd.read_parquet(file_options['path'])
-        elif file_type == 'table':
-            return pd.read_table(file_options['path'])
-        else:
-            check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
-
-
-class PandasDataFrameOutputConfigSchema(ConfigSelector):
-    def __init__(self):
-        super(PandasDataFrameOutputConfigSchema, self).__init__(
-            fields={
+class PandasDataFrameOutputSchema(OutputSchema):
+    @property
+    def schema_cls(self):
+        return Selector(
+            {
                 'csv': define_csv_dict_field(),
                 'parquet': define_path_dict_field(),
                 'table': define_path_dict_field(),
@@ -71,6 +62,31 @@ class PandasDataFrameOutputConfigSchema(ConfigSelector):
         check.failed('must implement')
 
 
+class PandasDataFrameInputSchema(InputSchema):
+    @property
+    def schema_cls(self):
+        return Selector(
+            {
+                'csv': define_csv_dict_field(),
+                'parquet': define_path_dict_field(),
+                'table': define_path_dict_field(),
+            }
+        )
+
+    def construct_from_config_value(self, value):
+        file_type, file_options = list(value.items())[0]
+        if file_type == 'csv':
+            path = file_options['path']
+            del file_options['path']
+            return pd.read_csv(path, **file_options)
+        elif file_type == 'parquet':
+            return pd.read_parquet(file_options['path'])
+        elif file_type == 'table':
+            return pd.read_table(file_options['path'])
+        else:
+            check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
+
+
 class DataFrame(FileMarshalable, types.PythonObjectType):
     def __init__(self):
         super(DataFrame, self).__init__(
@@ -78,17 +94,6 @@ class DataFrame(FileMarshalable, types.PythonObjectType):
             python_type=pd.DataFrame,
             description='''Two-dimensional size-mutable, potentially heterogeneous
     tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/''',
-            input_schema_cls=PandasDataFrameInputSchema,
-            output_schema_cls=PandasDataFrameOutputConfigSchema,
+            input_schema=PandasDataFrameInputSchema(),
+            output_schema=PandasDataFrameOutputSchema(),
         )
-
-    def marshal_value(self, value, to_file):
-        with open(to_file, 'wb') as ff:
-            pickle.dump(value, ff)
-
-    def unmarshal_value(self, from_file):
-        with open(from_file, 'rb') as ff:
-            return pickle.load(ff)
-
-    def define_materialization_config_schema(self):
-        return PandasDataFrameOutputConfigSchema

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -55,6 +55,7 @@ from dagster.core.types import (
     Nullable,
     Path,
     PythonObjectType,
+    Selector,
     String,
 )
 

--- a/python_modules/dagster/dagster/core/definitions/input.py
+++ b/python_modules/dagster/dagster/core/definitions/input.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.core.types.runtime import RuntimeType, resolve_runtime_type
+from dagster.core.types.runtime import RuntimeType, resolve_to_runtime_type
 
 from .expectation import ExpectationDefinition
 from .utils import check_valid_name
@@ -22,7 +22,7 @@ class InputDefinition(object):
         ''
         self.name = check_valid_name(name)
 
-        self.runtime_type = check.inst(resolve_runtime_type(runtime_type), RuntimeType)
+        self.runtime_type = check.inst(resolve_to_runtime_type(runtime_type), RuntimeType)
 
         self.expectations = check.opt_list_param(
             expectations, 'expectations', of_type=ExpectationDefinition

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -1,5 +1,5 @@
 from dagster import check
-from dagster.core.types.runtime import RuntimeType, resolve_runtime_type
+from dagster.core.types.runtime import RuntimeType, resolve_to_runtime_type
 
 from .expectation import ExpectationDefinition
 from .utils import check_valid_name, DEFAULT_OUTPUT
@@ -21,7 +21,7 @@ class OutputDefinition(object):
     def __init__(self, dagster_type=None, name=None, expectations=None, description=None):
         self.name = check_valid_name(check.opt_str_param(name, 'name', DEFAULT_OUTPUT))
 
-        self.runtime_type = check.inst(resolve_runtime_type(dagster_type), RuntimeType)
+        self.runtime_type = check.inst(resolve_to_runtime_type(dagster_type), RuntimeType)
 
         self.expectations = check.opt_list_param(
             expectations, 'expectations', of_type=ExpectationDefinition

--- a/python_modules/dagster/dagster/core/definitions/pipeline_creation.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_creation.py
@@ -178,10 +178,10 @@ def _gather_all_schemas(solid_defs):
     runtime_types = construct_runtime_type_dictionary(solid_defs)
     for rtt in runtime_types.values():
         if rtt.input_schema:
-            for ct in iterate_config_types(rtt.input_schema):
+            for ct in iterate_config_types(rtt.input_schema.schema_type):
                 yield ct
         if rtt.output_schema:
-            for ct in iterate_config_types(rtt.output_schema):
+            for ct in iterate_config_types(rtt.output_schema.schema_type):
                 yield ct
 
 

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -9,8 +9,11 @@ from .objects import ExecutionPlanInfo, ExecutionStep, StepOutput, StepOutputHan
 INPUT_THUNK_OUTPUT = 'input_thunk_output'
 
 
-def _create_input_thunk_execution_step(solid, input_def, value):
+def _create_input_thunk_execution_step(solid, input_def, config_value):
+    check.invariant(input_def.runtime_type.input_schema)
+
     def _fn(_context, _step, _inputs):
+        value = input_def.runtime_type.input_schema.construct_from_config_value(config_value)
         yield Result(value, INPUT_THUNK_OUTPUT)
 
     return ExecutionStep(

--- a/python_modules/dagster/dagster/core/system_config/types.py
+++ b/python_modules/dagster/dagster/core/system_config/types.py
@@ -288,7 +288,7 @@ def get_inputs_field(pipeline_def, solid):
         # If this input is not satisfied by a dependency you must
         # provide it via config
         if not pipeline_def.dependency_structure.has_dep(inp_handle):
-            inputs_field_fields[inp.name] = Field(type(inp.runtime_type.input_schema))
+            inputs_field_fields[inp.name] = Field(inp.runtime_type.input_schema.schema_cls)
 
     if not inputs_field_fields:
         return None
@@ -314,7 +314,9 @@ def get_outputs_field(pipeline_def, solid):
 
     output_dict_fields = {}
     for out in [out for out in solid_def.output_defs if out.runtime_type.output_schema]:
-        output_dict_fields[out.name] = Field(type(out.runtime_type.output_schema), is_optional=True)
+        output_dict_fields[out.name] = Field(
+            out.runtime_type.output_schema.schema_cls, is_optional=True
+        )
 
     output_entry_dict = NamedDict(
         '{pipeline_name}.{solid_name}.Outputs'.format(

--- a/python_modules/dagster/dagster/core/types/__init__.py
+++ b/python_modules/dagster/dagster/core/types/__init__.py
@@ -1,6 +1,6 @@
 from .builtin_enum import BuiltinEnum
 from .wrapping import Nullable, List
-from .field import Dict, Field, NamedDict
+from .field import Dict, Field, NamedDict, Selector
 from .runtime import PythonObjectType
 
 Any = BuiltinEnum.ANY

--- a/python_modules/dagster/dagster/core/types/config.py
+++ b/python_modules/dagster/dagster/core/types/config.py
@@ -234,15 +234,15 @@ def List(inner_type):
 
 def resolve_to_config_list(list_type):
     check.inst_param(list_type, 'list_type', WrappingListType)
-    return List(resolve_config_type(list_type.inner_type))
+    return List(resolve_to_config_type(list_type.inner_type))
 
 
 def resolve_to_config_nullable(nullable_type):
     check.inst_param(nullable_type, 'nullable_type', WrappingNullableType)
-    return Nullable(resolve_config_type(nullable_type.inner_type))
+    return Nullable(resolve_to_config_type(nullable_type.inner_type))
 
 
-def resolve_config_type(dagster_type):
+def resolve_to_config_type(dagster_type):
     if dagster_type is None:
         return ConfigAny.inst()
     if isinstance(dagster_type, BuiltinEnum):

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -1,0 +1,38 @@
+from dagster import check
+
+from .config import resolve_to_config_type
+
+
+class InputSchema:
+    @property
+    def schema_cls(self):
+        check.not_implemented('Must implement')
+
+    @property
+    def schema_type(self):
+        return resolve_to_config_type(self.schema_cls)
+
+    def construct_from_config_value(self, value):
+        return value
+
+
+def make_input_schema(dagster_type):
+    class _InputSchema(InputSchema):
+        @property
+        def schema_cls(self):
+            return dagster_type
+
+    return _InputSchema()
+
+
+class OutputSchema:
+    @property
+    def schema_cls(self):
+        check.not_implemented('Must implement')
+
+    @property
+    def schema_type(self):
+        return resolve_to_config_type(self.schema_cls)
+
+    def materialize_runtime_value(self, _config_value, _runtime_value):
+        check.not_implemented('Must implement')

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -29,13 +29,12 @@ def check_dagster_type_param(dagster_type, param_name, base_type):
         'Invalid dagster_type got {dagster_type}'.format(dagster_type=dagster_type),
     )
 
-    check.param_invariant(
-        issubclass(dagster_type, base_type),
-        'dagster_type',
-        (
-            'Parameter {param_name} must be a valid dagster type: A builtin (e.g. String, Int, '
-            'etc), a wrapping type (List or Nullable), or a type class'
-        ).format(param_name=param_name),
-    )
+    if not issubclass(dagster_type, base_type):
+        check.failed(
+            (
+                'Parameter {param_name} must be a valid dagster type: A builtin (e.g. String, Int, '
+                'etc), a wrapping type (List or Nullable), or a type class. Got {dagster_type}'
+            ).format(param_name=param_name, dagster_type=dagster_type)
+        )
 
     return dagster_type

--- a/python_modules/dagster/dagster/core/types/field.py
+++ b/python_modules/dagster/dagster/core/types/field.py
@@ -8,7 +8,7 @@ from .config import (
     Int,
     Path,
     String,
-    resolve_config_type,
+    resolve_to_config_type,
 )
 from .dagster_type import check_dagster_type_param
 
@@ -68,7 +68,7 @@ class Field:
         description=None,
     ):
         check_dagster_type_param(dagster_type, 'dagster_type', ConfigType)
-        self.config_type = resolve_config_type(dagster_type)
+        self.config_type = resolve_to_config_type(dagster_type)
         self.config_cls = type(self.config_type)
 
         self.description = check.opt_str_param(description, 'description')
@@ -207,3 +207,24 @@ def Dict(fields):
             )
 
     return _Dict
+
+
+def Selector(fields):
+    class _Selector(ConfigSelector):
+        def __init__(self):
+            super(_Selector, self).__init__(
+                name='Selector.' + str(DictCounter.get_next_count()),
+                fields=fields,
+                # description='A configuration dictionary with typed fields',
+                type_attributes=ConfigTypeAttributes(is_named=True, is_builtin=True),
+            )
+
+    return _Selector
+
+
+def NamedSelector(name, fields, description=None):
+    class _NamedSelector(ConfigSelector):
+        def __init__(self):
+            super(_NamedSelector, self).__init__(name=name, fields=fields, description=description)
+
+    return _NamedSelector

--- a/python_modules/dagster/dagster/core/types/materializable.py
+++ b/python_modules/dagster/dagster/core/types/materializable.py
@@ -1,17 +1,11 @@
-from dagster import check
-
-
-class Materializeable(object):
-    def define_materialization_config_schema(self):
-        check.failed('must implement')
-
-    def materialize_runtime_value(self, _config_spec, _runtime_value):
-        check.failed('must implement')
+import pickle
 
 
 class FileMarshalable:
-    def marshal_value(self, _value, _to_file):
-        check.not_implemented('must implement')
+    def marshal_value(self, value, to_file):
+        with open(to_file, 'wb') as ff:
+            pickle.dump(value, ff)
 
-    def unmarshal_value(self, _from_file):
-        check.not_implemented('must implement')
+    def unmarshal_value(self, from_file):
+        with open(from_file, 'rb') as ff:
+            return pickle.load(ff)

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -229,7 +229,7 @@ _RUNTIME_MAP = {
 }
 
 
-def resolve_runtime_type(dagster_type):
+def resolve_to_runtime_type(dagster_type):
     # circular dep
     from .decorator import is_runtime_type_decorated_klass, get_runtime_type_on_decorated_klass
 
@@ -253,9 +253,9 @@ def resolve_runtime_type(dagster_type):
 
 def resolve_to_runtime_list(list_type):
     check.inst_param(list_type, 'list_type', WrappingListType)
-    return List(resolve_runtime_type(list_type.inner_type))
+    return List(resolve_to_runtime_type(list_type.inner_type))
 
 
 def resolve_to_runtime_nullable(nullable_type):
     check.inst_param(nullable_type, 'nullable_type', WrappingNullableType)
-    return Nullable(resolve_runtime_type(nullable_type.inner_type))
+    return Nullable(resolve_to_runtime_type(nullable_type.inner_type))

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -93,11 +93,13 @@ class BuiltinScalarRuntimeType(RuntimeType):
         return True
 
 
+INT_SCHEMA = define_builtin_scalar_output_schema('Int')
+
+
 class Int(BuiltinScalarRuntimeType):
     def __init__(self):
         super(Int, self).__init__(
-            input_schema=make_input_schema(ConfigInt),
-            output_schema=define_builtin_scalar_output_schema('Int'),
+            input_schema=make_input_schema(ConfigInt), output_schema=INT_SCHEMA
         )
 
     def coerce_runtime_value(self, value):
@@ -106,11 +108,13 @@ class Int(BuiltinScalarRuntimeType):
         )
 
 
+STRING_SCHEMA = define_builtin_scalar_output_schema('String')
+
+
 class String(BuiltinScalarRuntimeType):
     def __init__(self):
         super(String, self).__init__(
-            input_schema=make_input_schema(ConfigString),
-            output_schema=define_builtin_scalar_output_schema('String'),
+            input_schema=make_input_schema(ConfigString), output_schema=STRING_SCHEMA
         )
 
     def coerce_runtime_value(self, value):

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -12,7 +12,8 @@ from .config import Any as ConfigAny
 from .config import ConfigType
 from .config import List as ConfigList
 from .config import Nullable as ConfigNullable
-from .config import resolve_config_type
+from .config_schema import InputSchema, OutputSchema, make_input_schema
+from .dagster_type import check_dagster_type_param
 from .wrapping import WrappingListType, WrappingNullableType
 
 
@@ -25,7 +26,7 @@ def check_opt_config_cls_param(config_cls, param_name):
 
 
 class RuntimeType(object):
-    def __init__(self, name=None, description=None, input_schema_cls=None, output_schema_cls=None):
+    def __init__(self, name=None, description=None, input_schema=None, output_schema=None):
 
         type_obj = type(self)
         if type_obj in RuntimeType.__cache:
@@ -38,16 +39,8 @@ class RuntimeType(object):
 
         self.name = check.opt_str_param(name, 'name', type(self).__name__)
         self.description = check.opt_str_param(description, 'description')
-        self.input_schema = (
-            None if input_schema_cls is None else resolve_config_type(input_schema_cls)
-        )
-        #  check_opt_config_cls_param(input_schema_cls, 'input_schema_cls')
-        self.output_schema = (
-            None if input_schema_cls is None else resolve_config_type(output_schema_cls)
-        )
-        # self.output_schema_cls = check_opt_config_cls_param(output_schema_cls, 'output_schema_cls')
-        # self.input_schema = None if input_schema_cls is None else input_schema_cls.inst()
-        # self.output_schema = None if output_schema_cls is None else output_schema_cls.inst()
+        self.input_schema = check.opt_inst_param(input_schema, 'input_schema', InputSchema)
+        self.output_schema = check.opt_inst_param(output_schema, 'output_schema', OutputSchema)
 
     __cache = {}
 
@@ -100,12 +93,12 @@ class BuiltinScalarRuntimeType(RuntimeType):
         return True
 
 
-_IntOutputSchema = define_builtin_scalar_output_schema('Int')
-
-
 class Int(BuiltinScalarRuntimeType):
     def __init__(self):
-        super(Int, self).__init__(input_schema_cls=ConfigInt, output_schema_cls=_IntOutputSchema)
+        super(Int, self).__init__(
+            input_schema=make_input_schema(ConfigInt),
+            output_schema=define_builtin_scalar_output_schema('Int'),
+        )
 
     def coerce_runtime_value(self, value):
         return self.throw_if_false(
@@ -113,13 +106,11 @@ class Int(BuiltinScalarRuntimeType):
         )
 
 
-_StringOutputSchema = define_builtin_scalar_output_schema('String')
-
-
 class String(BuiltinScalarRuntimeType):
     def __init__(self):
         super(String, self).__init__(
-            input_schema_cls=ConfigString, output_schema_cls=_StringOutputSchema
+            input_schema=make_input_schema(ConfigString),
+            output_schema=define_builtin_scalar_output_schema('String'),
         )
 
     def coerce_runtime_value(self, value):
@@ -148,7 +139,7 @@ class Bool(RuntimeType):
 
 class Any(RuntimeType):
     def __init__(self):
-        super(Any, self).__init__(input_schema_cls=ConfigAny)
+        super(Any, self).__init__(input_schema=make_input_schema(ConfigAny))
 
     @property
     def is_any(self):
@@ -168,7 +159,7 @@ class NullableType(RuntimeType):
     def __init__(self, inner_type):
         super(NullableType, self).__init__(
             name='Nullable.' + inner_type.name,
-            input_schema_cls=ConfigNullable(inner_type.input_schema)
+            input_schema=make_input_schema(ConfigNullable(inner_type.input_schema.schema_type))
             if inner_type.input_schema
             else None,
         )
@@ -186,7 +177,7 @@ class ListType(RuntimeType):
     def __init__(self, inner_type):
         super(ListType, self).__init__(
             name='List.' + inner_type.name,
-            input_schema_cls=ConfigList(inner_type.input_schema)
+            input_schema=make_input_schema(ConfigList(inner_type.input_schema.schema_type))
             if inner_type.input_schema
             else None,
         )
@@ -237,11 +228,11 @@ _RUNTIME_MAP = {
     BuiltinEnum.PATH: Path.inst(),
 }
 
-from .dagster_type import check_dagster_type_param
-from .decorator import is_runtime_type_decorated_klass, get_runtime_type_on_decorated_klass
-
 
 def resolve_runtime_type(dagster_type):
+    # circular dep
+    from .decorator import is_runtime_type_decorated_klass, get_runtime_type_on_decorated_klass
+
     check_dagster_type_param(dagster_type, 'dagster_type', RuntimeType)
 
     if dagster_type is None:

--- a/python_modules/dagster/dagster/core/types/type_printer.py
+++ b/python_modules/dagster/dagster/core/types/type_printer.py
@@ -3,7 +3,7 @@ from dagster import check
 
 from dagster.utils.indenting_printer import IndentingPrinter
 
-from .config import ConfigType, resolve_config_type
+from .config import ConfigType, resolve_to_config_type
 
 
 def print_type(config_type, print_fn=print):
@@ -42,7 +42,7 @@ def _do_print(config_type, printer):
 
 
 def print_type_to_string(dagster_type):
-    config_type = resolve_config_type(dagster_type)
+    config_type = resolve_to_config_type(dagster_type)
     prints = []
 
     def _push(text):

--- a/python_modules/dagster/dagster/core/types/types_tests/test_new_config_types.py
+++ b/python_modules/dagster/dagster/core/types/types_tests/test_new_config_types.py
@@ -1,11 +1,11 @@
 from dagster.core.types import Int, Nullable, List
-from dagster.core.types.config import resolve_config_type
+from dagster.core.types.config import resolve_to_config_type
 
 from dagster.core.types.evaluator import validate_config
 
 
 def test_config_int():
-    int_inst = resolve_config_type(Int)
+    int_inst = resolve_to_config_type(Int)
     assert not validate_config(int_inst, 1)
     assert validate_config(int_inst, None)
     assert validate_config(int_inst, 'r')
@@ -16,14 +16,14 @@ def test_config_int():
 
 
 def test_nullable_int():
-    nullable_int_inst = resolve_config_type(Nullable(Int))
+    nullable_int_inst = resolve_to_config_type(Nullable(Int))
     assert not validate_config(nullable_int_inst, 1)
     assert not validate_config(nullable_int_inst, None)
     assert validate_config(nullable_int_inst, 'r')
 
 
 def test_list_int():
-    list_int = resolve_config_type(List(Int))
+    list_int = resolve_to_config_type(List(Int))
     assert not validate_config(list_int, [1])
     assert not validate_config(list_int, [1, 2])
     assert not validate_config(list_int, [])
@@ -34,7 +34,7 @@ def test_list_int():
 
 
 def test_list_nullable_int():
-    lni = resolve_config_type(List(Nullable(Int)))
+    lni = resolve_to_config_type(List(Nullable(Int)))
     assert not validate_config(lni, [1])
     assert not validate_config(lni, [1, 2])
     assert not validate_config(lni, [])

--- a/python_modules/dagster/test/core_tests/types_tests/test_evaluator.py
+++ b/python_modules/dagster/test/core_tests/types_tests/test_evaluator.py
@@ -1,6 +1,6 @@
 from dagster import Field, Dict, String, Int, Bool, Nullable, List
 
-from dagster.core.types.config import resolve_config_type
+from dagster.core.types.config import resolve_to_config_type
 from dagster.core.types.evaluator import (
     DagsterEvaluationErrorReason,
     EvaluationStackListItemEntry,
@@ -13,7 +13,7 @@ from dagster.core.types.field import ConfigSelector
 
 
 def eval_config_value_from_dagster_type(dagster_type, value):
-    return evaluate_config_value(resolve_config_type(dagster_type), value)
+    return evaluate_config_value(resolve_to_config_type(dagster_type), value)
 
 
 def assert_success(result, expected_value):

--- a/python_modules/dagster/test/core_tests/types_tests/test_type_printer.py
+++ b/python_modules/dagster/test/core_tests/types_tests/test_type_printer.py
@@ -1,12 +1,12 @@
 from dagster import PipelineDefinition, SolidDefinition, Int, Field, String, List, Nullable, Dict
 
-from dagster.core.types.config import resolve_config_type
+from dagster.core.types.config import resolve_to_config_type
 from dagster.core.types.type_printer import print_type_to_string
 
 
 def assert_inner_types(parent_type, *dagster_types):
-    assert set(list(map(lambda t: t.name, resolve_config_type(parent_type).inner_types))) == set(
-        map(lambda x: x.name, map(resolve_config_type, dagster_types))
+    assert set(list(map(lambda t: t.name, resolve_to_config_type(parent_type).inner_types))) == set(
+        map(lambda x: x.name, map(resolve_to_config_type, dagster_types))
     )
 
 

--- a/python_modules/dagster/test/core_tests/types_tests/test_types.py
+++ b/python_modules/dagster/test/core_tests/types_tests/test_types.py
@@ -3,7 +3,7 @@ import pytest
 from dagster.core.errors import DagsterRuntimeCoercionError
 
 from dagster.core.types import Int, Nullable, List, PythonObjectType
-from dagster.core.types.runtime import resolve_runtime_type
+from dagster.core.types.runtime import resolve_to_runtime_type
 
 
 class BarObj(object):
@@ -29,7 +29,7 @@ def test_python_object_type():
 
 
 def test_nullable_python_object_type():
-    nullable_type_bar = resolve_runtime_type(Nullable(Bar))
+    nullable_type_bar = resolve_to_runtime_type(Nullable(Bar))
 
     assert nullable_type_bar.coerce_runtime_value(BarObj())
     assert nullable_type_bar.coerce_runtime_value(None) is None
@@ -39,13 +39,13 @@ def test_nullable_python_object_type():
 
 
 def test_nullable_int_coercion():
-    int_type = resolve_runtime_type(Int)
+    int_type = resolve_to_runtime_type(Int)
     assert int_type.coerce_runtime_value(1) == 1
 
     with pytest.raises(DagsterRuntimeCoercionError):
         assert int_type.coerce_runtime_value(None)
 
-    nullable_int_type = resolve_runtime_type(Nullable(Int))
+    nullable_int_type = resolve_to_runtime_type(Nullable(Int))
     assert nullable_int_type.coerce_runtime_value(1) == 1
     assert nullable_int_type.coerce_runtime_value(None) is None
 
@@ -61,27 +61,27 @@ def assert_failure(fn, value):
 
 def test_nullable_list_combos_coerciion():
 
-    list_of_int = resolve_runtime_type(List(Int))
+    list_of_int = resolve_to_runtime_type(List(Int))
 
     assert_failure(list_of_int.coerce_runtime_value, None)
     assert_success(list_of_int.coerce_runtime_value, [])
     assert_success(list_of_int.coerce_runtime_value, [1])
     assert_failure(list_of_int.coerce_runtime_value, [None])
 
-    nullable_int_of_list = resolve_runtime_type(Nullable(List(Int)))
+    nullable_int_of_list = resolve_to_runtime_type(Nullable(List(Int)))
 
     assert_success(nullable_int_of_list.coerce_runtime_value, None)
     assert_success(nullable_int_of_list.coerce_runtime_value, [])
     assert_success(nullable_int_of_list.coerce_runtime_value, [1])
     assert_failure(nullable_int_of_list.coerce_runtime_value, [None])
 
-    list_of_nullable_int = resolve_runtime_type(List(Nullable(Int)))
+    list_of_nullable_int = resolve_to_runtime_type(List(Nullable(Int)))
     assert_failure(list_of_nullable_int.coerce_runtime_value, None)
     assert_success(list_of_nullable_int.coerce_runtime_value, [])
     assert_success(list_of_nullable_int.coerce_runtime_value, [1])
     assert_success(list_of_nullable_int.coerce_runtime_value, [None])
 
-    nullable_list_of_nullable_int = resolve_runtime_type(Nullable(List(Nullable(Int))))
+    nullable_list_of_nullable_int = resolve_to_runtime_type(Nullable(List(Nullable(Int))))
     assert_success(nullable_list_of_nullable_int.coerce_runtime_value, None)
     assert_success(nullable_list_of_nullable_int.coerce_runtime_value, [])
     assert_success(nullable_list_of_nullable_int.coerce_runtime_value, [1])


### PR DESCRIPTION
This is a continuing refactor of the type system. Whenever one wants to implement a type with input and output config schemas, you implement subclasses of InputSchema and OutputSchema, respectively.