### PR TITLE
Sort keys when dumping to JSON

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -64,7 +64,7 @@ def execute_query_from_cli(repository_container, query, variables):
         executor=Executor(),
     )
 
-    print(json.dumps(result.to_dict()))
+    print(json.dumps(result.to_dict(), sort_keys=True))
 
 
 @click.command(

--- a/python_modules/dagit/dagit/pipeline_run_storage.py
+++ b/python_modules/dagit/dagit/pipeline_run_storage.py
@@ -161,7 +161,8 @@ class LogFilePipelineRun(InMemoryPipelineRun):
                         'pipeline_solid_subset': self.selector.solid_subset,
                         'config': self.config,
                         'execution_plan': 'TODO',
-                    }
+                    },
+                    sort_keys=True
                 )
             )
 
@@ -174,7 +175,7 @@ class LogFilePipelineRun(InMemoryPipelineRun):
             # Going to do the less error-prone, simpler, but slower strategy:
             # open, append, close for every log message for now
             with open(self._log_file, 'a', encoding='utf-8') as log_file_handle:
-                log_file_handle.write(json.dumps(new_event.to_dict()))
+                log_file_handle.write(json.dumps(new_event.to_dict(), sort_keys=True))
                 log_file_handle.write('\n')
 
 

--- a/python_modules/dagit/dagit/pipeline_run_storage.py
+++ b/python_modules/dagit/dagit/pipeline_run_storage.py
@@ -162,7 +162,7 @@ class LogFilePipelineRun(InMemoryPipelineRun):
                         'config': self.config,
                         'execution_plan': 'TODO',
                     },
-                    sort_keys=True
+                    sort_keys=True,
                 )
             )
 

--- a/python_modules/dagma/dagma/engine.py
+++ b/python_modules/dagma/dagma/engine.py
@@ -132,7 +132,7 @@ def _execute_step_async(lambda_client, lambda_step, context, payload):
 def _execute_step_sync(lambda_client, lambda_step, context, payload):
     res = lambda_client.invoke(
         FunctionName=lambda_step['FunctionArn'],
-        Payload=json.dumps({'config': list(payload)}),
+        Payload=json.dumps({'config': list(payload)}, sort_keys=True),
         InvocationType='RequestResponse',
         LogType='Tail',
     )

--- a/python_modules/dagster/dagster/core/events.py
+++ b/python_modules/dagster/dagster/core/events.py
@@ -88,7 +88,7 @@ class ExecutionEvents:
             event_type=EventType.EXECUTION_PLAN_STEP_FAILURE.value,
             step_key=step_key,
             # We really need a better serialization story here
-            error_info=json.dumps(serializable_error_info_from_exc_info(exc_info)),
+            error_info=json.dumps(serializable_error_info_from_exc_info(exc_info), sort_keys=True),
         )
 
     def pipeline_name(self):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -15,7 +15,10 @@ from .types.marshal import PersistenceStrategy
 
 def _kv_message(all_items):
     return ' '.join(
-        ['{key}={value}'.format(key=key, value=json.dumps(value)) for key, value in all_items]
+        [
+            '{key}={value}'.format(key=key, value=json.dumps(value, sort_keys=True))
+            for key, value in all_items
+        ]
     )
 
 

--- a/python_modules/dagster/dagster/core/types/builtin_config_schemas.py
+++ b/python_modules/dagster/dagster/core/types/builtin_config_schemas.py
@@ -55,7 +55,7 @@ def define_builtin_scalar_output_schema(scalar_name):
     def _builtin_output_schema(file_type, file_options, runtime_value):
         if file_type == 'json':
             json_file_path = file_options['path']
-            json_value = json.dumps({'value': runtime_value})
+            json_value = json.dumps({'value': runtime_value}, sort_keys=True)
             with open(json_file_path, 'w') as ff:
                 ff.write(json_value)
         elif file_type == 'pickle':

--- a/python_modules/dagster/dagster/utils/logging.py
+++ b/python_modules/dagster/dagster/utils/logging.py
@@ -58,7 +58,7 @@ class JsonFileHandler(logging.Handler):
             log_dict.update(dagster_meta_dict)
 
             with open(self.json_path, 'a') as ff:
-                text_line = json.dumps(log_dict)
+                text_line = json.dumps(log_dict, sort_keys=True)
                 ff.write(text_line + '\n')
         # Need to catch Exception here, so disabling lint
         except Exception as e:  # pylint: disable=W0703
@@ -90,7 +90,7 @@ class JsonEventLoggerHandler(logging.Handler):
         try:
             event_record = self.construct_event_record(record)
             with open(self.json_path, 'a') as ff:
-                text_line = json.dumps(event_record.to_dict())
+                text_line = json.dumps(event_record.to_dict(), sort_keys=True)
                 ff.write(text_line + '\n')
 
         # Need to catch Exception here, so disabling lint

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -246,7 +246,7 @@ def get_papermill_parameters(transform_execution_info, inputs, output_log_path):
         'output_log_path': output_log_path,
     }
 
-    parameters = dict(dm_context=json.dumps(dm_context_dict))
+    parameters = dict(dm_context=json.dumps(dm_context_dict, sort_keys=True))
 
     input_defs = transform_execution_info.solid_def.input_defs
     input_def_dict = {inp.name: inp for inp in input_defs}


### PR DESCRIPTION
This is a hygiene measure meant to avoid subtle differences in the output of code running under different Python versions.