### PR TITLE
Combine ExecutorConfig and RunConfig; move throw_on_user_error into executor_config

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -8,7 +8,12 @@ from dagster.core.execution import (
     execute_pipeline_iterator,
 )
 
-from dagster.core.execution_context import RunConfig
+from dagster.core.execution_context import (
+    InProcessExecutorConfig,
+    MultiprocessExecutorConfig,
+    RunConfig,
+)
+
 from dagster.core.user_context import ExecutionContext
 
 from dagster.core.definitions import (

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -30,6 +30,8 @@ from .definitions.environment_configs import construct_environment_config
 
 from .execution_context import (
     RunConfig,
+    InProcessExecutorConfig,
+    MultiprocessExecutorConfig,
     SystemPipelineExecutionContextData,
     SystemPipelineExecutionContext,
 )
@@ -54,10 +56,7 @@ from .execution_plan.objects import (
     StepKind,
 )
 
-from .execution_plan.multiprocessing_engine import (
-    multiprocess_execute_plan,
-    MultiprocessExecutorConfig,
-)
+from .execution_plan.multiprocessing_engine import multiprocess_execute_plan
 
 from .execution_plan.simple_engine import start_inprocess_executor
 
@@ -529,10 +528,6 @@ def execute_pipeline_iterator(
             pipeline_context.events.pipeline_success()
         else:
             pipeline_context.events.pipeline_failure()
-
-
-class InProcessExecutorConfig:
-    pass
 
 
 def execute_pipeline(

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -470,9 +470,7 @@ def get_resource_or_gen(pipeline_def, context_definition, resource_name, environ
     )
 
 
-def execute_pipeline_iterator(
-    pipeline, environment_dict=None, throw_on_user_error=True, run_config=None
-):
+def execute_pipeline_iterator(pipeline, environment_dict=None, run_config=None):
     '''Returns iterator that yields :py:class:`SolidExecutionResult` for each
     solid executed in the pipeline.
 
@@ -485,7 +483,6 @@ def execute_pipeline_iterator(
     '''
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
-    check.bool_param(throw_on_user_error, 'throw_on_user_error')
     run_config = check_run_config_param(run_config)
 
     with yield_pipeline_execution_context(
@@ -517,9 +514,7 @@ def execute_pipeline_iterator(
 
         pipeline_success = True
 
-        for step_event in invoke_executor_on_plan(
-            pipeline_context, execution_plan, throw_on_user_error
-        ):
+        for step_event in invoke_executor_on_plan(pipeline_context, execution_plan):
             if step_event.is_step_failure:
                 pipeline_success = False
             yield step_event
@@ -530,7 +525,7 @@ def execute_pipeline_iterator(
             pipeline_context.events.pipeline_failure()
 
 
-def execute_pipeline(pipeline, environment_dict=None, throw_on_user_error=True, run_config=None):
+def execute_pipeline(pipeline, environment_dict=None, run_config=None):
     '''
     "Synchronous" version of :py:func:`execute_pipeline_iterator`.
 
@@ -540,10 +535,6 @@ def execute_pipeline(pipeline, environment_dict=None, throw_on_user_error=True, 
     Parameters:
       pipeline (PipelineDefinition): Pipeline to run
       environment (dict): The enviroment that parameterizes this run
-      throw_on_user_error (bool):
-        throw_on_user_error makes the function throw when an error is encoutered rather than
-        returning the py:class:`SolidExecutionResult` in an error-state.
-
 
     Returns:
       PipelineExecutionResult
@@ -551,7 +542,6 @@ def execute_pipeline(pipeline, environment_dict=None, throw_on_user_error=True, 
 
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
-    check.bool_param(throw_on_user_error, 'throw_on_user_error')
     run_config = check_run_config_param(run_config)
 
     return PipelineExecutionResult(
@@ -559,10 +549,7 @@ def execute_pipeline(pipeline, environment_dict=None, throw_on_user_error=True, 
         run_config.run_id,
         list(
             execute_pipeline_iterator(
-                pipeline=pipeline,
-                environment_dict=environment_dict,
-                throw_on_user_error=throw_on_user_error,
-                run_config=run_config,
+                pipeline=pipeline, environment_dict=environment_dict, run_config=run_config
             )
         ),
     )
@@ -591,7 +578,7 @@ class PipelineConfigEvaluationError(Exception):
         super(PipelineConfigEvaluationError, self).__init__(error_msg, *args, **kwargs)
 
 
-def invoke_executor_on_plan(pipeline_context, execution_plan, throw_on_user_error):
+def invoke_executor_on_plan(pipeline_context, execution_plan):
     if isinstance(pipeline_context.executor_config, InProcessExecutorConfig):
         step_events_gen = start_inprocess_executor(
             pipeline_context, execution_plan, InMemoryIntermediatesManager()
@@ -602,8 +589,6 @@ def invoke_executor_on_plan(pipeline_context, execution_plan, throw_on_user_erro
         check.failed('Unsupported config {}'.format(pipeline_context.executor_config))
 
     for step_event in step_events_gen:
-        if throw_on_user_error and step_event.is_step_failure:
-            step_event.reraise_user_error()
         yield step_event
 
 
@@ -614,13 +599,11 @@ def execute_marshalling(
     outputs_to_marshal=None,
     environment_dict=None,
     run_config=None,
-    throw_on_user_error=True,
 ):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     check.list_param(step_keys, 'step_keys', of_type=str)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     run_config = check_run_config_param(run_config)
-    check.bool_param(throw_on_user_error, 'throw_on_user_error')
 
     with yield_pipeline_execution_context(
         pipeline, environment_dict, run_config
@@ -637,25 +620,19 @@ def execute_marshalling(
                         outputs_to_marshal
                     ),
                 ),
-                throw_on_user_error=throw_on_user_error,
             )
         )
 
 
-def execute_plan(execution_plan, environment_dict=None, run_config=None, throw_on_user_error=True):
+def execute_plan(execution_plan, environment_dict=None, run_config=None):
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
-
     run_config = check_run_config_param(run_config)
 
     with yield_pipeline_execution_context(
         execution_plan.pipeline_def, environment_dict, run_config
     ) as pipeline_context:
-        return list(
-            invoke_executor_on_plan(
-                pipeline_context, execution_plan, throw_on_user_error=throw_on_user_error
-            )
-        )
+        return list(invoke_executor_on_plan(pipeline_context, execution_plan))
 
 
 def create_environment_config(pipeline, environment_dict=None):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -25,12 +25,14 @@ class ExecutorConfig:
 
 
 class InProcessExecutorConfig(ExecutorConfig):
-    pass
+    def __init__(self, throw_on_user_error=True):
+        self.throw_on_user_error = check.bool_param(throw_on_user_error, 'throw_on_user_error')
 
 
 class MultiprocessExecutorConfig(ExecutorConfig):
     def __init__(self, pipeline_fn):
         self.pipeline_fn = check.callable_param(pipeline_fn, 'pipeline_fn')
+        self.throw_on_user_error = False
 
 
 def make_new_run_id():
@@ -51,6 +53,10 @@ class RunConfig(namedtuple('_RunConfig', 'run_id tags event_callback loggers exe
                 executor_config, 'executor_config', ExecutorConfig, InProcessExecutorConfig()
             ),
         )
+
+    @staticmethod
+    def nonthrowing_in_process():
+        return RunConfig(executor_config=InProcessExecutorConfig(throw_on_user_error=False))
 
     def with_tags(self, **tags):
         return RunConfig(

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -20,11 +20,15 @@ from .system_config.objects import EnvironmentConfig
 from .types.marshal import PersistenceStrategy
 
 
-class InProcessExecutorConfig:
+class ExecutorConfig:
     pass
 
 
-class MultiprocessExecutorConfig:
+class InProcessExecutorConfig(ExecutorConfig):
+    pass
+
+
+class MultiprocessExecutorConfig(ExecutorConfig):
     def __init__(self, pipeline_fn):
         self.pipeline_fn = check.callable_param(pipeline_fn, 'pipeline_fn')
 
@@ -33,14 +37,19 @@ def make_new_run_id():
     return str(uuid.uuid4())
 
 
-class RunConfig(namedtuple('_RunConfig', 'run_id tags event_callback loggers')):
-    def __new__(cls, run_id=None, tags=None, event_callback=None, loggers=None):
+class RunConfig(namedtuple('_RunConfig', 'run_id tags event_callback loggers executor_config')):
+    def __new__(
+        cls, run_id=None, tags=None, event_callback=None, loggers=None, executor_config=None
+    ):
         return super(RunConfig, cls).__new__(
             cls,
             run_id=check.str_param(run_id, 'run_id') if run_id else make_new_run_id(),
             tags=check.opt_dict_param(tags, 'tags', key_type=str, value_type=str),
             event_callback=check.opt_callable_param(event_callback, 'event_callback'),
             loggers=check.opt_list_param(loggers, 'loggers'),
+            executor_config=check.opt_inst_param(
+                executor_config, 'executor_config', ExecutorConfig, InProcessExecutorConfig()
+            ),
         )
 
     def with_tags(self, **tags):
@@ -49,13 +58,14 @@ class RunConfig(namedtuple('_RunConfig', 'run_id tags event_callback loggers')):
             event_callback=self.event_callback,
             loggers=self.loggers,
             tags=merge_dicts(self.tags, tags),
+            executor_config=self.executor_config,
         )
 
 
 class SystemPipelineExecutionContextData(
     namedtuple(
         '_SystemPipelineExecutionContextData',
-        ('run_config resources environment_config persistence_strategy pipeline_def ' 'files'),
+        'run_config resources environment_config persistence_strategy pipeline_def files',
     )
 ):
     '''
@@ -114,6 +124,10 @@ class SystemPipelineExecutionContext(object):
         tags = merge_dicts(self.tags, step.tags)
         log = DagsterLog(self.run_id, tags, self.log.loggers)
         return SystemStepExecutionContext(self._pipeline_context_data, tags, log, step)
+
+    @property
+    def executor_config(self):
+        return self.run_config.executor_config
 
     @property
     def run_config(self):

--- a/python_modules/dagster/dagster/core/execution_context.py
+++ b/python_modules/dagster/dagster/core/execution_context.py
@@ -20,6 +20,15 @@ from .system_config.objects import EnvironmentConfig
 from .types.marshal import PersistenceStrategy
 
 
+class InProcessExecutorConfig:
+    pass
+
+
+class MultiprocessExecutorConfig:
+    def __init__(self, pipeline_fn):
+        self.pipeline_fn = check.callable_param(pipeline_fn, 'pipeline_fn')
+
+
 def make_new_run_id():
     return str(uuid.uuid4())
 

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -5,7 +5,10 @@ from dagster import check
 from dagster.utils import mkdir_p
 from dagster.core.errors import DagsterSubprocessExecutionError
 
-from dagster.core.execution_context import SystemPipelineExecutionContext
+from dagster.core.execution_context import (
+    MultiprocessExecutorConfig,
+    SystemPipelineExecutionContext,
+)
 
 from .create import create_execution_plan_core
 from .intermediates_manager import FileSystemIntermediateManager
@@ -137,11 +140,6 @@ def _create_input_values(step_input_meta_dict, manager):
         input_value = manager.get_value(prev_output_handle_meta)
         input_values[step_input_name] = input_value
     return input_values
-
-
-class MultiprocessExecutorConfig:
-    def __init__(self, pipeline_fn):
-        self.pipeline_fn = pipeline_fn
 
 
 def _all_inputs_covered(step, intermediates_manager):

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -24,14 +24,13 @@ from .plan_subset import ExecutionPlanSubsetInfo
 from .simple_engine import start_inprocess_executor
 
 
-def _execute_in_child_process(
-    queue, executor_config, environment_dict, run_config, step_key, input_meta_dict
-):
+def _execute_in_child_process(queue, environment_dict, run_config, step_key, input_meta_dict):
     from dagster.core.execution import yield_pipeline_execution_context
 
+    check.inst(run_config.executor_config, MultiprocessExecutorConfig)
     check.dict_param(input_meta_dict, 'input_meta_data', key_type=str, value_type=StepOutputHandle)
 
-    pipeline = executor_config.pipeline_fn()
+    pipeline = run_config.executor_config.pipeline_fn()
 
     with yield_pipeline_execution_context(
         pipeline, environment_dict, run_config.with_tags(pid=str(os.getpid()))
@@ -71,7 +70,7 @@ def _execute_in_child_process(
     queue.close()
 
 
-def execute_step_out_of_process(executor_config, step_context, step, intermediates_manager):
+def execute_step_out_of_process(step_context, step, intermediates_manager):
     queue = multiprocessing.Queue()
 
     check.invariant(
@@ -83,7 +82,6 @@ def execute_step_out_of_process(executor_config, step_context, step, intermediat
         target=_execute_in_child_process,
         args=(
             queue,
-            executor_config,
             step_context.environment_dict,
             step_context.run_config,
             step.key,
@@ -149,8 +147,7 @@ def _all_inputs_covered(step, intermediates_manager):
     return True
 
 
-def multiprocess_execute_plan(executor_config, pipeline_context, execution_plan):
-    check.inst_param(executor_config, 'executor_config', MultiprocessExecutorConfig)
+def multiprocess_execute_plan(pipeline_context, execution_plan):
     check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
 
@@ -183,9 +180,7 @@ def multiprocess_execute_plan(executor_config, pipeline_context, execution_plan)
                 continue
 
             for step_event in check.generator(
-                execute_step_out_of_process(
-                    executor_config, step_context, step, intermediates_manager
-                )
+                execute_step_out_of_process(step_context, step, intermediates_manager)
             ):
                 check.inst(step_event, ExecutionStepEvent)
                 yield step_event

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -6,7 +6,7 @@ import six
 from dagster import check
 
 from .execution import execute_marshalling
-from .execution_context import RunConfig
+from .execution_context import RunConfig, InProcessExecutorConfig
 from .execution_plan.objects import ExecutionStepEvent, ExecutionStepEventType
 from .execution_plan.plan_subset import StepExecution
 
@@ -120,9 +120,10 @@ def execute_serializable_execution_plan(
         inputs_to_marshal=input_marshalling_dict_from_step_executions(step_executions),
         outputs_to_marshal={se.step_key: se.marshalled_outputs for se in step_executions},
         run_config=RunConfig(
-            run_id=serializable_execution_metadata.run_id, tags=serializable_execution_metadata.tags
+            run_id=serializable_execution_metadata.run_id,
+            tags=serializable_execution_metadata.tags,
+            executor_config=InProcessExecutorConfig(throw_on_user_error=False),
         ),
-        throw_on_user_error=False,
     )
 
     return list(map(_to_serializable_step_event, step_events))

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -2,9 +2,11 @@ from dagster import (
     DagsterEvaluateConfigValueError,
     DagsterInvariantViolationError,
     ExecutionContext,
+    InProcessExecutorConfig,
     PipelineDefinition,
     PipelineContextDefinition,
     Result,
+    RunConfig,
     SolidDefinition,
     check,
     execute_pipeline,
@@ -44,7 +46,9 @@ def execute_single_solid_in_isolation(
             ),
         ),
         environment_dict=single_solid_environment,
-        throw_on_user_error=throw_on_user_error,
+        run_config=RunConfig(
+            executor_config=InProcessExecutorConfig(throw_on_user_error=throw_on_user_error)
+        ),
     )
 
     return pipeline_result

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
@@ -2,6 +2,7 @@ from dagster import (
     DependencyDefinition,
     InputDefinition,
     PipelineDefinition,
+    RunConfig,
     execute_pipeline,
     lambda_solid,
 )
@@ -10,7 +11,9 @@ from dagster.core.execution import InProcessExecutorConfig, MultiprocessExecutor
 
 
 def test_diamond_simple_execution():
-    result = execute_pipeline(define_diamond_pipeline(), executor_config=InProcessExecutorConfig())
+    result = execute_pipeline(
+        define_diamond_pipeline(), run_config=RunConfig(executor_config=InProcessExecutorConfig())
+    )
     assert result.success
     assert result.result_for_solid('adder').transformed_value() == 11
 
@@ -22,7 +25,8 @@ def transform_event(result, solid_name):
 def test_diamond_multi_execution():
     pipeline = define_diamond_pipeline()
     result = execute_pipeline(
-        pipeline, executor_config=MultiprocessExecutorConfig(define_diamond_pipeline)
+        pipeline,
+        run_config=RunConfig(executor_config=MultiprocessExecutorConfig(define_diamond_pipeline)),
     )
     assert result.success
     assert result.result_for_solid('adder').transformed_value() == 11
@@ -77,7 +81,9 @@ def define_error_pipeline():
 def test_error_pipeline():
     pipeline = define_error_pipeline()
     result = execute_pipeline(
-        pipeline, throw_on_user_error=False, executor_config=InProcessExecutorConfig()
+        pipeline,
+        throw_on_user_error=False,
+        run_config=RunConfig(executor_config=InProcessExecutorConfig()),
     )
     assert not result.success
 
@@ -87,6 +93,6 @@ def test_error_pipeline_multiprocess():
     result = execute_pipeline(
         pipeline,
         throw_on_user_error=False,
-        executor_config=MultiprocessExecutorConfig(define_error_pipeline),
+        run_config=RunConfig(executor_config=MultiprocessExecutorConfig(define_error_pipeline)),
     )
     assert not result.success

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_multiprocessing.py
@@ -82,8 +82,7 @@ def test_error_pipeline():
     pipeline = define_error_pipeline()
     result = execute_pipeline(
         pipeline,
-        throw_on_user_error=False,
-        run_config=RunConfig(executor_config=InProcessExecutorConfig()),
+        run_config=RunConfig(executor_config=InProcessExecutorConfig(throw_on_user_error=False)),
     )
     assert not result.success
 
@@ -92,7 +91,6 @@ def test_error_pipeline_multiprocess():
     pipeline = define_error_pipeline()
     result = execute_pipeline(
         pipeline,
-        throw_on_user_error=False,
         run_config=RunConfig(executor_config=MultiprocessExecutorConfig(define_error_pipeline)),
     )
     assert not result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_custom_context.py
@@ -183,20 +183,12 @@ def test_invalid_context():
     with pytest.raises(
         PipelineConfigEvaluationError, match='Undefined field "not_found" at path root:context'
     ):
-        execute_pipeline(
-            default_context_pipeline,
-            environment_dict=environment_context_not_found,
-            throw_on_user_error=True,
-        )
+        execute_pipeline(default_context_pipeline, environment_dict=environment_context_not_found)
 
     environment_field_name_mismatch = {'context': {'default': {'config': {'unexpected': 'value'}}}}
 
     with pytest.raises(PipelineConfigEvaluationError, match='Undefined field "unexpected"'):
-        execute_pipeline(
-            default_context_pipeline,
-            environment_dict=environment_field_name_mismatch,
-            throw_on_user_error=True,
-        )
+        execute_pipeline(default_context_pipeline, environment_dict=environment_field_name_mismatch)
 
     with_argful_context_pipeline = PipelineDefinition(
         solids=[never_transform],
@@ -217,11 +209,7 @@ def test_invalid_context():
             'root:context:default:config Expected: "{ string_field: String }"'
         ),
     ):
-        execute_pipeline(
-            with_argful_context_pipeline,
-            environment_dict=environment_no_config_error,
-            throw_on_user_error=True,
-        )
+        execute_pipeline(with_argful_context_pipeline, environment_dict=environment_no_config_error)
 
     environment_type_mismatch_error = {'context': {'default': {'config': {'string_field': 1}}}}
 
@@ -234,7 +222,5 @@ def test_invalid_context():
         ),
     ):
         execute_pipeline(
-            with_argful_context_pipeline,
-            environment_dict=environment_type_mismatch_error,
-            throw_on_user_error=True,
+            with_argful_context_pipeline, environment_dict=environment_type_mismatch_error
         )

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 
 from dagster import (
     ExecutionContext,
+    InProcessExecutorConfig,
+    RunConfig,
     PipelineDefinition,
     PipelineContextDefinition,
     execute_pipeline,
@@ -102,7 +104,10 @@ def test_single_solid_pipeline_failure():
         name='single_solid_pipeline', solids=[solid_one], event_callback=_event_callback
     )
 
-    result = execute_pipeline(pipeline_def, throw_on_user_error=False)
+    result = execute_pipeline(
+        pipeline_def,
+        run_config=RunConfig(executor_config=InProcessExecutorConfig(throw_on_user_error=False)),
+    )
     assert not result.success
 
     start_event = single_event(events, EventType.EXECUTION_PLAN_STEP_START)

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -4,6 +4,8 @@ from dagster import (
     DependencyDefinition,
     InputDefinition,
     Int,
+    RunConfig,
+    InProcessExecutorConfig,
     OutputDefinition,
     PipelineDefinition,
     lambda_solid,
@@ -116,14 +118,13 @@ def test_external_execution_input_marshal_code_error():
             pipeline,
             ['add_one.transform'],
             inputs_to_marshal={'add_one.transform': {'num': 'nope'}},
-            throw_on_user_error=True,
         )
 
     step_events = execute_marshalling(
         pipeline,
         ['add_one.transform'],
         inputs_to_marshal={'add_one.transform': {'num': 'nope'}},
-        throw_on_user_error=False,
+        run_config=RunConfig.nonthrowing_in_process(),
     )
 
     assert len(step_events) == 1
@@ -176,7 +177,6 @@ def test_external_execution_marshal_output_code_error():
             pipeline,
             ['return_one.transform', 'add_one.transform'],
             outputs_to_marshal=outputs_to_marshal,
-            throw_on_user_error=True,
         )
 
     assert 'No such file or directory' in str(exc_info.value)
@@ -185,7 +185,7 @@ def test_external_execution_marshal_output_code_error():
         pipeline,
         ['return_one.transform', 'add_one.transform'],
         outputs_to_marshal=outputs_to_marshal,
-        throw_on_user_error=False,
+        run_config=RunConfig.nonthrowing_in_process(),
     )
 
     assert len(step_events) == 3
@@ -201,7 +201,7 @@ def test_external_execution_output_code_error_throw_on_user_error():
     pipeline = define_inty_pipeline()
 
     with pytest.raises(Exception) as exc_info:
-        execute_marshalling(pipeline, ['user_throw_exception.transform'], throw_on_user_error=True)
+        execute_marshalling(pipeline, ['user_throw_exception.transform'])
 
     assert str(exc_info.value) == 'whoops'
 
@@ -210,7 +210,7 @@ def test_external_execution_output_code_error_no_throw_on_user_error():
     pipeline = define_inty_pipeline()
 
     step_events = execute_marshalling(
-        pipeline, ['user_throw_exception.transform'], throw_on_user_error=False
+        pipeline, ['user_throw_exception.transform'], run_config=RunConfig.nonthrowing_in_process()
     )
 
     assert len(step_events) == 1

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -4,11 +4,13 @@ from dagster import (
     DagsterInvariantViolationError,
     DependencyDefinition,
     ExecutionContext,
+    InProcessExecutorConfig,
     InputDefinition,
     OutputDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
     Result,
+    RunConfig,
     SolidDefinition,
     check,
     execute_pipeline,
@@ -51,7 +53,7 @@ def create_root_transform_failure_solid(name):
 
 def test_transform_failure_pipeline():
     pipeline = silencing_pipeline(solids=[create_root_transform_failure_solid('failing')])
-    pipeline_result = execute_pipeline(pipeline, throw_on_user_error=False)
+    pipeline_result = execute_pipeline(pipeline, run_config=RunConfig.nonthrowing_in_process())
 
     assert not pipeline_result.success
 
@@ -83,7 +85,7 @@ def test_failure_midstream():
             'C': {'A': DependencyDefinition(solid_a.name), 'B': DependencyDefinition(solid_b.name)}
         },
     )
-    pipeline_result = execute_pipeline(pipeline, throw_on_user_error=False)
+    pipeline_result = execute_pipeline(pipeline, run_config=RunConfig.nonthrowing_in_process())
 
     assert pipeline_result.result_for_solid('A').success
     assert pipeline_result.result_for_solid('B').success

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_expectations.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_expectations.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dagster import DagsterExpectationFailedError, execute_pipeline
+from dagster import DagsterExpectationFailedError, execute_pipeline, RunConfig
 from dagster.tutorials.intro_tutorial.expectations import define_expectations_tutorial_pipeline
 
 
@@ -34,7 +34,7 @@ def test_intro_tutorial_expectations_step_two_fails_soft():
     result = execute_pipeline(
         define_expectations_tutorial_pipeline(),
         define_failing_environment_config(),
-        throw_on_user_error=False,
+        run_config=RunConfig.nonthrowing_in_process(),
     )
 
     assert not result.success

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20540,7 +20540,7 @@ snapshots['test_build_all_docs 53'] = '''
 <p>Executing pipelines and solids.</p>
 <dl class="function">
 <dt id="dagster.execute_pipeline">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_config=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>run_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline" title="Permalink to this definition">¶</a></dt>
 <dd><p>“Synchronous” version of <a class="reference internal" href="#dagster.execute_pipeline_iterator" title="dagster.execute_pipeline_iterator"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline_iterator()</span></code></a>.</p>
 <p>Note: throw_on_user_error is very useful in testing contexts when not testing for error
 conditions</p>
@@ -20551,8 +20551,6 @@ conditions</p>
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
 <li><strong>pipeline</strong> (<a class="reference internal" href="definitions.html#dagster.PipelineDefinition" title="dagster.PipelineDefinition"><em>PipelineDefinition</em></a>) – Pipeline to run</li>
 <li><strong>environment</strong> (<em>dict</em>) – The enviroment that parameterizes this run</li>
-<li><strong>throw_on_user_error</strong> (<em>bool</em>) – throw_on_user_error makes the function throw when an error is encoutered rather than
-returning the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 </ul>
 </td>
 </tr>
@@ -20565,7 +20563,7 @@ returning the py:class:<cite>SolidExecutionResult</cite> in an error-state.</li>
 
 <dl class="function">
 <dt id="dagster.execute_pipeline_iterator">
-<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>throw_on_user_error=True</em>, <em>run_config=None</em>, <em>executor_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">dagster.</code><code class="descname">execute_pipeline_iterator</code><span class="sig-paren">(</span><em>pipeline</em>, <em>environment_dict=None</em>, <em>run_config=None</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.execute_pipeline_iterator" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns iterator that yields <a class="reference internal" href="#dagster.SolidExecutionResult" title="dagster.SolidExecutionResult"><code class="xref py py-class docutils literal notranslate"><span class="pre">SolidExecutionResult</span></code></a> for each
 solid executed in the pipeline.</p>
 <p>This is intended to allow the caller to do things between each executed

--- a/python_modules/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from dagster import execute_pipeline
+from dagster import execute_pipeline, RunConfig
 
 from dagstermill import DagstermillError
 from dagstermill.examples.repository import (
@@ -66,7 +66,7 @@ def test_notebook_dag():
 def test_error_notebook():
     with pytest.raises(DagstermillError, match='Someone set up us the bomb'):
         execute_pipeline(define_error_pipeline())
-    res = execute_pipeline(define_error_pipeline(), throw_on_user_error=False)
+    res = execute_pipeline(define_error_pipeline(), run_config=RunConfig.nonthrowing_in_process())
     assert not res.success
     assert res.step_event_list[0].event_type.value == 'STEP_FAILURE'
 


### PR DESCRIPTION
This PR does two things:

1) It folds the "executor config" into the run config. There is now one master run config object that provides the knobs for execution behavior for a particular run
2) In that spirit, I have also folded the ever-present and -annoying "throw_on_user_error" parameter into the InProcessExecutorConfig. This parameter really only makes sense in that context. We default to aggressively rethrowing "out-of-the-box" as that is what one would expect in test environments, where the bulk of these calls can and should go. (Note: this is a direct lesson from graphql, which by default swallows errors which I think was a bad mistake). This removes a bunch of threading up and down call stacks which feels nice.