### PR TITLE
Execute pipelines with no config by passing `{}`, not `null` as config

### DIFF
--- a/js_modules/dagit/src/execution/PipelineExecution.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecution.tsx
@@ -184,7 +184,9 @@ export default class PipelineExecution extends React.Component<
               if (isExecuting) return;
               let config = {};
               try {
-                config = yaml.parse(currentSession.config);
+                // Note: parsing `` returns null rather than an empty object,
+                // which is preferable for representing empty config.
+                config = yaml.parse(currentSession.config) || {};
               } catch (err) {
                 alert(YAML_SYNTAX_INVALID);
                 return;


### PR DESCRIPTION
This is a very small patch - turns out the yaml parser returns `null` when an empty string (or just the config editor comment) is provided, which was causing a "required field PipelineConfig! not provided". For consistency, we'll default it to `{}`