### PR TITLE
New Input/Output Schema API

### DIFF
--- a/python_modules/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/dagster-pandas/dagster_pandas/data_frame.py
@@ -2,9 +2,7 @@ import pandas as pd
 
 from dagster import Dict, Field, Path, Selector, String, check, as_dagster_type
 
-from dagster.core.types.config_schema import InputSchema, OutputSchema
-
-from dagster.core.types.marshal import PickleMarshallingStrategy
+from dagster.core.types.config_schema import input_selector_schema, output_selector_schema
 
 
 def define_path_dict_field():
@@ -17,55 +15,48 @@ def define_csv_dict_field():
     )
 
 
-class PandasDataFrameOutputSchema(OutputSchema):
-    @property
-    def schema_cls(self):
-        return Selector(
-            {
-                'csv': define_csv_dict_field(),
-                'parquet': define_path_dict_field(),
-                'table': define_path_dict_field(),
-            }
-        )
-
-    def materialize_runtime_value(self, config_spec, runtime_value):
-        file_type, file_options = list(config_spec.items())[0]
-        if file_type == 'csv':
-            path = file_options['path']
-            del file_options['path']
-            return runtime_value.to_csv(path, index=False, **file_options)
-        elif file_type == 'parquet':
-            return runtime_value.to_parquet(file_options['path'])
-        elif file_type == 'table':
-            return runtime_value.to_csv(file_options['path'], sep='\t', index=False)
-        else:
-            check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
-        check.failed('must implement')
+@output_selector_schema(
+    Selector(
+        {
+            'csv': define_csv_dict_field(),
+            'parquet': define_path_dict_field(),
+            'table': define_path_dict_field(),
+        }
+    )
+)
+def dataframe_output_schema(file_type, file_options, runtime_value):
+    if file_type == 'csv':
+        path = file_options['path']
+        del file_options['path']
+        return runtime_value.to_csv(path, index=False, **file_options)
+    elif file_type == 'parquet':
+        return runtime_value.to_parquet(file_options['path'])
+    elif file_type == 'table':
+        return runtime_value.to_csv(file_options['path'], sep='\t', index=False)
+    else:
+        check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
 
 
-class PandasDataFrameInputSchema(InputSchema):
-    @property
-    def schema_cls(self):
-        return Selector(
-            {
-                'csv': define_csv_dict_field(),
-                'parquet': define_path_dict_field(),
-                'table': define_path_dict_field(),
-            }
-        )
-
-    def construct_from_config_value(self, value):
-        file_type, file_options = list(value.items())[0]
-        if file_type == 'csv':
-            path = file_options['path']
-            del file_options['path']
-            return pd.read_csv(path, **file_options)
-        elif file_type == 'parquet':
-            return pd.read_parquet(file_options['path'])
-        elif file_type == 'table':
-            return pd.read_table(file_options['path'])
-        else:
-            check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
+@input_selector_schema(
+    Selector(
+        {
+            'csv': define_csv_dict_field(),
+            'parquet': define_path_dict_field(),
+            'table': define_path_dict_field(),
+        }
+    )
+)
+def dataframe_input_schema(file_type, file_options):
+    if file_type == 'csv':
+        path = file_options['path']
+        del file_options['path']
+        return pd.read_csv(path, **file_options)
+    elif file_type == 'parquet':
+        return pd.read_parquet(file_options['path'])
+    elif file_type == 'table':
+        return pd.read_table(file_options['path'])
+    else:
+        check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
 
 
 DataFrame = as_dagster_type(
@@ -73,7 +64,6 @@ DataFrame = as_dagster_type(
     name='PandasDataFrame',
     description='''Two-dimensional size-mutable, potentially heterogeneous
 tabular data structure with labeled axes (rows and columns). See http://pandas.pydata.org/''',
-    input_schema=PandasDataFrameInputSchema(),
-    output_schema=PandasDataFrameOutputSchema(),
-    marshalling_strategy=PickleMarshallingStrategy(),
+    input_schema=dataframe_input_schema,
+    output_schema=dataframe_output_schema,
 )

--- a/python_modules/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/dagster-pandas/dagster_pandas/data_frame.py
@@ -24,15 +24,19 @@ def define_csv_dict_field():
         }
     )
 )
-def dataframe_output_schema(file_type, file_options, runtime_value):
+def dataframe_output_schema(file_type, file_options, pandas_df):
+    check.str_param(file_type, 'file_type')
+    check.dict_param(file_options, 'file_options')
+    check.inst_param(pandas_df, 'pandas_df', DataFrame)
+
     if file_type == 'csv':
         path = file_options['path']
         del file_options['path']
-        return runtime_value.to_csv(path, index=False, **file_options)
+        return pandas_df.to_csv(path, index=False, **file_options)
     elif file_type == 'parquet':
-        return runtime_value.to_parquet(file_options['path'])
+        return pandas_df.to_parquet(file_options['path'])
     elif file_type == 'table':
-        return runtime_value.to_csv(file_options['path'], sep='\t', index=False)
+        return pandas_df.to_csv(file_options['path'], sep='\t', index=False)
     else:
         check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
 
@@ -47,6 +51,9 @@ def dataframe_output_schema(file_type, file_options, runtime_value):
     )
 )
 def dataframe_input_schema(file_type, file_options):
+    check.str_param(file_type, 'file_type')
+    check.dict_param(file_options, 'file_options')
+
     if file_type == 'csv':
         path = file_options['path']
         del file_options['path']

--- a/python_modules/dagster/dagster/core/system_config/types.py
+++ b/python_modules/dagster/dagster/core/system_config/types.py
@@ -204,7 +204,7 @@ def get_inputs_field(pipeline_def, solid):
         # If this input is not satisfied by a dependency you must
         # provide it via config
         if not pipeline_def.dependency_structure.has_dep(inp_handle):
-            inputs_field_fields[inp.name] = Field(inp.runtime_type.input_schema.schema_cls)
+            inputs_field_fields[inp.name] = Field(type(inp.runtime_type.input_schema.schema_type))
 
     if not inputs_field_fields:
         return None
@@ -231,7 +231,7 @@ def get_outputs_field(pipeline_def, solid):
     output_dict_fields = {}
     for out in [out for out in solid_def.output_defs if out.runtime_type.output_schema]:
         output_dict_fields[out.name] = Field(
-            out.runtime_type.output_schema.schema_cls, is_optional=True
+            type(out.runtime_type.output_schema.schema_type), is_optional=True
         )
 
     output_entry_dict = SystemNamedDict(

--- a/python_modules/dagster/dagster/core/types/builtin_config_schemas.py
+++ b/python_modules/dagster/dagster/core/types/builtin_config_schemas.py
@@ -3,7 +3,7 @@ import json
 from dagster import check
 
 from .config import ConfigTypeAttributes, Path, Int, String, Bool, Any
-from .config_schema import OutputSchema, make_input_schema
+from .config_schema import OutputSchema, make_bare_input_schema
 from .field_utils import FieldImpl, Dict, NamedSelector
 
 
@@ -22,8 +22,8 @@ def define_builtin_scalar_output_schema(scalar_name):
 
     class _BuiltinScalarOutputSchema(OutputSchema):
         @property
-        def schema_cls(self):
-            return schema_cls
+        def schema_type(self):
+            return schema_cls.inst()
 
         def materialize_runtime_value(self, config_spec, runtime_value):
             check.dict_param(config_spec, 'config_spec')
@@ -43,17 +43,17 @@ def define_builtin_scalar_output_schema(scalar_name):
 
 
 class BuiltinSchemas:
-    INT_INPUT = make_input_schema(Int)
+    INT_INPUT = make_bare_input_schema(Int)
     INT_OUTPUT = define_builtin_scalar_output_schema('Int')
 
-    STRING_INPUT = make_input_schema(String)
+    STRING_INPUT = make_bare_input_schema(String)
     STRING_OUTPUT = define_builtin_scalar_output_schema('String')
 
-    PATH_INPUT = make_input_schema(Path)
+    PATH_INPUT = make_bare_input_schema(Path)
     PATH_OUTPUT = define_builtin_scalar_output_schema('Path')
 
-    BOOL_INPUT = make_input_schema(Bool)
+    BOOL_INPUT = make_bare_input_schema(Bool)
     BOOL_OUTPUT = define_builtin_scalar_output_schema('Bool')
 
-    ANY_INPUT = make_input_schema(Any)
+    ANY_INPUT = make_bare_input_schema(Any)
     ANY_OUTPUT = define_builtin_scalar_output_schema('Any')

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -1,40 +1,109 @@
 from dagster import check
+from dagster.utils import single_item
+
+from .builtin_enum import BuiltinEnum
+from .config import ConfigType
 
 
 class InputSchema:
     @property
-    def schema_cls(self):
-        check.not_implemented('Must implement')
-
-    @property
     def schema_type(self):
-        from .field import resolve_to_config_type
+        check.not_implemented(
+            'Must override schema_type in {klass}'.format(klass=type(self).__name__)
+        )
 
-        return resolve_to_config_type(self.schema_cls)
-
-    def construct_from_config_value(self, value):
-        return value
+    def construct_from_config_value(self, config_value):
+        return config_value
 
 
-def make_input_schema(dagster_type):
+def resolve_config_cls_arg(config_cls):
+    if isinstance(config_cls, BuiltinEnum):
+        return ConfigType.from_builtin_enum(config_cls)
+    else:
+        check.type_param(config_cls, 'config_cls')
+        check.param_invariant(issubclass(config_cls, ConfigType), 'config_cls')
+        return config_cls.inst()
+
+
+def make_bare_input_schema(config_cls):
+    config_type = resolve_config_cls_arg(config_cls)
+
     class _InputSchema(InputSchema):
         @property
-        def schema_cls(self):
-            return dagster_type
+        def schema_type(self):
+            return config_type
 
     return _InputSchema()
 
 
 class OutputSchema:
     @property
-    def schema_cls(self):
-        check.not_implemented('Must implement')
-
-    @property
     def schema_type(self):
-        from .field import resolve_to_config_type
-
-        return resolve_to_config_type(self.schema_cls)
+        check.not_implemented(
+            'Must override schema_type in {klass}'.format(klass=type(self).__name__)
+        )
 
     def materialize_runtime_value(self, _config_value, _runtime_value):
         check.not_implemented('Must implement')
+
+
+def _create_input_schema(config_type, func):
+    class _InputSchema(InputSchema):
+        @property
+        def schema_type(self):
+            return config_type
+
+        def construct_from_config_value(self, config_value):
+            return func(config_value)
+
+    return _InputSchema()
+
+
+def input_schema(config_cls):
+    config_type = resolve_config_cls_arg(config_cls)
+    return lambda func: _create_input_schema(config_type, func)
+
+
+def input_selector_schema(config_cls):
+    config_type = resolve_config_cls_arg(config_cls)
+    check.param_invariant(config_type.is_selector, 'config_cls')
+
+    def _wrap(func):
+        def _selector(config_value):
+            selector_key, selector_value = single_item(config_value)
+            return func(selector_key, selector_value)
+
+        return _create_input_schema(config_type, _selector)
+
+    return _wrap
+
+
+def _create_output_schema(config_type, func):
+    class _OutputSchema(OutputSchema):
+        @property
+        def schema_type(self):
+            return config_type
+
+        def materialize_runtime_value(self, config_value, runtime_value):
+            return func(config_value, runtime_value)
+
+    return _OutputSchema()
+
+
+def output_schema(config_cls):
+    config_type = resolve_config_cls_arg(config_cls)
+    return lambda func: _create_input_schema(config_type, func)
+
+
+def output_selector_schema(config_cls):
+    config_type = resolve_config_cls_arg(config_cls)
+    check.param_invariant(config_type.is_selector, 'config_cls')
+
+    def _wrap(func):
+        def _selector(config_value, runtime_value):
+            selector_key, selector_value = single_item(config_value)
+            return func(selector_key, selector_value, runtime_value)
+
+        return _create_output_schema(config_type, _selector)
+
+    return _wrap

--- a/python_modules/dagster/dagster/core/types/decorator.py
+++ b/python_modules/dagster/dagster/core/types/decorator.py
@@ -1,6 +1,6 @@
 from dagster import check
 from .config_schema import InputSchema, OutputSchema
-from .marshal import MarshallingStrategy
+from .marshal import MarshallingStrategy, PickleMarshallingStrategy
 from .runtime import PythonObjectType, RuntimeType
 
 
@@ -78,6 +78,9 @@ def as_dagster_type(
     check.opt_inst_param(input_schema, 'input_schema', InputSchema)
     check.opt_inst_param(output_schema, 'output_schema', OutputSchema)
     check.opt_inst_param(marshalling_strategy, 'marshalling_strategy', MarshallingStrategy)
+
+    if marshalling_strategy is None:
+        marshalling_strategy = PickleMarshallingStrategy()
 
     return _decorate_as_dagster_type(
         existing_type,

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -11,7 +11,7 @@ from .config import ConfigType
 from .config import List as ConfigList
 from .config import Nullable as ConfigNullable
 
-from .config_schema import InputSchema, OutputSchema, make_input_schema
+from .config_schema import InputSchema, OutputSchema, make_bare_input_schema
 
 from .marshal import MarshallingStrategy
 from .dagster_type import check_dagster_type_param
@@ -181,7 +181,7 @@ class NullableType(RuntimeType):
     def __init__(self, inner_type):
         super(NullableType, self).__init__(
             name='Nullable.' + inner_type.name,
-            input_schema=make_input_schema(ConfigNullable(inner_type.input_schema.schema_type))
+            input_schema=make_bare_input_schema(ConfigNullable(inner_type.input_schema.schema_type))
             if inner_type.input_schema
             else None,
         )
@@ -199,7 +199,7 @@ class ListType(RuntimeType):
     def __init__(self, inner_type):
         super(ListType, self).__init__(
             name='List.' + inner_type.name,
-            input_schema=make_input_schema(ConfigList(inner_type.input_schema.schema_type))
+            input_schema=make_bare_input_schema(ConfigList(inner_type.input_schema.schema_type))
             if inner_type.input_schema
             else None,
         )


### PR DESCRIPTION
This a proposal for a new, leaner API for specifying input and output schemas on user-defined types. An input and output schema at its core is a config type and then a function that transforms that a process config value to an in-memory object compatibility with the runtime type the schema is applied to.

This expresses schema just a decorated function then. We a variant for any type and a lightly specialized variant for selector types, which is common in these contexts.

So far example the input schema for a pandas data frame is fully specified as:

```
@input_selector_schema(
    Selector(
        {
            'csv': define_csv_dict_field(),
            'parquet': define_path_dict_field(),
            'table': define_path_dict_field(),
        }
    )
)
def dataframe_input_schema(file_type, file_options):
    if file_type == 'csv':
        path = file_options['path']
        del file_options['path']
        return pd.read_csv(path, **file_options)
    elif file_type == 'parquet':
        return pd.read_parquet(file_options['path'])
    elif file_type == 'table':
        return pd.read_table(file_options['path'])
    else:
        check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
```