### PR TITLE
Ensure config-less resource can be used with all api variants

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -255,7 +255,7 @@ def solid(name=None, inputs=None, outputs=None, config_field=None, description=N
                 return foo + info.config['str_value']
 
     '''
-    # This case is for when decorate is used bare, without arguments
+    # This case is for when decorator is used bare, without arguments. e.g. @solid versus @solid()
     if callable(name):
         check.invariant(inputs is None)
         check.invariant(outputs is None)

--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -255,6 +255,7 @@ def solid(name=None, inputs=None, outputs=None, config_field=None, description=N
                 return foo + info.config['str_value']
 
     '''
+    # This case is for when decorate is used bare, without arguments
     if callable(name):
         check.invariant(inputs is None)
         check.invariant(outputs is None)

--- a/python_modules/dagster/dagster/core/definitions/resource.py
+++ b/python_modules/dagster/dagster/core/definitions/resource.py
@@ -24,6 +24,10 @@ class ResourceDefinition(object):
 
 
 def resource(config_field=None, description=None):
+    # This case is for when decorate is used bare, without arguments
+    if callable(config_field):
+        return ResourceDefinition(resource_fn=config_field)
+
     def _wrap(resource_fn):
         return ResourceDefinition(resource_fn, config_field, description)
 

--- a/python_modules/dagster/dagster/core/definitions/resource.py
+++ b/python_modules/dagster/dagster/core/definitions/resource.py
@@ -24,7 +24,8 @@ class ResourceDefinition(object):
 
 
 def resource(config_field=None, description=None):
-    # This case is for when decorate is used bare, without arguments
+    # This case is for when decorator is used bare, without arguments.
+    # E.g. @resource versus @resource()
     if callable(config_field):
         return ResourceDefinition(resource_fn=config_field)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resource_definition.py
@@ -387,4 +387,3 @@ def test_no_config_resource_definition():
 
     assert called['resource']
     assert called['solid']
-

--- a/python_modules/dagster/dagster_tests/core_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resource_definition.py
@@ -278,3 +278,113 @@ def test_string_resource():
 
     assert result.success
     assert called['yup']
+
+
+def test_no_config_resource_pass_none():
+    called = {}
+
+    @resource(None)
+    def return_thing(_info):
+        called['resource'] = True
+        return 'thing'
+
+    @solid
+    def check_thing(info):
+        called['solid'] = True
+        assert info.resources.return_thing == 'thing'
+
+    pipeline = PipelineDefinition(
+        name='test_no_config_resource',
+        solids=[check_thing],
+        context_definitions={
+            'default': PipelineContextDefinition(resources={'return_thing': return_thing})
+        },
+    )
+
+    execute_pipeline(pipeline)
+
+    assert called['resource']
+    assert called['solid']
+
+
+def test_no_config_resource_no_arg():
+    called = {}
+
+    @resource()
+    def return_thing(_info):
+        called['resource'] = True
+        return 'thing'
+
+    @solid
+    def check_thing(info):
+        called['solid'] = True
+        assert info.resources.return_thing == 'thing'
+
+    pipeline = PipelineDefinition(
+        name='test_no_config_resource',
+        solids=[check_thing],
+        context_definitions={
+            'default': PipelineContextDefinition(resources={'return_thing': return_thing})
+        },
+    )
+
+    execute_pipeline(pipeline)
+
+    assert called['resource']
+    assert called['solid']
+
+
+def test_no_config_resource_bare_no_arg():
+    called = {}
+
+    @resource
+    def return_thing(_info):
+        called['resource'] = True
+        return 'thing'
+
+    @solid
+    def check_thing(info):
+        called['solid'] = True
+        assert info.resources.return_thing == 'thing'
+
+    pipeline = PipelineDefinition(
+        name='test_no_config_resource',
+        solids=[check_thing],
+        context_definitions={
+            'default': PipelineContextDefinition(resources={'return_thing': return_thing})
+        },
+    )
+
+    execute_pipeline(pipeline)
+
+    assert called['resource']
+    assert called['solid']
+
+
+def test_no_config_resource_definition():
+    called = {}
+
+    def _return_thing_resource_fn(_info):
+        called['resource'] = True
+        return 'thing'
+
+    @solid
+    def check_thing(info):
+        called['solid'] = True
+        assert info.resources.return_thing == 'thing'
+
+    pipeline = PipelineDefinition(
+        name='test_no_config_resource',
+        solids=[check_thing],
+        context_definitions={
+            'default': PipelineContextDefinition(
+                resources={'return_thing': ResourceDefinition(_return_thing_resource_fn)}
+            )
+        },
+    )
+
+    execute_pipeline(pipeline)
+
+    assert called['resource']
+    assert called['solid']
+


### PR DESCRIPTION
Wrote test cases to demo stuff to alex. Happened to find a minor bug.