### PR TITLE
Extracting out child process executor

### DIFF
--- a/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
+++ b/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
@@ -1,0 +1,87 @@
+from abc import ABCMeta, abstractmethod
+from collections import namedtuple
+import multiprocessing
+import os
+import sys
+
+import six
+
+from dagster import check
+from dagster.utils.error import serializable_error_info_from_exc_info, SerializableErrorInfo
+
+ChildProcessStartEvent = namedtuple('ChildProcessStartEvent', 'pid')
+ChildProcessDoneEvent = namedtuple('ChildProcessDoneEvent', 'pid')
+ChildProcessSystemErrorEvent = namedtuple('ChildProcessSystemErrorEvent', 'pid error_info')
+
+ChildProcessEvents = (ChildProcessStartEvent, ChildProcessDoneEvent, ChildProcessSystemErrorEvent)
+
+
+# Inherit from this class in order to use this library. The object must be pickable
+# and you instantiate it and pass it to execute_command_in_child_process. execute()
+# is invoked in a child process
+class ChildProcessCommand(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
+    @abstractmethod
+    def execute(self):
+        pass
+
+
+class ChildProcessException(Exception):
+    def __init__(self, *args, **kwargs):
+        super(ChildProcessException, self).__init__(*args)
+        self.error_info = check.inst_param(
+            kwargs.pop('error_info'), 'error_info', SerializableErrorInfo
+        )
+
+
+def execute_command_in_child_process(queue, command):
+    check.inst_param(command, 'command', ChildProcessCommand)
+
+    pid = os.getpid()
+    queue.put(ChildProcessStartEvent(pid=pid))
+    try:
+        for step_event in command.execute():
+            queue.put(step_event)
+        queue.put(ChildProcessDoneEvent(pid=pid))
+    except:  # pylint: disable=bare-except
+        queue.put(
+            ChildProcessSystemErrorEvent(
+                pid=pid, error_info=serializable_error_info_from_exc_info(sys.exc_info())
+            )
+        )
+    finally:
+        queue.close()
+
+
+def execute_child_process_command(command, return_process_events=False):
+    check.inst_param(command, 'command', ChildProcessCommand)
+    check.bool_param(return_process_events, 'return_process_events')
+
+    queue = multiprocessing.Queue()
+
+    process = multiprocessing.Process(
+        target=execute_command_in_child_process, args=(queue, command)
+    )
+
+    process.start()
+    while process.is_alive():
+        event = queue.get()
+
+        if return_process_events and isinstance(event, ChildProcessEvents):
+            yield event
+
+        if isinstance(event, ChildProcessStartEvent):
+            continue
+        if isinstance(event, ChildProcessDoneEvent):
+            break
+        if isinstance(event, ChildProcessSystemErrorEvent):
+            raise ChildProcessException(
+                'Uncaught exception in process {pid} with message "{message}"'.format(
+                    pid=event.pid, message=event.error_info.message
+                ),
+                error_info=event.error_info,
+            )
+
+        yield event
+
+    # TODO: Do something reasonable on total process failure
+    process.join()

--- a/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
+++ b/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import multiprocessing
 import os
 import sys
+import time
 
 import six
 
@@ -33,6 +34,10 @@ class ChildProcessException(Exception):
         )
 
 
+class ChildProcessCrashException(Exception):
+    pass
+
+
 def execute_command_in_child_process(queue, command):
     check.inst_param(command, 'command', ChildProcessCommand)
 
@@ -52,6 +57,38 @@ def execute_command_in_child_process(queue, command):
         queue.close()
 
 
+def flush_queue(queue):
+    events = []
+    while not queue.empty():
+        events.append(queue.get(block=False))
+    return events
+
+
+TICK = 20.0 * 1.0 / 1000.0
+
+PROCESS_DEAD_AND_QUEUE_EMPTY = 'PROCESS_DEAD_AND_QUEUE_EMPTY'
+
+
+def get_next_event(process, queue):
+    '''
+    This function polls the process until it returns a valid
+    item or returns PROCESS_DEAD_AND_QUEUE_EMPTY if it is in
+    a state where the process has terminated and the queue is empty
+    '''
+    while True:
+        try:
+            return queue.get(block=False)
+        except multiprocessing.queues.Empty:
+            if process.is_alive():
+                # processing still going
+                # sleep a bit and try to get the item out of the queue again
+                time.sleep(TICK)
+            else:
+                return PROCESS_DEAD_AND_QUEUE_EMPTY
+
+    check.failed('unreachable')
+
+
 def execute_child_process_command(command, return_process_events=False):
     check.inst_param(command, 'command', ChildProcessCommand)
     check.bool_param(return_process_events, 'return_process_events')
@@ -63,25 +100,36 @@ def execute_child_process_command(command, return_process_events=False):
     )
 
     process.start()
-    while process.is_alive():
-        event = queue.get()
 
+    time.sleep(TICK)
+
+    completed_properly = False
+
+    while not completed_properly:
+        event = get_next_event(process, queue)
+
+        if event == PROCESS_DEAD_AND_QUEUE_EMPTY:
+            break
+
+        # If we are configured to return process events by the caller,
+        # yield that event to the caller
         if return_process_events and isinstance(event, ChildProcessEvents):
             yield event
 
-        if isinstance(event, ChildProcessStartEvent):
-            continue
         if isinstance(event, ChildProcessDoneEvent):
-            break
-        if isinstance(event, ChildProcessSystemErrorEvent):
+            completed_properly = True
+        elif isinstance(event, ChildProcessSystemErrorEvent):
             raise ChildProcessException(
                 'Uncaught exception in process {pid} with message "{message}"'.format(
                     pid=event.pid, message=event.error_info.message
                 ),
                 error_info=event.error_info,
             )
+        elif not isinstance(event, ChildProcessEvents):
+            yield event
 
-        yield event
+    if not completed_properly:
+        # TODO Gather up stderr
+        raise ChildProcessCrashException()
 
-    # TODO: Do something reasonable on total process failure
     process.join()

--- a/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
+++ b/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 import multiprocessing
 import os
 import sys
-import time
 
 import six
 
@@ -67,6 +66,9 @@ def get_next_event(process, queue):
     This function polls the process until it returns a valid
     item or returns PROCESS_DEAD_AND_QUEUE_EMPTY if it is in
     a state where the process has terminated and the queue is empty
+
+    Warning: if the child process is in an infinite loop. This will
+    also infinitely loop.
     '''
     while True:
         try:
@@ -124,7 +126,7 @@ def execute_child_process_command(command, return_process_events=False):
             yield event
 
     if not completed_properly:
-        # TODO Gather up stderr
+        # TODO Gather up stderr and the process exit code
         raise ChildProcessCrashException()
 
     process.join()

--- a/python_modules/dagster/dagster/core/execution_plan/intermediates_manager.py
+++ b/python_modules/dagster/dagster/core/execution_plan/intermediates_manager.py
@@ -51,6 +51,15 @@ class IntermediatesManager(six.with_metaclass(ABCMeta)):  # pylint: disable=no-i
     def has_value(self, step_output_handle):
         pass
 
+    def all_inputs_covered(self, step):
+        from .objects import ExecutionStep
+
+        check.inst_param(step, 'step', ExecutionStep)
+        for step_input in step.step_inputs:
+            if not self.has_value(step_input.prev_output_handle):
+                return False
+        return True
+
 
 class InMemoryIntermediatesManager(IntermediatesManager):
     def __init__(self):

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -67,13 +67,6 @@ def _create_input_values(step_input_meta_dict, manager):
     return input_values
 
 
-def _all_inputs_covered(step, intermediates_manager):
-    for step_input in step.step_inputs:
-        if not intermediates_manager.has_value(step_input.prev_output_handle):
-            return False
-    return True
-
-
 def multiprocess_execute_plan(pipeline_context, execution_plan):
     check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(execution_plan, 'execution_plan', ExecutionPlan)
@@ -90,7 +83,7 @@ def multiprocess_execute_plan(pipeline_context, execution_plan):
         for step in step_level:
             step_context = pipeline_context.for_step(step)
 
-            if not _all_inputs_covered(step, intermediates_manager):
+            if not intermediates_manager.all_inputs_covered(step):
                 expected_outputs = [ni.prev_output_handle for ni in step.step_inputs]
 
                 step_context.log.debug(

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 
 from dagster import check
@@ -8,27 +7,29 @@ from dagster.core.execution_context import (
     SystemPipelineExecutionContext,
 )
 
+
 from .create import create_execution_plan_core
 from .intermediates_manager import FileSystemIntermediateManager
 from .objects import ExecutionPlan, ExecutionStepEvent
 from .simple_engine import start_inprocess_executor
 
-
-CHILD_PROCESS_DONE_SENTINEL = 'CHILD_PROCESS_DONE_SENTINEL'
-CHILD_PROCESS_SYSTEM_ERROR_SENTINEL = 'CHILD_PROCESS_SYSTEM_ERROR_SENTINEL'
+from .child_process_executor import ChildProcessCommand, execute_child_process_command
 
 
-def _execute_in_child_process(queue, environment_dict, run_config, step_key):
-    from dagster.core.execution import yield_pipeline_execution_context
+class InProcessExecutorChildProcessCommand(ChildProcessCommand):
+    def __init__(self, environment_dict, run_config, step_key):
+        self.environment_dict = environment_dict
+        self.run_config = run_config
+        self.step_key = step_key
 
-    check.inst(run_config.executor_config, MultiprocessExecutorConfig)
+    def execute(self):
+        from dagster.core.execution import yield_pipeline_execution_context
 
-    pipeline = run_config.executor_config.pipeline_fn()
-
-    try:
+        check.inst(self.run_config.executor_config, MultiprocessExecutorConfig)
+        pipeline = self.run_config.executor_config.pipeline_fn()
 
         with yield_pipeline_execution_context(
-            pipeline, environment_dict, run_config.with_tags(pid=str(os.getpid()))
+            pipeline, self.environment_dict, self.run_config.with_tags(pid=str(os.getpid()))
         ) as pipeline_context:
 
             intermediates_manager = FileSystemIntermediateManager(pipeline_context.files)
@@ -39,42 +40,23 @@ def _execute_in_child_process(queue, environment_dict, run_config, step_key):
                 pipeline_context,
                 execution_plan,
                 intermediates_manager,
-                step_keys_to_execute=[step_key],
+                step_keys_to_execute=[self.step_key],
             ):
-                queue.put(step_event)
-
-        queue.put(CHILD_PROCESS_DONE_SENTINEL)
-    except:  # pylint: disable=bare-except
-        queue.put(CHILD_PROCESS_SYSTEM_ERROR_SENTINEL)
-    finally:
-        queue.close()
+                yield step_event
 
 
 def execute_step_out_of_process(step_context, step):
-    queue = multiprocessing.Queue()
-
     check.invariant(
         not step_context.run_config.loggers,
-        'Cannot inject loggers via ExecutionMetadata with the Multiprocess executor',
+        'Cannot inject loggers via RunConfig with the Multiprocess executor',
     )
 
-    process = multiprocessing.Process(
-        target=_execute_in_child_process,
-        args=(queue, step_context.environment_dict, step_context.run_config, step.key),
+    command = InProcessExecutorChildProcessCommand(
+        step_context.environment_dict, step_context.run_config, step.key
     )
 
-    process.start()
-    while process.is_alive():
-        result = queue.get()
-        if result == CHILD_PROCESS_DONE_SENTINEL:
-            break
-        if result == CHILD_PROCESS_SYSTEM_ERROR_SENTINEL:
-            raise Exception('unexpected error in child process')
-
-        yield result
-
-    # Do something reasonable on total process failure
-    process.join()
+    for step_event in execute_child_process_command(command):
+        yield step_event
 
 
 def _create_input_values(step_input_meta_dict, manager):

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -76,7 +76,7 @@ def start_inprocess_executor(
 
             step_context = pipeline_context.for_step(step)
 
-            if not _all_inputs_covered(step, intermediates_manager):
+            if not intermediates_manager.all_inputs_covered(step):
                 expected_outputs = [ni.prev_output_handle for ni in step.step_inputs]
 
                 step_context.log.info(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_child_process_executor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_child_process_executor.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+from dagster.core.execution_plan.child_process_executor import (
+    ChildProcessCommand,
+    execute_child_process_command,
+    ChildProcessStartEvent,
+    ChildProcessDoneEvent,
+    ChildProcessException,
+)
+
+
+class DoubleAStringChildProcessCommand(ChildProcessCommand):
+    def __init__(self, a_str):
+        self.a_str = a_str
+
+    def execute(self):
+        yield self.a_str + self.a_str
+
+
+class AnError(Exception):
+    pass
+
+
+class ThrowAnErrorCommand(ChildProcessCommand):  # pylint: disable=no-init
+    def execute(self):
+        raise AnError('Oh noes!')
+
+
+def test_basic_child_process_command():
+    events = list(execute_child_process_command(DoubleAStringChildProcessCommand('aa')))
+    assert events == ['aaaa']
+
+
+def test_basic_child_process_command_with_process_events():
+    events = list(
+        execute_child_process_command(
+            DoubleAStringChildProcessCommand('aa'), return_process_events=True
+        )
+    )
+    assert len(events) == 3
+
+    assert isinstance(events[0], ChildProcessStartEvent)
+    child_pid = events[0].pid
+    assert child_pid != os.getpid()
+    assert events[1] == 'aaaa'
+    assert isinstance(events[2], ChildProcessDoneEvent)
+    assert events[2].pid == child_pid
+
+
+def test_child_process_uncaught_exception():
+    with pytest.raises(ChildProcessException) as excinfo:
+        list(execute_child_process_command(ThrowAnErrorCommand()))
+
+    assert 'AnError' in str(excinfo.value)


### PR DESCRIPTION
Extracting out child process executor for the multiprocessing engine. This is starting to overlap with the pipeline execution manager more and more, so merging this should be a goal. In particular the pipeline execution manager handles crashing processes and multiple child processes, so this is strictly inferior in terms of features.