### PR TITLE
Serialize Spark data frames to zipped parquet files

### DIFF
--- a/python_modules/airline-demo/airline_demo_tests/test_types.py
+++ b/python_modules/airline-demo/airline_demo_tests/test_types.py
@@ -1,0 +1,44 @@
+import sys
+import tempfile
+
+from airline_demo.resources import spark_session_local, tempfile_resource
+from airline_demo.types import SparkDataFrameSerializationStrategy
+
+
+class MockResources(object):
+    def __init__(self, spark, tempfile_):
+        self.spark = spark
+        self.tempfile = tempfile_
+
+
+class MockPipelineContext(object):
+    def __init__(self, spark, tempfile_):
+        self.resources = MockResources(spark, tempfile_)
+
+
+def test_spark_data_frame_serialization():
+    spark = spark_session_local.resource_fn(None)
+    if sys.version_info > (3,):
+        tempfile_ = tempfile_resource.resource_fn(None).__next__()
+    else:
+        tempfile_ = tempfile_resource.resource_fn(None).next()
+
+    try:
+        serialization_strategy = SparkDataFrameSerializationStrategy()
+
+        pipeline_context = MockPipelineContext(spark, tempfile_)
+
+        df = spark.createDataFrame([('Foo', 1), ('Bar', 2)])
+
+        with tempfile.NamedTemporaryFile(delete=False) as tempfile_obj:
+            serialization_strategy.serialize_value(pipeline_context, df, tempfile_obj)
+
+            tempfile_obj.close()
+
+        with open(tempfile_obj.name, 'r+b') as tempfile_obj:
+            new_df = serialization_strategy.deserialize_value(pipeline_context, tempfile_obj)
+
+        assert set(map(lambda x: x[0], new_df.collect())) == set(['Bar', 'Foo'])
+        assert set(map(lambda x: x[1], new_df.collect())) == set([1, 2])
+    finally:
+        tempfile_.close()

--- a/python_modules/airline-demo/airline_demo_tests/test_types.py
+++ b/python_modules/airline-demo/airline_demo_tests/test_types.py
@@ -2,7 +2,7 @@ import sys
 import tempfile
 
 from airline_demo.resources import spark_session_local, tempfile_resource
-from airline_demo.types import SparkDataFrameSerializationStrategy
+from airline_demo.types import SparkDataFrameParquetSerializationStrategy
 
 
 class MockResources(object):
@@ -24,7 +24,7 @@ def test_spark_data_frame_serialization():
         tempfile_ = tempfile_resource.resource_fn(None).next()
 
     try:
-        serialization_strategy = SparkDataFrameSerializationStrategy()
+        serialization_strategy = SparkDataFrameParquetSerializationStrategy()
 
         pipeline_context = MockPipelineContext(spark, tempfile_)
 


### PR DESCRIPTION
This demonstrates serializing a Spark data frame with the `serialize(value, binary_stream)` and `deserialize(binary_stream)` API. The issues here are:

1) A Spark data frame naturally serializes as a directory of Parquet files, not a single binary stream
2) Repackaging a directory as a single file requires tempfile manipulation and cleanup
3) Packaging a directory as a file involves APIs (e.g., shutil and zipfile) that don't necessarily play nicely with each other / our tempfile management of choice / our decision to use streams. 