### PR TITLE
System Config Change; Eliminate custom config types

### DIFF
--- a/python_modules/Makefile
+++ b/python_modules/Makefile
@@ -14,8 +14,8 @@ watch:
 	--drop dagster/dagster dagster/dagster_tests/ dagster-ge/dagster_ge dagster-ge/dagster_ge_tests dagit/dagit dagit/dagit_tests
 
 black:
-	black . --line-length 100 -S --fast --exclude "build/|buck-out/|dist/|_build/|\.eggs/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|python_modules/dagster/dagster/tutorials/" --check
-	black ./dagster/dagster/tutorials --line-length 79 -S --fast --check
+	black . --line-length 100 -S --fast --exclude "build/|buck-out/|dist/|_build/|\.eggs/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|python_modules/dagster/dagster/tutorials/"
+	black ./dagster/dagster/tutorials --line-length 79 -S --fast
 
 
 pylint:

--- a/python_modules/dagit/dagit/pipeline_execution_manager.py
+++ b/python_modules/dagit/dagit/pipeline_execution_manager.py
@@ -12,6 +12,7 @@ from dagster import check, ReentrantInfo, PipelineDefinition
 from dagster.core.execution import create_typed_environment, execute_reentrant_pipeline
 from dagster.core.events import PipelineEventRecord, EventType
 from dagster.core.types.evaluator import evaluate_config_value
+from dagster.core.system_config.types import construct_environment_config
 from dagster.utils.error import serializable_error_info_from_exc_info, SerializableErrorInfo
 from dagster.utils.logging import level_from_string
 
@@ -255,7 +256,9 @@ def execute_pipeline_through_queue(repository_info, pipeline_name, config, run_i
         return
 
     pipeline = repository_container.repository.get_pipeline(pipeline_name)
-    typed_environment = evaluate_config_value(pipeline.environment_type, config).value
+    typed_environment = construct_environment_config(
+        evaluate_config_value(pipeline.environment_type, config).value
+    )
 
     try:
         result = execute_reentrant_pipeline(

--- a/python_modules/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/dagster-pandas/dagster_pandas/data_frame.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 import pandas as pd
 
 from dagster import Dict, Field, Path, Selector, String, check, types
@@ -7,8 +5,6 @@ from dagster import Dict, Field, Path, Selector, String, check, types
 from dagster.core.types.config_schema import InputSchema, OutputSchema
 
 from dagster.core.types.materializable import FileMarshalable
-
-DataFrameMeta = namedtuple('DataFrameMeta', 'format path')
 
 
 def define_path_dict_field():

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -57,6 +57,7 @@ from .execution_plan.objects import (
 from .execution_plan.simple_engine import execute_plan_core
 
 from .system_config.objects import EnvironmentConfig
+from .system_config.types import construct_environment_config
 
 
 class PipelineExecutionResult(object):
@@ -631,4 +632,4 @@ def create_typed_environment(pipeline, environment=None):
     if not result.success:
         raise PipelineConfigEvaluationError(pipeline, result.errors, environment)
 
-    return result.value
+    return construct_environment_config(result.value)

--- a/python_modules/dagster/dagster/core/system_config/types.py
+++ b/python_modules/dagster/dagster/core/system_config/types.py
@@ -50,10 +50,6 @@ def define_maybe_optional_selector_field(config_cls):
     )
 
 
-def define_specific_resource_config_cls(name, config_field):
-    return NamedDict(name, {'config': config_field})
-
-
 def define_resource_dictionary_cls(name, resources):
     check.str_param(name, 'name')
     check.dict_param(resources, 'resources', key_type=str, value_type=ResourceDefinition)

--- a/python_modules/dagster/dagster/core/system_config/types.py
+++ b/python_modules/dagster/dagster/core/system_config/types.py
@@ -14,7 +14,7 @@ from dagster.core.definitions import (
 
 from dagster.core.types import Bool, Field, List
 from dagster.core.types.config import ConfigType, ConfigTypeAttributes
-from dagster.core.types.field import ConfigComposite, ConfigSelector, NamedDict
+from dagster.core.types.field import NamedDict, NamedSelector
 
 from dagster.core.types.evaluator import hard_create_config_value
 
@@ -51,37 +51,23 @@ def define_maybe_optional_selector_field(config_cls):
 
 
 def define_specific_resource_config_cls(name, config_field):
-    class _SpecificResourceConfig(ConfigComposite):
-        def __init__(self):
-            super(_SpecificResourceConfig, self).__init__(
-                name=name, fields={'config': config_field}
-            )
-
-    return _SpecificResourceConfig
+    return NamedDict(name, {'config': config_field})
 
 
 def define_resource_dictionary_cls(name, resources):
     check.str_param(name, 'name')
     check.dict_param(resources, 'resources', key_type=str, value_type=ResourceDefinition)
 
-    class _ResourceDictionaryType(ConfigComposite):
-        def __init__(self):
-            field_dict = {}
-
-            for resource_name, resource in resources.items():
-                if resource.config_field:
-                    specific_resource_type = define_specific_resource_config_cls(
-                        name + '.' + resource_name, resource.config_field
-                    )
-                    field_dict[resource_name] = Field(specific_resource_type)
-
-            super(_ResourceDictionaryType, self).__init__(
-                name=name,
-                fields=field_dict,
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
+    fields = {}
+    for resource_name, resource in resources.items():
+        if resource.config_field:
+            fields[resource_name] = Field(
+                NamedDict(name + '.' + resource_name, {'config': resource.config_field})
             )
 
-    return _ResourceDictionaryType
+    return NamedDict(
+        name=name, fields=fields, type_attributes=ConfigTypeAttributes(is_system_config=True)
+    )
 
 
 def define_specific_context_config_cls(name, config_field, resources):
@@ -89,20 +75,18 @@ def define_specific_context_config_cls(name, config_field, resources):
     check.opt_inst_param(config_field, 'config_field', Field)
     check.dict_param(resources, 'resources', key_type=str, value_type=ResourceDefinition)
 
-    class _SpecificContextConfig(ConfigComposite):
-        def __init__(self):
-            resource_dict_type = define_resource_dictionary_cls(
-                '{name}.Resources'.format(name=name), resources
-            )
-            super(_SpecificContextConfig, self).__init__(
-                name=name,
-                fields={'config': config_field, 'resources': Field(resource_dict_type)}
-                if config_field
-                else {'resources': Field(resource_dict_type)},
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
-            )
-
-    return _SpecificContextConfig
+    return NamedDict(
+        name,
+        fields=remove_none_entries(
+            {
+                'config': config_field,
+                'resources': Field(
+                    define_resource_dictionary_cls('{name}.Resources'.format(name=name), resources)
+                ),
+            }
+        ),
+        type_attributes=ConfigTypeAttributes(is_system_config=True),
+    )
 
 
 def single_item(ddict):
@@ -119,42 +103,23 @@ def define_context_context_cls(pipeline_name, context_definitions):
         key_type=str,
         value_type=PipelineContextDefinition,
     )
-
-    class _ContextConfigType(ConfigSelector):
-        def __init__(self):
-            full_type_name = '{pipeline_name}.ContextConfig'.format(pipeline_name=pipeline_name)
-
-            field_dict = {}
-            if len(context_definitions) == 1:
-                context_name, context_definition = single_item(context_definitions)
-                field_dict[context_name] = Field(
-                    define_specific_context_cls(pipeline_name, context_name, context_definition)
-                )
-            else:
-                for context_name, context_definition in context_definitions.items():
-                    field_dict[context_name] = Field(
-                        define_specific_context_cls(
-                            pipeline_name, context_name, context_definition
-                        ),
-                        is_optional=True,
-                    )
-
-            super(_ContextConfigType, self).__init__(
-                name=full_type_name,
-                fields=field_dict,
-                description='A configuration dictionary with typed fields',
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
+    full_type_name = '{pipeline_name}.ContextConfig'.format(pipeline_name=pipeline_name)
+    field_dict = {}
+    if len(context_definitions) == 1:
+        context_name, context_definition = single_item(context_definitions)
+        field_dict[context_name] = Field(
+            define_specific_context_cls(pipeline_name, context_name, context_definition)
+        )
+    else:
+        for context_name, context_definition in context_definitions.items():
+            field_dict[context_name] = Field(
+                define_specific_context_cls(pipeline_name, context_name, context_definition),
+                is_optional=True,
             )
 
-        def construct_from_config_value(self, config_value):
-            context_name, context_value = single_item(config_value)
-            return ContextConfig(
-                name=context_name,
-                config=context_value.get('config'),
-                resources=context_value['resources'],
-            )
-
-    return _ContextConfigType
+    return NamedSelector(
+        full_type_name, field_dict, type_attributes=ConfigTypeAttributes(is_system_config=True)
+    )
 
 
 def define_specific_context_cls(pipeline_name, context_name, context_definition):
@@ -167,102 +132,63 @@ def define_specific_context_cls(pipeline_name, context_name, context_definition)
     )
 
 
+def remove_none_entries(ddict):
+    return {k: v for k, v in ddict.items() if v is not None}
+
+
 def define_solid_config_cls(name, config_field, inputs_field, outputs_field):
     check.str_param(name, 'name')
     check.opt_inst_param(config_field, 'config_field', Field)
     check.opt_inst_param(inputs_field, 'inputs_field', Field)
     check.opt_inst_param(outputs_field, 'outputs_field', Field)
 
-    class _SolidConfigType(ConfigComposite):
-        def __init__(self):
-            fields = {}
-            if config_field:
-                fields['config'] = config_field
-            if inputs_field:
-                fields['inputs'] = inputs_field
-            if outputs_field:
-                fields['outputs'] = outputs_field
-
-            super(_SolidConfigType, self).__init__(
-                name=name,
-                fields=fields,
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
-            )
-
-        def construct_from_config_value(self, config_value):
-            # TODO we need better rules around optional and default evaluation
-            # making this permissive for now
-            return SolidConfig(
-                config=config_value.get('config'),
-                inputs=config_value.get('inputs', {}),
-                outputs=config_value.get('outputs', []),
-            )
-
-    return _SolidConfigType
+    return NamedDict(
+        name,
+        remove_none_entries(
+            {'config': config_field, 'inputs': inputs_field, 'outputs': outputs_field}
+        ),
+        type_attributes=ConfigTypeAttributes(is_system_config=True),
+    )
 
 
 def define_environment_cls(pipeline_def):
-    class _EnvironmentConfigType(ConfigComposite):
-        def __init__(self):
-            check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
-
-            pipeline_name = camelcase(pipeline_def.name)
-
-            context_field = define_maybe_optional_selector_field(
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    pipeline_name = camelcase(pipeline_def.name)
+    return NamedDict(
+        name='{pipeline_name}.Environment'.format(pipeline_name=pipeline_name),
+        fields={
+            'context': define_maybe_optional_selector_field(
                 define_context_context_cls(pipeline_name, pipeline_def.context_definitions)
-            )
-
-            solids_field = Field(
+            ),
+            'solids': Field(
                 define_solid_dictionary_cls(
                     '{pipeline_name}.SolidsConfigDictionary'.format(pipeline_name=pipeline_name),
                     pipeline_def,
                 )
-            )
-
-            expectations_field = Field(
+            ),
+            'expectations': Field(
                 define_expectations_config_cls(
                     '{pipeline_name}.ExpectationsConfig'.format(pipeline_name=pipeline_name)
                 )
-            )
-
-            execution_field = Field(
+            ),
+            'execution': Field(
                 define_execution_config_cls(
                     '{pipeline_name}.ExecutionConfig'.format(pipeline_name=pipeline_name)
                 )
-            )
-
-            super(_EnvironmentConfigType, self).__init__(
-                name='{pipeline_name}.Environment'.format(pipeline_name=pipeline_name),
-                fields={
-                    'context': context_field,
-                    'solids': solids_field,
-                    'expectations': expectations_field,
-                    'execution': execution_field,
-                },
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
-            )
-
-        def construct_from_config_value(self, config_value):
-            return EnvironmentConfig(**config_value)
-
-    return _EnvironmentConfigType
+            ),
+        },
+        type_attributes=ConfigTypeAttributes(is_system_config=True),
+    )
 
 
 def define_expectations_config_cls(name):
     check.str_param(name, 'name')
 
-    class _ExpectationsConfigType(ConfigComposite):
-        def __init__(self):
-            super(_ExpectationsConfigType, self).__init__(
-                name=name,
-                fields={'evaluate': Field(Bool, is_optional=True, default_value=True)},
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
-            )
-
-        def construct_from_config_value(self, config_value):
-            return ExpectationsConfig(**config_value)
-
-    return _ExpectationsConfigType
+    return NamedDict(
+        name,
+        fields={'evaluate': Field(Bool, is_optional=True, default_value=True)},
+        type_attributes=ConfigTypeAttributes(is_system_config=True),
+    )
 
 
 def solid_has_configurable_inputs(solid_def):
@@ -341,41 +267,49 @@ def define_solid_dictionary_cls(name, pipeline_def):
     check.str_param(name, 'name')
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
 
-    class _SolidDictionaryType(ConfigComposite):
-        def __init__(self):
-            field_dict = {}
-            for solid in pipeline_def.solids:
-                if solid_has_config_entry(solid.definition):
-                    solid_config_type = define_solid_config_cls(
-                        '{pipeline_name}.SolidConfig.{solid_name}'.format(
-                            pipeline_name=camelcase(pipeline_def.name),
-                            solid_name=camelcase(solid.name),
-                        ),
-                        solid.definition.config_field,
-                        inputs_field=get_inputs_field(pipeline_def, solid),
-                        outputs_field=get_outputs_field(pipeline_def, solid),
-                    )
-                    field_dict[solid.name] = Field(solid_config_type)
-
-            super(_SolidDictionaryType, self).__init__(
-                name=name,
-                fields=field_dict,
-                type_attributes=ConfigTypeAttributes(is_system_config=True),
+    fields = {}
+    for solid in pipeline_def.solids:
+        if solid_has_config_entry(solid.definition):
+            solid_config_type = define_solid_config_cls(
+                '{pipeline_name}.SolidConfig.{solid_name}'.format(
+                    pipeline_name=camelcase(pipeline_def.name), solid_name=camelcase(solid.name)
+                ),
+                solid.definition.config_field,
+                inputs_field=get_inputs_field(pipeline_def, solid),
+                outputs_field=get_outputs_field(pipeline_def, solid),
             )
+            fields[solid.name] = Field(solid_config_type)
 
-    return _SolidDictionaryType
+    return NamedDict(name, fields, type_attributes=ConfigTypeAttributes(is_system_config=True))
 
 
 def define_execution_config_cls(name):
     check.str_param(name, 'name')
+    return NamedDict(name, {}, type_attributes=ConfigTypeAttributes(is_system_config=True))
 
-    class _ExecutionConfigType(ConfigComposite):
-        def __init__(self):
-            super(_ExecutionConfigType, self).__init__(
-                name=name, fields={}, type_attributes=ConfigTypeAttributes(is_system_config=True)
-            )
 
-        def construct_from_config_value(self, config_value):
-            return ExecutionConfig(**config_value)
+def construct_environment_config(config_value):
+    return EnvironmentConfig(
+        solids=construct_solid_dictionary(config_value['solids']),
+        execution=ExecutionConfig(**config_value['execution']),
+        expectations=ExpectationsConfig(**config_value['expectations']),
+        context=construct_context_config(config_value['context']),
+    )
 
-    return _ExecutionConfigType
+
+def construct_context_config(config_value):
+    context_name, context_value = single_item(config_value)
+    return ContextConfig(
+        name=context_name, config=context_value.get('config'), resources=context_value['resources']
+    )
+
+
+def construct_solid_dictionary(solid_dict_value):
+    return {
+        key: SolidConfig(
+            config=value.get('config'),
+            inputs=value.get('inputs', {}),
+            outputs=value.get('outputs', []),
+        )
+        for key, value in solid_dict_value.items()
+    }

--- a/python_modules/dagster/dagster/core/types/config.py
+++ b/python_modules/dagster/dagster/core/types/config.py
@@ -100,10 +100,6 @@ class ConfigType(object):
     def inner_types(self):
         return []
 
-    def construct_from_config_value(self, config_value):
-        'User can override this to customize the construction of a verified value'
-        return config_value
-
 
 # Scalars, Composites, Selectors, Lists, Nullable, Any
 

--- a/python_modules/dagster/dagster/core/types/evaluator.py
+++ b/python_modules/dagster/dagster/core/types/evaluator.py
@@ -425,7 +425,7 @@ def deserialize_selector_config(selector_type, config_value):
 
     parent_field = selector_type.fields[field_name]
     field_value = _deserialize_config(parent_field.config_type, incoming_field_value)
-    return selector_type.construct_from_config_value({field_name: field_value})
+    return {field_name: field_value}
 
 
 ## Composites
@@ -505,7 +505,7 @@ def deserialize_composite_config_value(composite_type, config_value):
         elif not field_def.is_optional:
             check.failed('Missing non-optional composite member not caught in validation')
 
-    return composite_type.construct_from_config_value(processed_fields)
+    return processed_fields
 
 
 ## Lists

--- a/python_modules/dagster/dagster/core/types/field.py
+++ b/python_modules/dagster/dagster/core/types/field.py
@@ -9,6 +9,7 @@ from .config import (
     Path,
     String,
     resolve_to_config_type,
+    DEFAULT_TYPE_ATTRIBUTES,
 )
 from .dagster_type import check_dagster_type_param
 
@@ -156,13 +157,13 @@ class _ConfigHasFields(ConfigType):
                 yield inner_type
 
 
-class ConfigComposite(_ConfigHasFields):
+class _ConfigComposite(_ConfigHasFields):
     @property
     def is_composite(self):
         return True
 
 
-class ConfigSelector(_ConfigHasFields):
+class _ConfigSelector(_ConfigHasFields):
     @property
     def is_selector(self):
         return True
@@ -188,16 +189,18 @@ class DictCounter:
         return DictCounter._count
 
 
-def NamedDict(name, fields, description=None):
-    class _NamedDict(ConfigComposite):
+def NamedDict(name, fields, description=None, type_attributes=DEFAULT_TYPE_ATTRIBUTES):
+    class _NamedDict(_ConfigComposite):
         def __init__(self):
-            super(_NamedDict, self).__init__(name=name, fields=fields, description=description)
+            super(_NamedDict, self).__init__(
+                name=name, fields=fields, description=description, type_attributes=type_attributes
+            )
 
     return _NamedDict
 
 
 def Dict(fields):
-    class _Dict(ConfigComposite):
+    class _Dict(_ConfigComposite):
         def __init__(self):
             super(_Dict, self).__init__(
                 name='Dict.' + str(DictCounter.get_next_count()),
@@ -210,7 +213,7 @@ def Dict(fields):
 
 
 def Selector(fields):
-    class _Selector(ConfigSelector):
+    class _Selector(_ConfigSelector):
         def __init__(self):
             super(_Selector, self).__init__(
                 name='Selector.' + str(DictCounter.get_next_count()),
@@ -222,9 +225,11 @@ def Selector(fields):
     return _Selector
 
 
-def NamedSelector(name, fields, description=None):
-    class _NamedSelector(ConfigSelector):
+def NamedSelector(name, fields, description=None, type_attributes=DEFAULT_TYPE_ATTRIBUTES):
+    class _NamedSelector(_ConfigSelector):
         def __init__(self):
-            super(_NamedSelector, self).__init__(name=name, fields=fields, description=description)
+            super(_NamedSelector, self).__init__(
+                name=name, fields=fields, description=description, type_attributes=type_attributes
+            )
 
     return _NamedSelector

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -93,14 +93,13 @@ class BuiltinScalarRuntimeType(RuntimeType):
         return True
 
 
-INT_SCHEMA = define_builtin_scalar_output_schema('Int')
+INT_INPUT_SCHEMA = make_input_schema(ConfigInt)
+INT_OUTPUT_SCHEMA = define_builtin_scalar_output_schema('Int')
 
 
 class Int(BuiltinScalarRuntimeType):
     def __init__(self):
-        super(Int, self).__init__(
-            input_schema=make_input_schema(ConfigInt), output_schema=INT_SCHEMA
-        )
+        super(Int, self).__init__(input_schema=INT_INPUT_SCHEMA, output_schema=INT_OUTPUT_SCHEMA)
 
     def coerce_runtime_value(self, value):
         return self.throw_if_false(
@@ -108,13 +107,14 @@ class Int(BuiltinScalarRuntimeType):
         )
 
 
-STRING_SCHEMA = define_builtin_scalar_output_schema('String')
+STRING_INPUT_SCHEMA = make_input_schema(ConfigString)
+STRING_OUTPUT_SCHEMA = define_builtin_scalar_output_schema('String')
 
 
 class String(BuiltinScalarRuntimeType):
     def __init__(self):
         super(String, self).__init__(
-            input_schema=make_input_schema(ConfigString), output_schema=STRING_SCHEMA
+            input_schema=STRING_INPUT_SCHEMA, output_schema=STRING_OUTPUT_SCHEMA
         )
 
     def coerce_runtime_value(self, value):

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
@@ -23,8 +23,6 @@ from dagster import (
 
 from dagster.core.types.evaluator import evaluate_config_value, DagsterEvaluationErrorReason
 
-from dagster.core.types.field import ConfigComposite
-
 from dagster.core.test_utils import throwing_evaluate_config_value
 
 
@@ -236,36 +234,6 @@ def test_nested_optional_with_no_default():
     }
 
     assert _validate(_nested_optional_config_with_no_default(), {'nested': {}}) == {'nested': {}}
-
-
-CustomStructTuple = namedtuple('CustomStructTuple', 'foo bar')
-
-
-class CustomStructConfig(ConfigComposite):
-    def __init__(self):
-        super(CustomStructConfig, self).__init__(fields={'foo': Field(String), 'bar': Field(Int)})
-
-    def construct_from_config_value(self, config_value):
-        return CustomStructTuple(**config_value)
-
-
-def test_custom_composite_type():
-    config_type = CustomStructConfig.inst()
-
-    assert throwing_evaluate_config_value(
-        config_type, {'foo': 'some_string', 'bar': 2}
-    ) == CustomStructTuple(foo='some_string', bar=2)
-
-    with pytest.raises(DagsterEvaluateConfigValueError):
-        assert throwing_evaluate_config_value(config_type, {'foo': 'some_string'})
-
-    with pytest.raises(DagsterEvaluateConfigValueError):
-        assert throwing_evaluate_config_value(config_type, {'bar': 'some_string'})
-
-    with pytest.raises(DagsterEvaluateConfigValueError):
-        assert throwing_evaluate_config_value(
-            config_type, {'foo': 'some_string', 'bar': 'not_an_int'}
-        )
 
 
 def single_elem(ddict):

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_evaluator.py
@@ -1,4 +1,4 @@
-from dagster import Field, Dict, String, Int, Bool, Nullable, List
+from dagster import Field, Dict, String, Int, Bool, Nullable, List, Selector
 
 from dagster.core.types.config import resolve_to_config_type
 from dagster.core.types.evaluator import (
@@ -8,8 +8,6 @@ from dagster.core.types.evaluator import (
     EvaluateValueResult,
     evaluate_config_value,
 )
-
-from dagster.core.types.field import ConfigSelector
 
 
 def eval_config_value_from_dagster_type(dagster_type, value):
@@ -319,11 +317,7 @@ def test_deep_mixed_level_errors():
     assert final_level_error.reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
 
 
-class ExampleSelector(ConfigSelector):
-    def __init__(self):
-        super(ExampleSelector, self).__init__(
-            fields={'option_one': Field(String), 'option_two': Field(String)}
-        )
+ExampleSelector = Selector({'option_one': Field(String), 'option_two': Field(String)})
 
 
 def test_example_selector_success():
@@ -362,11 +356,7 @@ def test_example_selector_multiple_fields():
     assert result.errors[0].reason == DagsterEvaluationErrorReason.SELECTOR_FIELD_ERROR
 
 
-class SelectorWithDefaults(ConfigSelector):
-    def __init__(self):
-        super(SelectorWithDefaults, self).__init__(
-            fields={'default': Field(String, is_optional=True, default_value='foo')}
-        )
+SelectorWithDefaults = Selector({'default': Field(String, is_optional=True, default_value='foo')})
 
 
 def test_selector_with_defaults():


### PR DESCRIPTION
This diff makes the system config types just used plain ole types, moves object construction to a separate function, then removes the ability to make custom objects out of config types all together.