### PR TITLE
Refactor Normal and InNotebook Execution Infos

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -10,6 +10,8 @@ from dagster.core.execution import (
 
 from dagster.core.execution_context import ExecutionContext, ExecutionMetadata
 
+from dagster.core.execution_plan.transform import TransformExecutionInfo
+
 from dagster.core.definitions import (
     ContextCreationExecutionInfo,
     DependencyDefinition,
@@ -24,7 +26,6 @@ from dagster.core.definitions import (
     Result,
     SolidDefinition,
     SolidInstance,
-    TransformExecutionInfo,
 )
 
 from dagster.core.definitions.resource import ResourceDefinition, resource

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -10,7 +10,7 @@ from .dependency import (
 
 from .expectation import ExpectationDefinition, ExpectationResult
 
-from .infos import ContextCreationExecutionInfo, ExpectationExecutionInfo, TransformExecutionInfo
+from .infos import ContextCreationExecutionInfo, ExpectationExecutionInfo
 
 from .input import InputDefinition
 

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -216,6 +216,26 @@ class RuntimeExecutionContext:
         return self._environment_config
 
 
+class DagsterLog:
+    def __init__(self, context):
+        self.context = context
+
+    def debug(self, msg, **kwargs):
+        return self.context.debug(msg, **kwargs)
+
+    def info(self, msg, **kwargs):
+        return self.context.info(msg, **kwargs)
+
+    def warning(self, msg, **kwargs):
+        return self.context.warning(msg, **kwargs)
+
+    def error(self, msg, **kwargs):
+        return self.context.error(msg, **kwargs)
+
+    def critical(self, msg, **kwargs):
+        return self.context.critical(msg, **kwargs)
+
+
 class ExecutionMetadata(namedtuple('_ExecutionMetadata', 'run_id tags event_callback loggers')):
     def __new__(cls, run_id=None, tags=None, event_callback=None, loggers=None):
         return super(ExecutionMetadata, cls).__new__(


### PR DESCRIPTION
With the dagstermill we loosened some of the constraints on TransformExecutionInfo in order for the in-notebook case to work. This more explicitly separates out those use cases so that the common case is still as constrained (e.g. you can always access step, solid etc) and the in-notebook case is special. 

So we introduce a new abstract base class ITransformExecutionInfo, have the normal TransformExecutionInfo, and then introduce DagstermillInNotebookExecutionInfo. This way we can provide very explicit error messages as well.

As I was doing this i also noticed what is a bug in context management in dagstermill. See issue here https://github.com/dagster-io/dagster/issues/796