### PR TITLE
Use basic string prefix to improve click-to-filter log results 

### DIFF
--- a/js_modules/dagit/src/PipelinePage.tsx
+++ b/js_modules/dagit/src/PipelinePage.tsx
@@ -14,7 +14,8 @@ import PipelineExecutionRoot from "./execution/PipelineExecutionRoot";
 import {
   PipelinePageFragment,
   PipelinePageFragment_PythonError,
-  PipelinePageFragment_PipelineConnection_nodes
+  PipelinePageFragment_PipelineConnection_nodes,
+  PipelinePageFragment_InvalidDefinitionError
 } from "./types/PipelinePageFragment";
 
 export type IPipelinePageMatch = match<{
@@ -73,6 +74,10 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
           message
           stack
         }
+        ... on InvalidDefinitionError {
+          message
+          stack
+        }
         ... on PipelineConnection {
           nodes {
             ...PipelineExplorerFragment
@@ -93,10 +98,16 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
   render() {
     const { history, match, pipelinesOrError } = this.props;
 
-    let error: PipelinePageFragment_PythonError | null = null;
+    let error:
+      | PipelinePageFragment_PythonError
+      | PipelinePageFragment_InvalidDefinitionError
+      | null = null;
     let pipelines: Array<PipelinePageFragment_PipelineConnection_nodes> = [];
 
-    if (pipelinesOrError.__typename === "PythonError") {
+    if (
+      pipelinesOrError.__typename === "PythonError" ||
+      pipelinesOrError.__typename === "InvalidDefinitionError"
+    ) {
       error = pipelinesOrError;
     } else {
       pipelines = pipelinesOrError.nodes;

--- a/js_modules/dagit/src/execution/LogsFilterProvider.tsx
+++ b/js_modules/dagit/src/execution/LogsFilterProvider.tsx
@@ -49,8 +49,6 @@ export default class LogsFilterProvider<
           message
           timestamp
           level
-        }
-        ... on ExecutionStepEvent {
           step {
             name
           }
@@ -92,7 +90,7 @@ export default class LogsFilterProvider<
 
       if (filter.text) {
         if (filter.text.startsWith("step:")) {
-          return "step" in node && node["step"].name === filter.text.substr(5);
+          return node.step && node.step.name === filter.text.substr(5);
         } else {
           return node.message.toLowerCase().includes(textLower);
         }

--- a/js_modules/dagit/src/execution/PipelineRun.tsx
+++ b/js_modules/dagit/src/execution/PipelineRun.tsx
@@ -82,6 +82,7 @@ export class PipelineRun extends React.Component<
     const errorNode = this.props.pipelineRun.logs.nodes.find(
       node =>
         node.__typename === "ExecutionStepFailureEvent" &&
+        node.step != null &&
         node.step.name === step
     ) as PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent;
 

--- a/js_modules/dagit/src/execution/PipelineRun.tsx
+++ b/js_modules/dagit/src/execution/PipelineRun.tsx
@@ -103,7 +103,9 @@ export class PipelineRun extends React.Component<
               runMetadata={metadata}
               onShowStateDetails={this.onShowStateDetails}
               onApplyStepFilter={stepName =>
-                this.setState({ logsFilter: { ...logsFilter, text: stepName } })
+                this.setState({
+                  logsFilter: { ...logsFilter, text: `step:${stepName}` }
+                })
               }
             />
           )}

--- a/js_modules/dagit/src/execution/RunMetadataProvider.tsx
+++ b/js_modules/dagit/src/execution/RunMetadataProvider.tsx
@@ -53,7 +53,7 @@ function extractMetadataFromLogs(
       metadata.startedPipelineAt = Number.parseInt(log.timestamp);
     }
 
-    if ("step" in log) {
+    if (log.step) {
       const name = log.step.name;
       const timestamp = Number.parseInt(log.timestamp, 10);
 
@@ -108,6 +108,9 @@ export default class RunMetadataProvider extends React.Component<
         ... on MessageEvent {
           message
           timestamp
+          step {
+            name
+          }
         }
         ... on PipelineProcessStartedEvent {
           processId
@@ -118,11 +121,6 @@ export default class RunMetadataProvider extends React.Component<
           }
           fileLocation
           fileName
-        }
-        ... on ExecutionStepEvent {
-          step {
-            name
-          }
         }
       }
     `

--- a/js_modules/dagit/src/execution/types/LogsFilterProviderMessageFragment.ts
+++ b/js_modules/dagit/src/execution/types/LogsFilterProviderMessageFragment.ts
@@ -7,9 +7,24 @@ import { LogLevel } from "./../../types/globalTypes";
 // GraphQL fragment: LogsFilterProviderMessageFragment
 // ====================================================
 
-export interface LogsFilterProviderMessageFragment {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent" | "PipelineProcessStartEvent" | "PipelineProcessStartedEvent" | "StepMaterializationEvent";
+export interface LogsFilterProviderMessageFragment_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent" | "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
 }
+
+export interface LogsFilterProviderMessageFragment_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface LogsFilterProviderMessageFragment_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent" | "StepMaterializationEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: LogsFilterProviderMessageFragment_ExecutionStepStartEvent_step;
+}
+
+export type LogsFilterProviderMessageFragment = LogsFilterProviderMessageFragment_LogMessageEvent | LogsFilterProviderMessageFragment_ExecutionStepStartEvent;

--- a/js_modules/dagit/src/execution/types/LogsFilterProviderMessageFragment.ts
+++ b/js_modules/dagit/src/execution/types/LogsFilterProviderMessageFragment.ts
@@ -7,24 +7,15 @@ import { LogLevel } from "./../../types/globalTypes";
 // GraphQL fragment: LogsFilterProviderMessageFragment
 // ====================================================
 
-export interface LogsFilterProviderMessageFragment_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent" | "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-}
-
-export interface LogsFilterProviderMessageFragment_ExecutionStepStartEvent_step {
+export interface LogsFilterProviderMessageFragment_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface LogsFilterProviderMessageFragment_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent" | "StepMaterializationEvent";
+export interface LogsFilterProviderMessageFragment {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent" | "PipelineProcessStartEvent" | "PipelineProcessStartedEvent" | "StepMaterializationEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: LogsFilterProviderMessageFragment_ExecutionStepStartEvent_step;
+  step: LogsFilterProviderMessageFragment_step | null;
 }
-
-export type LogsFilterProviderMessageFragment = LogsFilterProviderMessageFragment_LogMessageEvent | LogsFilterProviderMessageFragment_ExecutionStepStartEvent;

--- a/js_modules/dagit/src/execution/types/LogsScrollingTableMessageFragment.ts
+++ b/js_modules/dagit/src/execution/types/LogsScrollingTableMessageFragment.ts
@@ -30,7 +30,7 @@ export interface LogsScrollingTableMessageFragment_ExecutionStepFailureEvent {
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: LogsScrollingTableMessageFragment_ExecutionStepFailureEvent_step;
+  step: LogsScrollingTableMessageFragment_ExecutionStepFailureEvent_step | null;
   error: LogsScrollingTableMessageFragment_ExecutionStepFailureEvent_error;
 }
 

--- a/js_modules/dagit/src/execution/types/PipelineExecutionContainerFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionContainerFragment.ts
@@ -14,6 +14,19 @@ export interface PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEv
   level: LogLevel;
 }
 
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent_step;
+}
+
 export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -34,14 +47,6 @@ export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionSte
   error: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
 export interface PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -57,20 +62,15 @@ export interface PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterial
   fileName: string;
 }
 
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineExecutionContainerFragment_runs_logs_nodes = PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent | PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent;
+export type PipelineExecutionContainerFragment_runs_logs_nodes = PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent | PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent;
 
 export interface PipelineExecutionContainerFragment_runs_logs_pageInfo {
   __typename: "PageInfo";

--- a/js_modules/dagit/src/execution/types/PipelineExecutionContainerFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionContainerFragment.ts
@@ -7,24 +7,17 @@ import { PipelineRunStatus, LogLevel, StepKind } from "./../../types/globalTypes
 // GraphQL fragment: PipelineExecutionContainerFragment
 // ====================================================
 
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-}
-
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent_step {
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent_step;
+  step: PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent_step | null;
 }
 
 export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent_step {
@@ -43,8 +36,22 @@ export interface PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionSte
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent_step;
+  step: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent_step | null;
   error: PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent_error;
+}
+
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +64,12 @@ export interface PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterial
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent_step;
+  step: PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineExecutionContainerFragment_runs_logs_nodes = PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepStartEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent | PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent;
+export type PipelineExecutionContainerFragment_runs_logs_nodes = PipelineExecutionContainerFragment_runs_logs_nodes_LogMessageEvent | PipelineExecutionContainerFragment_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionContainerFragment_runs_logs_nodes_PipelineProcessStartedEvent | PipelineExecutionContainerFragment_runs_logs_nodes_StepMaterializationEvent;
 
 export interface PipelineExecutionContainerFragment_runs_logs_pageInfo {
   __typename: "PageInfo";

--- a/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunEventFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunEventFragment.ts
@@ -34,12 +34,17 @@ export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureE
   error: PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
+export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  processId: number;
+  step: PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent_step;
 }
 
 export interface PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent_step {
@@ -57,17 +62,12 @@ export interface PipelineExecutionPipelineRunEventFragment_StepMaterializationEv
   fileName: string;
 }
 
-export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineExecutionPipelineRunEventFragment = PipelineExecutionPipelineRunEventFragment_LogMessageEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent | PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent;
+export type PipelineExecutionPipelineRunEventFragment = PipelineExecutionPipelineRunEventFragment_LogMessageEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent | PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent | PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent;

--- a/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunEventFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunEventFragment.ts
@@ -7,11 +7,17 @@ import { LogLevel } from "./../../types/globalTypes";
 // GraphQL fragment: PipelineExecutionPipelineRunEventFragment
 // ====================================================
 
+export interface PipelineExecutionPipelineRunEventFragment_LogMessageEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
 export interface PipelineExecutionPipelineRunEventFragment_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
+  step: PipelineExecutionPipelineRunEventFragment_LogMessageEvent_step | null;
 }
 
 export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent_step {
@@ -30,21 +36,22 @@ export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureE
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent_step;
+  step: PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent_step | null;
   error: PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent_step {
+export interface PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent_step;
+  step: PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent_step {
@@ -57,17 +64,9 @@ export interface PipelineExecutionPipelineRunEventFragment_StepMaterializationEv
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent_step;
+  step: PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineExecutionPipelineRunEventFragment = PipelineExecutionPipelineRunEventFragment_LogMessageEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepStartEvent | PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent | PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent;
+export type PipelineExecutionPipelineRunEventFragment = PipelineExecutionPipelineRunEventFragment_LogMessageEvent | PipelineExecutionPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineExecutionPipelineRunEventFragment_PipelineProcessStartedEvent | PipelineExecutionPipelineRunEventFragment_StepMaterializationEvent;

--- a/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunFragment.ts
@@ -14,6 +14,19 @@ export interface PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent
   level: LogLevel;
 }
 
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step;
+}
+
 export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -34,14 +47,6 @@ export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFa
   error: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
 export interface PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -57,20 +62,15 @@ export interface PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializa
   fileName: string;
 }
 
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineExecutionPipelineRunFragment_logs_nodes = PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent | PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent;
+export type PipelineExecutionPipelineRunFragment_logs_nodes = PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent | PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent;
 
 export interface PipelineExecutionPipelineRunFragment_logs {
   __typename: "LogMessageConnection";

--- a/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionPipelineRunFragment.ts
@@ -7,24 +7,17 @@ import { PipelineRunStatus, LogLevel, StepKind } from "./../../types/globalTypes
 // GraphQL fragment: PipelineExecutionPipelineRunFragment
 // ====================================================
 
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-}
-
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step {
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step;
+  step: PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent_step | null;
 }
 
 export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step {
@@ -43,8 +36,22 @@ export interface PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFa
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step;
+  step: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step | null;
   error: PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_error;
+}
+
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +64,12 @@ export interface PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializa
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent_step;
+  step: PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineExecutionPipelineRunFragment_logs_nodes = PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepStartEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent | PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent;
+export type PipelineExecutionPipelineRunFragment_logs_nodes = PipelineExecutionPipelineRunFragment_logs_nodes_LogMessageEvent | PipelineExecutionPipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionPipelineRunFragment_logs_nodes_PipelineProcessStartedEvent | PipelineExecutionPipelineRunFragment_logs_nodes_StepMaterializationEvent;
 
 export interface PipelineExecutionPipelineRunFragment_logs {
   __typename: "LogMessageConnection";

--- a/js_modules/dagit/src/execution/types/PipelineExecutionRootQuery.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionRootQuery.ts
@@ -7,24 +7,17 @@ import { PipelineRunStatus, LogLevel, StepKind } from "./../../types/globalTypes
 // GraphQL query operation: PipelineExecutionRootQuery
 // ====================================================
 
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-}
-
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent_step {
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent_step;
+  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent_step | null;
 }
 
 export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent_step {
@@ -43,8 +36,22 @@ export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionSt
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent_step;
+  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent_step | null;
   error: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent_error;
+}
+
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +64,12 @@ export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMateria
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent_step;
+  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineExecutionRootQuery_pipeline_runs_logs_nodes = PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent;
+export type PipelineExecutionRootQuery_pipeline_runs_logs_nodes = PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent;
 
 export interface PipelineExecutionRootQuery_pipeline_runs_logs_pageInfo {
   __typename: "PageInfo";

--- a/js_modules/dagit/src/execution/types/PipelineExecutionRootQuery.ts
+++ b/js_modules/dagit/src/execution/types/PipelineExecutionRootQuery.ts
@@ -14,6 +14,19 @@ export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageE
   level: LogLevel;
 }
 
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent_step;
+}
+
 export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -34,14 +47,6 @@ export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionSt
   error: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
 export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -57,20 +62,15 @@ export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMateria
   fileName: string;
 }
 
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineExecutionRootQuery_pipeline_runs_logs_nodes = PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent;
+export type PipelineExecutionRootQuery_pipeline_runs_logs_nodes = PipelineExecutionRootQuery_pipeline_runs_logs_nodes_LogMessageEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepStartEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_ExecutionStepFailureEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_StepMaterializationEvent | PipelineExecutionRootQuery_pipeline_runs_logs_nodes_PipelineProcessStartedEvent;
 
 export interface PipelineExecutionRootQuery_pipeline_runs_logs_pageInfo {
   __typename: "PageInfo";

--- a/js_modules/dagit/src/execution/types/PipelineRunFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunFragment.ts
@@ -7,24 +7,17 @@ import { LogLevel, StepKind } from "./../../types/globalTypes";
 // GraphQL fragment: PipelineRunFragment
 // ====================================================
 
-export interface PipelineRunFragment_logs_nodes_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-}
-
-export interface PipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step {
+export interface PipelineRunFragment_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineRunFragment_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineRunFragment_logs_nodes_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step;
+  step: PipelineRunFragment_logs_nodes_LogMessageEvent_step | null;
 }
 
 export interface PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step {
@@ -43,8 +36,22 @@ export interface PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent {
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step;
+  step: PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step | null;
   error: PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_error;
+}
+
+export interface PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineRunFragment_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +64,12 @@ export interface PipelineRunFragment_logs_nodes_StepMaterializationEvent {
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunFragment_logs_nodes_StepMaterializationEvent_step;
+  step: PipelineRunFragment_logs_nodes_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineRunFragment_logs_nodes = PipelineRunFragment_logs_nodes_LogMessageEvent | PipelineRunFragment_logs_nodes_ExecutionStepStartEvent | PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunFragment_logs_nodes_StepMaterializationEvent | PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent;
+export type PipelineRunFragment_logs_nodes = PipelineRunFragment_logs_nodes_LogMessageEvent | PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent | PipelineRunFragment_logs_nodes_StepMaterializationEvent;
 
 export interface PipelineRunFragment_logs {
   __typename: "LogMessageConnection";

--- a/js_modules/dagit/src/execution/types/PipelineRunFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunFragment.ts
@@ -14,6 +14,19 @@ export interface PipelineRunFragment_logs_nodes_LogMessageEvent {
   level: LogLevel;
 }
 
+export interface PipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineRunFragment_logs_nodes_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: PipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step;
+}
+
 export interface PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -34,14 +47,6 @@ export interface PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent {
   error: PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
 export interface PipelineRunFragment_logs_nodes_StepMaterializationEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -57,20 +62,15 @@ export interface PipelineRunFragment_logs_nodes_StepMaterializationEvent {
   fileName: string;
 }
 
-export interface PipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineRunFragment_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunFragment_logs_nodes_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineRunFragment_logs_nodes = PipelineRunFragment_logs_nodes_LogMessageEvent | PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent | PipelineRunFragment_logs_nodes_StepMaterializationEvent | PipelineRunFragment_logs_nodes_ExecutionStepStartEvent;
+export type PipelineRunFragment_logs_nodes = PipelineRunFragment_logs_nodes_LogMessageEvent | PipelineRunFragment_logs_nodes_ExecutionStepStartEvent | PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunFragment_logs_nodes_StepMaterializationEvent | PipelineRunFragment_logs_nodes_PipelineProcessStartedEvent;
 
 export interface PipelineRunFragment_logs {
   __typename: "LogMessageConnection";

--- a/js_modules/dagit/src/execution/types/PipelineRunLogsSubscription.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunLogsSubscription.ts
@@ -12,12 +12,18 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessage
   runId: string;
 }
 
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
 export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   run: PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent_run;
   message: string;
   timestamp: string;
   level: LogLevel;
+  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent_step | null;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent_run {
@@ -42,27 +48,28 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionS
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent_step;
+  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent_step | null;
   error: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_run {
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run {
   __typename: "PipelineRun";
   runId: string;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_step {
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
-  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_run;
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run;
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_step;
+  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent_run {
@@ -81,26 +88,12 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMateri
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent_step;
+  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run {
-  __typename: "PipelineRun";
-  runId: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run;
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineRunLogsSubscription_pipelineRunLogs_messages = PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent;
+export type PipelineRunLogsSubscription_pipelineRunLogs_messages = PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent;
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs {
   __typename: "PipelineRunLogsSubscriptionPayload";

--- a/js_modules/dagit/src/execution/types/PipelineRunLogsSubscription.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunLogsSubscription.ts
@@ -46,18 +46,23 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionS
   error: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run {
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_run {
   __typename: "PipelineRun";
   runId: string;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run;
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_run;
   message: string;
   timestamp: string;
   level: LogLevel;
-  processId: number;
+  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_step;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent_run {
@@ -81,26 +86,21 @@ export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMateri
   fileName: string;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_run {
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run {
   __typename: "PipelineRun";
   runId: string;
 }
 
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
-  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_run;
+export interface PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  run: PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent_run;
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineRunLogsSubscription_pipelineRunLogs_messages = PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent;
+export type PipelineRunLogsSubscription_pipelineRunLogs_messages = PipelineRunLogsSubscription_pipelineRunLogs_messages_LogMessageEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepFailureEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_ExecutionStepStartEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_StepMaterializationEvent | PipelineRunLogsSubscription_pipelineRunLogs_messages_PipelineProcessStartedEvent;
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs {
   __typename: "PipelineRunLogsSubscriptionPayload";

--- a/js_modules/dagit/src/execution/types/PipelineRunLogsUpdateFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunLogsUpdateFragment.ts
@@ -7,11 +7,17 @@ import { PipelineRunStatus, LogLevel } from "./../../types/globalTypes";
 // GraphQL fragment: PipelineRunLogsUpdateFragment
 // ====================================================
 
+export interface PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
 export interface PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
+  step: PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent_step | null;
 }
 
 export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent_step {
@@ -30,21 +36,22 @@ export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEv
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent_step;
+  step: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent_step | null;
   error: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent_step {
+export interface PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent_step;
+  step: PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +64,12 @@ export interface PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEve
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent_step;
+  step: PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineRunLogsUpdateFragment_logs_nodes = PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent | PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent | PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent;
+export type PipelineRunLogsUpdateFragment_logs_nodes = PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent | PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent;
 
 export interface PipelineRunLogsUpdateFragment_logs {
   __typename: "LogMessageConnection";

--- a/js_modules/dagit/src/execution/types/PipelineRunLogsUpdateFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunLogsUpdateFragment.ts
@@ -34,12 +34,17 @@ export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEv
   error: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
+export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  processId: number;
+  step: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent_step;
 }
 
 export interface PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +62,15 @@ export interface PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEve
   fileName: string;
 }
 
-export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineRunLogsUpdateFragment_logs_nodes = PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent | PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent;
+export type PipelineRunLogsUpdateFragment_logs_nodes = PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepFailureEvent | PipelineRunLogsUpdateFragment_logs_nodes_ExecutionStepStartEvent | PipelineRunLogsUpdateFragment_logs_nodes_StepMaterializationEvent | PipelineRunLogsUpdateFragment_logs_nodes_PipelineProcessStartedEvent;
 
 export interface PipelineRunLogsUpdateFragment_logs {
   __typename: "LogMessageConnection";

--- a/js_modules/dagit/src/execution/types/PipelineRunPipelineRunEventFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunPipelineRunEventFragment.ts
@@ -7,11 +7,17 @@ import { LogLevel } from "./../../types/globalTypes";
 // GraphQL fragment: PipelineRunPipelineRunEventFragment
 // ====================================================
 
+export interface PipelineRunPipelineRunEventFragment_LogMessageEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
 export interface PipelineRunPipelineRunEventFragment_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
+  step: PipelineRunPipelineRunEventFragment_LogMessageEvent_step | null;
 }
 
 export interface PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent_step {
@@ -30,21 +36,22 @@ export interface PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent {
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent_step;
+  step: PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent_step | null;
   error: PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent_step {
+export interface PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent_step;
+  step: PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface PipelineRunPipelineRunEventFragment_StepMaterializationEvent_step {
@@ -57,17 +64,9 @@ export interface PipelineRunPipelineRunEventFragment_StepMaterializationEvent {
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunPipelineRunEventFragment_StepMaterializationEvent_step;
+  step: PipelineRunPipelineRunEventFragment_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type PipelineRunPipelineRunEventFragment = PipelineRunPipelineRunEventFragment_LogMessageEvent | PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent | PipelineRunPipelineRunEventFragment_StepMaterializationEvent | PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent;
+export type PipelineRunPipelineRunEventFragment = PipelineRunPipelineRunEventFragment_LogMessageEvent | PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent | PipelineRunPipelineRunEventFragment_StepMaterializationEvent;

--- a/js_modules/dagit/src/execution/types/PipelineRunPipelineRunEventFragment.ts
+++ b/js_modules/dagit/src/execution/types/PipelineRunPipelineRunEventFragment.ts
@@ -34,12 +34,17 @@ export interface PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent {
   error: PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent_error;
 }
 
-export interface PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
+export interface PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  processId: number;
+  step: PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent_step;
 }
 
 export interface PipelineRunPipelineRunEventFragment_StepMaterializationEvent_step {
@@ -57,17 +62,12 @@ export interface PipelineRunPipelineRunEventFragment_StepMaterializationEvent {
   fileName: string;
 }
 
-export interface PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type PipelineRunPipelineRunEventFragment = PipelineRunPipelineRunEventFragment_LogMessageEvent | PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent | PipelineRunPipelineRunEventFragment_StepMaterializationEvent | PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent;
+export type PipelineRunPipelineRunEventFragment = PipelineRunPipelineRunEventFragment_LogMessageEvent | PipelineRunPipelineRunEventFragment_ExecutionStepFailureEvent | PipelineRunPipelineRunEventFragment_ExecutionStepStartEvent | PipelineRunPipelineRunEventFragment_StepMaterializationEvent | PipelineRunPipelineRunEventFragment_PipelineProcessStartedEvent;

--- a/js_modules/dagit/src/execution/types/RunMetadataProviderMessageFragment.ts
+++ b/js_modules/dagit/src/execution/types/RunMetadataProviderMessageFragment.ts
@@ -5,16 +5,28 @@
 // GraphQL fragment: RunMetadataProviderMessageFragment
 // ====================================================
 
+export interface RunMetadataProviderMessageFragment_LogMessageEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
 export interface RunMetadataProviderMessageFragment_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
+  step: RunMetadataProviderMessageFragment_LogMessageEvent_step | null;
+}
+
+export interface RunMetadataProviderMessageFragment_PipelineProcessStartedEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
 }
 
 export interface RunMetadataProviderMessageFragment_PipelineProcessStartedEvent {
   __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
+  step: RunMetadataProviderMessageFragment_PipelineProcessStartedEvent_step | null;
   processId: number;
 }
 
@@ -27,21 +39,9 @@ export interface RunMetadataProviderMessageFragment_StepMaterializationEvent {
   __typename: "StepMaterializationEvent";
   message: string;
   timestamp: string;
-  step: RunMetadataProviderMessageFragment_StepMaterializationEvent_step;
+  step: RunMetadataProviderMessageFragment_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface RunMetadataProviderMessageFragment_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface RunMetadataProviderMessageFragment_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "ExecutionStepFailureEvent";
-  message: string;
-  timestamp: string;
-  step: RunMetadataProviderMessageFragment_ExecutionStepStartEvent_step;
-}
-
-export type RunMetadataProviderMessageFragment = RunMetadataProviderMessageFragment_LogMessageEvent | RunMetadataProviderMessageFragment_PipelineProcessStartedEvent | RunMetadataProviderMessageFragment_StepMaterializationEvent | RunMetadataProviderMessageFragment_ExecutionStepStartEvent;
+export type RunMetadataProviderMessageFragment = RunMetadataProviderMessageFragment_LogMessageEvent | RunMetadataProviderMessageFragment_PipelineProcessStartedEvent | RunMetadataProviderMessageFragment_StepMaterializationEvent;

--- a/js_modules/dagit/src/execution/types/StartPipelineExecution.ts
+++ b/js_modules/dagit/src/execution/types/StartPipelineExecution.ts
@@ -14,6 +14,19 @@ export interface StartPipelineExecution_startPipelineExecution_StartPipelineExec
   level: LogLevel;
 }
 
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent {
+  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent_step;
+}
+
 export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -34,14 +47,6 @@ export interface StartPipelineExecution_startPipelineExecution_StartPipelineExec
   error: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent_error;
 }
 
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
 export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -57,20 +62,15 @@ export interface StartPipelineExecution_startPipelineExecution_StartPipelineExec
   fileName: string;
 }
 
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent_step {
-  __typename: "ExecutionStep";
-  name: string;
-}
-
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent_step;
+  processId: number;
 }
 
-export type StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes = StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent;
+export type StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes = StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent;
 
 export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_pageInfo {
   __typename: "PageInfo";

--- a/js_modules/dagit/src/execution/types/StartPipelineExecution.ts
+++ b/js_modules/dagit/src/execution/types/StartPipelineExecution.ts
@@ -7,24 +7,17 @@ import { ExecutionSelector, PipelineRunStatus, LogLevel, StepKind } from "./../.
 // GraphQL mutation operation: StartPipelineExecution
 // ====================================================
 
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent {
-  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "PipelineProcessStartEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-}
-
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent_step {
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
 }
 
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent {
-  __typename: "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent";
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent {
+  __typename: "LogMessageEvent" | "PipelineStartEvent" | "PipelineSuccessEvent" | "PipelineFailureEvent" | "ExecutionStepStartEvent" | "ExecutionStepSuccessEvent" | "PipelineProcessStartEvent";
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent_step;
+  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent_step | null;
 }
 
 export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent_step {
@@ -43,8 +36,22 @@ export interface StartPipelineExecution_startPipelineExecution_StartPipelineExec
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent_step;
+  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent_step | null;
   error: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent_error;
+}
+
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent_step {
+  __typename: "ExecutionStep";
+  name: string;
+}
+
+export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent {
+  __typename: "PipelineProcessStartedEvent";
+  message: string;
+  timestamp: string;
+  level: LogLevel;
+  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent_step | null;
+  processId: number;
 }
 
 export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent_step {
@@ -57,20 +64,12 @@ export interface StartPipelineExecution_startPipelineExecution_StartPipelineExec
   message: string;
   timestamp: string;
   level: LogLevel;
-  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent_step;
+  step: StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent_step | null;
   fileLocation: string;
   fileName: string;
 }
 
-export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent {
-  __typename: "PipelineProcessStartedEvent";
-  message: string;
-  timestamp: string;
-  level: LogLevel;
-  processId: number;
-}
-
-export type StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes = StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepStartEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent;
+export type StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes = StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_LogMessageEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_ExecutionStepFailureEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_PipelineProcessStartedEvent | StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_nodes_StepMaterializationEvent;
 
 export interface StartPipelineExecution_startPipelineExecution_StartPipelineExecutionSuccess_run_logs_pageInfo {
   __typename: "PageInfo";

--- a/js_modules/dagit/src/schema.json
+++ b/js_modules/dagit/src/schema.json
@@ -2106,6 +2106,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -2184,6 +2196,18 @@
                 "name": "LogLevel",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2285,515 +2309,6 @@
           }
         ],
         "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PipelineStartEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "run",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PipelineRun",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timestamp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "level",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "LogLevel",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pipeline",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Pipeline",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "PipelineEvent",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INTERFACE",
-        "name": "PipelineEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "pipeline",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Pipeline",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": [
-          {
-            "kind": "OBJECT",
-            "name": "PipelineStartEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "PipelineSuccessEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "PipelineFailureEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "PipelineProcessStartEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "PipelineProcessStartedEvent",
-            "ofType": null
-          }
-        ]
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PipelineSuccessEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "run",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PipelineRun",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timestamp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "level",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "LogLevel",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pipeline",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Pipeline",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "PipelineEvent",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PipelineFailureEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "run",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PipelineRun",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timestamp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "level",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "LogLevel",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pipeline",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Pipeline",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "PipelineEvent",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ExecutionStepStartEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "run",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PipelineRun",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timestamp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "level",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "LogLevel",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "step",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "ExecutionStepEvent",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INTERFACE",
-        "name": "ExecutionStepEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "step",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": [
-          {
-            "kind": "OBJECT",
-            "name": "ExecutionStepStartEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ExecutionStepSuccessEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ExecutionStepFailureEvent",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "StepMaterializationEvent",
-            "ofType": null
-          }
-        ]
       },
       {
         "kind": "OBJECT",
@@ -3087,6 +2602,494 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PipelineStartEvent",
+        "description": null,
+        "fields": [
+          {
+            "name": "run",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PipelineRun",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "level",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "LogLevel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pipeline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Pipeline",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessageEvent",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "PipelineEvent",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "PipelineEvent",
+        "description": null,
+        "fields": [
+          {
+            "name": "pipeline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Pipeline",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "PipelineStartEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PipelineSuccessEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PipelineFailureEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PipelineProcessStartEvent",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PipelineProcessStartedEvent",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PipelineSuccessEvent",
+        "description": null,
+        "fields": [
+          {
+            "name": "run",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PipelineRun",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "level",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "LogLevel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pipeline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Pipeline",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessageEvent",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "PipelineEvent",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PipelineFailureEvent",
+        "description": null,
+        "fields": [
+          {
+            "name": "run",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PipelineRun",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "level",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "LogLevel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pipeline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Pipeline",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessageEvent",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "PipelineEvent",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExecutionStepStartEvent",
+        "description": null,
+        "fields": [
+          {
+            "name": "run",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PipelineRun",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "level",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "LogLevel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MessageEvent",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ExecutionStepSuccessEvent",
         "description": null,
         "fields": [
@@ -3159,13 +3162,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3176,11 +3175,6 @@
           {
             "kind": "INTERFACE",
             "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "ExecutionStepEvent",
             "ofType": null
           }
         ],
@@ -3261,13 +3255,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3294,11 +3284,6 @@
           {
             "kind": "INTERFACE",
             "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "ExecutionStepEvent",
             "ofType": null
           }
         ],
@@ -3514,6 +3499,18 @@
             "deprecationReason": null
           },
           {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pipeline",
             "description": null,
             "args": [],
@@ -3611,6 +3608,18 @@
                 "name": "LogLevel",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "step",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3748,13 +3757,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ExecutionStep",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "ExecutionStep",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3797,11 +3802,6 @@
           {
             "kind": "INTERFACE",
             "name": "MessageEvent",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "ExecutionStepEvent",
             "ofType": null
           }
         ],

--- a/js_modules/dagit/src/schema.json
+++ b/js_modules/dagit/src/schema.json
@@ -3429,6 +3429,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "InvalidDefinitionError",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ConfigTypeNotFoundError",
             "ofType": null
           },
@@ -4107,6 +4112,11 @@
             "kind": "OBJECT",
             "name": "PythonError",
             "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "InvalidDefinitionError",
+            "ofType": null
           }
         ]
       },
@@ -4142,6 +4152,63 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InvalidDefinitionError",
+        "description": null,
+        "fields": [
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Error",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/js_modules/dagit/src/types/AppQuery.ts
+++ b/js_modules/dagit/src/types/AppQuery.ts
@@ -11,6 +11,12 @@ export interface AppQuery_pipelinesOrError_PythonError {
   stack: string[];
 }
 
+export interface AppQuery_pipelinesOrError_InvalidDefinitionError {
+  __typename: "InvalidDefinitionError";
+  message: string;
+  stack: string[];
+}
+
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_contexts_config_configType_EnumConfigType_innerTypes_EnumConfigType_innerTypes {
   __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
   key: string;
@@ -563,7 +569,7 @@ export interface AppQuery_pipelinesOrError_PipelineConnection {
   nodes: AppQuery_pipelinesOrError_PipelineConnection_nodes[];
 }
 
-export type AppQuery_pipelinesOrError = AppQuery_pipelinesOrError_PythonError | AppQuery_pipelinesOrError_PipelineConnection;
+export type AppQuery_pipelinesOrError = AppQuery_pipelinesOrError_PythonError | AppQuery_pipelinesOrError_InvalidDefinitionError | AppQuery_pipelinesOrError_PipelineConnection;
 
 export interface AppQuery {
   pipelinesOrError: AppQuery_pipelinesOrError;

--- a/js_modules/dagit/src/types/PipelinePageFragment.ts
+++ b/js_modules/dagit/src/types/PipelinePageFragment.ts
@@ -11,6 +11,12 @@ export interface PipelinePageFragment_PythonError {
   stack: string[];
 }
 
+export interface PipelinePageFragment_InvalidDefinitionError {
+  __typename: "InvalidDefinitionError";
+  message: string;
+  stack: string[];
+}
+
 export interface PipelinePageFragment_PipelineConnection_nodes_contexts_config_configType_EnumConfigType_innerTypes_EnumConfigType_innerTypes {
   __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ListConfigType" | "NullableConfigType";
   key: string;
@@ -563,4 +569,4 @@ export interface PipelinePageFragment_PipelineConnection {
   nodes: PipelinePageFragment_PipelineConnection_nodes[];
 }
 
-export type PipelinePageFragment = PipelinePageFragment_PythonError | PipelinePageFragment_PipelineConnection;
+export type PipelinePageFragment = PipelinePageFragment_PythonError | PipelinePageFragment_InvalidDefinitionError | PipelinePageFragment_PipelineConnection;


### PR DESCRIPTION
Clicking a step in the execution plan now shows only logs that were tagged with that step (rather than logs that contain the text). This isn't working as well as it could because user-logged messages don't have step metadata, but we'll fix that separately:

<img width="736" alt="image" src="https://user-images.githubusercontent.com/1037212/54238039-9f6d3280-44d4-11e9-82ad-dfc3579275af.png">

Closes #834