### PR TITLE
ExecutionMetadata ==> RunConfig

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.3.4
+
+  - API Additions and Changes:
+      - ExecutionMetadata has been renamed to RunConfig
+
 0.3.3
 
    - New features

--- a/python_modules/dagit/dagit/pipeline_execution_manager.py
+++ b/python_modules/dagit/dagit/pipeline_execution_manager.py
@@ -9,7 +9,7 @@ import time
 import gevent
 import six
 
-from dagster import check, RunConfiguration, PipelineDefinition, execute_pipeline
+from dagster import check, RunConfig, PipelineDefinition, execute_pipeline
 from dagster.core.events import PipelineEventRecord, EventType
 from dagster.utils.error import serializable_error_info_from_exc_info, SerializableErrorInfo
 from dagster.utils.logging import level_from_string
@@ -87,7 +87,7 @@ class SynchronousExecutionManager(PipelineExecutionManager):
             return execute_pipeline(
                 pipeline,
                 pipeline_run.config,
-                run_configuration=RunConfiguration(
+                run_config=RunConfig(
                     pipeline_run.run_id, event_callback=pipeline_run.handle_new_event
                 ),
                 throw_on_user_error=throw_on_user_error,
@@ -255,7 +255,7 @@ def execute_pipeline_through_queue(
 
     message_queue.put(ProcessStartedSentinel(os.getpid()))
 
-    run_configuration = RunConfiguration(run_id, event_callback=message_queue.put)
+    run_config = RunConfig(run_id, event_callback=message_queue.put)
 
     from .app import RepositoryContainer
 
@@ -274,7 +274,7 @@ def execute_pipeline_through_queue(
                 solid_subset
             ),
             environment_dict,
-            run_configuration=run_configuration,
+            run_config=run_config,
             throw_on_user_error=False,
         )
         return result

--- a/python_modules/dagit/dagit/pipeline_execution_manager.py
+++ b/python_modules/dagit/dagit/pipeline_execution_manager.py
@@ -9,7 +9,7 @@ import time
 import gevent
 import six
 
-from dagster import check, ExecutionMetadata, PipelineDefinition, execute_pipeline
+from dagster import check, RunConfiguration, PipelineDefinition, execute_pipeline
 from dagster.core.events import PipelineEventRecord, EventType
 from dagster.utils.error import serializable_error_info_from_exc_info, SerializableErrorInfo
 from dagster.utils.logging import level_from_string
@@ -87,7 +87,7 @@ class SynchronousExecutionManager(PipelineExecutionManager):
             return execute_pipeline(
                 pipeline,
                 pipeline_run.config,
-                execution_metadata=ExecutionMetadata(
+                run_configuration=RunConfiguration(
                     pipeline_run.run_id, event_callback=pipeline_run.handle_new_event
                 ),
                 throw_on_user_error=throw_on_user_error,
@@ -255,7 +255,7 @@ def execute_pipeline_through_queue(
 
     message_queue.put(ProcessStartedSentinel(os.getpid()))
 
-    execution_metadata = ExecutionMetadata(run_id, event_callback=message_queue.put)
+    run_configuration = RunConfiguration(run_id, event_callback=message_queue.put)
 
     from .app import RepositoryContainer
 
@@ -274,7 +274,7 @@ def execute_pipeline_through_queue(
                 solid_subset
             ),
             environment_dict,
-            execution_metadata=execution_metadata,
+            run_configuration=run_configuration,
             throw_on_user_error=False,
         )
         return result

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -6,7 +6,7 @@ import uuid
 
 from graphql.execution.base import ResolveInfo
 
-from dagster import RunConfiguration, check
+from dagster import RunConfig, check
 from dagster.core.execution_plan.objects import ExecutionStepEventType
 from dagster.core.execution_plan.plan_subset import MarshalledOutput, MarshalledInput, StepExecution
 
@@ -350,11 +350,10 @@ def step_executions_from_graphql_inputs(step_key, marshalled_inputs, marshalled_
 
 class SubplanExecutionArgs(
     namedtuple(
-        '_SubplanExecutionArgs',
-        'graphene_info pipeline_name env_config step_executions run_configuration',
+        '_SubplanExecutionArgs', 'graphene_info pipeline_name env_config step_executions run_config'
     )
 ):
-    def __new__(cls, graphene_info, pipeline_name, env_config, step_executions, run_configuration):
+    def __new__(cls, graphene_info, pipeline_name, env_config, step_executions, run_config):
         return super(SubplanExecutionArgs, cls).__new__(
             cls,
             graphene_info=check.inst_param(graphene_info, 'graphene_info', ResolveInfo),
@@ -363,9 +362,7 @@ class SubplanExecutionArgs(
             step_executions=check.list_param(
                 step_executions, 'step_executions', of_type=StepExecution
             ),
-            run_configuration=check.inst_param(
-                run_configuration, 'run_configuration', RunConfiguration
-            ),
+            run_config=check.inst_param(run_config, 'run_config', RunConfig),
         )
 
     @property
@@ -417,7 +414,7 @@ def _execute_marshalling_or_error(args, dauphin_pipeline, evaluate_value_result)
         execution_plan = create_execution_plan(
             dauphin_pipeline.get_dagster_pipeline(),
             environment_dict=environment_dict,
-            run_configuration=args.run_configuration,
+            run_config=args.run_config,
             subset_info=ExecutionPlanSubsetInfo.with_input_marshalling(
                 args.step_keys, input_marshalling_dict_from_step_executions(args.step_executions)
             ),
@@ -455,14 +452,14 @@ def _execute_marshalling_or_error(args, dauphin_pipeline, evaluate_value_result)
             )
         )
 
-    check.invariant(not args.run_configuration.loggers)
-    check.invariant(not args.run_configuration.event_callback)
+    check.invariant(not args.run_config.loggers)
+    check.invariant(not args.run_config.event_callback)
 
     step_events = execute_serializable_execution_plan(
         ForkedProcessPipelineFactory(pipeline_fn=dauphin_pipeline.get_dagster_pipeline),
         environment_dict=environment_dict,
-        run_configuration=SerializableExecutionMetadata(
-            run_id=args.run_configuration.run_id, tags=args.run_configuration.tags
+        run_config=SerializableExecutionMetadata(
+            run_id=args.run_config.run_id, tags=args.run_config.tags
         ),
         step_executions=args.step_executions,
     )

--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -458,7 +458,7 @@ def _execute_marshalling_or_error(args, dauphin_pipeline, evaluate_value_result)
     step_events = execute_serializable_execution_plan(
         ForkedProcessPipelineFactory(pipeline_fn=dauphin_pipeline.get_dagster_pipeline),
         environment_dict=environment_dict,
-        run_config=SerializableExecutionMetadata(
+        serializable_execution_metadata=SerializableExecutionMetadata(
             run_id=args.run_config.run_id, tags=args.run_config.tags
         ),
         step_executions=args.step_executions,

--- a/python_modules/dagit/dagit/schema/roots.py
+++ b/python_modules/dagit/dagit/schema/roots.py
@@ -1,6 +1,6 @@
 from dagit.schema import dauphin
 from dagit.schema import model
-from dagster.core.execution import ExecutionSelector, RunConfiguration
+from dagster.core.execution import ExecutionSelector, RunConfig
 from ..version import __version__
 
 
@@ -151,7 +151,7 @@ class DauphinExecutionMetadata(dauphin.InputObjectType):
             for tag in self.tags:  # pylint: disable=E1133
                 tags[tag['key']] = tag['value']
 
-        return RunConfiguration(run_id=self.runId, tags=tags)
+        return RunConfig(run_id=self.runId, tags=tags)
 
 
 class DauphinStartSubplanExecution(dauphin.Mutation):

--- a/python_modules/dagit/dagit/schema/roots.py
+++ b/python_modules/dagit/dagit/schema/roots.py
@@ -1,6 +1,6 @@
 from dagit.schema import dauphin
 from dagit.schema import model
-from dagster.core.execution import ExecutionSelector, ExecutionMetadata
+from dagster.core.execution import ExecutionSelector, RunConfiguration
 from ..version import __version__
 
 
@@ -151,7 +151,7 @@ class DauphinExecutionMetadata(dauphin.InputObjectType):
             for tag in self.tags:  # pylint: disable=E1133
                 tags[tag['key']] = tag['value']
 
-        return ExecutionMetadata(run_id=self.runId, tags=tags)
+        return RunConfiguration(run_id=self.runId, tags=tags)
 
 
 class DauphinStartSubplanExecution(dauphin.Mutation):

--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -6,11 +6,7 @@ import boto3
 from io import BytesIO
 
 from dagster import check, PipelineDefinition
-from dagster.core.execution import (
-    construct_pipeline_execution_context,
-    RunConfiguration,
-    ExecutionContext,
-)
+from dagster.core.execution import construct_pipeline_execution_context, RunConfig, ExecutionContext
 from dagster.core.execution_context import SystemPipelineExecutionContext
 from dagster.core.execution_plan.objects import ExecutionStepEvent
 from dagster.core.execution_plan.simple_engine import execute_step_in_memory
@@ -59,7 +55,7 @@ def aws_lambda_handler(event, _context):
     resources = deserialize(resources_object['Body'].read())
     execution_context = construct_pipeline_execution_context(
         pipeline=PipelineDefinition(name='dummy', solids=[]),
-        run_configuration=RunConfiguration(run_id=run_id),
+        run_config=RunConfig(run_id=run_id),
         execution_context=ExecutionContext(loggers=[logger]),
         resources=resources,
         environment_config={},

--- a/python_modules/dagma/dagma/handler.py
+++ b/python_modules/dagma/dagma/handler.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from dagster import check, PipelineDefinition
 from dagster.core.execution import (
     construct_pipeline_execution_context,
-    ExecutionMetadata,
+    RunConfiguration,
     ExecutionContext,
 )
 from dagster.core.execution_context import SystemPipelineExecutionContext
@@ -59,7 +59,7 @@ def aws_lambda_handler(event, _context):
     resources = deserialize(resources_object['Body'].read())
     execution_context = construct_pipeline_execution_context(
         pipeline=PipelineDefinition(name='dummy', solids=[]),
-        execution_metadata=ExecutionMetadata(run_id=run_id),
+        run_configuration=RunConfiguration(run_id=run_id),
         execution_context=ExecutionContext(loggers=[logger]),
         resources=resources,
         environment_config={},

--- a/python_modules/dagma/dagma_tests/test_lambda_engine.py
+++ b/python_modules/dagma/dagma_tests/test_lambda_engine.py
@@ -18,7 +18,7 @@ from dagster import (
     lambda_solid,
     PipelineContextDefinition,
     PipelineDefinition,
-    RunConfiguration,
+    RunConfig,
     ResourceDefinition,
 )
 from dagster.core.execution import (
@@ -93,8 +93,8 @@ TEST_ENVIRONMENT = {
 
 
 def run_test_pipeline(pipeline):
-    run_configuration = RunConfiguration(run_id=str(uuid.uuid4()))
-    with yield_pipeline_execution_context(pipeline, TEST_ENVIRONMENT, run_configuration) as context:
+    run_config = RunConfig(run_id=str(uuid.uuid4()))
+    with yield_pipeline_execution_context(pipeline, TEST_ENVIRONMENT, run_config) as context:
         execution_plan = create_execution_plan_core(context)
         return execute_plan(context, execution_plan)
 

--- a/python_modules/dagma/dagma_tests/test_lambda_engine.py
+++ b/python_modules/dagma/dagma_tests/test_lambda_engine.py
@@ -18,7 +18,7 @@ from dagster import (
     lambda_solid,
     PipelineContextDefinition,
     PipelineDefinition,
-    ExecutionMetadata,
+    RunConfiguration,
     ResourceDefinition,
 )
 from dagster.core.execution import (
@@ -93,10 +93,8 @@ TEST_ENVIRONMENT = {
 
 
 def run_test_pipeline(pipeline):
-    execution_metadata = ExecutionMetadata(run_id=str(uuid.uuid4()))
-    with yield_pipeline_execution_context(
-        pipeline, TEST_ENVIRONMENT, execution_metadata
-    ) as context:
+    run_configuration = RunConfiguration(run_id=str(uuid.uuid4()))
+    with yield_pipeline_execution_context(pipeline, TEST_ENVIRONMENT, run_configuration) as context:
         execution_plan = create_execution_plan_core(context)
         return execute_plan(context, execution_plan)
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -8,7 +8,7 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
 )
 
-from dagster.core.execution_context import RunConfiguration
+from dagster.core.execution_context import RunConfig
 from dagster.core.user_context import ExecutionContext
 
 from dagster.core.definitions import (

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -8,7 +8,7 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
 )
 
-from dagster.core.execution_context import ExecutionMetadata
+from dagster.core.execution_context import RunConfiguration
 from dagster.core.user_context import ExecutionContext
 
 from dagster.core.definitions import (

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -29,7 +29,7 @@ from .definitions.utils import DEFAULT_OUTPUT
 from .definitions.environment_configs import construct_environment_config
 
 from .execution_context import (
-    ExecutionMetadata,
+    RunConfiguration,
     SystemPipelineExecutionContextData,
     SystemPipelineExecutionContext,
 )
@@ -260,40 +260,40 @@ class SolidExecutionResult(object):
                 return result.step_failure_data.dagster_error
 
 
-def check_execution_metadata_param(execution_metadata):
+def check_run_configuration_param(run_configuration):
     return (
-        check.inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
-        if execution_metadata
-        else ExecutionMetadata()
+        check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
+        if run_configuration
+        else RunConfiguration()
     )
 
 
 def create_execution_plan(
-    pipeline, environment_dict=None, execution_metadata=None, subset_info=None, added_outputs=None
+    pipeline, environment_dict=None, run_configuration=None, subset_info=None, added_outputs=None
 ):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict', key_type=str)
-    execution_metadata = check_execution_metadata_param(execution_metadata)
-    check.inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
+    run_configuration = check_run_configuration_param(run_configuration)
+    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_outputs', ExecutionPlanAddedOutputs)
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, execution_metadata
+        pipeline, environment_dict, run_configuration
     ) as pipeline_context:
         return create_execution_plan_core(pipeline_context, subset_info, added_outputs)
 
 
-def get_tags(user_context_params, execution_metadata, pipeline):
+def get_tags(user_context_params, run_configuration, pipeline):
     check.inst_param(user_context_params, 'user_context_params', ExecutionContext)
-    check.opt_inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
+    check.opt_inst_param(run_configuration, 'run_configuration', RunConfiguration)
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
 
     base_tags = merge_dicts({'pipeline': pipeline.name}, user_context_params.tags)
 
-    if execution_metadata and execution_metadata.tags:
+    if run_configuration and run_configuration.tags:
         user_keys = set(user_context_params.tags.keys())
-        provided_keys = set(execution_metadata.tags.keys())
+        provided_keys = set(run_configuration.tags.keys())
         if not user_keys.isdisjoint(provided_keys):
             raise DagsterInvariantViolationError(
                 (
@@ -303,7 +303,7 @@ def get_tags(user_context_params, execution_metadata, pipeline):
                 ).format(user_keys=user_keys, provided_keys=provided_keys)
             )
 
-        return merge_dicts(base_tags, execution_metadata.tags)
+        return merge_dicts(base_tags, run_configuration.tags)
     else:
         return base_tags
 
@@ -352,10 +352,10 @@ def _create_persistence_strategy(persistence_config):
 
 
 @contextmanager
-def yield_pipeline_execution_context(pipeline_def, environment_dict, execution_metadata):
+def yield_pipeline_execution_context(pipeline_def, environment_dict, run_configuration):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.dict_param(environment_dict, 'environment_dict', key_type=str)
-    check.inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
+    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
 
     environment_config = create_environment_config(pipeline_def, environment_dict)
 
@@ -365,7 +365,7 @@ def yield_pipeline_execution_context(pipeline_def, environment_dict, execution_m
         InitContext(
             context_config=environment_config.context.config,
             pipeline_def=pipeline_def,
-            run_id=execution_metadata.run_id,
+            run_id=run_configuration.run_id,
         )
     )
 
@@ -377,51 +377,51 @@ def yield_pipeline_execution_context(pipeline_def, environment_dict, execution_m
             context_definition,
             environment_config,
             execution_context,
-            execution_metadata.run_id,
+            run_configuration.run_id,
         ) as resources:
             yield construct_pipeline_execution_context(
-                execution_metadata, execution_context, pipeline_def, resources, environment_config
+                run_configuration, execution_context, pipeline_def, resources, environment_config
             )
 
 
 def construct_pipeline_execution_context(
-    execution_metadata, execution_context, pipeline, resources, environment_config
+    run_configuration, execution_context, pipeline, resources, environment_config
 ):
-    check.inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
+    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
     check.inst_param(execution_context, 'execution_context', ExecutionContext)
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
 
-    loggers = _create_loggers(execution_metadata, execution_context)
-    tags = get_tags(execution_context, execution_metadata, pipeline)
-    log = DagsterLog(execution_metadata.run_id, tags, loggers)
+    loggers = _create_loggers(run_configuration, execution_context)
+    tags = get_tags(execution_context, run_configuration, pipeline)
+    log = DagsterLog(run_configuration.run_id, tags, loggers)
 
     return SystemPipelineExecutionContext(
         SystemPipelineExecutionContextData(
             pipeline_def=pipeline,
-            execution_metadata=execution_metadata,
+            run_configuration=run_configuration,
             resources=resources,
             environment_config=environment_config,
             persistence_strategy=_create_persistence_strategy(
                 environment_config.context.persistence
             ),
-            files=LocalTempFileStore(execution_metadata.run_id),
+            files=LocalTempFileStore(run_configuration.run_id),
         ),
         tags=tags,
         log=log,
     )
 
 
-def _create_loggers(execution_metadata, execution_context):
-    check.inst_param(execution_metadata, 'execution_metadata', ExecutionMetadata)
+def _create_loggers(run_configuration, execution_context):
+    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
     check.inst_param(execution_context, 'execution_context', ExecutionContext)
 
-    if execution_metadata.event_callback:
+    if run_configuration.event_callback:
         return execution_context.loggers + [
-            construct_event_logger(execution_metadata.event_callback)
+            construct_event_logger(run_configuration.event_callback)
         ]
-    elif execution_metadata.loggers:
-        return execution_context.loggers + execution_metadata.loggers
+    elif run_configuration.loggers:
+        return execution_context.loggers + run_configuration.loggers
     else:
         return execution_context.loggers
 
@@ -481,7 +481,7 @@ def execute_pipeline_iterator(
     pipeline,
     environment_dict=None,
     throw_on_user_error=True,
-    execution_metadata=None,
+    run_configuration=None,
     executor_config=None,
 ):
     '''Returns iterator that yields :py:class:`SolidExecutionResult` for each
@@ -497,10 +497,10 @@ def execute_pipeline_iterator(
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
-    execution_metadata = check_execution_metadata_param(execution_metadata)
+    run_configuration = check_run_configuration_param(run_configuration)
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, execution_metadata
+        pipeline, environment_dict, run_configuration
     ) as pipeline_context:
 
         pipeline_context.events.pipeline_start()
@@ -549,7 +549,7 @@ def execute_pipeline(
     pipeline,
     environment_dict=None,
     throw_on_user_error=True,
-    execution_metadata=None,
+    run_configuration=None,
     executor_config=None,
 ):
     '''
@@ -573,17 +573,17 @@ def execute_pipeline(
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
-    execution_metadata = check_execution_metadata_param(execution_metadata)
+    run_configuration = check_run_configuration_param(run_configuration)
 
     return PipelineExecutionResult(
         pipeline,
-        execution_metadata.run_id,
+        run_configuration.run_id,
         list(
             execute_pipeline_iterator(
                 pipeline=pipeline,
                 environment_dict=environment_dict,
                 throw_on_user_error=throw_on_user_error,
-                execution_metadata=execution_metadata,
+                run_configuration=run_configuration,
                 executor_config=executor_config,
             )
         ),
@@ -640,18 +640,18 @@ def execute_marshalling(
     inputs_to_marshal=None,
     outputs_to_marshal=None,
     environment_dict=None,
-    execution_metadata=None,
+    run_configuration=None,
     throw_on_user_error=True,
     executor_config=None,
 ):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.list_param(step_keys, 'step_keys', of_type=str)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
-    execution_metadata = check_execution_metadata_param(execution_metadata)
+    run_configuration = check_run_configuration_param(run_configuration)
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, execution_metadata
+        pipeline, environment_dict, run_configuration
     ) as pipeline_context:
         return list(
             invoke_executor_on_plan(
@@ -674,17 +674,17 @@ def execute_marshalling(
 def execute_plan(
     execution_plan,
     environment_dict=None,
-    execution_metadata=None,
+    run_configuration=None,
     throw_on_user_error=True,
     executor_config=None,
 ):
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
 
-    execution_metadata = check_execution_metadata_param(execution_metadata)
+    run_configuration = check_run_configuration_param(run_configuration)
 
     with yield_pipeline_execution_context(
-        execution_plan.pipeline_def, environment_dict, execution_metadata
+        execution_plan.pipeline_def, environment_dict, run_configuration
     ) as pipeline_context:
         return list(
             invoke_executor_on_plan(

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -29,7 +29,7 @@ from .definitions.utils import DEFAULT_OUTPUT
 from .definitions.environment_configs import construct_environment_config
 
 from .execution_context import (
-    RunConfiguration,
+    RunConfig,
     SystemPipelineExecutionContextData,
     SystemPipelineExecutionContext,
 )
@@ -260,40 +260,36 @@ class SolidExecutionResult(object):
                 return result.step_failure_data.dagster_error
 
 
-def check_run_configuration_param(run_configuration):
-    return (
-        check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
-        if run_configuration
-        else RunConfiguration()
-    )
+def check_run_config_param(run_config):
+    return check.inst_param(run_config, 'run_config', RunConfig) if run_config else RunConfig()
 
 
 def create_execution_plan(
-    pipeline, environment_dict=None, run_configuration=None, subset_info=None, added_outputs=None
+    pipeline, environment_dict=None, run_config=None, subset_info=None, added_outputs=None
 ):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict', key_type=str)
-    run_configuration = check_run_configuration_param(run_configuration)
-    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
+    run_config = check_run_config_param(run_config)
+    check.inst_param(run_config, 'run_config', RunConfig)
     check.opt_inst_param(subset_info, 'subset_info', ExecutionPlanSubsetInfo)
     check.opt_inst_param(added_outputs, 'added_outputs', ExecutionPlanAddedOutputs)
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, run_configuration
+        pipeline, environment_dict, run_config
     ) as pipeline_context:
         return create_execution_plan_core(pipeline_context, subset_info, added_outputs)
 
 
-def get_tags(user_context_params, run_configuration, pipeline):
+def get_tags(user_context_params, run_config, pipeline):
     check.inst_param(user_context_params, 'user_context_params', ExecutionContext)
-    check.opt_inst_param(run_configuration, 'run_configuration', RunConfiguration)
+    check.opt_inst_param(run_config, 'run_config', RunConfig)
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
 
     base_tags = merge_dicts({'pipeline': pipeline.name}, user_context_params.tags)
 
-    if run_configuration and run_configuration.tags:
+    if run_config and run_config.tags:
         user_keys = set(user_context_params.tags.keys())
-        provided_keys = set(run_configuration.tags.keys())
+        provided_keys = set(run_config.tags.keys())
         if not user_keys.isdisjoint(provided_keys):
             raise DagsterInvariantViolationError(
                 (
@@ -303,7 +299,7 @@ def get_tags(user_context_params, run_configuration, pipeline):
                 ).format(user_keys=user_keys, provided_keys=provided_keys)
             )
 
-        return merge_dicts(base_tags, run_configuration.tags)
+        return merge_dicts(base_tags, run_config.tags)
     else:
         return base_tags
 
@@ -352,10 +348,10 @@ def _create_persistence_strategy(persistence_config):
 
 
 @contextmanager
-def yield_pipeline_execution_context(pipeline_def, environment_dict, run_configuration):
+def yield_pipeline_execution_context(pipeline_def, environment_dict, run_config):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.dict_param(environment_dict, 'environment_dict', key_type=str)
-    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
+    check.inst_param(run_config, 'run_config', RunConfig)
 
     environment_config = create_environment_config(pipeline_def, environment_dict)
 
@@ -365,7 +361,7 @@ def yield_pipeline_execution_context(pipeline_def, environment_dict, run_configu
         InitContext(
             context_config=environment_config.context.config,
             pipeline_def=pipeline_def,
-            run_id=run_configuration.run_id,
+            run_id=run_config.run_id,
         )
     )
 
@@ -377,51 +373,49 @@ def yield_pipeline_execution_context(pipeline_def, environment_dict, run_configu
             context_definition,
             environment_config,
             execution_context,
-            run_configuration.run_id,
+            run_config.run_id,
         ) as resources:
             yield construct_pipeline_execution_context(
-                run_configuration, execution_context, pipeline_def, resources, environment_config
+                run_config, execution_context, pipeline_def, resources, environment_config
             )
 
 
 def construct_pipeline_execution_context(
-    run_configuration, execution_context, pipeline, resources, environment_config
+    run_config, execution_context, pipeline, resources, environment_config
 ):
-    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
+    check.inst_param(run_config, 'run_config', RunConfig)
     check.inst_param(execution_context, 'execution_context', ExecutionContext)
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
 
-    loggers = _create_loggers(run_configuration, execution_context)
-    tags = get_tags(execution_context, run_configuration, pipeline)
-    log = DagsterLog(run_configuration.run_id, tags, loggers)
+    loggers = _create_loggers(run_config, execution_context)
+    tags = get_tags(execution_context, run_config, pipeline)
+    log = DagsterLog(run_config.run_id, tags, loggers)
 
     return SystemPipelineExecutionContext(
         SystemPipelineExecutionContextData(
             pipeline_def=pipeline,
-            run_configuration=run_configuration,
+            run_config=run_config,
             resources=resources,
             environment_config=environment_config,
             persistence_strategy=_create_persistence_strategy(
                 environment_config.context.persistence
             ),
-            files=LocalTempFileStore(run_configuration.run_id),
+            files=LocalTempFileStore(run_config.run_id),
         ),
         tags=tags,
         log=log,
     )
 
 
-def _create_loggers(run_configuration, execution_context):
-    check.inst_param(run_configuration, 'run_configuration', RunConfiguration)
+def _create_loggers(run_config, execution_context):
+    check.inst_param(run_config, 'run_config', RunConfig)
     check.inst_param(execution_context, 'execution_context', ExecutionContext)
 
-    if run_configuration.event_callback:
-        return execution_context.loggers + [
-            construct_event_logger(run_configuration.event_callback)
-        ]
-    elif run_configuration.loggers:
-        return execution_context.loggers + run_configuration.loggers
+    if run_config.event_callback:
+        return execution_context.loggers + [construct_event_logger(run_config.event_callback)]
+    elif run_config.loggers:
+        return execution_context.loggers + run_config.loggers
     else:
         return execution_context.loggers
 
@@ -478,11 +472,7 @@ def get_resource_or_gen(pipeline_def, context_definition, resource_name, environ
 
 
 def execute_pipeline_iterator(
-    pipeline,
-    environment_dict=None,
-    throw_on_user_error=True,
-    run_configuration=None,
-    executor_config=None,
+    pipeline, environment_dict=None, throw_on_user_error=True, run_config=None, executor_config=None
 ):
     '''Returns iterator that yields :py:class:`SolidExecutionResult` for each
     solid executed in the pipeline.
@@ -497,10 +487,10 @@ def execute_pipeline_iterator(
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
-    run_configuration = check_run_configuration_param(run_configuration)
+    run_config = check_run_config_param(run_config)
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, run_configuration
+        pipeline, environment_dict, run_config
     ) as pipeline_context:
 
         pipeline_context.events.pipeline_start()
@@ -546,11 +536,7 @@ class InProcessExecutorConfig:
 
 
 def execute_pipeline(
-    pipeline,
-    environment_dict=None,
-    throw_on_user_error=True,
-    run_configuration=None,
-    executor_config=None,
+    pipeline, environment_dict=None, throw_on_user_error=True, run_config=None, executor_config=None
 ):
     '''
     "Synchronous" version of :py:func:`execute_pipeline_iterator`.
@@ -573,17 +559,17 @@ def execute_pipeline(
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
-    run_configuration = check_run_configuration_param(run_configuration)
+    run_config = check_run_config_param(run_config)
 
     return PipelineExecutionResult(
         pipeline,
-        run_configuration.run_id,
+        run_config.run_id,
         list(
             execute_pipeline_iterator(
                 pipeline=pipeline,
                 environment_dict=environment_dict,
                 throw_on_user_error=throw_on_user_error,
-                run_configuration=run_configuration,
+                run_config=run_config,
                 executor_config=executor_config,
             )
         ),
@@ -640,18 +626,18 @@ def execute_marshalling(
     inputs_to_marshal=None,
     outputs_to_marshal=None,
     environment_dict=None,
-    run_configuration=None,
+    run_config=None,
     throw_on_user_error=True,
     executor_config=None,
 ):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.list_param(step_keys, 'step_keys', of_type=str)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
-    run_configuration = check_run_configuration_param(run_configuration)
+    run_config = check_run_config_param(run_config)
     check.bool_param(throw_on_user_error, 'throw_on_user_error')
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, run_configuration
+        pipeline, environment_dict, run_config
     ) as pipeline_context:
         return list(
             invoke_executor_on_plan(
@@ -674,17 +660,17 @@ def execute_marshalling(
 def execute_plan(
     execution_plan,
     environment_dict=None,
-    run_configuration=None,
+    run_config=None,
     throw_on_user_error=True,
     executor_config=None,
 ):
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
 
-    run_configuration = check_run_configuration_param(run_configuration)
+    run_config = check_run_config_param(run_config)
 
     with yield_pipeline_execution_context(
-        execution_plan.pipeline_def, environment_dict, run_configuration
+        execution_plan.pipeline_def, environment_dict, run_config
     ) as pipeline_context:
         return list(
             invoke_executor_on_plan(

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -24,9 +24,9 @@ def make_new_run_id():
     return str(uuid.uuid4())
 
 
-class ExecutionMetadata(namedtuple('_ExecutionMetadata', 'run_id tags event_callback loggers')):
+class RunConfiguration(namedtuple('_RunConfiguration', 'run_id tags event_callback loggers')):
     def __new__(cls, run_id=None, tags=None, event_callback=None, loggers=None):
-        return super(ExecutionMetadata, cls).__new__(
+        return super(RunConfiguration, cls).__new__(
             cls,
             run_id=check.str_param(run_id, 'run_id') if run_id else make_new_run_id(),
             tags=check.opt_dict_param(tags, 'tags', key_type=str, value_type=str),
@@ -35,7 +35,7 @@ class ExecutionMetadata(namedtuple('_ExecutionMetadata', 'run_id tags event_call
         )
 
     def with_tags(self, **tags):
-        return ExecutionMetadata(
+        return RunConfiguration(
             run_id=self.run_id,
             event_callback=self.event_callback,
             loggers=self.loggers,
@@ -47,7 +47,7 @@ class SystemPipelineExecutionContextData(
     namedtuple(
         '_SystemPipelineExecutionContextData',
         (
-            'execution_metadata resources environment_config persistence_strategy pipeline_def '
+            'run_configuration resources environment_config persistence_strategy pipeline_def '
             'files'
         ),
     )
@@ -59,7 +59,7 @@ class SystemPipelineExecutionContextData(
 
     def __new__(
         cls,
-        execution_metadata,
+        run_configuration,
         resources,
         environment_config,
         persistence_strategy,
@@ -70,8 +70,8 @@ class SystemPipelineExecutionContextData(
 
         return super(SystemPipelineExecutionContextData, cls).__new__(
             cls,
-            execution_metadata=check.inst_param(
-                execution_metadata, 'execution_metadata', ExecutionMetadata
+            run_configuration=check.inst_param(
+                run_configuration, 'run_configuration', RunConfiguration
             ),
             resources=resources,
             environment_config=check.inst_param(
@@ -86,11 +86,11 @@ class SystemPipelineExecutionContextData(
 
     @property
     def run_id(self):
-        return self.execution_metadata.run_id
+        return self.run_configuration.run_id
 
     @property
     def event_callback(self):
-        return self.execution_metadata.event_callback
+        return self.run_configuration.event_callback
 
     @property
     def environment_dict(self):
@@ -118,8 +118,8 @@ class SystemPipelineExecutionContext(object):
         return SystemStepExecutionContext(self._pipeline_context_data, tags, log, step)
 
     @property
-    def execution_metadata(self):
-        return self._pipeline_context_data.execution_metadata
+    def run_configuration(self):
+        return self._pipeline_context_data.run_configuration
 
     @property
     def resources(self):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -24,9 +24,9 @@ def make_new_run_id():
     return str(uuid.uuid4())
 
 
-class RunConfiguration(namedtuple('_RunConfiguration', 'run_id tags event_callback loggers')):
+class RunConfig(namedtuple('_RunConfig', 'run_id tags event_callback loggers')):
     def __new__(cls, run_id=None, tags=None, event_callback=None, loggers=None):
-        return super(RunConfiguration, cls).__new__(
+        return super(RunConfig, cls).__new__(
             cls,
             run_id=check.str_param(run_id, 'run_id') if run_id else make_new_run_id(),
             tags=check.opt_dict_param(tags, 'tags', key_type=str, value_type=str),
@@ -35,7 +35,7 @@ class RunConfiguration(namedtuple('_RunConfiguration', 'run_id tags event_callba
         )
 
     def with_tags(self, **tags):
-        return RunConfiguration(
+        return RunConfig(
             run_id=self.run_id,
             event_callback=self.event_callback,
             loggers=self.loggers,
@@ -46,10 +46,7 @@ class RunConfiguration(namedtuple('_RunConfiguration', 'run_id tags event_callba
 class SystemPipelineExecutionContextData(
     namedtuple(
         '_SystemPipelineExecutionContextData',
-        (
-            'run_configuration resources environment_config persistence_strategy pipeline_def '
-            'files'
-        ),
+        ('run_config resources environment_config persistence_strategy pipeline_def ' 'files'),
     )
 ):
     '''
@@ -58,21 +55,13 @@ class SystemPipelineExecutionContextData(
     '''
 
     def __new__(
-        cls,
-        run_configuration,
-        resources,
-        environment_config,
-        persistence_strategy,
-        pipeline_def,
-        files,
+        cls, run_config, resources, environment_config, persistence_strategy, pipeline_def, files
     ):
         from .definitions.pipeline import PipelineDefinition
 
         return super(SystemPipelineExecutionContextData, cls).__new__(
             cls,
-            run_configuration=check.inst_param(
-                run_configuration, 'run_configuration', RunConfiguration
-            ),
+            run_config=check.inst_param(run_config, 'run_config', RunConfig),
             resources=resources,
             environment_config=check.inst_param(
                 environment_config, 'environment_config', EnvironmentConfig
@@ -86,11 +75,11 @@ class SystemPipelineExecutionContextData(
 
     @property
     def run_id(self):
-        return self.run_configuration.run_id
+        return self.run_config.run_id
 
     @property
     def event_callback(self):
-        return self.run_configuration.event_callback
+        return self.run_config.event_callback
 
     @property
     def environment_dict(self):
@@ -118,8 +107,8 @@ class SystemPipelineExecutionContext(object):
         return SystemStepExecutionContext(self._pipeline_context_data, tags, log, step)
 
     @property
-    def run_configuration(self):
-        return self._pipeline_context_data.run_configuration
+    def run_config(self):
+        return self._pipeline_context_data.run_config
 
     @property
     def resources(self):

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -22,7 +22,7 @@ from .simple_engine import start_inprocess_executor
 
 
 def _execute_in_child_process(
-    queue, executor_config, environment_dict, execution_metadata, step_key, input_meta_dict
+    queue, executor_config, environment_dict, run_configuration, step_key, input_meta_dict
 ):
     from dagster.core.execution import yield_pipeline_execution_context
 
@@ -31,7 +31,7 @@ def _execute_in_child_process(
     pipeline = executor_config.pipeline_fn()
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, execution_metadata.with_tags(pid=str(os.getpid()))
+        pipeline, environment_dict, run_configuration.with_tags(pid=str(os.getpid()))
     ) as pipeline_context:
 
         intermediates_manager = FileSystemIntermediateManager(pipeline_context.files)
@@ -72,7 +72,7 @@ def execute_step_out_of_process(executor_config, step_context, step, intermediat
     queue = multiprocessing.Queue()
 
     check.invariant(
-        not step_context.execution_metadata.loggers,
+        not step_context.run_configuration.loggers,
         'Cannot inject loggers via ExecutionMetadata with the Multiprocess executor',
     )
 
@@ -82,7 +82,7 @@ def execute_step_out_of_process(executor_config, step_context, step, intermediat
             queue,
             executor_config,
             step_context.environment_dict,
-            step_context.execution_metadata,
+            step_context.run_configuration,
             step.key,
             {step_input.name: step_input.prev_output_handle for step_input in step.step_inputs},
         ),

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -22,7 +22,7 @@ from .simple_engine import start_inprocess_executor
 
 
 def _execute_in_child_process(
-    queue, executor_config, environment_dict, run_configuration, step_key, input_meta_dict
+    queue, executor_config, environment_dict, run_config, step_key, input_meta_dict
 ):
     from dagster.core.execution import yield_pipeline_execution_context
 
@@ -31,7 +31,7 @@ def _execute_in_child_process(
     pipeline = executor_config.pipeline_fn()
 
     with yield_pipeline_execution_context(
-        pipeline, environment_dict, run_configuration.with_tags(pid=str(os.getpid()))
+        pipeline, environment_dict, run_config.with_tags(pid=str(os.getpid()))
     ) as pipeline_context:
 
         intermediates_manager = FileSystemIntermediateManager(pipeline_context.files)
@@ -72,7 +72,7 @@ def execute_step_out_of_process(executor_config, step_context, step, intermediat
     queue = multiprocessing.Queue()
 
     check.invariant(
-        not step_context.run_configuration.loggers,
+        not step_context.run_config.loggers,
         'Cannot inject loggers via ExecutionMetadata with the Multiprocess executor',
     )
 
@@ -82,7 +82,7 @@ def execute_step_out_of_process(executor_config, step_context, step, intermediat
             queue,
             executor_config,
             step_context.environment_dict,
-            step_context.run_configuration,
+            step_context.run_config,
             step.key,
             {step_input.name: step_input.prev_output_handle for step_input in step.step_inputs},
         ),

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -102,11 +102,15 @@ class ForkedProcessPipelineFactory(
 
 
 def execute_serializable_execution_plan(
-    pipeline_factory, environment_dict, run_config, step_executions
+    pipeline_factory, environment_dict, serializable_execution_metadata, step_executions
 ):
     check.inst_param(pipeline_factory, 'pipeline_factory', PipelineFactory)
     check.dict_param(environment_dict, 'enviroment_dict', key_type=str)
-    check.inst_param(run_config, 'run_config', SerializableExecutionMetadata)
+    check.inst_param(
+        serializable_execution_metadata,
+        'serializable_execution_metadata',
+        SerializableExecutionMetadata,
+    )
     check.list_param(step_executions, 'step_executions', of_type=StepExecution)
 
     step_events = execute_marshalling(
@@ -115,7 +119,9 @@ def execute_serializable_execution_plan(
         step_keys=list_pull(step_executions, 'step_key'),
         inputs_to_marshal=input_marshalling_dict_from_step_executions(step_executions),
         outputs_to_marshal={se.step_key: se.marshalled_outputs for se in step_executions},
-        run_config=RunConfig(run_id=run_config.run_id, tags=run_config.tags),
+        run_config=RunConfig(
+            run_id=serializable_execution_metadata.run_id, tags=serializable_execution_metadata.tags
+        ),
         throw_on_user_error=False,
     )
 

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -6,7 +6,7 @@ import six
 from dagster import check
 
 from .execution import execute_marshalling
-from .execution_context import RunConfiguration
+from .execution_context import RunConfig
 from .execution_plan.objects import ExecutionStepEvent, ExecutionStepEventType
 from .execution_plan.plan_subset import StepExecution
 
@@ -102,11 +102,11 @@ class ForkedProcessPipelineFactory(
 
 
 def execute_serializable_execution_plan(
-    pipeline_factory, environment_dict, run_configuration, step_executions
+    pipeline_factory, environment_dict, run_config, step_executions
 ):
     check.inst_param(pipeline_factory, 'pipeline_factory', PipelineFactory)
     check.dict_param(environment_dict, 'enviroment_dict', key_type=str)
-    check.inst_param(run_configuration, 'run_configuration', SerializableExecutionMetadata)
+    check.inst_param(run_config, 'run_config', SerializableExecutionMetadata)
     check.list_param(step_executions, 'step_executions', of_type=StepExecution)
 
     step_events = execute_marshalling(
@@ -115,9 +115,7 @@ def execute_serializable_execution_plan(
         step_keys=list_pull(step_executions, 'step_key'),
         inputs_to_marshal=input_marshalling_dict_from_step_executions(step_executions),
         outputs_to_marshal={se.step_key: se.marshalled_outputs for se in step_executions},
-        run_configuration=RunConfiguration(
-            run_id=run_configuration.run_id, tags=run_configuration.tags
-        ),
+        run_config=RunConfig(run_id=run_config.run_id, tags=run_config.tags),
         throw_on_user_error=False,
     )
 

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -6,7 +6,7 @@ import six
 from dagster import check
 
 from .execution import execute_marshalling
-from .execution_context import ExecutionMetadata
+from .execution_context import RunConfiguration
 from .execution_plan.objects import ExecutionStepEvent, ExecutionStepEventType
 from .execution_plan.plan_subset import StepExecution
 
@@ -102,11 +102,11 @@ class ForkedProcessPipelineFactory(
 
 
 def execute_serializable_execution_plan(
-    pipeline_factory, environment_dict, execution_metadata, step_executions
+    pipeline_factory, environment_dict, run_configuration, step_executions
 ):
     check.inst_param(pipeline_factory, 'pipeline_factory', PipelineFactory)
     check.dict_param(environment_dict, 'enviroment_dict', key_type=str)
-    check.inst_param(execution_metadata, 'execution_metadata', SerializableExecutionMetadata)
+    check.inst_param(run_configuration, 'run_configuration', SerializableExecutionMetadata)
     check.list_param(step_executions, 'step_executions', of_type=StepExecution)
 
     step_events = execute_marshalling(
@@ -115,8 +115,8 @@ def execute_serializable_execution_plan(
         step_keys=list_pull(step_executions, 'step_key'),
         inputs_to_marshal=input_marshalling_dict_from_step_executions(step_executions),
         outputs_to_marshal={se.step_key: se.marshalled_outputs for se in step_executions},
-        execution_metadata=ExecutionMetadata(
-            run_id=execution_metadata.run_id, tags=execution_metadata.tags
+        run_configuration=RunConfiguration(
+            run_id=run_configuration.run_id, tags=run_configuration.tags
         ),
         throw_on_user_error=False,
     )

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -16,7 +16,7 @@ from dagster import (
 
 from dagster.core.execution import (
     ExecutionContext,
-    RunConfiguration,
+    RunConfig,
     construct_pipeline_execution_context,
     create_environment_config,
 )
@@ -28,7 +28,7 @@ def create_test_pipeline_execution_context(loggers=None, resources=None, tags=No
     run_id = str(uuid.uuid4())
     pipeline_def = PipelineDefinition(name='test_legacy_context', solids=[])
     return construct_pipeline_execution_context(
-        run_configuration=RunConfiguration(run_id, tags=tags, loggers=loggers),
+        run_config=RunConfig(run_id, tags=tags, loggers=loggers),
         pipeline=pipeline_def,
         execution_context=ExecutionContext(),
         resources=resources,

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -15,8 +15,8 @@ from dagster import (
 )
 
 from dagster.core.execution import (
-    ExecutionMetadata,
     ExecutionContext,
+    RunConfiguration,
     construct_pipeline_execution_context,
     create_environment_config,
 )
@@ -28,7 +28,7 @@ def create_test_pipeline_execution_context(loggers=None, resources=None, tags=No
     run_id = str(uuid.uuid4())
     pipeline_def = PipelineDefinition(name='test_legacy_context', solids=[])
     return construct_pipeline_execution_context(
-        execution_metadata=ExecutionMetadata(run_id, tags=tags, loggers=loggers),
+        run_configuration=RunConfiguration(run_id, tags=tags, loggers=loggers),
         pipeline=pipeline_def,
         execution_context=ExecutionContext(),
         resources=resources,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -4,7 +4,7 @@ from dagster import (
     OutputDefinition,
     PipelineDefinition,
     Result,
-    ExecutionMetadata,
+    RunConfiguration,
     lambda_solid,
     solid,
     types,
@@ -154,7 +154,7 @@ def test_reentrant_execute_plan():
     execution_plan = create_execution_plan(pipeline_def)
 
     step_events = execute_plan(
-        execution_plan, execution_metadata=ExecutionMetadata(tags={'foo': 'bar'})
+        execution_plan, run_configuration=RunConfiguration(tags={'foo': 'bar'})
     )
 
     assert called['yup']

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -4,7 +4,7 @@ from dagster import (
     OutputDefinition,
     PipelineDefinition,
     Result,
-    RunConfiguration,
+    RunConfig,
     lambda_solid,
     solid,
     types,
@@ -153,9 +153,7 @@ def test_reentrant_execute_plan():
     pipeline_def = PipelineDefinition(name='has_tag_pipeline', solids=[has_tag])
     execution_plan = create_execution_plan(pipeline_def)
 
-    step_events = execute_plan(
-        execution_plan, run_configuration=RunConfiguration(tags={'foo': 'bar'})
-    )
+    step_events = execute_plan(execution_plan, run_config=RunConfig(tags={'foo': 'bar'}))
 
     assert called['yup']
     assert len(step_events) == 1

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -17,7 +17,7 @@ from dagster.core.errors import (
     DagsterInvalidSubplanOutputNotFoundError,
 )
 
-from dagster.core.execution import ExecutionMetadata, execute_marshalling
+from dagster.core.execution import execute_marshalling
 
 from dagster.core.execution_plan.objects import StepKind
 from dagster.core.execution_plan.plan_subset import MarshalledOutput
@@ -176,7 +176,6 @@ def test_external_execution_marshal_output_code_error():
             pipeline,
             ['return_one.transform', 'add_one.transform'],
             outputs_to_marshal=outputs_to_marshal,
-            execution_metadata=ExecutionMetadata(),
             throw_on_user_error=True,
         )
 
@@ -186,7 +185,6 @@ def test_external_execution_marshal_output_code_error():
         pipeline,
         ['return_one.transform', 'add_one.transform'],
         outputs_to_marshal=outputs_to_marshal,
-        execution_metadata=ExecutionMetadata(),
         throw_on_user_error=False,
     )
 
@@ -203,12 +201,7 @@ def test_external_execution_output_code_error_throw_on_user_error():
     pipeline = define_inty_pipeline()
 
     with pytest.raises(Exception) as exc_info:
-        execute_marshalling(
-            pipeline,
-            ['user_throw_exception.transform'],
-            execution_metadata=ExecutionMetadata(),
-            throw_on_user_error=True,
-        )
+        execute_marshalling(pipeline, ['user_throw_exception.transform'], throw_on_user_error=True)
 
     assert str(exc_info.value) == 'whoops'
 
@@ -217,10 +210,7 @@ def test_external_execution_output_code_error_no_throw_on_user_error():
     pipeline = define_inty_pipeline()
 
     step_events = execute_marshalling(
-        pipeline,
-        ['user_throw_exception.transform'],
-        execution_metadata=ExecutionMetadata(),
-        throw_on_user_error=False,
+        pipeline, ['user_throw_exception.transform'], throw_on_user_error=False
     )
 
     assert len(step_events) == 1
@@ -235,7 +225,7 @@ def test_external_execution_unsatisfied_input_error():
     pipeline = define_inty_pipeline()
 
     with pytest.raises(DagsterInvalidSubplanMissingInputError) as exc_info:
-        execute_marshalling(pipeline, ['add_one.transform'], execution_metadata=ExecutionMetadata())
+        execute_marshalling(pipeline, ['add_one.transform'])
 
     assert exc_info.value.pipeline_name == 'basic_external_plan_execution'
     assert exc_info.value.step_keys == ['add_one.transform']

--- a/python_modules/dagster/dagster_tests/core_tests/test_reentrant_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_reentrant_context.py
@@ -5,7 +5,7 @@ from dagster import (
     ExecutionContext,
     PipelineContextDefinition,
     PipelineDefinition,
-    RunConfiguration,
+    RunConfig,
     execute_pipeline,
     solid,
 )
@@ -14,7 +14,7 @@ from dagster import (
 def test_injected_run_id():
     run_id = 'kdjfkdjfkd'
     pipeline_def = PipelineDefinition(name='injected_run_id', solids=[])
-    result = execute_pipeline(pipeline_def, run_configuration=RunConfiguration(run_id=run_id))
+    result = execute_pipeline(pipeline_def, run_config=RunConfig(run_id=run_id))
 
     assert result.success
     assert result.run_id == run_id
@@ -29,7 +29,7 @@ def test_injected_tags():
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='injected_run_id', solids=[check_tags])
-    result = execute_pipeline(pipeline_def, run_configuration=RunConfiguration(tags={'foo': 'bar'}))
+    result = execute_pipeline(pipeline_def, run_config=RunConfig(tags={'foo': 'bar'}))
 
     assert result.success
     assert called['yup']
@@ -53,7 +53,7 @@ def test_user_injected_tags():
         context_definitions={'default': PipelineContextDefinition(context_fn=_create_context)},
     )
 
-    result = execute_pipeline(pipeline_def, run_configuration=RunConfiguration(tags={'foo': 'bar'}))
+    result = execute_pipeline(pipeline_def, run_config=RunConfig(tags={'foo': 'bar'}))
 
     assert result.success
     assert called['yup']
@@ -78,4 +78,4 @@ def test_user_injected_tags_collision():
     )
 
     with pytest.raises(DagsterInvariantViolationError, match='You have specified'):
-        execute_pipeline(pipeline_def, run_configuration=RunConfiguration(tags={'foo': 'bar'}))
+        execute_pipeline(pipeline_def, run_config=RunConfig(tags={'foo': 'bar'}))

--- a/python_modules/dagster/dagster_tests/core_tests/test_reentrant_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_reentrant_context.py
@@ -5,7 +5,7 @@ from dagster import (
     ExecutionContext,
     PipelineContextDefinition,
     PipelineDefinition,
-    ExecutionMetadata,
+    RunConfiguration,
     execute_pipeline,
     solid,
 )
@@ -14,7 +14,7 @@ from dagster import (
 def test_injected_run_id():
     run_id = 'kdjfkdjfkd'
     pipeline_def = PipelineDefinition(name='injected_run_id', solids=[])
-    result = execute_pipeline(pipeline_def, execution_metadata=ExecutionMetadata(run_id=run_id))
+    result = execute_pipeline(pipeline_def, run_configuration=RunConfiguration(run_id=run_id))
 
     assert result.success
     assert result.run_id == run_id
@@ -29,9 +29,7 @@ def test_injected_tags():
         called['yup'] = True
 
     pipeline_def = PipelineDefinition(name='injected_run_id', solids=[check_tags])
-    result = execute_pipeline(
-        pipeline_def, execution_metadata=ExecutionMetadata(tags={'foo': 'bar'})
-    )
+    result = execute_pipeline(pipeline_def, run_configuration=RunConfiguration(tags={'foo': 'bar'}))
 
     assert result.success
     assert called['yup']
@@ -55,9 +53,7 @@ def test_user_injected_tags():
         context_definitions={'default': PipelineContextDefinition(context_fn=_create_context)},
     )
 
-    result = execute_pipeline(
-        pipeline_def, execution_metadata=ExecutionMetadata(tags={'foo': 'bar'})
-    )
+    result = execute_pipeline(pipeline_def, run_configuration=RunConfiguration(tags={'foo': 'bar'}))
 
     assert result.success
     assert called['yup']
@@ -82,4 +78,4 @@ def test_user_injected_tags_collision():
     )
 
     with pytest.raises(DagsterInvariantViolationError, match='You have specified'):
-        execute_pipeline(pipeline_def, execution_metadata=ExecutionMetadata(tags={'foo': 'bar'}))
+        execute_pipeline(pipeline_def, run_configuration=RunConfiguration(tags={'foo': 'bar'}))

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_resources.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_resources.py
@@ -2,7 +2,7 @@ import runpy
 import sys
 import warnings
 
-from dagster import execute_pipeline, ExecutionMetadata
+from dagster import execute_pipeline, RunConfiguration
 from dagster.tutorials.intro_tutorial.resources import define_resource_test_pipeline
 
 
@@ -26,7 +26,7 @@ def test_run_local():
             'context': {'local': {}},
             'solids': {'add_ints': {'inputs': {'num_one': {'value': 2}, 'num_two': {'value': 3}}}},
         },
-        execution_metadata=ExecutionMetadata(event_callback=_event_callback),
+        run_configuration=RunConfiguration(event_callback=_event_callback),
     )
 
     assert result.success
@@ -54,7 +54,7 @@ def test_run_cloud():
             },
             'solids': {'add_ints': {'inputs': {'num_one': {'value': 2}, 'num_two': {'value': 6}}}},
         },
-        execution_metadata=ExecutionMetadata(event_callback=_event_callback),
+        run_configuration=RunConfiguration(event_callback=_event_callback),
     )
 
     assert result.success

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_resources.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_resources.py
@@ -2,7 +2,7 @@ import runpy
 import sys
 import warnings
 
-from dagster import execute_pipeline, RunConfiguration
+from dagster import execute_pipeline, RunConfig
 from dagster.tutorials.intro_tutorial.resources import define_resource_test_pipeline
 
 
@@ -26,7 +26,7 @@ def test_run_local():
             'context': {'local': {}},
             'solids': {'add_ints': {'inputs': {'num_one': {'value': 2}, 'num_two': {'value': 3}}}},
         },
-        run_configuration=RunConfiguration(event_callback=_event_callback),
+        run_config=RunConfig(event_callback=_event_callback),
     )
 
     assert result.success
@@ -54,7 +54,7 @@ def test_run_cloud():
             },
             'solids': {'add_ints': {'inputs': {'num_one': {'value': 2}, 'num_two': {'value': 6}}}},
         },
-        run_configuration=RunConfiguration(event_callback=_event_callback),
+        run_config=RunConfig(event_callback=_event_callback),
     )
 
     assert result.success

--- a/python_modules/dagster/docs/apidocs/execution.rst
+++ b/python_modules/dagster/docs/apidocs/execution.rst
@@ -15,7 +15,7 @@ Executing pipelines and solids.
 .. autoclass:: PipelineExecutionResult
    :members:
 
-.. autoclass:: RunConfiguration 
+.. autoclass:: RunConfig 
    :members:
 
 .. autoclass:: SolidExecutionResult

--- a/python_modules/dagster/docs/apidocs/execution.rst
+++ b/python_modules/dagster/docs/apidocs/execution.rst
@@ -15,7 +15,7 @@ Executing pipelines and solids.
 .. autoclass:: PipelineExecutionResult
    :members:
 
-.. autoclass:: ExecutionMetadata
+.. autoclass:: RunConfiguration 
    :members:
 
 .. autoclass:: SolidExecutionResult

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -836,7 +836,7 @@ snapshots['test_build_all_docs 4'] = '''
 </li>
       <li><a href="apidocs/decorators.html#dagster.MultipleResults.results">results (dagster.MultipleResults attribute)</a>
 </li>
-      <li><a href="apidocs/execution.html#dagster.RunConfiguration">RunConfiguration (class in dagster)</a>
+      <li><a href="apidocs/execution.html#dagster.RunConfig">RunConfig (class in dagster)</a>
 </li>
       <li><a href="apidocs/definitions.html#dagster.InputDefinition.runtime_type">runtime_type (dagster.InputDefinition attribute)</a>
 
@@ -2383,7 +2383,7 @@ Executing pipelines and solids.
 .. autoclass:: PipelineExecutionResult
    :members:
 
-.. autoclass:: RunConfiguration 
+.. autoclass:: RunConfig 
    :members:
 
 .. autoclass:: SolidExecutionResult
@@ -20540,7 +20540,7 @@ snapshots['test_build_all_docs 53'] = '''
 <p>Executing pipelines and solids.</p>
 <dl class="function">
 <dt id="dagster.execute_pipeline">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_configuration=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_config=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
 <dd><p>“Synchronous” version of <a class="reference internal" href="#dagster.execute_pipeline_iterator" title="dagster.execute_pipeline_iterator"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline_iterator()</span></code></a>.</p>
 <p>Note: throw_on_user_error is very useful in testing contexts when not testing for error
 conditions</p>
@@ -20565,7 +20565,7 @@ returning the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 
 <dl class="function">
 <dt id="dagster.execute_pipeline_iterator">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_configuration=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_config=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns iterator that yields <a class="reference internal" href="#dagster.SolidExecutionResult" title="dagster.SolidExecutionResult"><code class="xref py py-class docutils literal notranslate"><span class="pre">SolidExecutionResult</span></code></a> for each
 solid executed in the pipeline.</p>
 <p>This is intended to allow the caller to do things between each executed
@@ -20637,8 +20637,8 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 </dd></dl>
 
 <dl class="class">
-<dt id="dagster.RunConfiguration">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">RunConfiguration</code><a class="headerlink" href="#dagster.RunConfiguration" title="Permalink to this definition">¶</a></dt>
+<dt id="dagster.RunConfig">
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">RunConfig</code><a class="headerlink" href="#dagster.RunConfig" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="class">

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -652,11 +652,9 @@ snapshots['test_build_all_docs 4'] = '''
 </li>
       <li><a href="apidocs/utilities.html#dagster.execute_solids">execute_solids() (in module dagster)</a>
 </li>
-      <li><a href="apidocs/execution.html#dagster.ExecutionContext">ExecutionContext (class in dagster)</a>
-</li>
   </ul></td>
   <td style="width: 33%; vertical-align: top;"><ul>
-      <li><a href="apidocs/execution.html#dagster.ExecutionMetadata">ExecutionMetadata (class in dagster)</a>
+      <li><a href="apidocs/execution.html#dagster.ExecutionContext">ExecutionContext (class in dagster)</a>
 </li>
       <li><a href="apidocs/definitions.html#dagster.ExpectationDefinition.expectation_fn">expectation_fn (dagster.ExpectationDefinition attribute)</a>
 </li>
@@ -837,6 +835,8 @@ snapshots['test_build_all_docs 4'] = '''
       <li><a href="apidocs/execution.html#dagster.PipelineExecutionResult.result_list">result_list (dagster.PipelineExecutionResult attribute)</a>
 </li>
       <li><a href="apidocs/decorators.html#dagster.MultipleResults.results">results (dagster.MultipleResults attribute)</a>
+</li>
+      <li><a href="apidocs/execution.html#dagster.RunConfiguration">RunConfiguration (class in dagster)</a>
 </li>
       <li><a href="apidocs/definitions.html#dagster.InputDefinition.runtime_type">runtime_type (dagster.InputDefinition attribute)</a>
 
@@ -2383,7 +2383,7 @@ Executing pipelines and solids.
 .. autoclass:: PipelineExecutionResult
    :members:
 
-.. autoclass:: ExecutionMetadata
+.. autoclass:: RunConfiguration 
    :members:
 
 .. autoclass:: SolidExecutionResult
@@ -20540,7 +20540,7 @@ snapshots['test_build_all_docs 53'] = '''
 <p>Executing pipelines and solids.</p>
 <dl class="function">
 <dt id="dagster.execute_pipeline">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_configuration=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
 <dd><p>“Synchronous” version of <a class="reference internal" href="#dagster.execute_pipeline_iterator" title="dagster.execute_pipeline_iterator"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline_iterator()</span></code></a>.</p>
 <p>Note: throw_on_user_error is very useful in testing contexts when not testing for error
 conditions</p>
@@ -20565,7 +20565,7 @@ returning the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 
 <dl class="function">
 <dt id="dagster.execute_pipeline_iterator">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>execution_metadata=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_configuration=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns iterator that yields <a class="reference internal" href="#dagster.SolidExecutionResult" title="dagster.SolidExecutionResult"><code class="xref py py-class docutils literal notranslate"><span class="pre">SolidExecutionResult</span></code></a> for each
 solid executed in the pipeline.</p>
 <p>This is intended to allow the caller to do things between each executed
@@ -20637,8 +20637,8 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 </dd></dl>
 
 <dl class="class">
-<dt id="dagster.ExecutionMetadata">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">ExecutionMetadata</code><a class="headerlink" href="#dagster.ExecutionMetadata" title="Permalink to this definition">¶</a></dt>
+<dt id="dagster.RunConfiguration">
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">RunConfiguration</code><a class="headerlink" href="#dagster.RunConfiguration" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="class">

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -36,7 +36,7 @@ from dagster.core.events import construct_json_event_logger, EventRecord, EventT
 from dagster.core.execution import yield_pipeline_execution_context
 from dagster.core.execution_context import (
     DagsterLog,
-    ExecutionMetadata,
+    RunConfiguration,
     SystemPipelineExecutionContext,
     SystemTransformExecutionContext,
 )
@@ -123,7 +123,7 @@ class Manager:
         with yield_pipeline_execution_context(
             pipeline_def,
             {} if context_config is None else {'context': context_config},
-            ExecutionMetadata(run_id=''),
+            RunConfiguration(run_id=''),
         ) as pipeline_context:
             self.context = DagstermillInNotebookExecutionContext(pipeline_context)
         return self.context
@@ -176,11 +176,11 @@ class Manager:
             loggers = [event_logger]
         # do not include event_callback in ExecutionMetadata,
         # since that'll be taken care of by side-channel established by event_logger
-        execution_metadata = ExecutionMetadata(run_id, loggers=loggers)
+        run_configuration = RunConfiguration(run_id, loggers=loggers)
         # See block comment above referencing this issue
         # See https://github.com/dagster-io/dagster/issues/796
         with yield_pipeline_execution_context(
-            self.pipeline_def, environment_dict, execution_metadata
+            self.pipeline_def, environment_dict, run_configuration
         ) as pipeline_context:
             self.context = DagstermillInNotebookExecutionContext(pipeline_context)
 

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -36,7 +36,7 @@ from dagster.core.events import construct_json_event_logger, EventRecord, EventT
 from dagster.core.execution import yield_pipeline_execution_context
 from dagster.core.execution_context import (
     DagsterLog,
-    RunConfiguration,
+    RunConfig,
     SystemPipelineExecutionContext,
     SystemTransformExecutionContext,
 )
@@ -123,7 +123,7 @@ class Manager:
         with yield_pipeline_execution_context(
             pipeline_def,
             {} if context_config is None else {'context': context_config},
-            RunConfiguration(run_id=''),
+            RunConfig(run_id=''),
         ) as pipeline_context:
             self.context = DagstermillInNotebookExecutionContext(pipeline_context)
         return self.context
@@ -176,11 +176,11 @@ class Manager:
             loggers = [event_logger]
         # do not include event_callback in ExecutionMetadata,
         # since that'll be taken care of by side-channel established by event_logger
-        run_configuration = RunConfiguration(run_id, loggers=loggers)
+        run_config = RunConfig(run_id, loggers=loggers)
         # See block comment above referencing this issue
         # See https://github.com/dagster-io/dagster/issues/796
         with yield_pipeline_execution_context(
-            self.pipeline_def, environment_dict, run_configuration
+            self.pipeline_def, environment_dict, run_config
         ) as pipeline_context:
             self.context = DagstermillInNotebookExecutionContext(pipeline_context)
 


### PR DESCRIPTION
Now that this has more complex, non-serializable data, this is increasingly inaccurate. Instead we will name this run config. We may *reintroduce* the notion ExecutionMetadata to be the purely serializable parts of this.

Next steps:
    - Incorporate executor-specific config options. E.g. InProcess versus Multiprocess.
    - Incorporate throw_on_user_error into InProcessExecutorConfig
