### PR TITLE
Move default appliers outside for dep management

### DIFF
--- a/python_modules/dagster/dagster/core/system_config/types.py
+++ b/python_modules/dagster/dagster/core/system_config/types.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.utils import camelcase
+from dagster.utils import camelcase, single_item
 
 from dagster.core.definitions import (
     PipelineContextDefinition,
@@ -88,12 +88,6 @@ def define_specific_context_config_cls(name, config_field, resources):
             }
         ),
     )
-
-
-def single_item(ddict):
-    check.dict_param(ddict, 'ddict')
-    check.param_invariant(len(ddict) == 1, 'ddict')
-    return list(ddict.items())[0]
 
 
 def define_context_context_cls(pipeline_name, context_definitions):

--- a/python_modules/dagster/dagster/core/types/default_applier.py
+++ b/python_modules/dagster/dagster/core/types/default_applier.py
@@ -1,8 +1,12 @@
 from dagster import check
 from dagster.utils import single_item
 
+from .config import ConfigType
+
 
 def apply_default_values(config_type, config_value):
+    check.inst_param(config_type, 'config_type', ConfigType)
+
     if config_type.is_scalar:
         return config_value
     elif config_type.is_selector:
@@ -10,7 +14,7 @@ def apply_default_values(config_type, config_value):
     elif config_type.is_composite:
         return apply_defaults_to_composite_type(config_type, config_value)
     elif config_type.is_list:
-        return apply_defaults_to_list_tpye(config_type, config_value)
+        return apply_defaults_to_list_type(config_type, config_value)
     elif config_type.is_nullable:
         if config_value is None:
             return None
@@ -39,7 +43,6 @@ def apply_default_values_to_selector(selector_type, config_value):
 
 def apply_defaults_to_composite_type(composite_type, config_value):
     check.param_invariant(composite_type.is_composite, 'composite_type')
-
     config_value = check.opt_dict_param(config_value, 'config_value', key_type=str)
 
     fields = composite_type.fields
@@ -62,7 +65,7 @@ def apply_defaults_to_composite_type(composite_type, config_value):
     return processed_fields
 
 
-def apply_defaults_to_list_tpye(list_type, config_value):
+def apply_defaults_to_list_type(list_type, config_value):
     check.param_invariant(list_type.is_list, 'list_type')
 
     if not config_value:

--- a/python_modules/dagster/dagster/core/types/default_applier.py
+++ b/python_modules/dagster/dagster/core/types/default_applier.py
@@ -1,0 +1,71 @@
+from dagster import check
+from dagster.utils import single_item
+
+
+def apply_default_values(config_type, config_value):
+    if config_type.is_scalar:
+        return config_value
+    elif config_type.is_selector:
+        return apply_default_values_to_selector(config_type, config_value)
+    elif config_type.is_composite:
+        return apply_defaults_to_composite_type(config_type, config_value)
+    elif config_type.is_list:
+        return apply_defaults_to_list_tpye(config_type, config_value)
+    elif config_type.is_nullable:
+        if config_value is None:
+            return None
+        return apply_default_values(config_type.inner_type, config_value)
+    elif config_type.is_any:
+        return config_value
+    else:
+        check.failed('Unsupported type {name}'.format(name=config_type.name))
+
+
+def apply_default_values_to_selector(selector_type, config_value):
+    check.param_invariant(selector_type.is_selector, 'selector_type')
+
+    if config_value:
+        check.invariant(config_value and len(config_value) == 1)
+        field_name, incoming_field_value = single_item(config_value)
+
+    else:
+        field_name, field_def = single_item(selector_type.fields)
+        incoming_field_value = field_def.default_value if field_def.default_provided else None
+
+    parent_field = selector_type.fields[field_name]
+    field_value = apply_default_values(parent_field.config_type, incoming_field_value)
+    return {field_name: field_value}
+
+
+def apply_defaults_to_composite_type(composite_type, config_value):
+    check.param_invariant(composite_type.is_composite, 'composite_type')
+
+    config_value = check.opt_dict_param(config_value, 'config_value', key_type=str)
+
+    fields = composite_type.fields
+    incoming_fields = set(config_value.keys())
+
+    processed_fields = {}
+
+    for expected_field, field_def in fields.items():
+        if expected_field in incoming_fields:
+            processed_fields[expected_field] = apply_default_values(
+                field_def.config_type, config_value[expected_field]
+            )
+
+        elif field_def.default_provided:
+            processed_fields[expected_field] = field_def.default_value
+
+        elif not field_def.is_optional:
+            check.failed('Missing non-optional composite member not caught in validation')
+
+    return processed_fields
+
+
+def apply_defaults_to_list_tpye(list_type, config_value):
+    check.param_invariant(list_type.is_list, 'list_type')
+
+    if not config_value:
+        return []
+
+    return [apply_default_values(list_type.inner_type, item) for item in config_value]

--- a/python_modules/dagster/dagster/core/types/field.py
+++ b/python_modules/dagster/dagster/core/types/field.py
@@ -12,6 +12,7 @@ from .config import (
     DEFAULT_TYPE_ATTRIBUTES,
 )
 from .dagster_type import check_dagster_type_param
+from .default_applier import apply_default_values
 
 
 class __FieldValueSentinel:
@@ -76,9 +77,7 @@ class Field:
         if is_optional == INFER_OPTIONAL_COMPOSITE_FIELD:
             is_optional = all_optional_type(self.config_type)
             if is_optional is True:
-                from .evaluator import hard_create_config_value
-
-                self._default_value = lambda: hard_create_config_value(self.config_type, None)
+                self._default_value = lambda: apply_default_values(self.config_type, None)
             else:
                 self._default_value = default_value
         else:

--- a/python_modules/dagster/dagster/core/types/field.py
+++ b/python_modules/dagster/dagster/core/types/field.py
@@ -77,7 +77,7 @@ class Field:
         if is_optional == INFER_OPTIONAL_COMPOSITE_FIELD:
             is_optional = all_optional_type(self.config_type)
             if is_optional is True:
-                self._default_value = lambda: apply_default_values(self.config_type, None)
+                self._default_value = apply_default_values(self.config_type, None)
             else:
                 self._default_value = default_value
         else:

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -32,3 +32,9 @@ def camelcase(string):
     return str(string[0]).upper() + re.sub(
         r'[\-_\.\s]([a-z])', lambda matched: str(matched.group(1)).upper(), string[1:]
     )
+
+
+def single_item(ddict):
+    check.dict_param(ddict, 'ddict')
+    check.param_invariant(len(ddict) == 1, 'ddict')
+    return list(ddict.items())[0]

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_evaluator.py
@@ -1,4 +1,4 @@
-from dagster import Field, Dict, String, Int, Bool, Nullable, List, Selector
+from dagster import Field, Dict, String, Int, Bool, Nullable, List, Selector, Any
 
 from dagster.core.types.config import resolve_to_config_type
 from dagster.core.types.evaluator import (
@@ -525,3 +525,10 @@ def test_nullable_dict():
     assert eval_config_value_from_dagster_type(
         nullable_dict_with_nullable_int, {'int_field': 1}
     ).success
+
+
+def test_any_with_default_value():
+    dict_with_any = Dict({'any_field': Field(Any, default_value='foo', is_optional=True)})
+    result = eval_config_value_from_dagster_type(dict_with_any, None)
+    assert result.success
+    assert result.value == {'any_field': 'foo'}


### PR DESCRIPTION
We have deserialize* functions. Now that we actually don't create custom objects from the config system the only thing this code path does is apply defaults. In addition was able to clean up the default_value codepath in Field.