### PR TITLE
Make execute_plan report error on wrongly specified step

### DIFF
--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -37,7 +37,7 @@ from .execution_context import (
     SystemPipelineExecutionContext,
 )
 
-from .errors import DagsterInvariantViolationError
+from .errors import DagsterInvariantViolationError, DagsterExecutionStepNotFoundError
 
 from .events import construct_event_logger
 
@@ -706,6 +706,13 @@ def execute_plan(execution_plan, environment_dict=None, run_config=None, step_ke
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     run_config = check_run_config_param(run_config)
     check.opt_list_param(step_keys_to_execute, 'step_keys_to_execute', of_type=str)
+
+    if step_keys_to_execute:
+        for step_key in step_keys_to_execute:
+            if not execution_plan.has_step(step_key):
+                raise DagsterExecutionStepNotFoundError(
+                    'Execution plan does not contain step "{}"'.format(step_key), step_key=step_key
+                )
 
     with yield_pipeline_execution_context(
         execution_plan.pipeline_def, environment_dict, run_config

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -379,3 +379,16 @@ def test_using_s3_for_subplan(s3_bucket):
         ) as context:
             rm_s3_intermediate(context, s3_bucket, run_id, 'return_one.transform')
             rm_s3_intermediate(context, s3_bucket, run_id, 'add_one.transform')
+
+
+def test_execute_step_wrong_step_key():
+    pipeline = define_inty_pipeline()
+
+    execution_plan = create_execution_plan(pipeline)
+
+    with pytest.raises(DagsterExecutionStepNotFoundError) as exc_info:
+        execute_plan(execution_plan, step_keys_to_execute=['nope'])
+
+    assert exc_info.value.step_key == 'nope'
+
+    assert str(exc_info.value) == 'Execution plan does not contain step "nope"'


### PR DESCRIPTION
https://github.com/dagster-io/dagster/issues/976

Next step is to add proper graphql error. Waiting on test_graphql.py refactor.