### PR TITLE
[dagster] transformed values refactor

### DIFF
--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -206,8 +206,7 @@ class SolidExecutionResult(object):
         '''Return dictionary of transformed results, with keys being output names.
         Returns None if execution result isn't a success.
 
-        Reconstructs the pipeline context to materialize values. Results are memoized so
-        only the first call will reconstruct the context.
+        Reconstructs the pipeline context to materialize values.
         '''
         if self.success and self.transforms:
             with self.reconstruct_context() as context:
@@ -225,8 +224,7 @@ class SolidExecutionResult(object):
         '''Returns transformed value either for DEFAULT_OUTPUT or for the output
         given as output_name. Returns None if execution result isn't a success.
 
-        Looks up entry via transformed_values which will reconstruct the pipeline context
-        on first invocation.
+        Reconstructs the pipeline context to materialize value.
         '''
         check.str_param(output_name, 'output_name')
 

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -91,12 +91,13 @@ class PipelineExecutionResult(object):
     '''Result of execution of the whole pipeline. Returned eg by :py:func:`execute_pipeline`.
     '''
 
-    def __init__(self, pipeline, run_id, step_event_list):
+    def __init__(self, pipeline, run_id, step_event_list, reconstruct_context):
         self.pipeline = check.inst_param(pipeline, 'pipeline', PipelineDefinition)
         self.run_id = check.str_param(run_id, 'run_id')
         self.step_event_list = check.list_param(
             step_event_list, 'step_event_list', of_type=ExecutionStepEvent
         )
+        self.reconstruct_context = reconstruct_context
 
         solid_result_dict = self._context_solid_result_dict(step_event_list)
 
@@ -122,6 +123,7 @@ class PipelineExecutionResult(object):
             solid_result_dict[solid_name] = SolidExecutionResult(
                 self.pipeline.solid_named(solid_name),
                 dict(step_events_by_solid_by_kind[solid_name]),
+                self.reconstruct_context,
             )
         return solid_result_dict
 
@@ -163,11 +165,13 @@ class SolidExecutionResult(object):
       solid (SolidDefinition): Solid for which this result is
     '''
 
-    def __init__(self, solid, step_events_by_kind):
+    def __init__(self, solid, step_events_by_kind, reconstruct_context):
         self.solid = check.inst_param(solid, 'solid', Solid)
         self.step_events_by_kind = check.dict_param(
             step_events_by_kind, 'step_events_by_kind', key_type=StepKind, value_type=list
         )
+        self.reconstruct_context = reconstruct_context
+        self._memoized_values = None
 
     @property
     def transform(self):
@@ -186,28 +190,6 @@ class SolidExecutionResult(object):
     def output_expectations(self):
         return self.step_events_by_kind.get(StepKind.OUTPUT_EXPECTATION, [])
 
-    @staticmethod
-    def from_step_events(pipeline_context, step_events):
-        check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
-        step_events = check.list_param(step_events, 'step_events', ExecutionStepEvent)
-        if step_events:
-            step_events_by_kind = defaultdict(list)
-
-            solid = None
-            for result in step_events:
-                if solid is None:
-                    solid = result.step.solid
-                check.invariant(result.step.solid is solid, 'Must all be from same solid')
-
-            for result in step_events:
-                step_events_by_kind[result.kind].append(result)
-
-            return SolidExecutionResult(
-                solid=step_events[0].step.solid, step_events_by_kind=dict(step_events_by_kind)
-            )
-        else:
-            check.failed("Cannot create SolidExecutionResult from empty list")
-
     @property
     def success(self):
         '''Whether the solid execution was successful'''
@@ -223,18 +205,31 @@ class SolidExecutionResult(object):
     @property
     def transformed_values(self):
         '''Return dictionary of transformed results, with keys being output names.
-        Returns None if execution result isn't a success.'''
+        Returns None if execution result isn't a success.
+
+        Reconstructs the pipeline context to materialize values. Results are memoized so
+        only the first call will reconstruct the context.
+        '''
         if self.success and self.transforms:
-            return {
-                result.step_output_data.output_name: result.step_output_data.get_value()
-                for result in self.transforms
-            }
+            if self._memoized_values is None:
+                with self.reconstruct_context() as context:
+                    self._memoized_values = {
+                        result.step_output_data.output_name: self._get_value(
+                            context, result.step_output_data
+                        )
+                        for result in self.transforms
+                    }
+            return self._memoized_values
         else:
             return None
 
     def transformed_value(self, output_name=DEFAULT_OUTPUT):
         '''Returns transformed value either for DEFAULT_OUTPUT or for the output
-        given as output_name. Returns None if execution result isn't a success'''
+        given as output_name. Returns None if execution result isn't a success.
+
+        Looks up entry via transformed_values which will reconstruct the pipeline context
+        on first invocation.
+        '''
         check.str_param(output_name, 'output_name')
 
         if not self.solid.definition.has_output(output_name):
@@ -247,7 +242,7 @@ class SolidExecutionResult(object):
         if self.success:
             for result in self.transforms:
                 if result.step_output_data.output_name == output_name:
-                    return result.step_output_data.get_value()
+                    return self.transformed_values[output_name]
             raise DagsterInvariantViolationError(
                 (
                     'Did not find result {output_name} in solid {self.solid.name} '
@@ -256,6 +251,13 @@ class SolidExecutionResult(object):
             )
         else:
             return None
+
+    def _get_value(self, context, step_output_data):
+        return context.intermediates_manager.get_intermediate(
+            context=context,
+            runtime_type=self.solid.output_def_named(step_output_data.output_name).runtime_type,
+            step_output_handle=step_output_data.step_output_handle,
+        )
 
     @property
     def failure_data(self):
@@ -386,9 +388,8 @@ def construct_run_storage(run_config, environment_config):
         )
 
 
-def construct_intermediates_manager(run_config, init_context, environment_config, pipeline_def):
+def construct_intermediates_manager(run_config, environment_config, pipeline_def):
     check.inst_param(run_config, 'run_config', RunConfig)
-    check.inst_param(init_context, 'init_context', InitContext)
     check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
 
@@ -396,7 +397,7 @@ def construct_intermediates_manager(run_config, init_context, environment_config
         if run_config.storage_mode == RunStorageMode.FILESYSTEM:
             return ObjectStoreIntermediatesManager(
                 FileSystemObjectStore(
-                    init_context.run_id,
+                    run_config.run_id,
                     construct_type_registry(pipeline_def, RunStorageMode.FILESYSTEM),
                 )
             )
@@ -406,7 +407,7 @@ def construct_intermediates_manager(run_config, init_context, environment_config
             return ObjectStoreIntermediatesManager(
                 S3ObjectStore(
                     environment_config.storage.storage_config['s3_bucket'],
-                    init_context.run_id,
+                    run_config.run_id,
                     construct_type_registry(pipeline_def, RunStorageMode.S3),
                 )
             )
@@ -415,8 +416,7 @@ def construct_intermediates_manager(run_config, init_context, environment_config
     elif environment_config.storage.storage_mode == 'filesystem':
         return ObjectStoreIntermediatesManager(
             FileSystemObjectStore(
-                init_context.run_id,
-                construct_type_registry(pipeline_def, RunStorageMode.FILESYSTEM),
+                run_config.run_id, construct_type_registry(pipeline_def, RunStorageMode.FILESYSTEM)
             )
         )
     elif environment_config.storage.storage_mode == 'in_memory':
@@ -425,7 +425,7 @@ def construct_intermediates_manager(run_config, init_context, environment_config
         return ObjectStoreIntermediatesManager(
             S3ObjectStore(
                 environment_config.storage.storage_config['s3_bucket'],
-                init_context.run_id,
+                run_config.run_id,
                 construct_type_registry(pipeline_def, RunStorageMode.S3),
             )
         )
@@ -437,13 +437,28 @@ def construct_intermediates_manager(run_config, init_context, environment_config
         )
 
 
-@contextmanager
 def yield_pipeline_execution_context(pipeline_def, environment_dict, run_config):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.dict_param(environment_dict, 'environment_dict', key_type=str)
     check.inst_param(run_config, 'run_config', RunConfig)
 
     environment_config = create_environment_config(pipeline_def, environment_dict)
+    intermediates_manager = construct_intermediates_manager(
+        run_config, environment_config, pipeline_def
+    )
+    return pipeline_execution_context_manager(
+        pipeline_def, environment_config, run_config, intermediates_manager
+    )
+
+
+@contextmanager
+def pipeline_execution_context_manager(
+    pipeline_def, environment_config, run_config, intermediates_manager
+):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
+    check.inst_param(run_config, 'run_config', RunConfig)
+    check.inst_param(intermediates_manager, 'intermediates_manager', IntermediatesManager)
 
     context_definition = pipeline_def.context_definitions[environment_config.context.name]
 
@@ -481,9 +496,7 @@ def yield_pipeline_execution_context(pipeline_def, environment_dict, run_config)
                 resources,
                 environment_config,
                 run_storage,
-                construct_intermediates_manager(
-                    run_config, init_context, environment_config, pipeline_def
-                ),
+                intermediates_manager,
             )
 
 
@@ -584,6 +597,48 @@ def get_resource_or_gen(pipeline_def, context_definition, resource_name, environ
     )
 
 
+def _execute_pipeline_iterator(pipeline_context):
+    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+    pipeline_context.events.pipeline_start()
+
+    execution_plan = create_execution_plan_core(pipeline_context)
+
+    steps = execution_plan.topological_steps()
+
+    if not steps:
+        pipeline_context.log.debug(
+            'Pipeline {pipeline} has no nodes and no execution will happen'.format(
+                pipeline=pipeline_context.pipeline_def.display_name
+            )
+        )
+        pipeline_context.events.pipeline_success()
+        return
+
+    _setup_reexecution(pipeline_context.run_config, pipeline_context, execution_plan)
+
+    pipeline_context.log.debug(
+        'About to execute the compute node graph in the following order {order}'.format(
+            order=[step.key for step in steps]
+        )
+    )
+
+    check.invariant(len(steps[0].step_inputs) == 0)
+
+    pipeline_success = True
+
+    for step_event in invoke_executor_on_plan(
+        pipeline_context, execution_plan, pipeline_context.run_config.step_keys_to_execute
+    ):
+        if step_event.is_step_failure:
+            pipeline_success = False
+        yield step_event
+
+    if pipeline_success:
+        pipeline_context.events.pipeline_success()
+    else:
+        pipeline_context.events.pipeline_failure()
+
+
 def execute_pipeline_iterator(pipeline, environment_dict=None, run_config=None):
     '''Returns iterator that yields :py:class:`SolidExecutionResult` for each
     solid executed in the pipeline.
@@ -598,49 +653,15 @@ def execute_pipeline_iterator(pipeline, environment_dict=None, run_config=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     run_config = check_run_config_param(run_config)
+    environment_config = create_environment_config(pipeline, environment_dict)
+    intermediates_manager = construct_intermediates_manager(
+        run_config, environment_config, pipeline
+    )
 
-    with yield_pipeline_execution_context(
-        pipeline, environment_dict, run_config
+    with pipeline_execution_context_manager(
+        pipeline, environment_config, run_config, intermediates_manager
     ) as pipeline_context:
-
-        pipeline_context.events.pipeline_start()
-
-        execution_plan = create_execution_plan_core(pipeline_context)
-
-        steps = execution_plan.topological_steps()
-
-        if not steps:
-            pipeline_context.log.debug(
-                'Pipeline {pipeline} has no nodes and no execution will happen'.format(
-                    pipeline=pipeline.display_name
-                )
-            )
-            pipeline_context.events.pipeline_success()
-            return
-
-        _setup_reexecution(run_config, pipeline_context, execution_plan)
-
-        pipeline_context.log.debug(
-            'About to execute the compute node graph in the following order {order}'.format(
-                order=[step.key for step in steps]
-            )
-        )
-
-        check.invariant(len(steps[0].step_inputs) == 0)
-
-        pipeline_success = True
-
-        for step_event in invoke_executor_on_plan(
-            pipeline_context, execution_plan, run_config.step_keys_to_execute
-        ):
-            if step_event.is_step_failure:
-                pipeline_success = False
-            yield step_event
-
-        if pipeline_success:
-            pipeline_context.events.pipeline_success()
-        else:
-            pipeline_context.events.pipeline_failure()
+        return _execute_pipeline_iterator(pipeline_context)
 
 
 def execute_pipeline(pipeline, environment_dict=None, run_config=None):
@@ -661,14 +682,22 @@ def execute_pipeline(pipeline, environment_dict=None, run_config=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict')
     run_config = check_run_config_param(run_config)
+    environment_config = create_environment_config(pipeline, environment_dict)
+    intermediates_manager = construct_intermediates_manager(
+        run_config, environment_config, pipeline
+    )
+
+    with pipeline_execution_context_manager(
+        pipeline, environment_config, run_config, intermediates_manager
+    ) as pipeline_context:
+        step_event_list = list(_execute_pipeline_iterator(pipeline_context))
 
     return PipelineExecutionResult(
         pipeline,
         run_config.run_id,
-        list(
-            execute_pipeline_iterator(
-                pipeline=pipeline, environment_dict=environment_dict, run_config=run_config
-            )
+        step_event_list,
+        lambda: pipeline_execution_context_manager(
+            pipeline, environment_config, run_config, intermediates_manager
         ),
     )
 

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -8,7 +8,7 @@ from dagster.core.execution_context import (
     SystemPipelineExecutionContext,
     SystemStepExecutionContext,
 )
-from dagster.core.intermediates_manager import StepOutputHandle, InMemoryIntermediatesManager
+from dagster.core.intermediates_manager import StepOutputHandle
 from dagster.core.types.runtime import RuntimeType
 from dagster.core.utils import toposort
 from dagster.utils import merge_dicts
@@ -34,10 +34,9 @@ class SingleOutputStepCreationData(namedtuple('SingleOutputStepCreationData', 's
 
 
 class StepOutputData:
-    def __init__(self, step_output_handle, value_repr, intermediates_manager):
+    def __init__(self, step_output_handle, value_repr):
         self.step_output_handle = step_output_handle
         self._value_repr = value_repr
-        self._intermediates_manager = intermediates_manager
 
     @property
     def output_name(self):
@@ -46,18 +45,6 @@ class StepOutputData:
     @property
     def value_repr(self):
         return self._value_repr
-
-    def get_value(self):
-        # FIXME:
-        # https://github.com/dagster-io/dagster/issues/953
-        # For now we are disallowing getting the value for anything
-        # except the in-memory version of this. get_value will need to put
-        # on higher level object that will have access to pipeline_context
-
-        check.inst(self._intermediates_manager, InMemoryIntermediatesManager)
-        return self._intermediates_manager.get_intermediate(
-            context=None, runtime_type=None, step_output_handle=self.step_output_handle
-        )
 
 
 class StepFailureData(namedtuple('_StepFailureData', 'error_message error_cls_name stack')):

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -269,9 +269,7 @@ def _create_step_event(step_context, step_output_value, intermediates_manager):
         return ExecutionStepEvent.step_output_event(
             step_context=step_context,
             step_output_data=StepOutputData(
-                step_output_handle=step_output_handle,
-                value_repr=repr(value),
-                intermediates_manager=intermediates_manager,
+                step_output_handle=step_output_handle, value_repr=repr(value)
             ),
         )
     except DagsterRuntimeCoercionError as e:

--- a/python_modules/dagster/dagster/core/init_context.py
+++ b/python_modules/dagster/dagster/core/init_context.py
@@ -10,8 +10,8 @@ from .definitions.resource import ResourceDefinition
 
 class InitContext(namedtuple('_InitContext', 'context_config pipeline_def run_id')):
     '''
-    InitContext is the context object context creation functions In effect, it is 
-    the state available to those functions, and any function that is called 
+    InitContext is the context object context creation functions In effect, it is
+    the state available to those functions, and any function that is called
     prior to pipeline execution, plus the configuration value for that context.
     '''
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -44,11 +44,11 @@ def test_execution_plan_simple_two_steps():
 
     assert step_events[0].step_key == 'return_one.transform'
     assert step_events[0].is_successful_output
-    assert step_events[0].step_output_data.get_value() == 1
+    assert step_events[0].step_output_data.value_repr == '1'
 
     assert step_events[1].step_key == 'add_one.transform'
     assert step_events[1].is_successful_output
-    assert step_events[1].step_output_data.get_value() == 2
+    assert step_events[1].step_output_data.value_repr == '2'
 
 
 def test_execution_plan_two_outputs():
@@ -64,10 +64,10 @@ def test_execution_plan_two_outputs():
     step_events = execute_plan(execution_plan)
 
     assert step_events[0].step_key == 'return_one_two.transform'
-    assert step_events[0].step_output_data.get_value() == 1
+    assert step_events[0].step_output_data.value_repr == '1'
     assert step_events[0].step_output_data.output_name == 'num_one'
     assert step_events[1].step_key == 'return_one_two.transform'
-    assert step_events[1].step_output_data.get_value() == 2
+    assert step_events[1].step_output_data.value_repr == '2'
     assert step_events[1].step_output_data.output_name == 'num_two'
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -210,7 +210,7 @@ def assert_all_results_equivalent(expected_results, result_results):
 
 def test_pipeline_execution_graph_diamond():
     pipeline = PipelineDefinition(solids=create_diamond_solids(), dependencies=diamond_deps())
-    return _do_test(pipeline, lambda: execute_pipeline_iterator(pipeline))
+    return _do_test(pipeline)
 
 
 def test_execute_solid_in_diamond():
@@ -278,14 +278,8 @@ def test_two_root_solid_pipeline_with_partial_dependency_definition():
     assert result.success
 
 
-def _do_test(pipeline, do_execute_pipeline_iter):
-
-    results = list()
-
-    for result in do_execute_pipeline_iter():
-        results.append(result)
-
-    result = PipelineExecutionResult(pipeline, 'kdjfkdjfd', results)
+def _do_test(pipeline):
+    result = execute_pipeline(pipeline)
 
     assert result.result_for_solid('A').transformed_value() == [
         input_set('A_input'),
@@ -490,12 +484,12 @@ def test_pipeline_streaming_iterator():
 
     push_one_step_event = next(step_event_iterator)
     assert push_one_step_event.is_successful_output
-    assert push_one_step_event.step_output_data.get_value() == 1
+    assert push_one_step_event.step_output_data.value_repr == '1'
     assert events == [1]
 
     add_one_step_event = next(step_event_iterator)
     assert add_one_step_event.is_successful_output
-    assert add_one_step_event.step_output_data.get_value() == 2
+    assert add_one_step_event.step_output_data.value_repr == '2'
     assert events == [1, 2]
 
 
@@ -517,12 +511,12 @@ def test_pipeline_streaming_multiple_outputs():
 
     one_output_step_event = next(step_event_iterator)
     assert one_output_step_event.is_successful_output
-    assert one_output_step_event.step_output_data.get_value() == 1
+    assert one_output_step_event.step_output_data.value_repr == '1'
     assert one_output_step_event.step_output_data.output_name == 'one'
     assert events == [1]
 
     two_output_step_event = next(step_event_iterator)
     assert two_output_step_event.is_successful_output
-    assert two_output_step_event.step_output_data.get_value() == 2
+    assert two_output_step_event.step_output_data.value_repr == '2'
     assert two_output_step_event.step_output_data.output_name == 'two'
     assert events == [1, 2]

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -21,7 +21,7 @@ from dagster.core.definitions import Solid, solids_in_topological_order
 from dagster.core.definitions.dependency import DependencyStructure
 from dagster.core.definitions.pipeline import _create_adjacency_lists
 
-from dagster.core.execution import PipelineExecutionResult, SolidExecutionResult
+from dagster.core.execution import SolidExecutionResult
 
 from dagster.core.utility_solids import define_stub_solid
 

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20588,7 +20588,7 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 
 <dl class="class">
 <dt id="dagster.PipelineExecutionResult">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">PipelineExecutionResult</code><span class="sig-paren">(</span><em>pipeline</em>, <em>run_id</em>, <em>step_event_list</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.PipelineExecutionResult" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">PipelineExecutionResult</code><span class="sig-paren">(</span><em>pipeline</em>, <em>run_id</em>, <em>step_event_list</em>, <em>reconstruct_context</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.PipelineExecutionResult" title="Permalink to this definition">¶</a></dt>
 <dd><p>Result of execution of the whole pipeline. Returned eg by <a class="reference internal" href="#dagster.execute_pipeline" title="dagster.execute_pipeline"><code class="xref py py-func docutils literal notranslate"><span class="pre">execute_pipeline()</span></code></a>.</p>
 <dl class="method">
 <dt id="dagster.PipelineExecutionResult.result_for_solid">
@@ -20619,7 +20619,7 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 
 <dl class="class">
 <dt id="dagster.SolidExecutionResult">
-<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">SolidExecutionResult</code><span class="sig-paren">(</span><em>solid</em>, <em>step_events_by_kind</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.SolidExecutionResult" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">dagster.</code><code class="descname">SolidExecutionResult</code><span class="sig-paren">(</span><em>solid</em>, <em>step_events_by_kind</em>, <em>reconstruct_context</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.SolidExecutionResult" title="Permalink to this definition">¶</a></dt>
 <dd><p>Execution result for one solid of the pipeline.</p>
 <dl class="attribute">
 <dt id="dagster.SolidExecutionResult.context">
@@ -20649,7 +20649,9 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 <dt id="dagster.SolidExecutionResult.transformed_value">
 <code class="descname">transformed_value</code><span class="sig-paren">(</span><em>output_name=\'result\'</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.SolidExecutionResult.transformed_value" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns transformed value either for DEFAULT_OUTPUT or for the output
-given as output_name. Returns None if execution result isn’t a success</p>
+given as output_name. Returns None if execution result isn’t a success.</p>
+<p>Looks up entry via transformed_values which will reconstruct the pipeline context
+on first invocation.</p>
 </dd></dl>
 
 <dl class="attribute">
@@ -20657,6 +20659,8 @@ given as output_name. Returns None if execution result isn’t a success</p>
 <code class="descname">transformed_values</code><a class="headerlink" href="#dagster.SolidExecutionResult.transformed_values" title="Permalink to this definition">¶</a></dt>
 <dd><p>Return dictionary of transformed results, with keys being output names.
 Returns None if execution result isn’t a success.</p>
+<p>Reconstructs the pipeline context to materialize values. Results are memoized so
+only the first call will reconstruct the context.</p>
 </dd></dl>
 
 </dd></dl>

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -20650,8 +20650,7 @@ SystemPipelineExecutionContextCreationData although that seemed excessively verb
 <code class="descname">transformed_value</code><span class="sig-paren">(</span><em>output_name=\'result\'</em><span class="sig-paren">)</span><a class="headerlink" href="#dagster.SolidExecutionResult.transformed_value" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns transformed value either for DEFAULT_OUTPUT or for the output
 given as output_name. Returns None if execution result isn’t a success.</p>
-<p>Looks up entry via transformed_values which will reconstruct the pipeline context
-on first invocation.</p>
+<p>Reconstructs the pipeline context to materialize value.</p>
 </dd></dl>
 
 <dl class="attribute">
@@ -20659,8 +20658,7 @@ on first invocation.</p>
 <code class="descname">transformed_values</code><a class="headerlink" href="#dagster.SolidExecutionResult.transformed_values" title="Permalink to this definition">¶</a></dt>
 <dd><p>Return dictionary of transformed results, with keys being output names.
 Returns None if execution result isn’t a success.</p>
-<p>Reconstructs the pipeline context to materialize values. Results are memoized so
-only the first call will reconstruct the context.</p>
+<p>Reconstructs the pipeline context to materialize values.</p>
 </dd></dl>
 
 </dd></dl>


### PR DESCRIPTION
* exposes `reconstruct_context` on `PipelineExecutionResult` that allows you to re-up the context for passing in to `transform_value` to get materialized outputs
* refactors the execution functions to allow us to capture the necessary values in the `reconstruct_context` lambda
* clean up `StepDataOutput` making it serializable 
* fix up all the test call sites
