### PR TITLE
Intermediate Value Manager

### DIFF
--- a/js_modules/dagit/src/schema.json
+++ b/js_modules/dagit/src/schema.json
@@ -5933,7 +5933,7 @@
         "possibleTypes": [
           {
             "kind": "OBJECT",
-            "name": "InvalidSubplanExecutionError",
+            "name": "InvalidSubplanMissingInputError",
             "ofType": null
           },
           {
@@ -5963,7 +5963,7 @@
           },
           {
             "kind": "OBJECT",
-            "name": "StartSubplanExecutionInvalidStepsError",
+            "name": "StartSubplanExecutionInvalidStepError",
             "ofType": null
           },
           {
@@ -5975,19 +5975,19 @@
       },
       {
         "kind": "OBJECT",
-        "name": "InvalidSubplanExecutionError",
+        "name": "InvalidSubplanMissingInputError",
         "description": null,
         "fields": [
           {
-            "name": "step",
+            "name": "stepKey",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -6022,15 +6022,15 @@
         "description": null,
         "fields": [
           {
-            "name": "step",
+            "name": "stepKey",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -6065,15 +6065,15 @@
         "description": null,
         "fields": [
           {
-            "name": "step",
+            "name": "stepKey",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -6104,28 +6104,20 @@
       },
       {
         "kind": "OBJECT",
-        "name": "StartSubplanExecutionInvalidStepsError",
+        "name": "StartSubplanExecutionInvalidStepError",
         "description": null,
         "fields": [
           {
-            "name": "invalidStepKeys",
+            "name": "invalidStepKey",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/python_modules/dagit/dagit/schema/errors.py
+++ b/python_modules/dagit/dagit/schema/errors.py
@@ -339,7 +339,7 @@ class DauphinStartSubplanExecutionInvalidInputError(dauphin.ObjectType):
     class Meta:
         name = 'StartSubplanExecutionInvalidInputError'
 
-    step = dauphin.NonNull('ExecutionStep')
+    step_key = dauphin.NonNull(dauphin.String)
     invalid_input_name = dauphin.NonNull(dauphin.String)
 
 
@@ -347,7 +347,7 @@ class DauphinStartSubplanExecutionInvalidOutputError(dauphin.ObjectType):
     class Meta:
         name = 'StartSubplanExecutionInvalidOutputError'
 
-    step = dauphin.NonNull('ExecutionStep')
+    step_key = dauphin.NonNull(dauphin.String)
     invalid_output_name = dauphin.NonNull(dauphin.String)
 
 
@@ -355,7 +355,7 @@ class DauphinInvalidSubplanMissingInputError(dauphin.ObjectType):
     class Meta:
         name = 'InvalidSubplanMissingInputError'
 
-    step = dauphin.NonNull('ExecutionStep')
+    step_key = dauphin.NonNull(dauphin.String)
     missing_input_name = dauphin.NonNull(dauphin.String)
 
 

--- a/python_modules/dagit/dagit/schema/runs.py
+++ b/python_modules/dagit/dagit/schema/runs.py
@@ -256,14 +256,16 @@ class DauphinPipelineRunEvent(dauphin.Union):
         elif event.event_type == EventType.EXECUTION_PLAN_STEP_START:
             return graphene_info.schema.type_named('ExecutionStepStartEvent')(
                 step=graphene_info.schema.type_named('ExecutionStep')(
-                    pipeline_run.execution_plan.get_step_by_key(event.step_key)
+                    pipeline_run.execution_plan,
+                    pipeline_run.execution_plan.get_step_by_key(event.step_key),
                 ),
                 **basic_params
             )
         elif event.event_type == EventType.EXECUTION_PLAN_STEP_SUCCESS:
             return graphene_info.schema.type_named('ExecutionStepSuccessEvent')(
                 step=graphene_info.schema.type_named('ExecutionStep')(
-                    pipeline_run.execution_plan.get_step_by_key(event.step_key)
+                    pipeline_run.execution_plan,
+                    pipeline_run.execution_plan.get_step_by_key(event.step_key),
                 ),
                 **basic_params
             )
@@ -271,7 +273,8 @@ class DauphinPipelineRunEvent(dauphin.Union):
             check.inst(event.error_info, SerializableErrorInfo)
             return graphene_info.schema.type_named('ExecutionStepFailureEvent')(
                 step=graphene_info.schema.type_named('ExecutionStep')(
-                    pipeline_run.execution_plan.get_step_by_key(event.step_key)
+                    pipeline_run.execution_plan,
+                    pipeline_run.execution_plan.get_step_by_key(event.step_key),
                 ),
                 error=graphene_info.schema.type_named('PythonError')(event.error_info),
                 **basic_params
@@ -279,7 +282,8 @@ class DauphinPipelineRunEvent(dauphin.Union):
         elif event.event_type == EventType.STEP_MATERIALIZATION:
             return graphene_info.schema.type_named('StepMaterializationEvent')(
                 step=graphene_info.schema.type_named('ExecutionStep')(
-                    pipeline_run.execution_plan.get_step_by_key(event.step_key)
+                    pipeline_run.execution_plan,
+                    pipeline_run.execution_plan.get_step_by_key(event.step_key),
                 ),
                 file_name=event.file_name,
                 file_location=event.file_location,

--- a/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
+++ b/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
@@ -7,86 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_query_execution_plan_snapshot 1'] = {
-    'executionPlan': {
-        '__typename': 'ExecutionPlan',
-        'pipeline': {
-            'name': 'pandas_hello_world'
-        },
-        'steps': [
-            {
-                'inputs': [
-                ],
-                'kind': 'INPUT_THUNK',
-                'name': 'sum_solid.num.input_thunk',
-                'outputs': [
-                    {
-                        'name': 'input_thunk_output',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'solid': {
-                    'name': 'sum_solid'
-                }
-            },
-            {
-                'inputs': [
-                    {
-                        'dependsOn': {
-                            'name': 'sum_solid.num.input_thunk'
-                        },
-                        'name': 'num',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'kind': 'TRANSFORM',
-                'name': 'sum_solid.transform',
-                'outputs': [
-                    {
-                        'name': 'result',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'solid': {
-                    'name': 'sum_solid'
-                }
-            },
-            {
-                'inputs': [
-                    {
-                        'dependsOn': {
-                            'name': 'sum_solid.transform'
-                        },
-                        'name': 'sum_df',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'kind': 'TRANSFORM',
-                'name': 'sum_sq_solid.transform',
-                'outputs': [
-                    {
-                        'name': 'result',
-                        'type': {
-                            'name': 'PandasDataFrame'
-                        }
-                    }
-                ],
-                'solid': {
-                    'name': 'sum_sq_solid'
-                }
-            }
-        ]
-    }
-}
-
 snapshots['test_start_subplan_pipeline_not_found 1'] = {
     'startSubplanExecution': {
         '__typename': 'PipelineNotFoundError',
@@ -104,16 +24,6 @@ snapshots['test_start_subplan_invalid_config 1'] = {
         ],
         'pipeline': {
             'name': 'pandas_hello_world'
-        }
-    }
-}
-
-snapshots['test_invalid_subplan_missing_inputs 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'InvalidSubplanMissingInputError',
-        'missingInputName': 'num',
-        'step': {
-            'key': 'sum_solid.transform'
         }
     }
 }
@@ -254,13 +164,26 @@ snapshots['test_user_code_error_subplan 1'] = {
     }
 }
 
+snapshots['test_start_subplan_invalid_step_keys 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'StartSubplanExecutionInvalidStepError',
+        'invalidStepKey': 'nope'
+    }
+}
+
+snapshots['test_invalid_subplan_missing_inputs 1'] = {
+    'startSubplanExecution': {
+        '__typename': 'InvalidSubplanMissingInputError',
+        'missingInputName': 'num',
+        'stepKey': 'sum_solid.transform'
+    }
+}
+
 snapshots['test_start_subplan_invalid_output_name 1'] = {
     'startSubplanExecution': {
         '__typename': 'StartSubplanExecutionInvalidOutputError',
         'invalidOutputName': 'nope',
-        'step': {
-            'key': 'sum_solid.transform'
-        }
+        'stepKey': 'sum_solid.transform'
     }
 }
 
@@ -268,15 +191,86 @@ snapshots['test_start_subplan_invalid_input_name 1'] = {
     'startSubplanExecution': {
         '__typename': 'StartSubplanExecutionInvalidInputError',
         'invalidInputName': 'nope',
-        'step': {
-            'key': 'sum_solid.transform'
-        }
+        'stepKey': 'sum_solid.transform'
     }
 }
 
-snapshots['test_start_subplan_invalid_step_keys 1'] = {
-    'startSubplanExecution': {
-        '__typename': 'StartSubplanExecutionInvalidStepError',
-        'invalidStepKey': 'nope'
+snapshots['test_query_execution_plan_snapshot 1'] = {
+    'executionPlan': {
+        '__typename': 'ExecutionPlan',
+        'pipeline': {
+            'name': 'pandas_hello_world'
+        },
+        'steps': [
+            {
+                'inputs': [
+                ],
+                'kind': 'INPUT_THUNK',
+                'name': 'sum_solid.num.input_thunk',
+                'outputs': [
+                    {
+                        'name': 'input_thunk_output',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_solid'
+                }
+            },
+            {
+                'inputs': [
+                    {
+                        'dependsOn': {
+                            'name': 'sum_solid.num.input_thunk'
+                        },
+                        'name': 'num',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'kind': 'TRANSFORM',
+                'name': 'sum_solid.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_solid'
+                }
+            },
+            {
+                'inputs': [
+                    {
+                        'dependsOn': {
+                            'name': 'sum_solid.transform'
+                        },
+                        'name': 'sum_df',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'kind': 'TRANSFORM',
+                'name': 'sum_sq_solid.transform',
+                'outputs': [
+                    {
+                        'name': 'result',
+                        'type': {
+                            'name': 'PandasDataFrame'
+                        }
+                    }
+                ],
+                'solid': {
+                    'name': 'sum_sq_solid'
+                }
+            }
+        ]
     }
 }

--- a/python_modules/dagit/dagit_tests/test_graphql.py
+++ b/python_modules/dagit/dagit_tests/test_graphql.py
@@ -1904,7 +1904,7 @@ def test_start_subplan_invalid_input_name(snapshot):
         == 'StartSubplanExecutionInvalidInputError'
     )
 
-    assert result.data['startSubplanExecution']['step']['key'] == 'sum_solid.transform'
+    assert result.data['startSubplanExecution']['stepKey'] == 'sum_solid.transform'
     assert result.data['startSubplanExecution']['invalidInputName'] == 'nope'
     snapshot.assert_match(result.data)
 
@@ -1932,7 +1932,7 @@ def test_start_subplan_invalid_output_name(snapshot):
         == 'StartSubplanExecutionInvalidOutputError'
     )
 
-    assert result.data['startSubplanExecution']['step']['key'] == 'sum_solid.transform'
+    assert result.data['startSubplanExecution']['stepKey'] == 'sum_solid.transform'
     assert result.data['startSubplanExecution']['invalidOutputName'] == 'nope'
     snapshot.assert_match(result.data)
 
@@ -2029,7 +2029,7 @@ def test_invalid_subplan_missing_inputs(snapshot):
     assert not result.errors
     assert result.data
     assert result.data['startSubplanExecution']['__typename'] == 'InvalidSubplanMissingInputError'
-    assert result.data['startSubplanExecution']['step']['key'] == 'sum_solid.transform'
+    assert result.data['startSubplanExecution']['stepKey'] == 'sum_solid.transform'
     snapshot.assert_match(result.data)
 
 
@@ -2092,15 +2092,15 @@ mutation (
             invalidStepKey
         }
         ... on StartSubplanExecutionInvalidInputError {
-            step { key }
+            stepKey
             invalidInputName
         }
         ... on StartSubplanExecutionInvalidOutputError {
-            step { key }
+            stepKey
             invalidOutputName
         }
         ... on InvalidSubplanMissingInputError {
-            step { key }
+            stepKey
             missingInputName
         }
         ... on PythonError {

--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -88,7 +88,7 @@ def aws_lambda_handler(event, _context):
         prev_output_handle = step_input.prev_output_handle
         handle = (prev_output_handle.step.key, prev_output_handle.output_name)
         # FIXME - we need a less hacky strategy for serializing and deserializing input handles and
-        # result values -- the subscript below is like accessing .success_data on the namedtuple
+        # result values -- the subscript below is like accessing .step_output_data on the namedtuple
         # in the simple engine
         input_value = intermediate_results[handle][1].value
         input_values[step_input.name] = input_value
@@ -98,12 +98,12 @@ def aws_lambda_handler(event, _context):
 
     for step_event in step_events:
         check.invariant(isinstance(step_event, ExecutionStepEvent))
-        output_name = step_event.success_data.output_name
+        output_name = step_event.step_output_data.output_name
         output_handle = (step.key, output_name)
         intermediate_results[output_handle] = (
             step_event.success,
-            step_event.success_data,
-            step_event.failure_data,
+            step_event.step_output_data,
+            step_event.step_failure_data,
         )
         logger.info('Processing result: %s', output_name)
 

--- a/python_modules/dagster-airflow/dagster_airflow/scaffold.py
+++ b/python_modules/dagster-airflow/dagster_airflow/scaffold.py
@@ -328,7 +328,7 @@ def _make_static_scaffold(pipeline_name, env_config, execution_plan, image, edit
                             printer.line(
                                 '\'key\': \'{key}\''.format(
                                     key=_key_for_marshalled_result(
-                                        step_input.prev_output_handle.step.key,
+                                        step_input.prev_output_handle.step_key,
                                         step_input.prev_output_handle.output_name,
                                     )
                                 )
@@ -414,7 +414,7 @@ def _make_static_scaffold(pipeline_name, env_config, execution_plan, image, edit
 
             for step in execution_plan.topological_steps():
                 for step_input in step.step_inputs:
-                    prev_airflow_step_key = _normalize_key(step_input.prev_output_handle.step.key)
+                    prev_airflow_step_key = _normalize_key(step_input.prev_output_handle.step_key)
                     airflow_step_key = _normalize_key(step.key)
                     printer.line(
                         '{prev_airflow_step_key}_task.set_downstream('

--- a/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
+++ b/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
@@ -22,7 +22,7 @@ def test_unit_run_airflow_dag_steps(scaffold_dag):
         for step_input in step.step_inputs:
             assert os.path.isfile(
                 _key_for_marshalled_result(
-                    step_input.prev_output_handle.step.key,
+                    step_input.prev_output_handle.step_key,
                     step_input.prev_output_handle.output_name,
                     prepend_run_id=False,
                 )

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -48,7 +48,7 @@ class DagsterUserCodeExecutionError(DagsterUserError):
     output_type = step.step_output_dict[output_name].runtime_type
     try:
         context.persistence_strategy.write_value(
-            output_type.serialization_strategy, output['path'], result.success_data.value
+            output_type.serialization_strategy, output['path'], result.step_output_data.value
         )
     except Exception as e:  # pylint: disable=broad-except
         raise_from(

--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -129,8 +129,10 @@ def decorate_with_expectations(pipeline_context, solid, transform_step, output_d
             pipeline_context,
             solid,
             output_def,
-            StepOutputHandle(transform_step, output_def.name),
+            StepOutputHandle.from_step(transform_step, output_def.name),
             kind=StepKind.OUTPUT_EXPECTATION,
         )
     else:
-        return ExecutionValueSubplan.empty(StepOutputHandle(transform_step, output_def.name))
+        return ExecutionValueSubplan.empty(
+            StepOutputHandle.from_step(transform_step, output_def.name)
+        )

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -5,7 +5,13 @@ from dagster.core.definitions import InputDefinition, Solid
 
 from dagster.core.errors import DagsterInvariantViolationError
 
-from .objects import ExecutionStep, StepOutput, StepOutputHandle, StepOutputValue, StepKind
+from .objects import (
+    ExecutionStep,
+    StepOutput,
+    StepOutputValue,
+    StepKind,
+    SingleOutputStepCreationData,
+)
 
 INPUT_THUNK_OUTPUT = 'input_thunk_output'
 
@@ -56,4 +62,4 @@ def create_input_thunk_execution_step(pipeline_context, solid, input_def, input_
         )
 
     input_thunk = _create_input_thunk_execution_step(pipeline_context, solid, input_def, input_spec)
-    return StepOutputHandle(input_thunk, INPUT_THUNK_OUTPUT)
+    return SingleOutputStepCreationData(input_thunk, INPUT_THUNK_OUTPUT)

--- a/python_modules/dagster/dagster/core/execution_plan/intermediates_manager.py
+++ b/python_modules/dagster/dagster/core/execution_plan/intermediates_manager.py
@@ -1,0 +1,115 @@
+from abc import ABCMeta, abstractmethod
+from collections import namedtuple
+import os
+import pickle
+
+import six
+
+from dagster import check
+from dagster.utils import mkdir_p
+
+
+class StepOutputHandle(namedtuple('_StepOutputHandle', 'step_key output_name')):
+    @staticmethod
+    def from_step(step, output_name):
+        from .objects import ExecutionStep
+
+        check.inst_param(step, 'step', ExecutionStep)
+
+        return StepOutputHandle(step.key, output_name)
+
+    def __new__(cls, step_key, output_name):
+        return super(StepOutputHandle, cls).__new__(
+            cls,
+            step_key=check.str_param(step_key, 'step_key'),
+            output_name=check.str_param(output_name, 'output_name'),
+        )
+
+
+def read_pickle_file(path):
+    check.str_param(path, 'path')
+    with open(path, 'rb') as ff:
+        return pickle.load(ff)
+
+
+def write_pickle_file(path, value):
+    check.str_param(path, 'path')
+    with open(path, 'wb') as ff:
+        return pickle.dump(value, ff)
+
+
+class IntermediatesManager(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
+    @abstractmethod
+    def get_value(self, step_output_handle):
+        pass
+
+    @abstractmethod
+    def set_value(self, step_output_handle, value):
+        pass
+
+    @abstractmethod
+    def has_value(self, step_output_handle):
+        pass
+
+
+class InMemoryIntermediatesManager(IntermediatesManager):
+    def __init__(self):
+        self.values = {}
+
+    def get_value(self, step_output_handle):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        return self.values[step_output_handle]
+
+    def set_value(self, step_output_handle, value):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        self.values[step_output_handle] = value
+
+    def has_value(self, step_output_handle):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        return step_output_handle in self.values
+
+
+# TODO: This should go through persistence and serialization infrastructure
+# Fixing this requires getting the type information (serialization_strategy is
+# a property of runtime type) of the step output you are dealing with. As things
+# are structured now we construct the inputs before execution. The fix to this
+# will likely be to inject a different type of execution step that threads
+# the manager
+class FileSystemIntermediateManager(IntermediatesManager):
+    def __init__(self, root):
+        check.invariant(os.path.isdir(root))
+        self._root = root
+
+    @property
+    def root(self):
+        return self._root
+
+    def _create_path_from_handle(self, step_output_handle):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        return '{root}/{step_key}/{output_name}'.format(
+            root=self._root,
+            step_key=step_output_handle.step_key,
+            output_name=step_output_handle.output_name,
+        )
+
+    def get_value(self, step_output_handle):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        check.invariant(self.has_value(step_output_handle))
+        output_path = self._create_path_from_handle(step_output_handle)
+        check.invariant(os.path.isfile(output_path))
+        return read_pickle_file(output_path)
+
+    def set_value(self, step_output_handle, value):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        check.invariant(not self.has_value(step_output_handle))
+
+        mkdir_p('{root}/{step_key}'.format(root=self._root, step_key=step_output_handle.step_key))
+
+        output_path = self._create_path_from_handle(step_output_handle)
+        check.invariant(not os.path.exists(output_path))
+        write_pickle_file(output_path, value)
+
+    def has_value(self, step_output_handle):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        output_path = self._create_path_from_handle(step_output_handle)
+        return os.path.exists(output_path)

--- a/python_modules/dagster/dagster/core/execution_plan/intermediates_manager.py
+++ b/python_modules/dagster/dagster/core/execution_plan/intermediates_manager.py
@@ -86,11 +86,7 @@ class FileSystemIntermediateManager(IntermediatesManager):
 
     def _create_path_from_handle(self, step_output_handle):
         check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
-        return '{root}/{step_key}/{output_name}'.format(
-            root=self._root,
-            step_key=step_output_handle.step_key,
-            output_name=step_output_handle.output_name,
-        )
+        return os.path.join(self._root, step_output_handle.step_key, step_output_handle.output_name)
 
     def get_value(self, step_output_handle):
         check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
@@ -112,4 +108,8 @@ class FileSystemIntermediateManager(IntermediatesManager):
     def has_value(self, step_output_handle):
         check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
         output_path = self._create_path_from_handle(step_output_handle)
-        return os.path.exists(output_path)
+        if os.path.exists(output_path):
+            check.invariant(os.path.isfile(output_path))
+            return True
+        else:
+            return False

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -7,6 +7,7 @@ from .objects import (
     StepOutput,
     StepOutputHandle,
     StepOutputValue,
+    SingleOutputStepCreationData,
 )
 
 UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
@@ -26,7 +27,7 @@ def create_unmarshal_input_step(pipeline_context, step, step_input, marshalling_
             ),
         )
 
-    return StepOutputHandle(
+    return SingleOutputStepCreationData(
         ExecutionStep(
             pipeline_context=pipeline_context,
             key='{step_key}.unmarshal-input.{input_name}'.format(
@@ -68,7 +69,7 @@ def create_marshal_output_step(pipeline_context, step, step_output, marshalling_
             StepInput(
                 MARSHAL_OUTPUT_INPUT,
                 step_output.runtime_type,
-                StepOutputHandle(step, step_output.name),
+                StepOutputHandle.from_step(step, step_output.name),
             )
         ],
         step_outputs=[],

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -1,39 +1,63 @@
-import os
 import multiprocessing
+import os
 
 from dagster import check
+from dagster.utils import mkdir_p
+from dagster.core.errors import DagsterSubprocessExecutionError
 
 from dagster.core.execution_context import PipelineExecutionContext
 
 from .create import create_execution_plan_core
-from .objects import ExecutionPlan, ExecutionStepEvent, ExecutionStepEventType, StepOutputHandle
+from .intermediates_manager import FileSystemIntermediateManager
+from .objects import (
+    ExecutionPlan,
+    ExecutionStepEvent,
+    StepFailureData,
+    StepOutputHandle,
+    StepOutputData,
+    ExecutionStepEventType,
+)
 from .plan_subset import ExecutionPlanSubsetInfo
 from .simple_engine import start_inprocess_executor
 
 
 def _execute_in_child_process(
-    queue, executor_config, environment_dict, execution_metadata, step_key, inputs_for_step
+    queue, executor_config, environment_dict, execution_metadata, step_key, input_meta_dict, root
 ):
     from dagster.core.execution import yield_pipeline_execution_context
 
-    pipeline = executor_config.pipeline_fn()
+    check.dict_param(input_meta_dict, 'input_meta_data', key_type=str, value_type=StepOutputHandle)
 
-    inputs_to_inject = {step_key: inputs_for_step}
+    pipeline = executor_config.pipeline_fn()
 
     with yield_pipeline_execution_context(
         pipeline, environment_dict, execution_metadata.with_tags(pid=str(os.getpid()))
     ) as pipeline_context:
+
+        intermediates_manager = FileSystemIntermediateManager(root)
+
+        inputs_for_step = _create_input_values(input_meta_dict, intermediates_manager)
+
+        inputs_to_inject = {step_key: inputs_for_step}
 
         execution_plan = create_execution_plan_core(
             pipeline_context,
             subset_info=ExecutionPlanSubsetInfo.with_input_values([step_key], inputs_to_inject),
         )
 
-        for step_event in start_inprocess_executor(pipeline_context, execution_plan):
+        for step_event in start_inprocess_executor(
+            pipeline_context, execution_plan, intermediates_manager
+        ):
             data_to_put = {
                 'event_type': step_event.event_type,
-                'success_data': step_event.success_data,
-                'failure_data': step_event.failure_data,
+                'step_output_data': {
+                    'step_output_handle': step_event.step_output_data.step_output_handle,
+                    'value_repr': step_event.step_output_data.value_repr,
+                }
+                if step_event.event_type == ExecutionStepEventType.STEP_OUTPUT
+                else None,
+                # TODO actually marshal data
+                'step_failure_data': None,
                 'step_key': step_event.step.key,
                 'tags': step_event.tags,
             }
@@ -44,7 +68,7 @@ def _execute_in_child_process(
     queue.close()
 
 
-def execute_step_out_of_process(executor_config, step_context, step, prev_step_events):
+def execute_step_out_of_process(executor_config, step_context, step, intermediates_manager):
     queue = multiprocessing.Queue()
 
     check.invariant(
@@ -60,7 +84,8 @@ def execute_step_out_of_process(executor_config, step_context, step, prev_step_e
             step_context.environment_dict,
             step_context.execution_metadata,
             step.key,
-            _create_input_values(step, prev_step_events),
+            {step_input.name: step_input.prev_output_handle for step_input in step.step_inputs},
+            intermediates_manager.root,
         ),
     )
 
@@ -78,37 +103,53 @@ def execute_step_out_of_process(executor_config, step_context, step, prev_step_e
 
         check.invariant(step.key == result['step_key'])
 
-        yield ExecutionStepEvent(
-            event_type=event_type,
-            step=step,
-            success_data=result['success_data'],
-            failure_data=result['failure_data'],
-            tags=result['tags'],
-        )
+        if event_type == ExecutionStepEventType.STEP_OUTPUT:
+            yield ExecutionStepEvent(
+                event_type=ExecutionStepEventType.STEP_OUTPUT,
+                step=step,
+                step_output_data=StepOutputData(
+                    result['step_output_data']['step_output_handle'],
+                    result['step_output_data']['value_repr'],
+                    intermediates_manager,
+                ),
+                step_failure_data=None,
+                tags=result['tags'],
+            )
+        elif event_type == ExecutionStepEventType.STEP_FAILURE:
+            try:
+                # This is pretty hacky for now but it works
+                raise DagsterSubprocessExecutionError('TODO')
+            except DagsterSubprocessExecutionError as dagster_error:
+                yield ExecutionStepEvent(
+                    event_type=ExecutionStepEventType.STEP_FAILURE,
+                    step=step,
+                    step_output_data=None,
+                    step_failure_data=StepFailureData(dagster_error=dagster_error),
+                    tags=result['tags'],
+                )
 
     # Do something reasonable on total process failure
     process.join()
 
 
-def _all_inputs_covered(step, results):
-    for step_input in step.step_inputs:
-        if step_input.prev_output_handle not in results:
-            return False
-    return True
-
-
-def _create_input_values(step, prev_level_results):
+def _create_input_values(step_input_meta_dict, manager):
     input_values = {}
-    for step_input in step.step_inputs:
-        prev_output_handle = step_input.prev_output_handle
-        input_value = prev_level_results[prev_output_handle].success_data.value
-        input_values[step_input.name] = input_value
+    for step_input_name, prev_output_handle_meta in step_input_meta_dict.items():
+        input_value = manager.get_value(prev_output_handle_meta)
+        input_values[step_input_name] = input_value
     return input_values
 
 
 class MultiprocessExecutorConfig:
     def __init__(self, pipeline_fn):
         self.pipeline_fn = pipeline_fn
+
+
+def _all_inputs_covered(step, intermediates_manager):
+    for step_input in step.step_inputs:
+        if not intermediates_manager.has_value(step_input.prev_output_handle):
+            return False
+    return True
 
 
 def multiprocess_execute_plan(executor_config, pipeline_context, execution_plan):
@@ -118,35 +159,36 @@ def multiprocess_execute_plan(executor_config, pipeline_context, execution_plan)
 
     step_levels = execution_plan.topological_step_levels()
 
+    # TODO where to put in xplat way?
+    # TODO probably manage in pipeline execution context?
+    root_dir = '/tmp/dagster/runs/{run_id}'.format(run_id=pipeline_context.run_id)
+    mkdir_p(root_dir)
+
+    intermediates_manager = FileSystemIntermediateManager(root_dir)
+
     # It would be good to implement a reference tracking algorithm here so we could
     # garbage collection results that are no longer needed by any steps
     # https://github.com/dagster-io/dagster/issues/811
-    prev_step_events = {}
 
     for step_level in step_levels:
         for step in step_level:
             step_context = pipeline_context.for_step(step)
 
-            if not _all_inputs_covered(step, prev_step_events):
-                result_keys = set(prev_step_events.keys())
+            if not _all_inputs_covered(step, intermediates_manager):
                 expected_outputs = [ni.prev_output_handle for ni in step.step_inputs]
 
                 step_context.log.debug(
                     (
-                        'Not all inputs covered for {step}. Not executing. Keys in result: '
-                        '{result_keys}. Outputs need for inputs {expected_outputs}'
-                    ).format(
-                        expected_outputs=expected_outputs, step=step.key, result_keys=result_keys
-                    )
+                        'Not all inputs covered for {step}. Not executing.'
+                        'Outputs need for inputs {expected_outputs}'
+                    ).format(expected_outputs=expected_outputs, step=step.key)
                 )
                 continue
 
             for step_event in check.generator(
-                execute_step_out_of_process(executor_config, step_context, step, prev_step_events)
+                execute_step_out_of_process(
+                    executor_config, step_context, step, intermediates_manager
+                )
             ):
                 check.inst(step_event, ExecutionStepEvent)
                 yield step_event
-
-                if step_event.event_type == ExecutionStepEventType.STEP_OUTPUT:
-                    output_handle = StepOutputHandle(step, step_event.success_data.output_name)
-                    prev_step_events[output_handle] = step_event

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 import six
 
+
 from dagster import check
 from dagster.core.definitions import Solid, PipelineDefinition
 from dagster.core.errors import DagsterError
@@ -10,6 +11,8 @@ from dagster.core.execution_context import PipelineExecutionContext, StepExecuti
 from dagster.core.types.runtime import RuntimeType
 from dagster.core.utils import toposort
 from dagster.utils import merge_dicts
+
+from .intermediates_manager import StepOutputHandle
 
 
 class StepOutputValue(namedtuple('_StepOutputValue', 'output_name value')):
@@ -19,38 +22,34 @@ class StepOutputValue(namedtuple('_StepOutputValue', 'output_name value')):
         )
 
 
-class StepOutputHandle(namedtuple('_StepOutputHandle', 'step output_name')):
-    def __new__(cls, step, output_name):
-        return super(StepOutputHandle, cls).__new__(
-            cls,
-            step=check.inst_param(step, 'step', ExecutionStep),
-            output_name=check.str_param(output_name, 'output_name'),
-        )
+class SingleOutputStepCreationData(namedtuple('SingleOutputStepCreationData', 'step output_name')):
+    '''
+    It is very common for step creation to involve processing a single value (e.g. an input thunk).
+    This tuple is meant to be used by those functions to return both a new step and the output
+    that deals with the value in question.
+    '''
 
-    # Make this hashable so it be a key in a dictionary
-
-    def __str__(self):
-        return 'StepOutputHandle' '(step="{step.key}", output_name="{output_name}")'.format(
-            step=self.step, output_name=self.output_name
-        )
-
-    def __repr__(self):
-        return 'StepOutputHandle' '(step="{step.key}", output_name="{output_name}")'.format(
-            step=self.step, output_name=self.output_name
-        )
-
-    def __hash__(self):
-        return hash(self.step.key + self.output_name)
-
-    def __eq__(self, other):
-        return self.step.key == other.step.key and self.output_name == other.output_name
+    @property
+    def step_output_handle(self):
+        return StepOutputHandle.from_step(self.step, self.output_name)
 
 
-class StepSuccessData(namedtuple('_StepSuccessData', 'output_name value')):
-    def __new__(cls, output_name, value):
-        return super(StepSuccessData, cls).__new__(
-            cls, output_name=check.str_param(output_name, 'output_name'), value=value
-        )
+class StepOutputData:
+    def __init__(self, step_output_handle, value_repr, intermediates_manager):
+        self._value_repr = value_repr
+        self._intermediates_manager = intermediates_manager
+        self.step_output_handle = step_output_handle
+
+    @property
+    def output_name(self):
+        return self.step_output_handle.output_name
+
+    @property
+    def value_repr(self):
+        return self._value_repr
+
+    def get_value(self):
+        return self._intermediates_manager.get_value(self.step_output_handle)
 
 
 class StepFailureData(namedtuple('_StepFailureData', 'dagster_error')):
@@ -66,15 +65,15 @@ class ExecutionStepEventType(Enum):
 
 
 class ExecutionStepEvent(
-    namedtuple('_ExecutionStepEvent', 'event_type step success_data failure_data tags')
+    namedtuple('_ExecutionStepEvent', 'event_type step step_output_data step_failure_data tags')
 ):
-    def __new__(cls, event_type, step, success_data, failure_data, tags):
+    def __new__(cls, event_type, step, step_output_data, step_failure_data, tags):
         return super(ExecutionStepEvent, cls).__new__(
             cls,
             check.inst_param(event_type, 'event_type', ExecutionStepEventType),
             check.inst_param(step, 'step', ExecutionStep),
-            check.opt_inst_param(success_data, 'success_data', StepSuccessData),
-            check.opt_inst_param(failure_data, 'failure_data', StepFailureData),
+            check.opt_inst_param(step_output_data, 'step_output_data', StepOutputData),
+            check.opt_inst_param(step_failure_data, 'step_failure_data', StepFailureData),
             check.dict_param(tags, 'tags'),
         )
 
@@ -91,35 +90,37 @@ class ExecutionStepEvent(
         return self.event_type == ExecutionStepEventType.STEP_FAILURE
 
     @staticmethod
-    def step_output_event(step_context, success_data):
+    def step_output_event(step_context, step_output_data):
         check.inst_param(step_context, 'step_context', StepExecutionContext)
 
         return ExecutionStepEvent(
             event_type=ExecutionStepEventType.STEP_OUTPUT,
             step=step_context.step,
-            success_data=check.inst_param(success_data, 'success_data', StepSuccessData),
-            failure_data=None,
+            step_output_data=check.inst_param(step_output_data, 'step_output_data', StepOutputData),
+            step_failure_data=None,
             tags=step_context.tags,
         )
 
     @staticmethod
-    def step_failure_event(step_context, failure_data):
+    def step_failure_event(step_context, step_failure_data):
         check.inst_param(step_context, 'step_context', StepExecutionContext)
 
         return ExecutionStepEvent(
             event_type=ExecutionStepEventType.STEP_FAILURE,
             step=step_context.step,
-            success_data=None,
-            failure_data=check.inst_param(failure_data, 'failure_data', StepFailureData),
+            step_output_data=None,
+            step_failure_data=check.inst_param(
+                step_failure_data, 'step_failure_data', StepFailureData
+            ),
             tags=step_context.tags,
         )
 
     def reraise_user_error(self):
         check.invariant(self.event_type == ExecutionStepEventType.STEP_FAILURE)
-        if self.failure_data.dagster_error.is_user_code_error:
-            six.reraise(*self.failure_data.dagster_error.original_exc_info)
+        if self.step_failure_data.dagster_error.is_user_code_error:
+            six.reraise(*self.step_failure_data.dagster_error.original_exc_info)
         else:
-            raise self.failure_data.dagster_error
+            raise self.step_failure_data.dagster_error
 
     @property
     def kind(self):
@@ -288,6 +289,11 @@ class ExecutionPlan(namedtuple('_ExecutionPlan', 'pipeline_def step_dict, deps, 
             deps=check.dict_param(deps, 'deps', key_type=str, value_type=set),
             steps=list(step_dict.values()),
         )
+
+    def get_step_output(self, step_output_handle):
+        check.inst_param(step_output_handle, 'step_output_handle', StepOutputHandle)
+        step = self.get_step_by_key(step_output_handle.step_key)
+        return step.step_output_named(step_output_handle.output_name)
 
     def has_step(self, key):
         check.str_param(key, 'key')

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -11,6 +11,7 @@ from .objects import (
     StepOutputHandle,
     StepOutputValue,
     StepKind,
+    SingleOutputStepCreationData,
 )
 
 JOIN_OUTPUT = 'join_output'
@@ -38,7 +39,7 @@ def create_join_step(pipeline_context, solid, step_key, prev_steps, prev_output_
         else:
             check.invariant(seen_runtime_type == prev_step_output.runtime_type)
 
-        output_handle = StepOutputHandle(prev_step, prev_output_name)
+        output_handle = StepOutputHandle.from_step(prev_step, prev_output_name)
 
         step_inputs.append(StepInput(prev_step.key, prev_step_output.runtime_type, output_handle))
 
@@ -85,7 +86,7 @@ def create_joining_subplan(
 
     output_name = join_step.step_outputs[0].name
     return ExecutionValueSubplan(
-        parallel_steps + [join_step], StepOutputHandle(join_step, output_name)
+        parallel_steps + [join_step], StepOutputHandle.from_step(join_step, output_name)
     )
 
 
@@ -101,7 +102,7 @@ def create_value_thunk_step(pipeline_context, solid, runtime_type, step_key, val
     def _fn(_context, _inputs):
         yield StepOutputValue(output_name=VALUE_OUTPUT, value=value)
 
-    return StepOutputHandle(
+    return SingleOutputStepCreationData(
         ExecutionStep(
             pipeline_context=pipeline_context,
             key=step_key,

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -68,14 +68,14 @@ def _to_serializable_step_event(step_event):
         return SerializableStepOutputEvent(
             event_type=step_event.event_type,
             step_key=step_event.step.key,
-            output_name=step_event.success_data.output_name,
-            value_repr=repr(step_event.success_data.value),
+            output_name=step_event.step_output_data.output_name,
+            value_repr=step_event.step_output_data.value_repr,
         )
     elif step_event.is_step_failure:
         return SerializableStepFailureEvent(
             event_type=step_event.event_type,
             step_key=step_event.step.key,
-            error_message=str(step_event.failure_data.dagster_error),
+            error_message=str(step_event.step_failure_data.dagster_error),
         )
 
     check.failed('Unsupported step_event type {}'.format(step_event))

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -46,11 +46,11 @@ def test_execution_plan_simple_two_steps():
 
     assert step_events[0].step.key == 'return_one.transform'
     assert step_events[0].is_successful_output
-    assert step_events[0].success_data.value == 1
+    assert step_events[0].step_output_data.get_value() == 1
 
     assert step_events[1].step.key == 'add_one.transform'
     assert step_events[1].is_successful_output
-    assert step_events[1].success_data.value == 2
+    assert step_events[1].step_output_data.get_value() == 2
 
 
 def test_create_subplan_source_step():
@@ -82,7 +82,7 @@ def test_create_subplan_middle_step():
     assert steps[1].key == 'add_one.transform'
     assert len(steps[1].step_inputs) == 1
     step_input = steps[1].step_inputs[0]
-    assert step_input.prev_output_handle.step.key == 'add_one.transform.input.num.value'
+    assert step_input.prev_output_handle.step_key == 'add_one.transform.input.num.value'
     assert step_input.prev_output_handle.output_name == VALUE_OUTPUT
     assert len(steps[1].step_outputs) == 1
     assert len(subplan.topological_steps()) == 2
@@ -103,7 +103,7 @@ def test_execution_plan_source_step():
     step_events = execute_plan(execution_plan)
 
     assert len(step_events) == 1
-    assert step_events[0].success_data.value == 1
+    assert step_events[0].step_output_data.get_value() == 1
 
 
 def test_execution_plan_middle_step():
@@ -118,7 +118,7 @@ def test_execution_plan_middle_step():
     step_events = execute_plan(execution_plan)
 
     assert len(step_events) == 2
-    assert step_events[1].success_data.value == 3
+    assert step_events[1].step_output_data.get_value() == 3
 
 
 def test_execution_plan_two_outputs():
@@ -133,13 +133,12 @@ def test_execution_plan_two_outputs():
 
     step_events = execute_plan(execution_plan)
 
-    # FIXME: we should change this to be *single* result with two outputs
     assert step_events[0].step.key == 'return_one_two.transform'
-    assert step_events[0].success_data.value == 1
-    assert step_events[0].success_data.output_name == 'num_one'
+    assert step_events[0].step_output_data.get_value() == 1
+    assert step_events[0].step_output_data.output_name == 'num_one'
     assert step_events[1].step.key == 'return_one_two.transform'
-    assert step_events[1].success_data.value == 2
-    assert step_events[1].success_data.output_name == 'num_two'
+    assert step_events[1].step_output_data.get_value() == 2
+    assert step_events[1].step_output_data.output_name == 'num_two'
 
 
 def test_reentrant_execute_plan():

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
@@ -64,3 +64,29 @@ def define_diamond_pipeline():
             },
         },
     )
+
+
+def define_error_pipeline():
+    @lambda_solid
+    def throw_error():
+        raise Exception('bad programmer')
+
+    return PipelineDefinition(name='error_pipeline', solids=[throw_error])
+
+
+def test_error_pipeline():
+    pipeline = define_error_pipeline()
+    result = execute_pipeline(
+        pipeline, throw_on_user_error=False, executor_config=InProcessExecutorConfig()
+    )
+    assert not result.success
+
+
+def test_error_pipeline_multiprocess():
+    pipeline = define_error_pipeline()
+    result = execute_pipeline(
+        pipeline,
+        throw_on_user_error=False,
+        executor_config=MultiprocessExecutorConfig(define_error_pipeline),
+    )
+    assert not result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -78,8 +78,8 @@ def test_basic_pipeline_external_plan_execution():
     transform_step_output_event = step_events[1]
     assert transform_step_output_event.kind == StepKind.TRANSFORM
     assert transform_step_output_event.is_successful_output
-    assert transform_step_output_event.success_data.output_name == 'result'
-    assert transform_step_output_event.success_data.value == 6
+    assert transform_step_output_event.step_output_data.output_name == 'result'
+    assert transform_step_output_event.step_output_data.get_value() == 6
 
 
 def test_external_execution_marshal_wrong_input_error():
@@ -131,7 +131,7 @@ def test_external_execution_input_marshal_code_error():
     assert marshal_step_error.is_step_failure
     assert not marshal_step_error.is_successful_output
     assert marshal_step_error.step.kind == StepKind.UNMARSHAL_INPUT
-    assert isinstance(marshal_step_error.failure_data.dagster_error.user_exception, IOError)
+    assert isinstance(marshal_step_error.step_failure_data.dagster_error.user_exception, IOError)
 
 
 def test_external_execution_step_for_output_missing():
@@ -225,8 +225,10 @@ def test_external_execution_output_code_error_no_throw_on_user_error():
 
     assert len(step_events) == 1
     step_event = step_events[0]
-    assert isinstance(step_event.failure_data.dagster_error, DagsterExecutionStepExecutionError)
-    assert str(step_event.failure_data.dagster_error.user_exception) == 'whoops'
+    assert isinstance(
+        step_event.step_failure_data.dagster_error, DagsterExecutionStepExecutionError
+    )
+    assert str(step_event.step_failure_data.dagster_error.user_exception) == 'whoops'
 
 
 def test_external_execution_unsatisfied_input_error():

--- a/python_modules/dagster/dagster_tests/core_tests/test_output_materialization.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_output_materialization.py
@@ -250,7 +250,7 @@ def test_basic_int_and_string_execution_plan():
         'return_one_and_foo.materialization.output.string.0'
     )
     assert len(string_mat_step.step_inputs) == 1
-    assert string_mat_step.step_inputs[0].prev_output_handle == StepOutputHandle(
+    assert string_mat_step.step_inputs[0].prev_output_handle == StepOutputHandle.from_step(
         step=transform_step, output_name='string'
     )
 
@@ -258,7 +258,7 @@ def test_basic_int_and_string_execution_plan():
         'return_one_and_foo.materialization.output.string.join'
     )
     assert len(string_mat_join_step.step_inputs) == 1
-    assert string_mat_join_step.step_inputs[0].prev_output_handle == StepOutputHandle(
+    assert string_mat_join_step.step_inputs[0].prev_output_handle == StepOutputHandle.from_step(
         step=string_mat_step, output_name=MATERIALIZATION_THUNK_OUTPUT
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -493,12 +493,12 @@ def test_pipeline_streaming_iterator():
 
     push_one_step_event = next(step_event_iterator)
     assert push_one_step_event.is_successful_output
-    assert push_one_step_event.success_data.value == 1
+    assert push_one_step_event.step_output_data.get_value() == 1
     assert events == [1]
 
     add_one_step_event = next(step_event_iterator)
     assert add_one_step_event.is_successful_output
-    assert add_one_step_event.success_data.value == 2
+    assert add_one_step_event.step_output_data.get_value() == 2
     assert events == [1, 2]
 
 
@@ -520,12 +520,12 @@ def test_pipeline_streaming_multiple_outputs():
 
     one_output_step_event = next(step_event_iterator)
     assert one_output_step_event.is_successful_output
-    assert one_output_step_event.success_data.value == 1
-    assert one_output_step_event.success_data.output_name == 'one'
+    assert one_output_step_event.step_output_data.get_value() == 1
+    assert one_output_step_event.step_output_data.output_name == 'one'
     assert events == [1]
 
     two_output_step_event = next(step_event_iterator)
     assert two_output_step_event.is_successful_output
-    assert two_output_step_event.success_data.value == 2
-    assert two_output_step_event.success_data.output_name == 'two'
+    assert two_output_step_event.step_output_data.get_value() == 2
+    assert two_output_step_event.step_output_data.output_name == 'two'
     assert events == [1, 2]

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20383,7 +20383,7 @@ try:</p>
 <blockquote>
 <div><dl class="docutils">
 <dt>context.persistence_strategy.write_value(</dt>
-<dd>output_type.serialization_strategy, output[‘path’], result.success_data.value</dd>
+<dd>output_type.serialization_strategy, output[‘path’], result.step_output_data.value</dd>
 </dl>
 <p>)</p>
 </div></blockquote>

--- a/python_modules/dagster/internal_docs/adding_event.md
+++ b/python_modules/dagster/internal_docs/adding_event.md
@@ -86,6 +86,7 @@ The fields `file_name` and `file_location` are fields in the corresponding Graph
 elif event.event_type == EventType.STEP_MATERIALIZATION:
     return info.schema.type_named('StepMaterializationEvent')(
         step=info.schema.type_named('ExecutionStep')(
+            pipeline_run.execution_plan,
             pipeline_run.execution_plan.get_step_by_key(event.step_key)
         ),
         file_name=event.file_name,


### PR DESCRIPTION
This adds the notion of an IntermediatesManager to manage intermediate values. This is definitely a "midpoint" diff as there are a lot of follow up tasks. However, I wanted to get to a checkpoint, discuss direction, and then get this back into master. There are also a few refactoring changes that come along with this PR.

The primary value add of this PR is that the multiprocess engine no longer needs to hold all the input s and outputs for the pipeline in memory. Instead, if that caller needs to access these values they are accessed by demand, through the manager. Concretely, this means that produced values are accessed via the file system in the multiprocess case.


A few refactoring things:

- StepOutputHandle now only contains the step_key rather than the entire step. This means that it is directly serializable across processes. (It also eliminates all the custom hashing stuff implemented on that class in order to make it useable as a dictionary key). It should have always been like that. The only downside is that we need to do a little more work in the GraphQL engine to thread the execution_plan down to places where we want the entire Step (e.g. dependsOn on StepInput)

- success_data has been renamed to step_output_data. We will be adding more event types to this stream and success_data will soon become ambiguous. This rename should have been done when the class was renamed anyways.

- StepOutputHandle as used in the execution creation pathway to pass around full steps. This has been replaced by the SingleOutputStepCreationData tuple.

Next tasks:
1) Use the "serializable" execution path in the multiprocessing. This will replace the BS
custom serialization that is in the multiprocessing engine
2) Marshal higher quality error information across serialization boundaries.
3) Use the persistence and serialization infrastructure in the intermediates manager
4) Come up with common, rationalized management of temp files. This will likely be a first class resource similar to context.log. context.files or something.

I believe these tasks actually overlap with both @puma314 and @mgasner 's tasks. I think proceed in parallel and then consolidating later is a fine strategy, but we should be aware of what eachother are doing.


