### PR TITLE
Fix terrible scrollbars on Windows and MacOS with external mouse

### DIFF
--- a/js_modules/dagit/src/configeditor/ConfigEditor.tsx
+++ b/js_modules/dagit/src/configeditor/ConfigEditor.tsx
@@ -114,17 +114,17 @@ export default class ConfigEditor extends React.Component<IConfigEditorProps> {
 
 injectGlobal`
   .react-codemirror2 {
-    overflow-y: scroll;
-    && {
-      width: 100%;
-      flex: 1;
-    }
+    height: 100%;
+    flex: 1;
+    position: relative;
   }
-  .CodeMirror {
-    && {
-      height: 100%;
-      width: 100%;
-    }
+  .react-codemirror2 .CodeMirror {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: initial;
   }
   .cm-whitespace {
     /*

--- a/js_modules/dagit/src/execution/LogsScrollingTable.tsx
+++ b/js_modules/dagit/src/execution/LogsScrollingTable.tsx
@@ -235,6 +235,7 @@ class LogsScrollingTableSized extends React.Component<
           columnCount={3}
           width={this.props.width}
           height={this.props.height}
+          autoContainerWidth={true}
           deferredMeasurementCache={this.cache}
           rowHeight={this.cache.rowHeight}
           rowCount={this.props.nodes.length}
@@ -277,7 +278,7 @@ const Cell = styled.div<{ level: LogLevel }>`
     }[props.level])};
 `;
 
-const OverflowFade = styled.div`
+const OverflowFade = styled.div<{ level: LogLevel }>`
   position: absolute;
   bottom: 0;
   left: 0;
@@ -287,8 +288,24 @@ const OverflowFade = styled.div`
   pointer-events: none;
   background: linear-gradient(
     to bottom,
-    rgba(245, 248, 250, 0) 0%,
-    rgba(245, 248, 250, 255) 100%
+    ${props =>
+        ({
+          [LogLevel.DEBUG]: `rgba(245, 248, 250, 0)`,
+          [LogLevel.INFO]: `rgba(245, 248, 250, 0)`,
+          [LogLevel.WARNING]: `rgba(240, 241, 237, 0)`,
+          [LogLevel.ERROR]: `rgba(243, 236, 239, 0)`,
+          [LogLevel.CRITICAL]: `rgba(243, 236, 239, 0)`
+        }[props.level])}
+      0%,
+    ${props =>
+        ({
+          [LogLevel.DEBUG]: `rgba(245, 248, 250, 255)`,
+          [LogLevel.INFO]: `rgba(245, 248, 250, 255)`,
+          [LogLevel.WARNING]: `rgba(240, 241, 237, 255)`,
+          [LogLevel.ERROR]: `rgba(243, 236, 239, 255)`,
+          [LogLevel.CRITICAL]: `rgba(243, 236, 239, 255)`
+        }[props.level])}
+      100%
   );
 `;
 const OverflowBanner = styled.div`
@@ -354,7 +371,7 @@ class OverflowDetectingCell extends React.Component<
         {this.props.children}
         {this.state.isOverflowing && (
           <>
-            <OverflowFade />
+            <OverflowFade level={level} />
             <OverflowBanner onClick={this.onCopy}>
               Copy entire message
             </OverflowBanner>

--- a/js_modules/dagit/src/index.tsx
+++ b/js_modules/dagit/src/index.tsx
@@ -52,6 +52,7 @@ injectGlobal`
   html, body, #root {
     max-width: 100%;
     min-height: 100%;
+    overflow: hidden;
     display: flex;
     flex: 1 1;
   }


### PR DESCRIPTION
Before:
<img width="1589" alt="image" src="https://user-images.githubusercontent.com/1037212/54239522-a1d18b80-44d8-11e9-99a1-03745e101d26.png">


After:
<img width="1589" alt="image" src="https://user-images.githubusercontent.com/1037212/54239511-9716f680-44d8-11e9-924f-a046f18f806f.png">

Still ugly compared to the nice overlay scrolling that is the default on macOS, but should make us look less silly on Windows.