### PR TITLE
Separate Persistence Strategy and Serialization Strategy

### DIFF
--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -286,6 +286,12 @@ def dict_param(obj, param_name, key_type=None, value_type=None):
     return _check_key_value_types(obj, key_type, value_type)
 
 
+def opt_type_param(obj, param_name, default=None):
+    if obj is not None and not isinstance(obj, type):
+        raise_with_traceback(_not_type_param_subclass_mismatch_exception(obj, param_name))
+    return obj if obj is not None else default
+
+
 def type_param(obj, param_name):
     if not isinstance(obj, type):
         raise_with_traceback(_not_type_param_subclass_mismatch_exception(obj, param_name))

--- a/python_modules/dagster/dagster/core/definitions/environment_configs.py
+++ b/python_modules/dagster/dagster/core/definitions/environment_configs.py
@@ -11,7 +11,7 @@ from dagster.core.system_config.objects import (
     SolidConfig,
 )
 
-from dagster.core.types import Bool, Field, List, NamedDict, NamedSelector
+from dagster.core.types import Bool, Field, List, NamedDict, NamedSelector, Dict
 from dagster.core.types.config import ConfigType, ConfigTypeAttributes
 from dagster.core.types.default_applier import apply_default_values
 from dagster.core.types.field_utils import check_opt_field_param, FieldImpl
@@ -79,6 +79,11 @@ def define_specific_context_config_cls(name, config_field, resources):
                 'config': config_field,
                 'resources': Field(
                     define_resource_dictionary_cls('{name}.Resources'.format(name=name), resources)
+                ),
+                'marshalling': Field(
+                    SystemNamedSelector(
+                        '{name}.Marshalling'.format(name=name), {'file': Field(Dict({}))}
+                    )
                 ),
             }
         ),
@@ -325,7 +330,10 @@ def construct_environment_config(config_value):
 def construct_context_config(config_value):
     context_name, context_value = single_item(config_value)
     return ContextConfig(
-        name=context_name, config=context_value.get('config'), resources=context_value['resources']
+        name=context_name,
+        config=context_value.get('config'),
+        resources=context_value['resources'],
+        marshalling=context_value['marshalling'],
     )
 
 

--- a/python_modules/dagster/dagster/core/definitions/environment_configs.py
+++ b/python_modules/dagster/dagster/core/definitions/environment_configs.py
@@ -80,9 +80,9 @@ def define_specific_context_config_cls(name, config_field, resources):
                 'resources': Field(
                     define_resource_dictionary_cls('{name}.Resources'.format(name=name), resources)
                 ),
-                'marshalling': Field(
+                'persistence': Field(
                     SystemNamedSelector(
-                        '{name}.Marshalling'.format(name=name), {'file': Field(Dict({}))}
+                        '{name}.Persistence'.format(name=name), {'file': Field(Dict({}))}
                     )
                 ),
             }
@@ -333,7 +333,7 @@ def construct_context_config(config_value):
         name=context_name,
         config=context_value.get('config'),
         resources=context_value['resources'],
-        marshalling=context_value['marshalling'],
+        persistence=context_value['persistence'],
     )
 
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -592,7 +592,7 @@ def _marshal_outputs(context, results, outputs_to_marshal):
 
             path = output['path']
             output_type = result.step.step_output_dict[result.success_data.output_name].runtime_type
-            context.persistence_policy.marshal_value(
+            context.persistence_policy.write_value(
                 output_type.serialization_strategy, path, result.success_data.value
             )
 
@@ -607,7 +607,7 @@ def _unmarshal_inputs(context, inputs_to_marshal, execution_plan):
 
             check.invariant(input_type.serialization_strategy)
 
-            input_value = context.persistence_policy.unmarshal_value(
+            input_value = context.persistence_policy.read_write(
                 input_type.serialization_strategy, file_path
             )
             inputs[step_key][input_name] = input_value

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -607,7 +607,7 @@ def _unmarshal_inputs(context, inputs_to_marshal, execution_plan):
 
             check.invariant(input_type.serialization_strategy)
 
-            input_value = context.persistence_policy.read_write(
+            input_value = context.persistence_policy.read_value(
                 input_type.serialization_strategy, file_path
             )
             inputs[step_key][input_name] = input_value

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 import itertools
 import inspect
 
+
 from contextlib2 import ExitStack
 import six
 
@@ -43,8 +44,6 @@ from .execution_context import ExecutionContext, RuntimeExecutionContext, Execut
 
 from .errors import DagsterInvariantViolationError, DagsterUserCodeExecutionError
 
-from .types.evaluator import EvaluationError, evaluate_config_value, friendly_string_for_error
-
 from .events import construct_event_logger
 
 from .execution_plan.create import create_execution_plan_core, create_subplan
@@ -61,6 +60,9 @@ from .execution_plan.objects import (
 from .execution_plan.simple_engine import execute_plan_core
 
 from .system_config.objects import EnvironmentConfig
+
+from .types.evaluator import EvaluationError, evaluate_config_value, friendly_string_for_error
+from .types.marshal import FileMarshallingPolicy
 
 
 class PipelineExecutionResult(object):
@@ -318,6 +320,17 @@ def with_maybe_gen(thing_or_gen):
     check.invariant(stopped, 'Must yield one item. Yielded more than one item')
 
 
+def _create_marshalling_policy(marshalling_config):
+    check.dict_param(marshalling_config, 'marshalling_config', key_type=str)
+
+    marshalling_key, _config_value = list(marshalling_config.items())[0]
+
+    if marshalling_key == 'file':
+        return FileMarshallingPolicy()
+    else:
+        check.failed('Unsupported marshalling key: {}'.format(marshalling_key))
+
+
 @contextmanager
 def yield_context(pipeline, environment, execution_metadata):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
@@ -349,6 +362,7 @@ def yield_context(pipeline, environment, execution_metadata):
                 tags=get_tags(execution_context, execution_metadata, pipeline),
                 event_callback=get_event_callback(execution_metadata),
                 environment_config=environment.original_config_dict,
+                marshalling_policy=_create_marshalling_policy(environment.context.marshalling),
             )
 
 
@@ -544,27 +558,42 @@ def execute_externalized_plan(
     check.opt_dict_param(environment, 'environment')
     check.opt_inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
 
-    inputs = defaultdict(dict)
+    typed_environment = create_typed_environment(pipeline, environment)
+    with yield_context(pipeline, typed_environment, execution_metadata) as context:
 
-    for step_key, input_dict in inputs_to_marshal.items():
-        for input_name, file_path in input_dict.items():
-            step = execution_plan.get_step_by_key(step_key)
-            step_input = step.step_input_dict[input_name]
-            input_type = step_input.runtime_type
+        execution_plan = create_execution_plan_core(
+            ExecutionPlanInfo(context, pipeline, typed_environment),
+            execution_metadata=execution_metadata,
+        )
 
-            check.invariant(input_type.marshalling_strategy)
+        inputs = _unmarshal_inputs(context, inputs_to_marshal, execution_plan)
 
-            input_value = input_type.marshalling_strategy.unmarshal_value(file_path)
-            inputs[step_key][input_name] = input_value
+        results = _do_execute_plan(
+            context,
+            pipeline,
+            execution_plan,
+            typed_environment,
+            ExecutionPlanSubsetInfo(included_steps=step_keys, inputs=inputs),
+        )
 
-    results = execute_plan(
-        pipeline,
-        execution_plan,
-        environment=environment,
-        subset_info=ExecutionPlanSubsetInfo(included_steps=step_keys, inputs=inputs),
-        execution_metadata=execution_metadata,
-    )
+        _marshal_outputs(context, results, outputs_to_marshal)
 
+        return results
+
+
+# <<<<<<< HEAD
+#     results = execute_plan(
+#         pipeline,
+#         execution_plan,
+#         environment=environment,
+#         subset_info=ExecutionPlanSubsetInfo(included_steps=step_keys, inputs=inputs),
+#         execution_metadata=execution_metadata,
+#     )
+# =======
+# >>>>>>> Consolidated commit
+
+
+def _marshal_outputs(context, results, outputs_to_marshal):
     for result in results:
         if not (result.success and result.step.key in outputs_to_marshal):
             continue
@@ -575,9 +604,26 @@ def execute_externalized_plan(
 
             path = output['path']
             output_type = result.step.step_output_dict[result.success_data.output_name].runtime_type
-            output_type.marshalling_strategy.marshal_value(result.success_data.value, path)
+            context.marshalling_policy.marshal_value(
+                output_type.serialization_strategy, path, result.success_data.value
+            )
 
-    return results
+
+def _unmarshal_inputs(context, inputs_to_marshal, execution_plan):
+    inputs = defaultdict(dict)
+    for step_key, input_dict in inputs_to_marshal.items():
+        for input_name, file_path in input_dict.items():
+            step = execution_plan.get_step_by_key(step_key)
+            step_input = step.step_input_dict[input_name]
+            input_type = step_input.runtime_type
+
+            check.invariant(input_type.serialization_strategy)
+
+            input_value = context.marshalling_policy.unmarshal_value(
+                input_type.serialization_strategy, file_path
+            )
+            inputs[step_key][input_name] = input_value
+    return inputs
 
 
 def execute_plan(
@@ -592,19 +638,27 @@ def execute_plan(
 
     typed_environment = create_typed_environment(pipeline, environment)
     with yield_context(pipeline, typed_environment, execution_metadata) as context:
-        plan_to_execute = (
-            create_subplan(
-                ExecutionPlanInfo(
-                    context=context, pipeline=pipeline, environment=typed_environment
-                ),
-                StepBuilderState(pipeline_name=pipeline.name),
-                execution_plan,
-                subset_info,
-            )
-            if subset_info
-            else execution_plan
+        return _do_execute_plan(context, pipeline, execution_plan, typed_environment, subset_info)
+
+
+def _do_execute_plan(context, pipeline, execution_plan, typed_environment, subset_info):
+    check.inst_param(context, 'context', RuntimeExecutionContext)
+    check.inst_param(pipeline, 'pipeline', PipelineDefinition)
+    check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
+    check.inst_param(typed_environment, 'typed_environment', EnvironmentConfig)
+    check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
+
+    plan_to_execute = (
+        create_subplan(
+            ExecutionPlanInfo(context=context, pipeline=pipeline, environment=typed_environment),
+            StepBuilderState(pipeline.name),
+            execution_plan,
+            subset_info,
         )
-        return list(execute_plan_core(context, plan_to_execute))
+        if subset_info
+        else execution_plan
+    )
+    return list(execute_plan_core(context, plan_to_execute))
 
 
 def execute_pipeline(

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -10,7 +10,7 @@ from dagster.utils import merge_dicts
 from dagster.utils.logging import CompositeLogger, INFO, define_colored_console_logger
 
 from .events import ExecutionEvents
-from .types.marshal import MarshallingPolicy
+from .types.marshal import PersistenceStrategy
 
 
 def _kv_message(all_items):
@@ -70,7 +70,7 @@ class RuntimeExecutionContext:
         event_callback=None,
         environment_config=None,
         tags=None,
-        marshalling_policy=None,
+        persistence_policy=None,
     ):
 
         if loggers is None:
@@ -85,8 +85,8 @@ class RuntimeExecutionContext:
         # For re-construction purposes later on
         self._event_callback = check.opt_callable_param(event_callback, 'event_callback')
         self._environment_config = environment_config
-        self.marshalling_policy = check.opt_inst_param(
-            marshalling_policy, 'marshalling_policy', MarshallingPolicy
+        self.persistence_policy = check.opt_inst_param(
+            persistence_policy, 'persistence_policy', PersistenceStrategy
         )
 
     def for_step(self, step):
@@ -97,7 +97,7 @@ class RuntimeExecutionContext:
             tags=merge_dicts(step.tags, self._tags),
             environment_config=self.environment_config,
             event_callback=self.event_callback,
-            marshalling_policy=self.marshalling_policy,
+            persistence_policy=self.persistence_policy,
         )
 
     def _log(self, method, orig_message, message_props):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -10,6 +10,7 @@ from dagster.utils import merge_dicts
 from dagster.utils.logging import CompositeLogger, INFO, define_colored_console_logger
 
 from .events import ExecutionEvents
+from .types.marshal import MarshallingPolicy
 
 
 def _kv_message(all_items):
@@ -69,6 +70,7 @@ class RuntimeExecutionContext:
         event_callback=None,
         environment_config=None,
         tags=None,
+        marshalling_policy=None,
     ):
 
         if loggers is None:
@@ -83,6 +85,9 @@ class RuntimeExecutionContext:
         # For re-construction purposes later on
         self._event_callback = check.opt_callable_param(event_callback, 'event_callback')
         self._environment_config = environment_config
+        self.marshalling_policy = check.opt_inst_param(
+            marshalling_policy, 'marshalling_policy', MarshallingPolicy
+        )
 
     def for_step(self, step):
         return RuntimeExecutionContext(
@@ -92,6 +97,7 @@ class RuntimeExecutionContext:
             tags=merge_dicts(step.tags, self._tags),
             environment_config=self.environment_config,
             event_callback=self.event_callback,
+            marshalling_policy=self.marshalling_policy,
         )
 
     def _log(self, method, orig_message, message_props):
@@ -207,9 +213,6 @@ class RuntimeExecutionContext:
         return self._environment_config
 
 
-# class ReentrantInfo(namedtuple('_ReentrantInfo', 'run_id context_stack event_callback loggers')):
-#     def __new__(cls, run_id=None, context_stack=None, event_callback=None, loggers=None):
-#         return super(ReentrantInfo, cls).__new__(
 class ExecutionMetadata(namedtuple('_ExecutionMetadata', 'run_id tags event_callback loggers')):
     def __new__(cls, run_id=None, tags=None, event_callback=None, loggers=None):
         return super(ExecutionMetadata, cls).__new__(

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -63,7 +63,7 @@ def create_joining_subplan(state, solid, join_step_key, parallel_steps, parallel
 
     Currently the join step just does a passthrough with no computation. It remains
     to be seen if there should be any work or verification done in this step, especially
-    in multi-process environments that require marshalling between steps.
+    in multi-process environments that require persistence between steps.
     '''
     check.inst_param(state, 'state', StepBuilderState)
     check.inst_param(solid, 'solid', Solid)

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -5,21 +5,21 @@ from dagster import check
 DEFAULT_CONTEXT_NAME = 'default'
 
 
-def _default_marshalling_config():
+def _default_persistence_config():
     return {'file': {}}
 
 
 # lifted from https://bit.ly/2HcQAuv
-class ContextConfig(namedtuple('_ContextConfig', 'name config resources marshalling')):
-    def __new__(cls, name=None, config=None, resources=None, marshalling=None):
+class ContextConfig(namedtuple('_ContextConfig', 'name config resources persistence')):
+    def __new__(cls, name=None, config=None, resources=None, persistence=None):
         return super(ContextConfig, cls).__new__(
             cls,
             check.opt_str_param(name, 'name', DEFAULT_CONTEXT_NAME),
             config,
             check.opt_dict_param(resources, 'resources', key_type=str),
-            _default_marshalling_config()
-            if marshalling is None
-            else check.dict_param(marshalling, 'marshalling', key_type=str),
+            _default_persistence_config()
+            if persistence is None
+            else check.dict_param(persistence, 'persistence', key_type=str),
         )
 
 

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -5,14 +5,21 @@ from dagster import check
 DEFAULT_CONTEXT_NAME = 'default'
 
 
+def _default_marshalling_config():
+    return {'file': {}}
+
+
 # lifted from https://bit.ly/2HcQAuv
-class ContextConfig(namedtuple('_ContextConfig', 'name config resources')):
-    def __new__(cls, name=None, config=None, resources=None):
+class ContextConfig(namedtuple('_ContextConfig', 'name config resources marshalling')):
+    def __new__(cls, name=None, config=None, resources=None, marshalling=None):
         return super(ContextConfig, cls).__new__(
             cls,
             check.opt_str_param(name, 'name', DEFAULT_CONTEXT_NAME),
             config,
             check.opt_dict_param(resources, 'resources', key_type=str),
+            _default_marshalling_config()
+            if marshalling is None
+            else check.dict_param(marshalling, 'marshalling', key_type=str),
         )
 
 

--- a/python_modules/dagster/dagster/core/types/decorator.py
+++ b/python_modules/dagster/dagster/core/types/decorator.py
@@ -1,6 +1,6 @@
 from dagster import check
 from .config_schema import InputSchema, OutputSchema
-from .marshal import MarshallingStrategy, PickleMarshallingStrategy
+from .marshal import SerializationStrategy, PickleSerializationStrategy
 from .runtime import PythonObjectType, RuntimeType
 
 
@@ -19,7 +19,7 @@ def _decorate_as_dagster_type(
     description,
     input_schema=None,
     output_schema=None,
-    marshalling_strategy=None,
+    serialization_strategy=None,
 ):
     _ObjectType = _create_object_type_class(
         key=key,
@@ -28,7 +28,7 @@ def _decorate_as_dagster_type(
         python_type=bare_cls,
         input_schema=input_schema,
         output_schema=output_schema,
-        marshalling_strategy=marshalling_strategy,
+        serialization_strategy=serialization_strategy,
     )
 
     type_inst = _ObjectType.inst()
@@ -81,17 +81,17 @@ def as_dagster_type(
     description=None,
     input_schema=None,
     output_schema=None,
-    marshalling_strategy=None,
+    serialization_strategy=None,
 ):
     check.type_param(existing_type, 'existing_type')
     check.opt_str_param(name, 'name')
     check.opt_str_param(description, 'description')
     check.opt_inst_param(input_schema, 'input_schema', InputSchema)
     check.opt_inst_param(output_schema, 'output_schema', OutputSchema)
-    check.opt_inst_param(marshalling_strategy, 'marshalling_strategy', MarshallingStrategy)
+    check.opt_inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
 
-    if marshalling_strategy is None:
-        marshalling_strategy = PickleMarshallingStrategy()
+    if serialization_strategy is None:
+        serialization_strategy = PickleSerializationStrategy()
 
     name = existing_type.__name__ if name is None else name
 
@@ -102,5 +102,5 @@ def as_dagster_type(
         description=description,
         input_schema=input_schema,
         output_schema=output_schema,
-        marshalling_strategy=marshalling_strategy,
+        serialization_strategy=serialization_strategy,
     )

--- a/python_modules/dagster/dagster/core/types/marshal.py
+++ b/python_modules/dagster/dagster/core/types/marshal.py
@@ -32,7 +32,7 @@ class PersistenceStrategy:
         pass
 
     @abstractmethod
-    def read_write(self, serialization_strategy, key):
+    def read_value(self, serialization_strategy, key):
         pass
 
 
@@ -43,7 +43,7 @@ class FilePersistencePolicy(PersistenceStrategy):
 
         return serialize_to_file(serialization_strategy, value, key)
 
-    def read_write(self, serialization_strategy, key):
+    def read_value(self, serialization_strategy, key):
         check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
         check.str_param(key, 'key')
         return deserialize_from_file(serialization_strategy, key)

--- a/python_modules/dagster/dagster/core/types/marshal.py
+++ b/python_modules/dagster/dagster/core/types/marshal.py
@@ -28,22 +28,22 @@ class PickleSerializationStrategy(SerializationStrategy):
 @six.add_metaclass(ABCMeta)
 class PersistenceStrategy:
     @abstractmethod
-    def marshal_value(self, serialization_strategy, key, value):
+    def write_value(self, serialization_strategy, key, value):
         pass
 
     @abstractmethod
-    def unmarshal_value(self, serialization_strategy, key):
+    def read_write(self, serialization_strategy, key):
         pass
 
 
 class FilePersistencePolicy(PersistenceStrategy):
-    def marshal_value(self, serialization_strategy, key, value):
+    def write_value(self, serialization_strategy, key, value):
         check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
         check.str_param(key, 'key')
 
         return serialize_to_file(serialization_strategy, value, key)
 
-    def unmarshal_value(self, serialization_strategy, key):
+    def read_write(self, serialization_strategy, key):
         check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
         check.str_param(key, 'key')
         return deserialize_from_file(serialization_strategy, key)

--- a/python_modules/dagster/dagster/core/types/marshal.py
+++ b/python_modules/dagster/dagster/core/types/marshal.py
@@ -3,23 +3,63 @@ import pickle
 
 import six
 
+from dagster import check
+
 
 @six.add_metaclass(ABCMeta)
-class MarshallingStrategy:
+class SerializationStrategy:
     @abstractmethod
-    def marshal_value(self, value, to_file):
+    def serialize_value(self, value, write_file_obj):
         pass
 
     @abstractmethod
-    def unmarshal_value(self, from_file):
+    def deserialize_value(self, read_file_obj):
         pass
 
 
-class PickleMarshallingStrategy(MarshallingStrategy):
-    def marshal_value(self, value, to_file):
-        with open(to_file, 'wb') as ff:
-            pickle.dump(value, ff)
+class PickleSerializationStrategy(SerializationStrategy):
+    def serialize_value(self, value, write_file_obj):
+        pickle.dump(value, write_file_obj)
 
-    def unmarshal_value(self, from_file):
-        with open(from_file, 'rb') as ff:
-            return pickle.load(ff)
+    def deserialize_value(self, read_file_obj):
+        return pickle.load(read_file_obj)
+
+
+@six.add_metaclass(ABCMeta)
+class MarshallingPolicy:
+    @abstractmethod
+    def marshal_value(self, serialization_strategy, key, value):
+        pass
+
+    @abstractmethod
+    def unmarshal_value(self, serialization_strategy, key):
+        pass
+
+
+class FileMarshallingPolicy(MarshallingPolicy):
+    def marshal_value(self, serialization_strategy, key, value):
+        check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
+        check.str_param(key, 'key')
+
+        return serialize_to_file(serialization_strategy, value, key)
+
+    def unmarshal_value(self, serialization_strategy, key):
+        check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
+        check.str_param(key, 'key')
+        return deserialize_from_file(serialization_strategy, key)
+
+
+def serialize_to_file(serialization_strategy, value, write_path):
+    check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
+    check.str_param(write_path, 'write_path')
+
+    with open(write_path, 'wb') as write_obj:
+        return serialization_strategy.serialize_value(value, write_obj)
+
+
+def deserialize_from_file(serialization_strategy, read_path):
+    check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
+    check.str_param(read_path, 'read_path')
+
+    with open(read_path, 'rb') as read_obj:
+        return serialization_strategy.deserialize_value(read_obj)

--- a/python_modules/dagster/dagster/core/types/marshal.py
+++ b/python_modules/dagster/dagster/core/types/marshal.py
@@ -26,7 +26,7 @@ class PickleSerializationStrategy(SerializationStrategy):
 
 
 @six.add_metaclass(ABCMeta)
-class MarshallingPolicy:
+class PersistenceStrategy:
     @abstractmethod
     def marshal_value(self, serialization_strategy, key, value):
         pass
@@ -36,7 +36,7 @@ class MarshallingPolicy:
         pass
 
 
-class FileMarshallingPolicy(MarshallingPolicy):
+class FilePersistencePolicy(PersistenceStrategy):
     def marshal_value(self, serialization_strategy, key, value):
         check.inst_param(serialization_strategy, 'serialization_strategy', SerializationStrategy)
         check.str_param(key, 'key')

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -13,7 +13,7 @@ from .config import Nullable as ConfigNullable
 
 from .config_schema import InputSchema, OutputSchema
 
-from .marshal import MarshallingStrategy, PickleMarshallingStrategy
+from .marshal import SerializationStrategy, PickleSerializationStrategy
 from .dagster_type import check_dagster_type_param
 from .wrapping import WrappingListType, WrappingNullableType
 
@@ -34,7 +34,7 @@ class RuntimeType(object):
         description=None,
         input_schema=None,
         output_schema=None,
-        marshalling_strategy=None,
+        serialization_strategy=None,
     ):
 
         type_obj = type(self)
@@ -51,11 +51,11 @@ class RuntimeType(object):
         self.description = check.opt_str_param(description, 'description')
         self.input_schema = check.opt_inst_param(input_schema, 'input_schema', InputSchema)
         self.output_schema = check.opt_inst_param(output_schema, 'output_schema', OutputSchema)
-        self.marshalling_strategy = check.opt_inst_param(
-            marshalling_strategy,
-            'marshalling_strategy',
-            MarshallingStrategy,
-            PickleMarshallingStrategy(),
+        self.serialization_strategy = check.opt_inst_param(
+            serialization_strategy,
+            'serialization_strategy',
+            SerializationStrategy,
+            PickleSerializationStrategy(),
         )
 
     __cache = {}

--- a/python_modules/dagster/dagster_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/check_tests/test_check.py
@@ -561,6 +561,29 @@ def test_opt_tuple_param():
         assert check.tuple_param('kdjfkd', 'something')
 
 
+def test_opt_type_param():
+    class Foo(object):
+        pass
+
+    assert check.opt_type_param(int, 'foo')
+    assert check.opt_type_param(Foo, 'foo')
+
+    assert check.opt_type_param(None, 'foo') is None
+    assert check.opt_type_param(None, 'foo', Foo) is Foo
+
+    with pytest.raises(CheckError):
+        check.opt_type_param(check, 'foo')
+
+    with pytest.raises(CheckError):
+        check.opt_type_param(234, 'foo')
+
+    with pytest.raises(CheckError):
+        check.opt_type_param('bar', 'foo')
+
+    with pytest.raises(CheckError):
+        check.opt_type_param(Foo(), 'foo')
+
+
 def test_type_param():
     class Bar(object):
         pass

--- a/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
@@ -54,14 +54,18 @@ def test_basic_solids_config():
 
     default_context_config_type = context_config_type.fields['default'].config_type
 
-    assert set(default_context_config_type.fields.keys()) == set(['config', 'resources'])
+    assert set(default_context_config_type.fields.keys()) == set(
+        ['config', 'resources', 'marshalling']
+    )
 
     default_context_user_config_type = default_context_config_type.fields['config'].config_type
 
     assert set(default_context_user_config_type.fields.keys()) == set(['log_level'])
 
     assert scaffold_pipeline_config(pipeline_def, skip_optional=False) == {
-        'context': {'default': {'config': {'log_level': ''}, 'resources': {}}},
+        'context': {
+            'default': {'config': {'log_level': ''}, 'marshalling': {'file': {}}, 'resources': {}}
+        },
         'solids': {'required_field_solid': {'config': {'required_int': 0}}},
         'expectations': {'evaluate': True},
         'execution': {},
@@ -88,8 +92,16 @@ def test_two_contexts():
 
     assert scaffold_pipeline_config(pipeline_def, skip_optional=False) == {
         'context': {
-            'context_one': {'config': {'context_one_field': ''}, 'resources': {}},
-            'context_two': {'config': {'context_two_field': 0}, 'resources': {}},
+            'context_one': {
+                'config': {'context_one_field': ''},
+                'marshalling': {'file': {}},
+                'resources': {},
+            },
+            'context_two': {
+                'config': {'context_two_field': 0},
+                'marshalling': {'file': {}},
+                'resources': {},
+            },
         },
         'solids': {},
         'expectations': {'evaluate': True},

--- a/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
@@ -55,7 +55,7 @@ def test_basic_solids_config():
     default_context_config_type = context_config_type.fields['default'].config_type
 
     assert set(default_context_config_type.fields.keys()) == set(
-        ['config', 'resources', 'marshalling']
+        ['config', 'resources', 'persistence']
     )
 
     default_context_user_config_type = default_context_config_type.fields['config'].config_type
@@ -64,7 +64,7 @@ def test_basic_solids_config():
 
     assert scaffold_pipeline_config(pipeline_def, skip_optional=False) == {
         'context': {
-            'default': {'config': {'log_level': ''}, 'marshalling': {'file': {}}, 'resources': {}}
+            'default': {'config': {'log_level': ''}, 'persistence': {'file': {}}, 'resources': {}}
         },
         'solids': {'required_field_solid': {'config': {'required_int': 0}}},
         'expectations': {'evaluate': True},
@@ -94,12 +94,12 @@ def test_two_contexts():
         'context': {
             'context_one': {
                 'config': {'context_one_field': ''},
-                'marshalling': {'file': {}},
+                'persistence': {'file': {}},
                 'resources': {},
             },
             'context_two': {
                 'config': {'context_two_field': 0},
-                'marshalling': {'file': {}},
+                'persistence': {'file': {}},
                 'resources': {},
             },
         },

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -179,7 +179,7 @@ def test_provided_default_config():
     assert some_context_field.default_value == {
         'config': {'with_default_int': 23434},
         'resources': {},
-        'marshalling': {'file': {}},
+        'persistence': {'file': {}},
     }
 
     value = construct_environment_config(
@@ -423,7 +423,7 @@ def test_whole_environment():
     )
 
     assert isinstance(env, EnvironmentConfig)
-    assert env.context == ContextConfig('test', 1, marshalling={'file': {}})
+    assert env.context == ContextConfig('test', 1, persistence={'file': {}})
     assert env.solids == {'int_config_solid': SolidConfig(123)}
     assert env.expectations == ExpectationsConfig(evaluate=True)
 

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -179,6 +179,7 @@ def test_provided_default_config():
     assert some_context_field.default_value == {
         'config': {'with_default_int': 23434},
         'resources': {},
+        'marshalling': {'file': {}},
     }
 
     value = construct_environment_config(
@@ -422,7 +423,7 @@ def test_whole_environment():
     )
 
     assert isinstance(env, EnvironmentConfig)
-    assert env.context == ContextConfig('test', 1)
+    assert env.context == ContextConfig('test', 1, marshalling={'file': {}})
     assert env.solids == {'int_config_solid': SolidConfig(123)}
     assert env.expectations == ExpectationsConfig(evaluate=True)
 

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20475,7 +20475,7 @@ snapshots['test_build_all_docs 53'] = '''
 
 <dl class="function">
 <dt id="dagster.as_dagster_type">
-<code class="descclassname">dagster.</code><code class="descname">as_dagster_type</code><span class="sig-paren">(</span><em>existing_type</em>, <em>name=None</em>, <em>description=None</em>, <em>input_schema=None</em>, <em>output_schema=None</em>, <em>marshalling_strategy=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.as_dagster_type" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">as_dagster_type</code><span class="sig-paren">(</span><em>existing_type</em>, <em>name=None</em>, <em>description=None</em>, <em>input_schema=None</em>, <em>output_schema=None</em>, <em>serialization_strategy=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.as_dagster_type" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
@@ -20550,7 +20550,7 @@ snapshots['test_build_all_docs 53'] = '''
 
 <dl class="class">
 <dt id="dagster.RuntimeType">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">RuntimeType</code><span class="sig-paren">(</span><em>key</em>, <em>name</em>, <em>description=None</em>, <em>input_schema=None</em>, <em>output_schema=None</em>, <em>marshalling_strategy=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.RuntimeType" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">RuntimeType</code><span class="sig-paren">(</span><em>key</em>, <em>name</em>, <em>description=None</em>, <em>input_schema=None</em>, <em>output_schema=None</em>, <em>serialization_strategy=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.RuntimeType" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -212,7 +212,7 @@ def unmarshal_value(runtime_type, value):
         return deserialize_from_file(runtime_type.serialization_strategy, value)
     else:
         check.failed(
-            'Unsupported type {name}: no marshalling strategy defined'.format(
+            'Unsupported type {name}: no persistence strategy defined'.format(
                 name=runtime_type.name
             )
         )

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -199,10 +199,10 @@ def populate_context(dm_context_data):
 def load_parameter(input_name, input_value):
     solid_def = MANAGER_FOR_NOTEBOOK_INSTANCE.solid_def
     input_def = solid_def.input_def_named(input_name)
-    return read_write(input_def.runtime_type, input_value)
+    return read_value(input_def.runtime_type, input_value)
 
 
-def read_write(runtime_type, value):
+def read_value(runtime_type, value):
     check.inst_param(runtime_type, 'runtime_type', RuntimeType)
     if runtime_type.is_scalar:
         return value
@@ -408,7 +408,7 @@ def _dm_solid_transform(name, notebook_path):
             for output_def in info.solid_def.output_defs:
                 if output_def.name in output_nb.data:
 
-                    value = read_write(output_def.runtime_type, output_nb.data[output_def.name])
+                    value = read_value(output_def.runtime_type, output_nb.data[output_def.name])
 
                     yield Result(value, output_def.name)
 

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -30,6 +30,7 @@ from dagster import (
 )
 
 from dagster.core.definitions import TransformExecutionInfo
+from dagster.core.types.marshal import serialize_to_file, deserialize_from_file
 from dagster.core.types.runtime import RuntimeType
 
 from dagster.core.definitions.dependency import Solid
@@ -167,8 +168,8 @@ def marshal_value(runtime_type, value, target_file):
         return value
     elif runtime_type.is_any and is_json_serializable(value):
         return value
-    elif runtime_type.marshalling_strategy:
-        runtime_type.marshalling_strategy.marshal_value(value, target_file)
+    elif runtime_type.serialization_strategy:
+        serialize_to_file(runtime_type.serialization_strategy, value, target_file)
         return target_file
     else:
         check.failed('Unsupported type {name}'.format(name=runtime_type.name))
@@ -207,8 +208,8 @@ def unmarshal_value(runtime_type, value):
         return value
     elif runtime_type.is_any and is_json_serializable(value):
         return value
-    elif runtime_type.marshalling_strategy:
-        return runtime_type.marshalling_strategy.unmarshal_value(value)
+    elif runtime_type.serialization_strategy:
+        return deserialize_from_file(runtime_type.serialization_strategy, value)
     else:
         check.failed(
             'Unsupported type {name}: no marshalling strategy defined'.format(


### PR DESCRIPTION
This separates the notion of marshalling policy and serialization strategy. (Very open to feedback on names).

Serialization strategy are things like "pickling" or "json" or "parquet". File formats essentially.

Marshalling policy (could be called persistence) is more around concerns like "local file system" or "s3 bucket".

The idea is that types determine their own serialization strategy based on their characteristics, where as marshalling policy is more about where to stash values on a per-pipeline run basis. 