### PR TITLE
Improve error message

### DIFF
--- a/python_modules/dagster/dagster/core/types/evaluator.py
+++ b/python_modules/dagster/dagster/core/types/evaluator.py
@@ -144,7 +144,10 @@ def friendly_string_for_error(error):
         )
     elif error.reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH:
         return 'Type failure at path "{path}"{type_msg}. Got "{value_rep}". {message}.'.format(
-            path=path, type_msg=type_msg, value_rep=error.error_data.value_rep, message=error.message
+            path=path,
+            type_msg=type_msg,
+            value_rep=error.error_data.value_rep,
+            message=error.message,
         )
     elif error.reason == DagsterEvaluationErrorReason.SELECTOR_FIELD_ERROR:
         if error.error_data.incoming_fields:

--- a/python_modules/dagster/dagster/core/types/evaluator.py
+++ b/python_modules/dagster/dagster/core/types/evaluator.py
@@ -143,8 +143,8 @@ def friendly_string_for_error(error):
             field_name=error.error_data.field_name, path_msg=path_msg, type_msg=type_msg
         )
     elif error.reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH:
-        return 'Type failure at path "{path}"{type_msg}. Got "{value_rep}".'.format(
-            path=path, type_msg=type_msg, value_rep=error.error_data.value_rep
+        return 'Type failure at path "{path}"{type_msg}. Got "{value_rep}". {message}.'.format(
+            path=path, type_msg=type_msg, value_rep=error.error_data.value_rep, message=error.message
         )
     elif error.reason == DagsterEvaluationErrorReason.SELECTOR_FIELD_ERROR:
         if error.error_data.incoming_fields:

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
@@ -42,8 +42,7 @@ def test_hello_typed():
     with pytest.raises(
         PipelineConfigEvaluationError,
         match=(
-            'Type failure at path "root:solids:add_hello_to_word_typed:inputs:word". Got '
-            '"set([\'Foobar Baz\'])". Value for selector type String.InputSchema must be a dict got '
+            'Value for selector type String.InputSchema must be a dict got '
             'set([\'Foobar Baz\']).'
         ),
     ):
@@ -64,4 +63,3 @@ def test_hello_typed_bad_structure():
         result.result_for_solid('add_hello_to_word_typed').transformed_value()
         == 'Hello, Foobar Baz!'
     )
-

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
@@ -41,10 +41,7 @@ def test_hello_typed_inputs():
 def test_hello_typed():
     with pytest.raises(
         PipelineConfigEvaluationError,
-        match=(
-            'Value for selector type String.InputSchema must be a dict got '
-            'set([\'Foobar Baz\']).'
-        ),
+        match=('Value for selector type String.InputSchema must be a dict got '),
     ):
         result = execute_pipeline(
             define_hello_typed_inputs_pipeline(),

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
@@ -39,9 +39,24 @@ def test_hello_typed_inputs():
 
 
 def test_hello_typed():
+    with pytest.raises(
+        PipelineConfigEvaluationError,
+        match=(
+            'Type failure at path "root:solids:add_hello_to_word_typed:inputs:word". Got '
+            '"set([\'Foobar Baz\'])". Value for selector type String.InputSchema must be a dict got '
+            'set([\'Foobar Baz\']).'
+        ),
+    ):
+        result = execute_pipeline(
+            define_hello_typed_inputs_pipeline(),
+            {'solids': {'add_hello_to_word_typed': {'inputs': {'word': {'Foobar Baz'}}}}},
+        )
+
+
+def test_hello_typed_bad_structure():
     result = execute_pipeline(
         define_hello_typed_inputs_pipeline(),
-        {'solids': {'add_hello_to_word_typed': {'inputs': {'word': {'Foobar Baz'}}}}},
+        {'solids': {'add_hello_to_word_typed': {'inputs': {'word': {'value': 'Foobar Baz'}}}}},
     )
     assert result.success
     assert len(result.result_list) == 1
@@ -49,3 +64,4 @@ def test_hello_typed():
         result.result_for_solid('add_hello_to_word_typed').transformed_value()
         == 'Hello, Foobar Baz!'
     )
+

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_inputs.py
@@ -1,0 +1,51 @@
+import pytest
+
+from dagster import PipelineConfigEvaluationError, execute_pipeline
+from dagster.tutorials.intro_tutorial.inputs import (
+    execute_with_another_world,
+    define_hello_typed_inputs_pipeline,
+)
+from dagster.tutorials.utils import check_cli_execute_file_pipeline
+from dagster.utils import script_relative_path
+
+
+def test_hello_inputs_parameterized_pipeline():
+    result = execute_with_another_world()
+    assert result.success
+    solid_result = result.result_for_solid('add_hello_to_word')
+    assert solid_result.transformed_value() == 'Hello, Mars!'
+
+
+def test_hello_inputs_parameterized_cli_pipeline():
+    check_cli_execute_file_pipeline(
+        script_relative_path('../../../dagster/tutorials/intro_tutorial/inputs.py'),
+        'define_hello_inputs_pipeline',
+        script_relative_path('../../../dagster/tutorials/intro_tutorial/inputs_env.yml'),
+    )
+
+
+def test_hello_typed_inputs():
+    with pytest.raises(
+        PipelineConfigEvaluationError,
+        match=(
+            'Type failure at path '
+            '"root:solids:add_hello_to_word_typed:inputs:word:value" on type "String"'
+        ),
+    ):
+        execute_pipeline(
+            define_hello_typed_inputs_pipeline(),
+            {'solids': {'add_hello_to_word_typed': {'inputs': {'word': {'value': 343}}}}},
+        )
+
+
+def test_hello_typed():
+    result = execute_pipeline(
+        define_hello_typed_inputs_pipeline(),
+        {'solids': {'add_hello_to_word_typed': {'inputs': {'word': {'Foobar Baz'}}}}},
+    )
+    assert result.success
+    assert len(result.result_list) == 1
+    assert (
+        result.result_for_solid('add_hello_to_word_typed').transformed_value()
+        == 'Hello, Foobar Baz!'
+    )


### PR DESCRIPTION
OLD: `Error 1: Type failure at path "root:solids:add_hello_to_word_typed:inputs:word:value" on type "String". Got "3".` -> NEW: `Error 1: Type failure at path "root:solids:add_hello_to_word_typed:inputs:word:value" on type "String". Got "3". Value 3 is not valid for type String.`

OLD: `Error 1: Type failure at path "root:solids:add_hello_to_word_typed:inputs:word". Got "{'Foobar Baz'}".`-> NEW: `Error 1: Type failure at path "root:solids:add_hello_to_word_typed:inputs:word". Got "{'Foobar Baz'}". Value for selector type String.InputSchema must be a dict got {'Foobar Baz'}.`