### PR TITLE
Serializable execution plan

### DIFF
--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 import sys
 import uuid
 
@@ -496,4 +496,3 @@ def _create_dauphin_step_event(execution_plan, step_event):
 
 def _type_of(args, type_name):
     return args.graphene_info.schema.type_named(type_name)
-

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -7,7 +7,7 @@ import uuid
 from graphql.execution.base import ResolveInfo
 
 from dagster import ExecutionMetadata, check
-from dagster.core.execution_plan.objects import ExecutionStepEvent
+from dagster.core.execution_plan.objects import ExecutionStepEventType
 from dagster.core.execution_plan.plan_subset import MarshalledOutput, MarshalledInput, StepExecution
 
 from dagster.core.errors import (
@@ -15,10 +15,20 @@ from dagster.core.errors import (
     DagsterInvalidSubplanInputNotFoundError,
     DagsterInvalidSubplanMissingInputError,
     DagsterInvalidSubplanOutputNotFoundError,
-    DagsterUserCodeExecutionError,
 )
 
-from dagster.core.execution import ExecutionSelector, create_execution_plan, execute_marshalling
+from dagster.core.execution import (
+    ExecutionPlanAddedOutputs,
+    ExecutionPlanSubsetInfo,
+    ExecutionSelector,
+    create_execution_plan,
+)
+
+from dagster.core.serializable import (
+    execute_serializable_execution_plan,
+    SerializableExecutionMetadata,
+    SerializableStepEvents,
+)
 from dagster.core.types.evaluator import evaluate_config_value, EvaluateValueResult
 
 from dagster.utils.error import serializable_error_info_from_exc_info
@@ -394,15 +404,19 @@ def _execute_marshalling_or_error(args, dauphin_pipeline, evaluate_value_result)
     check.inst_param(dauphin_pipeline, 'dauphin_pipeline', DauphinPipeline)
     check.inst_param(evaluate_value_result, 'evaluate_value_result', EvaluateValueResult)
 
+    environment_dict = evaluate_value_result.value
+
     try:
-        step_events = execute_marshalling(
+        inputs_to_marshal = _get_inputs_to_marshal(args.step_executions)
+        outputs_to_marshal = {se.step_key: se.marshalled_outputs for se in args.step_executions}
+        execution_plan = create_execution_plan(
             dauphin_pipeline.get_dagster_pipeline(),
-            step_keys=args.step_keys,
-            inputs_to_marshal=_get_inputs_to_marshal(args.step_executions),
-            outputs_to_marshal={se.step_key: se.marshalled_outputs for se in args.step_executions},
-            environment_dict=evaluate_value_result.value,
+            environment_dict=environment_dict,
             execution_metadata=args.execution_metadata,
-            throw_on_user_error=False,
+            subset_info=ExecutionPlanSubsetInfo.with_input_marshalling(
+                args.step_keys, inputs_to_marshal
+            ),
+            added_outputs=ExecutionPlanAddedOutputs.with_output_marshalling(outputs_to_marshal),
         )
 
     except DagsterInvalidSubplanMissingInputError as invalid_subplan_error:
@@ -436,36 +450,44 @@ def _execute_marshalling_or_error(args, dauphin_pipeline, evaluate_value_result)
             )
         )
 
-    # https://github.com/dagster-io/dagster/issues/763
-    # Once this issue is resolve we should be able to eliminate this
-    except DagsterUserCodeExecutionError as ducee:
-        return EitherError(
-            _type_of(args, 'PythonError')(
-                serializable_error_info_from_exc_info(ducee.original_exc_info)
-            )
-        )
+    check.invariant(not args.execution_metadata.loggers)
+    check.invariant(not args.execution_metadata.event_callback)
+
+    step_events = execute_serializable_execution_plan(
+        dauphin_pipeline.get_dagster_pipeline,
+        environment_dict=environment_dict,
+        execution_metadata=SerializableExecutionMetadata(
+            run_id=args.execution_metadata.run_id, tags=args.execution_metadata.tags
+        ),
+        step_executions=args.step_executions,
+    )
 
     return _type_of(args, 'StartSubplanExecutionSuccess')(
         pipeline=dauphin_pipeline,
-        has_failures=any(se for se in step_events if se.is_step_failure),
-        step_events=list(map(_create_dauphin_step_event, step_events)),
+        has_failures=any(
+            se for se in step_events if se.event_type == ExecutionStepEventType.STEP_FAILURE
+        ),
+        step_events=list(
+            map(lambda se: _create_dauphin_step_event(execution_plan, se), step_events)
+        ),
     )
 
 
-def _create_dauphin_step_event(step_event):
-    check.inst_param(step_event, 'step_event', ExecutionStepEvent)
-    if step_event.is_successful_output:
+def _create_dauphin_step_event(execution_plan, step_event):
+    check.inst_param(step_event, 'step_event', SerializableStepEvents)
+
+    step = execution_plan.get_step_by_key(step_event.step_key)
+
+    if step_event.event_type == ExecutionStepEventType.STEP_OUTPUT:
         return DauphinSuccessfulStepOutputEvent(
-            success=step_event.is_successful_output,
-            step=DauphinExecutionStep(step_event.step),
-            output_name=step_event.success_data.output_name,
-            value_repr=repr(step_event.success_data.value),
+            success=True,
+            step=DauphinExecutionStep(step),
+            output_name=step_event.output_name,
+            value_repr=step_event.value_repr,
         )
-    elif step_event.is_step_failure:
+    elif step_event.event_type == ExecutionStepEventType.STEP_FAILURE:
         return DauphinStepFailureEvent(
-            success=step_event.is_successful_output,
-            step=DauphinExecutionStep(step_event.step),
-            error_message=str(step_event.failure_data.dagster_error),
+            success=False, step=DauphinExecutionStep(step), error_message=step_event.error_message
         )
     else:
         check.failed('{step_event} unsupported'.format(step_event=step_event))

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -28,6 +28,7 @@ from dagster.core.serializable import (
     execute_serializable_execution_plan,
     SerializableExecutionMetadata,
     SerializableStepEvents,
+    ForkedProcessPipelineFactory,
 )
 from dagster.core.types.evaluator import evaluate_config_value, EvaluateValueResult
 
@@ -454,7 +455,7 @@ def _execute_marshalling_or_error(args, dauphin_pipeline, evaluate_value_result)
     check.invariant(not args.execution_metadata.event_callback)
 
     step_events = execute_serializable_execution_plan(
-        dauphin_pipeline.get_dagster_pipeline,
+        ForkedProcessPipelineFactory(pipeline_fn=dauphin_pipeline.get_dagster_pipeline),
         environment_dict=environment_dict,
         execution_metadata=SerializableExecutionMetadata(
             run_id=args.execution_metadata.run_id, tags=args.execution_metadata.tags

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -475,6 +475,7 @@ def _type_of(args, type_name):
     return args.graphene_info.schema.type_named(type_name)
 
 
+# TODO include from .serializable
 def _get_inputs_to_marshal(step_executions):
     check.list_param(step_executions, 'step_executions', of_type=StepExecution)
     inputs_to_marshal = defaultdict(dict)

--- a/python_modules/dagit/dagit/schema/roots.py
+++ b/python_modules/dagit/dagit/schema/roots.py
@@ -174,7 +174,7 @@ class DauphinStartSubplanExecution(dauphin.Mutation):
                 kwargs.get('config'),
                 list(
                     map(
-                        lambda data: model.StepExecution(
+                        lambda data: model.step_executions_from_graphql_inputs(
                             data['stepKey'],
                             data.get('marshalledInputs', []),
                             data.get('marshalledOutputs', []),

--- a/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
+++ b/python_modules/dagster/dagster/core/execution_plan/plan_subset.py
@@ -146,6 +146,19 @@ class MarshalledOutput(namedtuple('_MarshalledOutput', 'output_name marshalling_
         )
 
 
+MarshalledInput = namedtuple('MarshalledInput', 'input_name key')
+
+
+class StepExecution(namedtuple('_StepExecution', 'step_key marshalled_inputs marshalled_outputs')):
+    def __new__(cls, step_key, marshalled_inputs, marshalled_outputs):
+        return super(StepExecution, cls).__new__(
+            cls,
+            check.str_param(step_key, 'step_key'),
+            check.list_param(marshalled_inputs, 'marshalled_inputs', of_type=MarshalledInput),
+            check.list_param(marshalled_outputs, 'marshalled_outputs', of_type=MarshalledOutput),
+        )
+
+
 class OutputStepFactoryEntry(namedtuple('_OutputStepFactoryEntry', 'output_name step_factory_fn')):
     def __new__(cls, output_name, step_factory_fn):
         return super(OutputStepFactoryEntry, cls).__new__(

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -1,18 +1,92 @@
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from dagster import check
 
-from .execution import execute_marshalling
+from .errors import (
+    DagsterExecutionStepNotFoundError,
+    DagsterInvalidSubplanInputNotFoundError,
+    DagsterInvalidSubplanMissingInputError,
+    DagsterInvalidSubplanOutputNotFoundError,
+    DagsterUserCodeExecutionError,
+)
+from .execution import execute_marshalling, create_execution_plan
+from .execution_context import ExecutionMetadata
+from .execution_plan.objects import ExecutionStepEvent
 from .execution_plan.plan_subset import MarshalledOutput, MarshalledInput, StepExecution
+
 
 SerializableExecutionMetadata = namedtuple('SerializableExecutionMetadata', 'run_id tags')
 SerializableExecutionTag = namedtuple('SerialiableExecutionTag', 'key value')
 
+SerializableStepOutputEvent = namedtuple(
+    'SerializableStepOutputEvent', 'success step_key output_name value_repr'
+)
 
-def serializable_execution_plan(
-    pipeline_name, environment_dict, execution_metadata, step_executions
-):
-    check.str_param(pipeline_name, 'pipeline_name')
+SerializableStepFailureEvent = namedtuple(
+    'SerializableStepFailureEvent', 'success step_key error_message'
+)
+
+
+def list_pull(alist, key):
+    return list(map(lambda elem: getattr(elem, key), alist))
+
+
+def _get_inputs_to_marshal(step_executions):
+    check.list_param(step_executions, 'step_executions', of_type=StepExecution)
+    inputs_to_marshal = defaultdict(dict)
+    for step_execution in step_executions:
+        for input_name, marshalling_key in step_execution.marshalled_inputs:
+            inputs_to_marshal[step_execution.step_key][input_name] = marshalling_key
+    return dict(inputs_to_marshal)
+
+
+def _to_serializable_step_event(step_event):
+    check.inst_param(step_event, 'step_event', ExecutionStepEvent)
+
+    if step_event.is_successful_output:
+        return SerializableStepOutputEvent(
+            success=step_event.is_successful_output,
+            step_key=step_event.step.key,
+            output_name=step_event.success_data.output_name,
+            value_repr=repr(step_event.success_data.value),
+        )
+    elif step_event.is_step_failure:
+        return SerializableStepFailureEvent(
+            success=step_event.is_successful_output,
+            step_key=step_event.step.key,
+            error_message=str(step_event.failure_data.dagster_error),
+        )
+
+    check.failed('Unsupported step_event type {}'.format(step_event))
+
+
+def serializable_execution_plan(pipeline_fn, environment_dict, execution_metadata, step_executions):
+    check.callable_param(pipeline_fn, 'pipeline_fn')
     check.dict_param(environment_dict, 'enviroment_dict', key_type=str)
     check.inst_param(execution_metadata, 'execution_metadata', SerializableExecutionMetadata)
     check.list_param(step_executions, 'step_executions', of_type=StepExecution)
+
+    # try:
+    step_events = execute_marshalling(
+        pipeline_fn(),
+        step_keys=list_pull(step_executions, 'step_key'),
+        inputs_to_marshal=_get_inputs_to_marshal(step_executions),
+        outputs_to_marshal={se.step_key: se.marshalled_outputs for se in step_executions},
+        execution_metadata=ExecutionMetadata(
+            run_id=execution_metadata.run_id, tags={t.key: t.value for t in execution_metadata.tags}
+        ),
+        throw_on_user_error=False,
+    )
+    # except DagsterInvalidSubplanMissingInputError as invalid_subplan_error:
+    #     pass
+
+    # except DagsterInvalidSubplanOutputNotFoundError as output_not_found_error:
+    #     pass
+
+    # except DagsterInvalidSubplanInputNotFoundError as input_not_found_error:
+    #     pass
+
+    # except DagsterExecutionStepNotFoundError as step_not_found_error:
+    #     pass
+
+    return list(map(_to_serializable_step_event, step_events))
 

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -1,0 +1,18 @@
+from collections import namedtuple
+from dagster import check
+
+from .execution import execute_marshalling
+from .execution_plan.plan_subset import MarshalledOutput, MarshalledInput, StepExecution
+
+SerializableExecutionMetadata = namedtuple('SerializableExecutionMetadata', 'run_id tags')
+SerializableExecutionTag = namedtuple('SerialiableExecutionTag', 'key value')
+
+
+def serializable_execution_plan(
+    pipeline_name, environment_dict, execution_metadata, step_executions
+):
+    check.str_param(pipeline_name, 'pipeline_name')
+    check.dict_param(environment_dict, 'enviroment_dict', key_type=str)
+    check.inst_param(execution_metadata, 'execution_metadata', SerializableExecutionMetadata)
+    check.list_param(step_executions, 'step_executions', of_type=StepExecution)
+

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -1,29 +1,23 @@
 from collections import namedtuple, defaultdict
 from dagster import check
 
-from .errors import (
-    DagsterExecutionStepNotFoundError,
-    DagsterInvalidSubplanInputNotFoundError,
-    DagsterInvalidSubplanMissingInputError,
-    DagsterInvalidSubplanOutputNotFoundError,
-    DagsterUserCodeExecutionError,
-)
-from .execution import execute_marshalling, create_execution_plan
+from .execution import execute_marshalling
 from .execution_context import ExecutionMetadata
 from .execution_plan.objects import ExecutionStepEvent
-from .execution_plan.plan_subset import MarshalledOutput, MarshalledInput, StepExecution
+from .execution_plan.plan_subset import StepExecution
 
 
 SerializableExecutionMetadata = namedtuple('SerializableExecutionMetadata', 'run_id tags')
-SerializableExecutionTag = namedtuple('SerialiableExecutionTag', 'key value')
 
 SerializableStepOutputEvent = namedtuple(
-    'SerializableStepOutputEvent', 'success step_key output_name value_repr'
+    'SerializableStepOutputEvent', 'event_type step_key output_name value_repr'
 )
 
 SerializableStepFailureEvent = namedtuple(
-    'SerializableStepFailureEvent', 'success step_key error_message'
+    'SerializableStepFailureEvent', 'event_type step_key error_message'
 )
+
+SerializableStepEvents = (SerializableStepOutputEvent, SerializableStepFailureEvent)
 
 
 def list_pull(alist, key):
@@ -44,14 +38,14 @@ def _to_serializable_step_event(step_event):
 
     if step_event.is_successful_output:
         return SerializableStepOutputEvent(
-            success=step_event.is_successful_output,
+            event_type=step_event.event_type,
             step_key=step_event.step.key,
             output_name=step_event.success_data.output_name,
             value_repr=repr(step_event.success_data.value),
         )
     elif step_event.is_step_failure:
         return SerializableStepFailureEvent(
-            success=step_event.is_successful_output,
+            event_type=step_event.event_type,
             step_key=step_event.step.key,
             error_message=str(step_event.failure_data.dagster_error),
         )
@@ -59,34 +53,24 @@ def _to_serializable_step_event(step_event):
     check.failed('Unsupported step_event type {}'.format(step_event))
 
 
-def serializable_execution_plan(pipeline_fn, environment_dict, execution_metadata, step_executions):
+def execute_serializable_execution_plan(
+    pipeline_fn, environment_dict, execution_metadata, step_executions
+):
     check.callable_param(pipeline_fn, 'pipeline_fn')
     check.dict_param(environment_dict, 'enviroment_dict', key_type=str)
     check.inst_param(execution_metadata, 'execution_metadata', SerializableExecutionMetadata)
     check.list_param(step_executions, 'step_executions', of_type=StepExecution)
 
-    # try:
     step_events = execute_marshalling(
         pipeline_fn(),
+        environment_dict=environment_dict,
         step_keys=list_pull(step_executions, 'step_key'),
         inputs_to_marshal=_get_inputs_to_marshal(step_executions),
         outputs_to_marshal={se.step_key: se.marshalled_outputs for se in step_executions},
         execution_metadata=ExecutionMetadata(
-            run_id=execution_metadata.run_id, tags={t.key: t.value for t in execution_metadata.tags}
+            run_id=execution_metadata.run_id, tags=execution_metadata.tags
         ),
         throw_on_user_error=False,
     )
-    # except DagsterInvalidSubplanMissingInputError as invalid_subplan_error:
-    #     pass
-
-    # except DagsterInvalidSubplanOutputNotFoundError as output_not_found_error:
-    #     pass
-
-    # except DagsterInvalidSubplanInputNotFoundError as input_not_found_error:
-    #     pass
-
-    # except DagsterExecutionStepNotFoundError as step_not_found_error:
-    #     pass
 
     return list(map(_to_serializable_step_event, step_events))
-


### PR DESCRIPTION
This creates a new API to execute plans in such a way that guarantees that it is serializable. We then use this API to implement the graphql backend in order to test it and consolidate code paths.

The general process for using this API is to construct the execution plan in the parent process before execution. This is fine because the parent process orchestrating the execution of subplans will have to create the plan to determine what subset to execute.

This effectively serves as a forcing function to make step events serializable.

Next steps:

1) Use this API to implement the multiprocessing executor.
2) Use this API within the dagit pipeline execution manager. 
3) As part of 1 and 2, expand the number of events that we are streaming through the step events channel. Part of this work will be to actually merge the notion of ExecutionStepEvents in the core executor and the "EventRecord" events in dagster.core.events. We have two parallel event streams which is wasteful and annoying.

