### PR TITLE
Run _error_check_step_output_values within error boundary

### DIFF
--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -199,15 +199,27 @@ def _execute_steps_core_loop(step_context, inputs, intermediates_manager):
             step_context.step, input_name, input_value
         )
 
-    step_output_value_iterator = check.generator(
-        _iterate_step_output_values_within_boundary(step_context, evaluated_inputs)
-    )
+    step = step_context.step
+    step_context.events.execution_plan_step_start(step.key)
 
-    for step_output_value in check.generator(
-        _error_check_step_output_values(step_context.step, step_output_value_iterator)
-    ):
+    try:
+        step_output_value_iterator = check.generator(
+            _iterate_step_output_values_within_boundary(step_context, evaluated_inputs)
+        )
 
-        yield _create_step_event(step_context, step_output_value, intermediates_manager)
+        for step_output_value in check.generator(
+            _error_check_step_output_values(step_context.step, step_output_value_iterator)
+        ):
+
+            yield _create_step_event(step_context, step_output_value, intermediates_manager)
+
+    except DagsterError as e:
+        step_context.events.execution_plan_step_failure(step.key, sys.exc_info())
+        stack_trace = get_formatted_stack_trace(e)
+        step_context.log.error(str(e), stack_trace=stack_trace)
+        raise e
+
+    step_context.events.execution_plan_step_success(step.key, timer_result.millis)
 
 
 def _create_step_event(step_context, step_output_value, intermediates_manager):
@@ -296,19 +308,10 @@ def _execution_step_error_boundary(step_context, msg, **kwargs):
     check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
     check.str_param(msg, 'msg')
 
-    step = step_context.step
-    step_context.events.execution_plan_step_start(step.key)
     try:
         with time_execution_scope() as timer_result:
             yield
-
-        step_context.events.execution_plan_step_success(step.key, timer_result.millis)
     except Exception as e:  # pylint: disable=W0703
-        step_context.events.execution_plan_step_failure(step.key, sys.exc_info())
-
-        stack_trace = get_formatted_stack_trace(e)
-        step_context.log.error(str(e), stack_trace=stack_trace)
-
         if isinstance(e, DagsterError):
             raise e
         else:

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -199,15 +199,16 @@ def _execute_steps_core_loop(step_context, inputs, intermediates_manager):
             step_context.step, input_name, input_value
         )
 
-    step_output_value_iterator = check.generator(
-        _iterate_step_output_values_within_boundary(step_context, evaluated_inputs)
-    )
+    error_str = 'Error occured during step {key}'.format(key=step_context.step.key)
+    with _execution_step_error_boundary(step_context, error_str):
+        step_output_value_iterator = check.generator(
+            _iterate_step_output_values(step_context, evaluated_inputs)
+        )
 
-    for step_output_value in check.generator(
-        _error_check_step_output_values(step_context.step, step_output_value_iterator)
-    ):
-
-        yield _create_step_event(step_context, step_output_value, intermediates_manager)
+        for step_output_value in check.generator(
+            _error_check_step_output_values(step_context.step, step_output_value_iterator)
+        ):
+            yield _create_step_event(step_context, step_output_value, intermediates_manager)
 
 
 def _create_step_event(step_context, step_output_value, intermediates_manager):
@@ -270,17 +271,15 @@ def _get_evaluated_input(step, input_name, input_value):
         )
 
 
-def _iterate_step_output_values_within_boundary(step_context, evaluated_inputs):
+def _iterate_step_output_values(step_context, evaluated_inputs):
     check.inst_param(step_context, 'step_context', SystemStepExecutionContext)
     check.dict_param(evaluated_inputs, 'evaluated_inputs', key_type=str)
 
-    error_str = 'Error occured during step {key}'.format(key=step_context.step.key)
-    with _execution_step_error_boundary(step_context, error_str):
-        gen = check.opt_generator(step_context.step.compute_fn(step_context, evaluated_inputs))
+    gen = check.opt_generator(step_context.step.compute_fn(step_context, evaluated_inputs))
 
-        if gen is not None:
-            for step_output_value in gen:
-                yield step_output_value
+    if gen is not None:
+        for step_output_value in gen:
+            yield step_output_value
 
 
 @contextmanager


### PR DESCRIPTION
This is a small fix for #955. It seems that the solid output validation (where `DagsterRuntimeCoercionError` is thrown) was happening outside of the error boundary that ensured the "step failed" event was emitted. I'm not sure if there's a better solution to this - just found that moving the error boundary worked and was a fairly straightforward change.