### PR TITLE
Exit properly on double Ctrl-C when running in watch mode

### DIFF
--- a/python_modules/dagit/bin/dagit
+++ b/python_modules/dagit/bin/dagit
@@ -1,19 +1,41 @@
-#!/bin/bash
-ARGS=()
-WATCH="0"
-for var in "$@"; do
-    if [ "$var" == '--no-watch' ]; then
-      WATCH="0"
-    if [ "$var" == '--watch' ]; then
-      WATCH="1"
-    else
-      ARGS+=("$var")
-    fi
-done
+#!/usr/bin/env python
+import sys
+import time
+import signal
+from watchdog.observers import Observer
+from watchdog.tricks import AutoRestartTrick
 
-if [ "$WATCH" = "1" ]; then
-  echo "Watching for file changes..."
-  watchmedo auto-restart -p="*.py" -R dagit-cli -- "$@"
-else
-  dagit-cli "${ARGS[@]}"
-fi
+# Build the dagit-cli command, omitting the --no-watch arg if present
+watch = True
+command = ["dagit-cli"]
+for arg in sys.argv[1:]:
+    if arg == "--no-watch":
+        watch = False
+    else:
+        command.append(arg)
+
+handler = AutoRestartTrick(command=command,
+                           patterns=["*.py"],
+                           ignore_patterns=[],
+                           ignore_directories=[],
+                           stop_signal=signal.SIGINT,
+                           kill_after=0.5)
+handler.start()
+
+if watch:
+    print("Watching for file changes...")
+    observer = Observer(timeout=1)
+    observer.schedule(handler, ".", True)
+    observer.start()
+
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    handler.stop()
+    if watch:
+        observer.stop()
+
+handler.stop()
+if watch:
+    observer.join()

--- a/python_modules/dagit/bin/dagit
+++ b/python_modules/dagit/bin/dagit
@@ -14,6 +14,19 @@ for arg in sys.argv[1:]:
     else:
         command.append(arg)
 
+# Use watchdog's python API to auto-restart the dagit-cli process when
+# python files in the current directory change. This is a slightly modified
+# version of the code in watchdog's `watchmedo` CLI. We've modified the
+# KeyboardInterupt handler below to call handler.stop() before tearing
+# down the observer so that repeated Ctrl-C's don't cause the process to
+# exit and leave dagit-cli dangling.
+#
+# Original source:
+# https://github.com/gorakhargosh/watchdog/blob/master/src/watchdog/watchmedo.py#L124
+#
+# Issue:
+# https://github.com/gorakhargosh/watchdog/issues/543
+
 handler = AutoRestartTrick(command=command,
                            patterns=["*.py"],
                            ignore_patterns=[],


### PR DESCRIPTION
This PR replaces the bash script I wrote to execute `dagit-cli` or `watchmedo dagit-cli` with a Python script that uses watchdog's API directly.

The problem we observed with the other approach is that the watchmedo CLI attempts to clean up the file watchers BEFORE sending a signal to the subprocess it launches. This process takes a while, and sending a second SIGINT in this time window kills the watchmedo process without a signal ever getting sent to the subprocess.

The relevant code in watchdog is here: https://github.com/gorakhargosh/watchdog/blob/master/src/watchdog/watchmedo.py#L124. This function runs `observer.stop()`, `observer.join()`, and then in the callsite the `handler` is stopped which kills the subprocess.

Thankfully watchdog's python API is pretty nice and watchmedo uses it directly - I basically pulled 20 lines of watchmedo out into our launch script and added the `handler.stop()` call that is missing.