### PR TITLE
Navigate steps level-by-level instead of seriallly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,18 +4,25 @@
       - Link to output notebook rendered in dagit when dagstermill solids are executed.
 
    - API Additions and changes
-      - The ``info`` object passed to transform functions has been renamed to ``context``. All fields that were previously
-        available on the ``info.context`` object are now hoisted to the top level ``context`` object. Additionally an alias
-        for ``config`` has been introduced: ``solid_config``. So where you would have written ``info.config`` it is now
-        ``context.solid_config`` Logging should be done with the top-level property ``context.log``. The ``context``
-        and ``config`` properies on this new context object are deprecated, will warn for now, and be eliminated
-        when 0.4.0 is released.
+      - The ``info`` object passed to transform and expectation functions has been renamed to ``context``.
+        All fields that were previously available on the ``info.context`` object are now hoisted to the
+        top level ``context`` object. Additionally an alias for ``config`` has been introduced: ``solid_config``.
+        So where you would have written ``info.config`` it is now ``context.solid_config`` Logging should be
+        done with the top-level property ``context.log``. The ``context`` and ``config`` properies on this
+        new context object are deprecated, will warn for now, and be eliminated when 0.4.0 is released.
+      - The ``info`` object passed context and resource creation functions is now named ``init_context`` by convention.
       - PipelineExecutionResult's (returned from execute_pipeline)
         ``result_list`` property has been renaming to ``solid_result_list``
       - execute_pipeline_iterator now returns an iterable of ExecutionStepEvent instead of SolidExecutionResult
+      - Breaking: All arguments named ``environment`` to ``execute_pipeline`` and its variants has
+        been renamed to ``environment_dict``.
+      - Breaking: Types of objects flows as argument one of context, resource, transform, and expectation functions have been
+        renamed. If you do instanceof checks on these objects, they will fail. Property-level compatibility has not changed
+        and should not require code changes.
 
    - Bug fixes
       - #792: execute_pipeline_iterator now properly streams results at step-event granularity.
+
 
    - GraphQL Schema Changes
       - ``StepResult`` has been renamed to ``StepEvent``.

--- a/python_modules/airline-demo/airline_demo/test/test_solids.py
+++ b/python_modules/airline-demo/airline_demo/test/test_solids.py
@@ -78,7 +78,9 @@ def test_sql_solid():
 
 def test_thunk():
     result = execute_solid(
-        PipelineDefinition([thunk]), 'thunk', environment={'solids': {'thunk': {'config': 'foo'}}}
+        PipelineDefinition([thunk]),
+        'thunk',
+        environment_dict={'solids': {'thunk': {'config': 'foo'}}},
     )
     assert result.success
     assert result.transformed_value() == 'foo'
@@ -89,7 +91,7 @@ def test_download_from_s3():
     result = execute_solid(
         PipelineDefinition([download_from_s3], context_definitions=_s3_context()),
         'download_from_s3',
-        environment={
+        environment_dict={
             'context': {'test': {}},
             'solids': {
                 'download_from_s3': {
@@ -112,7 +114,7 @@ def test_download_from_s3_tempfile():
     result = execute_solid(
         PipelineDefinition([download_from_s3], context_definitions=_s3_context()),
         'download_from_s3',
-        environment={
+        environment_dict={
             'context': {'test': {}},
             'solids': {
                 'download_from_s3': {
@@ -149,7 +151,7 @@ def test_unzip_file_tempfile():
             'archive_paths': [os.path.join(os.path.dirname(__file__), 'data/test.zip')],
             'archive_members': ['test/test_file'],
         },
-        environment={'solids': {'unzip_file': {'config': {'skip_if_present': False}}}},
+        environment_dict={'solids': {'unzip_file': {'config': {'skip_if_present': False}}}},
     )
     assert result.success
     assert result.transformed_value()
@@ -171,7 +173,7 @@ def test_ingest_csv_to_spark():
         ),
         'ingest_csv_to_spark',
         inputs={'input_csv': os.path.join(os.path.dirname(__file__), 'data/test.csv')},
-        environment={'context': {'test': {}}},
+        environment_dict={'context': {'test': {}}},
     )
     assert result.success
     assert isinstance(result.transformed_value(), pyspark.sql.dataframe.DataFrame)

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -268,9 +268,15 @@ class ExecutionPlan(object):
         return list(self._topological_steps())
 
     def _topological_steps(self):
-        ordered_step_keys = toposort.toposort_flatten(self.deps)
-        for step_key in ordered_step_keys:
+        for step_key in toposort.toposort_flatten(self.deps):
             yield self.step_dict[step_key]
+
+    def topological_step_levels(self):
+        return list(self._topological_step_levels())
+
+    def _topological_step_levels(self):
+        for step_key_level in toposort.toposort(self.deps):
+            yield [self.step_dict[step_key] for step_key in step_key_level]
 
 
 class StepOutputMap(dict):

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/unittesting.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/unittesting.py
@@ -59,9 +59,6 @@ def execute_test_a_plus_b_final_subdag():
         define_part_fourteen_step_one_pipeline(),
         ['a_plus_b', 'final'],
         inputs={'a_plus_b': {'num1': 2, 'num2': 4}, 'final': {'num2': 6}},
-        environment_dict={
-            'context': {'default': {'config': {'log_level': 'DEBUG'}}}
-        },
     )
 
     assert results['a_plus_b'].transformed_value() == 6

--- a/python_modules/dagster/dagster/tutorials/intro_tutorial/unittesting.py
+++ b/python_modules/dagster/dagster/tutorials/intro_tutorial/unittesting.py
@@ -59,6 +59,9 @@ def execute_test_a_plus_b_final_subdag():
         define_part_fourteen_step_one_pipeline(),
         ['a_plus_b', 'final'],
         inputs={'a_plus_b': {'num1': 2, 'num2': 4}, 'final': {'num2': 6}},
+        environment_dict={
+            'context': {'default': {'config': {'log_level': 'DEBUG'}}}
+        },
     )
 
     assert results['a_plus_b'].transformed_value() == 6

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -113,15 +113,15 @@ def build_pipeline_with_input_stubs(pipeline_def, inputs):
     )
 
 
-def execute_solids(pipeline_def, solid_names, inputs=None, environment=None):
+def execute_solids(pipeline_def, solid_names, inputs=None, environment_dict=None):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.list_param(solid_names, 'solid_names', of_type=str)
     inputs = check.opt_dict_param(inputs, 'inputs', key_type=str, value_type=dict)
-    environment = check.opt_dict_param(environment, 'environment')
+    environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
 
     sub_pipeline = build_sub_pipeline(pipeline_def, solid_names)
     stubbed_pipeline = build_pipeline_with_input_stubs(sub_pipeline, inputs)
-    result = execute_pipeline(stubbed_pipeline, environment)
+    result = execute_pipeline(stubbed_pipeline, environment_dict)
 
     if not result.success:
         for solid_result in result.solid_result_list:
@@ -131,12 +131,12 @@ def execute_solids(pipeline_def, solid_names, inputs=None, environment=None):
     return {sr.solid.name: sr for sr in result.solid_result_list}
 
 
-def execute_solid(pipeline_def, solid_name, inputs=None, environment=None):
+def execute_solid(pipeline_def, solid_name, inputs=None, environment_dict=None):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.str_param(solid_name, 'solid_name')
     inputs = check.opt_dict_param(inputs, 'inputs', key_type=str)
-    environment = check.opt_dict_param(environment, 'environment')
+    environment_dict = check.opt_dict_param(environment_dict, 'environment')
 
     return execute_solids(
-        pipeline_def, [solid_name], {solid_name: inputs} if inputs else None, environment
+        pipeline_def, [solid_name], {solid_name: inputs} if inputs else None, environment_dict
     )[solid_name]

--- a/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
@@ -68,7 +68,12 @@ def test_single_solid_with_multiple_inputs():
         },
     )
 
-    result = execute_solid(pipeline_def, 'add_solid', inputs={'num_one': 2, 'num_two': 3})
+    result = execute_solid(
+        pipeline_def,
+        'add_solid',
+        inputs={'num_one': 2, 'num_two': 3},
+        environment_dict={'context': {'default': {'config': {'log_level': 'DEBUG'}}}},
+    )
 
     assert result.success
     assert result.transformed_value() == 5
@@ -86,7 +91,7 @@ def test_single_solid_with_config():
     result = execute_solid(
         pipeline_def,
         'check_config_for_two',
-        environment={'solids': {'check_config_for_two': {'config': 2}}},
+        environment_dict={'solids': {'check_config_for_two': {'config': 2}}},
     )
 
     assert result.success
@@ -116,7 +121,7 @@ def test_single_solid_with_context_config():
     result = execute_solid(
         pipeline_def,
         'check_context_config_for_two',
-        environment={'context': {'test_context': {'config': 2}}},
+        environment_dict={'context': {'test_context': {'config': 2}}},
     )
 
     assert result.success

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20737,12 +20737,12 @@ snapshots['test_build_all_docs 54'] = '''
 <h1>Utilities<a class="headerlink" href="#utilities" title="Permalink to this headline">¶</a></h1>
 <dl class="function">
 <dt id="dagster.execute_solid">
-<code class="descclassname">dagster.</code><code class="descname">execute_solid</code><span class="sig-paren">(</span><em>pipeline_def</em>, <em>solid_name</em>, <em>inputs=None</em>, <em>environment=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_solid" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_solid</code><span class="sig-paren">(</span><em>pipeline_def</em>, <em>solid_name</em>, <em>inputs=None</em>, <em>environment_dict=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_solid" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="function">
 <dt id="dagster.execute_solids">
-<code class="descclassname">dagster.</code><code class="descname">execute_solids</code><span class="sig-paren">(</span><em>pipeline_def</em>, <em>solid_names</em>, <em>inputs=None</em>, <em>environment=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_solids" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_solids</code><span class="sig-paren">(</span><em>pipeline_def</em>, <em>solid_names</em>, <em>inputs=None</em>, <em>environment_dict=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_solids" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 </div>


### PR DESCRIPTION
The only material impact here is more efficient memory consumption (we can clear out intermediate values as they are used). The multiprocess engine will use this capability to parallelize so refactoring this in preparation so that we can share more code.

I also updated change log with already merged changes.