### PR TITLE
Hoist Resources and Log to the top level info object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,8 @@
 
    - API Additions
       - New decorated-based @resource API as a more concise alternative to ResourceDefinition
-      - Dagster config type system now supports enum types. (dagster.Enum and dagster.EnumType)
-
+      - Dagster config type system now supports enum types. (dagster.Enum and dagster.EnumType) 
+      - New top level properties `resources` and `log` on info.
    - Notes
       - GraphQL queries and mutations taking a pipeline name now take both a pipeline name and an optional
         solid subset and have slightly improved call signatures.

--- a/python_modules/airline-demo/airline_demo/solids.py
+++ b/python_modules/airline-demo/airline_demo/solids.py
@@ -107,7 +107,7 @@ def sql_solid(name, select_statement, materialization_strategy, table_name=None,
                 The table name of the newly materialized SQL select statement.
         '''
 
-        info.context.info(
+        info.log.info(
             'Executing sql statement:\n{sql_statement}'.format(sql_statement=sql_statement)
         )
         info.resources.db_info.engine.execute(text(sql_statement))
@@ -221,7 +221,7 @@ def download_from_s3(info):
             target_path = info.resources.tempfile.tempfile().name
 
         if file_['skip_if_present'] and safe_isfile(target_path):
-            info.context.info(
+            info.log.info(
                 'Skipping download, file already present at {target_path}'.format(
                     target_path=target_path
                 )
@@ -356,7 +356,7 @@ def unzip_file(
                     zip_ref.extract(archive_member, destination_dir)
                 else:
                     if is_file:
-                        info.context.info(
+                        info.log.info(
                             'Skipping unarchive of {archive_member} from {archive_path}, '
                             'file already present at {target_path}'.format(
                                 archive_member=archive_member,
@@ -365,7 +365,7 @@ def unzip_file(
                             )
                         )
                     if is_dir:
-                        info.context.info(
+                        info.log.info(
                             'Skipping unarchive of {archive_member} from {archive_path}, '
                             'directory already present at {target_path}'.format(
                                 archive_member=archive_member,
@@ -377,7 +377,7 @@ def unzip_file(
                 if not (info.config['skip_if_present'] and is_dir):
                     zip_ref.extractall(destination_dir)
                 else:
-                    info.context.info(
+                    info.log.info(
                         'Skipping unarchive of {archive_path}, directory already present '
                         'at {target_path}'.format(
                             archive_path=archive_path, target_path=target_path

--- a/python_modules/airline-demo/airline_demo/solids.py
+++ b/python_modules/airline-demo/airline_demo/solids.py
@@ -110,7 +110,7 @@ def sql_solid(name, select_statement, materialization_strategy, table_name=None,
         info.context.info(
             'Executing sql statement:\n{sql_statement}'.format(sql_statement=sql_statement)
         )
-        info.context.resources.db_info.engine.execute(text(sql_statement))
+        info.resources.db_info.engine.execute(text(sql_statement))
         yield Result(value=table_name, output_name='result')
 
     return SolidDefinition(
@@ -161,7 +161,7 @@ def thunk_database_engine(info):
     threads. So in order to get a database engine into a Jupyter notebook, we need to serialize
     it and pass it along.
     """
-    return info.context.resources.db
+    return info.resources.db
 
 
 @solid(
@@ -218,7 +218,7 @@ def download_from_s3(info):
         target_path = file_.get('target_path') or key
 
         if target_path is None:
-            target_path = info.context.resources.tempfile.tempfile().name
+            target_path = info.resources.tempfile.tempfile().name
 
         if file_['skip_if_present'] and safe_isfile(target_path):
             info.context.info(
@@ -230,7 +230,7 @@ def download_from_s3(info):
             if os.path.dirname(target_path):
                 mkdir_p(os.path.dirname(target_path))
 
-            info.context.resources.s3.download_file(bucket, key, target_path)
+            info.resources.s3.download_file(bucket, key, target_path)
         results.append(target_path)
     return results
 
@@ -274,7 +274,7 @@ def upload_to_s3(info, file_path):
     key = info.config['key']
 
     with open(file_path, 'rb') as fd:
-        info.context.resources.s3.put_object(
+        info.resources.s3.put_object(
             Bucket=bucket, Body=fd, Key=key, **(info.config.get('kwargs') or {})
         )
     yield Result(bucket, 'bucket')
@@ -394,7 +394,7 @@ def unzip_file(
 )
 def ingest_csv_to_spark(info, input_csv):
     data_frame = (
-        info.context.resources.spark.read.format('csv')
+        info.resources.spark.read.format('csv')
         .options(
             header='true',
             # inferSchema='true',
@@ -476,7 +476,7 @@ def normalize_weather_na_values(_info, data_frame):
     config_field=Field(Dict(fields={'table_name': Field(String, description='')})),
 )
 def load_data_to_database_from_spark(info, data_frame):
-    info.context.resources.db_info.load_table(data_frame, info.config['table_name'])
+    info.resources.db_info.load_table(data_frame, info.config['table_name'])
     return data_frame
 
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/subquery_builder_experimental.py
@@ -49,7 +49,7 @@ def define_create_table_solid(name):
         total_sql = '''CREATE TABLE {output_table_name} AS {query_text}'''.format(
             output_table_name=output_table_name, query_text=sql_expr.query_text
         )
-        info.context.resources.sa.engine.connect().execute(total_sql)
+        info.resources.sa.engine.connect().execute(total_sql)
 
     return SolidDefinition(
         name=name,

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_resource_based_tests.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_resource_based_tests.py
@@ -36,7 +36,7 @@ def execute_sql_text_on_context(info, sql_text):
     # if context.resources.sa.mock_sql:
     #     return
 
-    engine = info.context.resources.engine
+    engine = info.resources.engine
 
     if _is_sqlite_context(info.context):
         # sqlite3 does not support multiple statements in a single

--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -242,7 +242,7 @@ def solid(name=None, inputs=None, outputs=None, config_field=None, description=N
                 outputs=[OutputDefinition()],
             )
             def hello_world(info, foo):
-                info.context.info('log something')
+                info.log.info('log something')
                 return foo
 
             @solid(

--- a/python_modules/dagster/dagster/core/definitions/infos.py
+++ b/python_modules/dagster/dagster/core/definitions/infos.py
@@ -36,7 +36,7 @@ class ExpectationExecutionInfo(
 
 
 class TransformExecutionInfo(
-    namedtuple('_TransformExecutionInfo', 'context config solid pipeline_def')
+    namedtuple('_TransformExecutionInfo', 'context config solid pipeline_def resources log')
 ):
     '''An instance of TransformExecutionInfo is passed every solid transform function.
 
@@ -46,13 +46,15 @@ class TransformExecutionInfo(
         config (Any): Config object for current solid
     '''
 
-    def __new__(cls, context, config, solid, pipeline_def):
+    def __new__(cls, context, config, solid, pipeline_def, resources, log):
         return super(TransformExecutionInfo, cls).__new__(
             cls,
             check.inst_param(context, 'context', RuntimeExecutionContext),
             config,
             check.inst_param(solid, 'solid', Solid),
             check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition),
+            resources,
+            log,
         )
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/infos.py
+++ b/python_modules/dagster/dagster/core/definitions/infos.py
@@ -10,6 +10,26 @@ from .output import OutputDefinition
 from .pipeline import PipelineDefinition
 
 
+class DagsterLog:
+    def __init__(self, context):
+        self.context = context
+
+    def debug(self, msg, **kwargs):
+        return self.context.debug(msg, **kwargs)
+
+    def info(self, msg, **kwargs):
+        return self.context.info(msg, **kwargs)
+
+    def warning(self, msg, **kwargs):
+        return self.context.warning(msg, **kwargs)
+
+    def error(self, msg, **kwargs):
+        return self.context.error(msg, **kwargs)
+
+    def critical(self, msg, **kwargs):
+        return self.context.critical(msg, **kwargs)
+
+
 class ContextCreationExecutionInfo(
     namedtuple('_ContextCreationExecutionInfo', 'config pipeline_def run_id')
 ):
@@ -23,7 +43,7 @@ class ContextCreationExecutionInfo(
 
 
 class ExpectationExecutionInfo(
-    namedtuple('_ExpectationExecutionInfo', 'context inout_def solid expectation_def')
+    namedtuple('_ExpectationExecutionInfo', 'context inout_def solid expectation_def resources log')
 ):
     def __new__(cls, context, inout_def, solid, expectation_def):
         return super(ExpectationExecutionInfo, cls).__new__(
@@ -32,6 +52,8 @@ class ExpectationExecutionInfo(
             check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition)),
             check.inst_param(solid, 'solid', Solid),
             check.inst_param(expectation_def, 'expectation_def', ExpectationDefinition),
+            context.resources,
+            DagsterLog(context),
         )
 
 
@@ -46,15 +68,15 @@ class TransformExecutionInfo(
         config (Any): Config object for current solid
     '''
 
-    def __new__(cls, context, config, solid, pipeline_def, resources, log):
+    def __new__(cls, context, config, solid, pipeline_def):
         return super(TransformExecutionInfo, cls).__new__(
             cls,
             check.inst_param(context, 'context', RuntimeExecutionContext),
             config,
             check.inst_param(solid, 'solid', Solid),
             check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition),
-            resources,
-            log,
+            context.resources,
+            DagsterLog(context),
         )
 
     @property

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -26,37 +26,9 @@ def create_transform_step(execution_info, solid, step_inputs, conf):
     )
 
 
-class DagsterLog:
-    def __init__(self, context):
-        self.context = context
-
-    def debug(self, msg, **kwargs):
-        return self.context.debug(msg, **kwargs)
-
-    def info(self, msg, **kwargs):
-        return self.context.info(msg, **kwargs)
-
-    def warning(self, msg, **kwargs):
-        return self.context.warning(msg, **kwargs)
-
-    def error(self, msg, **kwargs):
-        return self.context.error(msg, **kwargs)
-
-    def critical(self, msg, **kwargs):
-        return self.context.critical(msg, **kwargs)
-
-
 def _yield_transform_results(execution_info, context, step, conf, inputs):
     gen = step.solid.definition.transform_fn(
-        TransformExecutionInfo(
-            context,
-            conf,
-            step.solid,
-            execution_info.pipeline,
-            context.resources,
-            DagsterLog(context),
-        ),
-        inputs,
+        TransformExecutionInfo(context, conf, step.solid, execution_info.pipeline), inputs
     )
 
     if isinstance(gen, Result):

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -26,9 +26,37 @@ def create_transform_step(execution_info, solid, step_inputs, conf):
     )
 
 
+class DagsterLog:
+    def __init__(self, context):
+        self.context = context
+
+    def debug(self, msg, **kwargs):
+        return self.context.debug(msg, **kwargs)
+
+    def info(self, msg, **kwargs):
+        return self.context.info(msg, **kwargs)
+
+    def warning(self, msg, **kwargs):
+        return self.context.warning(msg, **kwargs)
+
+    def error(self, msg, **kwargs):
+        return self.context.error(msg, **kwargs)
+
+    def critical(self, msg, **kwargs):
+        return self.context.critical(msg, **kwargs)
+
+
 def _yield_transform_results(execution_info, context, step, conf, inputs):
     gen = step.solid.definition.transform_fn(
-        TransformExecutionInfo(context, conf, step.solid, execution_info.pipeline), inputs
+        TransformExecutionInfo(
+            context,
+            conf,
+            step.solid,
+            execution_info.pipeline,
+            context.resources,
+            DagsterLog(context),
+        ),
+        inputs,
     )
 
     if isinstance(gen, Result):

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/execution_context.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/execution_context.py
@@ -3,13 +3,13 @@ from dagster import PipelineDefinition, execute_pipeline, solid
 
 @solid
 def debug_message(info):
-    info.context.debug('A debug message.')
+    info.log.debug('A debug message.')
     return 'foo'
 
 
 @solid
 def error_message(info):
-    info.context.error('An error occurred.')
+    info.log.error('An error occurred.')
 
 
 def define_execution_context_pipeline_step_one():
@@ -18,15 +18,13 @@ def define_execution_context_pipeline_step_one():
 
 def define_execution_context_pipeline_step_two():
     return PipelineDefinition(
-        name='execution_context_pipeline',
-        solids=[debug_message, error_message],
+        name='execution_context_pipeline', solids=[debug_message, error_message]
     )
 
 
 def define_execution_context_pipeline_step_three():
     return PipelineDefinition(
-        name='execution_context_pipeline',
-        solids=[debug_message, error_message],
+        name='execution_context_pipeline', solids=[debug_message, error_message]
     )
 
 

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/execution_context.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/execution_context.py
@@ -18,13 +18,15 @@ def define_execution_context_pipeline_step_one():
 
 def define_execution_context_pipeline_step_two():
     return PipelineDefinition(
-        name='execution_context_pipeline', solids=[debug_message, error_message]
+        name='execution_context_pipeline',
+        solids=[debug_message, error_message],
     )
 
 
 def define_execution_context_pipeline_step_three():
     return PipelineDefinition(
-        name='execution_context_pipeline', solids=[debug_message, error_message]
+        name='execution_context_pipeline',
+        solids=[debug_message, error_message],
     )
 
 

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/multiple_outputs.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/multiple_outputs.py
@@ -53,15 +53,13 @@ def conditional(info):
 
 @solid(inputs=[InputDefinition('num', dagster_type=Int)])
 def log_num(info, num):
-    info.context.info('num {num}'.format(num=num))
+    info.log.info('num {num}'.format(num=num))
     return num
 
 
 @solid(inputs=[InputDefinition('num', dagster_type=Int)])
 def log_num_squared(info, num):
-    info.context.info(
-        'num_squared {num_squared}'.format(num_squared=num * num)
-    )
+    info.log.info('num_squared {num_squared}'.format(num_squared=num * num))
     return num * num
 
 

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
@@ -31,8 +31,8 @@ class PublicCloudStore:
         # create credential and store it
         self.conn = PublicCloudConn(username, password)
 
-    def record_value(self, context, key, value):
-        context.info(
+    def record_value(self, log, key, value):
+        log.info(
             'Setting key={key} value={value} in cloud'.format(
                 key=key, value=value
             )
@@ -44,8 +44,8 @@ class InMemoryStore:
     def __init__(self):
         self.values = {}
 
-    def record_value(self, context, key, value):
-        context.info(
+    def record_value(self, log, key, value):
+        log.info(
             'Setting key={key} value={value} in memory'.format(
                 key=key, value=value
             )
@@ -82,7 +82,7 @@ def define_cloud_store_resource():
 )
 def add_ints(info, num_one, num_two):
     sum_ints = num_one + num_two
-    info.resources.store.record_value(info.context, 'add', sum_ints)
+    info.resources.store.record_value(info.log, 'add', sum_ints)
     return sum_ints
 
 

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
@@ -82,7 +82,7 @@ def define_cloud_store_resource():
 )
 def add_ints(info, num_one, num_two):
     sum_ints = num_one + num_two
-    info.context.resources.store.record_value(info.context, 'add', sum_ints)
+    info.resources.store.record_value(info.context, 'add', sum_ints)
     return sum_ints
 
 

--- a/python_modules/dagster/dagster/tutorials/log_spew/pipeline.py
+++ b/python_modules/dagster/dagster/tutorials/log_spew/pipeline.py
@@ -18,44 +18,21 @@ def nonce_solid(name, n_inputs, n_outputs):
 
     @solid(
         name=name,
-        inputs=[
-            InputDefinition(name='input_{}'.format(i)) for i in range(n_inputs)
-        ],
-        outputs=[
-            OutputDefinition(name='output_{}'.format(i))
-            for i in range(n_outputs)
-        ],
+        inputs=[InputDefinition(name='input_{}'.format(i)) for i in range(n_inputs)],
+        outputs=[OutputDefinition(name='output_{}'.format(i)) for i in range(n_outputs)],
     )
     def solid_fn(info, **_kwargs):
         for i in range(200):
             time.sleep(0.02)
             if i % 1000 == 420:
-                info.context.error(
-                    'Error message seq={i} from solid {name}'.format(
-                        i=i, name=name
-                    )
-                )
+                info.log.error('Error message seq={i} from solid {name}'.format(i=i, name=name))
             elif i % 100 == 0:
-                info.context.warning(
-                    'Warning message seq={i} from solid {name}'.format(
-                        i=i, name=name
-                    )
-                )
+                info.log.warning('Warning message seq={i} from solid {name}'.format(i=i, name=name))
             elif i % 10 == 0:
-                info.context.info(
-                    'Info message seq={i} from solid {name}'.format(
-                        i=i, name=name
-                    )
-                )
+                info.log.info('Info message seq={i} from solid {name}'.format(i=i, name=name))
             else:
-                info.context.debug(
-                    'Debug message seq={i} from solid {name}'.format(
-                        i=i, name=name
-                    )
-                )
-        return MultipleResults.from_dict(
-            {'output_{}'.format(i): 'foo' for i in range(n_outputs)}
-        )
+                info.log.debug('Debug message seq={i} from solid {name}'.format(i=i, name=name))
+        return MultipleResults.from_dict({'output_{}'.format(i): 'foo' for i in range(n_outputs)})
 
     return solid_fn
 

--- a/python_modules/dagster/dagster/tutorials/log_spew/pipeline.py
+++ b/python_modules/dagster/dagster/tutorials/log_spew/pipeline.py
@@ -18,21 +18,44 @@ def nonce_solid(name, n_inputs, n_outputs):
 
     @solid(
         name=name,
-        inputs=[InputDefinition(name='input_{}'.format(i)) for i in range(n_inputs)],
-        outputs=[OutputDefinition(name='output_{}'.format(i)) for i in range(n_outputs)],
+        inputs=[
+            InputDefinition(name='input_{}'.format(i)) for i in range(n_inputs)
+        ],
+        outputs=[
+            OutputDefinition(name='output_{}'.format(i))
+            for i in range(n_outputs)
+        ],
     )
     def solid_fn(info, **_kwargs):
         for i in range(200):
             time.sleep(0.02)
             if i % 1000 == 420:
-                info.log.error('Error message seq={i} from solid {name}'.format(i=i, name=name))
+                info.log.error(
+                    'Error message seq={i} from solid {name}'.format(
+                        i=i, name=name
+                    )
+                )
             elif i % 100 == 0:
-                info.log.warning('Warning message seq={i} from solid {name}'.format(i=i, name=name))
+                info.log.warning(
+                    'Warning message seq={i} from solid {name}'.format(
+                        i=i, name=name
+                    )
+                )
             elif i % 10 == 0:
-                info.log.info('Info message seq={i} from solid {name}'.format(i=i, name=name))
+                info.log.info(
+                    'Info message seq={i} from solid {name}'.format(
+                        i=i, name=name
+                    )
+                )
             else:
-                info.log.debug('Debug message seq={i} from solid {name}'.format(i=i, name=name))
-        return MultipleResults.from_dict({'output_{}'.format(i): 'foo' for i in range(n_outputs)})
+                info.log.debug(
+                    'Debug message seq={i} from solid {name}'.format(
+                        i=i, name=name
+                    )
+                )
+        return MultipleResults.from_dict(
+            {'output_{}'.format(i): 'foo' for i in range(n_outputs)}
+        )
 
     return solid_fn
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
@@ -76,7 +76,7 @@ def test_default_value():
     def _get_config_test_solid(config_key, config_value):
         @solid(inputs=[], outputs=[OutputDefinition()])
         def config_test(info):
-            assert info.context.resources == {config_key: config_value}
+            assert info.resources == {config_key: config_value}
 
         return config_test
 
@@ -106,7 +106,7 @@ def test_default_value():
 def test_custom_contexts():
     @solid(inputs=[], outputs=[OutputDefinition()])
     def custom_context_transform(info):
-        assert info.context.resources == {'field_one': 'value_two'}
+        assert info.resources == {'field_one': 'value_two'}
 
     pipeline = PipelineDefinition(
         solids=[custom_context_transform],
@@ -135,7 +135,7 @@ def test_yield_context():
 
     @solid(inputs=[], outputs=[OutputDefinition()])
     def custom_context_transform(info):
-        assert info.context.resources == {'field_one': 'value_two'}
+        assert info.resources == {'field_one': 'value_two'}
         assert info.context._context_stack['foo'] == 'bar'  # pylint: disable=W0212
         events.append('during')
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resource_definition.py
@@ -20,7 +20,7 @@ def test_basic_resource():
     @solid
     def a_solid(info):
         called['yup'] = True
-        assert info.context.resources.a_string == 'foo'
+        assert info.resources.a_string == 'foo'
 
     pipeline_def = PipelineDefinition(
         name='with_a_resource',
@@ -44,7 +44,7 @@ def test_yield_resource():
     @solid
     def a_solid(info):
         called['yup'] = True
-        assert info.context.resources.a_string == 'foo'
+        assert info.resources.a_string == 'foo'
 
     def _do_resource(info):
         yield info.config
@@ -75,8 +75,8 @@ def test_yield_multiple_resources():
     @solid
     def a_solid(info):
         called['yup'] = True
-        assert info.context.resources.string_one == 'foo'
-        assert info.context.resources.string_two == 'bar'
+        assert info.resources.string_one == 'foo'
+        assert info.resources.string_two == 'bar'
 
     def _do_resource(info):
         saw.append('before yield ' + info.config)
@@ -124,8 +124,8 @@ def test_resource_decorator():
     @solid
     def a_solid(info):
         called['yup'] = True
-        assert info.context.resources.string_one == 'foo'
-        assert info.context.resources.string_two == 'bar'
+        assert info.resources.string_one == 'foo'
+        assert info.resources.string_two == 'bar'
 
     @resource(Field(String))
     def yielding_string_resource(info):
@@ -175,8 +175,8 @@ def test_mixed_multiple_resources():
     @solid
     def a_solid(info):
         called['yup'] = True
-        assert info.context.resources.returned_string == 'foo'
-        assert info.context.resources.yielded_string == 'bar'
+        assert info.resources.returned_string == 'foo'
+        assert info.resources.yielded_string == 'bar'
 
     def _do_yield_resource(info):
         saw.append('before yield ' + info.config)
@@ -235,7 +235,7 @@ def test_none_resource():
 
     @solid
     def solid_test_null(info):
-        assert info.context.resources.test_null is None
+        assert info.resources.test_null is None
         called['yup'] = True
 
     pipeline = PipelineDefinition(
@@ -259,7 +259,7 @@ def test_string_resource():
 
     @solid
     def solid_test_string(info):
-        assert info.context.resources.test_string == 'foo'
+        assert info.resources.test_string == 'foo'
         called['yup'] = True
 
     pipeline = PipelineDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
@@ -491,7 +491,7 @@ def test_context_selector_working():
 
     @solid
     def check_context(info):
-        assert info.context.resources == 32
+        assert info.resources == 32
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(

--- a/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
@@ -98,7 +98,7 @@ def test_single_solid_with_context_config():
 
     @solid
     def check_context_config_for_two(info):
-        assert info.context.resources == 2
+        assert info.resources == 2
         ran['check_context_config_for_two'] += 1
 
     pipeline_def = PipelineDefinition(

--- a/python_modules/dagster/docs/intro_tutorial/execution_context.rst
+++ b/python_modules/dagster/docs/intro_tutorial/execution_context.rst
@@ -2,17 +2,18 @@ Execution Context
 =================
 
 One of the most important objects in the system is the execution context. The execution
-context is threaded throughout the entire computation (via the ``info`` object passed to
-user code) and contains handles to logging facilities and external resources. Interactions
-with logging systems, databases, and external clusters (e.g. a Spark cluster) should
-be managed through the context. 
+context, the logger, and the resources are threaded throughout the entire computation (
+via the ``info`` object passed to user code) and contains handles to logging facilities
+and external resources. Interactions with logging systems, databases, and external
+clusters (e.g. a Spark cluster) should be managed through these properties of the 
+info object.
 
 This provides a powerful layer of indirection that allows a solid to abstract
-away its surrounding environment. Using an execution context allows the system and pipeline
-infrastructure to provide different implementations for different environments,
-giving the engineer the opportunity to design pipelines that can be executed
-on your local machine or your CI/CD pipeline as readily as your production
-cluster environment.
+away its surrounding environment. Using an execution context allows the system and
+pipeline infrastructure to provide different implementations for different
+environments, giving the engineer the opportunity to design pipelines that
+can be executed on your local machine or your CI/CD pipeline as readily as
+your production cluster environment.
 
 Logging
 ~~~~~~~

--- a/python_modules/dagster/docs/intro_tutorial/resources.rst
+++ b/python_modules/dagster/docs/intro_tutorial/resources.rst
@@ -1,8 +1,8 @@
 Resources
 =========
 
-We've already learned about logging through the execution context. We can also use the execution
-context to manage pipelines' access to resources like the file system, databases, or cloud services.
+We've already learned about logging through the info object. We can also use the info object
+to manage pipelines' access to resources like the file system, databases, or cloud services.
 In general, interactions with features of the external environment like these should be modeled
 as resources.
 

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -22681,13 +22681,13 @@ cluster environment.</p>
 
 <span class="nd">@solid</span>
 <span class="k">def</span> <span class="nf">debug_message</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="s1">&#39;A debug message.&#39;</span><span class="p">)</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="s1">&#39;A debug message.&#39;</span><span class="p">)</span>
     <span class="k">return</span> <span class="s1">&#39;foo&#39;</span>
 
 
 <span class="nd">@solid</span>
 <span class="k">def</span> <span class="nf">error_message</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="s1">&#39;An error occurred.&#39;</span><span class="p">)</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="s1">&#39;An error occurred.&#39;</span><span class="p">)</span>
 
 
 <span class="k">def</span> <span class="nf">define_execution_context_pipeline_step_one</span><span class="p">():</span>

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -24993,7 +24993,7 @@ key of the <code class="docutils literal notranslate"><span class="pre">info</sp
 <span class="p">)</span>
 <span class="k">def</span> <span class="nf">add_ints</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num_one</span><span class="p">,</span> <span class="n">num_two</span><span class="p">):</span>
     <span class="n">sum_ints</span> <span class="o">=</span> <span class="n">num_one</span> <span class="o">+</span> <span class="n">num_two</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="o">.</span><span class="n">resources</span><span class="o">.</span><span class="n">store</span><span class="o">.</span><span class="n">record_value</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="p">,</span> <span class="s1">&#39;add&#39;</span><span class="p">,</span> <span class="n">sum_ints</span><span class="p">)</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">resources</span><span class="o">.</span><span class="n">store</span><span class="o">.</span><span class="n">record_value</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="p">,</span> <span class="s1">&#39;add&#39;</span><span class="p">,</span> <span class="n">sum_ints</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">sum_ints</span>
 
 

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -3295,17 +3295,18 @@ snapshots['test_build_all_docs 25'] = '''Execution Context
 =================
 
 One of the most important objects in the system is the execution context. The execution
-context is threaded throughout the entire computation (via the ``info`` object passed to
-user code) and contains handles to logging facilities and external resources. Interactions
-with logging systems, databases, and external clusters (e.g. a Spark cluster) should
-be managed through the context. 
+context, the logger, and the resources are threaded throughout the entire computation (
+via the ``info`` object passed to user code) and contains handles to logging facilities
+and external resources. Interactions with logging systems, databases, and external
+clusters (e.g. a Spark cluster) should be managed through these properties of the 
+info object.
 
 This provides a powerful layer of indirection that allows a solid to abstract
-away its surrounding environment. Using an execution context allows the system and pipeline
-infrastructure to provide different implementations for different environments,
-giving the engineer the opportunity to design pipelines that can be executed
-on your local machine or your CI/CD pipeline as readily as your production
-cluster environment.
+away its surrounding environment. Using an execution context allows the system and
+pipeline infrastructure to provide different implementations for different
+environments, giving the engineer the opportunity to design pipelines that
+can be executed on your local machine or your CI/CD pipeline as readily as
+your production cluster environment.
 
 Logging
 ~~~~~~~
@@ -4003,8 +4004,8 @@ with swappable config.
 snapshots['test_build_all_docs 33'] = '''Resources
 =========
 
-We've already learned about logging through the execution context. We can also use the execution
-context to manage pipelines' access to resources like the file system, databases, or cloud services.
+We've already learned about logging through the info object. We can also use the info object
+to manage pipelines' access to resources like the file system, databases, or cloud services.
 In general, interactions with features of the external environment like these should be modeled
 as resources.
 
@@ -19107,7 +19108,7 @@ multiple outputs. Useful for solids that have multiple outputs.</li>
     <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()],</span>
 <span class="p">)</span>
 <span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;log something&#39;</span><span class="p">)</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;log something&#39;</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">foo</span>
 
 <span class="nd">@solid</span><span class="p">(</span>
@@ -22661,16 +22662,17 @@ snapshots['test_build_all_docs 60'] = '''
   <div class="section" id="execution-context">
 <h1>Execution Context<a class="headerlink" href="#execution-context" title="Permalink to this headline">¶</a></h1>
 <p>One of the most important objects in the system is the execution context. The execution
-context is threaded throughout the entire computation (via the <code class="docutils literal notranslate"><span class="pre">info</span></code> object passed to
-user code) and contains handles to logging facilities and external resources. Interactions
-with logging systems, databases, and external clusters (e.g. a Spark cluster) should
-be managed through the context.</p>
+context, the logger, and the resources are threaded throughout the entire computation (
+via the <code class="docutils literal notranslate"><span class="pre">info</span></code> object passed to user code) and contains handles to logging facilities
+and external resources. Interactions with logging systems, databases, and external
+clusters (e.g. a Spark cluster) should be managed through these properties of the
+info object.</p>
 <p>This provides a powerful layer of indirection that allows a solid to abstract
-away its surrounding environment. Using an execution context allows the system and pipeline
-infrastructure to provide different implementations for different environments,
-giving the engineer the opportunity to design pipelines that can be executed
-on your local machine or your CI/CD pipeline as readily as your production
-cluster environment.</p>
+away its surrounding environment. Using an execution context allows the system and
+pipeline infrastructure to provide different implementations for different
+environments, giving the engineer the opportunity to design pipelines that
+can be executed on your local machine or your CI/CD pipeline as readily as
+your production cluster environment.</p>
 <div class="section" id="logging">
 <h2>Logging<a class="headerlink" href="#logging" title="Permalink to this headline">¶</a></h2>
 <p>One of the most basic pipeline-level facilities is logging.</p>
@@ -24055,18 +24057,18 @@ happened during the computation.</p>
 42</pre></div></td><td class="code"><div class="highlight"><pre><span></span>
 <span class="nd">@solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;num&#39;</span><span class="p">,</span> <span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">)])</span>
 <span class="k">def</span> <span class="nf">log_num</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num </span><span class="si">{num}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num</span><span class="o">=</span><span class="n">num</span><span class="p">))</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num </span><span class="si">{num}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num</span><span class="o">=</span><span class="n">num</span><span class="p">))</span>
     <span class="k">return</span> <span class="n">num</span>
 
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;num&#39;</span><span class="p">,</span> <span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">)])</span>
 <span class="k">def</span> <span class="nf">log_num_squared</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
-        <span class="s1">&#39;num_squared </span><span class="si">{num_squared}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num_squared</span><span class="o">=</span><span class="n">num</span> <span class="o">*</span> <span class="n">num</span><span class="p">)</span>
-    <span class="p">)</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num_squared </span><span class="si">{num_squared}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num_squared</span><span class="o">=</span><span class="n">num</span> <span class="o">*</span> <span class="n">num</span><span class="p">))</span>
     <span class="k">return</span> <span class="n">num</span> <span class="o">*</span> <span class="n">num</span>
 
 
+<span class="k">def</span> <span class="nf">define_multiple_outputs_step_one_pipeline</span><span class="p">():</span>
+    <span class="k">return</span> <span class="n">PipelineDefinition</span><span class="p">(</span>
 <span class="nd">@solid</span><span class="p">(</span>
     <span class="n">outputs</span><span class="o">=</span><span class="p">[</span>
         <span class="n">OutputDefinition</span><span class="p">(</span><span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;out_one&#39;</span><span class="p">),</span>
@@ -24076,8 +24078,6 @@ happened during the computation.</p>
 <span class="k">def</span> <span class="nf">return_dict_results</span><span class="p">(</span><span class="n">_info</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">MultipleResults</span><span class="o">.</span><span class="n">from_dict</span><span class="p">({</span><span class="s1">&#39;out_one&#39;</span><span class="p">:</span> <span class="mi">23</span><span class="p">,</span> <span class="s1">&#39;out_two&#39;</span><span class="p">:</span> <span class="mi">45</span><span class="p">})</span>
 
-
-<span class="k">def</span> <span class="nf">define_multiple_outputs_step_one_pipeline</span><span class="p">():</span>
     <span class="k">return</span> <span class="n">PipelineDefinition</span><span class="p">(</span>
         <span class="n">name</span><span class="o">=</span><span class="s1">&#39;multiple_outputs_step_one_pipeline&#39;</span><span class="p">,</span>
         <span class="n">solids</span><span class="o">=</span><span class="p">[</span><span class="n">return_dict_results</span><span class="p">,</span> <span class="n">log_num</span><span class="p">,</span> <span class="n">log_num_squared</span><span class="p">],</span>
@@ -24094,6 +24094,8 @@ happened during the computation.</p>
             <span class="p">},</span>
         <span class="p">},</span>
     <span class="p">)</span>
+
+
 </pre></div>
 </td></tr></table></div>
 </div>
@@ -24216,8 +24218,6 @@ and then execute that pipeline.</p>
     <span class="k">else</span><span class="p">:</span>
         <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s1">&#39;invalid config&#39;</span><span class="p">)</span>
 
-
-<span class="k">def</span> <span class="nf">define_multiple_outputs_step_two_pipeline</span><span class="p">():</span>
     <span class="k">return</span> <span class="n">PipelineDefinition</span><span class="p">(</span>
         <span class="n">name</span><span class="o">=</span><span class="s1">&#39;multiple_outputs_step_two_pipeline&#39;</span><span class="p">,</span>
         <span class="n">solids</span><span class="o">=</span><span class="p">[</span><span class="n">yield_outputs</span><span class="p">,</span> <span class="n">log_num</span><span class="p">,</span> <span class="n">log_num_squared</span><span class="p">],</span>
@@ -24230,6 +24230,8 @@ and then execute that pipeline.</p>
             <span class="p">},</span>
         <span class="p">},</span>
     <span class="p">)</span>
+
+
 </pre></div>
 </td></tr></table></div>
 </div>
@@ -24943,8 +24945,8 @@ snapshots['test_build_all_docs 68'] = '''
             
   <div class="section" id="resources">
 <h1>Resources<a class="headerlink" href="#resources" title="Permalink to this headline">¶</a></h1>
-<p>We’ve already learned about logging through the execution context. We can also use the execution
-context to manage pipelines’ access to resources like the file system, databases, or cloud services.
+<p>We’ve already learned about logging through the info object. We can also use the info object
+to manage pipelines’ access to resources like the file system, databases, or cloud services.
 In general, interactions with features of the external environment like these should be modeled
 as resources.</p>
 <p>Let’s imagine that we are using a key value store offered by a cloud service that has a python API.
@@ -24959,8 +24961,8 @@ We are going to record the results of computations in that key value store.</p>
         <span class="c1"># create credential and store it</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">conn</span> <span class="o">=</span> <span class="n">PublicCloudConn</span><span class="p">(</span><span class="n">username</span><span class="p">,</span> <span class="n">password</span><span class="p">)</span>
 
-    <span class="k">def</span> <span class="nf">record_value</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">context</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
-        <span class="n">context</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
+    <span class="k">def</span> <span class="nf">record_value</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">log</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
+        <span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
             <span class="s1">&#39;Setting key=</span><span class="si">{key}</span><span class="s1"> value=</span><span class="si">{value}</span><span class="s1"> in cloud&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">key</span><span class="o">=</span><span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="o">=</span><span class="n">value</span>
             <span class="p">)</span>
@@ -24993,7 +24995,7 @@ key of the <code class="docutils literal notranslate"><span class="pre">info</sp
 <span class="p">)</span>
 <span class="k">def</span> <span class="nf">add_ints</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num_one</span><span class="p">,</span> <span class="n">num_two</span><span class="p">):</span>
     <span class="n">sum_ints</span> <span class="o">=</span> <span class="n">num_one</span> <span class="o">+</span> <span class="n">num_two</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">resources</span><span class="o">.</span><span class="n">store</span><span class="o">.</span><span class="n">record_value</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">context</span><span class="p">,</span> <span class="s1">&#39;add&#39;</span><span class="p">,</span> <span class="n">sum_ints</span><span class="p">)</span>
+    <span class="n">info</span><span class="o">.</span><span class="n">resources</span><span class="o">.</span><span class="n">store</span><span class="o">.</span><span class="n">record_value</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="p">,</span> <span class="s1">&#39;add&#39;</span><span class="p">,</span> <span class="n">sum_ints</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">sum_ints</span>
 
 
@@ -25058,8 +25060,8 @@ in testing contexts but does not touch the public cloud:</p>
     <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">values</span> <span class="o">=</span> <span class="p">{}</span>
 
-    <span class="k">def</span> <span class="nf">record_value</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">context</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
-        <span class="n">context</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
+    <span class="k">def</span> <span class="nf">record_value</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">log</span><span class="p">,</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
+        <span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
             <span class="s1">&#39;Setting key=</span><span class="si">{key}</span><span class="s1"> value=</span><span class="si">{value}</span><span class="s1"> in memory&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
                 <span class="n">key</span><span class="o">=</span><span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="o">=</span><span class="n">value</span>
             <span class="p">)</span>

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -286,7 +286,7 @@ def _dm_solid_transform(name, notebook_path):
                 )
             )
 
-            info.context.info("Output notebook path is {}".format(output_notebook_dir))
+            info.log.info("Output notebook path is {}".format(output_notebook_dir))
 
             for output_def in info.solid_def.output_defs:
                 if output_def.name in output_nb.data:

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -236,7 +236,7 @@ def replace_parameters(info, nb, parameters):
         after = nb.cells[param_cell_index + 1 :]
     else:
         # Inject to the top of the notebook, presumably first cell includes dagstermill import
-        info.context.debug(
+        info.log.debug(
             (
                 "Warning notebook has no parameters cell, "
                 "so first cell must import dagstermill and call dm.declare_as_solid"
@@ -280,7 +280,7 @@ def _dm_solid_transform(name, notebook_path):
 
             output_nb = pm.read_notebook(temp_path)
 
-            info.context.debug(
+            info.log.debug(
                 'Notebook execution complete for {name}. Data is {data}'.format(
                     name=name, data=output_nb.data
                 )


### PR DESCRIPTION
To avoid excessive dotting hoist the resources to be a top-level property of info and add a new .log property for logging purposes. I think this is better and that we should deprecate and eventually eliminate these properties on the context object.