### PR TITLE
[consolidate events] step materialization

### DIFF
--- a/python_modules/dagit/dagit/schema/runs.py
+++ b/python_modules/dagit/dagit/schema/runs.py
@@ -313,6 +313,13 @@ class DauphinPipelineRunEvent(dauphin.Union):
                     storage_object_id=output_data.storage_object_id,
                     **basic_params
                 )
+            elif dagster_event.event_type == DagsterEventType.STEP_MATERIALIZATION:
+                materialization_data = dagster_event.step_materialization_data
+                return graphene_info.schema.type_named('StepMaterializationEvent')(
+                    file_name=materialization_data.name,
+                    file_location=materialization_data.path,
+                    **basic_params
+                )
             elif dagster_event.event_type == DagsterEventType.STEP_FAILURE:
                 check.inst(dagster_event.step_failure_data, StepFailureData)
                 return graphene_info.schema.type_named('ExecutionStepFailureEvent')(
@@ -340,9 +347,5 @@ class DauphinPipelineRunEvent(dauphin.Union):
                     )
                 )
 
-        elif event.event_type == EventType.STEP_MATERIALIZATION:
-            return graphene_info.schema.type_named('StepMaterializationEvent')(
-                file_name=event.file_name, file_location=event.file_location, **basic_params
-            )
         else:
             return graphene_info.schema.type_named('LogMessageEvent')(**basic_params)

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -28,6 +28,7 @@ from dagster.core.definitions import (
     PipelineDefinition,
     RepositoryDefinition,
     Result,
+    Materialization,
     SolidDefinition,
     SolidInstance,
 )
@@ -96,6 +97,7 @@ __all__ = [
     'Result',
     'SolidDefinition',
     'SolidInstance',
+    'Materialization',
     # Decorators
     'lambda_solid',
     'solid',

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -18,6 +18,8 @@ from .resource import ResourceDefinition
 
 from .result import Result
 
+from .materialization import Materialization
+
 from .repository import RepositoryDefinition
 
 from .pipeline import PipelineDefinition, solids_in_topological_order

--- a/python_modules/dagster/dagster/core/definitions/materialization.py
+++ b/python_modules/dagster/dagster/core/definitions/materialization.py
@@ -1,0 +1,10 @@
+from collections import namedtuple
+
+from dagster import check
+
+
+class Materialization(namedtuple('_Materialization', 'name path')):
+    def __new__(cls, name, path):
+        return super(Materialization, cls).__new__(
+            cls, check.str_param(name, 'name'), check.str_param(path, 'path')
+        )

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -625,12 +625,12 @@ def _execute_pipeline_iterator(pipeline_context):
 
     pipeline_success = True
 
-    for step_event in invoke_executor_on_plan(
+    for event in invoke_executor_on_plan(
         pipeline_context, execution_plan, pipeline_context.run_config.step_keys_to_execute
     ):
-        if step_event.is_step_failure:
+        if event.is_step_failure:
             pipeline_success = False
-        yield step_event
+        yield event
 
     if pipeline_success:
         yield DagsterEvent.pipeline_success(pipeline_context)

--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -26,6 +26,7 @@ from dagster import (
     OutputDefinition,
     RepositoryDefinition,
     Result,
+    Materialization,
     PipelineDefinition,
     SolidDefinition,
     check,
@@ -36,6 +37,7 @@ from dagster.core.definitions.dependency import Solid
 from dagster.core.definitions.environment_configs import construct_environment_config
 from dagster.core.errors import DagsterSubprocessExecutionError
 from dagster.core.events.logging import construct_json_event_logger, EventRecord, EventType
+from dagster.core.events import DagsterEvent
 from dagster.core.execution import yield_pipeline_execution_context
 from dagster.core.execution_context import (
     DagsterLog,
@@ -611,10 +613,8 @@ def _dm_solid_transform(name, notebook_path):
                 )
             )
 
-            system_transform_context.events.step_materialization(
-                system_transform_context.step.key,
-                '{name} output notebook'.format(name=transform_context.solid.name),
-                temp_path,
+            yield Materialization(
+                '{name} output notebook'.format(name=transform_context.solid.name), temp_path
             )
 
             for output_def in system_transform_context.solid_def.output_defs:


### PR DESCRIPTION
Adds `STEP_MATERIALIZATION` `DagsterEvent`

To allow `DagsterEvent`s to bubble up all the way up from where they can be yielded, i had to refactor code that previously was only expecting outputs and make it handle `output_or_event`. 

depends on #1060 