### PR TITLE
Highlight start/end nodes when highlighting connections on the DAG

### DIFF
--- a/js_modules/dagit/src/graph/PipelineColorScale.ts
+++ b/js_modules/dagit/src/graph/PipelineColorScale.ts
@@ -5,17 +5,21 @@ const PipelineColorScale = scaleOrdinal({
   domain: [
     "source",
     "input",
+    "inputHighlighted",
     "solid",
     "solidDarker",
     "output",
+    "outputHighlighted",
     "materializations"
   ],
   range: [
     Colors.TURQUOISE5,
     Colors.TURQUOISE3,
+    Colors.TURQUOISE1,
     "#DBE6EE",
     "#7D8C97",
     Colors.BLUE3,
+    Colors.BLUE1,
     Colors.ORANGE5
   ]
 });

--- a/js_modules/dagit/src/graph/PipelineGraph.tsx
+++ b/js_modules/dagit/src/graph/PipelineGraph.tsx
@@ -80,10 +80,12 @@ class PipelineGraphContents extends React.PureComponent<
       selectedSolid
     } = this.props;
 
+    const { highlightedConnections } = this.state;
+
     const isHighlighted = (c: ILayoutConnection) => {
       const from = c.from.solidName;
       const to = c.to.solidName;
-      return this.state.highlightedConnections.find(
+      return highlightedConnections.find(
         h => (h.a === from && h.b === to) || (h.b === from && h.a === to)
       );
     };
@@ -112,6 +114,7 @@ class PipelineGraphContents extends React.PureComponent<
             }
             layout={layout.solids[solid.name]}
             selected={selectedSolid === solid}
+            highlightedConnections={highlightedConnections}
             dim={
               highlightedSolids.length > 0 &&
               highlightedSolids.indexOf(solid) == -1

--- a/js_modules/dagit/src/graph/SolidNode.tsx
+++ b/js_modules/dagit/src/graph/SolidNode.tsx
@@ -21,6 +21,7 @@ import { DEFAULT_RESULT_NAME } from "../Util";
 interface ISolidNodeProps {
   layout: IFullSolidLayout;
   solid: SolidNodeFragment;
+  highlightedConnections: { a: string; b: string }[];
   minified: boolean;
   selected: boolean;
   dim: boolean;
@@ -119,10 +120,18 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
         "dependsOn" in item
           ? item.dependsOn && [item.dependsOn]
           : item.dependedBy;
+
       const connections = (connected || []).map(other => ({
         a: other.solid.name,
         b: this.props.solid.name
       }));
+
+      const highlighted = connections.some(
+        ({ a, b }) =>
+          !!this.props.highlightedConnections.find(
+            h => (h.a === a || h.a === b) && (h.b === a || h.b === b)
+          )
+      );
 
       return (
         <g
@@ -137,7 +146,11 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
             stroke="#979797"
             strokeWidth={1}
             maxWidth={300}
-            fill={PipelineColorScale(colorKey)}
+            fill={
+              highlighted
+                ? PipelineColorScale(`${colorKey}Highlighted`)
+                : PipelineColorScale(colorKey)
+            }
             padding={8}
             spacing={7}
             height={height}


### PR DESCRIPTION
<img width="575" alt="image" src="https://user-images.githubusercontent.com/1037212/51053118-9e2f9000-158d-11e9-84ba-5b2ffffad7c5.png">
