### PR TITLE
Use virtual package instead of enum34

### DIFF
--- a/python_modules/dagit/requirements.txt
+++ b/python_modules/dagit/requirements.txt
@@ -1,6 +1,6 @@
 click>=6.7
 dagster
-enum34>=1.1.6
+enum-compat==0.0.2
 flask-cors>=3.0.6
 Flask-GraphQL>=2.0.0
 Flask-Sockets>=0.2.1

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -54,7 +54,7 @@ def _do_setup(name='dagit'):
         include_package_data=True,
         install_requires=[
             # standard python 2/3 compatability things
-            'enum34>=1.1.6',
+            'enum-compat==0.0.2',
             'future>=0.16.0, <0.17.0a0',
             # cli
             # 'click>=6.7',

--- a/python_modules/dagster-airflow/setup.py
+++ b/python_modules/dagster-airflow/setup.py
@@ -38,7 +38,7 @@ def _do_setup(name='dagster-airflow'):
         packages=find_packages(exclude=['dagster_airflow_tests']),
         install_requires=[
             # standard python 2/3 compatability things
-            'enum34>=1.1.6',
+            'enum-compat==0.0.2',
             'future>=0.16.0, <0.17.0a0',  # pin to range for Airflow compat
             'six>=1.11.0',
             # cli

--- a/python_modules/dagster-ge/setup.py
+++ b/python_modules/dagster-ge/setup.py
@@ -44,7 +44,7 @@ def _do_setup(name='dagster-ge'):
         packages=find_packages(exclude=['dagster_ge_tests']),
         install_requires=[
             # standard python 2/3 compatability things
-            'enum34>=1.1.6',
+            'enum-compat==0.0.2',
             'future>=0.16.0',
             'dagster>=0.2.0',
             'great-expectations>=0.4.2',

--- a/python_modules/dagster/requirements.txt
+++ b/python_modules/dagster/requirements.txt
@@ -1,7 +1,7 @@
 click>=6.7
 coloredlogs>=10.0
 contextlib2>=0.5.5
-enum34>=1.1.6
+enum-compat==0.0.2
 # funcsigs pinned for compatibility with existing Airflow installs
 funcsigs==1.0.0
 # future pinned to range for compatibility with Airflow

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -53,7 +53,7 @@ def _do_setup(name='dagster'):
         packages=find_packages(exclude=['dagster_tests']),
         install_requires=[
             # standard python 2/3 compatability things
-            'enum34>=1.1.6',
+            'enum-compat==0.0.2',
             'future>=0.16.0, <0.17a0',  # pinned to range for compatibility with Airflow
             'funcsigs==1.0.0',  # pinned for compatibility with existing Airflow installs
             'contextlib2>=0.5.5',

--- a/python_modules/dagstermill/requirements.txt
+++ b/python_modules/dagstermill/requirements.txt
@@ -1,4 +1,4 @@
-enum34>=1.1.6
+enum-compat==0.0.2
 future>=0.16.0, <0.17.0a0
 ipykernel>=4.9.0
 papermill>=0.18.0

--- a/python_modules/dagstermill/setup.py
+++ b/python_modules/dagstermill/setup.py
@@ -42,7 +42,7 @@ def _do_setup(name='dagstermill'):
         ],
         install_requires=[
             # standard python 2/3 compatability things
-            'enum34>=1.1.6',
+            'enum-compat==0.0.2',
             'future>=0.16.0, <0.17.0a0',
             'ipykernel>=4.9.0',
             'papermill>=0.18.0',


### PR DESCRIPTION
enum34 is no longer compatible with the standard library and leads to errors when installing other packages on py37

see: https://stackoverflow.com/a/45716067