### PR TITLE
Show pipeline total execution time in a new status dot at the bottom

### DIFF
--- a/js_modules/dagit/src/Util.tsx
+++ b/js_modules/dagit/src/Util.tsx
@@ -40,3 +40,28 @@ export function debounce<T extends (...args: any[]) => any>(
 
   return (debounced as any) as T;
 }
+
+function twoDigit(v: number) {
+  return `${v < 10 ? "0" : ""}${v}`;
+}
+
+export function formatElapsedTime(elapsed: number) {
+  let text = "";
+
+  if (elapsed < 1000) {
+    // < 1 second, show "X msec"
+    text = `${Math.ceil(elapsed)} msec`;
+  } else {
+    // < 1 hour, show "42:12"
+    const sec = Math.floor(elapsed / 1000) % 60;
+    const min = Math.floor(elapsed / 1000 / 60) % 60;
+    const hours = Math.floor(elapsed / 1000 / 60 / 60);
+
+    if (hours > 0) {
+      text = `${hours}:${twoDigit(min)}:${twoDigit(sec)}`;
+    } else {
+      text = `${min}:${twoDigit(sec)}`;
+    }
+  }
+  return text;
+}

--- a/js_modules/dagit/src/execution/PipelineRunExecutionPlan.tsx
+++ b/js_modules/dagit/src/execution/PipelineRunExecutionPlan.tsx
@@ -5,6 +5,7 @@ import { Colors } from "@blueprintjs/core";
 import { PipelineRunExecutionPlanFragment } from "./types/PipelineRunExecutionPlanFragment";
 import { ExecutionPlanBox } from "./PipelineRunExecutionPlanBox";
 import { IRunMetadataDict, IStepState } from "./RunMetadataProvider";
+import { formatElapsedTime } from "../Util";
 
 interface IPipelineRunExecutionPlanProps {
   run: PipelineRunExecutionPlanFragment;
@@ -97,6 +98,16 @@ export default class PipelineRunExecutionPlan extends React.Component<
               />
             );
           })}
+          {runMetadata.exitedAt && runMetadata.startedProcessAt && (
+            <ExecutionTimelineMessage>
+              <ExecutionTimelineDot completed={startDone} />
+              <span>
+                {`Process exited in ${formatElapsedTime(
+                  runMetadata.exitedAt - runMetadata.startedProcessAt
+                )}`}
+              </span>
+            </ExecutionTimelineMessage>
+          )}
         </ExecutionPlanContainerInner>
       </ExecutionPlanContainer>
     );
@@ -111,9 +122,9 @@ const ExecutionPlanContainer = styled.div`
 `;
 
 const ExecutionPlanContainerInner = styled.div`
-  margin-top: 15px;
+  margin-top: 10px;
   position: relative;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -125,6 +136,8 @@ const ExecutionTimelineMessage = styled.div`
   align-items: center;
   position: relative;
   color: ${Colors.LIGHT_GRAY2};
+  margin-top: 3px;
+  margin-bottom: 3px;
   z-index: 2;
 `;
 

--- a/js_modules/dagit/src/execution/PipelineRunExecutionPlanBox.tsx
+++ b/js_modules/dagit/src/execution/PipelineRunExecutionPlanBox.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { Colors, Spinner, Intent } from "@blueprintjs/core";
 import { IStepState, IStepMaterialization } from "./RunMetadataProvider";
 import { Materialization } from "./Materialization";
+import { formatElapsedTime } from "../Util";
 
 interface IExecutionPlanBoxProps {
   state: IStepState;
@@ -17,10 +18,6 @@ interface IExecutionPlanBoxProps {
 
 interface IExecutionPlanBoxState {
   v: number;
-}
-
-function twoDigit(v: number) {
-  return `${v < 10 ? "0" : ""}${v}`;
 }
 
 export class ExecutionPlanBox extends React.Component<
@@ -163,24 +160,7 @@ const ExecutionStateDot = styled.div<{ state: IStepState }>`
 `;
 
 const ExecutionTime = ({ elapsed }: { elapsed: number }) => {
-  let text = "";
-
-  if (elapsed < 1000) {
-    // < 1 second, show "X msec"
-    text = `${Math.ceil(elapsed)} msec`;
-  } else {
-    // < 1 hour, show "42:12"
-    const sec = Math.floor(elapsed / 1000) % 60;
-    const min = Math.floor(elapsed / 1000 / 60) % 60;
-    const hours = Math.floor(elapsed / 1000 / 60 / 60);
-
-    if (hours > 0) {
-      text = `${hours}:${twoDigit(min)}:${twoDigit(sec)}`;
-    } else {
-      text = `${min}:${twoDigit(sec)}`;
-    }
-  }
-
+  let text = formatElapsedTime(elapsed);
   // Note: Adding a min-width prevents the size of the execution plan box from
   // shifting /slightly/ as the elapsed time increments.
   return (
@@ -228,9 +208,8 @@ const ExecutionPlanBoxContainer = styled.div<{ state: IStepState }>`
   color: ${Colors.DARK_GRAY3};
   padding: 4px;
   padding-right: 10px;
-  margin: 6px;
-  margin-left: 15px;
-  margin-bottom: 0;
+  margin: 3px;
+  margin-left: 12px;
   display: inline-flex;
   min-width: 150px;
   align-items: center;

--- a/js_modules/dagit/src/execution/RunMetadataProvider.tsx
+++ b/js_modules/dagit/src/execution/RunMetadataProvider.tsx
@@ -28,6 +28,7 @@ export interface IRunMetadataDict {
   startingProcessAt?: number;
   startedProcessAt?: number;
   startedPipelineAt?: number;
+  exitedAt?: number;
   processId?: number;
   steps: {
     [stepName: string]: IStepMetadata;
@@ -51,6 +52,12 @@ function extractMetadataFromLogs(
     }
     if (log.__typename === "PipelineStartEvent") {
       metadata.startedPipelineAt = Number.parseInt(log.timestamp);
+    }
+    if (
+      log.__typename === "PipelineFailureEvent" ||
+      log.__typename === "PipelineSuccessEvent"
+    ) {
+      metadata.exitedAt = Number.parseInt(log.timestamp);
     }
 
     if ("step" in log) {


### PR DESCRIPTION
This is a simple addition - Dagit now shows the elapsed time of the entire pipeline when the pipeline has finished executing. This should make it easier to time pipelines and see regressions in performance. #831

<img width="464" alt="image" src="https://user-images.githubusercontent.com/1037212/54240354-14436b00-44db-11e9-9b88-cc8946b92347.png">
