### PR TITLE
Properly cleanup context stack when user throws exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,4 @@
+0.3.1
+
+   - Bug fixes
+      - #670: Internal system error "dagster.check.CheckError: Invariant failed. Description: Should not be in context" raised when user throwing error during transform.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
 0.3.1
 
    - Bug fixes
-      - #670: Internal system error "dagster.check.CheckError: Invariant failed. Description: Should not be in context" raised when user throwing error during transform.
+      - #670: Internal system error "dagster.check.CheckError: Invariant failed. Description: Should not be in context" raised when user throwing error during transform. Now the appropriate user error should be raised.

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -208,10 +208,11 @@ class RuntimeExecutionContext:
             check.invariant(not key in self._context_stack, 'Should not be in context')
             self._context_stack[key] = value
 
-        yield
-
-        for key in ddict.keys():
-            self._context_stack.pop(key)
+        try:
+            yield
+        finally:
+            for key in ddict.keys():
+                self._context_stack.pop(key)
 
     @property
     def run_id(self):

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -158,4 +158,3 @@ def test_user_error_propogation():
 
     with pytest.raises(UserError):
         execute_pipeline(pipeline_def)
-

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -12,6 +12,7 @@ from dagster import (
     SolidDefinition,
     check,
     execute_pipeline,
+    lambda_solid,
 )
 
 from dagster.core.test_utils import execute_single_solid_in_isolation, single_output_transform
@@ -131,3 +132,30 @@ def test_single_transform_returning_result():
 
     with pytest.raises(DagsterInvariantViolationError):
         execute_single_solid_in_isolation(ExecutionContext(), solid_inst)
+
+
+def test_user_error_propogation():
+    class UserError(Exception):
+        pass
+
+    @lambda_solid
+    def throws_user_error():
+        raise UserError()
+
+    @lambda_solid
+    def return_one():
+        return 1
+
+    @lambda_solid(inputs=[InputDefinition('num')])
+    def add_one(num):
+        return num + 1
+
+    pipeline_def = PipelineDefinition(
+        name='test_user_error_propogation',
+        solids=[throws_user_error, return_one, add_one],
+        dependencies={'add_one': {'num': DependencyDefinition('return_one')}},
+    )
+
+    with pytest.raises(UserError):
+        execute_pipeline(pipeline_def)
+


### PR DESCRIPTION
Caught this one whilst upgrading. 

Tracking issue here.

https://github.com/dagster-io/dagster/issues/670

Also proposing adding a change log so we can incrementally build up release notes.