### PR TITLE
Separate User and System Context objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+0.3.3
+
+   - API Additions and Changes
+      - Removed step, environment_config, event_callback, has_event_callback, persistence_strategy, events, and execution_metadata properties from user-facing context objects.
 0.3.2
 
    - New features

--- a/python_modules/dagma/dagma/engine.py
+++ b/python_modules/dagma/dagma/engine.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 import cloudpickle as pickle
 
 from dagster import check
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 from dagster.core.execution_plan.objects import ExecutionPlan
 from dagster.utils.zip import zip_folder
 
@@ -147,7 +147,7 @@ def _execute_step_sync(lambda_client, lambda_step, context, payload):
 
 def execute_plan(context, execution_plan, cleanup_lambda_functions=True, local=False):
     """Core executor."""
-    check.inst_param(context, 'context', PipelineExecutionContext)
+    check.inst_param(context, 'context', SystemPipelineExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
 
     steps = list(execution_plan.topological_steps())

--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -11,7 +11,7 @@ from dagster.core.execution import (
     ExecutionMetadata,
     ExecutionContext,
 )
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 from dagster.core.execution_plan.objects import ExecutionStepEvent
 from dagster.core.execution_plan.simple_engine import execute_step_in_memory
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/common.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/common.py
@@ -2,7 +2,10 @@ import sqlalchemy
 
 from dagster import ExecutionContext, check
 
-from dagster.core.execution_context import PipelineExecutionContext, TransformExecutionContext
+from dagster.core.execution_context import (
+    SystemPipelineExecutionContext,
+    SystemTransformExecutionContext,
+)
 
 
 class SqlAlchemyResource(object):
@@ -17,7 +20,7 @@ class DefaultSqlAlchemyResources(object):
 
 
 def check_supports_sql_alchemy_resource(pipeline_context):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.invariant(pipeline_context.resources is not None)
     check.invariant(
         hasattr(pipeline_context.resources, 'sa'),
@@ -37,7 +40,7 @@ def create_sqlalchemy_context_from_engine(engine, loggers=None):
 
 
 def _is_sqlite_context(transform_context):
-    check.inst_param(transform_context, 'transform_context', TransformExecutionContext)
+    check.inst_param(transform_context, 'transform_context', SystemTransformExecutionContext)
 
     check_supports_sql_alchemy_resource(transform_context.legacy_context)
     return _is_sqlite_resource(transform_context.resources.sa)
@@ -54,7 +57,7 @@ def _is_sqlite_resource(sa_resource):
 
 
 def execute_sql_text_on_context(transform_context, sql_text):
-    check.inst_param(transform_context, 'transform_context', TransformExecutionContext)
+    check.inst_param(transform_context, 'transform_context', SystemTransformExecutionContext)
     check_supports_sql_alchemy_resource(transform_context)
 
     return execute_sql_text_on_sa_resource(transform_context.resources.sa, sql_text)

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/common.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/common.py
@@ -1,7 +1,6 @@
 import sqlalchemy
 
 from dagster import ExecutionContext, check
-
 from dagster.core.execution_context import (
     SystemPipelineExecutionContext,
     SystemTransformExecutionContext,
@@ -41,7 +40,6 @@ def create_sqlalchemy_context_from_engine(engine, loggers=None):
 
 def _is_sqlite_context(transform_context):
     check.inst_param(transform_context, 'transform_context', SystemTransformExecutionContext)
-
     check_supports_sql_alchemy_resource(transform_context.legacy_context)
     return _is_sqlite_resource(transform_context.resources.sa)
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/subquery_builder_experimental.py
@@ -1,6 +1,7 @@
 import os
 
 from dagster import Field, InputDefinition, OutputDefinition, SolidDefinition, check, Dict, String
+from dagster.core.user_context import TransformExecutionContext
 from dagster.core.execution_context import SystemTransformExecutionContext
 
 from dagster.core.test_utils import single_output_transform
@@ -94,8 +95,8 @@ def _create_sql_alchemy_transform_fn(sql_text):
     check.str_param(sql_text, 'sql_text')
 
     def transform_fn(context, _args):
-        check.inst_param(context, 'context', SystemTransformExecutionContext)
-        return execute_sql_text_on_context(context, sql_text)
+        check.inst_param(context, 'context', TransformExecutionContext)
+        return execute_sql_text_on_context(context.get_system_context(), sql_text)
 
     return transform_fn
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/subquery_builder_experimental.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/subquery_builder_experimental.py
@@ -1,7 +1,7 @@
 import os
 
 from dagster import Field, InputDefinition, OutputDefinition, SolidDefinition, check, Dict, String
-from dagster.core.execution_context import TransformExecutionContext
+from dagster.core.execution_context import SystemTransformExecutionContext
 
 from dagster.core.test_utils import single_output_transform
 
@@ -94,7 +94,7 @@ def _create_sql_alchemy_transform_fn(sql_text):
     check.str_param(sql_text, 'sql_text')
 
     def transform_fn(context, _args):
-        check.inst_param(context, 'context', TransformExecutionContext)
+        check.inst_param(context, 'context', SystemTransformExecutionContext)
         return execute_sql_text_on_context(context, sql_text)
 
     return transform_fn

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/templated.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy/templated.py
@@ -57,7 +57,7 @@ def _render_template_string(template_text, config_dict):
 def _create_templated_sql_transform_with_output(sql):
     def do_transform(context, _inputs):
         rendered_sql = _render_template_string(sql, context.solid_config)
-        execute_sql_text_on_context(context, rendered_sql)
+        execute_sql_text_on_context(context.get_system_context(), rendered_sql)
         yield Result(context.solid_config)
         yield Result(output_name='sql_text', value=rendered_sql)
 

--- a/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_mocked_context.py
+++ b/python_modules/dagster-sqlalchemy/dagster_sqlalchemy_tests/test_mocked_context.py
@@ -17,6 +17,7 @@ def create_sql_alchemy_context_from_sa_resource(sa_resource, *args, **kwargs):
     check.inst_param(sa_resource, 'sa_resource', SqlAlchemyResource)
     resources = DefaultSqlAlchemyResources(sa_resource)
     context = create_test_pipeline_execution_context(resources=resources, *args, **kwargs)
+
     return check_supports_sql_alchemy_resource(context)
 
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -8,7 +8,8 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
 )
 
-from dagster.core.execution_context import ExecutionContext, ExecutionMetadata
+from dagster.core.execution_context import ExecutionMetadata
+from dagster.core.user_context import ExecutionContext
 
 from dagster.core.definitions import (
     DependencyDefinition,

--- a/python_modules/dagster/dagster/core/definitions/context.py
+++ b/python_modules/dagster/dagster/core/definitions/context.py
@@ -4,7 +4,7 @@ from dagster import check
 
 from dagster.core.types import Field, Dict, String
 from dagster.core.types.field_utils import check_opt_field_param
-from dagster.core.execution_context import ExecutionContext
+from dagster.core.user_context import ExecutionContext
 from dagster.core.system_config.objects import DEFAULT_CONTEXT_NAME
 
 from dagster.utils.logging import level_from_string, define_colored_console_logger

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -35,7 +35,7 @@ class SolidDefinition(object):
 
         name (str): Name of the solid.
         input_defs (List[InputDefinition]): Inputs of the solid.
-        transform_fn (callable): Callable with the signature (**info**: `TransformExecutionContext`,
+        transform_fn (callable): Callable with the signature (**info**: `SystemTransformExecutionContext`,
             **inputs**: `Dict[str, Any]`) : `Iterable<Result>`
         outputs_defs (List[OutputDefinition]): Outputs of the solid.
         config_field (Field): How the solid configured.

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -204,12 +204,6 @@ class SystemTransformExecutionContext(SystemStepExecutionContext):
         solid_config = self.environment_config.solids.get(self.solid.name)
         return solid_config.config if solid_config else None
 
-    # TODO move to user_context
-    @property
-    def config(self):
-        # _warn_about_config_property()
-        return self.solid_config
-
 
 class SystemExpectationExecutionContext(SystemStepExecutionContext):
     __slots__ = ['_inout_def', '_expectation_def']

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -16,7 +16,7 @@ from dagster.core.errors import (
     DagsterInvariantViolationError,
 )
 
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 
 from .expectations import create_expectations_subplan, decorate_with_expectations
 
@@ -62,7 +62,7 @@ class PlanBuilder:
 
 
 def create_execution_plan_core(pipeline_context, subset_info=None, added_outputs=None):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_output', ExecutionPlanAddedOutputs)
 
@@ -96,7 +96,7 @@ def create_execution_plan_core(pipeline_context, subset_info=None, added_outputs
 
 
 def create_execution_plan_from_steps(pipeline_context, steps):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.list_param(steps, 'steps', of_type=ExecutionStep)
 
     step_dict = {step.key: step for step in steps}
@@ -120,7 +120,7 @@ def create_execution_plan_from_steps(pipeline_context, steps):
 
 
 def create_subplan_for_input(pipeline_context, solid, prev_step_output_handle, input_def):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
     check.inst_param(input_def, 'input_def', InputDefinition)
@@ -138,7 +138,7 @@ def create_subplan_for_input(pipeline_context, solid, prev_step_output_handle, i
 
 
 def create_subplan_for_output(pipeline_context, solid, solid_transform_step, output_def):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(solid_transform_step, 'solid_transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)
@@ -149,7 +149,7 @@ def create_subplan_for_output(pipeline_context, solid, solid_transform_step, out
 
 
 def get_input_source_step_handle(pipeline_context, plan_builder, solid, input_def):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
@@ -181,7 +181,7 @@ def get_input_source_step_handle(pipeline_context, plan_builder, solid, input_de
 
 
 def create_step_inputs(pipeline_context, plan_builder, solid):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
 
@@ -211,7 +211,7 @@ def _is_step_in_subset(execution_plan, subset_info, step_key):
 def _create_augmented_subplan(
     pipeline_context, execution_plan, subset_info=None, added_outputs=None
 ):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_outputs', ExecutionPlanAddedOutputs)
@@ -296,7 +296,7 @@ def _validate_new_plan(new_plan, subset_info, added_outputs, pipeline_context):
     check.inst_param(new_plan, 'new_plan', ExecutionPlan)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_outputs', ExecutionPlanAddedOutputs)
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
 
     for step in new_plan.steps:
         for step_input in step.step_inputs:
@@ -329,7 +329,7 @@ def _validate_new_plan(new_plan, subset_info, added_outputs, pipeline_context):
 
 
 def _all_augmented_steps_for_step(pipeline_context, step, subset_info, added_outputs):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_output', ExecutionPlanAddedOutputs)
@@ -355,7 +355,7 @@ def _all_augmented_steps_for_step(pipeline_context, step, subset_info, added_out
 
 
 def _create_new_step_with_added_inputs(pipeline_context, step, subset_info):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
 

--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -1,6 +1,11 @@
 from dagster import check
 
-from dagster.core.execution_context import StepExecutionContext, PipelineExecutionContext
+from dagster.core.execution_context import (
+    SystemStepExecutionContext,
+    SystemPipelineExecutionContext,
+)
+
+from dagster.core.user_context import ExpectationExecutionContext
 
 from dagster.core.definitions import ExpectationDefinition, InputDefinition, OutputDefinition, Solid
 
@@ -28,22 +33,25 @@ def _create_expectation_lambda(solid, inout_def, expectation_def, internal_outpu
     check.inst_param(expectation_def, 'expectations_def', ExpectationDefinition)
     check.str_param(internal_output_name, 'internal_output_name')
 
-    def _do_expectation(step_context, inputs):
-        check.inst_param(step_context, 'step_context', StepExecutionContext)
+    def _do_expectation(expectation_context, inputs):
+        check.inst_param(expectation_context, 'step_context', SystemStepExecutionContext)
         value = inputs[EXPECTATION_INPUT]
-        expectation_context = step_context.for_expectation(inout_def, expectation_def)
-        expt_result = expectation_def.expectation_fn(step_context, value)
+        expectation_context = expectation_context.for_expectation(inout_def, expectation_def)
+        expt_result = expectation_def.expectation_fn(
+            ExpectationExecutionContext(expectation_context), value
+        )
+        # step_context,  value)
         if expt_result.success:
             expectation_context.log.debug(
                 'Expectation {key} succeeded on {value}.'.format(
-                    key=step_context.step.key, value=value
+                    key=expectation_context.step.key, value=value
                 )
             )
             yield StepOutputValue(output_name=internal_output_name, value=inputs[EXPECTATION_INPUT])
         else:
             expectation_context.log.debug(
                 'Expectation {key} failed on {value}.'.format(
-                    key=step_context.step.key, value=value
+                    key=expectation_context.step.key, value=value
                 )
             )
             raise DagsterExpectationFailedError(expectation_context, value)
@@ -52,7 +60,7 @@ def _create_expectation_lambda(solid, inout_def, expectation_def, internal_outpu
 
 
 def create_expectations_subplan(pipeline_context, solid, inout_def, prev_step_output_handle, kind):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition))
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
@@ -90,7 +98,7 @@ def create_expectations_subplan(pipeline_context, solid, inout_def, prev_step_ou
 def create_expectation_step(
     pipeline_context, solid, expectation_def, key, kind, prev_step_output_handle, inout_def
 ):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(expectation_def, 'input_expct_def', ExpectationDefinition)
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
@@ -119,7 +127,7 @@ def create_expectation_step(
 
 
 def decorate_with_expectations(pipeline_context, solid, transform_step, output_def):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(transform_step, 'transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 from dagster.core.definitions import InputDefinition, Solid
 
 from dagster.core.errors import DagsterInvariantViolationError
@@ -17,7 +17,7 @@ INPUT_THUNK_OUTPUT = 'input_thunk_output'
 
 
 def _create_input_thunk_execution_step(pipeline_context, solid, input_def, input_spec):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
@@ -40,7 +40,7 @@ def _create_input_thunk_execution_step(pipeline_context, solid, input_def, input
 
 
 def create_input_thunk_execution_step(pipeline_context, solid, input_def, input_spec):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 

--- a/python_modules/dagster/dagster/core/execution_plan/marshal.py
+++ b/python_modules/dagster/dagster/core/execution_plan/marshal.py
@@ -1,5 +1,5 @@
 from dagster import check
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 from .objects import (
     ExecutionStep,
     StepInput,
@@ -14,7 +14,7 @@ UNMARSHAL_INPUT_OUTPUT = 'unmarshal-input-output'
 
 
 def create_unmarshal_input_step(pipeline_context, step, step_input, marshalling_key):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_input, 'step_input', StepInput)
     check.str_param(marshalling_key, 'marshalling_key')
@@ -48,7 +48,7 @@ MARSHAL_OUTPUT_INPUT = 'marshal-output-input'
 
 
 def create_marshal_output_step(pipeline_context, step, step_output, marshalling_key):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(step, 'step', ExecutionStep)
     check.inst_param(step_output, 'step_output', StepOutput)
     check.str_param(marshalling_key, 'marshalling_key')

--- a/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
@@ -1,7 +1,7 @@
 from dagster import check
 
 from dagster.core.definitions import Solid, OutputDefinition
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 
 from dagster.core.types.runtime import RuntimeType
 
@@ -42,7 +42,7 @@ def configs_for_output(solid, solid_config, output_def):
 
 
 def decorate_with_output_materializations(pipeline_context, solid, output_def, subplan):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(output_def, 'output_def', OutputDefinition)
     check.inst_param(subplan, 'subplan', ExecutionValueSubplan)

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -5,7 +5,7 @@ from dagster import check
 from dagster.utils import mkdir_p
 from dagster.core.errors import DagsterSubprocessExecutionError
 
-from dagster.core.execution_context import PipelineExecutionContext
+from dagster.core.execution_context import SystemPipelineExecutionContext
 
 from .create import create_execution_plan_core
 from .intermediates_manager import FileSystemIntermediateManager
@@ -154,7 +154,7 @@ def _all_inputs_covered(step, intermediates_manager):
 
 def multiprocess_execute_plan(executor_config, pipeline_context, execution_plan):
     check.inst_param(executor_config, 'executor_config', MultiprocessExecutorConfig)
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
 
     step_levels = execution_plan.topological_step_levels()

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -7,7 +7,10 @@ import six
 from dagster import check
 from dagster.core.definitions import Solid, PipelineDefinition
 from dagster.core.errors import DagsterError
-from dagster.core.execution_context import PipelineExecutionContext, StepExecutionContext
+from dagster.core.execution_context import (
+    SystemPipelineExecutionContext,
+    SystemStepExecutionContext,
+)
 from dagster.core.types.runtime import RuntimeType
 from dagster.core.utils import toposort
 from dagster.utils import merge_dicts
@@ -91,7 +94,7 @@ class ExecutionStepEvent(
 
     @staticmethod
     def step_output_event(step_context, step_output_data):
-        check.inst_param(step_context, 'step_context', StepExecutionContext)
+        check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
 
         return ExecutionStepEvent(
             event_type=ExecutionStepEventType.STEP_OUTPUT,
@@ -103,7 +106,7 @@ class ExecutionStepEvent(
 
     @staticmethod
     def step_failure_event(step_context, step_failure_data):
-        check.inst_param(step_context, 'step_context', StepExecutionContext)
+        check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
 
         return ExecutionStepEvent(
             event_type=ExecutionStepEventType.STEP_FAILURE,
@@ -176,7 +179,7 @@ class ExecutionStep(
         return super(ExecutionStep, cls).__new__(
             cls,
             pipeline_context=check.inst_param(
-                pipeline_context, 'pipeline_context', PipelineExecutionContext
+                pipeline_context, 'pipeline_context', SystemPipelineExecutionContext
             ),
             key=check.str_param(key, 'key'),
             step_inputs=check.list_param(step_inputs, 'step_inputs', of_type=StepInput),

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -17,7 +17,10 @@ from dagster.core.errors import (
     DagsterTypeError,
 )
 
-from dagster.core.execution_context import PipelineExecutionContext, StepExecutionContext
+from dagster.core.execution_context import (
+    SystemPipelineExecutionContext,
+    SystemStepExecutionContext,
+)
 
 from .objects import (
     ExecutionPlan,
@@ -38,7 +41,7 @@ def _all_inputs_covered(step, intermediates_manager):
 
 
 def start_inprocess_executor(pipeline_context, execution_plan, intermediates_manager):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
 
     step_levels = execution_plan.topological_step_levels()
@@ -82,7 +85,7 @@ def _create_input_values(step, manager):
 
 
 def execute_step_in_memory(step_context, inputs, intermediates_manager):
-    check.inst_param(step_context, 'step_context', StepExecutionContext)
+    check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
     check.dict_param(inputs, 'inputs', key_type=str)
 
     try:
@@ -137,7 +140,7 @@ def _error_check_step_output_values(step, step_output_values):
 
 
 def _execute_steps_core_loop(step_context, inputs, intermediates_manager):
-    check.inst_param(step_context, 'step_context', StepExecutionContext)
+    check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
     check.dict_param(inputs, 'inputs', key_type=str)
 
     evaluated_inputs = {}
@@ -218,7 +221,7 @@ def _get_evaluated_input(step, input_name, input_value):
 
 
 def _iterate_step_output_values_within_boundary(step_context, evaluated_inputs):
-    check.inst_param(step_context, 'step_context', StepExecutionContext)
+    check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
     check.dict_param(evaluated_inputs, 'evaluated_inputs', key_type=str)
 
     error_str = 'Error occured during step {key}'.format(key=step_context.step.key)
@@ -240,7 +243,7 @@ def _execution_step_error_boundary(step_context, msg, **kwargs):
     framework code in the stack trace, if a tool author wishes to do so. This has
     been especially help in a notebooking context.
     '''
-    check.inst_param(step_context, 'step_context', StepExecutionContext)
+    check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
     check.str_param(msg, 'msg')
 
     step = step_context.step

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -1,5 +1,5 @@
 from dagster import check
-from dagster.core.execution import PipelineExecutionContext
+from dagster.core.execution import SystemPipelineExecutionContext
 from dagster.core.definitions import Solid
 from dagster.core.types.runtime import RuntimeType
 
@@ -22,7 +22,7 @@ def __join_lambda(_context, inputs):
 
 
 def create_join_step(pipeline_context, solid, step_key, prev_steps, prev_output_name):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.str_param(step_key, 'step_key')
     check.list_param(prev_steps, 'prev_steps', of_type=ExecutionStep)
@@ -71,7 +71,7 @@ def create_joining_subplan(
     to be seen if there should be any work or verification done in this step, especially
     in multi-process environments that require persistence between steps.
     '''
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.str_param(join_step_key, 'join_step_key')
     check.list_param(parallel_steps, 'parallel_steps', of_type=ExecutionStep)
@@ -94,7 +94,7 @@ VALUE_OUTPUT = 'value_output'
 
 
 def create_value_thunk_step(pipeline_context, solid, runtime_type, step_key, value):
-    check.inst_param(pipeline_context, 'pipeline_context', PipelineExecutionContext)
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(runtime_type, 'runtime_type', RuntimeType)
     check.str_param(step_key, 'step_key')

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -1,6 +1,7 @@
 from dagster import (
     DagsterEvaluateConfigValueError,
     DagsterInvariantViolationError,
+    ExecutionContext,
     PipelineDefinition,
     PipelineContextDefinition,
     Result,
@@ -10,8 +11,6 @@ from dagster import (
 )
 
 from dagster.core.types.evaluator import evaluate_config_value
-
-from dagster.core.execution_context import ExecutionContext
 
 
 def execute_single_solid_in_isolation(

--- a/python_modules/dagster/dagster/core/user_context.py
+++ b/python_modules/dagster/dagster/core/user_context.py
@@ -1,0 +1,287 @@
+'''
+This module defines the different notions of context passed to user code during pipeline
+execution. There are currently four types of contexts defined:
+
+1) StepExecutionContext
+2) TransformExecutionContext
+3) ExpectationExecutionContext
+
+They inherit from each other in reverse order. They are also relatively lightweight
+objects, and a new one is created for every invocation into user space.
+
+Additionally in order to maintain backwards compatibility (where info.context used
+to rule the day) we have a separate class LegacyContextAdapter which can be
+easily deleted once we break that API guarantee in 0.4.0.
+'''
+
+from abc import ABCMeta, abstractproperty, abstractmethod
+from collections import namedtuple
+import logging
+import warnings
+import six
+from dagster import check
+from dagster.utils.logging import INFO, define_colored_console_logger
+from .execution_context import (
+    SystemPipelineExecutionContext,
+    SystemExpectationExecutionContext,
+    SystemStepExecutionContext,
+    SystemTransformExecutionContext,
+)
+
+
+class ExecutionContext(namedtuple('_ExecutionContext', 'loggers resources tags')):
+    '''
+    The user-facing object in the context creation function. The user constructs
+    this in order to effect the context creation process. This could be named
+    SystemPipelineExecutionContextCreationData although that seemed excessively verbose.
+    '''
+
+    def __new__(cls, loggers=None, resources=None, tags=None):
+        return super(ExecutionContext, cls).__new__(
+            cls,
+            loggers=check.opt_list_param(loggers, 'loggers', logging.Logger),
+            resources=resources,
+            tags=check.opt_dict_param(tags, 'tags'),
+        )
+
+    @staticmethod
+    def console_logging(log_level=INFO, resources=None):
+        return ExecutionContext(
+            loggers=[define_colored_console_logger('dagster', log_level)], resources=resources
+        )
+
+
+def _warn_about_context_property():
+    warnings.warn(
+        (
+            'As of 3.0.2 the context property is deprecated. Before your code likely looked '
+            'like info.context.some_method_or_property. All of the properties of the nested '
+            'context object have been hoisted to the top level, so just rename your info '
+            'object to context and access context.some_method_or_property. This property '
+            'will be removed in 0.4.0.'
+        )
+    )
+
+
+def _warn_about_config_property():
+    warnings.warn(
+        (
+            'As of 3.0.2 the config property is deprecated. Use solid_config instead. '
+            'This will be removed in 0.4.0.'
+        )
+    )
+
+
+# Delete this after 0.4.0
+class LegacyContextAdapter(object):
+    __slots__ = ['_pipeline_context']
+    '''
+    This class mimics the object that was at info.context prior to 0.3.1. It exists in
+    order to provide backwards compatibility.
+    '''
+
+    def __init__(self, pipeline_context):
+        self._pipeline_context = check.inst_param(
+            pipeline_context, 'pipeline_context', SystemPipelineExecutionContext
+        )
+
+    def has_tag(self, key):
+        check.str_param(key, 'key')
+        return key in self._pipeline_context.tags
+
+    def get_tag(self, key):
+        check.str_param(key, 'key')
+        return self._pipeline_context.tags[key]
+
+    @property
+    def run_id(self):
+        return self._pipeline_context.run_id
+
+    @property
+    def event_callback(self):
+        return self._pipeline_context.event_callback
+
+    @property
+    def has_event_callback(self):
+        return self._pipeline_context.event_callback is not None
+
+    @property
+    def environment_config(self):
+        return self._pipeline_context.environment_config
+
+    @property
+    def resources(self):
+        return self._pipeline_context.resources
+
+    @property
+    def tags(self):
+        return self._pipeline_context.tags
+
+    @property
+    def persistence_strategy(self):
+        return self._pipeline_context.persistence_strategy
+
+    @property
+    def events(self):
+        return self._pipeline_context.events
+
+    @property
+    def log(self):
+        return self._pipeline_context.log
+
+    @property
+    def pipeline_def(self):
+        return self._pipeline_context.pipeline_def
+
+    def debug(self, msg, **kwargs):
+        return self._pipeline_context.log.debug(msg, **kwargs)
+
+    def info(self, msg, **kwargs):
+        return self._pipeline_context.log.info(msg, **kwargs)
+
+    def warning(self, msg, **kwargs):
+        return self._pipeline_context.log.warning(msg, **kwargs)
+
+    def error(self, msg, **kwargs):
+        return self._pipeline_context.log.error(msg, **kwargs)
+
+    def critical(self, msg, **kwargs):
+        return self._pipeline_context.log.critical(msg, **kwargs)
+
+
+class StepExecutionContext(object):
+    __slots__ = ['_system_step_execution_context', '_legacy_context']
+
+    def __init__(self, system_step_execution_context):
+        self._system_step_execution_context = check.inst_param(
+            system_step_execution_context,
+            'system_step_execution_context',
+            SystemStepExecutionContext,
+        )
+        self._legacy_context = LegacyContextAdapter(system_step_execution_context)
+
+    @property
+    def resources(self):
+        return self._system_step_execution_context.resources
+
+    @property
+    def run_id(self):
+        return self._system_step_execution_context.run_id
+
+    @property
+    def environment_dict(self):
+        return self._system_step_execution_context.environment_dict
+
+    @property
+    def pipeline_def(self):
+        return self._system_step_execution_context.pipeline_def
+
+    @property
+    def log(self):
+        return self._system_step_execution_context.log
+
+    @property
+    def context(self):
+        _warn_about_context_property()
+        return self._legacy_context
+        # return self._system_step_execution_context.context
+
+    @property
+    def solid_def(self):
+        return self._system_step_execution_context.solid_def
+
+    @property
+    def solid(self):
+        return self._system_step_execution_context.solid
+
+    def has_tag(self, key):
+        return self._system_step_execution_context.has_tag(key)
+
+    def get_tag(self, key):
+        return self._system_step_execution_context.get_tag(key)
+
+    def get_system_context(self):
+        '''
+        This allows advanced users (e.g. framework authors) to punch through
+        to the underlying system context.
+        '''
+        return self._system_step_execution_context
+
+
+class AbstractTransformExecutionContext(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
+    @abstractmethod
+    def has_tag(self, key):
+        pass
+
+    @abstractmethod
+    def get_tag(self, key):
+        pass
+
+    @abstractproperty
+    def run_id(self):
+        pass
+
+    @abstractproperty
+    def context(self):
+        pass
+
+    @abstractproperty
+    def solid_def(self):
+        pass
+
+    @abstractproperty
+    def solid(self):
+        pass
+
+    @abstractproperty
+    def pipeline_def(self):
+        pass
+
+    @abstractproperty
+    def resources(self):
+        pass
+
+    @abstractproperty
+    def log(self):
+        pass
+
+
+class TransformExecutionContext(StepExecutionContext, AbstractTransformExecutionContext):
+    __slots__ = ['_system_transform_execution_context']
+
+    def __init__(self, system_transform_execution_context):
+        self._system_transform_execution_context = check.inst_param(
+            system_transform_execution_context,
+            'system_transform_execution_context',
+            SystemTransformExecutionContext,
+        )
+        super(TransformExecutionContext, self).__init__(system_transform_execution_context)
+
+    @property
+    def solid_config(self):
+        return self._system_transform_execution_context.solid_config
+
+    @property
+    def config(self):
+        _warn_about_config_property()
+        return self.solid_config
+
+
+class ExpectationExecutionContext(StepExecutionContext):
+    __slots__ = ['_system_expectation_execution_context']
+
+    def __init__(self, system_expectation_execution_context):
+        self._system_expectation_execution_context = check.inst_param(
+            system_expectation_execution_context,
+            'system_expectation_execution_context',
+            SystemExpectationExecutionContext,
+        )
+        super(ExpectationExecutionContext, self).__init__(system_expectation_execution_context)
+
+    @property
+    def expectation_def(self):
+        return self._system_expectation_execution_context.expectation_def
+
+    @property
+    def inout_def(self):
+        return self._system_expectation_execution_context.inout_def

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -159,3 +159,5 @@ def test_reentrant_execute_plan():
 
     assert called['yup']
     assert len(step_events) == 1
+
+    assert step_events[0].tags['foo'] == 'bar'

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -332,8 +332,7 @@ def test_pipeline_name_threaded_through_context():
 
     @solid()
     def assert_name_transform(context):
-        assert context.has_tag('pipeline')
-        assert context.get_tag('pipeline') == name
+        assert context.pipeline_def.name == name
 
     result = execute_pipeline(PipelineDefinition(name="foobar", solids=[assert_name_transform]))
 

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20142,7 +20142,7 @@ is generally used by framework authors.</p>
 <dl class="attribute">
 <dt id="dagster.SolidDefinition.transform_fn">
 <code class="descname">transform_fn</code><a class="headerlink" href="#dagster.SolidDefinition.transform_fn" title="Permalink to this definition">¶</a></dt>
-<dd><p><em>callable</em> – Callable with the signature (<strong>info</strong>: <cite>TransformExecutionContext</cite>,
+<dd><p><em>callable</em> – Callable with the signature (<strong>info</strong>: <cite>SystemTransformExecutionContext</cite>,
 <strong>inputs</strong>: <cite>Dict[str, Any]</cite>) : <cite>Iterable&lt;Result&gt;</cite></p>
 </dd></dl>
 
@@ -20589,7 +20589,7 @@ node. For the ‘synchronous’ API, see <a class="reference internal" href="#da
 <em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">ExecutionContext</code><a class="headerlink" href="#dagster.ExecutionContext" title="Permalink to this definition">¶</a></dt>
 <dd><p>The user-facing object in the context creation function. The user constructs
 this in order to effect the context creation process. This could be named
-PipelineExecutionContextCreationData although that seemed excessively verbose.</p>
+SystemPipelineExecutionContextCreationData although that seemed excessively verbose.</p>
 </dd></dl>
 
 <dl class="class">

--- a/python_modules/dagster/internal_docs/adding_event.md
+++ b/python_modules/dagster/internal_docs/adding_event.md
@@ -2,7 +2,7 @@
 
 We distill the process of adding a new event by examining how we added the new event `StepMaterialization` that is emitted whenever we materialize anything in a solid (currently only called for materializating output notebooks in Dagstermill.)
 
-The `context` object (type `TransformExecutionContext`) that is passed into the transform function of a solid has an attribute `info.context` (type `RuntimeExecutionContext`). The `context` object has an attribute `events` that is an instantiation of the `ExecutionEvents()` class (in the file `dagster.core.events`). To trigger an event that is consumed by the GraphQL API, we call a method of the `ExecutionEvents` class, such as `context.events.step_materialization_event(**kwargs)`. Thus we must add this event to the `ExecutionEvents` class as below:
+The `context` object (type `SystemTransformExecutionContext`) that is passed into the transform function of a solid has an attribute `context.events` that is an instantiation of the `ExecutionEvents()` class (in the file `dagster.core.events`). To trigger an event that is consumed by the GraphQL API, we call a method of the `ExecutionEvents` class, such as `context.events.step_materialization_event(**kwargs)`. Thus we must add this event to the `ExecutionEvents` class as below:
 
 `python_modules/dagster/dagster/core/events.py`
 
@@ -21,7 +21,7 @@ class ExecutionEvents()
         )
 ```
 
-When `ExecutionEvents()` is created, its `self.context` points to the corresponding `RuntimeExecutionContext` that contains it. Thus this function simply logs the event. However notice that the other arguments we're passing into the logger (such as `step_key` or `file_name` are stored as part of meta-information in the Structured Logger log message). Normally if the logger is just writing to the console, then this meta-information is just pretty-printed to the console. However, if there is a `event_callback` in the `RuntimeExecutionContext`, then we have that the logger message is converted to an `EventRecord` (by the function `construct_event_record(logger_message)`), which is passed into the `event_callback` (which might be provided by Dagit, for example).
+When `ExecutionEvents()` is created, its `self.context` points to the corresponding `RuntimeExecutionContext` that contains it. Thus this function simply logs the event. However notice that the other arguments we're passing into the logger (such as `step_key` or `file_name` are stored as part of meta-information in the Structured Logger log message). Normally if the logger is just writing to the console, then this meta-information is just pretty-printed to the console. However, if there is a `event_callback` in the `SystemTransformExecutionContext`, then we have that the logger message is converted to an `EventRecord` (by the function `construct_event_record(logger_message)`), which is passed into the `event_callback` (which might be provided by Dagit, for example).
 
 Thus we need to make a corresponding EventRecord class that corresponds to our new event.
 


### PR DESCRIPTION
In anticipation of the file resource work, I just separated out a layer of context objects that are user-facing versus system-facing. The logic is that we will have a place in the file system/whatever store for storing marshalled intermediates that we don't really want the average user to interact with. 