### PR TITLE
Launch python notebook in a subprocess

### DIFF
--- a/js_modules/dagit/src/execution/Materialization.tsx
+++ b/js_modules/dagit/src/execution/Materialization.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import styled from "styled-components";
+import { ROOT_SERVER_URI } from "../Util";
+import { Colors, Spinner } from "@blueprintjs/core";
+
+function fileLocationToHref(location: string) {
+  if (location.startsWith("/")) {
+    return `file://${location}`;
+  }
+  return location;
+}
+
+interface MaterializationProps {
+  fileLocation: string;
+  fileName: string;
+}
+interface MaterializationState {
+  opening: boolean;
+}
+
+export class Materialization extends React.Component<
+  MaterializationProps,
+  MaterializationState
+> {
+  state = {
+    opening: false
+  };
+
+  _openingTimeout?: NodeJS.Timeout;
+
+  componentWillUnmount() {
+    if (this._openingTimeout) {
+      clearTimeout(this._openingTimeout);
+    }
+  }
+
+  onOpenFileLink = async (event: React.MouseEvent<HTMLAnchorElement>) => {
+    const url = event.currentTarget.href;
+
+    // If the file's location is a path, tell dagit to open it on the machine.
+    if (url.startsWith("file://")) {
+      event.preventDefault();
+
+      // Display a loading spinner to give Dagit and the file handler (eg: jupyter notebooks)
+      // time to open the file. Otherwise the user might just think its not working. Just
+      // set to an arbitrary amount of time - jupyter is slow.
+      this.setState({ opening: true });
+      this._openingTimeout = setTimeout(() => {
+        this.setState({ opening: false });
+      }, 2000);
+
+      const path = url.replace("file://", "");
+      const result = await fetch(
+        `${ROOT_SERVER_URI}/dagit/open?path=${encodeURIComponent(path)}`
+      );
+
+      if (result.status !== 200) {
+        const error = await result.text();
+        this.setState({ opening: false });
+        alert(`Dagit was unable to open the file.\n\n${error}`);
+      }
+    } else {
+      // If the file's location is a URL, allow the browser to open it normally.
+    }
+  };
+
+  render() {
+    const { fileLocation, fileName } = this.props;
+
+    return (
+      <MaterializationLink
+        onClick={this.onOpenFileLink}
+        href={fileLocationToHref(fileLocation)}
+        key={fileLocation}
+        title={fileLocation}
+        target="__blank"
+      >
+        {this.state.opening ? (
+          <span style={{ paddingLeft: 3, paddingRight: 3 }}>
+            <Spinner size={14} />
+          </span>
+        ) : (
+          FileIcon
+        )}{" "}
+        {fileName}
+      </MaterializationLink>
+    );
+  }
+}
+
+const MaterializationLink = styled.a`
+  display: block;
+  color: ${Colors.GRAY3};
+  display: inline-block;
+  padding: 6px 3px;
+  padding-left: 23px;
+  display: inline-flex;
+  font-size: 12px;
+  &:hover {
+    color: ${Colors.WHITE};
+  }
+`;
+
+const FileIcon = (
+  <svg width="20px" height="14px" viewBox="-100 0 350 242" version="1.1">
+    <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+      <path
+        d="M-100,96 L0,96"
+        stroke={Colors.GRAY3}
+        strokeWidth="15"
+        strokeLinecap="square"
+      />
+      <polygon
+        stroke={Colors.GRAY3}
+        strokeWidth="15"
+        points="5.4296875 236.507812 5.4296875 5.84765625 137.851562 5.84765625 188.003906 56 188.003906 236.507812"
+      />
+      <path
+        d="M187.5,62.5078125 L130.5,62.5078125 M130.5,5.84765625 L130.5,62.5078125"
+        stroke={Colors.GRAY3}
+        strokeWidth="15"
+        strokeLinecap="square"
+      />
+    </g>
+  </svg>
+);

--- a/js_modules/dagit/src/execution/PipelineRunExecutionPlanBox.tsx
+++ b/js_modules/dagit/src/execution/PipelineRunExecutionPlanBox.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { Colors, Spinner, Intent } from "@blueprintjs/core";
 import { IStepState, IStepMaterialization } from "./RunMetadataProvider";
-import { ROOT_SERVER_URI } from "../Util";
+import { Materialization } from "./Materialization";
 
 interface IExecutionPlanBoxProps {
   state: IStepState;
@@ -21,13 +21,6 @@ interface IExecutionPlanBoxState {
 
 function twoDigit(v: number) {
   return `${v < 10 ? "0" : ""}${v}`;
-}
-
-function fileLocationToHref(location: string) {
-  if (location.startsWith("/")) {
-    return `file://${location}`;
-  }
-  return location;
 }
 
 export class ExecutionPlanBox extends React.Component<
@@ -88,27 +81,6 @@ export class ExecutionPlanBox extends React.Component<
     this.setState({ v: this.state.v + 1 });
   };
 
-  onOpenFileLink = async (event: React.MouseEvent<HTMLAnchorElement>) => {
-    const url = event.currentTarget.href;
-
-    // If the file's location is a path, tell dagit to open it on the machine.
-    if (url.startsWith("file://")) {
-      event.preventDefault();
-
-      const path = url.replace("file://", "");
-      const result = await fetch(
-        `${ROOT_SERVER_URI}/dagit/open?path=${encodeURIComponent(path)}`
-      );
-
-      if (result.status !== 200) {
-        const error = await result.text();
-        alert(`Dagit was unable to open the file.\n\n${error}`);
-      }
-    } else {
-      // If the file's location is a URL, allow the browser to open it normally.
-    }
-  };
-
   render() {
     const {
       state,
@@ -151,33 +123,15 @@ export class ExecutionPlanBox extends React.Component<
           {elapsed !== undefined && <ExecutionTime elapsed={elapsed} />}
         </ExecutionPlanBoxContainer>
         {(materializations || []).map(mat => (
-          <MaterializationLink
-            onClick={this.onOpenFileLink}
-            href={fileLocationToHref(mat.fileLocation)}
-            key={mat.fileLocation}
-            title={mat.fileLocation}
-            target="__blank"
-          >
-            {FileIcon} {mat.fileName}
-          </MaterializationLink>
+          <Materialization
+            fileLocation={mat.fileLocation}
+            fileName={mat.fileName}
+          />
         ))}
       </>
     );
   }
 }
-
-const MaterializationLink = styled.a`
-  display: block;
-  color: ${Colors.GRAY3};
-  display: inline-block;
-  padding: 6px 3px;
-  padding-left: 23px;
-  display: inline-flex;
-  font-size: 12px;
-  &:hover {
-    color: ${Colors.WHITE};
-  }
-`;
 
 const ExeuctionStateWrap = styled.div`
   display: inherit;
@@ -292,27 +246,3 @@ const ExecutionPlanBoxContainer = styled.div<{ state: IStepState }>`
       state === IStepState.WAITING ? Colors.LIGHT_GRAY4 : Colors.WHITE};
   }
 `;
-
-const FileIcon = (
-  <svg width="20px" height="14px" viewBox="-100 0 350 242" version="1.1">
-    <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-      <path
-        d="M-100,96 L0,96"
-        stroke={Colors.GRAY3}
-        strokeWidth="15"
-        strokeLinecap="square"
-      />
-      <polygon
-        stroke={Colors.GRAY3}
-        strokeWidth="15"
-        points="5.4296875 236.507812 5.4296875 5.84765625 137.851562 5.84765625 188.003906 56 188.003906 236.507812"
-      />
-      <path
-        d="M187.5,62.5078125 L130.5,62.5078125 M130.5,5.84765625 L130.5,62.5078125"
-        stroke={Colors.GRAY3}
-        strokeWidth="15"
-        strokeLinecap="square"
-      />
-    </g>
-  </svg>
-);

--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -127,6 +127,13 @@ def notebook_view():
 def open_file_view():
     path = request.args.get('path')
 
+    # Jupyter doesn't register as a handler for ipynb files, so calling `open` won't
+    # work. Instead, spawn a Jupyter notebook process.
+    if path.endswith(".ipynb"):
+        subprocess.Popen(['jupyter', 'notebook', path])
+        return "Success", 200
+
+    # Fall back to `open` or `xdg-open` for other file types
     if os.name == 'nt':  # For Windows
         os.startfile(path, 'open')  # pylint:disable=no-member
         return "Success", 200


### PR DESCRIPTION
This PR makes our custom API for opening paths on disk special-case jupyter notebooks and open them using the `jupyter notebook <path>` command.

I also added a little spinner to the UI that appears for a (totally arbitrary) 2 seconds after you click to open a materialization. This is a nice affordance because jupyter takes a minute to open a Chrome tab and in the interim it seems like it's not doing anything!