### PR TITLE
Update AWS dependency and S3 clients

### DIFF
--- a/scala_modules/README.md
+++ b/scala_modules/README.md
@@ -14,4 +14,5 @@ Some editor config to put in place: [Case Class Definition Style](https://stacko
 
 We follow the Twitter [Effective Scala](http://twitter.github.io/effectivescala/) style guide.
 
+Saving this here for future reference: [Spark + S3](https://medium.com/@subhojit20_27731/apache-spark-and-amazon-s3-gotchas-and-best-practices-a767242f3d98)
  

--- a/scala_modules/build.sbt
+++ b/scala_modules/build.sbt
@@ -25,7 +25,7 @@ lazy val events = project
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)
     },
-    // So, this is fun. Spark depends on hadoop-spark, which transitively depends on aws-java-sdk 1.7.4.
+    // So, this is fun. Spark depends on hadoop-aws, which transitively depends on aws-java-sdk 1.7.4.
     // We want to use 1.11.525 because otherwise we have to explicitly handle the credentials chain in client code, and
     // We want to be use the default credentials chain provider.
     //

--- a/scala_modules/events/src/main/scala/io/dagster/events/models/SparkJob.scala
+++ b/scala_modules/events/src/main/scala/io/dagster/events/models/SparkJob.scala
@@ -1,19 +1,13 @@
 package io.dagster.events.models
 
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
 import org.apache.log4j.{Level, LogManager}
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
 
-trait SparkJob {
-  final lazy val spark = SparkSession.builder.getOrCreate()
+abstract class SparkJob {
+  final lazy val spark: SparkSession = SparkSession.builder.getOrCreate()
+  final lazy val sc: SparkContext = spark.sparkContext
   final lazy val log = LogManager.getLogger(this.getClass.getName)
-  final lazy val s3Client = new AmazonS3Client(
-    new BasicAWSCredentials(
-      spark.sparkContext.getConf.get("spark.hadoop.fs.s3a.access.key"),
-      spark.sparkContext.getConf.get("spark.hadoop.fs.s3a.secret.key")
-    )
-  )
 
   def run(args: Array[String]): Unit
 


### PR DESCRIPTION
Here’s a great example I hit today of where local dev sometimes falls down for data projects. 

So, the job was working fine locally, and worked on the “cluster” running on my laptop with local data, but when I switched to the cluster + S3 data, the job kept dying with
```
WARN  TaskSetManager:66 - Lost task 0.1 in stage 0.0 (TID 1, 192.168.51.154, executor 0): java.lang.NoClassDefFoundError: Could not initialize class io.dagster.events.EventPipeline$
....
Caused by: org.apache.spark.SparkException: A master URL must be set in your configuration
```

Turns out, it was because Spark was attempting to serialize the S3 client I was instantiating here: https://github.com/dagster-io/dagster/pull/1045/files#diff-370dff405f5d67934fbd312d5ab732d8L11

and ship it out to the executors. This, in turn, followed `final lazy val spark = SparkSession.builder.getOrCreate()` and ran this on the executor JVMs, which created empty Spark sessions on the executors.

What actually needs to happen is for the job to instantiate S3 clients on each executor JVM, and instantiating those clients can't depend on state in our master's `SparkSession`. 

To instantiate an S3 client on each executor, we use `mapPartitions`, which gives us an opportunity to instantiate one S3 client per `Dataset` partition instead of on the master or per record.

However, a more complicated problem is avoiding the need to access the S3 credentials previously stashed in the `SparkSession`. To do this, we needed to use the default S3 credential chain, which didn't yet exist in the legacy AWS library we were using. As documented in `build.sbt`, Spark depends on `hadoop-aws`, which transitively depends on `aws-java-sdk` 1.7.4. Importing a more recent version of `aws-java-sdk` breaks `hadoop-aws`, in turn preventing use of S3 in Spark reads/writes.

To circumvent this issue, this PR shades the `aws-java-sdk` jar. This avoids thrashing the transitive dependency at jar assembly time, ensuring that Spark can continue using the legacy 1.7.4 AWS dependency, while our client code uses 1.11.525.
