### PR TITLE
Retry dagstermill test on specific failure

### DIFF
--- a/python_modules/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
+++ b/python_modules/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_solids.py
@@ -5,25 +5,14 @@ import pytest
 
 from dagster import execute_pipeline
 from dagster.utils import script_relative_path
+from dagstermill import DagstermillError
 
 from dagster_pandas.examples import (
     define_pandas_papermill_pandas_hello_world_pipeline,
     define_papermill_pandas_hello_world_pipeline,
 )
 
-
-def notebook_test(f):
-    # mark this with the "notebook_test" tag so that they can be all be skipped
-    # (for performance reasons) and mark them as python3 only
-    return pytest.mark.notebook_test(
-        pytest.mark.skipif(
-            sys.version_info < (3, 5),
-            reason='''Notebooks execute in their own process and hardcode what "kernel" they use.
-        All of the development notebooks currently use the python3 "kernel" so they will
-        not be executable in a container that only have python2.7 (e.g. in CircleCI)
-        ''',
-        )(f)
-    )
+from dagstermill.test_utils import notebook_test
 
 
 @pytest.mark.skip('Must ship over run id to notebook process')

--- a/python_modules/dagstermill/dagstermill/test_utils.py
+++ b/python_modules/dagstermill/dagstermill/test_utils.py
@@ -1,0 +1,30 @@
+import sys
+from dagstermill import DagstermillError
+
+
+def notebook_test(f):
+    # import this on demand so that main module does not require pytest if this is not called
+    import pytest
+
+    # mark this with the "notebook_test" tag so that they can be all be skipped
+    # (for performance reasons) and mark them as python3 only
+
+    # In our circleci environment we get periodic and annoying failures
+    # where we get this error and its unclear why. We insert a
+    # retry here
+    def do_test_with_retry():
+        try:
+            f()
+        except DagstermillError as de:
+            if 'Kernel died before replying to kernel_info' in str(de):
+                f()
+
+    return pytest.mark.notebook_test(
+        pytest.mark.skipif(
+            sys.version_info < (3, 5),
+            reason='''Notebooks execute in their own process and hardcode what "kernel" they use.
+        All of the development notebooks currently use the python3 "kernel" so they will
+        not be executable in a container that only have python2.7 (e.g. in CircleCI)
+        ''',
+        )(do_test_with_retry)
+    )

--- a/python_modules/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_basic_dagstermill_solids.py
@@ -1,10 +1,9 @@
-import sys
-
 import pytest
 
 from dagster import execute_pipeline, RunConfig
 
 from dagstermill import DagstermillError
+from dagstermill.test_utils import notebook_test
 from dagstermill.examples.repository import (
     define_add_pipeline,
     define_error_pipeline,
@@ -14,18 +13,6 @@ from dagstermill.examples.repository import (
     define_tutorial_pipeline,
     define_no_repo_registration_error_pipeline,
 )
-
-
-# Notebooks encode what version of python (e.g. their kernel)
-# they run on, so we can't run notebooks in python2 atm
-def notebook_test(f):
-    return pytest.mark.skipif(
-        sys.version_info < (3, 5),
-        reason='''Notebooks execute in their own process and hardcode what "kernel" they use.
-        All of the development notebooks currently use the python3 "kernel" so they will
-        not be executable in a container that only have python2.7 (e.g. in CircleCI)
-        ''',
-    )(f)
 
 
 @notebook_test

--- a/python_modules/dagstermill/dagstermill_tests/test_test_utils.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_test_utils.py
@@ -45,4 +45,3 @@ def test_double_fail():
         always_fail()
 
     assert has_been_called['times'] == 2
-

--- a/python_modules/dagstermill/dagstermill_tests/test_test_utils.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_test_utils.py
@@ -1,5 +1,20 @@
+import pytest
+
 from dagstermill import DagstermillError
 from dagstermill.test_utils import notebook_test
+
+
+def test_normal_test():
+    has_been_called = {}
+
+    @notebook_test
+    def normal_test():
+        has_been_called['yup'] = True
+        assert True
+
+    normal_test()
+
+    assert 'yup' in has_been_called
 
 
 def test_retry_logic():
@@ -16,3 +31,18 @@ def test_retry_logic():
 
     assert has_been_called['yup']
     assert has_been_called['times'] == 2
+
+
+def test_double_fail():
+    has_been_called = {'times': 0}
+
+    @notebook_test
+    def always_fail():
+        has_been_called['times'] = has_been_called['times'] + 1
+        raise DagstermillError('Kernel died before replying to kernel_info')
+
+    with pytest.raises(DagstermillError):
+        always_fail()
+
+    assert has_been_called['times'] == 2
+

--- a/python_modules/dagstermill/dagstermill_tests/test_test_utils.py
+++ b/python_modules/dagstermill/dagstermill_tests/test_test_utils.py
@@ -1,0 +1,18 @@
+from dagstermill import DagstermillError
+from dagstermill.test_utils import notebook_test
+
+
+def test_retry_logic():
+    has_been_called = {'times': 0}
+
+    @notebook_test
+    def execute_thing():
+        has_been_called['times'] = has_been_called['times'] + 1
+        if 'yup' not in has_been_called:
+            has_been_called['yup'] = True
+            raise DagstermillError('Kernel died before replying to kernel_info')
+
+    execute_thing()
+
+    assert has_been_called['yup']
+    assert has_been_called['times'] == 2


### PR DESCRIPTION
Getting relatively annoyed at the circle-ci only periodic failures about the kernel_info. Putting in an autoretry.