### PR TITLE
Fix regressions in config scaffolding, add list / float support

### DIFF
--- a/js_modules/dagit/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/src/configeditor/ConfigEditorUtils.tsx
@@ -1,7 +1,10 @@
 import gql from "graphql-tag";
 import { ApolloClient } from "apollo-boost";
 import { ValidationResult } from "./codemirror-yaml/mode";
-import { ConfigEditorPipelineFragment, ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes } from "./types/ConfigEditorPipelineFragment";
+import {
+  ConfigEditorPipelineFragment,
+  ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes
+} from "./types/ConfigEditorPipelineFragment";
 import {
   ConfigEditorCheckConfigQuery,
   ConfigEditorCheckConfigQueryVariables
@@ -138,7 +141,9 @@ export async function checkConfig(
 }
 
 function nullOrEmpty(val: any) {
-  return val === null || (val instanceof Object && Object.keys(val).length == 0)
+  return (
+    val === null || (val instanceof Object && Object.keys(val).length == 0)
+  );
 }
 
 export function scaffoldConfig(pipeline: ConfigEditorPipelineFragment): string {
@@ -160,7 +165,7 @@ export function scaffoldConfig(pipeline: ConfigEditorPipelineFragment): string {
       console.warn(`Unsure of how to scaffold missing type: ${typeKey}`);
       return null;
     }
-    
+
     if (type.__typename === "CompositeConfigType") {
       const result = {};
       type.fields.forEach((field, idx) => {
@@ -171,7 +176,8 @@ export function scaffoldConfig(pipeline: ConfigEditorPipelineFragment): string {
         let val = null;
 
         if (field.configType.__typename === "ListConfigType") {
-          let inner: ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes = field.configType;
+          let inner: ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes =
+            field.configType;
           let wrap = 0;
 
           // If the field's type is a list, we need to scaffold an item in the list.
@@ -181,14 +187,16 @@ export function scaffoldConfig(pipeline: ConfigEditorPipelineFragment): string {
           while (true) {
             if (inner.__typename !== "ListConfigType") break;
             const innerTypeKey: string = inner.ofType.key;
-            inner = field.configType.innerTypes.find(t => t.key === innerTypeKey)!
+            inner = field.configType.innerTypes.find(
+              t => t.key === innerTypeKey
+            )!;
             wrap += 1;
           }
           val = configPlaceholderFor(inner.key, commentDepth);
           if (nullOrEmpty(val)) return;
           while (wrap > 0) {
-            val = [val]
-            wrap --;
+            val = [val];
+            wrap--;
           }
         } else {
           val = configPlaceholderFor(field.configType.key, fieldCommentDepth);
@@ -205,7 +213,9 @@ export function scaffoldConfig(pipeline: ConfigEditorPipelineFragment): string {
       return result;
     }
 
-    console.warn(`Unsure of how to scaffold ${typeKey}: ${JSON.stringify(type)}`);
+    console.warn(
+      `Unsure of how to scaffold ${typeKey}: ${JSON.stringify(type)}`
+    );
     return null;
   };
 

--- a/js_modules/dagit/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/src/configeditor/ConfigEditorUtils.tsx
@@ -132,48 +132,49 @@ export function scaffoldConfig(pipeline: ConfigEditorPipelineFragment): string {
     String: "value",
     Int: 1,
     Bool: false,
-    Float: 1.0,
+    Float: 1.0
   };
 
-  const configPlaceholderFor = (
-    typeKey: string,
-    commentDepth: number
-  ): any => {
+  const configPlaceholderFor = (typeKey: string, commentDepth: number): any => {
     if (placeholders[typeKey] !== undefined) {
       return placeholders[typeKey];
     }
 
-    if (typeKey.startsWith('List.')) {
-      const innerPlaceholder = configPlaceholderFor(typeKey.substr(5), commentDepth)
+    if (typeKey.startsWith("List.")) {
+      const innerPlaceholder = configPlaceholderFor(
+        typeKey.substr(5),
+        commentDepth
+      );
       if (innerPlaceholder === null) return null;
-      return [innerPlaceholder]
+      return [innerPlaceholder];
     }
 
     const type = pipeline.configTypes.find(t => t.key === typeKey);
     if (!type || type.__typename !== "CompositeConfigType") {
-      console.warn(`Unsure of how to scaffold ${typeKey} ${JSON.stringify(type)}`);
+      console.warn(
+        `Unsure of how to scaffold ${typeKey} ${JSON.stringify(type)}`
+      );
       return null;
     }
     const result = {};
-    type.fields
-      .forEach((field, idx) => {
-        const startComment = type.isSelector && idx > 0;
-        const fieldCommentDepth =
-          commentDepth > 0 ? commentDepth + 2 : startComment ? 1 : 0;
+    type.fields.forEach((field, idx) => {
+      const startComment = type.isSelector && idx > 0;
+      const fieldCommentDepth =
+        commentDepth > 0 ? commentDepth + 2 : startComment ? 1 : 0;
 
-        const val = configPlaceholderFor(
-          field.configType.key,
-          fieldCommentDepth
-        );
-        if (val === null || (val instanceof Object && Object.keys(val).length == 0)) {
-          return;
-        }
-        if (fieldCommentDepth > 0) {
-          result[`COMMENTED_${fieldCommentDepth}_${field.name}`] = val;
-        } else {
-          result[field.name] = val;
-        }
-      });
+      const val = configPlaceholderFor(field.configType.key, fieldCommentDepth);
+      if (
+        val === null ||
+        (val instanceof Object && Object.keys(val).length == 0)
+      ) {
+        return;
+      }
+      if (fieldCommentDepth > 0) {
+        result[`COMMENTED_${fieldCommentDepth}_${field.name}`] = val;
+      } else {
+        result[field.name] = val;
+      }
+    });
     return result;
   };
 

--- a/js_modules/dagit/src/configeditor/types/ConfigEditorPipelineFragment.ts
+++ b/js_modules/dagit/src/configeditor/types/ConfigEditorPipelineFragment.ts
@@ -39,6 +39,24 @@ export interface ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fi
   isNullable: boolean;
 }
 
+export interface ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType {
+  __typename: "ListConfigType";
+  key: string;
+  ofType: ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType;
+}
+
+export type ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes = ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType | ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType;
+
 export interface ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType {
   __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
   key: string;
@@ -50,6 +68,7 @@ export interface ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fi
   name: string | null;
   isList: boolean;
   isNullable: boolean;
+  innerTypes: ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes[];
   ofType: ConfigEditorPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType;
 }
 

--- a/js_modules/dagit/src/execution/types/PipelineExecutionContainerFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionContainerFragment.ts
@@ -142,6 +142,24 @@ export interface PipelineExecutionContainerFragment_configTypes_CompositeConfigT
   isNullable: boolean;
 }
 
+export interface PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType {
+  __typename: "ListConfigType";
+  key: string;
+  ofType: PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType;
+}
+
+export type PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes = PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType | PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType;
+
 export interface PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType {
   __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
   key: string;
@@ -153,6 +171,7 @@ export interface PipelineExecutionContainerFragment_configTypes_CompositeConfigT
   name: string | null;
   isList: boolean;
   isNullable: boolean;
+  innerTypes: PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes[];
   ofType: PipelineExecutionContainerFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType;
 }
 

--- a/js_modules/dagit/src/execution/types/PipelineExecutionPipelineFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionPipelineFragment.ts
@@ -39,6 +39,24 @@ export interface PipelineExecutionPipelineFragment_configTypes_CompositeConfigTy
   isNullable: boolean;
 }
 
+export interface PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType {
+  __typename: "ListConfigType";
+  key: string;
+  ofType: PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType;
+}
+
+export type PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes = PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType | PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType;
+
 export interface PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType {
   __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
   key: string;
@@ -50,6 +68,7 @@ export interface PipelineExecutionPipelineFragment_configTypes_CompositeConfigTy
   name: string | null;
   isList: boolean;
   isNullable: boolean;
+  innerTypes: PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes[];
   ofType: PipelineExecutionPipelineFragment_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType;
 }
 

--- a/js_modules/dagit/src/execution/types/PipelineExecutionRootQuery.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionRootQuery.ts
@@ -142,6 +142,24 @@ export interface PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfig
   isNullable: boolean;
 }
 
+export interface PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
+  key: string;
+}
+
+export interface PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType {
+  __typename: "ListConfigType";
+  key: string;
+  ofType: PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType_ofType;
+}
+
+export type PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes = PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_EnumConfigType | PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes_ListConfigType;
+
 export interface PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType {
   __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
   key: string;
@@ -153,6 +171,7 @@ export interface PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfig
   name: string | null;
   isList: boolean;
   isNullable: boolean;
+  innerTypes: PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_innerTypes[];
   ofType: PipelineExecutionRootQuery_pipeline_configTypes_CompositeConfigType_fields_configType_ListConfigType_ofType;
 }
 


### PR DESCRIPTION
This PR also adds a `console.warn` which should make this easier to debug / triage if it ever breaks in the future. I'll see if we can get some jest tests added for this functionality soon.

Related: #820 