### PR TITLE
Rename classes in execution creation plan process

### DIFF
--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -22,7 +22,7 @@ from .objects import (
     ExecutionPlanInfo,
     ExecutionStep,
     ExecutionValueSubplan,
-    StepBuilderState,
+    PlanBuilder,
     StepInput,
     StepOutputHandle,
     StepKind,
@@ -50,40 +50,42 @@ def create_execution_plan_core(
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_output', ExecutionPlanAddedOutputs)
 
-    state = StepBuilderState(
+    plan_builder = PlanBuilder(
         pipeline_name=execution_info.pipeline.name, initial_tags=execution_metadata.tags
     )
 
     for solid in solids_in_topological_order(execution_info.pipeline):
 
-        with state.push_tags(solid=solid.name, solid_definition=solid.definition.name):
-            step_inputs = create_step_inputs(execution_info, state, solid)
+        with plan_builder.push_tags(solid=solid.name, solid_definition=solid.definition.name):
+            step_inputs = create_step_inputs(execution_info, plan_builder, solid)
 
             solid_transform_step = create_transform_step(
                 execution_info,
-                state,
+                plan_builder,
                 solid,
                 step_inputs,
                 get_solid_user_config(execution_info, solid),
             )
 
-            state.steps.append(solid_transform_step)
+            plan_builder.steps.append(solid_transform_step)
 
             for output_def in solid.definition.output_defs:
-                with state.push_tags(output=output_def.name):
+                with plan_builder.push_tags(output=output_def.name):
                     subplan = create_subplan_for_output(
-                        execution_info, state, solid, solid_transform_step, output_def
+                        execution_info, plan_builder, solid, solid_transform_step, output_def
                     )
-                    state.steps.extend(subplan.steps)
+                    plan_builder.steps.extend(subplan.steps)
 
                     output_handle = solid.output_handle(output_def.name)
-                    state.step_output_map[output_handle] = subplan.terminal_step_output_handle
+                    plan_builder.step_output_map[
+                        output_handle
+                    ] = subplan.terminal_step_output_handle
 
-    execution_plan = create_execution_plan_from_steps(state.steps)
+    execution_plan = create_execution_plan_from_steps(plan_builder.steps)
 
     if subset_info:
         return _create_augmented_subplan(
-            execution_info, state, execution_plan, subset_info, added_outputs
+            execution_info, plan_builder, execution_plan, subset_info, added_outputs
         )
     else:
         return execution_plan
@@ -112,38 +114,44 @@ def create_execution_plan_from_steps(steps):
     return ExecutionPlan(step_dict, deps)
 
 
-def create_subplan_for_input(execution_info, state, solid, prev_step_output_handle, input_def):
+def create_subplan_for_input(
+    execution_info, plan_builder, solid, prev_step_output_handle, input_def
+):
     check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
     if execution_info.environment.expectations.evaluate and input_def.expectations:
         return create_expectations_subplan(
-            state, solid, input_def, prev_step_output_handle, kind=StepKind.INPUT_EXPECTATION
+            plan_builder, solid, input_def, prev_step_output_handle, kind=StepKind.INPUT_EXPECTATION
         )
     else:
         return ExecutionValueSubplan.empty(prev_step_output_handle)
 
 
-def create_subplan_for_output(execution_info, state, solid, solid_transform_step, output_def):
+def create_subplan_for_output(
+    execution_info, plan_builder, solid, solid_transform_step, output_def
+):
     check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(solid_transform_step, 'solid_transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)
 
     subplan = decorate_with_expectations(
-        execution_info, state, solid, solid_transform_step, output_def
+        execution_info, plan_builder, solid, solid_transform_step, output_def
     )
 
-    return decorate_with_output_materializations(execution_info, state, solid, output_def, subplan)
+    return decorate_with_output_materializations(
+        execution_info, plan_builder, solid, output_def, subplan
+    )
 
 
-def get_input_source_step_handle(execution_info, state, solid, input_def):
+def get_input_source_step_handle(execution_info, plan_builder, solid, input_def):
     check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
@@ -152,13 +160,13 @@ def get_input_source_step_handle(execution_info, state, solid, input_def):
     dependency_structure = execution_info.pipeline.dependency_structure
     if solid_config and input_def.name in solid_config.inputs:
         input_thunk_output_handle = create_input_thunk_execution_step(
-            execution_info, state, solid, input_def, solid_config.inputs[input_def.name]
+            execution_info, plan_builder, solid, input_def, solid_config.inputs[input_def.name]
         )
-        state.steps.append(input_thunk_output_handle.step)
+        plan_builder.steps.append(input_thunk_output_handle.step)
         return input_thunk_output_handle
     elif dependency_structure.has_dep(input_handle):
         solid_output_handle = dependency_structure.get_dep(input_handle)
-        return state.step_output_map[solid_output_handle]
+        return plan_builder.step_output_map[solid_output_handle]
     else:
         raise DagsterInvariantViolationError(
             (
@@ -173,22 +181,24 @@ def get_input_source_step_handle(execution_info, state, solid, input_def):
         )
 
 
-def create_step_inputs(info, state, solid):
+def create_step_inputs(info, plan_builder, solid):
     check.inst_param(info, 'info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
 
     step_inputs = []
 
     for input_def in solid.definition.input_defs:
-        with state.push_tags(input=input_def.name):
-            prev_step_output_handle = get_input_source_step_handle(info, state, solid, input_def)
-
-            subplan = create_subplan_for_input(
-                info, state, solid, prev_step_output_handle, input_def
+        with plan_builder.push_tags(input=input_def.name):
+            prev_step_output_handle = get_input_source_step_handle(
+                info, plan_builder, solid, input_def
             )
 
-            state.steps.extend(subplan.steps)
+            subplan = create_subplan_for_input(
+                info, plan_builder, solid, prev_step_output_handle, input_def
+            )
+
+            plan_builder.steps.extend(subplan.steps)
             step_inputs.append(
                 StepInput(
                     input_def.name, input_def.runtime_type, subplan.terminal_step_output_handle
@@ -199,10 +209,10 @@ def create_step_inputs(info, state, solid):
 
 
 def _create_augmented_subplan(
-    execution_plan_info, state, execution_plan, subset_info=None, added_outputs=None
+    execution_info, plan_builder, execution_plan, subset_info=None, added_outputs=None
 ):
-    check.inst_param(execution_plan_info, 'execution_plan_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_outputs', ExecutionPlanAddedOutputs)
@@ -214,15 +224,21 @@ def _create_augmented_subplan(
             # Not included in subset. Skip.
             continue
 
-        with state.push_tags(**step.tags):
-            steps.extend(_all_augmented_steps_for_step(state, step, subset_info, added_outputs))
+        with plan_builder.push_tags(**step.tags):
+            steps.extend(
+                _all_augmented_steps_for_step(plan_builder, step, subset_info, added_outputs)
+            )
 
     new_plan = create_execution_plan_from_steps(steps)
 
-    return _validate_new_plan(new_plan, subset_info, execution_plan_info)
+    return _validate_new_plan(new_plan, subset_info, execution_info)
 
 
-def _validate_new_plan(new_plan, subset_info, execution_plan_info):
+def _validate_new_plan(new_plan, subset_info, execution_info):
+    check.inst_param(new_plan, 'new_plan', ExecutionPlan)
+    check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
+    check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
+
     for step in new_plan.steps:
         for step_input in step.step_inputs:
             if new_plan.has_step(step_input.prev_output_handle.step.key):
@@ -240,12 +256,12 @@ def _validate_new_plan(new_plan, subset_info, execution_plan_info):
                         'with step_keys {step_keys}. You have failed to provide the required input '
                         '{input_name} for step {step_key}.'
                     ).format(
-                        pipeline_name=execution_plan_info.pipeline.name,
+                        pipeline_name=execution_info.pipeline.name,
                         step_keys=list(subset_info.subset),
                         input_name=step_input.name,
                         step_key=step.key,
                     ),
-                    pipeline_name=execution_plan_info.pipeline.name,
+                    pipeline_name=execution_info.pipeline.name,
                     step_keys=list(subset_info.subset),
                     input_name=step_input.name,
                     step_key=step.key,
@@ -253,12 +269,16 @@ def _validate_new_plan(new_plan, subset_info, execution_plan_info):
     return new_plan
 
 
-def _all_augmented_steps_for_step(state, step, subset_info, added_outputs):
+def _all_augmented_steps_for_step(plan_builder, step, subset_info, added_outputs):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
+    check.inst_param(step, 'step', ExecutionStep)
+    check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
+    check.opt_inst_param(added_outputs, 'added_output', ExecutionPlanAddedOutputs)
 
     new_input_steps = []
 
     if subset_info and step.key in subset_info.input_step_factory_fns:
-        step, new_input_steps = _create_new_step_with_added_inputs(state, step, subset_info)
+        step, new_input_steps = _create_new_step_with_added_inputs(plan_builder, step, subset_info)
 
     all_new_steps = [step] + new_input_steps
 
@@ -267,13 +287,17 @@ def _all_augmented_steps_for_step(state, step, subset_info, added_outputs):
             check.invariant(step.has_step_output(output_step_factory_entry.output_name))
             step_output = step.step_output_named(output_step_factory_entry.output_name)
             all_new_steps.append(
-                output_step_factory_entry.step_factory_fn(state, step, step_output)
+                output_step_factory_entry.step_factory_fn(plan_builder, step, step_output)
             )
 
     return all_new_steps
 
 
-def _create_new_step_with_added_inputs(state, step, subset_info):
+def _create_new_step_with_added_inputs(plan_builder, step, subset_info):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
+    check.inst_param(step, 'step', ExecutionStep)
+    check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
+
     new_steps = []
     new_step_inputs = []
     for step_input in step.step_inputs:
@@ -281,7 +305,9 @@ def _create_new_step_with_added_inputs(state, step, subset_info):
             continue
 
         step_output_handle = check.inst(
-            subset_info.input_step_factory_fns[step.key][step_input.name](state, step, step_input),
+            subset_info.input_step_factory_fns[step.key][step_input.name](
+                plan_builder, step, step_input
+            ),
             StepOutputHandle,
             'Step factory function must create StepOutputHandle',
         )

--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -19,7 +19,7 @@ from .objects import (
     StepOutput,
     StepOutputHandle,
     StepKind,
-    StepBuilderState,
+    PlanBuilder,
 )
 
 from .utility import create_joining_subplan
@@ -50,8 +50,8 @@ def _create_expectation_lambda(solid, inout_def, expectation_def, internal_outpu
     return _do_expectation
 
 
-def create_expectations_subplan(state, solid, inout_def, prev_step_output_handle, kind):
-    check.inst_param(state, 'state', StepBuilderState)
+def create_expectations_subplan(plan_builder, solid, inout_def, prev_step_output_handle, kind):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition))
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
@@ -59,9 +59,9 @@ def create_expectations_subplan(state, solid, inout_def, prev_step_output_handle
 
     input_expect_steps = []
     for expectation_def in inout_def.expectations:
-        with state.push_tags(expectation=expectation_def.name):
+        with plan_builder.push_tags(expectation=expectation_def.name):
             expect_step = create_expectation_step(
-                state=state,
+                plan_builder=plan_builder,
                 solid=solid,
                 expectation_def=expectation_def,
                 key='{solid}.{desc_key}.{inout_name}.expectation.{expectation_name}'.format(
@@ -77,7 +77,7 @@ def create_expectations_subplan(state, solid, inout_def, prev_step_output_handle
             input_expect_steps.append(expect_step)
 
     return create_joining_subplan(
-        state,
+        plan_builder,
         solid,
         '{solid}.{desc_key}.{inout_name}.expectations.join'.format(
             solid=solid.name, desc_key=inout_def.descriptive_key, inout_name=inout_def.name
@@ -88,9 +88,9 @@ def create_expectations_subplan(state, solid, inout_def, prev_step_output_handle
 
 
 def create_expectation_step(
-    state, solid, expectation_def, key, kind, prev_step_output_handle, inout_def
+    plan_builder, solid, expectation_def, key, kind, prev_step_output_handle, inout_def
 ):
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(expectation_def, 'input_expct_def', ExpectationDefinition)
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
@@ -113,20 +113,20 @@ def create_expectation_step(
         ),
         kind=kind,
         solid=solid,
-        tags=state.get_tags(),
+        tags=plan_builder.get_tags(),
     )
 
 
-def decorate_with_expectations(execution_info, state, solid, transform_step, output_def):
+def decorate_with_expectations(execution_info, plan_builder, solid, transform_step, output_def):
     check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(transform_step, 'transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)
 
     if execution_info.environment.expectations.evaluate and output_def.expectations:
         return create_expectations_subplan(
-            state,
+            plan_builder,
             solid,
             output_def,
             StepOutputHandle(transform_step, output_def.name),

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -10,15 +10,15 @@ from .objects import (
     StepOutput,
     StepOutputHandle,
     StepKind,
-    StepBuilderState,
+    PlanBuilder,
 )
 
 INPUT_THUNK_OUTPUT = 'input_thunk_output'
 
 
-def _create_input_thunk_execution_step(state, solid, input_def, config_value):
+def _create_input_thunk_execution_step(plan_builder, solid, input_def, config_value):
     check.invariant(input_def.runtime_type.input_schema)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
 
     def _fn(_context, _step, _inputs):
         value = input_def.runtime_type.input_schema.construct_from_config_value(config_value)
@@ -31,13 +31,13 @@ def _create_input_thunk_execution_step(state, solid, input_def, config_value):
         compute_fn=_fn,
         kind=StepKind.INPUT_THUNK,
         solid=solid,
-        tags=state.get_tags(),
+        tags=plan_builder.get_tags(),
     )
 
 
-def create_input_thunk_execution_step(info, state, solid, input_def, value):
+def create_input_thunk_execution_step(info, plan_builder, solid, input_def, value):
     check.inst_param(info, 'info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
@@ -56,5 +56,5 @@ def create_input_thunk_execution_step(info, state, solid, input_def, value):
             )
         )
 
-    input_thunk = _create_input_thunk_execution_step(state, solid, input_def, value)
+    input_thunk = _create_input_thunk_execution_step(plan_builder, solid, input_def, value)
     return StepOutputHandle(input_thunk, INPUT_THUNK_OUTPUT)

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -1,19 +1,12 @@
 from dagster import check
 from dagster.core.definitions import Result
-from .objects import (
-    ExecutionStep,
-    StepBuilderState,
-    StepInput,
-    StepKind,
-    StepOutput,
-    StepOutputHandle,
-)
+from .objects import ExecutionStep, PlanBuilder, StepInput, StepKind, StepOutput, StepOutputHandle
 
 UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
 
 
-def create_unmarshal_input_step(state, step, step_input, marshalling_key):
-    check.inst_param(state, 'state', StepBuilderState)
+def create_unmarshal_input_step(plan_builder, step, step_input, marshalling_key):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_input, 'step_input', StepInput)
     check.str_param(marshalling_key, 'marshalling_key')
@@ -36,7 +29,7 @@ def create_unmarshal_input_step(state, step, step_input, marshalling_key):
             compute_fn=_compute_fn,
             kind=StepKind.UNMARSHAL_INPUT,
             solid=step.solid,
-            tags=state.get_tags(),
+            tags=plan_builder.get_tags(),
         ),
         UNMARSHAL_INPUT_OUTPUT,
     )
@@ -45,8 +38,8 @@ def create_unmarshal_input_step(state, step, step_input, marshalling_key):
 MARSHAL_OUTPUT_INPUT = 'marshal-output-input'
 
 
-def create_marshal_output_step(state, step, step_output, marshalling_key):
-    check.inst_param(state, 'state', StepBuilderState)
+def create_marshal_output_step(plan_builder, step, step_output, marshalling_key):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_output, 'step_output', StepOutput)
     check.str_param(marshalling_key, 'marshalling_key')
@@ -73,5 +66,5 @@ def create_marshal_output_step(state, step, step_output, marshalling_key):
         compute_fn=_compute_fn,
         kind=StepKind.MARSHAL_OUTPUT,
         solid=step.solid,
-        tags=state.get_tags(),
+        tags=plan_builder.get_tags(),
     )

--- a/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
@@ -8,7 +8,7 @@ from .objects import (
     ExecutionPlanInfo,
     ExecutionStep,
     ExecutionValueSubplan,
-    StepBuilderState,
+    PlanBuilder,
     StepInput,
     StepOutput,
     StepKind,
@@ -41,9 +41,9 @@ def configs_for_output(solid, solid_config, output_def):
             yield output_spec
 
 
-def decorate_with_output_materializations(execution_info, state, solid, output_def, subplan):
+def decorate_with_output_materializations(execution_info, plan_builder, solid, output_def, subplan):
     check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(output_def, 'output_def', OutputDefinition)
     check.inst_param(subplan, 'subplan', ExecutionValueSubplan)
@@ -76,12 +76,12 @@ def decorate_with_output_materializations(execution_info, state, solid, output_d
                 kind=StepKind.MATERIALIZATION_THUNK,
                 solid=solid,
                 compute_fn=_create_materialization_lambda(output_def.runtime_type, output_spec),
-                tags=state.get_tags(),
+                tags=plan_builder.get_tags(),
             )
         )
 
     return create_joining_subplan(
-        state,
+        plan_builder,
         solid,
         '{solid}.materialization.output.{output}.join'.format(
             solid=solid.name, output=output_def.name

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -273,7 +273,7 @@ class StepOutputMap(dict):
 # step_output_map maps logical solid outputs (solid_name, output_name) to particular
 # step outputs. This covers the case where a solid maps to multiple steps
 # and one wants to be able to attach to the logical output of a solid during execution
-class StepBuilderState:
+class PlanBuilder:
     def __init__(self, pipeline_name, initial_tags=None):
         self.steps = []
         self.step_output_map = StepOutputMap()

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -52,8 +52,8 @@ class ExecutionPlanSubsetInfo(
         check_two_dim_dict(inputs, 'inputs', key_type=str)
 
         def _create_injected_value_factory_fn(input_value):
-            return lambda state, step, step_input: create_value_thunk_step(
-                state=state,
+            return lambda plan_builder, step, step_input: create_value_thunk_step(
+                plan_builder=plan_builder,
                 solid=step.solid,
                 runtime_type=step_input.runtime_type,
                 step_key='{step_key}.input.{input_name}.value'.format(
@@ -87,8 +87,8 @@ class ExecutionPlanSubsetInfo(
         input_step_factory_fns = defaultdict(dict)
 
         def _create_unmarshal_input_factory_fn(marshalling_key):
-            return lambda state, step, step_input: create_unmarshal_input_step(
-                state, step, step_input, marshalling_key
+            return lambda plan_builder, step, step_input: create_unmarshal_input_step(
+                plan_builder, step, step_input, marshalling_key
             )
 
         for step_key, input_marshal_dict in marshalled_inputs.items():
@@ -175,8 +175,8 @@ class ExecutionPlanAddedOutputs(
         output_step_factory_fns = defaultdict(list)
 
         def _create_marshal_output_fn(key):
-            return lambda state, step, step_output: create_marshal_output_step(
-                state, step, step_output, key
+            return lambda plan_builder, step, step_output: create_marshal_output_step(
+                plan_builder, step, step_output, key
             )
 
         for step_key, outputs_for_step in marshalled_outputs.items():

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -3,19 +3,12 @@ from dagster.core.definitions import Result, Solid, TransformExecutionInfo
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution_context import RuntimeExecutionContext
 
-from .objects import (
-    ExecutionPlanInfo,
-    ExecutionStep,
-    StepBuilderState,
-    StepInput,
-    StepKind,
-    StepOutput,
-)
+from .objects import ExecutionPlanInfo, ExecutionStep, PlanBuilder, StepInput, StepKind, StepOutput
 
 
-def create_transform_step(execution_info, state, solid, step_inputs, conf):
+def create_transform_step(execution_info, plan_builder, solid, step_inputs, conf):
     check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.list_param(step_inputs, 'step_inputs', of_type=StepInput)
 
@@ -31,7 +24,7 @@ def create_transform_step(execution_info, state, solid, step_inputs, conf):
         ),
         kind=StepKind.TRANSFORM,
         solid=solid,
-        tags=state.get_tags(),
+        tags=plan_builder.get_tags(),
     )
 
 

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -9,7 +9,7 @@ from .objects import (
     StepOutput,
     StepOutputHandle,
     StepKind,
-    StepBuilderState,
+    PlanBuilder,
 )
 
 JOIN_OUTPUT = 'join_output'
@@ -19,8 +19,8 @@ def __join_lambda(_context, _step, inputs):
     yield Result(output_name=JOIN_OUTPUT, value=list(inputs.values())[0])
 
 
-def create_join_step(state, solid, step_key, prev_steps, prev_output_name):
-    check.inst_param(state, 'state', StepBuilderState)
+def create_join_step(plan_builder, solid, step_key, prev_steps, prev_output_name):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.str_param(step_key, 'step_key')
     check.list_param(prev_steps, 'prev_steps', of_type=ExecutionStep)
@@ -48,11 +48,13 @@ def create_join_step(state, solid, step_key, prev_steps, prev_output_name):
         compute_fn=__join_lambda,
         kind=StepKind.JOIN,
         solid=solid,
-        tags=state.get_tags(),
+        tags=plan_builder.get_tags(),
     )
 
 
-def create_joining_subplan(state, solid, join_step_key, parallel_steps, parallel_step_output):
+def create_joining_subplan(
+    plan_builder, solid, join_step_key, parallel_steps, parallel_step_output
+):
     '''
     This captures a common pattern of fanning out a single value to N steps,
     where each step has similar structure. The strict requirement here is that each step
@@ -65,7 +67,7 @@ def create_joining_subplan(state, solid, join_step_key, parallel_steps, parallel
     to be seen if there should be any work or verification done in this step, especially
     in multi-process environments that require persistence between steps.
     '''
-    check.inst_param(state, 'state', StepBuilderState)
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.str_param(join_step_key, 'join_step_key')
     check.list_param(parallel_steps, 'parallel_steps', of_type=ExecutionStep)
@@ -74,7 +76,9 @@ def create_joining_subplan(state, solid, join_step_key, parallel_steps, parallel
     for parallel_step in parallel_steps:
         check.invariant(parallel_step.has_step_output(parallel_step_output))
 
-    join_step = create_join_step(state, solid, join_step_key, parallel_steps, parallel_step_output)
+    join_step = create_join_step(
+        plan_builder, solid, join_step_key, parallel_steps, parallel_step_output
+    )
 
     output_name = join_step.step_outputs[0].name
     return ExecutionValueSubplan(
@@ -85,8 +89,8 @@ def create_joining_subplan(state, solid, join_step_key, parallel_steps, parallel
 VALUE_OUTPUT = 'value_output'
 
 
-def create_value_thunk_step(state, solid, runtime_type, step_key, value):
-    check.inst_param(state, 'state', StepBuilderState)
+def create_value_thunk_step(plan_builder, solid, runtime_type, step_key, value):
+    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(runtime_type, 'runtime_type', RuntimeType)
     check.str_param(step_key, 'step_key')
@@ -102,7 +106,7 @@ def create_value_thunk_step(state, solid, runtime_type, step_key, value):
             compute_fn=_fn,
             kind=StepKind.VALUE_THUNK,
             solid=solid,
-            tags=state.get_tags(),
+            tags=plan_builder.get_tags(),
         ),
         VALUE_OUTPUT,
     )

--- a/python_modules/dagster/dagster_tests/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_compute_nodes.py
@@ -19,7 +19,7 @@ from dagster.core.execution_plan.create import (
     create_execution_plan_from_steps,
 )
 
-from dagster.core.execution_plan.objects import ExecutionStep, StepKind, StepBuilderState
+from dagster.core.execution_plan.objects import ExecutionStep, StepKind, PlanBuilder
 
 from dagster.core.execution_plan.simple_engine import execute_step
 
@@ -82,7 +82,7 @@ def test_duplicate_steps():
                     lambda *args, **kwargs: None,
                     StepKind.TRANSFORM,
                     foo,
-                    StepBuilderState(
+                    PlanBuilder(
                         pipeline_name='dummy',
                         initial_tags=dict(
                             pipeline='dummy', solid='dummy', solid_definition='dummy'
@@ -96,7 +96,7 @@ def test_duplicate_steps():
                     lambda *args, **kwargs: None,
                     StepKind.TRANSFORM,
                     foo,
-                    StepBuilderState(
+                    PlanBuilder(
                         pipeline_name='dummy',
                         initial_tags=dict(
                             pipeline='dummy', solid='dummy', solid_definition='dummy'


### PR DESCRIPTION
I renamed these classes in the Execution Plan Sequencing branch and I think they are a better, so renaming here in order to ease merge pain.