### PR TITLE
Refactoring execution (stacked on #801)

### DIFF
--- a/python_modules/dagit/dagit/schema/context.py
+++ b/python_modules/dagit/dagit/schema/context.py
@@ -4,7 +4,9 @@ from dagit.pipeline_execution_manager import PipelineExecutionManager
 
 
 class DagsterGraphQLContext(object):
-    def __init__(self, repository_container, pipeline_runs, execution_manager):
+    def __init__(
+        self, repository_container, pipeline_runs, execution_manager, throw_on_user_error=False
+    ):
         from dagit.app import RepositoryContainer
 
         self.repository_container = check.inst_param(
@@ -14,3 +16,4 @@ class DagsterGraphQLContext(object):
         self.execution_manager = check.inst_param(
             execution_manager, 'pipeline_execution_manager', PipelineExecutionManager
         )
+        self.throw_on_user_error = check.bool_param(throw_on_user_error, 'throw_on_user_error')

--- a/python_modules/dagit/dagit_tests/test_multiprocessing.py
+++ b/python_modules/dagit/dagit_tests/test_multiprocessing.py
@@ -42,7 +42,9 @@ def test_running():
         run_id, selector, env_config, create_execution_plan(pipeline, env_config)
     )
     execution_manager = MultiprocessingExecutionManager()
-    execution_manager.execute_pipeline(repository_container, pipeline, pipeline_run)
+    execution_manager.execute_pipeline(
+        repository_container, pipeline, pipeline_run, throw_on_user_error=False
+    )
     execution_manager.join()
     assert pipeline_run.status == PipelineRunStatus.SUCCESS
     events = pipeline_run.all_logs()
@@ -76,7 +78,9 @@ def test_failing():
         run_id, selector, env_config, create_execution_plan(pipeline, env_config)
     )
     execution_manager = MultiprocessingExecutionManager()
-    execution_manager.execute_pipeline(repository_container, pipeline, pipeline_run)
+    execution_manager.execute_pipeline(
+        repository_container, pipeline, pipeline_run, throw_on_user_error=False
+    )
     execution_manager.join()
     assert pipeline_run.status == PipelineRunStatus.FAILURE
     assert pipeline_run.all_logs()
@@ -103,7 +107,9 @@ def test_execution_crash():
         run_id, selector, env_config, create_execution_plan(pipeline, env_config)
     )
     execution_manager = MultiprocessingExecutionManager()
-    execution_manager.execute_pipeline(repository_container, pipeline, pipeline_run)
+    execution_manager.execute_pipeline(
+        repository_container, pipeline, pipeline_run, throw_on_user_error=False
+    )
     execution_manager.join()
     assert pipeline_run.status == PipelineRunStatus.FAILURE
     last_log = pipeline_run.all_logs()[-1]

--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -62,7 +62,7 @@ def aws_lambda_handler(event, _context):
         execution_metadata=ExecutionMetadata(run_id=run_id),
         execution_context=ExecutionContext(loggers=[logger]),
         resources=resources,
-        environment={},
+        environment_config={},
     )
 
     logger.info('Looking for step body at %s/%s', s3_bucket, s3_key_body)

--- a/python_modules/dagma/dagma_tests/test_lambda_engine.py
+++ b/python_modules/dagma/dagma_tests/test_lambda_engine.py
@@ -23,8 +23,7 @@ from dagster import (
 )
 from dagster.core.execution import (
     create_execution_plan_core,
-    ExecutionPlanInfo,
-    create_typed_environment,
+    create_environment_config,
     yield_pipeline_execution_context,
 )
 from dagma import execute_plan, define_dagma_resource
@@ -94,15 +93,11 @@ TEST_ENVIRONMENT = {
 
 
 def run_test_pipeline(pipeline):
-    typed_environment = create_typed_environment(pipeline, TEST_ENVIRONMENT)
-
     execution_metadata = ExecutionMetadata(run_id=str(uuid.uuid4()))
     with yield_pipeline_execution_context(
-        pipeline, typed_environment, execution_metadata
+        pipeline, TEST_ENVIRONMENT, execution_metadata
     ) as context:
-        execution_plan = create_execution_plan_core(
-            ExecutionPlanInfo(context, pipeline, typed_environment)
-        )
+        execution_plan = create_execution_plan_core(context)
         return execute_plan(context, execution_plan)
 
 

--- a/python_modules/dagster-airflow/dagster_airflow_tests/test_project/dagster_airflow_demo.py
+++ b/python_modules/dagster-airflow/dagster_airflow_tests/test_project/dagster_airflow_demo.py
@@ -15,8 +15,8 @@ from dagster import (
 
 
 @solid(inputs=[InputDefinition('word', String)], config_field=Field(Dict({'factor': Field(Int)})))
-def multiply_the_word(context, word):
-    return word * context.solid_config['factor']
+def multiply_the_word(info, word):
+    return word * info.solid_config['factor']
 
 
 @lambda_solid(inputs=[InputDefinition('word')])

--- a/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
+++ b/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
@@ -14,7 +14,10 @@ from .test_project.dagster_airflow_demo import define_demo_execution_pipeline
 
 IMAGE = 'dagster-airflow-demo'
 
+import pytest
 
+
+# @pytest.mark.skip('do not understand; do not checkin')
 def test_unit_run_airflow_dag_steps(airflow_test, dags_path):
     pipeline = define_demo_execution_pipeline()
     env_config = load_yaml_from_path(script_relative_path('test_project/env.yml'))
@@ -59,6 +62,14 @@ def test_unit_run_airflow_dag_steps(airflow_test, dags_path):
         assert 'EXECUTION_PLAN_STEP_SUCCESS' in str(res)
 
         for step_output in step.step_outputs:
+
+            # TODO: I don't understand this failure
+            # Relying on logging output?
             assert 'for output {output_name}'.format(output_name=step_output.name) in str(res)
+            # E               assert 'for output result' in 'b\'[2019-02-11 14:35:24,503] {__init__.py:51} INFO - Using executor SequentialExecutor\\n[2019-02-11 14:35:24,743] {m...{"startSubplanExecution": {"__typename": "StartSubplanExecutionSuccess", "pipeline": {"name": "demo_pipeline"}}}}\\n\''
+            # E                +  where 'for output result' = <built-in method format of str object at 0x7fd7b9229bc0>(output_name='result')
+            # E                +    where <built-in method format of str object at 0x7fd7b9229bc0> = 'for output {output_name}'.format
+            # E                +    and   'result' = StepOutput(name='result', runtime_type=<dagster.core.types.runtime.Any object at 0x7fd7bbf48f98>).name
+            # E                +  and   'b\'[2019-02-11 14:35:24,503] {__init__.py:51} INFO - Using executor SequentialExecutor\\n[2019-02-11 14:35:24,743] {m...{"startSubplanExecution": {"__typename": "StartSubplanExecutionSuccess", "pipeline": {"name": "demo_pipeline"}}}}\\n\'' = str(b'[2019-02-11 14:35:24,503] {__init__.py:51} INFO - Using executor SequentialExecutor\n[2019-02-11 14:35:24,743] {mode...": {"startSubplanExecution": {"__typename": "StartSubplanExecutionSuccess", "pipeline": {"name": "demo_pipeline"}}}}\n')
 
             assert os.path.isfile(_key_for_marshalled_result(step.key, step_output.name))

--- a/python_modules/dagster-airflow/tox.ini
+++ b/python_modules/dagster-airflow/tox.ini
@@ -17,7 +17,7 @@ commands =
   pip install --upgrade pip<19.0
   pip install -e .
   airflow initdb
-  pytest -vv -m "not skip_on_circle" --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report=
+  pytest -s -vv -m "not skip_on_circle" --junitxml=test_results.xml --cov=dagster_airflow --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/dagster-pandas/dagster_pandas/data_frame.py
@@ -24,6 +24,10 @@ def define_csv_dict_field():
     )
 
 
+def dict_without_keys(ddict, *keys):
+    return {key: value for key, value in ddict.items() if key not in set(keys)}
+
+
 @output_selector_schema(
     NamedSelector(
         'DataFrameOutputSchema',
@@ -41,8 +45,7 @@ def dataframe_output_schema(file_type, file_options, pandas_df):
 
     if file_type == 'csv':
         path = file_options['path']
-        del file_options['path']
-        return pandas_df.to_csv(path, index=False, **file_options)
+        return pandas_df.to_csv(path, index=False, **dict_without_keys(file_options, 'path'))
     elif file_type == 'parquet':
         return pandas_df.to_parquet(file_options['path'])
     elif file_type == 'table':
@@ -67,8 +70,7 @@ def dataframe_input_schema(file_type, file_options):
 
     if file_type == 'csv':
         path = file_options['path']
-        del file_options['path']
-        return pd.read_csv(path, **file_options)
+        return pd.read_csv(path, **dict_without_keys(file_options, 'path'))
     elif file_type == 'parquet':
         return pd.read_parquet(file_options['path'])
     elif file_type == 'table':

--- a/python_modules/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -24,7 +24,7 @@ def test_execute_pipeline():
         }
     }
 
-    result = execute_pipeline(pipeline, environment=environment)
+    result = execute_pipeline(pipeline, environment_dict=environment)
 
     assert result.success
 

--- a/python_modules/dagster-pandas/dagster_pandas_tests/test_pandas_hello_world_library_slide.py
+++ b/python_modules/dagster-pandas/dagster_pandas_tests/test_pandas_hello_world_library_slide.py
@@ -33,7 +33,7 @@ def run_hello_world(hello_world):
 
     pipeline = PipelineDefinition(solids=[hello_world], dependencies={'hello_world': {}})
 
-    pipeline_result = execute_pipeline(pipeline, environment=create_num_csv_environment())
+    pipeline_result = execute_pipeline(pipeline, environment_dict=create_num_csv_environment())
 
     result = pipeline_result.result_for_solid('hello_world')
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_basic_solid.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_basic_solid.py
@@ -144,7 +144,7 @@ def test_output_sql_sum_sq_solid():
 
     environment = {'solids': {create_sum_sq_table.name: {'config': {'table_name': 'sum_sq_table'}}}}
 
-    pipeline_result = execute_pipeline(pipeline=pipeline, environment=environment)
+    pipeline_result = execute_pipeline(pipeline=pipeline, environment_dict=environment)
 
     assert pipeline_result.success
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_isolated_templated_sql_tests.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_isolated_templated_sql_tests.py
@@ -54,7 +54,7 @@ def test_single_templated_sql_solid_single_table_with_api():
 
     environment = {'solids': {'sum_table_transform': {'config': {'sum_table': sum_table_arg}}}}
 
-    result = execute_pipeline(pipeline, environment=environment)
+    result = execute_pipeline(pipeline, environment_dict=environment)
     assert result.success
 
     assert _load_table(result.context, sum_table_arg) == [(1, 2, 3), (3, 4, 7)]
@@ -81,7 +81,7 @@ def test_single_templated_sql_solid_double_table_raw_api():
         }
     }
 
-    result = execute_pipeline(pipeline, environment=environment)
+    result = execute_pipeline(pipeline, environment_dict=environment)
     assert result.success
 
     assert _load_table(result.context, sum_table_arg) == [(1, 2, 3), (3, 4, 7)]
@@ -108,7 +108,7 @@ def test_single_templated_sql_solid_double_table_with_api():
         }
     }
 
-    result = execute_pipeline(pipeline, environment=environment)
+    result = execute_pipeline(pipeline, environment_dict=environment)
     assert result.success
 
     assert _load_table(result.context, sum_table_arg) == [(1, 2, 3), (3, 4, 7)]
@@ -157,7 +157,7 @@ def test_templated_sql_solid_pipeline():
         }
     }
 
-    first_result = execute_pipeline(pipeline, environment=environment_one)
+    first_result = execute_pipeline(pipeline, environment_dict=environment_one)
     assert first_result.success
 
     assert len(first_result.result_list) == 2
@@ -185,7 +185,7 @@ def test_templated_sql_solid_pipeline():
 
     environment_two = {'solids': {'sum_sq_table': {'config': sum_sq_args}}}
 
-    second_result = execute_pipeline(pipeline_two, environment=environment_two)
+    second_result = execute_pipeline(pipeline_two, environment_dict=environment_two)
     assert second_result.success
     assert len(second_result.result_list) == 2
     assert _load_table(second_result.context, second_sum_sq_table) == [(1, 2, 3, 9), (3, 4, 7, 49)]
@@ -205,7 +205,7 @@ def test_templated_sql_solid_with_api():
 
     environment = {'solids': {'sum_solid': {'config': {'sum_table': sum_table_arg}}}}
 
-    result = execute_pipeline(pipeline, environment=environment)
+    result = execute_pipeline(pipeline, environment_dict=environment)
     assert result.success
 
     assert _load_table(result.context, sum_table_arg) == [(1, 2, 3), (3, 4, 7)]
@@ -232,7 +232,7 @@ def test_with_from_through_specifying_all_solids():
         }
     }
 
-    pipeline_result = execute_pipeline(pipeline, environment=environment)
+    pipeline_result = execute_pipeline(pipeline, environment_dict=environment)
     assert len(pipeline_result.result_list) == 3
     assert _load_table(pipeline_result.context, first_sum_table) == [(1, 2, 3), (3, 4, 7)]
     assert _load_table(pipeline_result.context, first_mult_table) == [(1, 2, 2), (3, 4, 12)]
@@ -260,7 +260,7 @@ def test_multi_input_partial_execution():
         }
     }
 
-    first_pipeline_result = execute_pipeline(pipeline, environment=environment)
+    first_pipeline_result = execute_pipeline(pipeline, environment_dict=environment)
 
     assert first_pipeline_result.success
     assert len(first_pipeline_result.result_list) == 3

--- a/python_modules/dagster/dagster/core/execution_plan/__init__.py
+++ b/python_modules/dagster/dagster/core/execution_plan/__init__.py
@@ -1,1 +1,1 @@
-from .create import create_execution_plan_core, ExecutionPlanInfo
+from .create import create_execution_plan_core

--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -1,13 +1,12 @@
 from dagster import check
 
-from dagster.core.execution_context import StepExecutionContext
+from dagster.core.execution_context import StepExecutionContext, PipelineExecutionContext
 
 from dagster.core.definitions import ExpectationDefinition, InputDefinition, OutputDefinition, Solid
 
 from dagster.core.errors import DagsterExpectationFailedError
 
 from .objects import (
-    ExecutionPlanInfo,
     ExecutionStep,
     ExecutionValueSubplan,
     StepInput,
@@ -116,14 +115,14 @@ def create_expectation_step(
     )
 
 
-def decorate_with_expectations(execution_info, plan_builder, solid, transform_step, output_def):
-    check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
+def decorate_with_expectations(pipeline_context, plan_builder, solid, transform_step, output_def):
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(transform_step, 'transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)
 
-    if execution_info.environment.expectations.evaluate and output_def.expectations:
+    if pipeline_context.environment_config.expectations.evaluate and output_def.expectations:
         return create_expectations_subplan(
             plan_builder,
             solid,

--- a/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
@@ -1,11 +1,11 @@
 from dagster import check
 
 from dagster.core.definitions import Solid, OutputDefinition
+from dagster.core.execution_context import PipelineExecutionContext
 
 from dagster.core.types.runtime import RuntimeType
 
 from .objects import (
-    ExecutionPlanInfo,
     ExecutionStep,
     ExecutionValueSubplan,
     PlanBuilder,
@@ -42,14 +42,16 @@ def configs_for_output(solid, solid_config, output_def):
             yield output_spec
 
 
-def decorate_with_output_materializations(execution_info, plan_builder, solid, output_def, subplan):
-    check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
+def decorate_with_output_materializations(
+    pipeline_context, plan_builder, solid, output_def, subplan
+):
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(output_def, 'output_def', OutputDefinition)
     check.inst_param(subplan, 'subplan', ExecutionValueSubplan)
 
-    solid_config = execution_info.environment.solids.get(solid.name)
+    solid_config = pipeline_context.environment_config.solids.get(solid.name)
 
     if not (solid_config and solid_config.outputs):
         return subplan

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -8,8 +8,7 @@ import six
 
 from dagster import check
 from dagster.utils import merge_dicts
-from dagster.core.system_config.objects import EnvironmentConfig
-from dagster.core.definitions import PipelineDefinition, Solid, SolidOutputHandle
+from dagster.core.definitions import Solid, SolidOutputHandle
 from dagster.core.errors import DagsterError
 from dagster.core.types.runtime import RuntimeType
 
@@ -268,18 +267,6 @@ class ExecutionPlan(object):
         ordered_step_keys = toposort.toposort_flatten(self.deps)
         for step_key in ordered_step_keys:
             yield self.step_dict[step_key]
-
-
-class ExecutionPlanInfo(namedtuple('_ExecutionPlanInfo', 'context pipeline environment')):
-    def __new__(cls, context, pipeline, environment):
-        from dagster.core.execution_context import PipelineExecutionContext
-
-        return super(ExecutionPlanInfo, cls).__new__(
-            cls,
-            check.inst_param(context, 'context', PipelineExecutionContext),
-            check.inst_param(pipeline, 'pipeline', PipelineDefinition),
-            check.inst_param(environment, 'environment', EnvironmentConfig),
-        )
 
 
 class StepOutputMap(dict):

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -1,21 +1,13 @@
 from dagster import check
 from dagster.core.definitions import Result, Solid
 from dagster.core.errors import DagsterInvariantViolationError
-from dagster.core.execution_context import TransformExecutionContext
+from dagster.core.execution_context import StepExecutionContext, PipelineExecutionContext
 
-from .objects import (
-    ExecutionPlanInfo,
-    ExecutionStep,
-    PlanBuilder,
-    StepInput,
-    StepKind,
-    StepOutput,
-    StepOutputValue,
-)
+from .objects import ExecutionStep, PlanBuilder, StepInput, StepKind, StepOutput, StepOutputValue
 
 
-def create_transform_step(execution_info, plan_builder, solid, step_inputs, solid_config):
-    check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
+def create_transform_step(pipeline_context, plan_builder, solid, step_inputs):
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.list_param(step_inputs, 'step_inputs', of_type=StepInput)
@@ -28,7 +20,7 @@ def create_transform_step(execution_info, plan_builder, solid, step_inputs, soli
             for output_def in solid.definition.output_defs
         ],
         compute_fn=lambda step_context, step, inputs: _execute_core_transform(
-            execution_info, step_context.for_transform(solid_config), step, inputs
+            pipeline_context, step_context.for_transform(), step, inputs
         ),
         kind=StepKind.TRANSFORM,
         solid=solid,
@@ -36,9 +28,9 @@ def create_transform_step(execution_info, plan_builder, solid, step_inputs, soli
     )
 
 
-def _yield_transform_results(_execution_info, transform_context, step, inputs):
-    check.inst_param(transform_context, 'transform_context', TransformExecutionContext)
-    gen = step.solid.definition.transform_fn(transform_context, inputs)
+def _yield_transform_results(_execution_info, step_context, step, inputs):
+    check.inst_param(step_context, 'step_context', StepExecutionContext)
+    gen = step.solid.definition.transform_fn(step_context, inputs)
 
     if isinstance(gen, Result):
         raise DagsterInvariantViolationError(
@@ -61,7 +53,7 @@ def _yield_transform_results(_execution_info, transform_context, step, inputs):
                 ).format(result=repr(result), solid_name=step.solid.name)
             )
 
-        transform_context.log.info(
+        step_context.log.info(
             'Solid {solid} emitted output "{output}" value {value}'.format(
                 solid=step.solid.name, output=result.output_name, value=repr(result.value)
             )
@@ -69,29 +61,27 @@ def _yield_transform_results(_execution_info, transform_context, step, inputs):
         yield StepOutputValue(output_name=result.output_name, value=result.value)
 
 
-def _execute_core_transform(execution_info, transform_context, step, inputs):
+def _execute_core_transform(pipeline_context, step_context, step, inputs):
     '''
     Execute the user-specified transform for the solid. Wrap in an error boundary and do
     all relevant logging and metrics tracking
     '''
-    check.inst_param(execution_info, 'execution_info', ExecutionPlanInfo)
-    check.inst_param(transform_context, 'transform_context', TransformExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(step_context, 'step_context', StepExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.dict_param(inputs, 'inputs', key_type=str)
 
     solid = step.solid
 
-    transform_context.log.debug(
-        'Executing core transform for solid {solid}.'.format(solid=solid.name)
-    )
+    step_context.log.debug('Executing core transform for solid {solid}.'.format(solid=solid.name))
 
-    all_results = list(_yield_transform_results(execution_info, transform_context, step, inputs))
+    all_results = list(_yield_transform_results(pipeline_context, step_context, step, inputs))
 
     if len(all_results) != len(solid.definition.output_defs):
         emitted_result_names = {r.output_name for r in all_results}
         solid_output_names = {output_def.name for output_def in solid.definition.output_defs}
         omitted_outputs = solid_output_names.difference(emitted_result_names)
-        transform_context.log.info(
+        step_context.log.info(
             'Solid {solid} did not fire outputs {outputs}'.format(
                 solid=solid.name, outputs=repr(omitted_outputs)
             )

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -44,7 +44,7 @@ def execute_single_solid_in_isolation(
                 context_params
             ),
         ),
-        environment=single_solid_environment,
+        environment_dict=single_solid_environment,
         throw_on_user_error=throw_on_user_error,
     )
 

--- a/python_modules/dagster/dagster/core/types/evaluator.py
+++ b/python_modules/dagster/dagster/core/types/evaluator.py
@@ -6,7 +6,7 @@ import six
 from dagster import check
 
 from dagster.core.errors import DagsterError
-from dagster.utils import single_item
+from dagster.utils import single_item, make_readonly_value
 
 from .config import ConfigType
 from .default_applier import apply_default_values
@@ -258,7 +258,7 @@ def evaluate_config_value(config_type, config_value):
 
     value = apply_default_values(config_type, config_value)
 
-    return EvaluateValueResult(success=True, value=value, errors=[])
+    return EvaluateValueResult(success=True, value=make_readonly_value(value), errors=[])
 
 
 def validate_config(config_type, config_value):

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/resources.py
@@ -105,7 +105,7 @@ def define_resource_test_pipeline():
 if __name__ == '__main__':
     result = execute_pipeline(
         define_resource_test_pipeline(),
-        environment={
+        environment_dict={
             'context': {
                 'cloud': {
                     'resources': {
@@ -131,7 +131,7 @@ if __name__ == '__main__':
 
     result = execute_pipeline(
         define_resource_test_pipeline(),
-        environment={
+        environment_dict={
             'context': {'local': {}},
             'solids': {
                 'add_ints': {

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -84,3 +84,42 @@ def merge_dicts(left, right):
     result = left.copy()
     result.update(right)
     return result
+
+
+class frozendict(dict):
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("Cannot modify ReadOnlyDict")
+
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    pop = __readonly__
+    popitem = __readonly__
+    clear = __readonly__
+    update = __readonly__
+    setdefault = __readonly__
+    del __readonly__
+
+
+class frozenlist(list):
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("Cannot modify ReadOnlyList")
+
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    append = __readonly__
+    clear = __readonly__
+    extend = __readonly__
+    insert = __readonly__
+    pop = __readonly__
+    remove = __readonly__
+    reverse = __readonly__
+    sort = __readonly__
+
+
+def make_readonly_value(value):
+    if isinstance(value, list):
+        return frozenlist(list(map(make_readonly_value, value)))
+    elif isinstance(value, dict):
+        return frozendict({key: make_readonly_value(value) for key, value in value.items()})
+    else:
+        return value

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -19,7 +19,7 @@ from dagster.core.execution import (
     ExecutionContext,
     build_sub_pipeline,
     construct_pipeline_execution_context,
-    create_typed_environment,
+    create_environment_config,
 )
 
 from dagster.core.utility_solids import define_stub_solid
@@ -33,7 +33,7 @@ def create_test_runtime_legacy_execution_context(loggers=None, resources=None, t
         pipeline=pipeline_def,
         execution_context=ExecutionContext(),
         resources=resources,
-        environment=create_typed_environment(pipeline_def),
+        environment_config=create_environment_config(pipeline_def),
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
@@ -63,12 +63,12 @@ def test_default_context_with_log_level():
 
     pipeline = PipelineDefinition(solids=[default_context_transform])
     execute_pipeline(
-        pipeline, environment={'context': {'default': {'config': {'log_level': 'INFO'}}}}
+        pipeline, environment_dict={'context': {'default': {'config': {'log_level': 'INFO'}}}}
     )
 
     with pytest.raises(PipelineConfigEvaluationError):
         execute_pipeline(
-            pipeline, environment={'context': {'default': {'config': {'log_level': 2}}}}
+            pipeline, environment_dict={'context': {'default': {'config': {'log_level': 2}}}}
         )
 
 
@@ -100,9 +100,9 @@ def test_default_value():
         },
     )
 
-    execute_pipeline(pipeline, environment={'context': {'custom_one': {}}})
+    execute_pipeline(pipeline, environment_dict={'context': {'custom_one': {}}})
 
-    execute_pipeline(pipeline, environment={'context': {'custom_one': None}})
+    execute_pipeline(pipeline, environment_dict={'context': {'custom_one': None}})
 
 
 def test_custom_contexts():
@@ -129,11 +129,11 @@ def test_custom_contexts():
     )
     environment_one = {'context': {'custom_one': {'config': {'field_one': 'value_two'}}}}
 
-    execute_pipeline(pipeline, environment=environment_one)
+    execute_pipeline(pipeline, environment_dict=environment_one)
 
     environment_two = {'context': {'custom_two': {'config': {'field_one': 'value_two'}}}}
 
-    execute_pipeline(pipeline, environment=environment_two)
+    execute_pipeline(pipeline, environment_dict=environment_two)
 
 
 def test_yield_context():
@@ -164,7 +164,7 @@ def test_yield_context():
 
     environment_one = {'context': {'custom_one': {'config': {'field_one': 'value_two'}}}}
 
-    execute_pipeline(pipeline, environment=environment_one)
+    execute_pipeline(pipeline, environment_dict=environment_one)
 
     assert events == ['before', 'during', 'after']
 
@@ -185,7 +185,7 @@ def test_invalid_context():
     ):
         execute_pipeline(
             default_context_pipeline,
-            environment=environment_context_not_found,
+            environment_dict=environment_context_not_found,
             throw_on_user_error=True,
         )
 
@@ -194,7 +194,7 @@ def test_invalid_context():
     with pytest.raises(PipelineConfigEvaluationError, match='Undefined field "unexpected"'):
         execute_pipeline(
             default_context_pipeline,
-            environment=environment_field_name_mismatch,
+            environment_dict=environment_field_name_mismatch,
             throw_on_user_error=True,
         )
 
@@ -219,7 +219,7 @@ def test_invalid_context():
     ):
         execute_pipeline(
             with_argful_context_pipeline,
-            environment=environment_no_config_error,
+            environment_dict=environment_no_config_error,
             throw_on_user_error=True,
         )
 
@@ -235,6 +235,6 @@ def test_invalid_context():
     ):
         execute_pipeline(
             with_argful_context_pipeline,
-            environment=environment_type_mismatch_error,
+            environment_dict=environment_type_mismatch_error,
             throw_on_user_error=True,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
@@ -51,7 +51,7 @@ def test_execute_solid_with_input_same_name():
     )
 
     result = execute_pipeline(
-        pipeline, environment={'solids': {'pass_value': {'config': {'value': 'foo'}}}}
+        pipeline, environment_dict={'solids': {'pass_value': {'config': {'value': 'foo'}}}}
     )
 
     assert result.result_for_solid('a_thing').transformed_value() == 'foofoo'
@@ -89,7 +89,7 @@ def test_execute_two_solids_with_same_input_name():
 
     result = execute_pipeline(
         pipeline,
-        environment={
+        environment_dict={
             'solids': {
                 'pass_to_one': {'config': {'value': 'foo'}},
                 'pass_to_two': {'config': {'value': 'bar'}},
@@ -129,7 +129,7 @@ def test_execute_dep_solid_different_input_name():
     )
 
     result = dagster.execute_pipeline(
-        pipeline, environment={'solids': {'pass_to_first': {'config': {'value': 'bar'}}}}
+        pipeline, environment_dict={'solids': {'pass_to_first': {'config': {'value': 'bar'}}}}
     )
 
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_output_materialization.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_output_materialization.py
@@ -21,7 +21,7 @@ from dagster.core.definitions.environment_configs import (
     solid_has_configurable_outputs,
 )
 
-from dagster.core.execution import create_typed_environment, create_execution_plan
+from dagster.core.execution import create_environment_config, create_execution_plan
 
 from dagster.core.execution_plan.objects import StepOutputHandle
 
@@ -90,7 +90,7 @@ def test_solid_has_config_entry():
 
 
 def test_basic_json_default_output_config_schema():
-    env = create_typed_environment(
+    env = create_environment_config(
         single_int_output_pipeline(),
         {'solids': {'return_one': {'outputs': [{'result': {'json': {'path': 'foo'}}}]}}},
     )
@@ -100,7 +100,7 @@ def test_basic_json_default_output_config_schema():
 
 
 def test_basic_json_named_output_config_schema():
-    env = create_typed_environment(
+    env = create_environment_config(
         single_int_named_output_pipeline(),
         {'solids': {'return_named_one': {'outputs': [{'named': {'json': {'path': 'foo'}}}]}}},
     )
@@ -111,7 +111,7 @@ def test_basic_json_named_output_config_schema():
 
 def test_basic_json_misnamed_output_config_schema():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
-        create_typed_environment(
+        create_environment_config(
             single_int_named_output_pipeline(),
             {
                 'solids': {
@@ -126,23 +126,23 @@ def test_basic_json_misnamed_output_config_schema():
 
 
 def test_no_outputs_no_inputs_config_schema():
-    assert create_typed_environment(no_input_no_output_pipeline())
+    assert create_environment_config(no_input_no_output_pipeline())
 
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
-        create_typed_environment(no_input_no_output_pipeline(), {'solids': {'return_one': {}}})
+        create_environment_config(no_input_no_output_pipeline(), {'solids': {'return_one': {}}})
 
     assert len(exc_info.value.errors) == 1
     assert 'Error 1: Undefined field "return_one" at path root:solids' in exc_info.value.message
 
 
 def test_no_outputs_one_input_config_schema():
-    assert create_typed_environment(
+    assert create_environment_config(
         one_input_no_output_pipeline(),
         {'solids': {'take_input_return_nothing': {'inputs': {'dummy': {'value': 'value'}}}}},
     )
 
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
-        create_typed_environment(
+        create_environment_config(
             one_input_no_output_pipeline(),
             {
                 'solids': {

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -371,14 +371,16 @@ def test_pipeline_subset():
 
     env_config = {'solids': {'add_one': {'inputs': {'num': {'value': 3}}}}}
 
-    subset_result = execute_pipeline(pipeline_def, environment=env_config, solid_subset=['add_one'])
+    subset_result = execute_pipeline(
+        pipeline_def, environment_dict=env_config, solid_subset=['add_one']
+    )
 
     assert subset_result.success
     assert len(subset_result.result_list) == 1
     assert subset_result.result_for_solid('add_one').transformed_value() == 4
 
     iter_results = execute_pipeline_iterator(
-        pipeline_def, environment=env_config, solid_subset=['add_one']
+        pipeline_def, environment_dict=env_config, solid_subset=['add_one']
     )
 
     for result in iter_results:
@@ -422,7 +424,7 @@ def test_pipeline_execution_disjoint_subset():
     pipeline_def = define_created_disjoint_three_part_pipeline()
 
     result = execute_pipeline(
-        pipeline_def, environment=env_config, solid_subset=['add_one', 'add_three']
+        pipeline_def, environment_dict=env_config, solid_subset=['add_one', 'add_three']
     )
 
     assert result.success
@@ -450,23 +452,25 @@ def test_pipeline_wrapping_types():
     pipeline_def = PipelineDefinition(name='wrapping_test', solids=[double_string_for_all])
 
     assert execute_pipeline(
-        pipeline_def, environment={'solids': {'double_string_for_all': {'inputs': {'value': None}}}}
-    ).success
-
-    assert execute_pipeline(
-        pipeline_def, environment={'solids': {'double_string_for_all': {'inputs': {'value': []}}}}
+        pipeline_def,
+        environment_dict={'solids': {'double_string_for_all': {'inputs': {'value': None}}}},
     ).success
 
     assert execute_pipeline(
         pipeline_def,
-        environment={
+        environment_dict={'solids': {'double_string_for_all': {'inputs': {'value': []}}}},
+    ).success
+
+    assert execute_pipeline(
+        pipeline_def,
+        environment_dict={
             'solids': {'double_string_for_all': {'inputs': {'value': [{'value': 'foo'}]}}}
         },
     ).success
 
     assert execute_pipeline(
         pipeline_def,
-        environment={
+        environment_dict={
             'solids': {'double_string_for_all': {'inputs': {'value': [{'value': 'bar'}, None]}}}
         },
     ).success

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_builtin_schemas.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_builtin_schemas.py
@@ -105,7 +105,7 @@ def single_input_env(solid_name, input_name, input_spec):
 def test_int_input_schema_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_int', 'num', {'value': 2}),
+        environment_dict=single_input_env('take_int', 'num', {'value': 2}),
         solid_subset=['take_int'],
     )
 
@@ -117,7 +117,7 @@ def test_int_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_int', 'num', {'value': 'dkjdfkdj'}),
+            environment_dict=single_input_env('take_int', 'num', {'value': 'dkjdfkdj'}),
             solid_subset=['take_int'],
         )
 
@@ -134,7 +134,7 @@ def test_int_json_schema_roundtrip():
     with get_temp_file_name() as tmp_file:
         mat_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_output_env('produce_int', {'json': {'path': tmp_file}}),
+            environment_dict=single_output_env('produce_int', {'json': {'path': tmp_file}}),
             solid_subset=['produce_int'],
         )
 
@@ -142,7 +142,7 @@ def test_int_json_schema_roundtrip():
 
         source_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_int', 'num', {'json': {'path': tmp_file}}),
+            environment_dict=single_input_env('take_int', 'num', {'json': {'path': tmp_file}}),
             solid_subset=['take_int'],
         )
 
@@ -153,7 +153,7 @@ def test_int_pickle_schema_roundtrip():
     with get_temp_file_name() as tmp_file:
         mat_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_output_env('produce_int', {'pickle': {'path': tmp_file}}),
+            environment_dict=single_output_env('produce_int', {'pickle': {'path': tmp_file}}),
             solid_subset=['produce_int'],
         )
 
@@ -161,7 +161,7 @@ def test_int_pickle_schema_roundtrip():
 
         source_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_int', 'num', {'pickle': {'path': tmp_file}}),
+            environment_dict=single_input_env('take_int', 'num', {'pickle': {'path': tmp_file}}),
             solid_subset=['take_int'],
         )
 
@@ -171,7 +171,7 @@ def test_int_pickle_schema_roundtrip():
 def test_string_input_schema_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_string', 'string', {'value': 'dkjkfd'}),
+        environment_dict=single_input_env('take_string', 'string', {'value': 'dkjkfd'}),
         solid_subset=['take_string'],
     )
 
@@ -183,7 +183,7 @@ def test_string_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_string', 'string', {'value': 3343}),
+            environment_dict=single_input_env('take_string', 'string', {'value': 3343}),
             solid_subset=['take_string'],
         )
 
@@ -196,7 +196,7 @@ def test_string_input_schema_failure():
 def test_float_input_schema_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_float', 'float_number', {'value': 3.34}),
+        environment_dict=single_input_env('take_float', 'float_number', {'value': 3.34}),
         solid_subset=['take_float'],
     )
 
@@ -208,7 +208,7 @@ def test_float_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_float', 'float_number', {'value': '3343'}),
+            environment_dict=single_input_env('take_float', 'float_number', {'value': '3343'}),
             solid_subset=['take_float'],
         )
 
@@ -221,7 +221,7 @@ def test_float_input_schema_failure():
 def test_bool_input_schema_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_bool', 'bool_value', {'value': True}),
+        environment_dict=single_input_env('take_bool', 'bool_value', {'value': True}),
         solid_subset=['take_bool'],
     )
 
@@ -233,7 +233,7 @@ def test_bool_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_bool', 'bool_value', {'value': '3343'}),
+            environment_dict=single_input_env('take_bool', 'bool_value', {'value': '3343'}),
             solid_subset=['take_bool'],
         )
 
@@ -246,7 +246,7 @@ def test_bool_input_schema_failure():
 def test_any_input_schema_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_any', 'any_value', {'value': 'ff'}),
+        environment_dict=single_input_env('take_any', 'any_value', {'value': 'ff'}),
         solid_subset=['take_any'],
     )
 
@@ -255,7 +255,7 @@ def test_any_input_schema_value():
 
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_any', 'any_value', {'value': 3843}),
+        environment_dict=single_input_env('take_any', 'any_value', {'value': 3843}),
         solid_subset=['take_any'],
     )
 
@@ -267,7 +267,7 @@ def test_none_string_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_string', 'string', None),
+            environment_dict=single_input_env('take_string', 'string', None),
             solid_subset=['take_string'],
         )
 
@@ -281,7 +281,7 @@ def test_value_none_string_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_string', 'string', {'value': None}),
+            environment_dict=single_input_env('take_string', 'string', {'value': None}),
             solid_subset=['take_string'],
         )
 
@@ -295,7 +295,7 @@ def test_string_json_schema_roundtrip():
     with get_temp_file_name() as tmp_file:
         mat_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_output_env('produce_string', {'json': {'path': tmp_file}}),
+            environment_dict=single_output_env('produce_string', {'json': {'path': tmp_file}}),
             solid_subset=['produce_string'],
         )
 
@@ -303,7 +303,9 @@ def test_string_json_schema_roundtrip():
 
         source_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_string', 'string', {'json': {'path': tmp_file}}),
+            environment_dict=single_input_env(
+                'take_string', 'string', {'json': {'path': tmp_file}}
+            ),
             solid_subset=['take_string'],
         )
 
@@ -314,7 +316,7 @@ def test_string_pickle_schema_roundtrip():
     with get_temp_file_name() as tmp_file:
         mat_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_output_env('produce_string', {'pickle': {'path': tmp_file}}),
+            environment_dict=single_output_env('produce_string', {'pickle': {'path': tmp_file}}),
             solid_subset=['produce_string'],
         )
 
@@ -322,7 +324,9 @@ def test_string_pickle_schema_roundtrip():
 
         source_result = execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_string', 'string', {'pickle': {'path': tmp_file}}),
+            environment_dict=single_input_env(
+                'take_string', 'string', {'pickle': {'path': tmp_file}}
+            ),
             solid_subset=['take_string'],
         )
 
@@ -332,7 +336,7 @@ def test_string_pickle_schema_roundtrip():
 def test_path_input_schema_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_path', 'path', '/a/path'),
+        environment_dict=single_input_env('take_path', 'path', '/a/path'),
         solid_subset=['take_path'],
     )
 
@@ -344,7 +348,7 @@ def test_path_input_schema_failure():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env('take_path', 'path', {'value': 3343}),
+            environment_dict=single_input_env('take_path', 'path', {'value': 3343}),
             solid_subset=['take_path'],
         )
 
@@ -356,7 +360,7 @@ def test_path_input_schema_failure():
 def test_string_list_input():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_string_list', 'string_list', [{'value': 'foobar'}]),
+        environment_dict=single_input_env('take_string_list', 'string_list', [{'value': 'foobar'}]),
         solid_subset=['take_string_list'],
     )
 
@@ -368,7 +372,7 @@ def test_string_list_input():
 def test_nullable_string_input_with_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env(
+        environment_dict=single_input_env(
             'take_nullable_string', 'nullable_string', {'value': 'foobar'}
         ),
         solid_subset=['take_nullable_string'],
@@ -385,7 +389,7 @@ def test_nullable_string_input_with_none_value():
     with pytest.raises(PipelineConfigEvaluationError) as exc_info:
         execute_pipeline(
             define_test_all_scalars_pipeline(),
-            environment=single_input_env(
+            environment_dict=single_input_env(
                 'take_nullable_string', 'nullable_string', {'value': None}
             ),
             solid_subset=['take_nullable_string'],
@@ -400,7 +404,7 @@ def test_nullable_string_input_with_none_value():
 def test_nullable_string_input_without_value():
     result = execute_pipeline(
         define_test_all_scalars_pipeline(),
-        environment=single_input_env('take_nullable_string', 'nullable_string', None),
+        environment_dict=single_input_env('take_nullable_string', 'nullable_string', None),
         solid_subset=['take_nullable_string'],
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_config_type_system.py
@@ -372,7 +372,7 @@ def test_solid_list_config():
     )
 
     result = execute_pipeline(
-        pipeline_def, environment={'solids': {'solid_list_config': {'config': value}}}
+        pipeline_def, environment_dict={'solids': {'solid_list_config': {'config': value}}}
     )
 
     assert result.success
@@ -406,18 +406,20 @@ def test_multilevel_default_handling():
     )
 
     assert execute_pipeline(pipeline_def).success
-    assert execute_pipeline(pipeline_def, environment=None).success
-    assert execute_pipeline(pipeline_def, environment={}).success
-    assert execute_pipeline(pipeline_def, environment={'solids': None}).success
-    assert execute_pipeline(pipeline_def, environment={'solids': {}}).success
+    assert execute_pipeline(pipeline_def, environment_dict=None).success
+    assert execute_pipeline(pipeline_def, environment_dict={}).success
+    assert execute_pipeline(pipeline_def, environment_dict={'solids': None}).success
+    assert execute_pipeline(pipeline_def, environment_dict={'solids': {}}).success
     assert execute_pipeline(
-        pipeline_def, environment={'solids': {'has_default_value': None}}
+        pipeline_def, environment_dict={'solids': {'has_default_value': None}}
     ).success
 
-    assert execute_pipeline(pipeline_def, environment={'solids': {'has_default_value': {}}}).success
+    assert execute_pipeline(
+        pipeline_def, environment_dict={'solids': {'has_default_value': {}}}
+    ).success
 
     assert execute_pipeline(
-        pipeline_def, environment={'solids': {'has_default_value': {'config': 234}}}
+        pipeline_def, environment_dict={'solids': {'has_default_value': {'config': 234}}}
     ).success
 
 
@@ -459,7 +461,7 @@ def test_root_extra_field():
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
         execute_pipeline(
             pipeline_def,
-            environment={'solids': {'required_int_solid': {'config': 948594}}, 'nope': None},
+            environment_dict={'solids': {'required_int_solid': {'config': 948594}}, 'nope': None},
         )
 
     pe = pe_info.value
@@ -478,7 +480,7 @@ def test_deeper_path():
 
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
         execute_pipeline(
-            pipeline_def, environment={'solids': {'required_int_solid': {'config': 'asdf'}}}
+            pipeline_def, environment_dict={'solids': {'required_int_solid': {'config': 'asdf'}}}
         )
 
     pe = pe_info.value
@@ -498,7 +500,7 @@ def test_working_list_path():
     pipeline_def = PipelineDefinition(name='list_path', solids=[required_list_int_solid])
 
     result = execute_pipeline(
-        pipeline_def, environment={'solids': {'required_list_int_solid': {'config': [1, 2]}}}
+        pipeline_def, environment_dict={'solids': {'required_list_int_solid': {'config': [1, 2]}}}
     )
 
     assert result.success
@@ -518,7 +520,7 @@ def test_item_error_list_path():
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
         execute_pipeline(
             pipeline_def,
-            environment={'solids': {'required_list_int_solid': {'config': [1, 'nope']}}},
+            environment_dict={'solids': {'required_list_int_solid': {'config': [1, 'nope']}}},
         )
 
     pe = pe_info.value
@@ -551,7 +553,7 @@ def test_context_selector_working():
     )
 
     result = execute_pipeline(
-        pipeline_def, environment={'context': {'context_required_int': {'config': 32}}}
+        pipeline_def, environment_dict={'context': {'context_required_int': {'config': 32}}}
     )
 
     assert result.success
@@ -579,7 +581,7 @@ def test_context_selector_extra_context():
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
         execute_pipeline(
             pipeline_def,
-            environment={
+            environment_dict={
                 'context': {
                     'context_required_int': {'config': 32},
                     'extra_context': {'config': None},
@@ -612,7 +614,9 @@ def test_context_selector_wrong_name():
     )
 
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
-        execute_pipeline(pipeline_def, environment={'context': {'wrong_name': {'config': None}}})
+        execute_pipeline(
+            pipeline_def, environment_dict={'context': {'wrong_name': {'config': None}}}
+        )
 
     pe = pe_info.value
     cse = pe.errors[0]
@@ -639,7 +643,7 @@ def test_context_selector_none_given():
     )
 
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
-        execute_pipeline(pipeline_def, environment={'context': None})
+        execute_pipeline(pipeline_def, environment_dict={'context': None})
 
     pe = pe_info.value
     cse = pe.errors[0]
@@ -657,7 +661,7 @@ def test_multilevel_good_error_handling_solids():
     )
 
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
-        execute_pipeline(pipeline_def, environment={'solids': None})
+        execute_pipeline(pipeline_def, environment_dict={'solids': None})
 
     assert (
         'Missing required field  "good_error_handling" at path root:solids Expected: '
@@ -675,7 +679,7 @@ def test_multilevel_good_error_handling_solid_name_solids():
     )
 
     with pytest.raises(PipelineConfigEvaluationError) as pe_info:
-        execute_pipeline(pipeline_def, environment={'solids': {'good_error_handling': {}}})
+        execute_pipeline(pipeline_def, environment_dict={'solids': {'good_error_handling': {}}})
 
     assert (
         'Missing required field  "config" at path root:solids:good_error_handling Expected: '
@@ -693,5 +697,5 @@ def test_multilevel_good_error_handling_config_solids_name_solids():
     )
 
     execute_pipeline(
-        pipeline_def, environment={'solids': {'good_error_handling': {'config': None}}}
+        pipeline_def, environment_dict={'solids': {'good_error_handling': {'config': None}}}
     )

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_resources.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_resources.py
@@ -22,7 +22,7 @@ def test_run_local():
 
     result = execute_pipeline(
         define_resource_test_pipeline(),
-        environment={
+        environment_dict={
             'context': {'local': {}},
             'solids': {'add_ints': {'inputs': {'num_one': {'value': 2}, 'num_two': {'value': 3}}}},
         },
@@ -44,7 +44,7 @@ def test_run_cloud():
 
     result = execute_pipeline(
         define_resource_test_pipeline(),
-        environment={
+        environment_dict={
             'context': {
                 'cloud': {
                     'resources': {

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20235,7 +20235,7 @@ snapshots['test_build_all_docs 52'] = '''
 <p>Executing pipelines and solids.</p>
 <dl class="function">
 <dt id="dagster.execute_pipeline">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>solid_subset=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>solid_subset=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
 <dd><p>“Synchronous” version of <a class="reference internal" href="#dagster.execute_pipeline_iterator" title="dagster.execute_pipeline_iterator"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline_iterator()</span></code></a>.</p>
 <p>Note: throw_on_user_error is very useful in testing contexts when not testing for error conditions</p>
 <table class="docutils field-list" frame="void" rules="none">
@@ -20259,7 +20259,7 @@ the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 
 <dl class="function">
 <dt id="dagster.execute_pipeline_iterator">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>solid_subset=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>solid_subset=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns iterator that yields <a class="reference internal" href="#dagster.SolidExecutionResult" title="dagster.SolidExecutionResult"><code class="xref py py-class docutils literal notranslate"><span class="pre">SolidExecutionResult</span></code></a> for each
 solid executed in the pipeline.</p>
 <p>This is intended to allow the caller to do things between each executed
@@ -25061,7 +25061,7 @@ resource.</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">_name__</span> <span class="o">==</span> <span class="s1">&#39;__main__&#39;</span><span class="p">:</span>
 <span class="n">result</span> <span class="o">=</span> <span class="n">execute_pipeline</span><span class="p">(</span>
     <span class="n">define_resource_test_pipeline</span><span class="p">(),</span>
-    <span class="n">environment</span><span class="o">=</span><span class="p">{</span>
+    <span class="n">environment_dict</span><span class="o">=</span><span class="p">{</span>
         <span class="s1">&#39;context&#39;</span><span class="p">:</span> <span class="p">{</span>
             <span class="s1">&#39;cloud&#39;</span><span class="p">:</span> <span class="p">{</span>
                 <span class="s1">&#39;resources&#39;</span><span class="p">:</span> <span class="p">{</span>
@@ -25138,7 +25138,7 @@ resource will be used instead of the cloud version:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>
 <span class="n">result</span> <span class="o">=</span> <span class="n">execute_pipeline</span><span class="p">(</span>
     <span class="n">define_resource_test_pipeline</span><span class="p">(),</span>
-<span class="hll">    <span class="n">environment</span><span class="o">=</span><span class="p">{</span>
+<span class="hll">    <span class="n">environment_dict</span><span class="o">=</span><span class="p">{</span>
 </span>        <span class="s1">&#39;context&#39;</span><span class="p">:</span> <span class="p">{</span><span class="s1">&#39;local&#39;</span><span class="p">:</span> <span class="p">{}},</span>
         <span class="s1">&#39;solids&#39;</span><span class="p">:</span> <span class="p">{</span>
             <span class="s1">&#39;add_ints&#39;</span><span class="p">:</span> <span class="p">{</span>
@@ -25567,14 +25567,14 @@ in the dagster-pandas library, building it step by step along the way.</p>
 <div class="section" id="basic-typing">
 <h2>Basic Typing<a class="headerlink" href="#basic-typing" title="Permalink to this headline">¶</a></h2>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">pandas</span> <span class="k">as</span> <span class="nn">pd</span>
+        <span class="k">raise</span> <span class="n">DagsterInvariantViolationError</span><span class="p">(</span>
+            <span class="s1">&#39;Unsupported file_type </span><span class="si">{file_type}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">file_type</span><span class="o">=</span><span class="n">file_type</span><span class="p">)</span>
         <span class="p">)</span>
 
 
 <span class="n">DataFrame</span> <span class="o">=</span> <span class="n">as_dagster_type</span><span class="p">(</span>
     <span class="n">pd</span><span class="o">.</span><span class="n">DataFrame</span><span class="p">,</span>
-    <span class="n">name</span><span class="o">=</span><span class="s1">&#39;PandasDataFrame&#39;</span><span class="p">,</span>
-    <span class="n">description</span><span class="o">=</span><span class="s1">&#39;&#39;&#39;Two-dimensional size-mutable, potentially heterogeneous</span>
-<span class="s1">    input_schema=dataframe_input_schema,</span>
+    <span class="n">tabular</span> <span class="n">data</span> <span class="n">structure</span> <span class="k">with</span> <span class="n">labeled</span> <span class="n">axes</span> <span class="p">(</span><span class="n">rows</span> <span class="ow">and</span> <span class="n">columns</span><span class="p">)</span><span class="o">.</span>
 </pre></div>
 </div>
 <p>What this code doing is annotating/registering an existing type as a dagster type. Now one can
@@ -25648,7 +25648,10 @@ values have been applied.</p>
 API that removes some boilerplate around manipulating the config_value dictionary. Instead, the
 user-provided function takes the unpacked key and value of config_value directly, since in the
 case of a selector, the config_value dictionary has only 1 (key, value) pair.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>    <span class="k">else</span><span class="p">:</span>
+        <span class="n">check</span><span class="o">.</span><span class="n">failed</span><span class="p">(</span><span class="s1">&#39;Unsupported file_type </span><span class="si">{file_type}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">file_type</span><span class="o">=</span><span class="n">file_type</span><span class="p">))</span>
+
+
 <span class="nd">@input_selector_schema</span><span class="p">(</span>
     <span class="n">NamedSelector</span><span class="p">(</span>
         <span class="s1">&#39;DataFrameInputSchema&#39;</span><span class="p">,</span>
@@ -25665,27 +25668,24 @@ case of a selector, the config_value dictionary has only 1 (key, value) pair.</p
 
     <span class="k">if</span> <span class="n">file_type</span> <span class="o">==</span> <span class="s1">&#39;csv&#39;</span><span class="p">:</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">]</span>
-        <span class="k">del</span> <span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">]</span>
-        <span class="k">return</span> <span class="n">pd</span><span class="o">.</span><span class="n">read_csv</span><span class="p">(</span><span class="n">path</span><span class="p">,</span> <span class="o">**</span><span class="n">file_options</span><span class="p">)</span>
+        <span class="k">return</span> <span class="n">pd</span><span class="o">.</span><span class="n">read_csv</span><span class="p">(</span><span class="n">path</span><span class="p">,</span> <span class="o">**</span><span class="n">dict_without_keys</span><span class="p">(</span><span class="n">file_options</span><span class="p">,</span> <span class="s1">&#39;path&#39;</span><span class="p">))</span>
     <span class="k">elif</span> <span class="n">file_type</span> <span class="o">==</span> <span class="s1">&#39;parquet&#39;</span><span class="p">:</span>
         <span class="k">return</span> <span class="n">pd</span><span class="o">.</span><span class="n">read_parquet</span><span class="p">(</span><span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">])</span>
     <span class="k">elif</span> <span class="n">file_type</span> <span class="o">==</span> <span class="s1">&#39;table&#39;</span><span class="p">:</span>
         <span class="k">return</span> <span class="n">pd</span><span class="o">.</span><span class="n">read_table</span><span class="p">(</span><span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">])</span>
-    <span class="k">else</span><span class="p">:</span>
-        <span class="k">raise</span> <span class="n">DagsterInvariantViolationError</span><span class="p">(</span>
 </pre></div>
 </div>
 <p>You’ll note that we no longer need to manipulate the <code class="docutils literal notranslate"><span class="pre">config_value</span></code> dictionary. It grabs
 that key and value for you and calls the provided function.</p>
 <p>Finally insert this into the original declaration:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>            <span class="s1">&#39;Unsupported file_type </span><span class="si">{file_type}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">file_type</span><span class="o">=</span><span class="n">file_type</span><span class="p">)</span>
+        <span class="p">)</span>
+
 
 <span class="n">DataFrame</span> <span class="o">=</span> <span class="n">as_dagster_type</span><span class="p">(</span>
     <span class="n">pd</span><span class="o">.</span><span class="n">DataFrame</span><span class="p">,</span>
-    <span class="n">name</span><span class="o">=</span><span class="s1">&#39;PandasDataFrame&#39;</span><span class="p">,</span>
-    <span class="n">description</span><span class="o">=</span><span class="s1">&#39;&#39;&#39;Two-dimensional size-mutable, potentially heterogeneous</span>
-<span class="hll"><span class="s1">    tabular data structure with labeled axes (rows and columns).</span>
-</span><span class="s1">    input_schema=dataframe_input_schema,</span>
+<span class="hll">    <span class="n">name</span><span class="o">=</span><span class="s1">&#39;PandasDataFrame&#39;</span><span class="p">,</span>
+</span>    <span class="n">tabular</span> <span class="n">data</span> <span class="n">structure</span> <span class="k">with</span> <span class="n">labeled</span> <span class="n">axes</span> <span class="p">(</span><span class="n">rows</span> <span class="ow">and</span> <span class="n">columns</span><span class="p">)</span><span class="o">.</span>
 </pre></div>
 </div>
 <p>Now if you run a pipeline with this solid from dagit you will be able to provide sources for
@@ -25699,8 +25699,12 @@ for taking the in-memory object flowed through your computation and materializin
 persistent store. Outputs are purely <em>optional</em> for any computation, whereas inputs <em>must</em> be provided
 for a computation to proceed. You will likely want outputs as for a pipeline to be useful it
 should produce some materialization that outlives the computation.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="hll"><span class="nd">@output_selector_schema</span><span class="p">(</span>
-</span>    <span class="n">NamedSelector</span><span class="p">(</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="hll"><span class="k">def</span> <span class="nf">dict_without_keys</span><span class="p">(</span><span class="n">ddict</span><span class="p">,</span> <span class="o">*</span><span class="n">keys</span><span class="p">):</span>
+</span>    <span class="k">return</span> <span class="p">{</span><span class="n">key</span><span class="p">:</span> <span class="n">value</span> <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">ddict</span><span class="o">.</span><span class="n">items</span><span class="p">()</span> <span class="k">if</span> <span class="n">key</span> <span class="ow">not</span> <span class="ow">in</span> <span class="nb">set</span><span class="p">(</span><span class="n">keys</span><span class="p">)}</span>
+
+
+<span class="nd">@output_selector_schema</span><span class="p">(</span>
+    <span class="n">NamedSelector</span><span class="p">(</span>
         <span class="s1">&#39;DataFrameOutputSchema&#39;</span><span class="p">,</span>
         <span class="p">{</span>
             <span class="s1">&#39;csv&#39;</span><span class="p">:</span> <span class="n">define_csv_dict_field</span><span class="p">(),</span>
@@ -25716,13 +25720,9 @@ should produce some materialization that outlives the computation.</p>
 
     <span class="k">if</span> <span class="n">file_type</span> <span class="o">==</span> <span class="s1">&#39;csv&#39;</span><span class="p">:</span>
         <span class="n">path</span> <span class="o">=</span> <span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">]</span>
-        <span class="k">del</span> <span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">]</span>
-        <span class="k">return</span> <span class="n">pandas_df</span><span class="o">.</span><span class="n">to_csv</span><span class="p">(</span><span class="n">path</span><span class="p">,</span> <span class="n">index</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="o">**</span><span class="n">file_options</span><span class="p">)</span>
+        <span class="k">return</span> <span class="n">pandas_df</span><span class="o">.</span><span class="n">to_csv</span><span class="p">(</span><span class="n">path</span><span class="p">,</span> <span class="n">index</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="o">**</span><span class="n">dict_without_keys</span><span class="p">(</span><span class="n">file_options</span><span class="p">,</span> <span class="s1">&#39;path&#39;</span><span class="p">))</span>
     <span class="k">elif</span> <span class="n">file_type</span> <span class="o">==</span> <span class="s1">&#39;parquet&#39;</span><span class="p">:</span>
         <span class="k">return</span> <span class="n">pandas_df</span><span class="o">.</span><span class="n">to_parquet</span><span class="p">(</span><span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">])</span>
-    <span class="k">elif</span> <span class="n">file_type</span> <span class="o">==</span> <span class="s1">&#39;table&#39;</span><span class="p">:</span>
-        <span class="k">return</span> <span class="n">pandas_df</span><span class="o">.</span><span class="n">to_csv</span><span class="p">(</span><span class="n">file_options</span><span class="p">[</span><span class="s1">&#39;path&#39;</span><span class="p">],</span> <span class="n">sep</span><span class="o">=</span><span class="s1">&#39;</span><span class="se">\\t</span><span class="s1">&#39;</span><span class="p">,</span> <span class="n">index</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
-    <span class="k">else</span><span class="p">:</span>
 </pre></div>
 </div>
 <p>This has a similar aesthetic to an input schema but performs a different function. Notice that
@@ -25730,15 +25730,15 @@ it takes a third argument, <cite>pandas_df</cite> (it can be named anything), th
 outputted from the solid in question. It then takes the configuration data as “instructions” as to
 how to materialize the value.</p>
 <p>One connects the output schema to the type as follows:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>            <span class="s1">&#39;Unsupported file_type </span><span class="si">{file_type}</span><span class="s1">&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">file_type</span><span class="o">=</span><span class="n">file_type</span><span class="p">)</span>
+        <span class="p">)</span>
+
 
 <span class="n">DataFrame</span> <span class="o">=</span> <span class="n">as_dagster_type</span><span class="p">(</span>
     <span class="n">pd</span><span class="o">.</span><span class="n">DataFrame</span><span class="p">,</span>
     <span class="n">name</span><span class="o">=</span><span class="s1">&#39;PandasDataFrame&#39;</span><span class="p">,</span>
-    <span class="n">description</span><span class="o">=</span><span class="s1">&#39;&#39;&#39;Two-dimensional size-mutable, potentially heterogeneous</span>
-<span class="s1">    tabular data structure with labeled axes (rows and columns).</span>
-<span class="hll"><span class="s1">    See http://pandas.pydata.org/&#39;&#39;&#39;</span><span class="p">,</span>
-</span>    <span class="n">input_schema</span><span class="o">=</span><span class="n">dataframe_input_schema</span><span class="p">,</span>
+<span class="hll">    <span class="n">description</span><span class="o">=</span><span class="s1">&#39;&#39;&#39;Two-dimensional size-mutable, potentially heterogeneous</span>
+</span><span class="s1">    tabular data structure with labeled axes (rows and columns).</span>
 </pre></div>
 </div>
 <p>Now we can provide a list of materializations to a given execution.</p>

--- a/python_modules/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -52,7 +52,7 @@ def test_add_pipeline():
 def test_notebook_dag():
     pipeline_result = execute_pipeline(
         define_test_notebook_dag_pipeline(),
-        environment={'solids': {'load_a': {'config': 1}, 'load_b': {'config': 2}}},
+        environment_dict={'solids': {'load_a': {'config': 1}, 'load_b': {'config': 2}}},
     )
     assert pipeline_result.success
     assert pipeline_result.result_for_solid('add_two').transformed_value() == 3


### PR DESCRIPTION
Various and sundry refactoring as a result of poking at the execution engine a couple times.

Stack PRs would have made this made eight or so smaller PRs, but we are where we are.

Summary

- throw_on_user_error threaded through the graphql stack for better debugging
- New naming convention around environment:
  - ``environment_dict`` specifies the user-specific dictionary for the the enviroment. (Note: also called environment_dict after default values applied)
  - ``environment_config`` specifies the typed objects constructed internally in the engine.
 - environment_config now totally eliminated in all public execution.py apis. It is now constructed  *within* yield_pipeline_execution_context
 - The environment dictionary is now readonly. This diff became more disciplined around not creating copies of the environment dictionary and the pandas library destructively unsetting 'path' caused a very very hard to find bug. (Note: this is an argument for using pyrsistent)
- ExecutionPlanInfo is totally unnecessary now and PipelineExecutionContext can be used in its stead.
- With no public apis taking EnvironmentConfig, in dagstermill we reconstruct context from a raw dict rather than the typed object. Therefore create_typed_context has been eliminated.