### PR TITLE
Disable the execute button when dagit is offline, make it prettier 💄

### DIFF
--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -99,6 +99,15 @@ Array [
     <div
       className="bp3-navbar-group bp3-align-right"
     >
+      <div
+        className="sc-htpNat eBXEsV"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
       <span
         className="sc-bxivhb cvIdVt"
       />
@@ -659,6 +668,15 @@ Array [
     <div
       className="bp3-navbar-group bp3-align-right"
     >
+      <div
+        className="sc-htpNat eBXEsV"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
       <span
         className="sc-bxivhb cvIdVt"
       />
@@ -778,6 +796,15 @@ Array [
     <div
       className="bp3-navbar-group bp3-align-right"
     >
+      <div
+        className="sc-htpNat eBXEsV"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
       <span
         className="sc-bxivhb cvIdVt"
       />
@@ -1439,6 +1466,15 @@ Array [
     <div
       className="bp3-navbar-group bp3-align-right"
     >
+      <div
+        className="sc-htpNat eBXEsV"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
       <span
         className="sc-bxivhb cvIdVt"
       />
@@ -2100,6 +2136,15 @@ Array [
     <div
       className="bp3-navbar-group bp3-align-right"
     >
+      <div
+        className="sc-htpNat eBXEsV"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
       <span
         className="sc-bxivhb cvIdVt"
       />
@@ -2818,6 +2863,15 @@ Array [
     <div
       className="bp3-navbar-group bp3-align-right"
     >
+      <div
+        className="sc-htpNat eBXEsV"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
       <span
         className="sc-bxivhb cvIdVt"
       />

--- a/js_modules/dagit/src/execution/ExecutionStartButton.tsx
+++ b/js_modules/dagit/src/execution/ExecutionStartButton.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import styled from "styled-components";
+import { Icon, Intent, Spinner, Colors } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { WebsocketStatusContext } from "../WebsocketStatus";
+
+interface IExecutionStartButtonProps {
+  isExecuting: boolean;
+  onClick: () => void;
+}
+
+export default function ExecutionStartButton(
+  props: IExecutionStartButtonProps
+) {
+  return (
+    <WebsocketStatusContext.Consumer>
+      {websocketStatus => {
+        if (props.isExecuting) {
+          return (
+            <IconWrapper
+              role="button"
+              title={"Pipeline execution is in progress..."}
+            >
+              <Spinner intent={Intent.NONE} size={39} />
+            </IconWrapper>
+          );
+        }
+
+        if (websocketStatus !== WebSocket.OPEN) {
+          return (
+            <IconWrapper
+              role="button"
+              disabled={true}
+              title={"Dagit is disconnected"}
+            >
+              <Icon icon={IconNames.OFFLINE} iconSize={40} />
+            </IconWrapper>
+          );
+        }
+
+        return (
+          <IconWrapper
+            role="button"
+            title={"Start pipeline execution"}
+            onClick={props.onClick}
+          >
+            <Icon icon={IconNames.PLAY} iconSize={40} />
+          </IconWrapper>
+        );
+      }}
+    </WebsocketStatusContext.Consumer>
+  );
+}
+
+const IconWrapper = styled.div<{ disabled?: boolean }>`
+  flex: 0 1 0;
+  width: 60px;
+  height: 60px;
+  border-radius: 30px;
+  background: ${({ disabled }) =>
+    disabled
+      ? "linear-gradient(to bottom, rgb(145, 145, 145) 30%, rgb(130, 130, 130) 100%);"
+      : "linear-gradient(to bottom, rgb(36, 145, 235) 30%, rgb(27, 112, 187) 100%);"}
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  border-top: 1px solid rgba(255,255,255,0.25);
+  border-bottom: 1px solid rgba(0,0,0,0.25);
+  transition: background 200ms linear;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  color: ${({ disabled }) => (disabled ? "rgba(255,255,255,0.5)" : "white")};;
+  cursor: ${({ disabled }) => (disabled ? "normal" : "pointer")};
+  z-index: 2;
+
+  &:hover {
+    background: ${({ disabled }) =>
+      disabled
+        ? "linear-gradient(to bottom, rgb(145, 145, 145) 30%, rgb(130, 130, 130) 100%);"
+        : "linear-gradient(to bottom, rgb(27, 112, 187) 30%, rgb(21, 89, 150) 100%);"}
+  }
+
+  &:active {
+    background-color: ${Colors.GRAY3};
+  }
+
+  path.bp3-spinner-head {
+    stroke: white;
+  }
+`;

--- a/js_modules/dagit/src/execution/ExecutionStartButton.tsx
+++ b/js_modules/dagit/src/execution/ExecutionStartButton.tsx
@@ -5,7 +5,7 @@ import { IconNames } from "@blueprintjs/icons";
 import { WebsocketStatusContext } from "../WebsocketStatus";
 
 interface IExecutionStartButtonProps {
-  isExecuting: boolean;
+  executing: boolean;
   onClick: () => void;
 }
 
@@ -15,7 +15,7 @@ export default function ExecutionStartButton(
   return (
     <WebsocketStatusContext.Consumer>
       {websocketStatus => {
-        if (props.isExecuting) {
+        if (props.executing) {
           return (
             <IconWrapper
               role="button"

--- a/js_modules/dagit/src/execution/PipelineExecution.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecution.tsx
@@ -32,7 +32,6 @@ interface IPipelineExecutionProps {
   activeRun: PipelineExecutionPipelineRunFragment | null;
   sessions: { [name: string]: IExecutionSession };
   currentSession: IExecutionSession;
-  isExecuting: boolean;
   onSelectSession: (session: string) => void;
   onSaveSession: (session: string, changes: IExecutionSessionChanges) => void;
   onCreateSession: () => void;
@@ -115,16 +114,23 @@ export default class PipelineExecution extends React.Component<
   };
 
   render() {
-    const {
-      sessions,
-      pipeline,
-      activeRun,
-      isExecuting,
-      currentSession
-    } = this.props;
+    const { sessions, pipeline, activeRun, currentSession } = this.props;
 
     if (!currentSession) {
       return <span />;
+    }
+
+    let activeRunExecuting = false;
+    if (activeRun) {
+      const start = activeRun.logs.nodes.find(
+        l => l.__typename === "PipelineProcessStartEvent"
+      );
+      const end = activeRun.logs.nodes.find(
+        l =>
+          l.__typename === "PipelineSuccessEvent" ||
+          l.__typename === "PipelineFailureEvent"
+      );
+      activeRunExecuting = start !== null && end == null;
     }
 
     return (
@@ -175,7 +181,7 @@ export default class PipelineExecution extends React.Component<
             />
           </SessionSettingsFooter>
           <ExecutionStartButton
-            isExecuting={isExecuting}
+            executing={activeRunExecuting}
             onClick={this.props.onExecute}
           />
         </Split>

--- a/js_modules/dagit/src/execution/PipelineExecution.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecution.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
 import gql from "graphql-tag";
 import styled from "styled-components";
-import * as yaml from "yaml";
-import { Icon, Colors } from "@blueprintjs/core";
-import { IconNames } from "@blueprintjs/icons";
+import { Colors } from "@blueprintjs/core";
 import { ApolloConsumer } from "react-apollo";
 
 import { PipelineRun, PipelineRunEmpty } from "./PipelineRun";
 import { ExecutionTabs, ExecutionTab } from "./ExecutionTabs";
 import { PanelDivider } from "../PanelDivider";
 import PipelineSolidSelector from "./PipelineSolidSelector";
+import ExecutionStartButton from "./ExecutionStartButton";
 import ConfigEditor from "../configeditor/ConfigEditor";
 import {
   IExecutionSession,
@@ -28,8 +27,6 @@ import { PipelineExecutionPipelineRunFragment } from "./types/PipelineExecutionP
 
 const CONFIRM_RESET_TO_SCAFFOLD = `Would you like to reset your config to a scaffold based on this subset of the pipeline?`;
 
-const YAML_SYNTAX_INVALID = `The YAML you provided couldn't be parsed. Please fix the syntax errors and try again.`;
-
 interface IPipelineExecutionProps {
   pipeline: PipelineExecutionPipelineFragment;
   activeRun: PipelineExecutionPipelineRunFragment | null;
@@ -40,7 +37,7 @@ interface IPipelineExecutionProps {
   onSaveSession: (session: string, changes: IExecutionSessionChanges) => void;
   onCreateSession: () => void;
   onRemoveSession: (session: string) => void;
-  onExecute: (config: any) => void;
+  onExecute: () => void;
 }
 
 interface IPipelineExecutionState {
@@ -177,28 +174,10 @@ export default class PipelineExecution extends React.Component<
               onChange={this.onSolidSubsetChange}
             />
           </SessionSettingsFooter>
-          <IconWrapper
-            role="button"
-            disabled={isExecuting}
-            onClick={async event => {
-              if (isExecuting) return;
-              let config = {};
-              try {
-                // Note: parsing `` returns null rather than an empty object,
-                // which is preferable for representing empty config.
-                config = yaml.parse(currentSession.config) || {};
-              } catch (err) {
-                alert(YAML_SYNTAX_INVALID);
-                return;
-              }
-              this.props.onExecute(config);
-            }}
-          >
-            <Icon
-              icon={isExecuting ? IconNames.REFRESH : IconNames.PLAY}
-              iconSize={40}
-            />
-          </IconWrapper>
+          <ExecutionStartButton
+            isExecuting={isExecuting}
+            onClick={this.props.onExecute}
+          />
         </Split>
         <PanelDivider
           axis="horizontal"
@@ -224,31 +203,6 @@ const PipelineExecutionWrapper = styled.div`
   height: 100vh;
   position: absolute;
   padding-top: 50px;
-`;
-
-const IconWrapper = styled.div<{ disabled: boolean }>`
-  flex: 0 1 0;
-  width: 60px;
-  height: 60px;
-  border-radius: 30px;
-  background-color: ${Colors.GRAY5};
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  justify-content: center;
-  align-items: center;
-  display: flex;
-  cursor: ${({ disabled }) => (disabled ? "normal" : "pointer")};
-  z-index: 2;
-
-  &:hover {
-    background-color: ${({ disabled }) =>
-      disabled ? Colors.GRAY5 : Colors.GRAY4};
-  }
-
-  &:active {
-    background-color: ${Colors.GRAY3};
-  }
 `;
 
 const SessionSettingsFooter = styled.div`

--- a/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
@@ -4,6 +4,8 @@ import { ApolloClient } from "apollo-client";
 import { DataProxy } from "apollo-cache";
 import produce from "immer";
 import { Mutation, FetchResult } from "react-apollo";
+import * as yaml from "yaml";
+
 import {
   applyChangesToSession,
   applySelectSession,
@@ -25,6 +27,8 @@ import {
 } from "./types/StartPipelineExecution";
 import { PipelineRunLogsSubscription } from "./types/PipelineRunLogsSubscription";
 import { PipelineRunLogsUpdateFragment } from "./types/PipelineRunLogsUpdateFragment";
+
+const YAML_SYNTAX_INVALID = `The YAML you provided couldn't be parsed. Please fix the syntax errors and try again.`;
 
 interface IPipelineExecutionContainerProps {
   client: ApolloClient<any>;
@@ -223,6 +227,28 @@ export default class PipelineExecutionContainer extends React.Component<
     });
   };
 
+  buildExecutionVariables = () => {
+    const { currentSession, pipeline } = this.props;
+
+    let config = {};
+    try {
+      // Note: parsing `` returns null rather than an empty object,
+      // which is preferable for representing empty config.
+      config = yaml.parse(currentSession.config) || {};
+    } catch (err) {
+      alert(YAML_SYNTAX_INVALID);
+      return;
+    }
+
+    return {
+      config,
+      pipeline: {
+        name: pipeline.name,
+        solidSubset: currentSession.solidSubset
+      }
+    };
+  };
+
   render() {
     let activeRun: PipelineExecutionContainerFragment_runs | null = null;
     if (this.props.pipeline.runs.length > 0) {
@@ -246,17 +272,10 @@ export default class PipelineExecutionContainer extends React.Component<
               onSaveSession={this.handleSaveSession}
               onCreateSession={this.handleCreateSession}
               onRemoveSession={this.handleRemoveSession}
-              onExecute={config =>
-                startPipelineExecution({
-                  variables: {
-                    config,
-                    pipeline: {
-                      name: this.props.pipeline.name,
-                      solidSubset: this.props.currentSession.solidSubset
-                    }
-                  }
-                })
-              }
+              onExecute={() => {
+                const variables = this.buildExecutionVariables();
+                if (variables) startPipelineExecution({ variables });
+              }}
             />
           );
         }}

--- a/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
@@ -264,7 +264,6 @@ export default class PipelineExecutionContainer extends React.Component<
           return (
             <PipelineExecution
               activeRun={activeRun}
-              isExecuting={loading}
               pipeline={this.props.pipeline}
               sessions={this.props.data.sessions}
               currentSession={this.props.currentSession}

--- a/js_modules/dagit/src/index.tsx
+++ b/js_modules/dagit/src/index.tsx
@@ -5,7 +5,7 @@ import ApolloClient from "apollo-client";
 import { ApolloProvider } from "react-apollo";
 import { SubscriptionClient } from "subscriptions-transport-ws";
 import { WebSocketLink } from "apollo-link-ws";
-import { WebsocketContext } from "./WebsocketStatus";
+import { WebsocketStatusProvider } from "./WebsocketStatus";
 import App from "./App";
 import ApiResultRenderer from "./ApiResultRenderer";
 import AppCache from "./AppCache";
@@ -35,11 +35,11 @@ if (process.env.REACT_APP_RENDER_API_RESULTS) {
   );
 } else {
   ReactDOM.render(
-    <WebsocketContext.Provider value={websocketClient}>
+    <WebsocketStatusProvider websocket={websocketClient}>
       <ApolloProvider client={client}>
         <App />
       </ApolloProvider>
-    </WebsocketContext.Provider>,
+    </WebsocketStatusProvider>,
     document.getElementById("root") as HTMLElement
   );
 }

--- a/js_modules/dagit/src/typeexplorer/TypeExplorerContainer.tsx
+++ b/js_modules/dagit/src/typeexplorer/TypeExplorerContainer.tsx
@@ -11,8 +11,7 @@ interface ITypeExplorerContainerProps {
 }
 
 export default class TypeExplorerContainer extends React.Component<
-  ITypeExplorerContainerProps,
-  {}
+  ITypeExplorerContainerProps
 > {
   render() {
     return (


### PR DESCRIPTION
This PR changes the WebsocktStatus React context so that it's easy for any component to subscribe to the availability of the websocket and be conditionally disabled.

The first use case for this is the Execute button, which now has a pretty gray state and is unclickable when dagit is disconnected.

I also took the opportunity to make all the button states prettier and use the Dagit theme colors:

<img width="335" alt="screen shot 2019-01-25 at 11 25 56 am" src="https://user-images.githubusercontent.com/1037212/51768144-541dd280-2094-11e9-9b9d-bbd311fa2d22.png">
<img width="266" alt="screen shot 2019-01-25 at 11 26 21 am" src="https://user-images.githubusercontent.com/1037212/51768145-541dd280-2094-11e9-94a1-9e3d5c2a1645.png">
<img width="293" alt="screen shot 2019-01-25 at 11 26 34 am" src="https://user-images.githubusercontent.com/1037212/51768146-54b66900-2094-11e9-9769-07f14dc75e62.png">
