### PR TITLE
Schrockn/input thunk to injected steps

### DIFF
--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -571,8 +571,8 @@ def execute_externalized_plan(
             ),
         )
 
-        results = _do_execute_plan(
-            context, pipeline, execution_plan, typed_environment, throw_on_user_error
+        results = list(
+            execute_plan_core(context, execution_plan, throw_on_user_error=throw_on_user_error)
         )
 
         _marshal_outputs(context, results, outputs_to_marshal)
@@ -698,19 +698,9 @@ def execute_plan(
 
     typed_environment = create_typed_environment(pipeline, environment)
     with yield_context(pipeline, typed_environment, execution_metadata) as context:
-        return _do_execute_plan(
-            context, pipeline, execution_plan, typed_environment, throw_on_user_error
+        return list(
+            execute_plan_core(context, execution_plan, throw_on_user_error=throw_on_user_error)
         )
-
-
-def _do_execute_plan(context, pipeline, execution_plan, typed_environment, throw_on_user_error):
-    check.inst_param(context, 'context', RuntimeExecutionContext)
-    check.inst_param(pipeline, 'pipeline', PipelineDefinition)
-    check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
-    check.inst_param(typed_environment, 'typed_environment', EnvironmentConfig)
-    check.bool_param(throw_on_user_error, 'throw_on_user_error')
-
-    return list(execute_plan_core(context, execution_plan, throw_on_user_error=throw_on_user_error))
 
 
 def execute_pipeline(

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -253,23 +253,20 @@ def _create_new_steps_for_input(state, step, subset_info):
     new_steps = []
     new_step_inputs = []
     for step_input in step.step_inputs:
-        if subset_info.has_injected_step(step.key, step_input.name):
-            subset_info.step_factory_fns[step.key][step_input.name](state, step, step_input)
+        check.invariant(subset_info.has_injected_step(step.key, step_input.name))
 
-            step_output_handle = check.inst(
-                subset_info.step_factory_fns[step.key][step_input.name](state, step, step_input),
-                StepOutputHandle,
-                'Step factory function must create StepOutputHandle',
-            )
+        subset_info.step_factory_fns[step.key][step_input.name](state, step, step_input)
 
-            new_steps.append(step_output_handle.step)
-            new_step_inputs.append(
-                StepInput(step_input.name, step_input.runtime_type, step_output_handle)
-            )
+        step_output_handle = check.inst(
+            subset_info.step_factory_fns[step.key][step_input.name](state, step, step_input),
+            StepOutputHandle,
+            'Step factory function must create StepOutputHandle',
+        )
 
-        else:
-            # TODO: I don't think you should able to get here
-            new_step_inputs.append(step_input)
+        new_steps.append(step_output_handle.step)
+        new_step_inputs.append(
+            StepInput(step_input.name, step_input.runtime_type, step_output_handle)
+        )
 
     new_steps.append(step.with_new_inputs(new_step_inputs))
     return new_steps

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -79,13 +79,7 @@ def create_execution_plan_core(execution_info, execution_metadata, subset_info=N
     execution_plan = create_execution_plan_from_steps(state.steps)
 
     if subset_info:
-        return _create_subplan(
-            execution_info,
-            # ExecutionPlanInfo(context=context, pipeline=pipeline, environment=typed_environment),
-            StepBuilderState(execution_info.pipeline.name),
-            execution_plan,
-            subset_info,
-        )
+        return _create_subplan(execution_info, state, execution_plan, subset_info)
     else:
         return execution_plan
 

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -255,19 +255,6 @@ class ExecutionPlanInfo(namedtuple('_ExecutionPlanInfo', 'context pipeline envir
         )
 
 
-class ExecutionPlanSubsetInfo(namedtuple('_ExecutionPlanSubsetInfo', 'subset inputs')):
-    '''
-    inputs is a two dimensional dictionary that maps step_key => input_name => input_value
-    '''
-
-    def __new__(cls, included_steps, inputs=None):
-        return super(ExecutionPlanSubsetInfo, cls).__new__(
-            cls,
-            set(check.list_param(included_steps, 'included_steps', of_type=str)),
-            check.opt_dict_param(inputs, 'inputs'),
-        )
-
-
 class StepOutputMap(dict):
     def __getitem__(self, key):
         check.inst_param(key, 'key', SolidOutputHandle)

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -1,0 +1,93 @@
+from collections import defaultdict, namedtuple
+from dagster import check
+from dagster.core.definitions.utils import check_opt_two_dim_dict
+from .objects import StepBuilderState, ExecutionStep, StepInput
+from .utility import create_value_thunk_step
+
+
+class ExecutionPlanSubsetInfo(namedtuple('_ExecutionPlanSubsetInfo', 'subset step_factory_fns')):
+    '''
+    ExecutionPlanSubsetInfo is created in order to build subset of an execution plan. If
+    the caller has removed execution steps from the plan that provide outputs to downstream
+    steps, they must somehow provide new values. In order to make this facility generic,
+    the interface that this object provides to the guts to the execution engine is a set
+    of functions that create ExecutionSteps, indexed by step key and input name. When
+    the execution creation plan process needs an input and it is not in the subset
+    provided, it instead calls this function to create the execution step.
+
+    Callers of create_execution_plan and similar should use the static method functions
+    which provide handy, easier-to-use functions that manage this callback creation
+    process.
+    '''
+
+    @staticmethod
+    def only_subset(included_step_keys):
+        ''' Creates a subset with no injected steps at all.'''
+        return ExecutionPlanSubsetInfo(included_step_keys, {})
+
+    @staticmethod
+    def with_input_values(included_step_keys, inputs):
+        '''
+        Create an execution subset with hardcoded values as inputs. This will create
+        execution steps with the key "{step_key}.input.{input_name}.value" that simply
+        emit the value
+        '''
+        check.list_param(included_step_keys, 'included_step_keys', of_type=str)
+        check_opt_two_dim_dict(inputs, 'inputs', key_type=str)
+
+        def _create_injected_value_factory_fn(input_value):
+            def _injected_value_factory_fn(state, step, step_input):
+                check.inst_param(state, 'state', StepBuilderState)
+                check.inst_param(step, 'step', ExecutionStep)
+                check.inst_param(step_input, 'step_input', StepInput)
+                return create_value_thunk_step(
+                    state=state,
+                    solid=step.solid,
+                    runtime_type=step_input.runtime_type,
+                    step_key='{step_key}.input.{input_name}.value'.format(
+                        step_key=step.key, input_name=step_input.name
+                    ),
+                    value=input_value,
+                )
+
+            return _injected_value_factory_fn
+
+        step_factory_fns = defaultdict(dict)
+        for step_key, input_dict in inputs.items():
+            for input_name, input_value in input_dict.items():
+                factory_fn = _create_injected_value_factory_fn(input_value)
+                step_factory_fns[step_key][input_name] = factory_fn
+
+        return ExecutionPlanSubsetInfo(included_step_keys, step_factory_fns)
+
+    def has_injected_step(self, step_key, input_name):
+        check.str_param(step_key, 'step_key')
+        check.str_param(input_name, 'input_name')
+        return step_key in self.step_factory_fns and input_name in self.step_factory_fns[step_key]
+
+    def __new__(cls, included_step_keys, step_factory_fns):
+        '''
+            This should not be called directly, but instead through the static methods
+            on this class.
+
+            included_step_keys: list of step keys to include in the subset
+
+            step_factory_fns: A 2D dictinoary step_key => input_name => callable
+
+            callable should have signature of
+
+            (StepBuilderState, ExecutionStep, StepInput): StepOutputHandle
+
+            Full type signature is
+            Dict[str,
+                Dict[str,
+                    Callable[StepBuilderState, ExecutionStep, StepInput]: StepOutputHandle
+                ]
+            ]
+        '''
+
+        return super(ExecutionPlanSubsetInfo, cls).__new__(
+            cls,
+            set(check.list_param(included_step_keys, 'included_step_keys', of_type=str)),
+            check_opt_two_dim_dict(step_factory_fns, 'step_factory_fns', key_type=str),
+        )

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -67,7 +67,6 @@ def test_create_subplan_source_step():
 
 
 def test_create_subplan_middle_step():
-    # TODO: replace with top-level create_plan call
     subplan = create_execution_plan(
         define_two_int_pipeline(),
         subset_info=ExecutionPlanSubsetInfo.with_input_values(


### PR DESCRIPTION
From comment on subset stuff:

```
    ExecutionPlanSubsetInfo is created in order to build subset of an execution plan. If
    the caller has removed execution steps from the plan that provide outputs to downstream
    steps, they must somehow provide new values. In order to make this facility generic,
    the interface that this object provides to the guts to the execution engine is a set
    of functions that create ExecutionSteps, indexed by step key and input name. When
    the execution creation plan process needs an input and it is not in the subset
    provided, it instead calls this function to create the execution step.

    Callers of create_execution_plan and similar should use the static method functions
    which provide handy, easier-to-use functions that manage this callback creation
    process.
```

I started with the facilities that just inject values, but I will also use this to put our marshaling and marshaling into the execution plan.