### PR TITLE
Info --> Context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@
       - The `info` object passed to transform functions has been renamed to `context`. All fields that were previously
         available on the `info.context` object are now hoisted to the top level `context` object. Additionally an alias
         for `config` has been introduced: `solid_config`. So where you would have written `info.config` it is now
-        `context.solid_config` Logging should be done with the top-level property `context.log`.
+        `context.solid_config` Logging should be done with the top-level property `context.log`. The `context`
+        and `config` properies on this new context object are deprecated, will warn for now, and be eliminated
+        when 0.4.0 is released.
 
    - GraphQL Schema Changes
       - `StepResult` has been renamed to `StepEvent`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,22 @@
+0.3.2
+
+   - New features
+      - Link to output notebook rendered in dagit when dagstermill solids are executed.
+
+   - API Additions and changes
+      - The `info` object passed to transform functions has been renamed to `context`. All fields that were previously
+        available on the `info.context` object are now hoisted to the top level `context` object. Additionally an alias
+        for `config` has been introduced: `solid_config`. So where you would have written `info.config` it is now
+        `context.solid_config` Logging should be done with the top-level property `context.log`.
+
+   - GraphQL Schema Changes
+      - `StepResult` has been renamed to `StepEvent`.
+      - `stepResults` property on `startSubplanExecution` has been renamed to `stepEvents`.
+      - `StepSuccessResult` is now `SuccessfulStepOutputEvent`
+      - `StepFailureResult` is now `StepFailureEvent`
+      - Added `UNMARSHAL_INPUT` and `MARSHAL_OUTPUT` values to the `StepKind` enumeration. Marshalling steps are now
+        implemented as execution steps themselves.
+
 
 0.3.1
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,19 +4,19 @@
       - Link to output notebook rendered in dagit when dagstermill solids are executed.
 
    - API Additions and changes
-      - The `info` object passed to transform functions has been renamed to `context`. All fields that were previously
-        available on the `info.context` object are now hoisted to the top level `context` object. Additionally an alias
-        for `config` has been introduced: `solid_config`. So where you would have written `info.config` it is now
-        `context.solid_config` Logging should be done with the top-level property `context.log`. The `context`
-        and `config` properies on this new context object are deprecated, will warn for now, and be eliminated
+      - The ``info`` object passed to transform functions has been renamed to ``context``. All fields that were previously
+        available on the ``info.context`` object are now hoisted to the top level ``context`` object. Additionally an alias
+        for ``config`` has been introduced: ``solid_config``. So where you would have written ``info.config`` it is now
+        ``context.solid_config`` Logging should be done with the top-level property ``context.log``. The ``context``
+        and ``config`` properies on this new context object are deprecated, will warn for now, and be eliminated
         when 0.4.0 is released.
 
    - GraphQL Schema Changes
-      - `StepResult` has been renamed to `StepEvent`.
-      - `stepResults` property on `startSubplanExecution` has been renamed to `stepEvents`.
-      - `StepSuccessResult` is now `SuccessfulStepOutputEvent`
-      - `StepFailureResult` is now `StepFailureEvent`
-      - Added `UNMARSHAL_INPUT` and `MARSHAL_OUTPUT` values to the `StepKind` enumeration. Marshalling steps are now
+      - ``StepResult`` has been renamed to ``StepEvent``.
+      - ``stepResults`` property on ``startSubplanExecution`` has been renamed to ``stepEvents``.
+      - ``StepSuccessResult`` is now ``SuccessfulStepOutputEvent``
+      - ``StepFailureResult`` is now ``StepFailureEvent``
+      - Added ``UNMARSHAL_INPUT`` and ``MARSHAL_OUTPUT`` values to the ``StepKind`` enumeration. Marshalling steps are now
         implemented as execution steps themselves.
 
 
@@ -37,7 +37,7 @@
    - API Additions and Changes
       - New decorated-based @resource API as a more concise alternative to ResourceDefinition
       - Dagster config type system now supports enum types. (dagster.Enum and dagster.EnumType) 
-      - New top level properties `resources` and `log` on info.
+      - New top level properties ``resources`` and ``log`` on info.
       - The context stack in RuntimeExecutionContext is no longer modify-able by the user during a transform. It has been renamed to 'tags'.
       - ReentrantInfo has been renamed to ExecutionMetadata
 

--- a/python_modules/dagma/dagma/engine.py
+++ b/python_modules/dagma/dagma/engine.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 import cloudpickle as pickle
 
 from dagster import check
-from dagster.core.execution_context import RuntimeExecutionContext
+from dagster.core.execution_context import LegacyRuntimeExecutionContext
 from dagster.core.execution_plan.objects import ExecutionPlan
 from dagster.utils.zip import zip_folder
 
@@ -147,7 +147,7 @@ def _execute_step_sync(lambda_client, lambda_step, context, payload):
 
 def execute_plan(context, execution_plan, cleanup_lambda_functions=True, local=False):
     """Core executor."""
-    check.inst_param(context, 'context', RuntimeExecutionContext)
+    check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
 
     steps = list(execution_plan.topological_steps())

--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -6,7 +6,7 @@ import boto3
 from io import BytesIO
 
 from dagster import check
-from dagster.core.execution_context import RuntimeExecutionContext
+from dagster.core.execution_context import LegacyRuntimeExecutionContext
 from dagster.core.execution_plan.objects import ExecutionStepEvent
 from dagster.core.execution_plan.simple_engine import iterate_step_events_for_step
 
@@ -52,7 +52,7 @@ def aws_lambda_handler(event, _context):
     logger.info('Looking for resources at %s/%s', s3_bucket, s3_key_resources)
     resources_object = s3.get_object(Bucket=s3_bucket, Key=s3_key_resources)
     resources = deserialize(resources_object['Body'].read())
-    execution_context = RuntimeExecutionContext(run_id, loggers=[logger], resources=resources)
+    execution_context = LegacyRuntimeExecutionContext(run_id, loggers=[logger], resources=resources)
 
     logger.info('Looking for step body at %s/%s', s3_bucket, s3_key_body)
     step_body_object = s3.get_object(Bucket=s3_bucket, Key=s3_key_body)

--- a/python_modules/dagster-pandas/dagster_pandas_tests/test_config_driven_df.py
+++ b/python_modules/dagster-pandas/dagster_pandas_tests/test_config_driven_df.py
@@ -24,7 +24,7 @@ def test_dataframe_csv_from_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_config(_info, df):
+    def df_as_config(_context, df):
         assert df.to_dict('list') == {'num1': [1, 3], 'num2': [2, 4]}
         called['yup'] = True
 
@@ -49,7 +49,7 @@ def test_dataframe_wrong_sep_from_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_config(_info, df):
+    def df_as_config(_context, df):
         # this is the pandas behavior
         assert df.to_dict('list') == {'num1,num2': ['1,2', '3,4']}
         called['yup'] = True
@@ -75,7 +75,7 @@ def test_dataframe_pipe_sep_csv_from_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_config(_info, df):
+    def df_as_config(_context, df):
         assert df.to_dict('list') == {'num1': [1, 3], 'num2': [2, 4]}
         called['yup'] = True
 
@@ -102,7 +102,7 @@ def test_dataframe_csv_missing_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_input(_info, df):  # pylint: disable=W0613
+    def df_as_input(_context, df):  # pylint: disable=W0613
         called['yup'] = True
 
     pipeline = PipelineDefinition(name='missing_inputs', solids=[df_as_input])
@@ -123,11 +123,11 @@ def test_dataframe_csv_missing_input_collision():
     called = {}
 
     @solid(outputs=[OutputDefinition(DataFrame)])
-    def df_as_output(_info):
+    def df_as_output(_context):
         return pd.DataFrame()
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_input(_info, df):  # pylint: disable=W0613
+    def df_as_input(_context, df):  # pylint: disable=W0613
         called['yup'] = True
 
     pipeline = PipelineDefinition(
@@ -158,7 +158,7 @@ def test_dataframe_parquet_from_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_config(_info, df):
+    def df_as_config(_context, df):
         assert df.to_dict('list') == {'num1': [1, 3], 'num2': [2, 4]}
         called['yup'] = True
 
@@ -183,7 +183,7 @@ def test_dataframe_table_from_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('df', DataFrame)])
-    def df_as_config(_info, df):
+    def df_as_config(_context, df):
         assert df.to_dict('list') == {'num1': [1, 3], 'num2': [2, 4]}
         called['yup'] = True
 
@@ -206,7 +206,7 @@ def test_dataframe_table_from_inputs():
 
 def test_dataframe_csv_materialization():
     @solid(outputs=[OutputDefinition(DataFrame)])
-    def return_df(_info):
+    def return_df(_context):
         return pd.DataFrame({'num1': [1, 3], 'num2': [2, 4]})
 
     pipeline_def = PipelineDefinition(name='return_df_pipeline', solids=[return_df])
@@ -225,7 +225,7 @@ def test_dataframe_csv_materialization():
 
 def test_dataframe_parquet_materialization():
     @solid(outputs=[OutputDefinition(DataFrame)])
-    def return_df(_info):
+    def return_df(_context):
         return pd.DataFrame({'num1': [1, 3], 'num2': [2, 4]})
 
     pipeline_def = PipelineDefinition(name='return_df_pipeline', solids=[return_df])
@@ -244,7 +244,7 @@ def test_dataframe_parquet_materialization():
 
 def test_dataframe_table_materialization():
     @solid(outputs=[OutputDefinition(DataFrame)])
-    def return_df(_info):
+    def return_df(_context):
         return pd.DataFrame({'num1': [1, 3], 'num2': [2, 4]})
 
     pipeline_def = PipelineDefinition(name='return_df_pipeline', solids=[return_df])

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/templated.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/templated.py
@@ -55,10 +55,10 @@ def _render_template_string(template_text, config_dict):
 
 
 def _create_templated_sql_transform_with_output(sql):
-    def do_transform(info, _inputs):
-        rendered_sql = _render_template_string(sql, info.config)
-        execute_sql_text_on_context(info.context, rendered_sql)
-        yield Result(info.config)
+    def do_transform(context, _inputs):
+        rendered_sql = _render_template_string(sql, context.solid_config)
+        execute_sql_text_on_context(context, rendered_sql)
+        yield Result(context.solid_config)
         yield Result(output_name='sql_text', value=rendered_sql)
 
     return do_transform

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/math_test_db.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/math_test_db.py
@@ -7,7 +7,7 @@ from dagster_sqlalchemy.common import (
     create_sql_alchemy_context_params_from_engine,
 )
 
-from dagster.utils.test import create_test_runtime_execution_context
+from dagster.utils.test import create_test_runtime_legacy_execution_context
 
 
 def create_num_table(engine, num_table_name='num_table'):
@@ -37,7 +37,7 @@ def in_mem_engine(num_table_name='num_table'):
 
 def create_sql_alchemy_context_from_engine(engine, *args, **kwargs):
     resources = DefaultSqlAlchemyResources(SqlAlchemyResource(engine))
-    context = create_test_runtime_execution_context(resources=resources, *args, **kwargs)
+    context = create_test_runtime_legacy_execution_context(resources=resources, *args, **kwargs)
     return check_supports_sql_alchemy_resource(context)
 
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_mocked_context.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_mocked_context.py
@@ -35,5 +35,5 @@ class MockEngine(sqlalchemy.engine.Engine):
 
 def test_mock():
     sa_resource = dagster_sa.SqlAlchemyResource(engine=MockEngine(), mock_sql=True)
-    context = create_sql_alchemy_context_from_sa_resource(sa_resource)
-    dagster_sa.common.execute_sql_text_on_context(context, 'NOPE')
+    legacy_context = create_sql_alchemy_context_from_sa_resource(sa_resource)
+    dagster_sa.common.execute_sql_text_on_sa_resource(legacy_context.resources.sa, 'NOPE')

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_mocked_context.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_mocked_context.py
@@ -2,7 +2,7 @@ import sqlalchemy
 
 from dagster import check
 
-from dagster.utils.test import create_test_runtime_execution_context
+from dagster.utils.test import create_test_runtime_legacy_execution_context
 
 import dagster_sqlalchemy as dagster_sa
 
@@ -16,7 +16,7 @@ from dagster_sqlalchemy.common import (
 def create_sql_alchemy_context_from_sa_resource(sa_resource, *args, **kwargs):
     check.inst_param(sa_resource, 'sa_resource', SqlAlchemyResource)
     resources = DefaultSqlAlchemyResources(sa_resource)
-    context = create_test_runtime_execution_context(resources=resources, *args, **kwargs)
+    context = create_test_runtime_legacy_execution_context(resources=resources, *args, **kwargs)
     return check_supports_sql_alchemy_resource(context)
 
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_resource_based_tests.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_resource_based_tests.py
@@ -29,16 +29,16 @@ def _is_sqlite_context(context):
     return type(raw_connection.connection).__module__ == 'sqlite3'
 
 
-def execute_sql_text_on_context(info, sql_text):
+def execute_sql_text_on_context(context, sql_text):
     # check_supports_sql_alchemy_resource(context)
     check.str_param(sql_text, 'sql_text')
 
     # if context.resources.sa.mock_sql:
     #     return
 
-    engine = info.resources.engine
+    engine = context.resources.engine
 
-    if _is_sqlite_context(info.context):
+    if _is_sqlite_context(context):
         # sqlite3 does not support multiple statements in a single
         # sql text and sqlalchemy does not abstract that away AFAICT
         # so have to hack around this
@@ -59,8 +59,8 @@ def execute_sql_text_on_context(info, sql_text):
 def _create_sql_alchemy_transform_fn(sql_text):
     check.str_param(sql_text, 'sql_text')
 
-    def transform_fn(info, _args):
-        yield Result(execute_sql_text_on_context(info, sql_text))
+    def transform_fn(context, _args):
+        yield Result(execute_sql_text_on_context(context, sql_text))
 
     return transform_fn
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -8,9 +8,12 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
 )
 
-from dagster.core.execution_context import ExecutionContext, ExecutionMetadata
-
-from dagster.core.execution_plan.transform import TransformExecutionInfo
+from dagster.core.execution_context import (
+    ExecutionContext,
+    ExecutionMetadata,
+    ITransformExecutionContext,
+    TransformExecutionContext,
+)
 
 from dagster.core.definitions import (
     ContextCreationExecutionInfo,
@@ -92,7 +95,7 @@ __all__ = [
     # Infos
     'ContextCreationExecutionInfo',
     'ExpectationExecutionInfo',
-    'TransformExecutionInfo',
+    'TransformExecutionContext',
     # Decorators
     'lambda_solid',
     'solid',

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -11,7 +11,7 @@ from dagster.core.execution import (
 from dagster.core.execution_context import (
     ExecutionContext,
     ExecutionMetadata,
-    ITransformExecutionContext,
+    TransformExecutionContextMetadata,
     TransformExecutionContext,
 )
 

--- a/python_modules/dagster/dagster/core/definitions/infos.py
+++ b/python_modules/dagster/dagster/core/definitions/infos.py
@@ -1,10 +1,8 @@
-from abc import ABCMeta, abstractproperty
 from collections import namedtuple
 
-import six
 
 from dagster import check
-from dagster.core.execution_context import RuntimeExecutionContext, DagsterLog
+from dagster.core.execution_context import LegacyRuntimeExecutionContext, DagsterLog
 
 from .dependency import Solid
 from .expectation import ExpectationDefinition
@@ -31,44 +29,10 @@ class ExpectationExecutionInfo(
     def __new__(cls, context, inout_def, solid, expectation_def):
         return super(ExpectationExecutionInfo, cls).__new__(
             cls,
-            check.inst_param(context, 'context', RuntimeExecutionContext),
+            check.inst_param(context, 'context', LegacyRuntimeExecutionContext),
             check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition)),
             check.inst_param(solid, 'solid', Solid),
             check.inst_param(expectation_def, 'expectation_def', ExpectationDefinition),
             context.resources,
             DagsterLog(context),
         )
-
-
-class ITransformExecutionInfo(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
-    @abstractproperty
-    def context(self):
-        pass
-
-    @abstractproperty
-    def config(self):
-        pass
-
-    @abstractproperty
-    def step(self):
-        pass
-
-    @abstractproperty
-    def solid_def(self):
-        pass
-
-    @abstractproperty
-    def solid(self):
-        pass
-
-    @abstractproperty
-    def pipeline_def(self):
-        pass
-
-    @abstractproperty
-    def resources(self):
-        pass
-
-    @abstractproperty
-    def log(self):
-        pass

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -35,7 +35,7 @@ class SolidDefinition(object):
 
         name (str): Name of the solid.
         input_defs (List[InputDefinition]): Inputs of the solid.
-        transform_fn (callable): Callable with the signature (**info**: `TransformExecutionInfo`,
+        transform_fn (callable): Callable with the signature (**info**: `TransformExecutionContext`,
             **inputs**: `Dict[str, Any]`) : `Iterable<Result>`
         outputs_defs (List[OutputDefinition]): Outputs of the solid.
         config_field (Field): How the solid configured.

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -36,7 +36,7 @@ from .definitions import (
 from .definitions.utils import DEFAULT_OUTPUT
 from .definitions.environment_configs import construct_environment_config, construct_context_config
 
-from .execution_context import ExecutionContext, RuntimeExecutionContext, ExecutionMetadata
+from .execution_context import ExecutionContext, LegacyRuntimeExecutionContext, ExecutionMetadata
 
 from .errors import (
     DagsterInvariantViolationError,
@@ -82,7 +82,7 @@ class PipelineExecutionResult(object):
 
     def __init__(self, pipeline, context, result_list):
         self.pipeline = check.inst_param(pipeline, 'pipeline', PipelineDefinition)
-        self.context = check.inst_param(context, 'context', RuntimeExecutionContext)
+        self.context = check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
         self.result_list = check.list_param(
             result_list, 'result_list', of_type=SolidExecutionResult
         )
@@ -126,7 +126,7 @@ class SolidExecutionResult(object):
     '''
 
     def __init__(self, context, solid, step_events_by_kind):
-        self.context = check.inst_param(context, 'context', RuntimeExecutionContext)
+        self.context = check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
         self.solid = check.inst_param(solid, 'solid', Solid)
         self.step_events_by_kind = check.dict_param(
             step_events_by_kind, 'step_events_by_kind', key_type=StepKind, value_type=list
@@ -146,7 +146,7 @@ class SolidExecutionResult(object):
 
     @staticmethod
     def from_step_events(context, step_events):
-        check.inst_param(context, 'context', RuntimeExecutionContext)
+        check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
         step_events = check.list_param(step_events, 'step_events', ExecutionStepEvent)
         if step_events:
             step_events_by_kind = defaultdict(list)
@@ -356,7 +356,7 @@ def yield_context(pipeline, environment, execution_metadata):
         ) as resources:
             loggers = _create_loggers(execution_metadata, execution_context)
 
-            yield RuntimeExecutionContext(
+            yield LegacyRuntimeExecutionContext(
                 run_id=execution_metadata.run_id,
                 loggers=loggers,
                 resources=resources,
@@ -425,7 +425,7 @@ def get_resource_or_gen(context_definition, resource_name, environment, run_id):
 def _do_iterate_pipeline(
     pipeline, context, typed_environment, execution_metadata, throw_on_user_error=True
 ):
-    check.inst(context, RuntimeExecutionContext)
+    check.inst(context, LegacyRuntimeExecutionContext)
 
     context.events.pipeline_start()
 
@@ -504,7 +504,7 @@ def execute_pipeline_iterator(
 
 
 def _process_step_events(context, pipeline, step_events):
-    check.inst_param(context, 'context', RuntimeExecutionContext)
+    check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
 
     # TODO: actually make this stream results. Right now it collects

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import logging
 import uuid
+import warnings
 
 import six
 
@@ -386,7 +387,13 @@ class TransformExecutionContext(
 
     @property
     def context(self):
-        # Deprecated
+        warnings.warn(
+            'As of 3.0.2 the context property is deprecated. Before your code likely looked '
+            'like info.context.some_method_or_property. All of the properties of the nested '
+            'context object have been hoisted to the top level, so just rename your info '
+            'object to context and access context.some_method_or_property. This property '
+            'will be removed in 0.4.0.'
+        )
         return self.context__
 
     @property
@@ -399,7 +406,7 @@ class TransformExecutionContext(
 
     @property
     def config(self):
-        # Deprecated
+        warnings.warn('As of 3.0.2 the config property is deprecated. Use solid_config instead.')
         return self.config__
 
     @property

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -252,7 +252,7 @@ class ExecutionMetadata(namedtuple('_ExecutionMetadata', 'run_id tags event_call
         )
 
 
-class ITransformExecutionContext(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
+class TransformExecutionContextMetadata(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
     @abstractmethod
     def has_tag(self, key):
         pass
@@ -362,7 +362,7 @@ class WithLegacyContext(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
 
 class TransformExecutionContext(
     WithLegacyContext,
-    ITransformExecutionContext,
+    TransformExecutionContextMetadata,
     namedtuple('_TransformExecutionContext', 'context__ config__ step__ pipeline_def__'),
 ):
     '''An instance of TransformExecutionContext is passed every solid transform function.

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -11,7 +11,7 @@ from dagster.utils import merge_dicts
 from dagster.core.system_config.objects import EnvironmentConfig
 from dagster.core.definitions import PipelineDefinition, Solid, SolidOutputHandle
 from dagster.core.errors import DagsterError
-from dagster.core.execution_context import RuntimeExecutionContext
+from dagster.core.execution_context import LegacyRuntimeExecutionContext
 from dagster.core.types.runtime import RuntimeType
 
 
@@ -275,7 +275,7 @@ class ExecutionPlanInfo(namedtuple('_ExecutionPlanInfo', 'context pipeline envir
     def __new__(cls, context, pipeline, environment):
         return super(ExecutionPlanInfo, cls).__new__(
             cls,
-            check.inst_param(context, 'context', RuntimeExecutionContext),
+            check.inst_param(context, 'context', LegacyRuntimeExecutionContext),
             check.inst_param(pipeline, 'pipeline', PipelineDefinition),
             check.inst_param(environment, 'environment', EnvironmentConfig),
         )

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -17,7 +17,7 @@ from dagster.core.errors import (
     DagsterTypeError,
 )
 
-from dagster.core.execution_context import RuntimeExecutionContext
+from dagster.core.execution_context import LegacyRuntimeExecutionContext
 
 from .objects import (
     ExecutionPlan,
@@ -39,7 +39,7 @@ def _all_inputs_covered(step, results):
 
 
 def iterate_step_events_for_execution_plan(context, execution_plan, throw_on_user_error):
-    check.inst_param(context, 'base_context', RuntimeExecutionContext)
+    check.inst_param(context, 'base_context', LegacyRuntimeExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
 
@@ -86,7 +86,7 @@ def iterate_step_events_for_execution_plan(context, execution_plan, throw_on_use
 
 def iterate_step_events_for_step(step, context, inputs):
     check.inst_param(step, 'step', ExecutionStep)
-    check.inst_param(context, 'context', RuntimeExecutionContext)
+    check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
     check.dict_param(inputs, 'inputs', key_type=str)
 
     try:
@@ -217,7 +217,7 @@ def _execution_step_error_boundary(context, step, msg, **kwargs):
     framework code in the stack trace, if a tool author wishes to do so. This has
     been especially help in a notebooking context.
     '''
-    check.inst_param(context, 'context', RuntimeExecutionContext)
+    check.inst_param(context, 'context', LegacyRuntimeExecutionContext)
     check.str_param(msg, 'msg')
 
     context.events.execution_plan_step_start(step.key)

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -81,8 +81,8 @@ def single_output_transform(name, inputs, transform_fn, output, description=None
 
     '''
 
-    def _new_transform_fn(info, inputs):
-        value = transform_fn(info.context, inputs)
+    def _new_transform_fn(context, inputs):
+        value = transform_fn(context, inputs)
         if isinstance(value, Result):
             raise DagsterInvariantViolationError(
                 '''Single output transform Solid {name} returned a Result. Just return

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/config.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/config.py
@@ -7,10 +7,10 @@ from dagster import Field, PipelineDefinition, execute_pipeline, solid, types
 @solid(
     config_field=Field(types.String, is_optional=True, default_value='en-us')
 )
-def configurable_hello(info):
-    if len(info.config) >= 3 and info.config[:3] == 'haw':
+def configurable_hello(context):
+    if len(context.solid_config) >= 3 and context.solid_config[:3] == 'haw':
         return 'Aloha honua!'
-    elif len(info.config) >= 2 and info.config[:2] == 'cn':
+    elif len(context.solid_config) >= 2 and context.solid_config[:2] == 'cn':
         return '你好, 世界!'
     else:
         return 'Hello, world!'

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/configuration_schemas.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/configuration_schemas.py
@@ -16,8 +16,8 @@ from dagster import (
 
 
 @solid(inputs=[InputDefinition('word', String)], config_field=Field(Any))
-def multiply_the_word(info, word):
-    return word * info.config['factor']
+def multiply_the_word(context, word):
+    return word * context.solid_config['factor']
 
 
 @lambda_solid(inputs=[InputDefinition('word')])
@@ -32,16 +32,16 @@ def count_letters(word):
     inputs=[InputDefinition('word', String)],
     config_field=Field(Dict({'factor': Field(Int)})),
 )
-def typed_multiply_the_word(info, word):
-    return word * info.config['factor']
+def typed_multiply_the_word(context, word):
+    return word * context.solid_config['factor']
 
 
 @solid(
     inputs=[InputDefinition('word', String)],
     config_field=Field(Dict({'factor': Field(String)})),
 )
-def typed_multiply_the_word_error(info, word):
-    return word * info.config['factor']
+def typed_multiply_the_word_error(context, word):
+    return word * context.solid_config['factor']
 
 
 def define_demo_configuration_schema_pipeline():

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/execution_context.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/execution_context.py
@@ -2,14 +2,14 @@ from dagster import PipelineDefinition, execute_pipeline, solid
 
 
 @solid
-def debug_message(info):
-    info.log.debug('A debug message.')
+def debug_message(context):
+    context.log.debug('A debug message.')
     return 'foo'
 
 
 @solid
-def error_message(info):
-    info.log.error('An error occurred.')
+def error_message(context):
+    context.log.error('An error occurred.')
 
 
 def define_execution_context_pipeline_step_one():

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/multiple_outputs.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/multiple_outputs.py
@@ -18,7 +18,7 @@ from dagster import (
         OutputDefinition(dagster_type=Int, name='out_two'),
     ]
 )
-def yield_outputs(_info):
+def yield_outputs(_context):
     yield Result(23, 'out_one')
     yield Result(45, 'out_two')
 
@@ -29,7 +29,7 @@ def yield_outputs(_info):
         OutputDefinition(dagster_type=Int, name='out_two'),
     ]
 )
-def return_dict_results(_info):
+def return_dict_results(_context):
     return MultipleResults.from_dict({'out_one': 23, 'out_two': 45})
 
 
@@ -42,24 +42,24 @@ def return_dict_results(_info):
         OutputDefinition(dagster_type=Int, name='out_two'),
     ],
 )
-def conditional(info):
-    if info.config == 'out_one':
+def conditional(context):
+    if context.solid_config == 'out_one':
         yield Result(23, 'out_one')
-    elif info.config == 'out_two':
+    elif context.solid_config == 'out_two':
         yield Result(45, 'out_two')
     else:
         raise Exception('invalid config')
 
 
 @solid(inputs=[InputDefinition('num', dagster_type=Int)])
-def log_num(info, num):
-    info.log.info('num {num}'.format(num=num))
+def log_num(context, num):
+    context.log.info('num {num}'.format(num=num))
     return num
 
 
 @solid(inputs=[InputDefinition('num', dagster_type=Int)])
-def log_num_squared(info, num):
-    info.log.info('num_squared {num_squared}'.format(num_squared=num * num))
+def log_num_squared(context, num):
+    context.log.info('num_squared {num_squared}'.format(num_squared=num * num))
     return num * num
 
 

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/pipeline_cli_execution.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/pipeline_cli_execution.py
@@ -18,8 +18,8 @@ from dagster import (
     inputs=[InputDefinition('word', String)],
     config_field=Field(Dict({'factor': Field(Int)})),
 )
-def multiply_the_word(info, word):
-    return word * info.config['factor']
+def multiply_the_word(context, word):
+    return word * context.solid_config['factor']
 
 
 @lambda_solid(inputs=[InputDefinition('word')])

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
@@ -80,9 +80,9 @@ def define_cloud_store_resource():
     inputs=[InputDefinition('num_one', Int), InputDefinition('num_two', Int)],
     outputs=[OutputDefinition(Int)],
 )
-def add_ints(info, num_one, num_two):
+def add_ints(context, num_one, num_two):
     sum_ints = num_one + num_two
-    info.resources.store.record_value(info.log, 'add', sum_ints)
+    context.resources.store.record_value(context.log, 'add', sum_ints)
     return sum_ints
 
 

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -19,7 +19,7 @@ from dagster.core.execution_context import LegacyRuntimeExecutionContext
 from dagster.core.utility_solids import define_stub_solid
 
 
-def create_test_runtime_execution_context(loggers=None, resources=None, tags=None):
+def create_test_runtime_legacy_execution_context(loggers=None, resources=None, tags=None):
     run_id = str(uuid.uuid4())
     return LegacyRuntimeExecutionContext(
         run_id=run_id, loggers=loggers, resources=resources, tags=tags

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -15,13 +15,15 @@ from dagster import (
 )
 
 from dagster.core.execution import build_sub_pipeline
-from dagster.core.execution_context import RuntimeExecutionContext
+from dagster.core.execution_context import LegacyRuntimeExecutionContext
 from dagster.core.utility_solids import define_stub_solid
 
 
 def create_test_runtime_execution_context(loggers=None, resources=None, tags=None):
     run_id = str(uuid.uuid4())
-    return RuntimeExecutionContext(run_id=run_id, loggers=loggers, resources=resources, tags=tags)
+    return LegacyRuntimeExecutionContext(
+        run_id=run_id, loggers=loggers, resources=resources, tags=tags
+    )
 
 
 def _unlink_swallow_errors(path):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_decorators.py
@@ -76,7 +76,7 @@ def test_empty_solid():
 
 def test_solid():
     @solid(outputs=[OutputDefinition()])
-    def hello_world(_info):
+    def hello_world(_context):
         return {'foo': 'bar'}
 
     result = execute_single_solid_in_isolation(create_test_context(), hello_world)
@@ -100,7 +100,7 @@ def test_solid_one_output():
 
 def test_solid_yield():
     @solid(outputs=[OutputDefinition()])
-    def hello_world(_info):
+    def hello_world(_context):
         yield Result(value={'foo': 'bar'})
 
     result = execute_single_solid_in_isolation(create_test_context(), hello_world)
@@ -112,7 +112,7 @@ def test_solid_yield():
 
 def test_solid_result_return():
     @solid(outputs=[OutputDefinition()])
-    def hello_world(_info):
+    def hello_world(_context):
         return Result(value={'foo': 'bar'})
 
     result = execute_single_solid_in_isolation(create_test_context(), hello_world)
@@ -124,7 +124,7 @@ def test_solid_result_return():
 
 def test_solid_multiple_outputs():
     @solid(outputs=[OutputDefinition(name="left"), OutputDefinition(name="right")])
-    def hello_world(_info):
+    def hello_world(_context):
         return MultipleResults(
             Result(value={'foo': 'left'}, output_name='left'),
             Result(value={'foo': 'right'}, output_name='right'),
@@ -141,7 +141,7 @@ def test_solid_multiple_outputs():
 
 def test_dict_multiple_outputs():
     @solid(outputs=[OutputDefinition(name="left"), OutputDefinition(name="right")])
-    def hello_world(_info):
+    def hello_world(_context):
         return MultipleResults.from_dict({'left': {'foo': 'left'}, 'right': {'foo': 'right'}})
 
     result = execute_single_solid_in_isolation(create_test_context(), hello_world)
@@ -155,7 +155,7 @@ def test_dict_multiple_outputs():
 
 def test_solid_with_explicit_empty_outputs():
     @solid(outputs=[])
-    def hello_world(_info):
+    def hello_world(_context):
         return 'foo'
 
     with pytest.raises(DagsterInvariantViolationError) as exc_info:
@@ -174,7 +174,7 @@ def test_solid_with_explicit_empty_outputs():
 
 def test_solid_with_implicit_single_output():
     @solid()
-    def hello_world(_info):
+    def hello_world(_context):
         return 'foo'
 
     result = execute_single_solid_in_isolation(create_test_context(), hello_world)
@@ -187,7 +187,7 @@ def test_solid_with_implicit_single_output():
 
 def test_solid_return_list_instead_of_multiple_results():
     @solid(outputs=[OutputDefinition(name='foo'), OutputDefinition(name='bar')])
-    def hello_world(_info):
+    def hello_world(_context):
         return ['foo', 'bar']
 
     with pytest.raises(DagsterInvariantViolationError) as exc_info:
@@ -210,7 +210,7 @@ def test_lambda_solid_with_name():
 
 def test_solid_with_name():
     @solid(name="foobar", outputs=[OutputDefinition()])
-    def hello_world(_info):
+    def hello_world(_context):
         return {'foo': 'bar'}
 
     result = execute_single_solid_in_isolation(create_test_context(), hello_world)
@@ -271,13 +271,13 @@ def test_solid_definition_errors():
     with pytest.raises(DagsterInvalidDefinitionError):
 
         @solid(inputs=[InputDefinition(name="foo")], outputs=[OutputDefinition()])
-        def no_info(foo):
+        def no_context(foo):
             pass
 
     with pytest.raises(DagsterInvalidDefinitionError):
 
         @solid(inputs=[InputDefinition(name="foo")], outputs=[OutputDefinition()])
-        def extras(_info, foo, bar):
+        def extras(_context, foo, bar):
             pass
 
     @solid(
@@ -324,7 +324,7 @@ def test_any_config_field():
 
     @solid(config_field=Field(Any))
     def hello_world(info):
-        assert info.config == conf_value
+        assert info.solid_config == conf_value
         called['yup'] = True
 
     result = execute_single_solid_in_isolation(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -24,13 +24,13 @@ def solid_a_b_list():
             name='A',
             inputs=[],
             outputs=[OutputDefinition()],
-            transform_fn=lambda _info, _inputs: None,
+            transform_fn=lambda _context, _inputs: None,
         ),
         SolidDefinition(
             name='B',
             inputs=[InputDefinition('b_input')],
             outputs=[],
-            transform_fn=lambda _info, _inputs: None,
+            transform_fn=lambda _context, _inputs: None,
         ),
     ]
 
@@ -102,11 +102,11 @@ def test_invalid_item_in_solid_list():
 
 def test_double_type():
     @solid(config_field=Field(NamedDict('Name', {'some_field': Field(String)})))
-    def solid_one(_info):
+    def solid_one(_context):
         raise Exception('should not execute')
 
     @solid(config_field=Field(NamedDict('Name', {'some_field': Field(String)})))
-    def solid_two(_info):
+    def solid_two(_context):
         raise Exception('should not execute')
 
     with pytest.raises(DagsterInvalidDefinitionError, match='Type names must be unique.'):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -35,7 +35,7 @@ def test_pipeline_types():
         outputs=[OutputDefinition(types.Any)],
         config_field=Field(Dict({'another_field': Field(types.Int)})),
     )
-    def solid_one(_info, input_one):
+    def solid_one(_context, input_one):
         raise Exception('should not execute')
 
     pipeline_def = PipelineDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -123,7 +123,7 @@ def test_execution_plan_middle_step():
 
 def test_execution_plan_two_outputs():
     @solid(outputs=[OutputDefinition(types.Int, 'num_one'), OutputDefinition(types.Int, 'num_two')])
-    def return_one_two(_info):
+    def return_one_two(_context):
         yield Result(1, 'num_one')
         yield Result(2, 'num_two')
 
@@ -146,9 +146,9 @@ def test_reentrant_execute_plan():
     called = {}
 
     @solid
-    def has_tag(info):
-        assert info.context.has_tag('foo')
-        assert info.context.get_tag('foo') == 'bar'
+    def has_tag(context):
+        assert context.has_tag('foo')
+        assert context.get_tag('foo') == 'bar'
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='has_tag_pipeline', solids=[has_tag])

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -444,7 +444,7 @@ def test_solid_config_error():
 
 def test_optional_solid_with_no_config():
     def _assert_config_none(info, value):
-        assert info.config is value
+        assert info.solid_config is value
 
     pipeline_def = PipelineDefinition(
         name='some_pipeline',
@@ -470,7 +470,7 @@ def test_optional_solid_with_no_config():
 
 def test_optional_solid_with_optional_scalar_config():
     def _assert_config_none(info, value):
-        assert info.config is value
+        assert info.solid_config is value
 
     pipeline_def = PipelineDefinition(
         name='some_pipeline',
@@ -506,7 +506,7 @@ def test_optional_solid_with_optional_scalar_config():
 
 def test_optional_solid_with_required_scalar_config():
     def _assert_config_none(info, value):
-        assert info.config is value
+        assert info.solid_config is value
 
     pipeline_def = PipelineDefinition(
         name='some_pipeline',

--- a/python_modules/dagster/dagster_tests/core_tests/test_compute_nodes.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_compute_nodes.py
@@ -23,7 +23,7 @@ from dagster.core.execution_plan.objects import ExecutionStep, StepKind, PlanBui
 
 from dagster.core.execution_plan.simple_engine import iterate_step_events_for_step
 
-from dagster.utils.test import create_test_runtime_execution_context
+from dagster.utils.test import create_test_runtime_legacy_execution_context
 
 
 def silencing_default_context():
@@ -45,14 +45,16 @@ def test_compute_noop_node_core():
     environment = EnvironmentConfig()
 
     plan = create_execution_plan_core(
-        ExecutionPlanInfo(create_test_runtime_execution_context(), pipeline, environment),
+        ExecutionPlanInfo(create_test_runtime_legacy_execution_context(), pipeline, environment),
         ExecutionMetadata(),
     )
 
     assert len(plan.steps) == 1
 
     events = list(
-        iterate_step_events_for_step(plan.steps[0], create_test_runtime_execution_context(), {})
+        iterate_step_events_for_step(
+            plan.steps[0], create_test_runtime_legacy_execution_context(), {}
+        )
     )
 
     assert events[0].success_data.value == 'foo'
@@ -65,7 +67,9 @@ def test_compute_noop_node():
 
     assert len(plan.steps) == 1
     events = list(
-        iterate_step_events_for_step(plan.steps[0], create_test_runtime_execution_context(), {})
+        iterate_step_events_for_step(
+            plan.steps[0], create_test_runtime_legacy_execution_context(), {}
+        )
     )
 
     assert events[0].success_data.value == 'foo'

--- a/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
@@ -27,9 +27,9 @@ def test_default_context():
     called = {}
 
     @solid(inputs=[], outputs=[OutputDefinition()])
-    def default_context_transform(info):
+    def default_context_transform(context):
         called['yes'] = True
-        for logger in info.context._logger.loggers:
+        for logger in context.loggers:
             assert logger.level == INFO
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
@@ -41,9 +41,9 @@ def test_default_context():
 def test_run_id():
     called = {}
 
-    def construct_context(info):
+    def construct_context(context):
         called['yes'] = True
-        assert uuid.UUID(info.run_id)
+        assert uuid.UUID(context.run_id)
         return ExecutionContext()
 
     pipeline = PipelineDefinition(
@@ -57,8 +57,8 @@ def test_run_id():
 
 def test_default_context_with_log_level():
     @solid(inputs=[], outputs=[OutputDefinition()])
-    def default_context_transform(info):
-        for logger in info.context._logger.loggers:
+    def default_context_transform(context):
+        for logger in context.loggers:
             assert logger.level == INFO
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
@@ -75,8 +75,8 @@ def test_default_context_with_log_level():
 def test_default_value():
     def _get_config_test_solid(config_key, config_value):
         @solid(inputs=[], outputs=[OutputDefinition()])
-        def config_test(info):
-            assert info.resources == {config_key: config_value}
+        def config_test(context):
+            assert context.resources == {config_key: config_value}
 
         return config_test
 
@@ -105,8 +105,8 @@ def test_default_value():
 
 def test_custom_contexts():
     @solid(inputs=[], outputs=[OutputDefinition()])
-    def custom_context_transform(info):
-        assert info.resources == {'field_one': 'value_two'}
+    def custom_context_transform(context):
+        assert context.resources == {'field_one': 'value_two'}
 
     pipeline = PipelineDefinition(
         solids=[custom_context_transform],
@@ -134,9 +134,9 @@ def test_yield_context():
     events = []
 
     @solid(inputs=[], outputs=[OutputDefinition()])
-    def custom_context_transform(info):
-        assert info.resources == {'field_one': 'value_two'}
-        assert info.context._tags['foo'] == 'bar'  # pylint: disable=W0212
+    def custom_context_transform(context):
+        assert context.resources == {'field_one': 'value_two'}
+        assert context.get_tag('foo') == 'bar'  # pylint: disable=W0212
         events.append('during')
 
     def _yield_context(info):

--- a/python_modules/dagster/dagster_tests/core_tests/test_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_execution_context.py
@@ -1,10 +1,42 @@
+import warnings
 import uuid
 
-from dagster.utils.test import create_test_runtime_execution_context
+from dagster import PipelineDefinition, solid, execute_pipeline
+from dagster.utils.test import create_test_runtime_legacy_execution_context
 
 # pylint: disable=W0212
 
 
 def test_noarg_ctor():
-    context = create_test_runtime_execution_context()
-    assert uuid.UUID(context.run_id)
+    legacy_context = create_test_runtime_legacy_execution_context()
+    assert uuid.UUID(legacy_context.run_id)
+
+
+def test_warning_on_context():
+    @solid
+    def log_something(context):
+        context.context.info('hi')
+
+    pipeline = PipelineDefinition(name='warning_on_context', solids=[log_something])
+
+    with warnings.catch_warnings(record=True) as list_of_warnings:
+        result = execute_pipeline(pipeline)
+        assert result.success
+        assert len(list_of_warnings) == 1
+        warning = list_of_warnings[0]
+        assert 'As of 3.0.2 the context property is deprecated.' in str(warning.message)
+
+
+def test_warning_on_config():
+    @solid
+    def check_config_is_none(context):
+        assert context.config is None
+
+    pipeline = PipelineDefinition(name='warning_on_config', solids=[check_config_is_none])
+
+    with warnings.catch_warnings(record=True) as list_of_warnings:
+        result = execute_pipeline(pipeline)
+        assert result.success
+        assert len(list_of_warnings) == 1
+        warning = list_of_warnings[0]
+        assert 'As of 3.0.2 the config property is deprecated.' in str(warning.message)

--- a/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_input_injection.py
@@ -17,7 +17,7 @@ def test_string_from_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('string_input', types.String)])
-    def str_as_input(_info, string_input):
+    def str_as_input(_context, string_input):
         assert string_input == 'foo'
         called['yup'] = True
 
@@ -35,7 +35,7 @@ def test_string_from_aliased_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('string_input', types.String)])
-    def str_as_input(_info, string_input):
+    def str_as_input(_context, string_input):
         assert string_input == 'foo'
         called['yup'] = True
 
@@ -55,7 +55,7 @@ def test_string_missing_inputs():
     called = {}
 
     @solid(inputs=[InputDefinition('string_input', types.String)])
-    def str_as_input(_info, string_input):  # pylint: disable=W0613
+    def str_as_input(_context, string_input):  # pylint: disable=W0613
         called['yup'] = True
 
     pipeline = PipelineDefinition(name='missing_inputs', solids=[str_as_input])
@@ -76,11 +76,11 @@ def test_string_missing_input_collision():
     called = {}
 
     @solid(outputs=[OutputDefinition(types.String)])
-    def str_as_output(_info):
+    def str_as_output(_context):
         return 'bar'
 
     @solid(inputs=[InputDefinition('string_input', types.String)])
-    def str_as_input(_info, string_input):  # pylint: disable=W0613
+    def str_as_input(_context, string_input):  # pylint: disable=W0613
         called['yup'] = True
 
     pipeline = PipelineDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
@@ -25,7 +25,7 @@ def define_pass_value_solid(name, description=None):
     check.opt_str_param(description, 'description')
 
     def _value_t_fn(info, _inputs):
-        yield Result(info.config['value'])
+        yield Result(info.solid_config['value'])
 
     return SolidDefinition(
         name=name,

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -47,7 +47,7 @@ def create_dep_input_fn(name):
 
 
 def make_transform():
-    def transform(info, inputs):
+    def transform(context, inputs):
         passed_rows = []
         seen = set()
         for row in inputs.values():
@@ -59,13 +59,13 @@ def make_transform():
 
         result = []
         result.extend(passed_rows)
-        result.append({info.solid.name: 'transform_called'})
+        result.append({context.solid.name: 'transform_called'})
         return result
 
     return transform
 
 
-def _transform_fn(info, inputs):
+def _transform_fn(context, inputs):
     passed_rows = []
     seen = set()
     for row in inputs.values():
@@ -77,7 +77,7 @@ def _transform_fn(info, inputs):
 
     result = []
     result.extend(passed_rows)
-    result.append({info.solid.name: 'transform_called'})
+    result.append({context.solid.name: 'transform_called'})
     yield Result(result)
 
 
@@ -335,9 +335,9 @@ def test_pipeline_name_threaded_through_context():
     name = 'foobar'
 
     @solid()
-    def assert_name_transform(info):
-        assert info.context._tags['pipeline']
-        assert info.context._tags['pipeline'] == name
+    def assert_name_transform(context):
+        assert context.has_tag('pipeline')
+        assert context.get_tag('pipeline') == name
 
     result = execute_pipeline(PipelineDefinition(name="foobar", solids=[assert_name_transform]))
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -31,7 +31,7 @@ from dagster.core.execution import (
 
 from dagster.core.utility_solids import define_stub_solid
 
-from dagster.utils.test import create_test_runtime_execution_context, execute_solid
+from dagster.utils.test import create_test_runtime_legacy_execution_context, execute_solid
 
 # protected members
 # pylint: disable=W0212
@@ -291,7 +291,7 @@ def _do_test(pipeline, do_execute_pipeline_iter):
     for result in do_execute_pipeline_iter():
         results.append(result)
 
-    result = PipelineExecutionResult(pipeline, create_test_runtime_execution_context(), results)
+    result = PipelineExecutionResult(pipeline, create_test_runtime_legacy_execution_context(), results)
 
     assert result.result_for_solid('A').transformed_value() == [
         input_set('A_input'),

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -291,7 +291,9 @@ def _do_test(pipeline, do_execute_pipeline_iter):
     for result in do_execute_pipeline_iter():
         results.append(result)
 
-    result = PipelineExecutionResult(pipeline, create_test_runtime_legacy_execution_context(), results)
+    result = PipelineExecutionResult(
+        pipeline, create_test_runtime_legacy_execution_context(), results
+    )
 
     assert result.result_for_solid('A').transformed_value() == [
         input_set('A_input'),

--- a/python_modules/dagster/dagster_tests/core_tests/test_reentrant_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_reentrant_context.py
@@ -24,8 +24,8 @@ def test_injected_tags():
     called = {}
 
     @solid
-    def check_tags(info):
-        assert info.context.get_tag('foo') == 'bar'
+    def check_tags(context):
+        assert context.get_tag('foo') == 'bar'
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='injected_run_id', solids=[check_tags])
@@ -41,12 +41,12 @@ def test_user_injected_tags():
     called = {}
 
     @solid
-    def check_tags(info):
-        assert info.context.get_tag('foo') == 'bar'
-        assert info.context.get_tag('quux') == 'baaz'
+    def check_tags(context):
+        assert context.get_tag('foo') == 'bar'
+        assert context.get_tag('quux') == 'baaz'
         called['yup'] = True
 
-    def _create_context(_info):
+    def _create_context(_context):
         return ExecutionContext(tags={'quux': 'baaz'})
 
     pipeline_def = PipelineDefinition(
@@ -67,12 +67,12 @@ def test_user_injected_tags_collision():
     called = {}
 
     @solid
-    def check_tags(info):
-        assert info.context.get_tag('foo') == 'bar'
-        assert info.context.get_tag('quux') == 'baaz'
+    def check_tags(context):
+        assert context.get_tag('foo') == 'bar'
+        assert context.get_tag('quux') == 'baaz'
         called['yup'] = True
 
-    def _create_context(_info):
+    def _create_context(_context):
         return ExecutionContext(tags={'foo': 'baaz'})
 
     pipeline_def = PipelineDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_aliases.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_aliases.py
@@ -65,7 +65,7 @@ def test_only_aliased_solids():
 def test_aliased_configs():
     @solid(inputs=[], config_field=Field(Int))
     def load_constant(info):
-        return info.config
+        return info.solid_config
 
     pipeline = PipelineDefinition(
         solids=[load_constant],
@@ -88,9 +88,9 @@ def test_aliased_solids_context():
     record = defaultdict(set)
 
     @solid
-    def log_things(info):
-        solid_value = info.context.get_tag('solid')
-        solid_def_value = info.context.get_tag('solid_definition')
+    def log_things(context):
+        solid_value = context.get_tag('solid')
+        solid_def_value = context.get_tag('solid_definition')
         record[solid_def_value].add(solid_value)
 
     pipeline = PipelineDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_with_config.py
@@ -15,7 +15,7 @@ def test_basic_solid_with_config():
     did_get = {}
 
     def _t_fn(info, _inputs):
-        did_get['yep'] = info.config
+        did_get['yep'] = info.solid_config
 
     solid = SolidDefinition(
         name='solid_with_context',

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_enums.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_enums.py
@@ -54,8 +54,8 @@ def test_enum_in_pipeline_execution():
         )
     )
     def config_me(info):
-        assert info.config['int_field'] == 2
-        assert info.config['enum_field'] == 'ENUM_VALUE'
+        assert info.solid_config['int_field'] == 2
+        assert info.solid_config['enum_field'] == 'ENUM_VALUE'
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='enum_in_pipeline', solids=[config_me])
@@ -97,7 +97,7 @@ def test_native_enum_dagster_enum():
 
     @solid(config_field=Field(dagster_enum))
     def dagster_enum_me(info):
-        assert info.config == NativeEnum.BAR
+        assert info.solid_config == NativeEnum.BAR
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='native_enum_dagster_pipeline', solids=[dagster_enum_me])

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
@@ -355,7 +355,7 @@ def test_solid_list_config():
     called = {}
 
     def _test_config(info, _inputs):
-        assert info.config == value
+        assert info.solid_config == value
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(
@@ -399,7 +399,7 @@ def test_two_list_types():
 def test_multilevel_default_handling():
     @solid(config_field=Field(Int, is_optional=True, default_value=234))
     def has_default_value(info):
-        assert info.config == 234
+        assert info.solid_config == 234
 
     pipeline_def = PipelineDefinition(
         name='multilevel_default_handling', solids=[has_default_value]
@@ -492,7 +492,7 @@ def test_working_list_path():
 
     @solid(config_field=Field(List(Int)))
     def required_list_int_solid(info):
-        assert info.config == [1, 2]
+        assert info.solid_config == [1, 2]
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='list_path', solids=[required_list_int_solid])
@@ -510,7 +510,7 @@ def test_item_error_list_path():
 
     @solid(config_field=Field(List(Int)))
     def required_list_int_solid(info):
-        assert info.config == [1, 2]
+        assert info.solid_config == [1, 2]
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='list_path', solids=[required_list_int_solid])
@@ -566,7 +566,7 @@ def test_context_selector_extra_context():
         solids=[check_context],
         context_definitions={
             'context_required_int': PipelineContextDefinition(
-                context_fn=lambda info: ExecutionContext(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.solid_config),
                 config_field=Field(Int),
             )
         },
@@ -599,7 +599,7 @@ def test_context_selector_wrong_name():
         solids=[check_context],
         context_definitions={
             'context_required_int': PipelineContextDefinition(
-                context_fn=lambda info: ExecutionContext(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.solid_config),
                 config_field=Field(Int),
             )
         },
@@ -624,7 +624,7 @@ def test_context_selector_none_given():
         solids=[check_context],
         context_definitions={
             'context_required_int': PipelineContextDefinition(
-                context_fn=lambda info: ExecutionContext(resources=info.config),
+                context_fn=lambda info: ExecutionContext(resources=info.solid_config),
                 config_field=Field(Int),
             )
         },

--- a/python_modules/dagster/dagster_tests/utils_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_json_logging.py
@@ -1,6 +1,6 @@
 import json
 
-from dagster.utils.test import create_test_runtime_execution_context, get_temp_file_name
+from dagster.utils.test import create_test_runtime_legacy_execution_context, get_temp_file_name
 
 from dagster.utils.logging import define_json_file_logger, DEBUG, INFO
 
@@ -63,7 +63,7 @@ def test_no_double_write_same_names():
 def test_write_dagster_meta():
     with get_temp_file_name() as tf_name:
         logger = define_json_file_logger('foo', tf_name, DEBUG)
-        execution_context = create_test_runtime_execution_context(loggers=[logger])
+        execution_context = create_test_runtime_legacy_execution_context(loggers=[logger])
         execution_context.debug('some_debug_message', context_key='context_value')
         data = list(parse_json_lines(tf_name))
         assert len(data) == 1

--- a/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
@@ -79,7 +79,7 @@ def test_single_solid_with_config():
 
     @solid(config_field=Field(Int))
     def check_config_for_two(info):
-        assert info.config == 2
+        assert info.solid_config == 2
         ran['check_config_for_two'] = True
 
     pipeline_def = PipelineDefinition(solids=[check_config_for_two])

--- a/python_modules/dagster/dagster_tests/utils_tests/test_structured_logging.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_structured_logging.py
@@ -7,7 +7,7 @@ from dagster.core.events import (
     PipelineEventRecord,
 )
 
-from dagster.utils.test import create_test_runtime_execution_context
+from dagster.utils.test import create_test_runtime_legacy_execution_context
 
 
 def test_structured_logger_in_context():
@@ -17,7 +17,7 @@ def test_structured_logger_in_context():
         messages.append(logger_message)
 
     logger = define_structured_logger('some_name', _append_message, level=DEBUG)
-    context = create_test_runtime_execution_context(loggers=[logger])
+    context = create_test_runtime_legacy_execution_context(loggers=[logger])
     context.debug('from_context', foo=2)
     assert len(messages) == 1
     message = messages[0]
@@ -34,7 +34,7 @@ def test_construct_event_record():
         messages.append(construct_event_record(logger_message))
 
     logger = define_structured_logger('some_name', _append_message, level=DEBUG)
-    context = create_test_runtime_execution_context(
+    context = create_test_runtime_legacy_execution_context(
         loggers=[logger], tags={'pipeline': 'some_pipeline'}
     )
     context.info('random message')

--- a/python_modules/dagster/docs/apidocs/definitions.rst
+++ b/python_modules/dagster/docs/apidocs/definitions.rst
@@ -49,5 +49,5 @@ Core API for defining solids and pipelines.
 .. autoclass:: SolidInstance
     :members:
 
-.. autoclass:: TransformExecutionInfo
+.. autoclass:: TransformExecutionContext
    :members:

--- a/python_modules/dagster/docs/apidocs/execution.rst
+++ b/python_modules/dagster/docs/apidocs/execution.rst
@@ -15,7 +15,7 @@ Executing pipelines and solids.
 .. autoclass:: PipelineExecutionResult
    :members:
 
-.. autoclass:: ReentrantInfo
+.. autoclass:: ExecutionMetadata
    :members:
 
 .. autoclass:: SolidExecutionResult

--- a/python_modules/dagster/docs/intro_tutorial/config.rst
+++ b/python_modules/dagster/docs/intro_tutorial/config.rst
@@ -31,8 +31,8 @@ proceeds. For now, the salient differences are:
    solid. This parameter should be a :py:func:`Field <dagster.Field>`, which tells the dagster
    machinery how to translate config values into runtime values available to the solid.
 2. The function annotated by the :py:func:`@solid <dagster.solid>` API receives an additional first
-   parameter, ``info``, of type :py:class:`TransformExecutionInfo <dagster.TransformExecutionInfo>`.
-   The configuration passed into each solid is available to the annotated function as ``info.config``.
+   parameter, ``context``, of type :py:class:`TransformExecutionContext <dagster.TransformExecutionContext>`.
+   The configuration passed into each solid is available to the annotated function as ``context.solid_config``.
 
 Configuration values are passed in a dict as the second argument to
 :py:func:`execute_pipeline <dagster.execute_pipeline>`. This dict specifies *all* of the

--- a/python_modules/dagster/docs/intro_tutorial/execution_context.rst
+++ b/python_modules/dagster/docs/intro_tutorial/execution_context.rst
@@ -3,7 +3,7 @@ Execution Context
 
 One of the most important objects in the system is the execution context. The execution
 context, the logger, and the resources are threaded throughout the entire computation (
-via the ``info`` object passed to user code) and contains handles to logging facilities
+via the ``context`` object passed to user code) and contains handles to logging facilities
 and external resources. Interactions with logging systems, databases, and external
 clusters (e.g. a Spark cluster) should be managed through these properties of the 
 info object.

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -562,7 +562,7 @@ snapshots['test_build_all_docs 4'] = '''
 <h2 id="C">C</h2>
 <table style="width: 100%" class="indextable genindextable"><tr>
   <td style="width: 33%; vertical-align: top;"><ul>
-      <li><a href="apidocs/definitions.html#dagster.TransformExecutionInfo.config">config (dagster.TransformExecutionInfo attribute)</a>
+      <li><a href="apidocs/definitions.html#dagster.TransformExecutionContext.config">config (dagster.TransformExecutionContext attribute)</a>
 </li>
       <li><a href="apidocs/definitions.html#dagster.PipelineContextDefinition.config_field">config_field (dagster.PipelineContextDefinition attribute)</a>
 
@@ -577,7 +577,7 @@ snapshots['test_build_all_docs 4'] = '''
       <ul>
         <li><a href="apidocs/execution.html#dagster.SolidExecutionResult.context">(dagster.SolidExecutionResult attribute)</a>
 </li>
-        <li><a href="apidocs/definitions.html#dagster.TransformExecutionInfo.context">(dagster.TransformExecutionInfo attribute)</a>
+        <li><a href="apidocs/definitions.html#dagster.TransformExecutionContext.context">(dagster.TransformExecutionContext attribute)</a>
 </li>
       </ul></li>
   </ul></td>
@@ -658,6 +658,8 @@ snapshots['test_build_all_docs 4'] = '''
 </li>
   </ul></td>
   <td style="width: 33%; vertical-align: top;"><ul>
+      <li><a href="apidocs/execution.html#dagster.ExecutionMetadata">ExecutionMetadata (class in dagster)</a>
+</li>
       <li><a href="apidocs/definitions.html#dagster.ExpectationDefinition.expectation_fn">expectation_fn (dagster.ExpectationDefinition attribute)</a>
 </li>
       <li><a href="apidocs/definitions.html#dagster.ExpectationDefinition">ExpectationDefinition (class in dagster)</a>
@@ -898,7 +900,7 @@ snapshots['test_build_all_docs 4'] = '''
   <td style="width: 33%; vertical-align: top;"><ul>
       <li><a href="apidocs/execution.html#dagster.SolidExecutionResult.transformed_values">transformed_values (dagster.SolidExecutionResult attribute)</a>
 </li>
-      <li><a href="apidocs/definitions.html#dagster.TransformExecutionInfo">TransformExecutionInfo (class in dagster)</a>
+      <li><a href="apidocs/definitions.html#dagster.TransformExecutionContext">TransformExecutionContext (class in dagster)</a>
 </li>
   </ul></td>
 </tr></table>
@@ -2338,7 +2340,7 @@ Core API for defining solids and pipelines.
 .. autoclass:: SolidInstance
     :members:
 
-.. autoclass:: TransformExecutionInfo
+.. autoclass:: TransformExecutionContext
    :members:'''
 
 snapshots['test_build_all_docs 16'] = '''Errors
@@ -2380,7 +2382,7 @@ Executing pipelines and solids.
 .. autoclass:: PipelineExecutionResult
    :members:
 
-.. autoclass:: ReentrantInfo
+.. autoclass:: ExecutionMetadata
    :members:
 
 .. autoclass:: SolidExecutionResult
@@ -3203,8 +3205,8 @@ proceeds. For now, the salient differences are:
    solid. This parameter should be a :py:func:`Field <dagster.Field>`, which tells the dagster
    machinery how to translate config values into runtime values available to the solid.
 2. The function annotated by the :py:func:`@solid <dagster.solid>` API receives an additional first
-   parameter, ``info``, of type :py:class:`TransformExecutionInfo <dagster.TransformExecutionInfo>`.
-   The configuration passed into each solid is available to the annotated function as ``info.config``.
+   parameter, ``context``, of type :py:class:`TransformExecutionContext <dagster.TransformExecutionContext>`.
+   The configuration passed into each solid is available to the annotated function as ``context.solid_config``.
 
 Configuration values are passed in a dict as the second argument to
 :py:func:`execute_pipeline <dagster.execute_pipeline>`. This dict specifies *all* of the
@@ -3353,7 +3355,7 @@ snapshots['test_build_all_docs 25'] = '''Execution Context
 
 One of the most important objects in the system is the execution context. The execution
 context, the logger, and the resources are threaded throughout the entire computation (
-via the ``info`` object passed to user code) and contains handles to logging facilities
+via the ``context`` object passed to user code) and contains handles to logging facilities
 and external resources. Interactions with logging systems, databases, and external
 clusters (e.g. a Spark cluster) should be managed through these properties of the 
 info object.
@@ -19124,30 +19126,30 @@ multiple outputs. Useful for solids that have multiple outputs.</li>
 </table>
 <p class="rubric">Examples</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="nd">@solid</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">print</span><span class="p">(</span><span class="s1">&#39;hello&#39;</span><span class="p">)</span>
 
 <span class="nd">@solid</span><span class="p">()</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">print</span><span class="p">(</span><span class="s1">&#39;hello&#39;</span><span class="p">)</span>
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()])</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">return</span> <span class="p">{</span><span class="s1">&#39;foo&#39;</span><span class="p">:</span> <span class="s1">&#39;bar&#39;</span><span class="p">}</span>
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()])</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">Result</span><span class="p">(</span><span class="n">value</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;foo&#39;</span><span class="p">:</span> <span class="s1">&#39;bar&#39;</span><span class="p">})</span>
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()])</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">yield</span> <span class="n">Result</span><span class="p">(</span><span class="n">value</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;foo&#39;</span><span class="p">:</span> <span class="s1">&#39;bar&#39;</span><span class="p">})</span>
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">outputs</span><span class="o">=</span><span class="p">[</span>
     <span class="n">OutputDefinition</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s2">&quot;left&quot;</span><span class="p">),</span>
     <span class="n">OutputDefinition</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s2">&quot;right&quot;</span><span class="p">),</span>
 <span class="p">])</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">MultipleResults</span><span class="o">.</span><span class="n">from_dict</span><span class="p">({</span>
         <span class="s1">&#39;left&#39;</span><span class="p">:</span> <span class="p">{</span><span class="s1">&#39;foo&#39;</span><span class="p">:</span> <span class="s1">&#39;left&#39;</span><span class="p">},</span>
         <span class="s1">&#39;right&#39;</span><span class="p">:</span> <span class="p">{</span><span class="s1">&#39;foo&#39;</span><span class="p">:</span> <span class="s1">&#39;right&#39;</span><span class="p">},</span>
@@ -19157,15 +19159,15 @@ multiple outputs. Useful for solids that have multiple outputs.</li>
     <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s2">&quot;foo&quot;</span><span class="p">)],</span>
     <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()]</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">_context</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">foo</span>
 
 <span class="nd">@solid</span><span class="p">(</span>
     <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s2">&quot;foo&quot;</span><span class="p">)],</span>
     <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()],</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;log something&#39;</span><span class="p">)</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
+    <span class="n">context</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;log something&#39;</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">foo</span>
 
 <span class="nd">@solid</span><span class="p">(</span>
@@ -19173,9 +19175,9 @@ multiple outputs. Useful for solids that have multiple outputs.</li>
     <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">()],</span>
     <span class="n">config_field</span><span class="o">=</span><span class="n">Field</span><span class="p">(</span><span class="n">types</span><span class="o">.</span><span class="n">Dict</span><span class="p">({</span><span class="s1">&#39;str_value&#39;</span> <span class="p">:</span> <span class="n">Field</span><span class="p">(</span><span class="n">types</span><span class="o">.</span><span class="n">String</span><span class="p">)})),</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
-    <span class="c1"># info.config is a dictionary with &#39;str_value&#39; key</span>
-    <span class="k">return</span> <span class="n">foo</span> <span class="o">+</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[</span><span class="s1">&#39;str_value&#39;</span><span class="p">]</span>
+<span class="k">def</span> <span class="nf">hello_world</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">foo</span><span class="p">):</span>
+    <span class="c1"># context.solid_config is a dictionary with &#39;str_value&#39; key</span>
+    <span class="k">return</span> <span class="n">foo</span> <span class="o">+</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[</span><span class="s1">&#39;str_value&#39;</span><span class="p">]</span>
 </pre></div>
 </div>
 </dd></dl>
@@ -19867,7 +19869,7 @@ is generally used by framework authors.</p>
 <dl class="attribute">
 <dt id="dagster.SolidDefinition.transform_fn">
 <code class="descname">transform_fn</code><a class="headerlink" href="#dagster.SolidDefinition.transform_fn" title="Permalink to this definition">¶</a></dt>
-<dd><p><em>callable</em> – Callable with the signature (<strong>info</strong>: <cite>TransformExecutionInfo</cite>,
+<dd><p><em>callable</em> – Callable with the signature (<strong>info</strong>: <cite>TransformExecutionContext</cite>,
 <strong>inputs</strong>: <cite>Dict[str, Any]</cite>) : <cite>Iterable&lt;Result&gt;</cite></p>
 </dd></dl>
 
@@ -19932,18 +19934,18 @@ like the alias.</p>
 </dd></dl>
 
 <dl class="class">
-<dt id="dagster.TransformExecutionInfo">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">TransformExecutionInfo</code><a class="headerlink" href="#dagster.TransformExecutionInfo" title="Permalink to this definition">¶</a></dt>
-<dd><p>An instance of TransformExecutionInfo is passed every solid transform function.</p>
+<dt id="dagster.TransformExecutionContext">
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">TransformExecutionContext</code><a class="headerlink" href="#dagster.TransformExecutionContext" title="Permalink to this definition">¶</a></dt>
+<dd><p>An instance of TransformExecutionContext is passed every solid transform function.</p>
 <dl class="attribute">
-<dt id="dagster.TransformExecutionInfo.context">
-<code class="descname">context</code><a class="headerlink" href="#dagster.TransformExecutionInfo.context" title="Permalink to this definition">¶</a></dt>
+<dt id="dagster.TransformExecutionContext.context">
+<code class="descname">context</code><a class="headerlink" href="#dagster.TransformExecutionContext.context" title="Permalink to this definition">¶</a></dt>
 <dd><p><em>ExecutionContext</em> – Context instance for this pipeline invocation</p>
 </dd></dl>
 
 <dl class="attribute">
-<dt id="dagster.TransformExecutionInfo.config">
-<code class="descname">config</code><a class="headerlink" href="#dagster.TransformExecutionInfo.config" title="Permalink to this definition">¶</a></dt>
+<dt id="dagster.TransformExecutionContext.config">
+<code class="descname">config</code><a class="headerlink" href="#dagster.TransformExecutionContext.config" title="Permalink to this definition">¶</a></dt>
 <dd><p><em>Any</em> – Config object for current solid</p>
 </dd></dl>
 
@@ -20370,6 +20372,11 @@ node. For the ‘synchronous’ API, see <a class="reference internal" href="#da
 </dd></dl>
 
 </dd></dl>
+
+<dl class="class">
+<dt id="dagster.ExecutionMetadata">
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">ExecutionMetadata</code><a class="headerlink" href="#dagster.ExecutionMetadata" title="Permalink to this definition">¶</a></dt>
+<dd></dd></dl>
 
 <dl class="class">
 <dt id="dagster.SolidExecutionResult">
@@ -22051,10 +22058,10 @@ languages.</p>
 <span class="nd">@solid</span><span class="p">(</span>
     <span class="n">config_field</span><span class="o">=</span><span class="n">Field</span><span class="p">(</span><span class="n">types</span><span class="o">.</span><span class="n">String</span><span class="p">,</span> <span class="n">is_optional</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">default_value</span><span class="o">=</span><span class="s1">&#39;en-us&#39;</span><span class="p">)</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">configurable_hello</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
-    <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">)</span> <span class="o">&gt;=</span> <span class="mi">3</span> <span class="ow">and</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[:</span><span class="mi">3</span><span class="p">]</span> <span class="o">==</span> <span class="s1">&#39;haw&#39;</span><span class="p">:</span>
+<span class="k">def</span> <span class="nf">configurable_hello</span><span class="p">(</span><span class="n">context</span><span class="p">):</span>
+    <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">)</span> <span class="o">&gt;=</span> <span class="mi">3</span> <span class="ow">and</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[:</span><span class="mi">3</span><span class="p">]</span> <span class="o">==</span> <span class="s1">&#39;haw&#39;</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;Aloha honua!&#39;</span>
-    <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">)</span> <span class="o">&gt;=</span> <span class="mi">2</span> <span class="ow">and</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[:</span><span class="mi">2</span><span class="p">]</span> <span class="o">==</span> <span class="s1">&#39;cn&#39;</span><span class="p">:</span>
+    <span class="k">elif</span> <span class="nb">len</span><span class="p">(</span><span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">)</span> <span class="o">&gt;=</span> <span class="mi">2</span> <span class="ow">and</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[:</span><span class="mi">2</span><span class="p">]</span> <span class="o">==</span> <span class="s1">&#39;cn&#39;</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;你好, 世界!&#39;</span>
     <span class="k">else</span><span class="p">:</span>
         <span class="k">return</span> <span class="s1">&#39;Hello, world!&#39;</span>
@@ -22082,8 +22089,8 @@ defines the structure and type of configuration values that can be set on each e
 solid. This parameter should be a <a class="reference internal" href="../apidocs/definitions.html#dagster.Field" title="dagster.Field"><code class="xref py py-func docutils literal notranslate"><span class="pre">Field</span></code></a>, which tells the dagster
 machinery how to translate config values into runtime values available to the solid.</li>
 <li>The function annotated by the <a class="reference internal" href="../apidocs/decorators.html#dagster.solid" title="dagster.solid"><code class="xref py py-func docutils literal notranslate"><span class="pre">&#64;solid</span></code></a> API receives an additional first
-parameter, <code class="docutils literal notranslate"><span class="pre">info</span></code>, of type <a class="reference internal" href="../apidocs/definitions.html#dagster.TransformExecutionInfo" title="dagster.TransformExecutionInfo"><code class="xref py py-class docutils literal notranslate"><span class="pre">TransformExecutionInfo</span></code></a>.
-The configuration passed into each solid is available to the annotated function as <code class="docutils literal notranslate"><span class="pre">info.config</span></code>.</li>
+parameter, <code class="docutils literal notranslate"><span class="pre">context</span></code>, of type <a class="reference internal" href="../apidocs/definitions.html#dagster.TransformExecutionContext" title="dagster.TransformExecutionContext"><code class="xref py py-class docutils literal notranslate"><span class="pre">TransformExecutionContext</span></code></a>.
+The configuration passed into each solid is available to the annotated function as <code class="docutils literal notranslate"><span class="pre">context.solid_config</span></code>.</li>
 </ol>
 <p>Configuration values are passed in a dict as the second argument to
 <a class="reference internal" href="../apidocs/execution.html#dagster.execute_pipeline" title="dagster.execute_pipeline"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline</span></code></a>. This dict specifies <em>all</em> of the
@@ -22369,8 +22376,8 @@ We’ll replace the config field in our solid definition with a structured, stro
 
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;word&#39;</span><span class="p">,</span> <span class="n">String</span><span class="p">)],</span> <span class="n">config_field</span><span class="o">=</span><span class="n">Field</span><span class="p">(</span><span class="n">Any</span><span class="p">))</span>
-<span class="k">def</span> <span class="nf">multiply_the_word</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
-    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
+<span class="k">def</span> <span class="nf">multiply_the_word</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
+    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
 
 
 <span class="nd">@lambda_solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;word&#39;</span><span class="p">)])</span>
@@ -22385,16 +22392,16 @@ We’ll replace the config field in our solid definition with a structured, stro
     <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;word&#39;</span><span class="p">,</span> <span class="n">String</span><span class="p">)],</span>
     <span class="n">config_field</span><span class="o">=</span><span class="n">Field</span><span class="p">(</span><span class="n">Dict</span><span class="p">({</span><span class="s1">&#39;factor&#39;</span><span class="p">:</span> <span class="n">Field</span><span class="p">(</span><span class="n">Int</span><span class="p">)})),</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">typed_multiply_the_word</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
-    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
+<span class="k">def</span> <span class="nf">typed_multiply_the_word</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
+    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
 
 
 <span class="nd">@solid</span><span class="p">(</span>
     <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;word&#39;</span><span class="p">,</span> <span class="n">String</span><span class="p">)],</span>
     <span class="n">config_field</span><span class="o">=</span><span class="n">Field</span><span class="p">(</span><span class="n">Dict</span><span class="p">({</span><span class="s1">&#39;factor&#39;</span><span class="p">:</span> <span class="n">Field</span><span class="p">(</span><span class="n">String</span><span class="p">)})),</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">typed_multiply_the_word_error</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
-    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
+<span class="k">def</span> <span class="nf">typed_multiply_the_word_error</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
+    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
 
 
 <span class="k">def</span> <span class="nf">define_demo_configuration_schema_pipeline</span><span class="p">():</span>
@@ -22737,7 +22744,7 @@ snapshots['test_build_all_docs 60'] = '''
 <h1>Execution Context<a class="headerlink" href="#execution-context" title="Permalink to this headline">¶</a></h1>
 <p>One of the most important objects in the system is the execution context. The execution
 context, the logger, and the resources are threaded throughout the entire computation (
-via the <code class="docutils literal notranslate"><span class="pre">info</span></code> object passed to user code) and contains handles to logging facilities
+via the <code class="docutils literal notranslate"><span class="pre">context</span></code> object passed to user code) and contains handles to logging facilities
 and external resources. Interactions with logging systems, databases, and external
 clusters (e.g. a Spark cluster) should be managed through these properties of the
 info object.</p>
@@ -22756,14 +22763,14 @@ your production cluster environment.</p>
 
 
 <span class="nd">@solid</span>
-<span class="k">def</span> <span class="nf">debug_message</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="s1">&#39;A debug message.&#39;</span><span class="p">)</span>
+<span class="k">def</span> <span class="nf">debug_message</span><span class="p">(</span><span class="n">context</span><span class="p">):</span>
+    <span class="n">context</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="s1">&#39;A debug message.&#39;</span><span class="p">)</span>
     <span class="k">return</span> <span class="s1">&#39;foo&#39;</span>
 
 
 <span class="nd">@solid</span>
-<span class="k">def</span> <span class="nf">error_message</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="s1">&#39;An error occurred.&#39;</span><span class="p">)</span>
+<span class="k">def</span> <span class="nf">error_message</span><span class="p">(</span><span class="n">context</span><span class="p">):</span>
+    <span class="n">context</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">error</span><span class="p">(</span><span class="s1">&#39;An error occurred.&#39;</span><span class="p">)</span>
 
 
 <span class="k">def</span> <span class="nf">define_execution_context_pipeline_step_one</span><span class="p">():</span>
@@ -24130,14 +24137,14 @@ happened during the computation.</p>
 41
 42</pre></div></td><td class="code"><div class="highlight"><pre><span></span>
 <span class="nd">@solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;num&#39;</span><span class="p">,</span> <span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">)])</span>
-<span class="k">def</span> <span class="nf">log_num</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num </span><span class="si">{num}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num</span><span class="o">=</span><span class="n">num</span><span class="p">))</span>
+<span class="k">def</span> <span class="nf">log_num</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">num</span><span class="p">):</span>
+    <span class="n">context</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num </span><span class="si">{num}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num</span><span class="o">=</span><span class="n">num</span><span class="p">))</span>
     <span class="k">return</span> <span class="n">num</span>
 
 
 <span class="nd">@solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;num&#39;</span><span class="p">,</span> <span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">)])</span>
-<span class="k">def</span> <span class="nf">log_num_squared</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num</span><span class="p">):</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num_squared </span><span class="si">{num_squared}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num_squared</span><span class="o">=</span><span class="n">num</span> <span class="o">*</span> <span class="n">num</span><span class="p">))</span>
+<span class="k">def</span> <span class="nf">log_num_squared</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">num</span><span class="p">):</span>
+    <span class="n">context</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s1">&#39;num_squared </span><span class="si">{num_squared}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">num_squared</span><span class="o">=</span><span class="n">num</span> <span class="o">*</span> <span class="n">num</span><span class="p">))</span>
     <span class="k">return</span> <span class="n">num</span> <span class="o">*</span> <span class="n">num</span>
 
 
@@ -24149,7 +24156,7 @@ happened during the computation.</p>
         <span class="n">OutputDefinition</span><span class="p">(</span><span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;out_two&#39;</span><span class="p">),</span>
     <span class="p">]</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">return_dict_results</span><span class="p">(</span><span class="n">_info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">return_dict_results</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">MultipleResults</span><span class="o">.</span><span class="n">from_dict</span><span class="p">({</span><span class="s1">&#39;out_one&#39;</span><span class="p">:</span> <span class="mi">23</span><span class="p">,</span> <span class="s1">&#39;out_two&#39;</span><span class="p">:</span> <span class="mi">45</span><span class="p">})</span>
 
     <span class="k">return</span> <span class="n">PipelineDefinition</span><span class="p">(</span>
@@ -24222,7 +24229,7 @@ the iterator form.)</p>
         <span class="n">OutputDefinition</span><span class="p">(</span><span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;out_two&#39;</span><span class="p">),</span>
     <span class="p">]</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">yield_outputs</span><span class="p">(</span><span class="n">_info</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">yield_outputs</span><span class="p">(</span><span class="n">_context</span><span class="p">):</span>
     <span class="k">yield</span> <span class="n">Result</span><span class="p">(</span><span class="mi">23</span><span class="p">,</span> <span class="s1">&#39;out_one&#39;</span><span class="p">)</span>
     <span class="k">yield</span> <span class="n">Result</span><span class="p">(</span><span class="mi">45</span><span class="p">,</span> <span class="s1">&#39;out_two&#39;</span><span class="p">)</span>
 
@@ -24284,10 +24291,10 @@ and then execute that pipeline.</p>
         <span class="n">OutputDefinition</span><span class="p">(</span><span class="n">dagster_type</span><span class="o">=</span><span class="n">Int</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;out_two&#39;</span><span class="p">),</span>
     <span class="p">],</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">conditional</span><span class="p">(</span><span class="n">info</span><span class="p">):</span>
-    <span class="k">if</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span> <span class="o">==</span> <span class="s1">&#39;out_one&#39;</span><span class="p">:</span>
+<span class="k">def</span> <span class="nf">conditional</span><span class="p">(</span><span class="n">context</span><span class="p">):</span>
+    <span class="k">if</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span> <span class="o">==</span> <span class="s1">&#39;out_one&#39;</span><span class="p">:</span>
         <span class="k">yield</span> <span class="n">Result</span><span class="p">(</span><span class="mi">23</span><span class="p">,</span> <span class="s1">&#39;out_one&#39;</span><span class="p">)</span>
-    <span class="k">elif</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span> <span class="o">==</span> <span class="s1">&#39;out_two&#39;</span><span class="p">:</span>
+    <span class="k">elif</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span> <span class="o">==</span> <span class="s1">&#39;out_two&#39;</span><span class="p">:</span>
         <span class="k">yield</span> <span class="n">Result</span><span class="p">(</span><span class="mi">45</span><span class="p">,</span> <span class="s1">&#39;out_two&#39;</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
         <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s1">&#39;invalid config&#39;</span><span class="p">)</span>
@@ -24541,8 +24548,8 @@ a yaml file to tell the CLI tool about the repository.</p>
     <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;word&#39;</span><span class="p">,</span> <span class="n">String</span><span class="p">)],</span>
     <span class="n">config_field</span><span class="o">=</span><span class="n">Field</span><span class="p">(</span><span class="n">Dict</span><span class="p">({</span><span class="s1">&#39;factor&#39;</span><span class="p">:</span> <span class="n">Field</span><span class="p">(</span><span class="n">Int</span><span class="p">)})),</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">multiply_the_word</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
-    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">info</span><span class="o">.</span><span class="n">config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
+<span class="k">def</span> <span class="nf">multiply_the_word</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">word</span><span class="p">):</span>
+    <span class="k">return</span> <span class="n">word</span> <span class="o">*</span> <span class="n">context</span><span class="o">.</span><span class="n">solid_config</span><span class="p">[</span><span class="s1">&#39;factor&#39;</span><span class="p">]</span>
 
 
 <span class="nd">@lambda_solid</span><span class="p">(</span><span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;word&#39;</span><span class="p">)])</span>
@@ -25067,9 +25074,9 @@ key of the <code class="docutils literal notranslate"><span class="pre">info</sp
     <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;num_one&#39;</span><span class="p">,</span> <span class="n">Int</span><span class="p">),</span> <span class="n">InputDefinition</span><span class="p">(</span><span class="s1">&#39;num_two&#39;</span><span class="p">,</span> <span class="n">Int</span><span class="p">)],</span>
     <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">OutputDefinition</span><span class="p">(</span><span class="n">Int</span><span class="p">)],</span>
 <span class="p">)</span>
-<span class="k">def</span> <span class="nf">add_ints</span><span class="p">(</span><span class="n">info</span><span class="p">,</span> <span class="n">num_one</span><span class="p">,</span> <span class="n">num_two</span><span class="p">):</span>
+<span class="k">def</span> <span class="nf">add_ints</span><span class="p">(</span><span class="n">context</span><span class="p">,</span> <span class="n">num_one</span><span class="p">,</span> <span class="n">num_two</span><span class="p">):</span>
     <span class="n">sum_ints</span> <span class="o">=</span> <span class="n">num_one</span> <span class="o">+</span> <span class="n">num_two</span>
-    <span class="n">info</span><span class="o">.</span><span class="n">resources</span><span class="o">.</span><span class="n">store</span><span class="o">.</span><span class="n">record_value</span><span class="p">(</span><span class="n">info</span><span class="o">.</span><span class="n">log</span><span class="p">,</span> <span class="s1">&#39;add&#39;</span><span class="p">,</span> <span class="n">sum_ints</span><span class="p">)</span>
+    <span class="n">context</span><span class="o">.</span><span class="n">resources</span><span class="o">.</span><span class="n">store</span><span class="o">.</span><span class="n">record_value</span><span class="p">(</span><span class="n">context</span><span class="o">.</span><span class="n">log</span><span class="p">,</span> <span class="s1">&#39;add&#39;</span><span class="p">,</span> <span class="n">sum_ints</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">sum_ints</span>
 
 

--- a/python_modules/dagster/internal_docs/adding_event.md
+++ b/python_modules/dagster/internal_docs/adding_event.md
@@ -2,7 +2,7 @@
 
 We distill the process of adding a new event by examining how we added the new event `StepMaterialization` that is emitted whenever we materialize anything in a solid (currently only called for materializating output notebooks in Dagstermill.)
 
-The `info` object (type `TransformExecutionInfo`) that is passed into the transform function of a solid has an attribute `info.context` (type `RuntimeExecutionContext`). The `info.context` object has an attribute `events` that is an instantiation of the `ExecutionEvents()` class (in the file `dagster.core.events`). To trigger an event that is consumed by the GraphQL API, we call a method of the `ExecutionEvents` class, such as `info.context.events.step_materialization_event(**kwargs)`. Thus we must add this event to the `ExecutionEvents` class as below:
+The `info` object (type `TransformExecutionContext`) that is passed into the transform function of a solid has an attribute `info.context` (type `RuntimeExecutionContext`). The `info.context` object has an attribute `events` that is an instantiation of the `ExecutionEvents()` class (in the file `dagster.core.events`). To trigger an event that is consumed by the GraphQL API, we call a method of the `ExecutionEvents` class, such as `info.context.events.step_materialization_event(**kwargs)`. Thus we must add this event to the `ExecutionEvents` class as below:
 
 `python_modules/dagster/dagster/core/events.py`
 

--- a/python_modules/dagster/internal_docs/adding_event.md
+++ b/python_modules/dagster/internal_docs/adding_event.md
@@ -2,7 +2,7 @@
 
 We distill the process of adding a new event by examining how we added the new event `StepMaterialization` that is emitted whenever we materialize anything in a solid (currently only called for materializating output notebooks in Dagstermill.)
 
-The `info` object (type `TransformExecutionContext`) that is passed into the transform function of a solid has an attribute `info.context` (type `RuntimeExecutionContext`). The `info.context` object has an attribute `events` that is an instantiation of the `ExecutionEvents()` class (in the file `dagster.core.events`). To trigger an event that is consumed by the GraphQL API, we call a method of the `ExecutionEvents` class, such as `info.context.events.step_materialization_event(**kwargs)`. Thus we must add this event to the `ExecutionEvents` class as below:
+The `context` object (type `TransformExecutionContext`) that is passed into the transform function of a solid has an attribute `info.context` (type `RuntimeExecutionContext`). The `context` object has an attribute `events` that is an instantiation of the `ExecutionEvents()` class (in the file `dagster.core.events`). To trigger an event that is consumed by the GraphQL API, we call a method of the `ExecutionEvents` class, such as `context.events.step_materialization_event(**kwargs)`. Thus we must add this event to the `ExecutionEvents` class as below:
 
 `python_modules/dagster/dagster/core/events.py`
 
@@ -21,9 +21,10 @@ class ExecutionEvents()
         )
 ```
 
-When `ExecutionEvents()` is created, its `self.context` points to the corresponding `RuntimeExecutionContext` that contains it. Thus this function simply logs the event. However notice that the other arguments we're passing into the logger (such as `step_key` or `file_name` are stored as part of meta-information in the Structured Logger log message). Normally if the logger is just writing to the console, then this meta-information is just pretty-printed to the console. However, if there is a `event_callback` in the `RuntimeExecutionContext`, then we have that the logger message is converted to an `EventRecord` (by the function `construct_event_record(logger_message)`), which is passed into the `event_callback` (which might be provided by Dagit, for example). 
+When `ExecutionEvents()` is created, its `self.context` points to the corresponding `RuntimeExecutionContext` that contains it. Thus this function simply logs the event. However notice that the other arguments we're passing into the logger (such as `step_key` or `file_name` are stored as part of meta-information in the Structured Logger log message). Normally if the logger is just writing to the console, then this meta-information is just pretty-printed to the console. However, if there is a `event_callback` in the `RuntimeExecutionContext`, then we have that the logger message is converted to an `EventRecord` (by the function `construct_event_record(logger_message)`), which is passed into the `event_callback` (which might be provided by Dagit, for example).
 
 Thus we need to make a corresponding EventRecord class that corresponds to our new event.
+
 ```
 class StepMaterializationRecord(ExecutionStepEventRecord):
     def __init__(self, file_name, file_location, **kwargs):
@@ -34,20 +35,26 @@ class StepMaterializationRecord(ExecutionStepEventRecord):
     def to_dict(self):
         ...
 ```
-We need to make sure `construct_event_record` calls the correct `EventRecord` constructor, so we must add our EventRecord to the `EVENT_CLS_LOOKUP` dictionary: 
+
+We need to make sure `construct_event_record` calls the correct `EventRecord` constructor, so we must add our EventRecord to the `EVENT_CLS_LOOKUP` dictionary:
+
 ```
 EVENT_CLS_LOOKUP = {
     ...
     EventType.STEP_MATERIALIAZATION: StepMaterializationRecord,
 }
 ```
+
 We also need to make sure we add the new event to the `EventType` enum, like below
+
 ```
 class EventType(Enum):
     ...
     STEP_MATERIALIAZATION = 'STEP_MATERIALIZATION'
 ```
+
 We also need to modify the `logger_to_kwargs` function that constructs the kwargs dictionary that gets passed into `StepMaterializationRecord` constructor in `construct_event_record` to add new arguments necesary for the constructor. Notice this should remind us of something we've already done since we're already passed in these parameters as keyword args when we did logging in the function `step_materialization_event` in the `ExecutionEvents()` class, so now we're unpacking these arguments that were stored in the meta information of the logging and re-constructing them in creation of the EventRecord.
+
 ```
 def logger_to_kwargs(logger_message):
     ...
@@ -56,11 +63,13 @@ def logger_to_kwargs(logger_message):
         step_args['file_location'] = logger_message.meta['file_location']
     ...
 ```
+
 This is the end of all the changes necesary in the `events.py` file, but we still need to hook up emission of a Dagster `EventRecord` to a GraphQL schema and GraphQL event.
 
 `python_modules/dagit/dagit/schema/runs.py`
 
 The above file is where the function `from_dagster_event()` converts an `EventRecord` to an `Dauphin` object (which itself is a wrapper on Graphene objects). To add a Dauphin class, we actually create a wrapper class that uses this `Meta` incantation that auto-registers itself with the Dauphin reigstry (in `dagit.dagit.schema.dauphin`) that we later lookup according to the `name` field. Spoooooky 👻! Example below...
+
 ```
 class DauphinStepMaterializationEvent(dauphin.ObjectType):
     class Meta:
@@ -69,8 +78,10 @@ class DauphinStepMaterializationEvent(dauphin.ObjectType):
 
     file_name = dauphin.NonNull(dauphin.String)
     file_location = dauphin.NonNull(dauphin.String)
-```    
+```
+
 The fields `file_name` and `file_location` are fields in the corresponding GraphQL schema for `StepMaterializationEvent`. The interfaces that the event implements define additional fields contained in thos classes. Finally, we need to add code to the `from_dagster_event()` function to actually return an instance of the `DauphinStepMaterializationEvent` class.
+
 ```
 elif event.event_type == EventType.STEP_MATERIALIAZATION:
     return info.schema.type_named('StepMaterializationEvent')(
@@ -82,9 +93,7 @@ elif event.event_type == EventType.STEP_MATERIALIAZATION:
         **basic_params
     )
 ```
-The line `info.schema.type_named('StepMaterializationEvent')` auto-magically looks up the `DauphinStepMaterializationEvent` class within the `DauphinRegistry` and calls its constructor with the provided arguments. It is *essential* to include `**basic_params`, as those arguments generally are used in the interfaces that the  Dauphin class implements.
+
+The line `info.schema.type_named('StepMaterializationEvent')` auto-magically looks up the `DauphinStepMaterializationEvent` class within the `DauphinRegistry` and calls its constructor with the provided arguments. It is _essential_ to include `**basic_params`, as those arguments generally are used in the interfaces that the Dauphin class implements.
 
 There you go, now you know how to add an event type to the GraphQL schema and thread it through the entire codebase!
-
-
-

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -30,7 +30,6 @@ from dagster import (
     types,
 )
 
-from dagster.core.definitions.infos import ITransformExecutionInfo
 from dagster.core.types.marshal import serialize_to_file, deserialize_from_file
 from dagster.core.types.runtime import RuntimeType
 
@@ -38,7 +37,13 @@ from dagster.core.definitions.dependency import Solid
 from dagster.core.events import construct_json_event_logger, EventRecord, EventType
 from dagster.core.definitions.environment_configs import construct_environment_config
 from dagster.core.execution import yield_context
-from dagster.core.execution_context import ExecutionMetadata, DagsterLog, RuntimeExecutionContext
+from dagster.core.execution_context import (
+    ExecutionMetadata,
+    DagsterLog,
+    LegacyRuntimeExecutionContext,
+    ITransformExecutionContext,
+    WithLegacyContext,
+)
 
 # magic incantation for syncing up notebooks to enclosing virtual environment.
 # I don't claim to understand it.
@@ -46,19 +51,24 @@ from dagster.core.execution_context import ExecutionMetadata, DagsterLog, Runtim
 # python3 -m ipykernel install --user
 
 
-class DagstermillInNotebookExecutionInfo(
-    ITransformExecutionInfo,
-    namedtuple('_DagstermillInNotebookExecutionInfo', 'context__ pipeline_def__'),
+class DagstermillInNotebookExecutionContext(
+    WithLegacyContext,
+    ITransformExecutionContext,
+    namedtuple('_DagstermillInNotebookExecutionContext', 'context__ pipeline_def__'),
 ):
     def __new__(cls, context, pipeline_def):
-        return super(DagstermillInNotebookExecutionInfo, cls).__new__(
+        return super(DagstermillInNotebookExecutionContext, cls).__new__(
             cls,
-            check.inst_param(context, 'context', RuntimeExecutionContext),
+            check.inst_param(context, 'context', LegacyRuntimeExecutionContext),
             check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition),
         )
 
     @property
     def context(self):
+        return self.context__
+
+    @property
+    def legacy_context(self):
         return self.context__
 
     @property
@@ -80,14 +90,6 @@ class DagstermillInNotebookExecutionInfo(
     @property
     def pipeline_def(self):
         return self.pipeline_def__
-
-    @property
-    def resources(self):
-        return self.context__.resources
-
-    @property
-    def log(self):
-        return DagsterLog(self.context__)
 
 
 class DagstermillError(Exception):
@@ -126,7 +128,7 @@ class Manager:
         with yield_context(
             pipeline_def, dummy_environment_config, ExecutionMetadata(run_id='')
         ) as context:
-            self.info = DagstermillInNotebookExecutionInfo(context, pipeline_def)
+            self.info = DagstermillInNotebookExecutionContext(context, pipeline_def)
         return self.info
 
     def get_pipeline(self, name):
@@ -167,7 +169,7 @@ class Manager:
         # See block comment above referencing this issue
         # See https://github.com/dagster-io/dagster/issues/796
         with yield_context(pipeline_def, typed_environment, execution_metadata) as context:
-            self.info = DagstermillInNotebookExecutionInfo(context, pipeline_def)
+            self.info = DagstermillInNotebookExecutionContext(context, pipeline_def)
 
         return self.info
 
@@ -266,36 +268,36 @@ def read_value(runtime_type, value):
         )
 
 
-def get_papermill_parameters(transform_execution_info, inputs, output_log_path):
-    check.inst_param(transform_execution_info, 'transform_execution_info', ITransformExecutionInfo)
+def get_papermill_parameters(transform_context, inputs, output_log_path):
+    check.inst_param(transform_context, 'transform_context', ITransformExecutionContext)
     check.param_invariant(
-        isinstance(transform_execution_info.context.environment_config, dict),
-        'transform_execution_info',
-        'TransformExecutionInfo must have valid environment_config',
+        isinstance(transform_context.environment_config, dict),
+        'transform_context',
+        'TransformExecutionContext must have valid environment_config',
     )
     check.dict_param(inputs, 'inputs', key_type=six.string_types)
 
-    run_id = transform_execution_info.context.run_id
+    run_id = transform_context.run_id
 
     marshal_dir = '/tmp/dagstermill/{run_id}/marshal'.format(run_id=run_id)
     if not os.path.exists(marshal_dir):
         os.makedirs(marshal_dir)
 
-    if not transform_execution_info.context.has_event_callback:
-        transform_execution_info.log.info("get_papermill_parameters.context has no event_callback!")
+    if not transform_context.has_event_callback:
+        transform_context.log.info("get_papermill_parameters.context has no event_callback!")
         output_log_path = 0  # stands for null
 
     dm_context_dict = {
         'run_id': run_id,
-        'pipeline_name': transform_execution_info.pipeline_def.name,
+        'pipeline_name': transform_context.pipeline_def.name,
         'marshal_dir': marshal_dir,
-        'environment_config': transform_execution_info.context.environment_config,
+        'environment_config': transform_context.environment_config,
         'output_log_path': output_log_path,
     }
 
     parameters = dict(dm_context=json.dumps(dm_context_dict, sort_keys=True))
 
-    input_defs = transform_execution_info.solid_def.input_defs
+    input_defs = transform_context.solid_def.input_defs
     input_def_dict = {inp.name: inp for inp in input_defs}
     for input_name, input_value in inputs.items():
         assert (
@@ -310,7 +312,7 @@ def get_papermill_parameters(transform_execution_info, inputs, output_log_path):
     return parameters
 
 
-def replace_parameters(info, nb, parameters):
+def replace_parameters(context, nb, parameters):
     # Uma: This is a copy-paste from papermill papermill/execute.py:104 (execute_parameters).
     # Typically, papermill injects the injected-parameters cell *below* the parameters cell
     # but we want to *replace* the parameters cell, which is what this function does.
@@ -349,7 +351,7 @@ def replace_parameters(info, nb, parameters):
         after = nb.cells[param_cell_index + 1 :]
     else:
         # Inject to the top of the notebook, presumably first cell includes dagstermill import
-        info.log.debug(
+        context.log.debug(
             (
                 "Warning notebook has no parameters cell, "
                 "so first cell must import dagstermill and call dm.declare_as_solid"
@@ -380,14 +382,14 @@ def _dm_solid_transform(name, notebook_path):
 
     do_cleanup = False  # for now
 
-    def _t_fn(info, inputs):
+    def _t_fn(context, inputs):
         check.param_invariant(
-            isinstance(info.context.environment_config, dict),
-            'info',
-            'TransformExecutionInfo must have valid environment_config',
+            isinstance(context.environment_config, dict),
+            'context',
+            'TransformExecutionContext must have valid environment_config',
         )
 
-        base_dir = '/tmp/dagstermill/{run_id}/'.format(run_id=info.context.run_id)
+        base_dir = '/tmp/dagstermill/{run_id}/'.format(run_id=context.run_id)
         output_notebook_dir = os.path.join(base_dir, 'output_notebooks/')
 
         if not os.path.exists(output_notebook_dir):
@@ -402,7 +404,7 @@ def _dm_solid_transform(name, notebook_path):
         try:
             nb = load_notebook_node(notebook_path)
             nb_no_parameters = replace_parameters(
-                info, nb, get_papermill_parameters(info, inputs, output_log_path)
+                context, nb, get_papermill_parameters(context, inputs, output_log_path)
             )
             intermediate_path = os.path.join(
                 output_notebook_dir, '{prefix}-inter.ipynb'.format(prefix=str(uuid.uuid4()))
@@ -415,7 +417,7 @@ def _dm_solid_transform(name, notebook_path):
             process = subprocess.Popen(['papermill', intermediate_path, temp_path])
 
             while process.poll() is None:  # while subprocess alive
-                if info.context.event_callback:
+                if context.event_callback:
                     with open(output_log_path, 'r') as ff:
                         current_time = os.path.getmtime(output_log_path)
                         while process.poll() is None:
@@ -429,28 +431,30 @@ def _dm_solid_transform(name, notebook_path):
                                 event_record_dict['event_type'] = EventType(
                                     event_record_dict['event_type']
                                 )
-                                info.context.event_callback(EventRecord(**event_record_dict))
+                                context.event_callback(EventRecord(**event_record_dict))
                                 current_time = new_time
 
             if process.returncode != 0:
                 raise DagstermillError(
-                    'There wsas an error when Papermill tried to execute the notebook. '
+                    'There was an error when Papermill tried to execute the notebook. '
                     'The process stderr is {stderr}'.format(stderr=process.stderr)
                 )
 
             output_nb = pm.read_notebook(temp_path)
 
-            info.log.debug(
+            context.log.debug(
                 'Notebook execution complete for {name}. Data is {data}'.format(
                     name=name, data=output_nb.data
                 )
             )
 
-            info.context.events.step_materialization(
-                info.step.key, "{name} output notebook".format(name=info.solid.name), temp_path
+            context.events.step_materialization(
+                context.step.key,
+                "{name} output notebook".format(name=context.solid.name),
+                temp_path,
             )
 
-            for output_def in info.solid_def.output_defs:
+            for output_def in context.solid_def.output_defs:
                 if output_def.name in output_nb.data:
 
                     value = read_value(output_def.runtime_type, output_nb.data[output_def.name])

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -41,7 +41,7 @@ from dagster.core.execution_context import (
     ExecutionMetadata,
     DagsterLog,
     LegacyRuntimeExecutionContext,
-    ITransformExecutionContext,
+    TransformExecutionContextMetadata,
     WithLegacyContext,
 )
 
@@ -53,7 +53,7 @@ from dagster.core.execution_context import (
 
 class DagstermillInNotebookExecutionContext(
     WithLegacyContext,
-    ITransformExecutionContext,
+    TransformExecutionContextMetadata,
     namedtuple('_DagstermillInNotebookExecutionContext', 'context__ pipeline_def__'),
 ):
     def __new__(cls, context, pipeline_def):
@@ -269,7 +269,7 @@ def read_value(runtime_type, value):
 
 
 def get_papermill_parameters(transform_context, inputs, output_log_path):
-    check.inst_param(transform_context, 'transform_context', ITransformExecutionContext)
+    check.inst_param(transform_context, 'transform_context', TransformExecutionContextMetadata)
     check.param_invariant(
         isinstance(transform_context.environment_config, dict),
         'transform_context',

--- a/python_modules/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/dagstermill/dagstermill/examples/repository.py
@@ -95,8 +95,8 @@ def define_add_pipeline():
 
 
 @solid(inputs=[], config_field=Field(Int))
-def load_constant(info):
-    return info.config
+def load_constant(context):
+    return context.solid_config
 
 
 def define_test_notebook_dag_pipeline():


### PR DESCRIPTION
This diff changes the top-level object from info to context everywhere. What was RuntimeExecutionContext is now LegacyRuntimeExecutionContext. (With the new API in place we can do subsequent refactors to eliminate this object). All top-level fields that were available on the legacy context object have been hoisted to the formerly-info-but-now-context object. TransformExecutionInfo is now TransformExecutionContext.

This also renames the `config` field on the formerly info object to `solid_config`. Using `context.config` to access the config for the solid was super confusing, so i changed it to `context.solid_config` which is much clearer.

This is a non-breaking change (for now). Old code with `info.context` syntax will continue to work as will `info.config`. At some point we should deprecated and eliminate, but I think that is an 0.4.0 conversation.

Follow on work:

- Eliminate LegacyRuntimeExecutionContext
- Rename/refactor info object passed to context and resource creation. (Maybe call it InitializationContext?)
- Rename/refactor info object passed to expectations functions.