### PR TITLE
Schrockn/improved builtin scalar schemas (stacked on #600)

### DIFF
--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -135,8 +135,14 @@ class String(BuiltinScalarRuntimeType):
         return self.throw_if_not_string(value)
 
 
-class Path(String):
-    pass
+class Path(BuiltinScalarRuntimeType):
+    def __init__(self):
+        super(Path, self).__init__(
+            input_schema=make_input_schema(ConfigString), output_schema=STRING_OUTPUT_SCHEMA
+        )
+
+    def coerce_runtime_value(self, value):
+        return self.throw_if_not_string(value)
 
 
 class Float(RuntimeType):

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -5,7 +5,10 @@ from dagster import check
 from dagster.core.errors import DagsterRuntimeCoercionError
 
 from .builtin_enum import BuiltinEnum
-from .builtin_config_schemas import define_builtin_scalar_output_schema
+from .builtin_config_schemas import (
+    define_builtin_scalar_input_schema,
+    define_builtin_scalar_output_schema,
+)
 from .config import Int as ConfigInt
 from .config import String as ConfigString
 from .config import Any as ConfigAny
@@ -104,7 +107,7 @@ class BuiltinScalarRuntimeType(RuntimeType):
         return True
 
 
-INT_INPUT_SCHEMA = make_input_schema(ConfigInt)
+INT_INPUT_SCHEMA = define_builtin_scalar_input_schema('Int', ConfigInt)
 INT_OUTPUT_SCHEMA = define_builtin_scalar_output_schema('Int')
 
 
@@ -118,7 +121,7 @@ class Int(BuiltinScalarRuntimeType):
         )
 
 
-STRING_INPUT_SCHEMA = make_input_schema(ConfigString)
+STRING_INPUT_SCHEMA = define_builtin_scalar_input_schema('String', ConfigString)
 STRING_OUTPUT_SCHEMA = define_builtin_scalar_output_schema('String')
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
@@ -24,7 +24,7 @@ def test_string_from_inputs():
     pipeline = PipelineDefinition(solids=[str_as_input])
 
     result = execute_pipeline(
-        pipeline, {'solids': {'str_as_input': {'inputs': {'string_input': 'foo'}}}}
+        pipeline, {'solids': {'str_as_input': {'inputs': {'string_input': {'value': 'foo'}}}}}
     )
 
     assert result.success
@@ -44,7 +44,7 @@ def test_string_from_aliased_inputs():
     )
 
     result = execute_pipeline(
-        pipeline, {'solids': {'aliased': {'inputs': {'string_input': 'foo'}}}}
+        pipeline, {'solids': {'aliased': {'inputs': {'string_input': {'value': 'foo'}}}}}
     )
 
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -410,7 +410,10 @@ def test_pipeline_disjoint_subset():
 
 def test_pipeline_execution_disjoint_subset():
     env_config = {
-        'solids': {'add_one': {'inputs': {'num': 2}}, 'add_three': {'inputs': {'num': 5}}},
+        'solids': {
+            'add_one': {'inputs': {'num': {'value': 2}}},
+            'add_three': {'inputs': {'num': {'value': 5}}},
+        },
         'context': {'default': {'config': {'log_level': 'ERROR'}}},
     }
 
@@ -454,10 +457,14 @@ def test_pipeline_wrapping_types():
 
     assert execute_pipeline(
         pipeline_def,
-        environment={'solids': {'double_string_for_all': {'inputs': {'value': ['foo']}}}},
+        environment={
+            'solids': {'double_string_for_all': {'inputs': {'value': [{'value': 'foo'}]}}}
+        },
     ).success
 
     assert execute_pipeline(
         pipeline_def,
-        environment={'solids': {'double_string_for_all': {'inputs': {'value': ['bar', None]}}}},
+        environment={
+            'solids': {'double_string_for_all': {'inputs': {'value': [{'value': 'bar'}, None]}}}
+        },
     ).success

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_builtin_schemas.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_builtin_schemas.py
@@ -1,0 +1,173 @@
+import pytest
+
+from dagster import (
+    Any,
+    Bool,
+    Float,
+    InputDefinition,
+    Int,
+    OutputDefinition,
+    PipelineDefinition,
+    PipelineConfigEvaluationError,
+    String,
+    lambda_solid,
+    execute_pipeline,
+)
+
+from dagster.utils.test import get_temp_file_name
+
+
+def define_test_all_scalars_pipeline():
+    @lambda_solid(inputs=[InputDefinition('num', Int)])
+    def take_int(num):
+        return num
+
+    @lambda_solid(output=OutputDefinition(Int))
+    def produce_int():
+        return 2
+
+    @lambda_solid(inputs=[InputDefinition('string', String)])
+    def take_string(string):
+        return string
+
+    @lambda_solid(output=OutputDefinition(String))
+    def produce_string():
+        return 'foo'
+
+    return PipelineDefinition(
+        name='test_all_scalars_pipeline',
+        solids=[take_int, produce_int, take_string, produce_string],
+    )
+
+
+def single_input_env(solid_name, input_name, input_spec):
+    return {'solids': {solid_name: {'inputs': {input_name: input_spec}}}}
+
+
+def test_int_input_schema_value():
+    result = execute_pipeline(
+        define_test_all_scalars_pipeline(),
+        environment=single_input_env('take_int', 'num', {'value': 2}),
+        solid_subset=['take_int'],
+    )
+
+    assert result.success
+    assert result.result_for_solid('take_int').transformed_value() == 2
+
+
+def test_int_input_schema_failure():
+    with pytest.raises(PipelineConfigEvaluationError) as exc_info:
+        execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_input_env('take_int', 'num', {'value': 'dkjdfkdj'}),
+            solid_subset=['take_int'],
+        )
+
+    assert 'Type failure at path "root:solids:take_int:inputs:num:value" on type "Int"' in str(
+        exc_info.value
+    )
+
+
+def single_output_env(solid_name, output_spec):
+    return {'solids': {solid_name: {'outputs': [{'result': output_spec}]}}}
+
+
+def test_int_json_schema_roundtrip():
+    with get_temp_file_name() as tmp_file:
+        mat_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_output_env('produce_int', {'json': {'path': tmp_file}}),
+            solid_subset=['produce_int'],
+        )
+
+        assert mat_result.success
+
+        source_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_input_env('take_int', 'num', {'json': {'path': tmp_file}}),
+            solid_subset=['take_int'],
+        )
+
+        assert source_result.result_for_solid('take_int').transformed_value() == 2
+
+
+def test_int_pickle_schema_roundtrip():
+    with get_temp_file_name() as tmp_file:
+        mat_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_output_env('produce_int', {'pickle': {'path': tmp_file}}),
+            solid_subset=['produce_int'],
+        )
+
+        assert mat_result.success
+
+        source_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_input_env('take_int', 'num', {'pickle': {'path': tmp_file}}),
+            solid_subset=['take_int'],
+        )
+
+        assert source_result.result_for_solid('take_int').transformed_value() == 2
+
+
+def test_string_input_schema_value():
+    result = execute_pipeline(
+        define_test_all_scalars_pipeline(),
+        environment=single_input_env('take_string', 'string', {'value': 'dkjkfd'}),
+        solid_subset=['take_string'],
+    )
+
+    assert result.success
+    assert result.result_for_solid('take_string').transformed_value() == 'dkjkfd'
+
+
+def test_string_input_schema_failure():
+    with pytest.raises(PipelineConfigEvaluationError) as exc_info:
+        execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_input_env('take_string', 'string', {'value': 3343}),
+            solid_subset=['take_string'],
+        )
+
+    assert (
+        'Type failure at path "root:solids:take_string:inputs:string:value" on type "String"'
+        in str(exc_info.value)
+    )
+
+
+def test_string_json_schema_roundtrip():
+    with get_temp_file_name() as tmp_file:
+        mat_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_output_env('produce_string', {'json': {'path': tmp_file}}),
+            solid_subset=['produce_string'],
+        )
+
+        assert mat_result.success
+
+        source_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_input_env('take_string', 'string', {'json': {'path': tmp_file}}),
+            solid_subset=['take_string'],
+        )
+
+        assert source_result.result_for_solid('take_string').transformed_value() == 'foo'
+
+
+def test_string_pickle_schema_roundtrip():
+    with get_temp_file_name() as tmp_file:
+        mat_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_output_env('produce_string', {'pickle': {'path': tmp_file}}),
+            solid_subset=['produce_string'],
+        )
+
+        assert mat_result.success
+
+        source_result = execute_pipeline(
+            define_test_all_scalars_pipeline(),
+            environment=single_input_env('take_string', 'string', {'pickle': {'path': tmp_file}}),
+            solid_subset=['take_string'],
+        )
+
+        assert source_result.result_for_solid('take_string').transformed_value() == 'foo'


### PR DESCRIPTION
This adds a more feature-rich input/output config schema to builtin-scalars, allowing scalars to be deserialized to and from json and pickle files, in addition to being set inline in the configuration files itself. Attempting to add this feature the first time is what cause we to embark on the runtime/config type system split and rearchitecture. It's nice to see that work bear fruit.

One interesting topic of discussion here is the input schema difference between `Path` and `String`. I think we should allow strings to be loadable from files, but that makes less sense for paths, since that will inevitably lead to a file itself. So here I'm proposed that Path only takes an inline string, but strings takes a selector where you can use `value`, `json`, or `pickle`. Curious to hear your thoughts.