### PR TITLE
Eliminate tag stack totally

### DIFF
--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1,6 +1,7 @@
+import inspect
+
 from future.utils import raise_with_traceback
 
-import inspect
 
 from six import string_types
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -698,14 +698,15 @@ def execute_pipeline(
     '''
     "Synchronous" version of :py:func:`execute_pipeline_iterator`.
 
-    Note: throw_on_user_error is very useful in testing contexts when not testing for error conditions
+    Note: throw_on_user_error is very useful in testing contexts when not testing for error
+    conditions
 
     Parameters:
       pipeline (PipelineDefinition): Pipeline to run
       environment (dict): The enviroment that parameterizes this run
       throw_on_user_error (bool):
-        throw_on_user_error makes the function throw when an error is encoutered rather than returning
-        the py:class:`SolidExecutionResult` in an error-state.
+        throw_on_user_error makes the function throw when an error is encoutered rather than
+        returning the py:class:`SolidExecutionResult` in an error-state.
 
 
     Returns:

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -1,7 +1,7 @@
 from dagster import check
+from dagster.core.execution_context import PipelineExecutionContext
 from .objects import (
     ExecutionStep,
-    PlanBuilder,
     StepInput,
     StepKind,
     StepOutput,
@@ -12,8 +12,8 @@ from .objects import (
 UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
 
 
-def create_unmarshal_input_step(plan_builder, step, step_input, marshalling_key):
-    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
+def create_unmarshal_input_step(pipeline_context, step, step_input, marshalling_key):
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_input, 'step_input', StepInput)
     check.str_param(marshalling_key, 'marshalling_key')
@@ -28,6 +28,7 @@ def create_unmarshal_input_step(plan_builder, step, step_input, marshalling_key)
 
     return StepOutputHandle(
         ExecutionStep(
+            pipeline_context=pipeline_context,
             key='{step_key}.unmarshal-input.{input_name}'.format(
                 step_key=step.key, input_name=step_input.name
             ),
@@ -36,7 +37,7 @@ def create_unmarshal_input_step(plan_builder, step, step_input, marshalling_key)
             compute_fn=_compute_fn,
             kind=StepKind.UNMARSHAL_INPUT,
             solid=step.solid,
-            tags=plan_builder.get_tags(),
+            tags=step.tags,
         ),
         UNMARSHAL_INPUT_OUTPUT,
     )
@@ -45,8 +46,8 @@ def create_unmarshal_input_step(plan_builder, step, step_input, marshalling_key)
 MARSHAL_OUTPUT_INPUT = 'marshal-output-input'
 
 
-def create_marshal_output_step(plan_builder, step, step_output, marshalling_key):
-    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
+def create_marshal_output_step(pipeline_context, step, step_output, marshalling_key):
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_output, 'step_output', StepOutput)
     check.str_param(marshalling_key, 'marshalling_key')
@@ -59,6 +60,7 @@ def create_marshal_output_step(plan_builder, step, step_output, marshalling_key)
         )
 
     return ExecutionStep(
+        pipeline_context=pipeline_context,
         key='{step_key}.marshal-output.{output_name}'.format(
             step_key=step.key, output_name=step_output.name
         ),
@@ -73,5 +75,5 @@ def create_marshal_output_step(plan_builder, step, step_output, marshalling_key)
         compute_fn=_compute_fn,
         kind=StepKind.MARSHAL_OUTPUT,
         solid=step.solid,
-        tags=plan_builder.get_tags(),
+        tags=step.tags,
     )

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -299,4 +299,3 @@ class ExecutionPlan(object):
     def _topological_step_levels(self):
         for step_key_level in toposort.toposort(self.deps):
             yield [self.step_dict[step_key] for step_key in step_key_level]
-

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -1,6 +1,4 @@
 from collections import namedtuple
-from contextlib import contextmanager
-import copy
 from enum import Enum
 
 import toposort
@@ -8,6 +6,7 @@ import six
 
 from dagster import check
 from dagster.utils import merge_dicts
+from dagster.core.execution_context import PipelineExecutionContext
 from dagster.core.definitions import Solid, SolidOutputHandle
 from dagster.core.errors import DagsterError
 from dagster.core.types.runtime import RuntimeType
@@ -148,17 +147,25 @@ class StepOutput(namedtuple('_StepOutput', 'name runtime_type')):
 class ExecutionStep(
     namedtuple(
         '_ExecutionStep',
-        'key step_inputs step_input_dict step_outputs step_output_dict compute_fn kind solid tags',
+        (
+            'pipeline_context key step_inputs step_input_dict step_outputs step_output_dict '
+            'compute_fn kind solid tags'
+        ),
     )
 ):
-    def __new__(cls, key, step_inputs, step_outputs, compute_fn, kind, solid, tags):
-        check.param_invariant('pipeline' in tags, 'tags', 'Step must have pipeline tag')
-        check.param_invariant('solid' in tags, 'tags', 'Step must have solid tag')
-        check.param_invariant('solid_definition' in tags, 'tags', 'Step must have solid tag')
-        check.dict_param(tags, 'tags', key_type=str, value_type=str)
+    def __new__(
+        cls, pipeline_context, key, step_inputs, step_outputs, compute_fn, kind, solid, tags=None
+    ):
+        # check.param_invariant('pipeline' in tags, 'tags', 'Step must have pipeline tag')
+        # check.param_invariant('solid' in tags, 'tags', 'Step must have solid tag')
+        # check.param_invariant('solid_definition' in tags, 'tags', 'Step must have solid tag')
+        # check.p[tdict_param(tags, 'tags', key_type=str, value_type=str)
 
         return super(ExecutionStep, cls).__new__(
             cls,
+            pipeline_context=check.inst_param(
+                pipeline_context, 'pipeline_context', PipelineExecutionContext
+            ),
             key=check.str_param(key, 'key'),
             step_inputs=check.list_param(step_inputs, 'step_inputs', of_type=StepInput),
             step_input_dict={si.name: si for si in step_inputs},
@@ -167,20 +174,34 @@ class ExecutionStep(
             compute_fn=check.callable_param(compute_fn, 'compute_fn'),
             kind=check.inst_param(kind, 'kind', StepKind),
             solid=check.inst_param(solid, 'solid', Solid),
-            tags=merge_dicts({'step_key': key}, tags),
+            tags=merge_dicts(
+                merge_dicts(
+                    {
+                        'step_key': key,
+                        'pipeline': pipeline_context.pipeline_def.name,
+                        'solid': solid.name,
+                        'solid_definition': solid.definition.name,
+                    },
+                    check.opt_dict_param(tags, 'tags'),
+                ),
+                pipeline_context.tags,
+            ),
         )
 
     @property
     def pipeline_name(self):
-        return self.tags['pipeline']
+        return self.pipeline_context.pipeline_def.name
+        # return self.tags['pipeline']
 
     @property
     def solid_name(self):
-        return self.tags['solid']
+        # return self.tags['solid']
+        return self.solid.name
 
     @property
     def solid_definition_name(self):
-        return self.tags['solid_definition']
+        # return self.tags['solid_definition']
+        return self.solid.definition.name
 
     def __getnewargs__(self):
         # print('getnewargs was called')
@@ -195,6 +216,7 @@ class ExecutionStep(
 
     def with_new_inputs(self, step_inputs):
         return ExecutionStep(
+            pipeline_context=self.pipeline_context,
             key=self.key,
             step_inputs=step_inputs,
             step_outputs=self.step_outputs,
@@ -296,23 +318,19 @@ class StepOutputMap(dict):
 # step outputs. This covers the case where a solid maps to multiple steps
 # and one wants to be able to attach to the logical output of a solid during execution
 class PlanBuilder:
-    def __init__(self, pipeline_name, initial_tags=None):
+    def __init__(self):
         self.steps = []
         self.step_output_map = StepOutputMap()
-        self._tags = check.opt_dict_param(
-            initial_tags, 'initial_tags', key_type=str, value_type=str
-        )
-        self._tags['pipeline'] = pipeline_name
 
-    def get_tags(self, **additional_tags):
-        additional_tags.update(self._tags)
-        return additional_tags
+    # def get_tags(self, **additional_tags):
+    #     additional_tags.update(self._tags)
+    #     return additional_tags
 
-    @contextmanager
-    def push_tags(self, **kwargs):
-        old_tags = copy.copy(self._tags)
-        self._tags.update(kwargs)
-        try:
-            yield
-        finally:
-            self._tags = old_tags
+    # @contextmanager
+    # def push_tags(self, **kwargs):
+    #     old_tags = copy.copy(self._tags)
+    #     self._tags.update(kwargs)
+    #     try:
+    #         yield
+    #     finally:
+    #         self._tags = old_tags

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -7,7 +7,7 @@ import six
 from dagster import check
 from dagster.utils import merge_dicts
 from dagster.core.execution_context import PipelineExecutionContext
-from dagster.core.definitions import Solid, SolidOutputHandle
+from dagster.core.definitions import Solid
 from dagster.core.errors import DagsterError
 from dagster.core.types.runtime import RuntimeType
 
@@ -300,37 +300,3 @@ class ExecutionPlan(object):
         for step_key_level in toposort.toposort(self.deps):
             yield [self.step_dict[step_key] for step_key in step_key_level]
 
-
-class StepOutputMap(dict):
-    def __getitem__(self, key):
-        check.inst_param(key, 'key', SolidOutputHandle)
-        return dict.__getitem__(self, key)
-
-    def __setitem__(self, key, val):
-        check.inst_param(key, 'key', SolidOutputHandle)
-        check.inst_param(val, 'val', StepOutputHandle)
-        return dict.__setitem__(self, key, val)
-
-
-# This is the state that is built up during the execution plan build process.
-# steps is just a list of the steps that have been created
-# step_output_map maps logical solid outputs (solid_name, output_name) to particular
-# step outputs. This covers the case where a solid maps to multiple steps
-# and one wants to be able to attach to the logical output of a solid during execution
-class PlanBuilder:
-    def __init__(self):
-        self.steps = []
-        self.step_output_map = StepOutputMap()
-
-    # def get_tags(self, **additional_tags):
-    #     additional_tags.update(self._tags)
-    #     return additional_tags
-
-    # @contextmanager
-    # def push_tags(self, **kwargs):
-    #     old_tags = copy.copy(self._tags)
-    #     self._tags.update(kwargs)
-    #     try:
-    #         yield
-    #     finally:
-    #         self._tags = old_tags

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -52,8 +52,8 @@ class ExecutionPlanSubsetInfo(
         check.two_dim_dict_param(inputs, 'inputs', key_type=str)
 
         def _create_injected_value_factory_fn(input_value):
-            return lambda plan_builder, step, step_input: create_value_thunk_step(
-                plan_builder=plan_builder,
+            return lambda pipeline_context, step, step_input: create_value_thunk_step(
+                pipeline_context=pipeline_context,
                 solid=step.solid,
                 runtime_type=step_input.runtime_type,
                 step_key='{step_key}.input.{input_name}.value'.format(
@@ -87,8 +87,8 @@ class ExecutionPlanSubsetInfo(
         input_step_factory_fns = defaultdict(dict)
 
         def _create_unmarshal_input_factory_fn(marshalling_key):
-            return lambda plan_builder, step, step_input: create_unmarshal_input_step(
-                plan_builder, step, step_input, marshalling_key
+            return lambda pipeline_context, step, step_input: create_unmarshal_input_step(
+                pipeline_context, step, step_input, marshalling_key
             )
 
         for step_key, input_marshal_dict in marshalled_inputs.items():
@@ -177,8 +177,8 @@ class ExecutionPlanAddedOutputs(
         output_step_factory_fns = defaultdict(list)
 
         def _create_marshal_output_fn(key):
-            return lambda plan_builder, step, step_output: create_marshal_output_step(
-                plan_builder, step, step_output, key
+            return lambda pipeline_context, step, step_output: create_marshal_output_step(
+                pipeline_context, step, step_output, key
             )
 
         for step_key, outputs_for_step in marshalled_outputs.items():

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -3,16 +3,16 @@ from dagster.core.definitions import Result, Solid
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution_context import TransformExecutionContext, PipelineExecutionContext
 
-from .objects import ExecutionStep, PlanBuilder, StepInput, StepKind, StepOutput, StepOutputValue
+from .objects import ExecutionStep, StepInput, StepKind, StepOutput, StepOutputValue
 
 
-def create_transform_step(pipeline_context, plan_builder, solid, step_inputs):
-    check.inst_param(pipeline_context, 'pipeline_execution_context', PipelineExecutionContext)
-    check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
+def create_transform_step(pipeline_context, solid, step_inputs):
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.list_param(step_inputs, 'step_inputs', of_type=StepInput)
 
     return ExecutionStep(
+        pipeline_context=pipeline_context,
         key='{solid.name}.transform'.format(solid=solid),
         step_inputs=step_inputs,
         step_outputs=[
@@ -24,7 +24,6 @@ def create_transform_step(pipeline_context, plan_builder, solid, step_inputs):
         ),
         kind=StepKind.TRANSFORM,
         solid=solid,
-        tags=plan_builder.get_tags(),
     )
 
 

--- a/python_modules/dagster/dagster_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/check_tests/test_check.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from contextlib import contextmanager
-import pytest
 import sys
+
+import pytest
 
 from dagster import check
 from dagster.check import (

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20237,7 +20237,8 @@ snapshots['test_build_all_docs 52'] = '''
 <dt id="dagster.execute_pipeline">
 <code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>solid_subset=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
 <dd><p>“Synchronous” version of <a class="reference internal" href="#dagster.execute_pipeline_iterator" title="dagster.execute_pipeline_iterator"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline_iterator()</span></code></a>.</p>
-<p>Note: throw_on_user_error is very useful in testing contexts when not testing for error conditions</p>
+<p>Note: throw_on_user_error is very useful in testing contexts when not testing for error
+conditions</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -20245,8 +20246,8 @@ snapshots['test_build_all_docs 52'] = '''
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
 <li><strong>pipeline</strong> (<a class="reference internal" href="definitions.html#dagster.PipelineDefinition" title="dagster.PipelineDefinition"><em>PipelineDefinition</em></a>) – Pipeline to run</li>
 <li><strong>environment</strong> (<em>dict</em>) – The enviroment that parameterizes this run</li>
-<li><strong>throw_on_user_error</strong> (<em>bool</em>) – throw_on_user_error makes the function throw when an error is encoutered rather than returning
-the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
+<li><strong>throw_on_user_error</strong> (<em>bool</em>) – throw_on_user_error makes the function throw when an error is encoutered rather than
+returning the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 </ul>
 </td>
 </tr>


### PR DESCRIPTION
With our improved structure, it has become clear that the tag stack is a totally unnecessary abstraction, so let's kill it.