### PR TITLE
Nightlies: always resolve merge conflicts to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,7 +745,7 @@ jobs:
             git checkout master
             git reset --hard origin/master
             git checkout nightly
-            GIT_MERGE_AUTOEDIT=no git merge master
+            GIT_MERGE_AUTOEDIT=no git merge master -s ours
 
       - run:
           name: Install requirements


### PR DESCRIPTION
In the event we have merge conflicts, this will always take master over what's on nightly.