### PR TITLE
Do not recursively watch all files in parent dir

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -125,7 +125,7 @@ def host_dagit_ui(log, log_dir, watch, repository_container, sync, host, port):
     if watch:
         observer = Observer()
         handler = ReloaderHandler(repository_container)
-        observer.schedule(handler, os.path.dirname(os.path.abspath(os.getcwd())), recursive=True)
+        observer.schedule(handler, os.path.abspath(os.getcwd()), recursive=True)
         observer.start()
     try:
         app = create_app(


### PR DESCRIPTION
If I create a directory in my home dir:

`mkdir ~/test`

and then run dagit from inside that directory:

`cd ~/test && dagit`

the current code recursively watches all files in the parent directory,
which in this case is home. Not only does this seem incorrect, it also
makes dagit load very slowly on my machine because there is a ton of
stuff in my home directory. The current working directory is already a
dir, so this patch removes the (accidental?) dirname call.