### PR TITLE
Multiprocessing executor

### DIFF
--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -13,7 +13,7 @@ from dagster.core.execution import (
 )
 from dagster.core.execution_context import PipelineExecutionContext
 from dagster.core.execution_plan.objects import ExecutionStepEvent
-from dagster.core.execution_plan.simple_engine import iterate_step_events_for_step
+from dagster.core.execution_plan.simple_engine import execute_step_in_memory
 
 from .serialize import deserialize, serialize
 from .utils import get_input_key, get_resources_key, get_step_key, LambdaInvocationPayload
@@ -94,7 +94,7 @@ def aws_lambda_handler(event, _context):
         input_values[step_input.name] = input_value
 
     logger.info('Executing step {key}'.format(key=key))
-    step_events = list(iterate_step_events_for_step(step, execution_context, input_values))
+    step_events = list(execute_step_in_memory(step, execution_context, input_values))
 
     for step_event in step_events:
         check.invariant(isinstance(step_event, ExecutionStepEvent))

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -613,7 +613,7 @@ def invoke_executor_on_plan(pipeline_context, execution_plan, throw_on_user_erro
             executor_config, pipeline_context, execution_plan
         )
     else:
-        check.failed('Unsupport config {}'.format(executor_config))
+        check.failed('Unsupported config {}'.format(executor_config))
 
     for step_event in step_events_gen:
         if throw_on_user_error and step_event.is_step_failure:

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -1,0 +1,152 @@
+import os
+import multiprocessing
+
+from dagster import check
+
+from dagster.core.execution_context import PipelineExecutionContext
+
+from .create import create_execution_plan_core
+from .objects import ExecutionPlan, ExecutionStepEvent, ExecutionStepEventType, StepOutputHandle
+from .plan_subset import ExecutionPlanSubsetInfo
+from .simple_engine import start_inprocess_executor
+
+
+def _execute_in_child_process(
+    queue, executor_config, environment_dict, execution_metadata, step_key, inputs_for_step
+):
+    from dagster.core.execution import yield_pipeline_execution_context
+
+    pipeline = executor_config.pipeline_fn()
+
+    inputs_to_inject = {step_key: inputs_for_step}
+
+    with yield_pipeline_execution_context(
+        pipeline, environment_dict, execution_metadata.with_tags(pid=str(os.getpid()))
+    ) as pipeline_context:
+
+        execution_plan = create_execution_plan_core(
+            pipeline_context,
+            subset_info=ExecutionPlanSubsetInfo.with_input_values([step_key], inputs_to_inject),
+        )
+
+        for step_event in start_inprocess_executor(pipeline_context, execution_plan):
+            data_to_put = {
+                'event_type': step_event.event_type,
+                'success_data': step_event.success_data,
+                'failure_data': step_event.failure_data,
+                'step_key': step_event.step.key,
+                'tags': step_event.tags,
+            }
+
+            queue.put(data_to_put)
+
+    queue.put('DONE')
+    queue.close()
+
+
+def execute_step_out_of_process(executor_config, step_context, step, prev_step_events):
+    queue = multiprocessing.Queue()
+
+    check.invariant(
+        not step_context.execution_metadata.loggers,
+        'Cannot inject loggers via ExecutionMetadata with the Multiprocess executor',
+    )
+
+    process = multiprocessing.Process(
+        target=_execute_in_child_process,
+        args=(
+            queue,
+            executor_config,
+            step_context.environment_dict,
+            step_context.execution_metadata,
+            step.key,
+            _create_input_values(step, prev_step_events),
+        ),
+    )
+
+    process.start()
+    while process.is_alive():
+        result = queue.get()
+        if result == 'DONE':
+            break
+        event_type = result['event_type']
+
+        # TODO: should we filter out? Need to think about the relationship between pipelines
+        # and subplans
+        if step.key != result['step_key']:
+            continue
+
+        check.invariant(step.key == result['step_key'])
+
+        yield ExecutionStepEvent(
+            event_type=event_type,
+            step=step,
+            success_data=result['success_data'],
+            failure_data=result['failure_data'],
+            tags=result['tags'],
+        )
+
+    # Do something reasonable on total process failure
+    process.join()
+
+
+def _all_inputs_covered(step, results):
+    for step_input in step.step_inputs:
+        if step_input.prev_output_handle not in results:
+            return False
+    return True
+
+
+def _create_input_values(step, prev_level_results):
+    input_values = {}
+    for step_input in step.step_inputs:
+        prev_output_handle = step_input.prev_output_handle
+        input_value = prev_level_results[prev_output_handle].success_data.value
+        input_values[step_input.name] = input_value
+    return input_values
+
+
+class MultiprocessExecutorConfig:
+    def __init__(self, pipeline_fn):
+        self.pipeline_fn = pipeline_fn
+
+
+def multiprocess_execute_plan(executor_config, pipeline_context, execution_plan):
+    check.inst_param(executor_config, 'executor_config', MultiprocessExecutorConfig)
+    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
+
+    step_levels = execution_plan.topological_step_levels()
+
+    # It would be good to implement a reference tracking algorithm here so we could
+    # garbage collection results that are no longer needed by any steps
+    # https://github.com/dagster-io/dagster/issues/811
+    prev_step_events = {}
+
+    for step_level in step_levels:
+        for step in step_level:
+            step_context = pipeline_context.for_step(step)
+
+            if not _all_inputs_covered(step, prev_step_events):
+                result_keys = set(prev_step_events.keys())
+                expected_outputs = [ni.prev_output_handle for ni in step.step_inputs]
+
+                step_context.log.debug(
+                    (
+                        'Not all inputs covered for {step}. Not executing. Keys in result: '
+                        '{result_keys}. Outputs need for inputs {expected_outputs}'
+                    ).format(
+                        expected_outputs=expected_outputs, step=step.key, result_keys=result_keys
+                    )
+                )
+                continue
+
+            for step_event in check.generator(
+                execute_step_out_of_process(executor_config, step_context, step, prev_step_events)
+            ):
+                check.inst(step_event, ExecutionStepEvent)
+                yield step_event
+
+                if step_event.event_type == ExecutionStepEventType.STEP_OUTPUT:
+                    output_handle = StepOutputHandle(step, step_event.success_data.output_name)
+                    prev_step_events[output_handle] = step_event

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
@@ -1,0 +1,66 @@
+from dagster import (
+    DependencyDefinition,
+    InputDefinition,
+    PipelineDefinition,
+    execute_pipeline,
+    lambda_solid,
+)
+
+from dagster.core.execution import InProcessExecutorConfig, MultiprocessExecutorConfig
+
+
+def test_diamond_simple_execution():
+    result = execute_pipeline(define_diamond_pipeline(), executor_config=InProcessExecutorConfig())
+    assert result.success
+    assert result.result_for_solid('adder').transformed_value() == 11
+
+
+def transform_event(result, solid_name):
+    return result.result_for_solid(solid_name).transforms[0]
+
+
+def test_diamond_multi_execution():
+    pipeline = define_diamond_pipeline()
+    result = execute_pipeline(
+        pipeline, executor_config=MultiprocessExecutorConfig(define_diamond_pipeline)
+    )
+    assert result.success
+    assert result.result_for_solid('adder').transformed_value() == 11
+
+    pids_by_solid = {}
+    for solid in pipeline.solids:
+        pids_by_solid[solid.name] = transform_event(result, solid.name).tags['pid']
+
+    # guarantee that all solids ran in their own process
+    assert len(set(pids_by_solid.values())) == len(pipeline.solids)
+
+
+def define_diamond_pipeline():
+    @lambda_solid
+    def return_two():
+        return 2
+
+    @lambda_solid(inputs=[InputDefinition('num')])
+    def add_three(num):
+        return num + 3
+
+    @lambda_solid(inputs=[InputDefinition('num')])
+    def mult_three(num):
+        return num * 3
+
+    @lambda_solid(inputs=[InputDefinition('left'), InputDefinition('right')])
+    def adder(left, right):
+        return left + right
+
+    return PipelineDefinition(
+        name='diamond_execution',
+        solids=[return_two, add_three, mult_three, adder],
+        dependencies={
+            'add_three': {'num': DependencyDefinition('return_two')},
+            'mult_three': {'num': DependencyDefinition('return_two')},
+            'adder': {
+                'left': DependencyDefinition('add_three'),
+                'right': DependencyDefinition('mult_three'),
+            },
+        },
+    )

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20235,7 +20235,7 @@ snapshots['test_build_all_docs 52'] = '''
 <p>Executing pipelines and solids.</p>
 <dl class="function">
 <dt id="dagster.execute_pipeline">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
 <dd><p>“Synchronous” version of <a class="reference internal" href="#dagster.execute_pipeline_iterator" title="dagster.execute_pipeline_iterator"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline_iterator()</span></code></a>.</p>
 <p>Note: throw_on_user_error is very useful in testing contexts when not testing for error
 conditions</p>
@@ -20260,7 +20260,7 @@ returning the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 
 <dl class="function">
 <dt id="dagster.execute_pipeline_iterator">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns iterator that yields <a class="reference internal" href="#dagster.SolidExecutionResult" title="dagster.SolidExecutionResult"><code class="xref py py-class docutils literal notranslate"><span class="pre">SolidExecutionResult</span></code></a> for each
 solid executed in the pipeline.</p>
 <p>This is intended to allow the caller to do things between each executed


### PR DESCRIPTION
Here's the first show at the multiprocessing executor.

Next steps:

1) Actually exploit parallelism with a configurable number of parallel processes
2) Actually stream real events that represent execution plan start and and stop events rather than the hardcoded 'DONE' string
3) Perhaps use the filesystem as the intermediate values instead of holding everything in memory.