### PR TITLE
Implement Marshal and Unmarshal as execution steps

### DIFF
--- a/python_modules/dagit/dagit/schema/execution.py
+++ b/python_modules/dagit/dagit/schema/execution.py
@@ -74,6 +74,7 @@ class DauphinStepKind(dauphin.Enum):
     INPUT_THUNK = 'INPUT_THUNK'
     MATERIALIZATION_THUNK = 'MATERIALIZATION_THUNK'
     UNMARSHAL_INPUT = 'UNMARSHAL_INPUT'
+    MARSHAL_OUTPUT = 'MARSHAL_OUTPUT'
 
     @property
     def description(self):

--- a/python_modules/dagit/dagit/schema/execution.py
+++ b/python_modules/dagit/dagit/schema/execution.py
@@ -73,6 +73,7 @@ class DauphinStepKind(dauphin.Enum):
     SERIALIZE = 'SERIALIZE'
     INPUT_THUNK = 'INPUT_THUNK'
     MATERIALIZATION_THUNK = 'MATERIALIZATION_THUNK'
+    UNMARSHAL_INPUT = 'UNMARSHAL_INPUT'
 
     @property
     def description(self):
@@ -104,7 +105,7 @@ class DauphinStepKind(dauphin.Enum):
                 'the environment'
             )
         else:
-            return 'Unknown enum {value}'.format(value=self)
+            return None
 
 
 class DauphinExecutionStep(dauphin.ObjectType):

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -494,12 +494,11 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     check.failed('Should not get here')
 
 
-# TODO pass MarshalledOutput all the way through
 def _get_outputs_to_marshal(args):
     outputs_to_marshal = defaultdict(list)
     for step_execution in args.step_executions:
-        for output_name, key in step_execution.marshalled_outputs:
-            outputs_to_marshal[step_execution.step_key].append({'output': output_name, 'path': key})
+        for marshalled_output in step_execution.marshalled_outputs:
+            outputs_to_marshal[step_execution.step_key].append(marshalled_output)
     return dict(outputs_to_marshal)
 
 

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -436,19 +436,19 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
             execution_plan=execution_plan,
             step_keys=args.step_keys,
             inputs_to_marshal=_get_inputs_to_marshal(args),
-            outputs_to_marshal=_get_outputs_to_marshal(args),
+            outputs_to_marshal={se.step_key: se.marshalled_outputs for se in args.step_executions},
             environment=evaluate_value_result.value,
             execution_metadata=args.execution_metadata,
             throw_on_user_error=False,
         )
 
         has_failures = False
-        dauphin_steps = []
+        dauphin_step_results = []
         for result in results:
             if not result.success:
                 has_failures = True
 
-            dauphin_steps.append(
+            dauphin_step_results.append(
                 type_of('StepSuccessResult')(
                     success=result.success,
                     step=type_of('ExecutionStep')(result.step),
@@ -464,7 +464,7 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
             )
 
         return type_of('StartSubplanExecutionSuccess')(
-            pipeline=dauphin_pipeline, has_failures=has_failures, step_results=dauphin_steps
+            pipeline=dauphin_pipeline, has_failures=has_failures, step_results=dauphin_step_results
         )
 
     except DagsterInvalidSubplanExecutionError as invalid_subplan_error:
@@ -501,17 +501,9 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     check.failed('Should not get here')
 
 
-def _get_outputs_to_marshal(args):
-    outputs_to_marshal = defaultdict(list)
-    for step_execution in args.step_executions:
-        for marshalled_output in step_execution.marshalled_outputs:
-            outputs_to_marshal[step_execution.step_key].append(marshalled_output)
-    return dict(outputs_to_marshal)
-
-
 def _get_inputs_to_marshal(args):
     inputs_to_marshal = defaultdict(dict)
     for step_execution in args.step_executions:
-        for input_name, key in step_execution.marshalled_inputs:
-            inputs_to_marshal[step_execution.step_key][input_name] = key
+        for input_name, marshalling_key in step_execution.marshalled_inputs:
+            inputs_to_marshal[step_execution.step_key][input_name] = marshalling_key
     return dict(inputs_to_marshal)

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -8,6 +8,8 @@ from graphql.execution.base import ResolveInfo
 
 from dagster import ExecutionMetadata, check
 from dagster.core.definitions.environment_configs import construct_environment_config
+from dagster.core.execution_plan.plan_subset import MarshalledOutput
+
 from dagster.core.errors import (
     DagsterInvalidSubplanExecutionError,
     DagsterMarshalOutputNotFoundError,
@@ -304,7 +306,6 @@ def _config_or_error_from_pipeline(info, pipeline, env_config):
 
 
 MarshalledInput = namedtuple('MarshalledInput', 'input_name key')
-MarshalledOutput = namedtuple('MarshalledOutput', 'output_name key')
 
 
 class StepExecution(namedtuple('_StepExecution', 'step_key marshalled_inputs marshalled_outputs')):
@@ -493,6 +494,7 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     check.failed('Should not get here')
 
 
+# TODO pass MarshalledOutput all the way through
 def _get_outputs_to_marshal(args):
     outputs_to_marshal = defaultdict(list)
     for step_execution in args.step_executions:

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -314,7 +314,14 @@ class StepExecution(namedtuple('_StepExecution', 'step_key marshalled_inputs mar
             cls,
             check.str_param(step_key, 'step_key'),
             list(map(lambda inp: MarshalledInput(**inp), marshalled_inputs)),
-            list(map(lambda out: MarshalledOutput(**out), marshalled_outputs)),
+            list(
+                map(
+                    lambda out: MarshalledOutput(
+                        output_name=out['output_name'], marshalling_key=out['key']
+                    ),
+                    marshalled_outputs,
+                )
+            ),
         )
 
 

--- a/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
+++ b/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
@@ -117,9 +117,9 @@ snapshots['test_successful_start_subplan 1'] = {
         'stepResults': [
             {
                 '__typename': 'StepSuccessResult',
-                'outputName': 'value_output',
+                'outputName': 'unmarshal-input-output',
                 'step': {
-                    'key': 'sum_solid.transform.input.num.value'
+                    'key': 'sum_solid.transform.unmarshal-input.num'
                 },
                 'success': True,
                 'valueRepr': '''   num1  num2
@@ -206,7 +206,21 @@ snapshots['test_start_subplan_invalid_output_name 1'] = {
 
 snapshots['test_start_subplan_invalid_input_path 1'] = {
     'startSubplanExecution': {
-        '__typename': 'PythonError'
+        '__typename': 'StartSubplanExecutionSuccess',
+        'hasFailures': True,
+        'pipeline': {
+            'name': 'pandas_hello_world'
+        },
+        'stepResults': [
+            {
+                '__typename': 'StepFailureResult',
+                'errorMessage': 'Error occured during step sum_solid.transform.unmarshal-input.num',
+                'step': {
+                    'key': 'sum_solid.transform.unmarshal-input.num'
+                },
+                'success': False
+            }
+        ]
     }
 }
 

--- a/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
+++ b/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
@@ -48,3 +48,237 @@ snapshots['test_start_subplan_invalid_output_path 1'] = {
         ]
     }
 }
+
+snapshots['test_query_execution_plan_snapshot 1'] = {
+    'executionPlan': {
+        '__typename': 'ExecutionPlan',
+        'pipeline': {
+            'name': 'pandas_hello_world'
+        },
+        'steps': [
+            {
+                'inputs': [
+                ],
+                'kind': 'INPUT_THUNK',
+                'name': 'sum_solid.num.input_thunk',
+                'outputs': [
+                    {
+                        'name': 'input_thunk_output',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_solid'
+                }
+            },
+            {
+                'inputs': [
+                    {
+                        'dependsOn': {
+                            'name': 'sum_solid.num.input_thunk'
+                        },
+                        'name': 'num',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'kind': 'TRANSFORM',
+                'name': 'sum_solid.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_solid'
+                }
+            },
+            {
+                'inputs': [
+                    {
+                        'dependsOn': {
+                            'name': 'sum_solid.transform'
+                        },
+                        'name': 'sum_df',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'kind': 'TRANSFORM',
+                'name': 'sum_sq_solid.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_sq_solid'
+                }
+            }
+        ]
+    }
+}
+
+snapshots['test_successful_start_subplan 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionSuccess',
+        'hasFailures': False,
+        'pipeline': {
+            'name': 'pandas_hello_world'
+        },
+        'stepResults': [
+            {
+                '__typename': 'StepSuccessResult',
+                'outputName': 'unmarshal-input-output',
+                'step': {
+                    'key': 'sum_solid.transform.unmarshal-input.num'
+                },
+                'success': True,
+                'valueRepr': '''   num1  num2
+0     1     2
+1     3     4'''
+            },
+            {
+                '__typename': 'StepSuccessResult',
+                'outputName': 'result',
+                'step': {
+                    'key': 'sum_solid.transform'
+                },
+                'success': True,
+                'valueRepr': '''   num1  num2  sum
+0     1     2    3
+1     3     4    7'''
+            }
+        ]
+    }
+}
+
+snapshots['test_user_error_pipeline 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionSuccess',
+        'hasFailures': True,
+        'pipeline': {
+            'name': 'naughty_programmer_pipeline'
+        },
+        'stepResults': [
+            {
+                '__typename': 'StepFailureResult',
+                'errorMessage': 'Error occured during step throw_a_thing.transform',
+                'step': {
+                    'key': 'throw_a_thing.transform'
+                },
+                'success': False
+            }
+        ]
+    }
+}
+
+snapshots['test_start_subplan_pipeline_not_found 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'PipelineNotFoundError',
+        'pipelineName': 'nope'
+    }
+}
+
+snapshots['test_start_subplan_invalid_config 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'PipelineConfigValidationInvalid',
+        'errors': [
+            {
+                'message': 'Value "384938439" at path root:solids:sum_solid:inputs:num:csv:path is not valid. Expected "Path"'
+            }
+        ],
+        'pipeline': {
+            'name': 'pandas_hello_world'
+        }
+    }
+}
+
+snapshots['test_start_subplan_invalid_step_keys 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionInvalidStepsError',
+        'invalidStepKeys': [
+            'nope'
+        ]
+    }
+}
+
+snapshots['test_start_subplan_invalid_input_name 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionInvalidInputError',
+        'invalidInputName': 'nope',
+        'step': {
+            'key': 'sum_solid.transform'
+        }
+    }
+}
+
+snapshots['test_start_subplan_invalid_output_name 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionInvalidOutputError',
+        'invalidOutputName': 'nope',
+        'step': {
+            'key': 'sum_solid.transform'
+        }
+    }
+}
+
+snapshots['test_start_subplan_invalid_input_path 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionSuccess',
+        'hasFailures': True,
+        'pipeline': {
+            'name': 'pandas_hello_world'
+        },
+        'stepResults': [
+            {
+                '__typename': 'StepFailureResult',
+                'errorMessage': 'Error occured during step sum_solid.transform.unmarshal-input.num',
+                'step': {
+                    'key': 'sum_solid.transform.unmarshal-input.num'
+                },
+                'success': False
+            }
+        ]
+    }
+}
+
+snapshots['test_invalid_subplan_missing_inputs 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'InvalidSubplanExecutionError',
+        'missingInputName': 'num',
+        'step': {
+            'key': 'sum_solid.transform'
+        }
+    }
+}
+
+snapshots['test_user_code_error_subplan 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionSuccess',
+        'hasFailures': True,
+        'pipeline': {
+            'name': 'naughty_programmer_pipeline'
+        },
+        'stepResults': [
+            {
+                '__typename': 'StepFailureResult',
+                'errorMessage': 'Error occured during step throw_a_thing.transform',
+                'step': {
+                    'key': 'throw_a_thing.transform'
+                },
+                'success': False
+            }
+        ]
+    }
+}

--- a/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
+++ b/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
@@ -7,110 +7,10 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_query_execution_plan_snapshot 1'] = {
-    'executionPlan': {
-        '__typename': 'ExecutionPlan',
-        'pipeline': {
-            'name': 'pandas_hello_world'
-        },
-        'steps': [
-            {
-                'inputs': [
-                ],
-                'kind': 'INPUT_THUNK',
-                'name': 'sum_solid.num.input_thunk',
-                'outputs': [
-                    {
-                        'name': 'input_thunk_output',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'solid': {
-                    'name': 'sum_solid'
-                }
-            },
-            {
-                'inputs': [
-                    {
-                        'dependsOn': {
-                            'name': 'sum_solid.num.input_thunk'
-                        },
-                        'name': 'num',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'kind': 'TRANSFORM',
-                'name': 'sum_solid.transform',
-                'outputs': [
-                    {
-                        'name': 'result',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'solid': {
-                    'name': 'sum_solid'
-                }
-            },
-            {
-                'inputs': [
-                    {
-                        'dependsOn': {
-                            'name': 'sum_solid.transform'
-                        },
-                        'name': 'sum_df',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'kind': 'TRANSFORM',
-                'name': 'sum_sq_solid.transform',
-                'outputs': [
-                    {
-                        'name': 'result',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'solid': {
-                    'name': 'sum_sq_solid'
-                }
-            }
-        ]
-    }
-}
-
-snapshots['test_user_code_error_subplan 1'] = {
+snapshots['test_start_subplan_invalid_output_path 1'] = {
     'startSubplanExecution': {
         '__typename': 'StartSubplanExecutionSuccess',
         'hasFailures': True,
-        'pipeline': {
-            'name': 'naughty_programmer_pipeline'
-        },
-        'stepResults': [
-            {
-                '__typename': 'StepFailureResult',
-                'errorMessage': 'Error occured during step throw_a_thing.transform',
-                'step': {
-                    'key': 'throw_a_thing.transform'
-                },
-                'success': False
-            }
-        ]
-    }
-}
-
-snapshots['test_successful_start_subplan 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionSuccess',
-        'hasFailures': False,
         'pipeline': {
             'name': 'pandas_hello_world'
         },
@@ -136,113 +36,15 @@ snapshots['test_successful_start_subplan 1'] = {
                 'valueRepr': '''   num1  num2  sum
 0     1     2    3
 1     3     4    7'''
-            }
-        ]
-    }
-}
-
-snapshots['test_user_error_pipeline 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionSuccess',
-        'hasFailures': True,
-        'pipeline': {
-            'name': 'naughty_programmer_pipeline'
-        },
-        'stepResults': [
+            },
             {
                 '__typename': 'StepFailureResult',
-                'errorMessage': 'Error occured during step throw_a_thing.transform',
+                'errorMessage': 'Error occured during step sum_solid.transform.marshal-output.result',
                 'step': {
-                    'key': 'throw_a_thing.transform'
+                    'key': 'sum_solid.transform.marshal-output.result'
                 },
                 'success': False
             }
         ]
-    }
-}
-
-snapshots['test_start_subplan_invalid_config 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'PipelineConfigValidationInvalid',
-        'errors': [
-            {
-                'message': 'Value "384938439" at path root:solids:sum_solid:inputs:num:csv:path is not valid. Expected "Path"'
-            }
-        ],
-        'pipeline': {
-            'name': 'pandas_hello_world'
-        }
-    }
-}
-
-snapshots['test_start_subplan_invalid_step_keys 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionInvalidStepsError',
-        'invalidStepKeys': [
-            'nope'
-        ]
-    }
-}
-
-snapshots['test_start_subplan_invalid_input_name 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionInvalidInputError',
-        'invalidInputName': 'nope',
-        'step': {
-            'key': 'sum_solid.transform'
-        }
-    }
-}
-
-snapshots['test_start_subplan_invalid_output_name 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionInvalidOutputError',
-        'invalidOutputName': 'nope',
-        'step': {
-            'key': 'sum_solid.transform'
-        }
-    }
-}
-
-snapshots['test_start_subplan_invalid_input_path 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionSuccess',
-        'hasFailures': True,
-        'pipeline': {
-            'name': 'pandas_hello_world'
-        },
-        'stepResults': [
-            {
-                '__typename': 'StepFailureResult',
-                'errorMessage': 'Error occured during step sum_solid.transform.unmarshal-input.num',
-                'step': {
-                    'key': 'sum_solid.transform.unmarshal-input.num'
-                },
-                'success': False
-            }
-        ]
-    }
-}
-
-snapshots['test_start_subplan_invalid_output_path 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'PythonError'
-    }
-}
-
-snapshots['test_invalid_subplan_missing_inputs 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'InvalidSubplanExecutionError',
-        'missingInputName': 'num',
-        'step': {
-            'key': 'sum_solid.transform'
-        }
-    }
-}
-
-snapshots['test_start_subplan_pipeline_not_found 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'PipelineNotFoundError',
-        'pipelineName': 'nope'
     }
 }

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -1941,10 +1941,9 @@ def test_start_subplan_invalid_input_path(snapshot):
 
     assert not result.errors
     assert result.data
-    assert result.data['startSubplanExecution']['__typename'] == 'PythonError'
-    assert 'No such file or directory:' in result.data['startSubplanExecution']['message']
-    # Exception types differ between python 2 and 3 which breaks snapshots
-    del result.data['startSubplanExecution']['message']
+    assert result.data['startSubplanExecution']['__typename'] == 'StartSubplanExecutionSuccess'
+    step_results_data = result.data['startSubplanExecution']['stepResults']
+    assert step_results_data[0]['success'] is False
     snapshot.assert_match(result.data)
 
 

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -1981,11 +1981,18 @@ def test_start_subplan_invalid_output_path(snapshot):
 
         assert not result.errors
         assert result.data
-        assert result.data['startSubplanExecution']['__typename'] == 'PythonError'
-        assert 'No such file or directory:' in result.data['startSubplanExecution']['message']
+        assert result.data['startSubplanExecution']['__typename'] == 'StartSubplanExecutionSuccess'
+        step_results_data = result.data['startSubplanExecution']['stepResults']
+        assert len(step_results_data) == 3
+        assert [step_result['step']['key'] for step_result in step_results_data] == [
+            'sum_solid.transform.unmarshal-input.num',
+            'sum_solid.transform',
+            'sum_solid.transform.marshal-output.result',
+        ]
 
-        # Exception types differ between python 2 and 3 which breaks snapshots
-        del result.data['startSubplanExecution']['message']
+        assert step_results_data[0]['success']
+        assert step_results_data[1]['success']
+        assert not step_results_data[2]['success']
 
         snapshot.assert_match(result.data)
 

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -52,15 +52,7 @@ class DagsterUserCodeExecutionError(DagsterUserError):
         )
     except Exception as e:  # pylint: disable=broad-except
         raise_from(
-            DagsterMarshalOutputError(
-                'Error during the marshalling of output {output_name} in step {step_key}'.format(
-                    output_name=output_name, step_key=step.key
-                ),
-                user_exception=e,
-                original_exc_info=sys.exc_info(),
-                output_name=output_name,
-                step_key=step.key,
-            ),
+            DagsterExecutionStepExecutionError(...)
             e,
         )
 
@@ -116,15 +108,6 @@ class DagsterMarshalOutputNotFoundError(DagsterUserError):
         self.output_name = check.str_param(kwargs.pop('output_name'), 'output_name')
         self.step_key = check.str_param(kwargs.pop('step_key'), 'step_key')
         super(DagsterMarshalOutputNotFoundError, self).__init__(*args, **kwargs)
-
-
-class DagsterMarshalOutputError(DagsterUserCodeExecutionError):
-    '''Indicates an error doing marshalling on a specific output'''
-
-    def __init__(self, *args, **kwargs):
-        self.output_name = check.str_param(kwargs.pop('output_name'), 'output_name')
-        self.step_key = check.str_param(kwargs.pop('step_key'), 'step_key')
-        super(DagsterMarshalOutputError, self).__init__(*args, **kwargs)
 
 
 class DagsterExecutionStepExecutionError(DagsterUserCodeExecutionError):

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -109,15 +109,6 @@ class DagsterUnmarshalInputNotFoundError(DagsterUserError):
         super(DagsterUnmarshalInputNotFoundError, self).__init__(*args, **kwargs)
 
 
-class DagsterUnmarshalInputError(DagsterUserCodeExecutionError):
-    '''Indicates an error doing marshalling a specific input'''
-
-    def __init__(self, *args, **kwargs):
-        self.input_name = check.str_param(kwargs.pop('input_name'), 'input_name')
-        self.step_key = check.str_param(kwargs.pop('step_key'), 'step_key')
-        super(DagsterUnmarshalInputError, self).__init__(*args, **kwargs)
-
-
 class DagsterMarshalOutputNotFoundError(DagsterUserError):
     '''Throw if user tries to marshal an output that does not exist on the step'''
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -571,10 +571,7 @@ def execute_externalized_plan(
             subset_info=ExecutionPlanSubsetInfo.with_input_marshalling(
                 included_step_keys=step_keys, marshalled_inputs=inputs_to_marshal
             ),
-            added_outputs=ExecutionPlanAddedOutputs.with_output_marshalling(
-                outputs_to_marshal,
-                # _process_outputs_to_marshall_param(outputs_to_marshal)
-            ),
+            added_outputs=ExecutionPlanAddedOutputs.with_output_marshalling(outputs_to_marshal),
         )
 
         return list(

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -563,9 +563,6 @@ def execute_externalized_plan(
         execution_plan = create_execution_plan_core(
             ExecutionPlanInfo(context, pipeline, typed_environment),
             execution_metadata=execution_metadata,
-            # subset_info=ExecutionPlanSubsetInfo.with_input_values(
-            #     included_step_keys=step_keys, inputs=inputs
-            # ),
             subset_info=ExecutionPlanSubsetInfo.with_marshalling_steps(
                 included_step_keys=step_keys, marshalled_inputs=inputs_to_marshal
             ),

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -593,16 +593,16 @@ def execute_externalized_plan(
             subset_info=ExecutionPlanSubsetInfo.with_input_marshalling(
                 included_step_keys=step_keys, marshalled_inputs=inputs_to_marshal
             ),
-            # added_outputs=ExecutionPlanAddedOutputs.with_output_marshalling(
-            #     _process_outputs_to_marshall_param(outputs_to_marshal)
-            # ),
+            added_outputs=ExecutionPlanAddedOutputs.with_output_marshalling(
+                _process_outputs_to_marshall_param(outputs_to_marshal)
+            ),
         )
 
         results = list(
             execute_plan_core(context, execution_plan, throw_on_user_error=throw_on_user_error)
         )
 
-        _marshal_outputs(context, results, outputs_to_marshal)
+        # _marshal_outputs(context, results, outputs_to_marshal)
 
         return results
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -563,7 +563,7 @@ def execute_externalized_plan(
         execution_plan = create_execution_plan_core(
             ExecutionPlanInfo(context, pipeline, typed_environment),
             execution_metadata=execution_metadata,
-            subset_info=ExecutionPlanSubsetInfo.with_marshalling_steps(
+            subset_info=ExecutionPlanSubsetInfo.with_input_marshalling(
                 included_step_keys=step_keys, marshalled_inputs=inputs_to_marshal
             ),
         )

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -595,11 +595,9 @@ def execute_externalized_plan(
             ),
         )
 
-        results = list(
+        return list(
             execute_plan_core(context, execution_plan, throw_on_user_error=throw_on_user_error)
         )
-
-        return results
 
 
 def _check_outputs_to_marshal(execution_plan, outputs_to_marshal):

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -207,7 +207,7 @@ def _create_subplan(execution_plan_info, state, execution_plan, subset_info):
             continue
 
         with state.push_tags(**step.tags):
-            if step.key not in subset_info.step_factory_fns:
+            if step.key not in subset_info.input_step_factory_fns:
                 steps.append(step)
             else:
                 steps.extend(_create_new_steps_for_input(state, step, subset_info))
@@ -222,7 +222,7 @@ def _create_subplan(execution_plan_info, state, execution_plan, subset_info):
 
             # Now check to see if the input is provided
 
-            if not subset_info.has_injected_step(step.key, step_input.name):
+            if not subset_info.has_injected_step_for_input(step.key, step_input.name):
                 raise DagsterInvalidSubplanExecutionError(
                     (
                         'You have specified a subset execution on pipeline {pipeline_name} '
@@ -247,12 +247,12 @@ def _create_new_steps_for_input(state, step, subset_info):
     new_steps = []
     new_step_inputs = []
     for step_input in step.step_inputs:
-        check.invariant(subset_info.has_injected_step(step.key, step_input.name))
+        check.invariant(subset_info.has_injected_step_for_input(step.key, step_input.name))
 
-        subset_info.step_factory_fns[step.key][step_input.name](state, step, step_input)
+        subset_info.input_step_factory_fns[step.key][step_input.name](state, step, step_input)
 
         step_output_handle = check.inst(
-            subset_info.step_factory_fns[step.key][step_input.name](state, step, step_input),
+            subset_info.input_step_factory_fns[step.key][step_input.name](state, step, step_input),
             StepOutputHandle,
             'Step factory function must create StepOutputHandle',
         )

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -82,7 +82,9 @@ def create_execution_plan_core(
     execution_plan = create_execution_plan_from_steps(state.steps)
 
     if subset_info:
-        return _create_augmented_subplan(execution_info, state, execution_plan, subset_info)
+        return _create_augmented_subplan(
+            execution_info, state, execution_plan, subset_info, added_outputs
+        )
     else:
         return execution_plan
 

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -254,7 +254,11 @@ def _validate_new_plan(new_plan, subset_info, execution_plan_info):
 
 
 def _all_augmented_steps_for_step(state, step, subset_info, added_outputs):
-    step, new_input_steps = _create_new_step_with_added_inputs(state, step, subset_info)
+
+    new_input_steps = []
+
+    if subset_info and step.key in subset_info.input_step_factory_fns:
+        step, new_input_steps = _create_new_step_with_added_inputs(state, step, subset_info)
 
     all_new_steps = [step] + new_input_steps
 
@@ -270,12 +274,6 @@ def _all_augmented_steps_for_step(state, step, subset_info, added_outputs):
 
 
 def _create_new_step_with_added_inputs(state, step, subset_info):
-    if not subset_info:
-        return step, []
-
-    if step.key not in subset_info.input_step_factory_fns:
-        return step, []
-
     new_steps = []
     new_step_inputs = []
     for step_input in step.step_inputs:

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -1,0 +1,41 @@
+from dagster import check
+from dagster.core.definitions import Result
+from .objects import (
+    ExecutionStep,
+    StepBuilderState,
+    StepInput,
+    StepKind,
+    StepOutput,
+    StepOutputHandle,
+)
+
+UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
+
+
+def create_unmarshal_step(state, step, step_input, key):
+    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(step, 'step', ExecutionStep)
+    check.inst_param(step_input, 'step_input', StepInput)
+    check.str_param(key, 'key')
+
+    def _compute_fn(context, _step, _inputs):
+        input_value = context.persistence_policy.read_value(
+            step_input.runtime_type.serialization_strategy, key
+        )
+
+        yield Result(input_value, UNMARSHAL_INPUT_OUTPUT)
+
+    return StepOutputHandle(
+        ExecutionStep(
+            key='{step_key}.unmarshal-input.{input_name}'.format(
+                step_key=step.key, input_name=step_input.name
+            ),
+            step_inputs=[],
+            step_outputs=[StepOutput(UNMARSHAL_INPUT_OUTPUT, step_input.runtime_type)],
+            compute_fn=_compute_fn,
+            kind=StepKind.UNMARSHAL_INPUT,
+            solid=step.solid,
+            tags=state.get_tags(),
+        ),
+        UNMARSHAL_INPUT_OUTPUT,
+    )

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -12,16 +12,16 @@ from .objects import (
 UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
 
 
-def create_unmarshal_input_step(state, step, step_input, key):
+def create_unmarshal_input_step(state, step, step_input, marshalling_key):
     check.inst_param(state, 'state', StepBuilderState)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_input, 'step_input', StepInput)
-    check.str_param(key, 'key')
+    check.str_param(marshalling_key, 'marshalling_key')
 
     def _compute_fn(context, _step, _inputs):
         yield Result(
             context.persistence_policy.read_value(
-                step_input.runtime_type.serialization_strategy, key
+                step_input.runtime_type.serialization_strategy, marshalling_key
             ),
             UNMARSHAL_INPUT_OUTPUT,
         )
@@ -45,15 +45,17 @@ def create_unmarshal_input_step(state, step, step_input, key):
 MARSHAL_OUTPUT_INPUT = 'marshal-output-input'
 
 
-def create_marshal_output_step(state, step, step_output, key):
+def create_marshal_output_step(state, step, step_output, marshalling_key):
     check.inst_param(state, 'state', StepBuilderState)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_output, 'step_output', StepOutput)
-    check.str_param(key, 'key')
+    check.str_param(marshalling_key, 'marshalling_key')
 
     def _compute_fn(context, _step, inputs):
         context.persistence_policy.write_value(
-            step_output.runtime_type.serialization_strategy, key, inputs[MARSHAL_OUTPUT_INPUT]
+            step_output.runtime_type.serialization_strategy,
+            marshalling_key,
+            inputs[MARSHAL_OUTPUT_INPUT],
         )
 
     return ExecutionStep(

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -12,18 +12,19 @@ from .objects import (
 UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
 
 
-def create_unmarshal_step(state, step, step_input, key):
+def create_unmarshal_input_step(state, step, step_input, key):
     check.inst_param(state, 'state', StepBuilderState)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_input, 'step_input', StepInput)
     check.str_param(key, 'key')
 
     def _compute_fn(context, _step, _inputs):
-        input_value = context.persistence_policy.read_value(
-            step_input.runtime_type.serialization_strategy, key
+        yield Result(
+            context.persistence_policy.read_value(
+                step_input.runtime_type.serialization_strategy, key
+            ),
+            UNMARSHAL_INPUT_OUTPUT,
         )
-
-        yield Result(input_value, UNMARSHAL_INPUT_OUTPUT)
 
     return StepOutputHandle(
         ExecutionStep(

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -95,6 +95,7 @@ class StepKind(Enum):
     MATERIALIZATION_THUNK = 'MATERIALIZATION_THUNK'
     VALUE_THUNK = 'VALUE_THUNK'
     UNMARSHAL_INPUT = 'UNMARSHAL_INPUT'
+    MARSHAL_OUTPUT = 'MARSHAL_OUTPUT'
 
 
 class StepInput(namedtuple('_StepInput', 'name runtime_type prev_output_handle')):

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -94,6 +94,7 @@ class StepKind(Enum):
     INPUT_THUNK = 'INPUT_THUNK'
     MATERIALIZATION_THUNK = 'MATERIALIZATION_THUNK'
     VALUE_THUNK = 'VALUE_THUNK'
+    UNMARSHAL_INPUT = 'UNMARSHAL_INPUT'
 
 
 class StepInput(namedtuple('_StepInput', 'name runtime_type prev_output_handle')):

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -1,7 +1,7 @@
 from collections import defaultdict, namedtuple
 from dagster import check
 from dagster.core.definitions.utils import check_two_dim_dict, check_opt_two_dim_dict
-from .marshal import create_unmarshal_step, create_marshal_output_step
+from .marshal import create_unmarshal_input_step, create_marshal_output_step
 from .utility import create_value_thunk_step
 
 
@@ -65,7 +65,7 @@ class ExecutionPlanSubsetInfo(
         input_step_factory_fns = defaultdict(dict)
 
         def _create_unmarshal_input_factory_fn(key):
-            return lambda state, step, step_input: create_unmarshal_step(
+            return lambda state, step, step_input: create_unmarshal_input_step(
                 state, step, step_input, key
             )
 

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -127,8 +127,7 @@ class ExecutionPlanAddedOutputs(
             output_step_factory_fns, 'output_step_factory_fns', key_type=str, value_type=list
         )
         for step_factory_fns_for_output in output_step_factory_fns.values():
-            for step_factory_nf in step_factory_fns_for_output:
-                check.callable_param(step_factory_nf, 'output_step_factory_fns')
+            check.list_param(step_factory_fns_for_output, 'rename', of_type=OutputStepFactoryEntry)
 
         return super(ExecutionPlanAddedOutputs, cls).__new__(cls, output_step_factory_fns)
 

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -2,7 +2,6 @@ from collections import defaultdict, namedtuple
 from dagster import check
 from dagster.core.definitions.utils import check_two_dim_dict, check_opt_two_dim_dict
 from .marshal import create_unmarshal_step
-from .objects import StepBuilderState, ExecutionStep, StepInput
 from .utility import create_value_thunk_step
 
 

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -36,7 +36,7 @@ class ExecutionPlanSubsetInfo(
 
         inputs dictionary is a Dict[str,Dict[str,Any]] mapping
 
-        step_key => input_name = > value
+        step_key => input_name => value
 
         Example:
 
@@ -79,7 +79,7 @@ class ExecutionPlanSubsetInfo(
 
         inputs dictionary is a Dict[str,Dict[str,Any]] mapping
 
-        step_key => input_name = > marshalling_key
+        step_key => input_name => marshalling_key
         '''
         check.list_param(included_step_keys, 'included_step_keys', of_type=str)
         check_opt_two_dim_dict(marshalled_inputs, 'marshalled_inputs')

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -5,8 +5,6 @@ from .marshal import create_unmarshal_step
 from .objects import StepBuilderState, ExecutionStep, StepInput
 from .utility import create_value_thunk_step
 
-MarshalledOutput = namedtuple('MarshalledOutput', 'output_name key')
-
 
 class ExecutionPlanSubsetInfo(namedtuple('_ExecutionPlanSubsetInfo', 'subset step_factory_fns')):
     '''
@@ -59,15 +57,9 @@ class ExecutionPlanSubsetInfo(namedtuple('_ExecutionPlanSubsetInfo', 'subset ste
         return ExecutionPlanSubsetInfo(included_step_keys, step_factory_fns)
 
     @staticmethod
-    def with_marshalling_steps(included_step_keys, marshalled_inputs=None, marshalled_outputs=None):
+    def with_input_marshalling(included_step_keys, marshalled_inputs=None):
         check.list_param(included_step_keys, 'included_step_keys', of_type=str)
         check_opt_two_dim_dict(marshalled_inputs, 'marshalled_inputs')
-        check.opt_dict_param(
-            marshalled_outputs, 'marshalled_outputs', key_type=str, value_type=list
-        )
-        if marshalled_outputs:
-            for output_list in marshalled_outputs.values():
-                check.list_param(output_list, 'marshalled_outputs', of_type=MarshalledOutput)
 
         step_factory_fns = defaultdict(dict)
 

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -33,6 +33,20 @@ class ExecutionPlanSubsetInfo(
         Create an execution subset with hardcoded values as inputs. This will create
         execution steps with the key "{step_key}.input.{input_name}.value" that simply
         emit the value
+
+        inputs dictionary is a Dict[str,Dict[str,Any]] mapping
+
+        step_key => input_name = > value
+
+        Example:
+
+        create_execution_plan(
+            define_two_int_pipeline(),
+            subset_info=ExecutionPlanSubsetInfo.with_input_values(
+                ['add_one.transform'], {'add_one.transform': {'num': 2}}
+            ),
+        )
+
         '''
         check.list_param(included_step_keys, 'included_step_keys', of_type=str)
         check_two_dim_dict(inputs, 'inputs', key_type=str)
@@ -59,14 +73,22 @@ class ExecutionPlanSubsetInfo(
 
     @staticmethod
     def with_input_marshalling(included_step_keys, marshalled_inputs=None):
+        '''
+        Create an execution subset that uses the marshalling infrastruture in order
+        to provide values to includes.
+
+        inputs dictionary is a Dict[str,Dict[str,Any]] mapping
+
+        step_key => input_name = > marshalling_key
+        '''
         check.list_param(included_step_keys, 'included_step_keys', of_type=str)
         check_opt_two_dim_dict(marshalled_inputs, 'marshalled_inputs')
 
         input_step_factory_fns = defaultdict(dict)
 
-        def _create_unmarshal_input_factory_fn(key):
+        def _create_unmarshal_input_factory_fn(marshalling_key):
             return lambda state, step, step_input: create_unmarshal_input_step(
-                state, step, step_input, key
+                state, step, step_input, marshalling_key
             )
 
         for step_key, input_marshal_dict in marshalled_inputs.items():

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -144,7 +144,13 @@ class MarshalledOutput(namedtuple('_MarshalledOutput', 'output_name marshalling_
         )
 
 
-OutputStepFactoryEntry = namedtuple('OutputStepFactoryEntry', 'output_name step_factory_fn')
+class OutputStepFactoryEntry(namedtuple('_OutputStepFactoryEntry', 'output_name step_factory_fn')):
+    def __new__(cls, output_name, step_factory_fn):
+        return super(OutputStepFactoryEntry, cls).__new__(
+            cls,
+            check.str_param(output_name, 'output_name'),
+            check.callable_param(step_factory_fn, 'step_factory_fn'),
+        )
 
 
 class ExecutionPlanAddedOutputs(

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -2,7 +2,6 @@ from collections import defaultdict, namedtuple
 from dagster import check
 from dagster.core.definitions.utils import check_two_dim_dict, check_opt_two_dim_dict
 from .marshal import create_unmarshal_step, create_marshal_output_step
-from .objects import ExecutionPlan
 from .utility import create_value_thunk_step
 
 

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -135,7 +135,14 @@ class ExecutionPlanSubsetInfo(
         )
 
 
-MarshalledOutput = namedtuple('MarshalledOutput', 'output_name key')
+class MarshalledOutput(namedtuple('_MarshalledOutput', 'output_name marshalling_key')):
+    def __new__(cls, output_name, marshalling_key):
+        return super(MarshalledOutput, cls).__new__(
+            cls,
+            check.str_param(output_name, 'output_name'),
+            check.str_param(marshalling_key, 'marshalling_key'),
+        )
+
 
 OutputStepFactoryEntry = namedtuple('OutputStepFactoryEntry', 'output_name step_factory_fn')
 
@@ -174,7 +181,9 @@ class ExecutionPlanAddedOutputs(
                 output_step_factory_fns[step_key].append(
                     OutputStepFactoryEntry(
                         output_name=marshalled_output.output_name,
-                        step_factory_fn=_create_marshal_output_fn(marshalled_output.key),
+                        step_factory_fn=_create_marshal_output_fn(
+                            marshalled_output.marshalling_key
+                        ),
                     )
                 )
 

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -196,7 +196,7 @@ def _compute_result_list(step, context, evaluated_inputs):
 
         if gen is None:
             check.invariant(not step.step_outputs)
-            return
+            return []
 
         return list(gen)
 

--- a/python_modules/dagster/dagster/core/types/evaluator.py
+++ b/python_modules/dagster/dagster/core/types/evaluator.py
@@ -422,7 +422,6 @@ def validate_selector_config_value(selector_type, config_value, stack):
 
         field_name, incoming_field_value = single_item(config_value)
         if field_name not in selector_type.fields:
-            print('calling ' + 'create_field_not_defined_error')
             yield create_field_not_defined_error(selector_type, stack, field_name)
             return
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -164,7 +164,7 @@ def test_external_execution_step_for_output_missing():
             pipeline,
             execution_plan,
             ['add_one.transform'],
-            outputs_to_marshal={'nope': [MarshalledOutput(output_name='nope', key='nope')]},
+            outputs_to_marshal={'nope': [MarshalledOutput('nope', 'nope')]},
             execution_metadata=ExecutionMetadata(),
         )
 
@@ -194,7 +194,9 @@ def test_external_execution_marshal_output_code_error():
 
     outputs_to_marshal = {
         'add_one.transform': [
-            MarshalledOutput(output_name='result', key='{uuid}/{uuid}'.format(uuid=hardcoded_uuid))
+            MarshalledOutput(
+                output_name='result', marshalling_key='{uuid}/{uuid}'.format(uuid=hardcoded_uuid)
+            )
         ]
     }
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -11,7 +11,6 @@ from dagster import (
 from dagster.core.errors import (
     DagsterExecutionStepNotFoundError,
     DagsterInvalidSubplanExecutionError,
-    DagsterMarshalOutputError,
     DagsterMarshalOutputNotFoundError,
     DagsterUnmarshalInputNotFoundError,
     DagsterExecutionStepExecutionError,

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20073,22 +20073,8 @@ try:</p>
 <dt>except Exception as e:  # pylint: disable=broad-except</dt>
 <dd><dl class="first docutils">
 <dt>raise_from(</dt>
-<dd><dl class="first docutils">
-<dt>DagsterMarshalOutputError(</dt>
-<dd><dl class="first docutils">
-<dt>‘Error during the marshalling of output {output_name} in step {step_key}’.format(</dt>
-<dd>output_name=output_name, step_key=step.key</dd>
-</dl>
-<p class="last">),
-user_exception=e,
-original_exc_info=sys.exc_info(),
-output_name=output_name,
-step_key=step.key,</p>
-</dd>
-</dl>
-<p class="last">),
-e,</p>
-</dd>
+<dd>DagsterExecutionStepExecutionError(…)
+e,</dd>
 </dl>
 <p class="last">)</p>
 </dd>


### PR DESCRIPTION
It should have always been like this. Instead of doing unmarshalling and marshalling outside of plan execution, do it within it by injected a step per input and output that needs to be marshalled. This unifies error handling and partial execution, and will assist as we build debugging features and viz on top of the execution plan abstraction. 

Code needs some more comments (esp step factory function stuff) but wanted to get out there.