### PR TITLE
multiprocessing util

### DIFF
--- a/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
+++ b/python_modules/dagster/dagster/core/execution_plan/child_process_executor.py
@@ -8,6 +8,7 @@ import six
 
 from dagster import check
 from dagster.utils.error import serializable_error_info_from_exc_info, SerializableErrorInfo
+from dagster.utils import get_multiprocessing_context
 
 ChildProcessStartEvent = namedtuple('ChildProcessStartEvent', 'pid')
 ChildProcessDoneEvent = namedtuple('ChildProcessDoneEvent', 'pid')
@@ -92,9 +93,10 @@ def execute_child_process_command(command, return_process_events=False):
     check.inst_param(command, 'command', ChildProcessCommand)
     check.bool_param(return_process_events, 'return_process_events')
 
-    queue = multiprocessing.Queue()
+    multiprocessing_context = get_multiprocessing_context()
+    queue = multiprocessing_context.Queue()
 
-    process = multiprocessing.Process(
+    process = multiprocessing_context.Process(
         target=execute_command_in_child_process, args=(queue, command)
     )
 

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -96,10 +96,10 @@ class frozendict(dict):
     # By default pickle will iteratively call __setitem__ for restoring dict
     # Overriding __reduce__ allows us to ensure __setstate__ is used instead
     def __reduce__(self):
-        return (frozendict, (), self.__dict__)
+        return (frozendict, (), dict(self))
 
     def __setstate__(self, state):
-        self.__dict__ = state  # pylint:disable=attribute-defined-outside-init
+        self.__init__(state)
 
     __setitem__ = __readonly__
     __delitem__ = __readonly__

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -93,8 +93,12 @@ class frozendict(dict):
     def __readonly__(self, *args, **kwargs):
         raise RuntimeError("Cannot modify ReadOnlyDict")
 
-    # By default pickle will iteratively call __setitem__ for restoring dict
-    # Overriding __reduce__ allows us to ensure __setstate__ is used instead
+    # https://docs.python.org/3/library/pickle.html#object.__reduce__
+    #
+    # For a dict, the default behavior for pickle is to iteratively call __setitem__ (see 5th item in __reduce__ tuple).
+    # Since we want to disable __setitem__ and still inherit dict, we override this behavior by defining __reduce__.
+    # We return the 3rd item in the tuple, which is passed to __setstate__ allowing us to restore the frozendict.
+
     def __reduce__(self):
         return (frozendict, (), dict(self))
 


### PR DESCRIPTION
move the spawn context behavior to dagster/utils and use it in multiproc execution in addition to dagit

resolves #1003 