### PR TITLE
StepOutputValue instead of Result

### DIFF
--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -5,7 +5,6 @@ from dagster.core.definitions import (
     ExpectationExecutionInfo,
     InputDefinition,
     OutputDefinition,
-    Result,
     Solid,
 )
 
@@ -18,6 +17,7 @@ from .objects import (
     StepInput,
     StepOutput,
     StepOutputHandle,
+    StepOutputValue,
     StepKind,
     PlanBuilder,
 )
@@ -42,7 +42,7 @@ def _create_expectation_lambda(solid, inout_def, expectation_def, internal_outpu
             context.debug(
                 'Expectation {key} succeeded on {value}.'.format(key=step.key, value=value)
             )
-            yield Result(output_name=internal_output_name, value=inputs[EXPECTATION_INPUT])
+            yield StepOutputValue(output_name=internal_output_name, value=inputs[EXPECTATION_INPUT])
         else:
             context.debug('Expectation {key} failed on {value}.'.format(key=step.key, value=value))
             raise DagsterExpectationFailedError(info, value)

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.core.definitions import InputDefinition, Result, Solid
+from dagster.core.definitions import InputDefinition, Solid
 
 from dagster.core.errors import DagsterInvariantViolationError
 
@@ -9,6 +9,7 @@ from .objects import (
     ExecutionStep,
     StepOutput,
     StepOutputHandle,
+    StepOutputValue,
     StepKind,
     PlanBuilder,
 )
@@ -22,7 +23,7 @@ def _create_input_thunk_execution_step(plan_builder, solid, input_def, config_va
 
     def _fn(_context, _step, _inputs):
         value = input_def.runtime_type.input_schema.construct_from_config_value(config_value)
-        yield Result(value, INPUT_THUNK_OUTPUT)
+        yield StepOutputValue(output_name=INPUT_THUNK_OUTPUT, value=value)
 
     return ExecutionStep(
         key=solid.name + '.' + input_def.name + '.input_thunk',

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -1,6 +1,13 @@
 from dagster import check
-from dagster.core.definitions import Result
-from .objects import ExecutionStep, PlanBuilder, StepInput, StepKind, StepOutput, StepOutputHandle
+from .objects import (
+    ExecutionStep,
+    PlanBuilder,
+    StepInput,
+    StepKind,
+    StepOutput,
+    StepOutputHandle,
+    StepOutputValue,
+)
 
 UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
 
@@ -12,11 +19,11 @@ def create_unmarshal_input_step(plan_builder, step, step_input, marshalling_key)
     check.str_param(marshalling_key, 'marshalling_key')
 
     def _compute_fn(context, _step, _inputs):
-        yield Result(
-            context.persistence_policy.read_value(
+        yield StepOutputValue(
+            output_name=UNMARSHAL_INPUT_OUTPUT,
+            value=context.persistence_policy.read_value(
                 step_input.runtime_type.serialization_strategy, marshalling_key
             ),
-            UNMARSHAL_INPUT_OUTPUT,
         )
 
     return StepOutputHandle(

--- a/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.core.definitions import Result, Solid, OutputDefinition
+from dagster.core.definitions import Solid, OutputDefinition
 
 from dagster.core.types.runtime import RuntimeType
 
@@ -11,6 +11,7 @@ from .objects import (
     PlanBuilder,
     StepInput,
     StepOutput,
+    StepOutputValue,
     StepKind,
 )
 
@@ -27,7 +28,7 @@ def _create_materialization_lambda(runtime_type, config_spec):
     def _fn(_info, _step, inputs):
         runtime_value = inputs[MATERIALIZATION_THUNK_INPUT]
         runtime_type.output_schema.materialize_runtime_value(config_spec, runtime_value)
-        yield Result(runtime_value, MATERIALIZATION_THUNK_OUTPUT)
+        yield StepOutputValue(output_name=MATERIALIZATION_THUNK_OUTPUT, value=runtime_value)
 
     return _fn
 

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -15,6 +15,13 @@ from dagster.core.execution_context import RuntimeExecutionContext
 from dagster.core.types.runtime import RuntimeType
 
 
+class StepOutputValue(namedtuple('_StepOutputValue', 'output_name value')):
+    def __new__(cls, output_name, value):
+        return super(StepOutputValue, cls).__new__(
+            cls, output_name=check.str_param(output_name, 'output_name'), value=value
+        )
+
+
 class StepOutputHandle(namedtuple('_StepOutputHandle', 'step output_name')):
     def __new__(cls, step, output_name):
         return super(StepOutputHandle, cls).__new__(

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -108,6 +108,7 @@ def execute_step(step, context, inputs):
 def _error_check_results(step, step_output_values):
     check.inst_param(step, 'step', ExecutionStep)
     check.list_param(step_output_values, 'step_output_values', of_type=StepOutputValue)
+
     seen_outputs = set()
     for step_output_value in step_output_values:
         if not step.has_step_output(step_output_value.output_name):

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -3,7 +3,15 @@ from dagster.core.definitions import Result, Solid, TransformExecutionInfo
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution_context import RuntimeExecutionContext
 
-from .objects import ExecutionPlanInfo, ExecutionStep, PlanBuilder, StepInput, StepKind, StepOutput
+from .objects import (
+    ExecutionPlanInfo,
+    ExecutionStep,
+    PlanBuilder,
+    StepInput,
+    StepKind,
+    StepOutput,
+    StepOutputValue,
+)
 
 
 def create_transform_step(execution_info, plan_builder, solid, step_inputs, conf):
@@ -37,8 +45,8 @@ def _yield_transform_results(execution_info, context, step, conf, inputs):
         raise DagsterInvariantViolationError(
             (
                 'Transform for solid {solid_name} returned a Result rather than '
-                + 'yielding it. The transform_fn of the core SolidDefinition must yield '
-                + 'its results'
+                'yielding it. The transform_fn of the core SolidDefinition must yield '
+                'its results'
             ).format(solid_name=step.solid.name)
         )
 
@@ -50,7 +58,7 @@ def _yield_transform_results(execution_info, context, step, conf, inputs):
             raise DagsterInvariantViolationError(
                 (
                     'Transform for solid {solid_name} yielded {result} rather an '
-                    + 'an instance of the Result class.'
+                    'an instance of the Result class.'
                 ).format(result=repr(result), solid_name=step.solid.name)
             )
 
@@ -59,7 +67,7 @@ def _yield_transform_results(execution_info, context, step, conf, inputs):
                 solid=step.solid.name, output=result.output_name, value=repr(result.value)
             )
         )
-        yield result
+        yield StepOutputValue(output_name=result.output_name, value=result.value)
 
 
 def _execute_core_transform(execution_info, context, step, conf, inputs):

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -1,5 +1,5 @@
 from dagster import check
-from dagster.core.definitions import Result, Solid
+from dagster.core.definitions import Solid
 from dagster.core.types.runtime import RuntimeType
 
 from .objects import (
@@ -8,6 +8,7 @@ from .objects import (
     StepInput,
     StepOutput,
     StepOutputHandle,
+    StepOutputValue,
     StepKind,
     PlanBuilder,
 )
@@ -16,7 +17,7 @@ JOIN_OUTPUT = 'join_output'
 
 
 def __join_lambda(_context, _step, inputs):
-    yield Result(output_name=JOIN_OUTPUT, value=list(inputs.values())[0])
+    yield StepOutputValue(output_name=JOIN_OUTPUT, value=list(inputs.values())[0])
 
 
 def create_join_step(plan_builder, solid, step_key, prev_steps, prev_output_name):
@@ -96,7 +97,7 @@ def create_value_thunk_step(plan_builder, solid, runtime_type, step_key, value):
     check.str_param(step_key, 'step_key')
 
     def _fn(_context, _step, _inputs):
-        yield Result(value, VALUE_OUTPUT)
+        yield StepOutputValue(output_name=VALUE_OUTPUT, value=value)
 
     return StepOutputHandle(
         ExecutionStep(


### PR DESCRIPTION
We were using the user-facing Result object as an internal object within the execution engine, which got confusing. It's better to have a separate structure. We're going to change the form of reporting execution results, so this is a first step to that.