### PR TITLE
Replace DebouncingLogQueue with a simpler throttle mechanism

### DIFF
--- a/python_modules/dagit/dagit/pipeline_run_storage.py
+++ b/python_modules/dagit/dagit/pipeline_run_storage.py
@@ -219,4 +219,3 @@ class PipelineRunObservableSubscribe(object):
 
 class LogSequence(pyrsistent.CheckedPVector):
     __type__ = EventRecord
-


### PR DESCRIPTION
This resolves the issue where the Dagit UI would hang after an arbitrary amount of time and no more logs would appear. Rather than allowing `attempt_dequeue` to be called a lot and blocking it for X seconds, and having all the calls in the interim return an empty result, we use a very simple throttle mechanism that schedules a flush whenever a log arrives and one is not already queued. (Note that this is a "throttle" and not a "debounce", which is also preferable I think.)