### PR TITLE
Spin the start button while making the execute pipeline request

### DIFF
--- a/js_modules/dagit/src/execution/ExecutionStartButton.tsx
+++ b/js_modules/dagit/src/execution/ExecutionStartButton.tsx
@@ -19,6 +19,10 @@ export default class ExecutionStartButton extends React.Component<
 > {
   _mounted: boolean = false;
 
+  state = {
+    starting: false
+  };
+
   componentDidMount() {
     this._mounted = true;
   }

--- a/js_modules/dagit/src/execution/ExecutionStartButton.tsx
+++ b/js_modules/dagit/src/execution/ExecutionStartButton.tsx
@@ -9,47 +9,73 @@ interface IExecutionStartButtonProps {
   onClick: () => void;
 }
 
-export default function ExecutionStartButton(
-  props: IExecutionStartButtonProps
-) {
-  return (
-    <WebsocketStatusContext.Consumer>
-      {websocketStatus => {
-        if (props.executing) {
+interface IExecutionStartButtonState {
+  starting: boolean;
+}
+
+export default class ExecutionStartButton extends React.Component<
+  IExecutionStartButtonProps,
+  IExecutionStartButtonState
+> {
+  _mounted: boolean = false;
+
+  componentDidMount() {
+    this._mounted = true;
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
+  }
+
+  onClick = async () => {
+    this.setState({ starting: true });
+    await this.props.onClick();
+    setTimeout(() => {
+      if (!this._mounted) return;
+      this.setState({ starting: false });
+    }, 300);
+  };
+
+  render() {
+    return (
+      <WebsocketStatusContext.Consumer>
+        {websocketStatus => {
+          if (this.props.executing || this.state.starting) {
+            return (
+              <IconWrapper
+                role="button"
+                title={"Pipeline execution is in progress..."}
+              >
+                <Spinner intent={Intent.NONE} size={39} />
+              </IconWrapper>
+            );
+          }
+
+          if (websocketStatus !== WebSocket.OPEN) {
+            return (
+              <IconWrapper
+                role="button"
+                disabled={true}
+                title={"Dagit is disconnected"}
+              >
+                <Icon icon={IconNames.OFFLINE} iconSize={40} />
+              </IconWrapper>
+            );
+          }
+
           return (
             <IconWrapper
               role="button"
-              title={"Pipeline execution is in progress..."}
+              title={"Start pipeline execution"}
+              onClick={this.onClick}
             >
-              <Spinner intent={Intent.NONE} size={39} />
+              <Icon icon={IconNames.PLAY} iconSize={40} />
             </IconWrapper>
           );
-        }
-
-        if (websocketStatus !== WebSocket.OPEN) {
-          return (
-            <IconWrapper
-              role="button"
-              disabled={true}
-              title={"Dagit is disconnected"}
-            >
-              <Icon icon={IconNames.OFFLINE} iconSize={40} />
-            </IconWrapper>
-          );
-        }
-
-        return (
-          <IconWrapper
-            role="button"
-            title={"Start pipeline execution"}
-            onClick={props.onClick}
-          >
-            <Icon icon={IconNames.PLAY} iconSize={40} />
-          </IconWrapper>
-        );
-      }}
-    </WebsocketStatusContext.Consumer>
-  );
+        }}
+      </WebsocketStatusContext.Consumer>
+    );
+  }
 }
 
 const IconWrapper = styled.div<{ disabled?: boolean }>`

--- a/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
@@ -273,7 +273,8 @@ export default class PipelineExecutionContainer extends React.Component<
               onRemoveSession={this.handleRemoveSession}
               onExecute={() => {
                 const variables = this.buildExecutionVariables();
-                if (variables) startPipelineExecution({ variables });
+                if (!variables) return
+                return startPipelineExecution({ variables });
               }}
             />
           );

--- a/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execution/PipelineExecutionContainer.tsx
@@ -273,7 +273,7 @@ export default class PipelineExecutionContainer extends React.Component<
               onRemoveSession={this.handleRemoveSession}
               onExecute={() => {
                 const variables = this.buildExecutionVariables();
-                if (!variables) return
+                if (!variables) return;
                 return startPipelineExecution({ variables });
               }}
             />

--- a/js_modules/dagit/src/schema.json
+++ b/js_modules/dagit/src/schema.json
@@ -5933,7 +5933,7 @@
         "possibleTypes": [
           {
             "kind": "OBJECT",
-            "name": "InvalidSubplanExecutionError",
+            "name": "InvalidSubplanMissingInputError",
             "ofType": null
           },
           {
@@ -5963,7 +5963,7 @@
           },
           {
             "kind": "OBJECT",
-            "name": "StartSubplanExecutionInvalidStepsError",
+            "name": "StartSubplanExecutionInvalidStepError",
             "ofType": null
           },
           {
@@ -5975,7 +5975,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "InvalidSubplanExecutionError",
+        "name": "InvalidSubplanMissingInputError",
         "description": null,
         "fields": [
           {
@@ -6104,28 +6104,20 @@
       },
       {
         "kind": "OBJECT",
-        "name": "StartSubplanExecutionInvalidStepsError",
+        "name": "StartSubplanExecutionInvalidStepError",
         "description": null,
         "fields": [
           {
-            "name": "invalidStepKeys",
+            "name": "invalidStepKey",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "isDeprecated": false,


### PR DESCRIPTION
Currently the UI doesn't show that the pipeline is running until the startExecution mutation succeeds and we receive the first log message. The resources are necessary to start the pipeline, and it'll be a pretty significant effort to make resource loading happen in an execution plan step. Until we do that, this PR makes the Play button in the UI animate as soon as you click it. It continues animating until 300ms after the startExecutionMutation has ended, giving us time to receive the first log message and avoiding flicker.

I've also modified this code on the "run history" branch, so not putting too much time in to it here. 

Also bumped React to 16.8 so I could use Hooks. 