### PR TITLE
Improved meta-data experience in dagstermill

### DIFF
--- a/python_modules/airline-demo/airline_demo/notebooks/Delays by Geography.ipynb
+++ b/python_modules/airline-demo/airline_demo/notebooks/Delays by Geography.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from airline_demo.pipelines import define_repo\n",
-    "dm.declare_as_solid(define_repo(), 'delays_by_geo')\n",
+    "dm.register_repository(define_repo())\n",
     "# dm_context = dm.define_context(\n",
     "#     inputs=dict(db_url='', eastbound_delays='', westbound_delays='')\n",
     "# )\n",

--- a/python_modules/airline-demo/airline_demo/notebooks/Fares vs. Delays.ipynb
+++ b/python_modules/airline-demo/airline_demo/notebooks/Fares vs. Delays.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from airline_demo.pipelines import define_repo\n",
-    "dm.declare_as_solid(define_repo(), 'fares_vs_delays')\n",
+    "dm.register_repository(define_repo())\n",
     "#dm_context = dm.define_context(inputs=dict(db_url='', table_name=''))\n",
     "# db_url = 'postgresql://test:test@127.0.0.1:5432/test'\n",
     "# table_name = 'delays_vs_fares'"

--- a/python_modules/airline-demo/airline_demo/notebooks/SFO Delays by Destination.ipynb
+++ b/python_modules/airline-demo/airline_demo/notebooks/SFO Delays by Destination.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from airline_demo.pipelines import define_repo\n",
-    "dm.declare_as_solid(define_repo(), 'sfo_delays_by_destination')\n",
+    "dm.register_repository(define_repo())\n",
     "#dm_context = dm.define_context(inputs=dict(db_url='', table_name=''))\n",
     "# db_url = 'postgresql://test:test@127.0.0.1:5432/test'\n",
     "# table_name = 'average_sfo_outbound_avg_delays_by_destination'"

--- a/python_modules/dagster-pandas/dagster_pandas/examples/notebooks/papermill_pandas_hello_world.ipynb
+++ b/python_modules/dagster-pandas/dagster_pandas/examples/notebooks/papermill_pandas_hello_world.ipynb
@@ -9,7 +9,7 @@
     "from dagster_pandas.examples import define_pandas_repository\n",
     "import dagstermill as dm\n",
     "import pandas as pd\n",
-    "dm.declare_as_solid(define_pandas_repository(), 'papermill_pandas_hello_world')"
+    "dm.register_repository(define_pandas_repository())"
    ]
   },
   {

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -381,7 +381,7 @@ def replace_parameters(context, nb, parameters):
         context.log.debug(
             (
                 'Warning notebook has no parameters cell, '
-                'so first cell must import dagstermill and call dm.declare_as_solid'
+                'so first cell must import dagstermill and call dm.register_repo()'
             )
         )
         before = nb.cells[:1]

--- a/python_modules/dagstermill/dagstermill/cli.py
+++ b/python_modules/dagstermill/dagstermill/cli.py
@@ -45,7 +45,7 @@ def get_module_target_function(repo_target_info):
 
 def get_notebook_scaffolding(register_repo_info):
     if register_repo_info is None:  # do not register repo
-        first_cell_source = 'import dagstermill as dm\\n'
+        first_cell_source = '"import dagstermill as dm"'
     else:
         check.str_param(register_repo_info.import_statement, 'register_repo_info.import_statement')
         check.str_param(

--- a/python_modules/dagstermill/dagstermill/cli.py
+++ b/python_modules/dagstermill/dagstermill/cli.py
@@ -80,7 +80,7 @@ def get_notebook_scaffolding(register_repo_info):
     }},
     "outputs": [],
     "source": [
-        "info = dm.get_info()"
+        "context = dm.get_context()"
     ]
     }}
     ],

--- a/python_modules/dagstermill/dagstermill/cli.py
+++ b/python_modules/dagstermill/dagstermill/cli.py
@@ -1,8 +1,11 @@
 from collections import namedtuple
+import copy
 import os
 import re
 
 import click
+from papermill.iorw import load_notebook_node, write_ipynb
+import nbformat
 
 from dagster import check
 from dagster.cli.dynamic_loader import (
@@ -41,10 +44,19 @@ def get_module_target_function(repo_target_info):
 
 
 def get_notebook_scaffolding(register_repo_info):
-    check.str_param(register_repo_info.import_statement, 'register_repo_info.import_statement')
-    check.str_param(
-        register_repo_info.declaration_statement, 'register_repo_info.declaration_statement'
-    )
+    if register_repo_info is None:  # do not register repo
+        first_cell_source = 'import dagstermill as dm\\n'
+    else:
+        check.str_param(register_repo_info.import_statement, 'register_repo_info.import_statement')
+        check.str_param(
+            register_repo_info.declaration_statement, 'register_repo_info.declaration_statement'
+        )
+        first_cell_source = '''"import dagstermill as dm\\n",
+        "{import_statement}\\n",
+        "{declaration_statement}"'''.format(
+            import_statement=register_repo_info.import_statement,
+            declaration_statement=register_repo_info.declaration_statement,
+        )
 
     starting_notebook_init = '''
     {{
@@ -55,9 +67,7 @@ def get_notebook_scaffolding(register_repo_info):
     "metadata": {{}},
     "outputs": [],
     "source": [
-        "import dagstermill as dm\\n",
-        "{import_statement}\\n",
-        "{declaration_statement}"
+        {first_cell_source}
     ]
     }},
     {{
@@ -70,6 +80,7 @@ def get_notebook_scaffolding(register_repo_info):
     }},
     "outputs": [],
     "source": [
+        "info = dm.get_info()"
     ]
     }}
     ],
@@ -79,35 +90,81 @@ def get_notebook_scaffolding(register_repo_info):
     "nbformat": 4,
     "nbformat_minor": 2
     }}'''
-    return starting_notebook_init.format(
+    return starting_notebook_init.format(first_cell_source=first_cell_source)
+
+
+@click.command(name='register-notebook', help=('Registers repository in existing notebook'))
+@repository_target_argument
+@click.option('--notebook', '-note', type=click.STRING, help='Path to notebook')
+def retroactively_scaffold_notebook(notebook, **kwargs):
+    execute_retroactive_scaffold(notebook, **kwargs)
+
+
+def execute_retroactive_scaffold(notebook_path, **kwargs):
+    nb = load_notebook_node(notebook_path)
+    new_nb = copy.deepcopy(nb)
+    register_repo_info = get_register_repo_info(kwargs, allow_none=False)
+
+    cell_source = 'import dagstermill as dm\n{import_statement}\n{declaration_statement}'.format(
         import_statement=register_repo_info.import_statement,
         declaration_statement=register_repo_info.declaration_statement,
     )
+
+    newcell = nbformat.v4.new_code_cell(source=cell_source)
+    newcell.metadata['tags'] = ['injected-repo-registration']
+    new_nb.cells = [newcell] + nb.cells
+    write_ipynb(new_nb, notebook_path)
 
 
 @click.command(name='create-notebook', help=('Creates new dagstermill notebook.'))
 @repository_target_argument
 @click.option('--notebook', '-note', type=click.STRING, help="Name of notebook")
 @click.option(
-    '--solid-name',
-    '-s',
-    default="",
-    type=click.STRING,
-    help=(
-        'Name of solid that represents notebook in the repository. '
-        'If empty, defaults to notebook name.'
-    ),
-)
-@click.option(
     '--force-overwrite',
     is_flag=True,
     help="Will force overwrite any existing notebook or file with the same name.",
 )
-def create_notebook(notebook, solid_name, force_overwrite, **kwargs):
-    execute_create_notebook(notebook, solid_name, force_overwrite, **kwargs)
+def create_notebook(notebook, force_overwrite, **kwargs):
+    execute_create_notebook(notebook, force_overwrite, **kwargs)
 
 
-def execute_create_notebook(notebook, solid_name, force_overwrite, **kwargs):
+def get_register_repo_info(cli_args, allow_none=True):
+    def all_none(kwargs):
+        for value in kwargs.values():
+            if value is not None:
+                return False
+        return True
+
+    scaffolding_with_repo = True
+    if all_none(cli_args):
+        if os.path.exists(os.path.join(os.getcwd(), 'repository.yml')):
+            cli_args['repository_yaml'] = 'repository.yml'
+        elif allow_none:  # register_repo_info can remain None
+            scaffolding_with_repo = False
+
+    register_repo_info = None
+    if scaffolding_with_repo:
+        repository_target_info = load_target_info_from_cli_args(cli_args)
+        module_target_info = get_module_target_function(repository_target_info)
+
+        if module_target_info:
+            module = module_target_info.module_name
+            fn_name = module_target_info.fn_name
+            RegisterRepoInfo = namedtuple(
+                'RegisterRepoInfo', 'import_statement declaration_statement'
+            )
+            register_repo_info = RegisterRepoInfo(
+                "from {module} import {fn_name}".format(module=module, fn_name=fn_name),
+                "dm.register_repository({fn_name}())".format(fn_name=fn_name),
+            )
+        else:
+            raise click.UsageError(
+                "Cannot instantiate notebook with repository definition given by a function from a file"
+            )
+    return register_repo_info
+
+
+def execute_create_notebook(notebook, force_overwrite, **kwargs):
     if not re.match(r'^[a-zA-Z0-9\-_\\/]+$', notebook):
         raise click.BadOptionUsage(
             notebook,
@@ -135,27 +192,7 @@ def execute_create_notebook(notebook, solid_name, force_overwrite, **kwargs):
             ).format(notebook_path=notebook_path),
             abort=True,
         )
-
-    if not solid_name:
-        solid_name = os.path.basename(notebook_path).split(".")[0]
-
-    repository_target_info = load_target_info_from_cli_args(kwargs)
-    module_target_info = get_module_target_function(repository_target_info)
-
-    if module_target_info:
-        module = module_target_info.module_name
-        fn_name = module_target_info.fn_name
-        RegisterRepoInfo = namedtuple('RegisterRepoInfo', 'import_statement declaration_statement')
-        register_repo_info = RegisterRepoInfo(
-            "from {module} import {fn_name}".format(module=module, fn_name=fn_name),
-            "dm.declare_as_solid({fn_name}(), '{solid_name}')".format(
-                fn_name=fn_name, solid_name=solid_name
-            ),
-        )
-    else:
-        raise click.UsageError(
-            "Cannot instantiate notebook with repository definition given by a function from a file"
-        )
+    register_repo_info = get_register_repo_info(kwargs)
 
     with open(notebook_path, 'w') as f:
         f.write(get_notebook_scaffolding(register_repo_info))
@@ -163,8 +200,9 @@ def execute_create_notebook(notebook, solid_name, force_overwrite, **kwargs):
 
 
 def create_dagstermill_cli():
-    group = click.Group(name="create-notebook")
+    group = click.Group(name="dagstermill")
     group.add_command(create_notebook)
+    group.add_command(retroactively_scaffold_notebook)
     return group
 
 

--- a/python_modules/dagstermill/dagstermill/examples/notebooks/add_two_numbers.ipynb
+++ b/python_modules/dagstermill/dagstermill/examples/notebooks/add_two_numbers.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from dagstermill.examples.repository import define_example_repository\n",
-    "dm.declare_as_solid(define_example_repository(), 'add_two_numbers')"
+    "dm.register_repository(define_example_repository())"
    ]
   },
   {

--- a/python_modules/dagstermill/dagstermill/examples/notebooks/add_two_numbers.ipynb
+++ b/python_modules/dagstermill/dagstermill/examples/notebooks/add_two_numbers.ipynb
@@ -21,7 +21,7 @@
    },
    "outputs": [],
    "source": [
-    "info = dm.get_info({'context': {'default': {\"config\": {\"log_level\": \"DEBUG\"}}}})\n",
+    "context = dm.get_context({'context': {'default': {\"config\": {\"log_level\": \"DEBUG\"}}}})\n",
     "a = 3\n",
     "b = 4"
    ]
@@ -41,8 +41,8 @@
     }
    ],
    "source": [
-    "info.log.info(\"This is a test info log!\")\n",
-    "info.log.debug(\"This is test debug log!\")"
+    "context.log.info(\"This is a test info log!\")\n",
+    "context.log.debug(\"This is test debug log!\")"
    ]
   },
   {

--- a/python_modules/dagstermill/dagstermill/examples/notebooks/hello_world.ipynb
+++ b/python_modules/dagstermill/dagstermill/examples/notebooks/hello_world.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from dagstermill.examples.repository import define_example_repository\n",
-    "dm.declare_as_solid(define_example_repository(), 'hello_world')"
+    "dm.register_repository(define_example_repository())"
    ]
   },
   {

--- a/python_modules/dagstermill/dagstermill/examples/notebooks/hello_world_output.ipynb
+++ b/python_modules/dagstermill/dagstermill/examples/notebooks/hello_world_output.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from dagstermill.examples.repository import define_example_repository\n",
-    "dm.declare_as_solid(define_example_repository(), 'hello_world_output')"
+    "dm.register_repository(define_example_repository())"
    ]
   },
   {

--- a/python_modules/dagstermill/dagstermill/examples/notebooks/mult_two_numbers.ipynb
+++ b/python_modules/dagstermill/dagstermill/examples/notebooks/mult_two_numbers.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "import dagstermill as dm\n",
     "from dagstermill.examples.repository import define_example_repository\n",
-    "dm.declare_as_solid(define_example_repository(), 'mult_two_numbers')"
+    "dm.register_repository(define_example_repository())"
    ]
   },
   {

--- a/python_modules/dagstermill/dagstermill_tests/test_cli_commands.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_cli_commands.py
@@ -28,7 +28,7 @@ EXPECTED_OUTPUT_SHELL = '''
     }},
     "outputs": [],
     "source": [
-        "info = dm.get_info()"
+        "context = dm.get_context()"
     ]
     }}
     ],


### PR DESCRIPTION
There are several changes in this PR that address issue #782. 

Previously, the user was required to call

```dm.declare_as_solid(repo_def, solid_name)``` 

within the notebook for the notebook to work in-pipeline. This PR removes the need for the user to have `solid_name`. Instead they can simply register the repo as follows:

```dm.register_repository(repo_def)```

**CLI Changes**

Previously when calling `dagstermill create-notebook`, the user would be required to provide a notebook name and arguments that told the CLI what repository to register. Now, the CLI does not require a repository for notebook creation. Instead, the CLI has a new command `register-notebook` that takes in arguments that point it to a repository (either filename, module name, .yml, etc.) and an existing notebook and then retroactively scaffolds the notebook so that the top cell has the call to `dm.register_repository(repo_def)` with the correct repository definition! 

Finally, the CLI (in either case of having a repository or not) will automatically include `context = dm.get_context()` in the parameters cell, so that the user by default has a minimal context with a logger and empty resources, etc.