### PR TITLE
Make ExecutionStepEvent Serializable; Use in Multiprocessing Engine (stacked on #890)

### DIFF
--- a/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
+++ b/python_modules/dagit/dagit_tests/snapshots/snap_test_graphql.py
@@ -61,7 +61,8 @@ snapshots['test_user_error_pipeline 1'] = {
         'stepEvents': [
             {
                 '__typename': 'StepFailureEvent',
-                'errorMessage': 'Error occured during step throw_a_thing.transform',
+                'errorMessage': '''Exception: bad programmer, bad
+''',
                 'step': {
                     'key': 'throw_a_thing.transform'
                 },
@@ -81,7 +82,8 @@ snapshots['test_user_code_error_subplan 1'] = {
         'stepEvents': [
             {
                 '__typename': 'StepFailureEvent',
-                'errorMessage': 'Error occured during step throw_a_thing.transform',
+                'errorMessage': '''Exception: bad programmer, bad
+''',
                 'step': {
                     'key': 'throw_a_thing.transform'
                 },

--- a/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
+++ b/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
@@ -93,7 +93,5 @@ def test_run_airflow_error_dag(scaffold_error_dag):
     for task in tasks:
         ti = TaskInstance(task=task, execution_date=execution_date)
         context = ti.get_template_context()
-        with pytest.raises(
-            AirflowException, match='Error occured during step error_solid.transform'
-        ):
+        with pytest.raises(AirflowException, match='Unusual error'):
             task.execute(context)

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -9,7 +9,7 @@ import click
 from dagster import PipelineDefinition, check
 
 from dagster.core.definitions import Solid
-from dagster.core.execution import execute_pipeline_iterator
+from dagster.core.execution import execute_pipeline
 from dagster.core.execution_plan.create import solids_in_topological_order
 from dagster.graphviz import build_graphviz_graph
 from dagster.utils import load_yaml_from_glob_list
@@ -310,9 +310,7 @@ def do_execute_command(pipeline, env_file_list, printer):
 
     env_config = load_yaml_from_glob_list(env_file_list) if env_file_list else {}
 
-    pipeline_iter = execute_pipeline_iterator(pipeline, env_config)
-
-    process_results_for_console(pipeline_iter)
+    execute_pipeline(pipeline, env_config)
 
 
 @click.command(
@@ -341,14 +339,3 @@ def do_scaffold_command(pipeline, printer, skip_optional):
     config_dict = scaffold_pipeline_config(pipeline, skip_optional=skip_optional)
     yaml_string = yaml.dump(config_dict, default_flow_style=False)
     printer(yaml_string)
-
-
-def process_results_for_console(pipeline_iter):
-    step_events = []
-
-    for step_event in pipeline_iter:
-        if step_event.is_step_failure:
-            step_event.reraise_user_error()
-        step_events.append(step_event)
-
-    return step_events

--- a/python_modules/dagster/dagster/core/execute_marshalling.py
+++ b/python_modules/dagster/dagster/core/execute_marshalling.py
@@ -169,7 +169,7 @@ def marshal_outputs(
         for event in events:
             if event.is_successful_output:
                 successful_outputs.add(
-                    StepOutputHandle(event.step.key, event.step_output_data.output_name)
+                    StepOutputHandle(event.step_key, event.step_output_data.output_name)
                 )
 
         for step_key, marshalled_outputs in outputs_to_marshal.items():

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -1,12 +1,9 @@
 from collections import namedtuple
 from enum import Enum
 
-import six
-
 
 from dagster import check
 from dagster.core.definitions import Solid, PipelineDefinition
-from dagster.core.errors import DagsterError
 from dagster.core.execution_context import (
     SystemPipelineExecutionContext,
     SystemStepExecutionContext,
@@ -39,9 +36,9 @@ class SingleOutputStepCreationData(namedtuple('SingleOutputStepCreationData', 's
 
 class StepOutputData:
     def __init__(self, step_output_handle, value_repr, intermediates_manager):
+        self.step_output_handle = step_output_handle
         self._value_repr = value_repr
         self._intermediates_manager = intermediates_manager
-        self.step_output_handle = step_output_handle
 
     @property
     def output_name(self):
@@ -55,10 +52,13 @@ class StepOutputData:
         return self._intermediates_manager.get_value(self.step_output_handle)
 
 
-class StepFailureData(namedtuple('_StepFailureData', 'dagster_error')):
-    def __new__(cls, dagster_error):
+class StepFailureData(namedtuple('_StepFailureData', 'error_message error_cls_name stack')):
+    def __new__(cls, error_message, error_cls_name, stack):
         return super(StepFailureData, cls).__new__(
-            cls, dagster_error=check.inst_param(dagster_error, 'dagster_error', DagsterError)
+            cls,
+            error_cls_name=check.str_param(error_cls_name, 'error_cls_name'),
+            error_message=check.str_param(error_message, 'error_message'),
+            stack=check.list_param(stack, 'stack', of_type=str),
         )
 
 
@@ -68,13 +68,32 @@ class ExecutionStepEventType(Enum):
 
 
 class ExecutionStepEvent(
-    namedtuple('_ExecutionStepEvent', 'event_type step step_output_data step_failure_data tags')
+    namedtuple(
+        '_ExecutionStepEvent',
+        'event_type step_key solid_name step_kind step_output_data step_failure_data tags',
+    )
 ):
-    def __new__(cls, event_type, step, step_output_data, step_failure_data, tags):
+    @staticmethod
+    def from_step(event_type, step, step_output_data, step_failure_data, tags):
+        return ExecutionStepEvent(
+            event_type,
+            step.key,
+            step.solid.name,
+            step.kind,
+            step_output_data,
+            step_failure_data,
+            tags,
+        )
+
+    def __new__(
+        cls, event_type, step_key, solid_name, step_kind, step_output_data, step_failure_data, tags
+    ):
         return super(ExecutionStepEvent, cls).__new__(
             cls,
             check.inst_param(event_type, 'event_type', ExecutionStepEventType),
-            check.inst_param(step, 'step', ExecutionStep),
+            check.str_param(step_key, 'step_key'),
+            check.str_param(solid_name, 'solid_name'),
+            check.inst_param(step_kind, 'step_kind', StepKind),
             check.opt_inst_param(step_output_data, 'step_output_data', StepOutputData),
             check.opt_inst_param(step_failure_data, 'step_failure_data', StepFailureData),
             check.dict_param(tags, 'tags'),
@@ -96,7 +115,7 @@ class ExecutionStepEvent(
     def step_output_event(step_context, step_output_data):
         check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
 
-        return ExecutionStepEvent(
+        return ExecutionStepEvent.from_step(
             event_type=ExecutionStepEventType.STEP_OUTPUT,
             step=step_context.step,
             step_output_data=check.inst_param(step_output_data, 'step_output_data', StepOutputData),
@@ -108,7 +127,7 @@ class ExecutionStepEvent(
     def step_failure_event(step_context, step_failure_data):
         check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
 
-        return ExecutionStepEvent(
+        return ExecutionStepEvent.from_step(
             event_type=ExecutionStepEventType.STEP_FAILURE,
             step=step_context.step,
             step_output_data=None,
@@ -117,17 +136,6 @@ class ExecutionStepEvent(
             ),
             tags=step_context.tags,
         )
-
-    def reraise_user_error(self):
-        check.invariant(self.event_type == ExecutionStepEventType.STEP_FAILURE)
-        if self.step_failure_data.dagster_error.is_user_code_error:
-            six.reraise(*self.step_failure_data.dagster_error.original_exc_info)
-        else:
-            raise self.step_failure_data.dagster_error
-
-    @property
-    def kind(self):
-        return self.step.kind
 
 
 class StepKind(Enum):

--- a/python_modules/dagster/dagster/core/serializable.py
+++ b/python_modules/dagster/dagster/core/serializable.py
@@ -66,15 +66,15 @@ def _to_serializable_step_event(step_event):
     if step_event.is_successful_output:
         return SerializableStepOutputEvent(
             event_type=step_event.event_type,
-            step_key=step_event.step.key,
+            step_key=step_event.step_key,
             output_name=step_event.step_output_data.output_name,
             value_repr=step_event.step_output_data.value_repr,
         )
     elif step_event.is_step_failure:
         return SerializableStepFailureEvent(
             event_type=step_event.event_type,
-            step_key=step_event.step.key,
-            error_message=str(step_event.step_failure_data.dagster_error),
+            step_key=step_event.step_key,
+            error_message=step_event.step_failure_data.error_message,
         )
 
     check.failed('Unsupported step_event type {}'.format(step_event))

--- a/python_modules/dagster/dagster/utils/test.py
+++ b/python_modules/dagster/dagster/utils/test.py
@@ -122,11 +122,6 @@ def execute_solids(pipeline_def, solid_names, inputs=None, environment_dict=None
     stubbed_pipeline = build_pipeline_with_input_stubs(sub_pipeline, inputs)
     result = execute_pipeline(stubbed_pipeline, environment_dict)
 
-    if not result.success:
-        for solid_result in result.solid_result_list:
-            if not solid_result.success:
-                solid_result.reraise_user_error()
-
     return {sr.solid.name: sr for sr in result.solid_result_list}
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -42,11 +42,11 @@ def test_execution_plan_simple_two_steps():
     step_events = execute_plan(execution_plan)
     assert len(step_events) == 2
 
-    assert step_events[0].step.key == 'return_one.transform'
+    assert step_events[0].step_key == 'return_one.transform'
     assert step_events[0].is_successful_output
     assert step_events[0].step_output_data.get_value() == 1
 
-    assert step_events[1].step.key == 'add_one.transform'
+    assert step_events[1].step_key == 'add_one.transform'
     assert step_events[1].is_successful_output
     assert step_events[1].step_output_data.get_value() == 2
 
@@ -63,10 +63,10 @@ def test_execution_plan_two_outputs():
 
     step_events = execute_plan(execution_plan)
 
-    assert step_events[0].step.key == 'return_one_two.transform'
+    assert step_events[0].step_key == 'return_one_two.transform'
     assert step_events[0].step_output_data.get_value() == 1
     assert step_events[0].step_output_data.output_name == 'num_one'
-    assert step_events[1].step.key == 'return_one_two.transform'
+    assert step_events[1].step_key == 'return_one_two.transform'
     assert step_events[1].step_output_data.get_value() == 2
     assert step_events[1].step_output_data.output_name == 'num_two'
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -11,7 +11,6 @@ from dagster import (
 )
 
 from dagster.core.errors import (
-    DagsterExecutionStepExecutionError,
     DagsterExecutionStepNotFoundError,
     DagsterInvalidSubplanInputNotFoundError,
     DagsterInvalidSubplanMissingInputError,
@@ -72,7 +71,7 @@ def test_basic_pipeline_external_plan_execution():
     assert len(step_events) == 1
 
     transform_step_output_event = step_events[0]
-    assert transform_step_output_event.kind == StepKind.TRANSFORM
+    assert transform_step_output_event.step_kind == StepKind.TRANSFORM
     assert transform_step_output_event.is_successful_output
     assert transform_step_output_event.step_output_data.output_name == 'result'
     assert transform_step_output_event.step_output_data.get_value() == 6
@@ -198,10 +197,9 @@ def test_external_execution_output_code_error_no_throw_on_user_error():
 
     assert len(step_events) == 1
     step_event = step_events[0]
-    assert isinstance(
-        step_event.step_failure_data.dagster_error, DagsterExecutionStepExecutionError
-    )
-    assert str(step_event.step_failure_data.dagster_error.user_exception) == 'whoops'
+    assert step_event.step_failure_data
+    assert step_event.step_failure_data.error_cls_name == 'Exception'
+    assert step_event.step_failure_data.error_message == 'Exception: whoops\n'
 
 
 def test_external_execution_unsatisfied_input_error():

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -17,7 +17,6 @@ from dagster import (
 )
 
 from dagster.core.test_utils import execute_single_solid_in_isolation, single_output_transform
-from dagster.core.errors import DagsterExecutionStepExecutionError
 
 
 def silencing_default_context():
@@ -60,7 +59,7 @@ def test_transform_failure_pipeline():
 
     assert len(result_list) == 1
     assert not result_list[0].success
-    assert result_list[0].dagster_error
+    assert result_list[0].failure_data
 
 
 def test_failure_midstream():
@@ -89,9 +88,8 @@ def test_failure_midstream():
     assert pipeline_result.result_for_solid('A').success
     assert pipeline_result.result_for_solid('B').success
     assert not pipeline_result.result_for_solid('C').success
-    assert isinstance(
-        pipeline_result.result_for_solid('C').dagster_error, DagsterExecutionStepExecutionError
-    )
+
+    assert pipeline_result.result_for_solid('C').failure_data.error_cls_name == 'CheckError'
 
 
 def test_do_not_yield_result():

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -594,8 +594,6 @@ snapshots['test_build_all_docs 4'] = '''
   <td style="width: 33%; vertical-align: top;"><ul>
       <li><a href="apidocs/types.html#module-dagster">dagster (module)</a>
 </li>
-      <li><a href="apidocs/execution.html#dagster.SolidExecutionResult.dagster_error">dagster_error (dagster.SolidExecutionResult attribute)</a>
-</li>
       <li><a href="apidocs/types.html#dagster.dagster_type">dagster_type() (in module dagster)</a>
 </li>
       <li><a href="apidocs/errors.html#dagster.DagsterExpectationFailedError">DagsterExpectationFailedError</a>
@@ -612,10 +610,10 @@ snapshots['test_build_all_docs 4'] = '''
 </li>
       <li><a href="apidocs/definitions.html#dagster.PipelineDefinition.dependencies">dependencies (dagster.PipelineDefinition attribute)</a>
 </li>
-  </ul></td>
-  <td style="width: 33%; vertical-align: top;"><ul>
       <li><a href="apidocs/definitions.html#dagster.PipelineDefinition.dependency_structure">dependency_structure (dagster.PipelineDefinition attribute)</a>
 </li>
+  </ul></td>
+  <td style="width: 33%; vertical-align: top;"><ul>
       <li><a href="apidocs/definitions.html#dagster.DependencyDefinition">DependencyDefinition (class in dagster)</a>
 </li>
       <li><a href="apidocs/definitions.html#dagster.DependencyDefinition.description">description (dagster.DependencyDefinition attribute)</a>
@@ -670,10 +668,12 @@ snapshots['test_build_all_docs 4'] = '''
 <h2 id="F">F</h2>
 <table style="width: 100%" class="indextable genindextable"><tr>
   <td style="width: 33%; vertical-align: top;"><ul>
-      <li><a href="apidocs/definitions.html#dagster.Field">Field() (in module dagster)</a>
+      <li><a href="apidocs/execution.html#dagster.SolidExecutionResult.failure_data">failure_data (dagster.SolidExecutionResult attribute)</a>
 </li>
   </ul></td>
   <td style="width: 33%; vertical-align: top;"><ul>
+      <li><a href="apidocs/definitions.html#dagster.Field">Field() (in module dagster)</a>
+</li>
       <li><a href="apidocs/decorators.html#dagster.MultipleResults.from_dict">from_dict() (dagster.MultipleResults static method)</a>
 </li>
   </ul></td>
@@ -20656,9 +20656,9 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 </dd></dl>
 
 <dl class="attribute">
-<dt id="dagster.SolidExecutionResult.dagster_error">
-<code class="descname">dagster_error</code><a class="headerlink" href="#dagster.SolidExecutionResult.dagster_error" title="Permalink to this definition">¶</a></dt>
-<dd><p>Returns exception that happened during this solid’s execution, if any</p>
+<dt id="dagster.SolidExecutionResult.failure_data">
+<code class="descname">failure_data</code><a class="headerlink" href="#dagster.SolidExecutionResult.failure_data" title="Permalink to this definition">¶</a></dt>
+<dd><p>Returns the failing step’s data that happened during this solid’s execution, if any</p>
 </dd></dl>
 
 <dl class="attribute">


### PR DESCRIPTION
This makes the execution step completely serializable, and so now we are able to transmit the execution steps across process boundaries. This removed a ton of boilerplate in the multiprocess engine.