### PR TITLE
Rename StepResult to ExecutionStepEvent

### DIFF
--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -500,7 +500,9 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     # Once this issue is resolve we should be able to eliminate this
     except DagsterUserCodeExecutionError as ducee:
         return EitherError(
-            type_of('PythonError')(serializable_error_info_from_exc_info(ducee.original_exc_info))
+            _type_of(args, 'PythonError')(
+                serializable_error_info_from_exc_info(ducee.original_exc_info)
+            )
         )
 
     check.failed('Should not get here')

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -8,6 +8,7 @@ from graphql.execution.base import ResolveInfo
 
 from dagster import ExecutionMetadata, check
 from dagster.core.definitions.environment_configs import construct_environment_config
+from dagster.core.execution_plan.objects import ExecutionStepEvent
 from dagster.core.execution_plan.plan_subset import MarshalledOutput
 
 from dagster.core.errors import (
@@ -28,6 +29,8 @@ from dagster.core.types.evaluator import evaluate_config_value, EvaluateValueRes
 from dagster.utils.error import serializable_error_info_from_exc_info
 
 from .config_types import to_dauphin_config_type
+from .errors import DauphinStepSuccessResult, DauphinStepFailureResult
+from .execution import DauphinExecutionStep
 from .pipelines import DauphinPipeline
 from .runtime_types import to_dauphin_runtime_type
 from .utils import EitherValue, EitherError
@@ -418,6 +421,25 @@ def _execution_plan_or_error(subplan_execution_args, dauphin_pipeline, evaluate_
         return EitherValue(execution_plan)
 
 
+def _create_dauphin_step_event(step_event):
+    check.inst_param(step_event, 'step_event', ExecutionStepEvent)
+    if step_event.is_successful_output:
+        return DauphinStepSuccessResult(
+            success=step_event.is_successful_output,
+            step=DauphinExecutionStep(step_event.step),
+            output_name=step_event.success_data.output_name,
+            value_repr=repr(step_event.success_data.value),
+        )
+    elif step_event.is_step_failure:
+        return DauphinStepFailureResult(
+            success=step_event.is_successful_output,
+            step=DauphinExecutionStep(step_event.step),
+            error_message=str(step_event.failure_data.dagster_error),
+        )
+    else:
+        check.failed('{step_event} unsupported'.format(step_event=step_event))
+
+
 def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_value_result):
     check.inst_param(args, 'args', SubplanExecutionArgs)
     check.inst_param(dauphin_pipeline, 'dauphin_pipeline', DauphinPipeline)
@@ -428,10 +450,12 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     # type_of retrieves a dauphin type class based on graphql type name
     type_of = args.info.schema.type_named
     # step_of retrives the step associated with an error object
-    step_of = lambda error: execution_plan.get_step_by_key(error.step_key)
+    dauphin_step_of = lambda error: DauphinExecutionStep(
+        execution_plan.get_step_by_key(error.step_key)
+    )
 
     try:
-        results = execute_externalized_plan(
+        step_events = execute_externalized_plan(
             pipeline=dauphin_pipeline.get_dagster_pipeline(),
             execution_plan=execution_plan,
             step_keys=args.step_keys,
@@ -442,35 +466,16 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
             throw_on_user_error=False,
         )
 
-        has_failures = False
-        dauphin_step_results = []
-        for result in results:
-            if not result.success:
-                has_failures = True
-
-            dauphin_step_results.append(
-                type_of('StepSuccessResult')(
-                    success=result.success,
-                    step=type_of('ExecutionStep')(result.step),
-                    output_name=result.success_data.output_name,
-                    value_repr=repr(result.success_data.value),
-                )
-                if result.success
-                else type_of('StepFailureResult')(
-                    success=result.success,
-                    step=type_of('ExecutionStep')(result.step),
-                    error_message=str(result.failure_data.dagster_error),
-                )
-            )
-
         return type_of('StartSubplanExecutionSuccess')(
-            pipeline=dauphin_pipeline, has_failures=has_failures, step_results=dauphin_step_results
+            pipeline=dauphin_pipeline,
+            has_failures=any(se for se in step_events if se.is_step_failure),
+            step_results=list(map(_create_dauphin_step_event, step_events)),
         )
 
     except DagsterInvalidSubplanExecutionError as invalid_subplan_error:
         return EitherError(
             type_of('InvalidSubplanExecutionError')(
-                step=type_of('ExecutionStep')(step_of(invalid_subplan_error)),
+                step=dauphin_step_of(invalid_subplan_error),
                 missing_input_name=invalid_subplan_error.input_name,
             )
         )
@@ -478,7 +483,7 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     except DagsterUnmarshalInputNotFoundError as input_not_found_error:
         return EitherError(
             type_of('StartSubplanExecutionInvalidInputError')(
-                step=type_of('ExecutionStep')(step_of(input_not_found_error)),
+                step=dauphin_step_of(input_not_found_error),
                 invalid_input_name=input_not_found_error.input_name,
             )
         )
@@ -486,7 +491,7 @@ def _execute_subplan_or_error(args, dauphin_pipeline, execution_plan, evaluate_v
     except DagsterMarshalOutputNotFoundError as output_not_found_error:
         return EitherError(
             type_of('StartSubplanExecutionInvalidOutputError')(
-                step=type_of('ExecutionStep')(step_of(output_not_found_error)),
+                step=dauphin_step_of(output_not_found_error),
                 invalid_output_name=output_not_found_error.output_name,
             )
         )

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -45,11 +45,11 @@ def test_execution_plan_simple_two_steps():
     assert len(step_results) == 2
 
     assert step_results[0].step.key == 'return_one.transform'
-    assert step_results[0].success
+    assert step_results[0].is_successful_output
     assert step_results[0].success_data.value == 1
 
     assert step_results[1].step.key == 'add_one.transform'
-    assert step_results[1].success
+    assert step_results[1].is_successful_output
     assert step_results[1].success_data.value == 2
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_compute_nodes.py
@@ -21,7 +21,7 @@ from dagster.core.execution_plan.create import (
 
 from dagster.core.execution_plan.objects import ExecutionStep, StepKind, PlanBuilder
 
-from dagster.core.execution_plan.simple_engine import execute_step
+from dagster.core.execution_plan.simple_engine import iterate_step_events_for_step
 
 from dagster.utils.test import create_test_runtime_execution_context
 
@@ -51,9 +51,11 @@ def test_compute_noop_node_core():
 
     assert len(plan.steps) == 1
 
-    outputs = list(execute_step(plan.steps[0], create_test_runtime_execution_context(), {}))
+    events = list(
+        iterate_step_events_for_step(plan.steps[0], create_test_runtime_execution_context(), {})
+    )
 
-    assert outputs[0].success_data.value == 'foo'
+    assert events[0].success_data.value == 'foo'
 
 
 def test_compute_noop_node():
@@ -62,9 +64,11 @@ def test_compute_noop_node():
     plan = create_execution_plan(pipeline)
 
     assert len(plan.steps) == 1
-    outputs = list(execute_step(plan.steps[0], create_test_runtime_execution_context(), {}))
+    events = list(
+        iterate_step_events_for_step(plan.steps[0], create_test_runtime_execution_context(), {})
+    )
 
-    assert outputs[0].success_data.value == 'foo'
+    assert events[0].success_data.value == 'foo'
 
 
 def test_duplicate_steps():

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20314,7 +20314,7 @@ node. For the ‘synchronous’ API, see <a class="reference internal" href="#da
 
 <dl class="class">
 <dt id="dagster.SolidExecutionResult">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">SolidExecutionResult</code><span class="sig-paren">(</span><em>context</em>, <em>solid</em>, <em>step_results_by_kind</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.SolidExecutionResult" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">SolidExecutionResult</code><span class="sig-paren">(</span><em>context</em>, <em>solid</em>, <em>step_events_by_kind</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.SolidExecutionResult" title="Permalink to this definition">¶</a></dt>
 <dd><p>Execution result for one solid of the pipeline.</p>
 <dl class="attribute">
 <dt id="dagster.SolidExecutionResult.context">


### PR DESCRIPTION
Result was actually a really confusing name for this. When one executions an execution plan what you are getting is a stream of events. In this case the event is either a successful output of a single output or a failure of an *entire* step. I think this makes that much more clear.