### PR TITLE
Pylint 1.9.2 causes crash

### DIFF
--- a/dev_env_setup.sh
+++ b/dev_env_setup.sh
@@ -44,4 +44,7 @@ popd
 
 pushd python_modules
 make rebuild_dagit
+make black
+make pylint
 popd
+

--- a/python_modules/airline-demo/dev-requirements.txt
+++ b/python_modules/airline-demo/dev-requirements.txt
@@ -1,5 +1,5 @@
 docker-compose==1.23.1
-pylint==1.9.2
+pylint>=2.2.2
 pytest==4.0.2
 pytest-cov==2.6.0
 yapf==0.22.0

--- a/python_modules/dagma/dev-requirements.txt
+++ b/python_modules/dagma/dev-requirements.txt
@@ -1,4 +1,4 @@
-pylint==1.9.2
+pylint>=2.2.2
 pytest==4.0.2
 pytest-cov==2.6.0
 yapf==0.22.0


### PR DESCRIPTION
Upgrading works, so let's just do that.