### PR TITLE
Fix regression with solid navigation

### DIFF
--- a/js_modules/dagit/src/PipelinePage.tsx
+++ b/js_modules/dagit/src/PipelinePage.tsx
@@ -124,13 +124,14 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
             component={PipelineRunsRoot}
           />
           <Route
+            // TODO for Ben: I'm sure there is a cleaner and more idiomatic
+            // way to handle these three cases and not hardcode the undefined.
+            // Tracking in https://github.com/dagster-io/dagster/issues/1070
+            //
+            // -- schrockn 03/30/2019
+            exact={true}
             path="/:pipelineName"
             render={({ match }) => (
-              // TODO for Ben: I'm sure there is a cleaner and more idiomatic
-              // way to handle these three cases and not hardcode the undefined.
-              // Tracking in https://github.com/dagster-io/dagster/issues/1070 
-              // 
-              // -- schrockn 03/30/2019
               <PipelineExplorer
                 history={history}
                 pipeline={selectedPipeline}

--- a/js_modules/dagit/src/PipelinePage.tsx
+++ b/js_modules/dagit/src/PipelinePage.tsx
@@ -124,7 +124,7 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
             component={PipelineRunsRoot}
           />
           <Route
-            path="/:pipelineName/:solid"
+            path="/:pipelineName/explore/:solid"
             render={({ match }) => (
               <PipelineExplorer
                 history={history}

--- a/js_modules/dagit/src/PipelinePage.tsx
+++ b/js_modules/dagit/src/PipelinePage.tsx
@@ -124,15 +124,27 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
             component={PipelineRunsRoot}
           />
           <Route
+            path="/:pipelineName"
+            render={({ match }) => (
+              // TODO for Ben: I'm sure there is a cleaner and more idiomatic
+              // way to handle these three cases and not hardcode the undefined.
+              // Tracking in https://github.com/dagster-io/dagster/issues/1070 
+              // 
+              // -- schrockn 03/30/2019
+              <PipelineExplorer
+                history={history}
+                pipeline={selectedPipeline}
+                solid={undefined}
+              />
+            )}
+          />
+          <Route
             exact={true}
             path="/:pipelineName/explore"
             render={({ match }) => (
               <PipelineExplorer
                 history={history}
                 pipeline={selectedPipeline}
-                // TODO for Ben: I'm sure there is a cleaner and more idiomatic
-                // way to handle these two cases and not hardcode the undefined.
-                // -- schrockn 03/30/2019
                 solid={undefined}
               />
             )}

--- a/js_modules/dagit/src/PipelinePage.tsx
+++ b/js_modules/dagit/src/PipelinePage.tsx
@@ -130,10 +130,13 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
               <PipelineExplorer
                 history={history}
                 pipeline={selectedPipeline}
+                // TODO for Ben: I'm sure there is a cleaner and more idiomatic
+                // way to handle these two cases and not hardcode the undefined.
+                // -- schrockn 03/30/2019
                 solid={undefined}
               />
             )}
-            />
+          />
           <Route
             path="/:pipelineName/explore/:solid"
             render={({ match }) => (

--- a/js_modules/dagit/src/PipelinePage.tsx
+++ b/js_modules/dagit/src/PipelinePage.tsx
@@ -124,6 +124,17 @@ export default class PipelinePage extends React.Component<IPipelinePageProps> {
             component={PipelineRunsRoot}
           />
           <Route
+            exact={true}
+            path="/:pipelineName/explore"
+            render={({ match }) => (
+              <PipelineExplorer
+                history={history}
+                pipeline={selectedPipeline}
+                solid={undefined}
+              />
+            )}
+            />
+          <Route
             path="/:pipelineName/explore/:solid"
             render={({ match }) => (
               <PipelineExplorer

--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,122 +1,921 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders execution 1`] = `
-<div
-  className="bp3-navbar"
->
+Array [
   <div
-    className="bp3-navbar-group bp3-align-left"
+    className="bp3-navbar"
   >
     <div
-      className="bp3-navbar-heading"
-      onClick={[Function]}
+      className="bp3-navbar-group bp3-align-left"
     >
-      <img
-        style={
-          Object {
-            "height": 34,
-          }
-        }
-      />
-    </div>
-    <div
-      className="bp3-navbar-divider"
-    />
-    <div
-      className="sc-cIShpX iWIiAw"
-    >
-      <span
-        className="bp3-popover-wrapper"
+      <div
+        className="bp3-navbar-heading"
+        onClick={[Function]}
       >
-        <span
-          className="bp3-popover-target"
-          onClick={[Function]}
-        >
-          <div
-            className=""
-            onKeyDown={[Function]}
-          >
-            <button
-              className="bp3-button"
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              type="button"
-            >
-              <span
-                className="bp3-button-text"
-              >
-                pandas_hello_world
-              </span>
-              <span
-                className="bp3-icon bp3-icon-double-caret-vertical"
-                icon="double-caret-vertical"
-              >
-                <svg
-                  data-icon="double-caret-vertical"
-                  height={16}
-                  viewBox="0 0 16 16"
-                  width={16}
-                >
-                  <desc>
-                    double-caret-vertical
-                  </desc>
-                  <path
-                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </span>
-      </span>
+        <img
+          style={
+            Object {
+              "height": 34,
+            }
+          }
+        />
+      </div>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-cIShpX iWIiAw"
       >
-        <a
-          className="active sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/explore"
-          onClick={[Function]}
+        <span
+          className="bp3-popover-wrapper"
         >
-          Explore
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/execute"
-          onClick={[Function]}
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  pandas_hello_world
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <div
+          className="bp3-navbar-divider"
+        />
+        <div
+          className="sc-kafWEX dOcLVX"
         >
-          Execute
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/runs"
-          onClick={[Function]}
-        >
-          Runs
-        </a>
+          <a
+            className="active sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/explore"
+            onClick={[Function]}
+          >
+            Explore
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/execute"
+            onClick={[Function]}
+          >
+            Execute
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/runs"
+            onClick={[Function]}
+          >
+            Runs
+          </a>
+        </div>
       </div>
     </div>
-  </div>
+    <div
+      className="bp3-navbar-group bp3-align-right"
+    >
+      <div
+        className="sc-bRBYWo jpDyyc"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
+      <span
+        className="sc-ktHwxA doWHPT"
+      />
+    </div>
+  </div>,
   <div
-    className="bp3-navbar-group bp3-align-right"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
-          "background": "#3DCC91",
+          "width": "70vw",
         }
       }
-      title="Connecting..."
-    />
-    <span
-      className="sc-ktHwxA doWHPT"
-    />
-  </div>
-</div>
+    >
+      <div
+        className="sc-jDwBTQ bSCVyv"
+      >
+        <span
+          className="bp3-popover-wrapper"
+        >
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  Select a Solid...
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <input
+          className="sc-gPEVay ldPQtW"
+          onChange={[Function]}
+          placeholder="Filter..."
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onWheel={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#F5F8FA",
+            "height": "100%",
+            "overflow": "hidden",
+            "position": "relative",
+            "userSelect": "none",
+            "width": "100%",
+          }
+        }
+        tabIndex={-1}
+      >
+        <div
+          style={
+            Object {
+              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
+              "transformOrigin": "top left",
+            }
+          }
+        >
+          <svg
+            className="sc-gzVnrw gBGkHq"
+            height={514}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            width={625}
+          >
+            <g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.2,
+                  }
+                }
+              >
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <path
+                    className="vx-link-vertical sc-htoDjs jbckmQ"
+                    d="M115,214C115,257,115,257,115,300"
+                  >
+                    <title>
+                      sum_solid - sum_sq_solid
+                    </title>
+                  </path>
+                </g>
+              </g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.75,
+                  }
+                }
+              />
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={130}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={167.4}
+                  x={112}
+                  y={151}
+                >
+                  sum_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    num: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={100}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={118}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={196}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={214}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={312}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={223.2}
+                  x={112}
+                  y={333}
+                >
+                  sum_sq_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    sum_df: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={282}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={300}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={378}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={396}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-dnqmqq gDcGMW"
+    >
+      <div
+        className="sc-gZMcBi bksKfm"
+        onMouseDown={[Function]}
+      />
+    </div>
+    <div
+      className="sc-jAaTju cVRbSZ"
+      style={
+        Object {
+          "width": "30vw",
+        }
+      }
+    >
+      <div
+        className="sc-cvbbAY eJUIRn"
+      >
+        <a
+          href="/pandas_hello_world/load_num_csv"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP jjMzhC"
+          >
+            <span
+              className="bp3-icon bp3-icon-diagram-tree"
+              icon="diagram-tree"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="diagram-tree"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  diagram-tree
+                </desc>
+                <path
+                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Info
+          </div>
+        </a>
+        <a
+          href="/pandas_hello_world/load_num_csv?types=true"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP hPUXXS"
+          >
+            <span
+              className="bp3-icon bp3-icon-manual"
+              icon="manual"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="manual"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  manual
+                </desc>
+                <path
+                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Types
+          </div>
+        </a>
+      </div>
+      <div>
+        <div
+          className="sc-kgoBCf igxmqw"
+        />
+        <h3
+          className="sc-kAzzGY jYDBGE"
+        >
+          <a
+            href="/pandas_hello_world/load_num_csv?types=true"
+            onClick={[Function]}
+          >
+            Pipeline Types
+          </a>
+           &gt; 
+          PandasDataFrame
+        </h3>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Description
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              >
+                Two-dimensional size-mutable, potentially heterogeneous
+    tabular data structure with labeled axes (rows and columns).
+    See http://pandas.pydata.org/
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Input
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              >
+                <code
+                  className="sc-VigVT dhvbCT"
+                >
+                  {
+                  <div
+                    className="sc-jzJRlG jDBHIi"
+                  >
+                      /* One of the following: */
+                  </div>
+                  <div
+                    className="sc-jTzLTM eCMmlJ"
+                  >
+                      
+                    <span
+                      className="sc-fjdhpX bNrcsK"
+                    >
+                      csv
+                    </span>
+                    : 
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        path
+                      </span>
+                      : 
+                      <span>
+                        Path
+                      </span>
+                    </div>
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        sep
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#BF7326",
+                            "fontWeight": 500,
+                          }
+                        }
+                      >
+                        ?
+                      </span>
+                      : 
+                      <span>
+                        String
+                      </span>
+                    </div>
+                      }
+                  </div>
+                  <div
+                    className="sc-jTzLTM eCMmlJ"
+                  >
+                      
+                    <span
+                      className="sc-fjdhpX bNrcsK"
+                    >
+                      parquet
+                    </span>
+                    : 
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        path
+                      </span>
+                      : 
+                      <span>
+                        Path
+                      </span>
+                    </div>
+                      }
+                  </div>
+                  <div
+                    className="sc-jTzLTM eCMmlJ"
+                  >
+                      
+                    <span
+                      className="sc-fjdhpX bNrcsK"
+                    >
+                      table
+                    </span>
+                    : 
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        path
+                      </span>
+                      : 
+                      <span>
+                        Path
+                      </span>
+                    </div>
+                      }
+                  </div>
+                  }
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Output
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              >
+                <code
+                  className="sc-VigVT dhvbCT"
+                >
+                  {
+                  <div
+                    className="sc-jzJRlG jDBHIi"
+                  >
+                      /* One of the following: */
+                  </div>
+                  <div
+                    className="sc-jTzLTM eCMmlJ"
+                  >
+                      
+                    <span
+                      className="sc-fjdhpX bNrcsK"
+                    >
+                      csv
+                    </span>
+                    : 
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        path
+                      </span>
+                      : 
+                      <span>
+                        Path
+                      </span>
+                    </div>
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        sep
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#BF7326",
+                            "fontWeight": 500,
+                          }
+                        }
+                      >
+                        ?
+                      </span>
+                      : 
+                      <span>
+                        String
+                      </span>
+                    </div>
+                      }
+                  </div>
+                  <div
+                    className="sc-jTzLTM eCMmlJ"
+                  >
+                      
+                    <span
+                      className="sc-fjdhpX bNrcsK"
+                    >
+                      parquet
+                    </span>
+                    : 
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        path
+                      </span>
+                      : 
+                      <span>
+                        Path
+                      </span>
+                    </div>
+                      }
+                  </div>
+                  <div
+                    className="sc-jTzLTM eCMmlJ"
+                  >
+                      
+                    <span
+                      className="sc-fjdhpX bNrcsK"
+                    >
+                      table
+                    </span>
+                    : 
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                          
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        path
+                      </span>
+                      : 
+                      <span>
+                        Path
+                      </span>
+                    </div>
+                      }
+                  </div>
+                  }
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders pipeline page 1`] = `
@@ -225,360 +1024,1976 @@ Array [
 `;
 
 exports[`renders pipeline solid page 1`] = `
-<div
-  className="bp3-navbar"
->
+Array [
   <div
-    className="bp3-navbar-group bp3-align-left"
+    className="bp3-navbar"
   >
     <div
-      className="bp3-navbar-heading"
-      onClick={[Function]}
+      className="bp3-navbar-group bp3-align-left"
     >
-      <img
-        style={
-          Object {
-            "height": 34,
-          }
-        }
-      />
-    </div>
-    <div
-      className="bp3-navbar-divider"
-    />
-    <div
-      className="sc-cIShpX iWIiAw"
-    >
-      <span
-        className="bp3-popover-wrapper"
+      <div
+        className="bp3-navbar-heading"
+        onClick={[Function]}
       >
-        <span
-          className="bp3-popover-target"
-          onClick={[Function]}
-        >
-          <div
-            className=""
-            onKeyDown={[Function]}
-          >
-            <button
-              className="bp3-button"
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              type="button"
-            >
-              <span
-                className="bp3-button-text"
-              >
-                pandas_hello_world
-              </span>
-              <span
-                className="bp3-icon bp3-icon-double-caret-vertical"
-                icon="double-caret-vertical"
-              >
-                <svg
-                  data-icon="double-caret-vertical"
-                  height={16}
-                  viewBox="0 0 16 16"
-                  width={16}
-                >
-                  <desc>
-                    double-caret-vertical
-                  </desc>
-                  <path
-                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </span>
-      </span>
+        <img
+          style={
+            Object {
+              "height": 34,
+            }
+          }
+        />
+      </div>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-cIShpX iWIiAw"
       >
-        <a
-          className="active sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/explore"
-          onClick={[Function]}
+        <span
+          className="bp3-popover-wrapper"
         >
-          Explore
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/execute"
-          onClick={[Function]}
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  pandas_hello_world
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <div
+          className="bp3-navbar-divider"
+        />
+        <div
+          className="sc-kafWEX dOcLVX"
         >
-          Execute
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/runs"
-          onClick={[Function]}
-        >
-          Runs
-        </a>
+          <a
+            className="active sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/explore"
+            onClick={[Function]}
+          >
+            Explore
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/execute"
+            onClick={[Function]}
+          >
+            Execute
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/runs"
+            onClick={[Function]}
+          >
+            Runs
+          </a>
+        </div>
       </div>
     </div>
-  </div>
+    <div
+      className="bp3-navbar-group bp3-align-right"
+    >
+      <div
+        className="sc-bRBYWo jpDyyc"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
+      <span
+        className="sc-ktHwxA doWHPT"
+      />
+    </div>
+  </div>,
   <div
-    className="bp3-navbar-group bp3-align-right"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
-          "background": "#3DCC91",
+          "width": "70vw",
         }
       }
-      title="Connecting..."
-    />
-    <span
-      className="sc-ktHwxA doWHPT"
-    />
-  </div>
-</div>
+    >
+      <div
+        className="sc-jDwBTQ bSCVyv"
+      >
+        <span
+          className="bp3-popover-wrapper"
+        >
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  Select a Solid...
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <input
+          className="sc-gPEVay ldPQtW"
+          onChange={[Function]}
+          placeholder="Filter..."
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onWheel={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#F5F8FA",
+            "height": "100%",
+            "overflow": "hidden",
+            "position": "relative",
+            "userSelect": "none",
+            "width": "100%",
+          }
+        }
+        tabIndex={-1}
+      >
+        <div
+          style={
+            Object {
+              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
+              "transformOrigin": "top left",
+            }
+          }
+        >
+          <svg
+            className="sc-gzVnrw gBGkHq"
+            height={514}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            width={625}
+          >
+            <g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.2,
+                  }
+                }
+              >
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <path
+                    className="vx-link-vertical sc-htoDjs jbckmQ"
+                    d="M115,214C115,257,115,257,115,300"
+                  >
+                    <title>
+                      sum_solid - sum_sq_solid
+                    </title>
+                  </path>
+                </g>
+              </g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.75,
+                  }
+                }
+              />
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={130}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={167.4}
+                  x={112}
+                  y={151}
+                >
+                  sum_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    num: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={100}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={118}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={196}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={214}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={312}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={223.2}
+                  x={112}
+                  y={333}
+                >
+                  sum_sq_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    sum_df: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={282}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={300}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={378}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={396}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-dnqmqq gDcGMW"
+    >
+      <div
+        className="sc-gZMcBi bksKfm"
+        onMouseDown={[Function]}
+      />
+    </div>
+    <div
+      className="sc-jAaTju cVRbSZ"
+      style={
+        Object {
+          "width": "30vw",
+        }
+      }
+    >
+      <div
+        className="sc-cvbbAY eJUIRn"
+      >
+        <a
+          href="/pandas_hello_world"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP hPUXXS"
+          >
+            <span
+              className="bp3-icon bp3-icon-diagram-tree"
+              icon="diagram-tree"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="diagram-tree"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  diagram-tree
+                </desc>
+                <path
+                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Info
+          </div>
+        </a>
+        <a
+          href="/pandas_hello_world?types=true"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP jjMzhC"
+          >
+            <span
+              className="bp3-icon bp3-icon-manual"
+              icon="manual"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="manual"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  manual
+                </desc>
+                <path
+                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Types
+          </div>
+        </a>
+      </div>
+      <div>
+        <div
+          className="sc-kgoBCf igxmqw"
+        >
+          Pipeline
+        </div>
+        <h3
+          className="sc-kAzzGY jYDBGE"
+        >
+          pandas_hello_world
+        </h3>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Description
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Contexts
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              >
+                <div
+                  className="sc-kGXeez eAvgrC"
+                >
+                  <h4
+                    className="sc-chPdSV bzfSHL"
+                  >
+                    default
+                  </h4>
+                  <code
+                    className="sc-VigVT dhvbCT"
+                  >
+                    <div
+                      className="sc-jzJRlG jDBHIi"
+                    >
+                      /* A configuration dictionary with typed fields */
+                    </div>
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                        
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        log_level
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#BF7326",
+                            "fontWeight": 500,
+                          }
+                        }
+                      >
+                        ?
+                      </span>
+                      : 
+                      <span>
+                        String
+                      </span>
+                    </div>
+                    }
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders type page 1`] = `
-<div
-  className="bp3-navbar"
->
+Array [
   <div
-    className="bp3-navbar-group bp3-align-left"
+    className="bp3-navbar"
   >
     <div
-      className="bp3-navbar-heading"
-      onClick={[Function]}
+      className="bp3-navbar-group bp3-align-left"
     >
-      <img
-        style={
-          Object {
-            "height": 34,
-          }
-        }
-      />
-    </div>
-    <div
-      className="bp3-navbar-divider"
-    />
-    <div
-      className="sc-cIShpX iWIiAw"
-    >
-      <span
-        className="bp3-popover-wrapper"
+      <div
+        className="bp3-navbar-heading"
+        onClick={[Function]}
       >
-        <span
-          className="bp3-popover-target"
-          onClick={[Function]}
-        >
-          <div
-            className=""
-            onKeyDown={[Function]}
-          >
-            <button
-              className="bp3-button"
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              type="button"
-            >
-              <span
-                className="bp3-button-text"
-              >
-                pandas_hello_world
-              </span>
-              <span
-                className="bp3-icon bp3-icon-double-caret-vertical"
-                icon="double-caret-vertical"
-              >
-                <svg
-                  data-icon="double-caret-vertical"
-                  height={16}
-                  viewBox="0 0 16 16"
-                  width={16}
-                >
-                  <desc>
-                    double-caret-vertical
-                  </desc>
-                  <path
-                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </span>
-      </span>
+        <img
+          style={
+            Object {
+              "height": 34,
+            }
+          }
+        />
+      </div>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-cIShpX iWIiAw"
       >
-        <a
-          className="active sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/explore"
-          onClick={[Function]}
+        <span
+          className="bp3-popover-wrapper"
         >
-          Explore
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/execute"
-          onClick={[Function]}
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  pandas_hello_world
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <div
+          className="bp3-navbar-divider"
+        />
+        <div
+          className="sc-kafWEX dOcLVX"
         >
-          Execute
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/runs"
-          onClick={[Function]}
-        >
-          Runs
-        </a>
+          <a
+            className="active sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/explore"
+            onClick={[Function]}
+          >
+            Explore
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/execute"
+            onClick={[Function]}
+          >
+            Execute
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/runs"
+            onClick={[Function]}
+          >
+            Runs
+          </a>
+        </div>
       </div>
     </div>
-  </div>
+    <div
+      className="bp3-navbar-group bp3-align-right"
+    >
+      <div
+        className="sc-bRBYWo jpDyyc"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
+      <span
+        className="sc-ktHwxA doWHPT"
+      />
+    </div>
+  </div>,
   <div
-    className="bp3-navbar-group bp3-align-right"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
-          "background": "#3DCC91",
+          "width": "70vw",
         }
       }
-      title="Connecting..."
-    />
-    <span
-      className="sc-ktHwxA doWHPT"
-    />
-  </div>
-</div>
+    >
+      <div
+        className="sc-jDwBTQ bSCVyv"
+      >
+        <span
+          className="bp3-popover-wrapper"
+        >
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  Select a Solid...
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <input
+          className="sc-gPEVay ldPQtW"
+          onChange={[Function]}
+          placeholder="Filter..."
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onWheel={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#F5F8FA",
+            "height": "100%",
+            "overflow": "hidden",
+            "position": "relative",
+            "userSelect": "none",
+            "width": "100%",
+          }
+        }
+        tabIndex={-1}
+      >
+        <div
+          style={
+            Object {
+              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
+              "transformOrigin": "top left",
+            }
+          }
+        >
+          <svg
+            className="sc-gzVnrw gBGkHq"
+            height={514}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            width={625}
+          >
+            <g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.2,
+                  }
+                }
+              >
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <path
+                    className="vx-link-vertical sc-htoDjs jbckmQ"
+                    d="M115,214C115,257,115,257,115,300"
+                  >
+                    <title>
+                      sum_solid - sum_sq_solid
+                    </title>
+                  </path>
+                </g>
+              </g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.75,
+                  }
+                }
+              />
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={130}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={167.4}
+                  x={112}
+                  y={151}
+                >
+                  sum_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    num: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={100}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={118}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={196}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={214}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={312}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={223.2}
+                  x={112}
+                  y={333}
+                >
+                  sum_sq_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    sum_df: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={282}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={300}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={378}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={396}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-dnqmqq gDcGMW"
+    >
+      <div
+        className="sc-gZMcBi bksKfm"
+        onMouseDown={[Function]}
+      />
+    </div>
+    <div
+      className="sc-jAaTju cVRbSZ"
+      style={
+        Object {
+          "width": "30vw",
+        }
+      }
+    >
+      <div
+        className="sc-cvbbAY eJUIRn"
+      >
+        <a
+          href="/pandas_hello_world/load_num_csv"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP hPUXXS"
+          >
+            <span
+              className="bp3-icon bp3-icon-diagram-tree"
+              icon="diagram-tree"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="diagram-tree"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  diagram-tree
+                </desc>
+                <path
+                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Info
+          </div>
+        </a>
+        <a
+          href="/pandas_hello_world/load_num_csv?types=true"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP jjMzhC"
+          >
+            <span
+              className="bp3-icon bp3-icon-manual"
+              icon="manual"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="manual"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  manual
+                </desc>
+                <path
+                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Types
+          </div>
+        </a>
+      </div>
+      <div>
+        <div
+          className="sc-kgoBCf igxmqw"
+        >
+          Pipeline
+        </div>
+        <h3
+          className="sc-kAzzGY jYDBGE"
+        >
+          pandas_hello_world
+        </h3>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Description
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            className="sc-kpOJdX goxjbg"
+            onClick={[Function]}
+          >
+            Contexts
+            <span
+              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            className="bp3-collapse"
+            style={
+              Object {
+                "height": "auto",
+                "overflowY": "visible",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              className="bp3-collapse-body"
+              style={
+                Object {
+                  "transform": "translateY(0)",
+                  "transition": "none",
+                }
+              }
+            >
+              <div
+                className="sc-dxgOiQ dPbrCh"
+              >
+                <div
+                  className="sc-kGXeez eAvgrC"
+                >
+                  <h4
+                    className="sc-chPdSV bzfSHL"
+                  >
+                    default
+                  </h4>
+                  <code
+                    className="sc-VigVT dhvbCT"
+                  >
+                    <div
+                      className="sc-jzJRlG jDBHIi"
+                    >
+                      /* A configuration dictionary with typed fields */
+                    </div>
+                    {
+                    <div
+                      className="sc-jTzLTM eCMmlJ"
+                    >
+                        
+                      <span
+                        className="sc-fjdhpX bNrcsK"
+                      >
+                        log_level
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#BF7326",
+                            "fontWeight": 500,
+                          }
+                        }
+                      >
+                        ?
+                      </span>
+                      : 
+                      <span>
+                        String
+                      </span>
+                    </div>
+                    }
+                  </code>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders type page 2`] = `
-<div
-  className="bp3-navbar"
->
+Array [
   <div
-    className="bp3-navbar-group bp3-align-left"
+    className="bp3-navbar"
   >
     <div
-      className="bp3-navbar-heading"
-      onClick={[Function]}
+      className="bp3-navbar-group bp3-align-left"
     >
-      <img
-        style={
-          Object {
-            "height": 34,
-          }
-        }
-      />
-    </div>
-    <div
-      className="bp3-navbar-divider"
-    />
-    <div
-      className="sc-cIShpX iWIiAw"
-    >
-      <span
-        className="bp3-popover-wrapper"
+      <div
+        className="bp3-navbar-heading"
+        onClick={[Function]}
       >
-        <span
-          className="bp3-popover-target"
-          onClick={[Function]}
-        >
-          <div
-            className=""
-            onKeyDown={[Function]}
-          >
-            <button
-              className="bp3-button"
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              type="button"
-            >
-              <span
-                className="bp3-button-text"
-              >
-                pandas_hello_world
-              </span>
-              <span
-                className="bp3-icon bp3-icon-double-caret-vertical"
-                icon="double-caret-vertical"
-              >
-                <svg
-                  data-icon="double-caret-vertical"
-                  height={16}
-                  viewBox="0 0 16 16"
-                  width={16}
-                >
-                  <desc>
-                    double-caret-vertical
-                  </desc>
-                  <path
-                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </span>
-      </span>
+        <img
+          style={
+            Object {
+              "height": 34,
+            }
+          }
+        />
+      </div>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-cIShpX iWIiAw"
       >
-        <a
-          className="active sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/explore"
-          onClick={[Function]}
+        <span
+          className="bp3-popover-wrapper"
         >
-          Explore
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/execute"
-          onClick={[Function]}
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  pandas_hello_world
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <div
+          className="bp3-navbar-divider"
+        />
+        <div
+          className="sc-kafWEX dOcLVX"
         >
-          Execute
-        </a>
-        <a
-          className="sc-feJyhm kTrNTW"
-          href="/pandas_hello_world/runs"
-          onClick={[Function]}
-        >
-          Runs
-        </a>
+          <a
+            className="active sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/explore"
+            onClick={[Function]}
+          >
+            Explore
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/execute"
+            onClick={[Function]}
+          >
+            Execute
+          </a>
+          <a
+            className="sc-feJyhm kTrNTW"
+            href="/pandas_hello_world/runs"
+            onClick={[Function]}
+          >
+            Runs
+          </a>
+        </div>
       </div>
     </div>
-  </div>
+    <div
+      className="bp3-navbar-group bp3-align-right"
+    >
+      <div
+        className="sc-bRBYWo jpDyyc"
+        style={
+          Object {
+            "background": "#3DCC91",
+          }
+        }
+        title="Connecting..."
+      />
+      <span
+        className="sc-ktHwxA doWHPT"
+      />
+    </div>
+  </div>,
   <div
-    className="bp3-navbar-group bp3-align-right"
+    className="sc-brqgnP kbTxLu"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-cMljjf bkQPOZ"
       style={
         Object {
-          "background": "#3DCC91",
+          "width": "70vw",
         }
       }
-      title="Connecting..."
-    />
-    <span
-      className="sc-ktHwxA doWHPT"
-    />
-  </div>
-</div>
+    >
+      <div
+        className="sc-jDwBTQ bSCVyv"
+      >
+        <span
+          className="bp3-popover-wrapper"
+        >
+          <span
+            className="bp3-popover-target"
+            onClick={[Function]}
+          >
+            <div
+              className=""
+              onKeyDown={[Function]}
+            >
+              <button
+                className="bp3-button"
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                type="button"
+              >
+                <span
+                  className="bp3-button-text"
+                >
+                  Select a Solid...
+                </span>
+                <span
+                  className="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </span>
+        </span>
+        <input
+          className="sc-gPEVay ldPQtW"
+          onChange={[Function]}
+          placeholder="Filter..."
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onWheel={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#F5F8FA",
+            "height": "100%",
+            "overflow": "hidden",
+            "position": "relative",
+            "userSelect": "none",
+            "width": "100%",
+          }
+        }
+        tabIndex={-1}
+      >
+        <div
+          style={
+            Object {
+              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
+              "transformOrigin": "top left",
+            }
+          }
+        >
+          <svg
+            className="sc-gzVnrw gBGkHq"
+            height={514}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            width={625}
+          >
+            <g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.2,
+                  }
+                }
+              >
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <path
+                    className="vx-link-vertical sc-htoDjs jbckmQ"
+                    d="M115,214C115,257,115,257,115,300"
+                  >
+                    <title>
+                      sum_solid - sum_sq_solid
+                    </title>
+                  </path>
+                </g>
+              </g>
+              <g
+                style={
+                  Object {
+                    "opacity": 0.75,
+                  }
+                }
+              />
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={130}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={167.4}
+                  x={112}
+                  y={151}
+                >
+                  sum_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    num: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={100}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={118}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={196}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={214}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
+                  y={312}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={223.2}
+                  x={112}
+                  y={333}
+                >
+                  sum_sq_solid
+                </text>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    sum_df: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={282}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={300}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={378}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={396}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-dnqmqq gDcGMW"
+    >
+      <div
+        className="sc-gZMcBi bksKfm"
+        onMouseDown={[Function]}
+      />
+    </div>
+    <div
+      className="sc-jAaTju cVRbSZ"
+      style={
+        Object {
+          "width": "30vw",
+        }
+      }
+    >
+      <div
+        className="sc-cvbbAY eJUIRn"
+      >
+        <a
+          href="/pandas_hello_world/load_num_csv"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP jjMzhC"
+          >
+            <span
+              className="bp3-icon bp3-icon-diagram-tree"
+              icon="diagram-tree"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="diagram-tree"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  diagram-tree
+                </desc>
+                <path
+                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Info
+          </div>
+        </a>
+        <a
+          href="/pandas_hello_world/load_num_csv?types=true"
+          onClick={[Function]}
+        >
+          <div
+            className="sc-jWBwVP hPUXXS"
+          >
+            <span
+              className="bp3-icon bp3-icon-manual"
+              icon="manual"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
+            >
+              <svg
+                data-icon="manual"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <desc>
+                  manual
+                </desc>
+                <path
+                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </span>
+            Types
+          </div>
+        </a>
+      </div>
+      <div
+        className="sc-kgoBCf igxmqw"
+      />
+      <h3
+        className="sc-kAzzGY jYDBGE"
+      >
+        Pipeline Types
+      </h3>
+      <div>
+        <div
+          className="sc-kpOJdX goxjbg"
+          onClick={[Function]}
+        >
+          Custom
+          <span
+            className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
+            icon="chevron-down"
+          >
+            <svg
+              data-icon="chevron-down"
+              height={16}
+              viewBox="0 0 16 16"
+              width={16}
+            >
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          className="bp3-collapse"
+          style={
+            Object {
+              "height": "auto",
+              "overflowY": "visible",
+              "transition": "none",
+            }
+          }
+        >
+          <div
+            aria-hidden={false}
+            className="bp3-collapse-body"
+            style={
+              Object {
+                "transform": "translateY(0)",
+                "transition": "none",
+              }
+            }
+          >
+            <div
+              className="sc-dxgOiQ dPbrCh"
+            >
+              <ul
+                className="bp3-list"
+              >
+                <li
+                  className="sc-jKJlTe hLXNeg"
+                >
+                  <a
+                    href="/?typeExplorer=PandasDataFrame"
+                    onClick={[Function]}
+                  >
+                    <code
+                      className="sc-ckVGcZ iRVuvl"
+                    >
+                      PandasDataFrame
+                    </code>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          className="sc-kpOJdX goxjbg"
+          onClick={[Function]}
+        >
+          Built-in
+          <span
+            className="bp3-icon bp3-icon-chevron-up sc-cSHVUG fvtgDa"
+            icon="chevron-up"
+          >
+            <svg
+              data-icon="chevron-up"
+              height={16}
+              viewBox="0 0 16 16"
+              width={16}
+            >
+              <desc>
+                chevron-up
+              </desc>
+              <path
+                d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 0 0 1.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          className="bp3-collapse"
+          style={
+            Object {
+              "height": undefined,
+              "overflowY": undefined,
+              "transition": undefined,
+            }
+          }
+        >
+          <div
+            aria-hidden={false}
+            className="bp3-collapse-body"
+            style={
+              Object {
+                "transform": "translateY(-undefinedpx)",
+                "transition": undefined,
+              }
+            }
+          />
+        </div>
+      </div>
+      <h3
+        className="bp3-heading"
+      />
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders without error 1`] = `

--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,921 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders execution 1`] = `
-Array [
+<div
+  className="bp3-navbar"
+>
   <div
-    className="bp3-navbar"
+    className="bp3-navbar-group bp3-align-left"
   >
     <div
-      className="bp3-navbar-group bp3-align-left"
+      className="bp3-navbar-heading"
+      onClick={[Function]}
     >
-      <div
-        className="bp3-navbar-heading"
-        onClick={[Function]}
-      >
-        <img
-          style={
-            Object {
-              "height": 34,
-            }
+      <img
+        style={
+          Object {
+            "height": 34,
           }
-        />
-      </div>
+        }
+      />
+    </div>
+    <div
+      className="bp3-navbar-divider"
+    />
+    <div
+      className="sc-cIShpX iWIiAw"
+    >
+      <span
+        className="bp3-popover-wrapper"
+      >
+        <span
+          className="bp3-popover-target"
+          onClick={[Function]}
+        >
+          <div
+            className=""
+            onKeyDown={[Function]}
+          >
+            <button
+              className="bp3-button"
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              type="button"
+            >
+              <span
+                className="bp3-button-text"
+              >
+                pandas_hello_world
+              </span>
+              <span
+                className="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height={16}
+                  viewBox="0 0 16 16"
+                  width={16}
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </span>
+      </span>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-kafWEX dOcLVX"
       >
-        <span
-          className="bp3-popover-wrapper"
+        <a
+          className="active sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/explore"
+          onClick={[Function]}
         >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  pandas_hello_world
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <div
-          className="bp3-navbar-divider"
-        />
-        <div
-          className="sc-kafWEX dOcLVX"
+          Explore
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/execute"
+          onClick={[Function]}
         >
-          <a
-            className="active sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/explore"
-            onClick={[Function]}
-          >
-            Explore
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/execute"
-            onClick={[Function]}
-          >
-            Execute
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/runs"
-            onClick={[Function]}
-          >
-            Runs
-          </a>
-        </div>
+          Execute
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/runs"
+          onClick={[Function]}
+        >
+          Runs
+        </a>
       </div>
     </div>
-    <div
-      className="bp3-navbar-group bp3-align-right"
-    >
-      <div
-        className="sc-bRBYWo jpDyyc"
-        style={
-          Object {
-            "background": "#3DCC91",
-          }
-        }
-        title="Connecting..."
-      />
-      <span
-        className="sc-ktHwxA doWHPT"
-      />
-    </div>
-  </div>,
+  </div>
   <div
-    className="sc-brqgnP kbTxLu"
+    className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-cMljjf bkQPOZ"
+      className="sc-bRBYWo jpDyyc"
       style={
         Object {
-          "width": "70vw",
+          "background": "#3DCC91",
         }
       }
-    >
-      <div
-        className="sc-jDwBTQ bSCVyv"
-      >
-        <span
-          className="bp3-popover-wrapper"
-        >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  Select a Solid...
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <input
-          className="sc-gPEVay ldPQtW"
-          onChange={[Function]}
-          placeholder="Filter..."
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        onWheel={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#F5F8FA",
-            "height": "100%",
-            "overflow": "hidden",
-            "position": "relative",
-            "userSelect": "none",
-            "width": "100%",
-          }
-        }
-        tabIndex={-1}
-      >
-        <div
-          style={
-            Object {
-              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
-              "transformOrigin": "top left",
-            }
-          }
-        >
-          <svg
-            className="sc-gzVnrw gBGkHq"
-            height={514}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            width={625}
-          >
-            <g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.2,
-                  }
-                }
-              >
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <path
-                    className="vx-link-vertical sc-htoDjs jbckmQ"
-                    d="M115,214C115,257,115,257,115,300"
-                  >
-                    <title>
-                      sum_solid - sum_sq_solid
-                    </title>
-                  </path>
-                </g>
-              </g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.75,
-                  }
-                }
-              />
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={130}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={167.4}
-                  x={112}
-                  y={151}
-                >
-                  sum_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    num: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={100}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={118}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={196}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-dnqmqq gDcGMW"
-    >
-      <div
-        className="sc-gZMcBi bksKfm"
-        onMouseDown={[Function]}
-      />
-    </div>
-    <div
-      className="sc-jAaTju cVRbSZ"
-      style={
-        Object {
-          "width": "30vw",
-        }
-      }
-    >
-      <div
-        className="sc-cvbbAY eJUIRn"
-      >
-        <a
-          href="/pandas_hello_world/load_num_csv"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP jjMzhC"
-          >
-            <span
-              className="bp3-icon bp3-icon-diagram-tree"
-              icon="diagram-tree"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="diagram-tree"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  diagram-tree
-                </desc>
-                <path
-                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Info
-          </div>
-        </a>
-        <a
-          href="/pandas_hello_world/load_num_csv?types=true"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP hPUXXS"
-          >
-            <span
-              className="bp3-icon bp3-icon-manual"
-              icon="manual"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="manual"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  manual
-                </desc>
-                <path
-                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Types
-          </div>
-        </a>
-      </div>
-      <div>
-        <div
-          className="sc-kgoBCf igxmqw"
-        />
-        <h3
-          className="sc-kAzzGY jYDBGE"
-        >
-          <a
-            href="/pandas_hello_world/load_num_csv?types=true"
-            onClick={[Function]}
-          >
-            Pipeline Types
-          </a>
-           &gt; 
-          PandasDataFrame
-        </h3>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Description
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                Two-dimensional size-mutable, potentially heterogeneous
-    tabular data structure with labeled axes (rows and columns).
-    See http://pandas.pydata.org/
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Input
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                <code
-                  className="sc-VigVT dhvbCT"
-                >
-                  {
-                  <div
-                    className="sc-jzJRlG jDBHIi"
-                  >
-                      /* One of the following: */
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      csv
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        sep
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#BF7326",
-                            "fontWeight": 500,
-                          }
-                        }
-                      >
-                        ?
-                      </span>
-                      : 
-                      <span>
-                        String
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      parquet
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      table
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  }
-                </code>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Output
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                <code
-                  className="sc-VigVT dhvbCT"
-                >
-                  {
-                  <div
-                    className="sc-jzJRlG jDBHIi"
-                  >
-                      /* One of the following: */
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      csv
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        sep
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#BF7326",
-                            "fontWeight": 500,
-                          }
-                        }
-                      >
-                        ?
-                      </span>
-                      : 
-                      <span>
-                        String
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      parquet
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      table
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  }
-                </code>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
+      title="Connecting..."
+    />
+    <span
+      className="sc-ktHwxA doWHPT"
+    />
+  </div>
+</div>
 `;
 
 exports[`renders pipeline page 1`] = `
@@ -1143,1308 +344,241 @@ exports[`renders pipeline solid page 1`] = `
 `;
 
 exports[`renders type page 1`] = `
-Array [
+<div
+  className="bp3-navbar"
+>
   <div
-    className="bp3-navbar"
+    className="bp3-navbar-group bp3-align-left"
   >
     <div
-      className="bp3-navbar-group bp3-align-left"
+      className="bp3-navbar-heading"
+      onClick={[Function]}
     >
-      <div
-        className="bp3-navbar-heading"
-        onClick={[Function]}
-      >
-        <img
-          style={
-            Object {
-              "height": 34,
-            }
+      <img
+        style={
+          Object {
+            "height": 34,
           }
-        />
-      </div>
+        }
+      />
+    </div>
+    <div
+      className="bp3-navbar-divider"
+    />
+    <div
+      className="sc-cIShpX iWIiAw"
+    >
+      <span
+        className="bp3-popover-wrapper"
+      >
+        <span
+          className="bp3-popover-target"
+          onClick={[Function]}
+        >
+          <div
+            className=""
+            onKeyDown={[Function]}
+          >
+            <button
+              className="bp3-button"
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              type="button"
+            >
+              <span
+                className="bp3-button-text"
+              >
+                pandas_hello_world
+              </span>
+              <span
+                className="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height={16}
+                  viewBox="0 0 16 16"
+                  width={16}
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </span>
+      </span>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-kafWEX dOcLVX"
       >
-        <span
-          className="bp3-popover-wrapper"
+        <a
+          className="active sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/explore"
+          onClick={[Function]}
         >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  pandas_hello_world
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <div
-          className="bp3-navbar-divider"
-        />
-        <div
-          className="sc-kafWEX dOcLVX"
+          Explore
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/execute"
+          onClick={[Function]}
         >
-          <a
-            className="active sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/explore"
-            onClick={[Function]}
-          >
-            Explore
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/execute"
-            onClick={[Function]}
-          >
-            Execute
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/runs"
-            onClick={[Function]}
-          >
-            Runs
-          </a>
-        </div>
+          Execute
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/runs"
+          onClick={[Function]}
+        >
+          Runs
+        </a>
       </div>
     </div>
-    <div
-      className="bp3-navbar-group bp3-align-right"
-    >
-      <div
-        className="sc-bRBYWo jpDyyc"
-        style={
-          Object {
-            "background": "#3DCC91",
-          }
-        }
-        title="Connecting..."
-      />
-      <span
-        className="sc-ktHwxA doWHPT"
-      />
-    </div>
-  </div>,
+  </div>
   <div
-    className="sc-brqgnP kbTxLu"
+    className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-cMljjf bkQPOZ"
+      className="sc-bRBYWo jpDyyc"
       style={
         Object {
-          "width": "70vw",
+          "background": "#3DCC91",
         }
       }
-    >
-      <div
-        className="sc-jDwBTQ bSCVyv"
-      >
-        <span
-          className="bp3-popover-wrapper"
-        >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  Select a Solid...
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <input
-          className="sc-gPEVay ldPQtW"
-          onChange={[Function]}
-          placeholder="Filter..."
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        onWheel={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#F5F8FA",
-            "height": "100%",
-            "overflow": "hidden",
-            "position": "relative",
-            "userSelect": "none",
-            "width": "100%",
-          }
-        }
-        tabIndex={-1}
-      >
-        <div
-          style={
-            Object {
-              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
-              "transformOrigin": "top left",
-            }
-          }
-        >
-          <svg
-            className="sc-gzVnrw gBGkHq"
-            height={514}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            width={625}
-          >
-            <g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.2,
-                  }
-                }
-              >
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <path
-                    className="vx-link-vertical sc-htoDjs jbckmQ"
-                    d="M115,214C115,257,115,257,115,300"
-                  >
-                    <title>
-                      sum_solid - sum_sq_solid
-                    </title>
-                  </path>
-                </g>
-              </g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.75,
-                  }
-                }
-              />
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={130}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={167.4}
-                  x={112}
-                  y={151}
-                >
-                  sum_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    num: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={100}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={118}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={196}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-dnqmqq gDcGMW"
-    >
-      <div
-        className="sc-gZMcBi bksKfm"
-        onMouseDown={[Function]}
-      />
-    </div>
-    <div
-      className="sc-jAaTju cVRbSZ"
-      style={
-        Object {
-          "width": "30vw",
-        }
-      }
-    >
-      <div
-        className="sc-cvbbAY eJUIRn"
-      >
-        <a
-          href="/pandas_hello_world/load_num_csv"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP hPUXXS"
-          >
-            <span
-              className="bp3-icon bp3-icon-diagram-tree"
-              icon="diagram-tree"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="diagram-tree"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  diagram-tree
-                </desc>
-                <path
-                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Info
-          </div>
-        </a>
-        <a
-          href="/pandas_hello_world/load_num_csv?types=true"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP jjMzhC"
-          >
-            <span
-              className="bp3-icon bp3-icon-manual"
-              icon="manual"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="manual"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  manual
-                </desc>
-                <path
-                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Types
-          </div>
-        </a>
-      </div>
-      <div>
-        <div
-          className="sc-kgoBCf igxmqw"
-        >
-          Pipeline
-        </div>
-        <h3
-          className="sc-kAzzGY jYDBGE"
-        >
-          pandas_hello_world
-        </h3>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Description
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              />
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Contexts
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                <div
-                  className="sc-kGXeez eAvgrC"
-                >
-                  <h4
-                    className="sc-chPdSV bzfSHL"
-                  >
-                    default
-                  </h4>
-                  <code
-                    className="sc-VigVT dhvbCT"
-                  >
-                    <div
-                      className="sc-jzJRlG jDBHIi"
-                    >
-                      /* A configuration dictionary with typed fields */
-                    </div>
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                        
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        log_level
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#BF7326",
-                            "fontWeight": 500,
-                          }
-                        }
-                      >
-                        ?
-                      </span>
-                      : 
-                      <span>
-                        String
-                      </span>
-                    </div>
-                    }
-                  </code>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
+      title="Connecting..."
+    />
+    <span
+      className="sc-ktHwxA doWHPT"
+    />
+  </div>
+</div>
 `;
 
 exports[`renders type page 2`] = `
-Array [
+<div
+  className="bp3-navbar"
+>
   <div
-    className="bp3-navbar"
+    className="bp3-navbar-group bp3-align-left"
   >
     <div
-      className="bp3-navbar-group bp3-align-left"
+      className="bp3-navbar-heading"
+      onClick={[Function]}
     >
-      <div
-        className="bp3-navbar-heading"
-        onClick={[Function]}
-      >
-        <img
-          style={
-            Object {
-              "height": 34,
-            }
+      <img
+        style={
+          Object {
+            "height": 34,
           }
-        />
-      </div>
+        }
+      />
+    </div>
+    <div
+      className="bp3-navbar-divider"
+    />
+    <div
+      className="sc-cIShpX iWIiAw"
+    >
+      <span
+        className="bp3-popover-wrapper"
+      >
+        <span
+          className="bp3-popover-target"
+          onClick={[Function]}
+        >
+          <div
+            className=""
+            onKeyDown={[Function]}
+          >
+            <button
+              className="bp3-button"
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              type="button"
+            >
+              <span
+                className="bp3-button-text"
+              >
+                pandas_hello_world
+              </span>
+              <span
+                className="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height={16}
+                  viewBox="0 0 16 16"
+                  width={16}
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </span>
+      </span>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-kafWEX dOcLVX"
       >
-        <span
-          className="bp3-popover-wrapper"
+        <a
+          className="active sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/explore"
+          onClick={[Function]}
         >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  pandas_hello_world
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <div
-          className="bp3-navbar-divider"
-        />
-        <div
-          className="sc-kafWEX dOcLVX"
+          Explore
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/execute"
+          onClick={[Function]}
         >
-          <a
-            className="active sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/explore"
-            onClick={[Function]}
-          >
-            Explore
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/execute"
-            onClick={[Function]}
-          >
-            Execute
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/runs"
-            onClick={[Function]}
-          >
-            Runs
-          </a>
-        </div>
+          Execute
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/runs"
+          onClick={[Function]}
+        >
+          Runs
+        </a>
       </div>
     </div>
-    <div
-      className="bp3-navbar-group bp3-align-right"
-    >
-      <div
-        className="sc-bRBYWo jpDyyc"
-        style={
-          Object {
-            "background": "#3DCC91",
-          }
-        }
-        title="Connecting..."
-      />
-      <span
-        className="sc-ktHwxA doWHPT"
-      />
-    </div>
-  </div>,
+  </div>
   <div
-    className="sc-brqgnP kbTxLu"
+    className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-cMljjf bkQPOZ"
+      className="sc-bRBYWo jpDyyc"
       style={
         Object {
-          "width": "70vw",
+          "background": "#3DCC91",
         }
       }
-    >
-      <div
-        className="sc-jDwBTQ bSCVyv"
-      >
-        <span
-          className="bp3-popover-wrapper"
-        >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  Select a Solid...
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <input
-          className="sc-gPEVay ldPQtW"
-          onChange={[Function]}
-          placeholder="Filter..."
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        onWheel={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#F5F8FA",
-            "height": "100%",
-            "overflow": "hidden",
-            "position": "relative",
-            "userSelect": "none",
-            "width": "100%",
-          }
-        }
-        tabIndex={-1}
-      >
-        <div
-          style={
-            Object {
-              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
-              "transformOrigin": "top left",
-            }
-          }
-        >
-          <svg
-            className="sc-gzVnrw gBGkHq"
-            height={514}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            width={625}
-          >
-            <g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.2,
-                  }
-                }
-              >
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <path
-                    className="vx-link-vertical sc-htoDjs jbckmQ"
-                    d="M115,214C115,257,115,257,115,300"
-                  >
-                    <title>
-                      sum_solid - sum_sq_solid
-                    </title>
-                  </path>
-                </g>
-              </g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.75,
-                  }
-                }
-              />
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={130}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={167.4}
-                  x={112}
-                  y={151}
-                >
-                  sum_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    num: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={100}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={118}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={196}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-dnqmqq gDcGMW"
-    >
-      <div
-        className="sc-gZMcBi bksKfm"
-        onMouseDown={[Function]}
-      />
-    </div>
-    <div
-      className="sc-jAaTju cVRbSZ"
-      style={
-        Object {
-          "width": "30vw",
-        }
-      }
-    >
-      <div
-        className="sc-cvbbAY eJUIRn"
-      >
-        <a
-          href="/pandas_hello_world/load_num_csv"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP jjMzhC"
-          >
-            <span
-              className="bp3-icon bp3-icon-diagram-tree"
-              icon="diagram-tree"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="diagram-tree"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  diagram-tree
-                </desc>
-                <path
-                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Info
-          </div>
-        </a>
-        <a
-          href="/pandas_hello_world/load_num_csv?types=true"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP hPUXXS"
-          >
-            <span
-              className="bp3-icon bp3-icon-manual"
-              icon="manual"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="manual"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  manual
-                </desc>
-                <path
-                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Types
-          </div>
-        </a>
-      </div>
-      <div
-        className="sc-kgoBCf igxmqw"
-      />
-      <h3
-        className="sc-kAzzGY jYDBGE"
-      >
-        Pipeline Types
-      </h3>
-      <div>
-        <div
-          className="sc-kpOJdX goxjbg"
-          onClick={[Function]}
-        >
-          Custom
-          <span
-            className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-            icon="chevron-down"
-          >
-            <svg
-              data-icon="chevron-down"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-            >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                fillRule="evenodd"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          className="bp3-collapse"
-          style={
-            Object {
-              "height": "auto",
-              "overflowY": "visible",
-              "transition": "none",
-            }
-          }
-        >
-          <div
-            aria-hidden={false}
-            className="bp3-collapse-body"
-            style={
-              Object {
-                "transform": "translateY(0)",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              className="sc-dxgOiQ dPbrCh"
-            >
-              <ul
-                className="bp3-list"
-              >
-                <li
-                  className="sc-jKJlTe hLXNeg"
-                >
-                  <a
-                    href="/?typeExplorer=PandasDataFrame"
-                    onClick={[Function]}
-                  >
-                    <code
-                      className="sc-ckVGcZ iRVuvl"
-                    >
-                      PandasDataFrame
-                    </code>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <div
-          className="sc-kpOJdX goxjbg"
-          onClick={[Function]}
-        >
-          Built-in
-          <span
-            className="bp3-icon bp3-icon-chevron-up sc-cSHVUG fvtgDa"
-            icon="chevron-up"
-          >
-            <svg
-              data-icon="chevron-up"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-            >
-              <desc>
-                chevron-up
-              </desc>
-              <path
-                d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 0 0 1.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71z"
-                fillRule="evenodd"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          className="bp3-collapse"
-          style={
-            Object {
-              "height": undefined,
-              "overflowY": undefined,
-              "transition": undefined,
-            }
-          }
-        >
-          <div
-            aria-hidden={false}
-            className="bp3-collapse-body"
-            style={
-              Object {
-                "transform": "translateY(-undefinedpx)",
-                "transition": undefined,
-              }
-            }
-          />
-        </div>
-      </div>
-      <h3
-        className="bp3-heading"
-      />
-    </div>
-  </div>,
-]
+      title="Connecting..."
+    />
+    <span
+      className="sc-ktHwxA doWHPT"
+    />
+  </div>
+</div>
 `;
 
 exports[`renders without error 1`] = `

--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,921 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders execution 1`] = `
-Array [
+<div
+  className="bp3-navbar"
+>
   <div
-    className="bp3-navbar"
+    className="bp3-navbar-group bp3-align-left"
   >
     <div
-      className="bp3-navbar-group bp3-align-left"
+      className="bp3-navbar-heading"
+      onClick={[Function]}
     >
-      <div
-        className="bp3-navbar-heading"
-        onClick={[Function]}
-      >
-        <img
-          style={
-            Object {
-              "height": 34,
-            }
+      <img
+        style={
+          Object {
+            "height": 34,
           }
-        />
-      </div>
+        }
+      />
+    </div>
+    <div
+      className="bp3-navbar-divider"
+    />
+    <div
+      className="sc-cIShpX iWIiAw"
+    >
+      <span
+        className="bp3-popover-wrapper"
+      >
+        <span
+          className="bp3-popover-target"
+          onClick={[Function]}
+        >
+          <div
+            className=""
+            onKeyDown={[Function]}
+          >
+            <button
+              className="bp3-button"
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              type="button"
+            >
+              <span
+                className="bp3-button-text"
+              >
+                pandas_hello_world
+              </span>
+              <span
+                className="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height={16}
+                  viewBox="0 0 16 16"
+                  width={16}
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </span>
+      </span>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-kafWEX dOcLVX"
       >
-        <span
-          className="bp3-popover-wrapper"
+        <a
+          className="active sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/explore"
+          onClick={[Function]}
         >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  pandas_hello_world
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <div
-          className="bp3-navbar-divider"
-        />
-        <div
-          className="sc-kafWEX dOcLVX"
+          Explore
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/execute"
+          onClick={[Function]}
         >
-          <a
-            className="active sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/explore"
-            onClick={[Function]}
-          >
-            Explore
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/execute"
-            onClick={[Function]}
-          >
-            Execute
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/runs"
-            onClick={[Function]}
-          >
-            Runs
-          </a>
-        </div>
+          Execute
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/runs"
+          onClick={[Function]}
+        >
+          Runs
+        </a>
       </div>
     </div>
-    <div
-      className="bp3-navbar-group bp3-align-right"
-    >
-      <div
-        className="sc-bRBYWo jpDyyc"
-        style={
-          Object {
-            "background": "#3DCC91",
-          }
-        }
-        title="Connecting..."
-      />
-      <span
-        className="sc-ktHwxA doWHPT"
-      />
-    </div>
-  </div>,
+  </div>
   <div
-    className="sc-brqgnP kbTxLu"
+    className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-cMljjf bkQPOZ"
+      className="sc-bRBYWo jpDyyc"
       style={
         Object {
-          "width": "70vw",
+          "background": "#3DCC91",
         }
       }
-    >
-      <div
-        className="sc-jDwBTQ bSCVyv"
-      >
-        <span
-          className="bp3-popover-wrapper"
-        >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  Select a Solid...
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <input
-          className="sc-gPEVay ldPQtW"
-          onChange={[Function]}
-          placeholder="Filter..."
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        onWheel={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#F5F8FA",
-            "height": "100%",
-            "overflow": "hidden",
-            "position": "relative",
-            "userSelect": "none",
-            "width": "100%",
-          }
-        }
-        tabIndex={-1}
-      >
-        <div
-          style={
-            Object {
-              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
-              "transformOrigin": "top left",
-            }
-          }
-        >
-          <svg
-            className="sc-gzVnrw gBGkHq"
-            height={514}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            width={625}
-          >
-            <g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.2,
-                  }
-                }
-              >
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <path
-                    className="vx-link-vertical sc-htoDjs jbckmQ"
-                    d="M115,214C115,257,115,257,115,300"
-                  >
-                    <title>
-                      sum_solid - sum_sq_solid
-                    </title>
-                  </path>
-                </g>
-              </g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.75,
-                  }
-                }
-              />
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={130}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={167.4}
-                  x={112}
-                  y={151}
-                >
-                  sum_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    num: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={100}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={118}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={196}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-dnqmqq gDcGMW"
-    >
-      <div
-        className="sc-gZMcBi bksKfm"
-        onMouseDown={[Function]}
-      />
-    </div>
-    <div
-      className="sc-jAaTju cVRbSZ"
-      style={
-        Object {
-          "width": "30vw",
-        }
-      }
-    >
-      <div
-        className="sc-cvbbAY eJUIRn"
-      >
-        <a
-          href="/pandas_hello_world/load_num_csv"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP jjMzhC"
-          >
-            <span
-              className="bp3-icon bp3-icon-diagram-tree"
-              icon="diagram-tree"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="diagram-tree"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  diagram-tree
-                </desc>
-                <path
-                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Info
-          </div>
-        </a>
-        <a
-          href="/pandas_hello_world/load_num_csv?types=true"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP hPUXXS"
-          >
-            <span
-              className="bp3-icon bp3-icon-manual"
-              icon="manual"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="manual"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  manual
-                </desc>
-                <path
-                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Types
-          </div>
-        </a>
-      </div>
-      <div>
-        <div
-          className="sc-kgoBCf igxmqw"
-        />
-        <h3
-          className="sc-kAzzGY jYDBGE"
-        >
-          <a
-            href="/pandas_hello_world/load_num_csv?types=true"
-            onClick={[Function]}
-          >
-            Pipeline Types
-          </a>
-           &gt; 
-          PandasDataFrame
-        </h3>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Description
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                Two-dimensional size-mutable, potentially heterogeneous
-    tabular data structure with labeled axes (rows and columns).
-    See http://pandas.pydata.org/
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Input
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                <code
-                  className="sc-VigVT dhvbCT"
-                >
-                  {
-                  <div
-                    className="sc-jzJRlG jDBHIi"
-                  >
-                      /* One of the following: */
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      csv
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        sep
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#BF7326",
-                            "fontWeight": 500,
-                          }
-                        }
-                      >
-                        ?
-                      </span>
-                      : 
-                      <span>
-                        String
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      parquet
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      table
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  }
-                </code>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Output
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                <code
-                  className="sc-VigVT dhvbCT"
-                >
-                  {
-                  <div
-                    className="sc-jzJRlG jDBHIi"
-                  >
-                      /* One of the following: */
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      csv
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        sep
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#BF7326",
-                            "fontWeight": 500,
-                          }
-                        }
-                      >
-                        ?
-                      </span>
-                      : 
-                      <span>
-                        String
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      parquet
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  <div
-                    className="sc-jTzLTM eCMmlJ"
-                  >
-                      
-                    <span
-                      className="sc-fjdhpX bNrcsK"
-                    >
-                      table
-                    </span>
-                    : 
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                          
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        path
-                      </span>
-                      : 
-                      <span>
-                        Path
-                      </span>
-                    </div>
-                      }
-                  </div>
-                  }
-                </code>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
+      title="Connecting..."
+    />
+    <span
+      className="sc-ktHwxA doWHPT"
+    />
+  </div>
+</div>
 `;
 
 exports[`renders pipeline page 1`] = `
@@ -1692,1308 +893,241 @@ Array [
 `;
 
 exports[`renders type page 1`] = `
-Array [
+<div
+  className="bp3-navbar"
+>
   <div
-    className="bp3-navbar"
+    className="bp3-navbar-group bp3-align-left"
   >
     <div
-      className="bp3-navbar-group bp3-align-left"
+      className="bp3-navbar-heading"
+      onClick={[Function]}
     >
-      <div
-        className="bp3-navbar-heading"
-        onClick={[Function]}
-      >
-        <img
-          style={
-            Object {
-              "height": 34,
-            }
+      <img
+        style={
+          Object {
+            "height": 34,
           }
-        />
-      </div>
+        }
+      />
+    </div>
+    <div
+      className="bp3-navbar-divider"
+    />
+    <div
+      className="sc-cIShpX iWIiAw"
+    >
+      <span
+        className="bp3-popover-wrapper"
+      >
+        <span
+          className="bp3-popover-target"
+          onClick={[Function]}
+        >
+          <div
+            className=""
+            onKeyDown={[Function]}
+          >
+            <button
+              className="bp3-button"
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              type="button"
+            >
+              <span
+                className="bp3-button-text"
+              >
+                pandas_hello_world
+              </span>
+              <span
+                className="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height={16}
+                  viewBox="0 0 16 16"
+                  width={16}
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </span>
+      </span>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-kafWEX dOcLVX"
       >
-        <span
-          className="bp3-popover-wrapper"
+        <a
+          className="active sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/explore"
+          onClick={[Function]}
         >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  pandas_hello_world
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <div
-          className="bp3-navbar-divider"
-        />
-        <div
-          className="sc-kafWEX dOcLVX"
+          Explore
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/execute"
+          onClick={[Function]}
         >
-          <a
-            className="active sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/explore"
-            onClick={[Function]}
-          >
-            Explore
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/execute"
-            onClick={[Function]}
-          >
-            Execute
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/runs"
-            onClick={[Function]}
-          >
-            Runs
-          </a>
-        </div>
+          Execute
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/runs"
+          onClick={[Function]}
+        >
+          Runs
+        </a>
       </div>
     </div>
-    <div
-      className="bp3-navbar-group bp3-align-right"
-    >
-      <div
-        className="sc-bRBYWo jpDyyc"
-        style={
-          Object {
-            "background": "#3DCC91",
-          }
-        }
-        title="Connecting..."
-      />
-      <span
-        className="sc-ktHwxA doWHPT"
-      />
-    </div>
-  </div>,
+  </div>
   <div
-    className="sc-brqgnP kbTxLu"
+    className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-cMljjf bkQPOZ"
+      className="sc-bRBYWo jpDyyc"
       style={
         Object {
-          "width": "70vw",
+          "background": "#3DCC91",
         }
       }
-    >
-      <div
-        className="sc-jDwBTQ bSCVyv"
-      >
-        <span
-          className="bp3-popover-wrapper"
-        >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  Select a Solid...
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <input
-          className="sc-gPEVay ldPQtW"
-          onChange={[Function]}
-          placeholder="Filter..."
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        onWheel={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#F5F8FA",
-            "height": "100%",
-            "overflow": "hidden",
-            "position": "relative",
-            "userSelect": "none",
-            "width": "100%",
-          }
-        }
-        tabIndex={-1}
-      >
-        <div
-          style={
-            Object {
-              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
-              "transformOrigin": "top left",
-            }
-          }
-        >
-          <svg
-            className="sc-gzVnrw gBGkHq"
-            height={514}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            width={625}
-          >
-            <g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.2,
-                  }
-                }
-              >
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <path
-                    className="vx-link-vertical sc-htoDjs jbckmQ"
-                    d="M115,214C115,257,115,257,115,300"
-                  >
-                    <title>
-                      sum_solid - sum_sq_solid
-                    </title>
-                  </path>
-                </g>
-              </g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.75,
-                  }
-                }
-              />
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={130}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={167.4}
-                  x={112}
-                  y={151}
-                >
-                  sum_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    num: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={100}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={118}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={196}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-dnqmqq gDcGMW"
-    >
-      <div
-        className="sc-gZMcBi bksKfm"
-        onMouseDown={[Function]}
-      />
-    </div>
-    <div
-      className="sc-jAaTju cVRbSZ"
-      style={
-        Object {
-          "width": "30vw",
-        }
-      }
-    >
-      <div
-        className="sc-cvbbAY eJUIRn"
-      >
-        <a
-          href="/pandas_hello_world/load_num_csv"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP hPUXXS"
-          >
-            <span
-              className="bp3-icon bp3-icon-diagram-tree"
-              icon="diagram-tree"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="diagram-tree"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  diagram-tree
-                </desc>
-                <path
-                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Info
-          </div>
-        </a>
-        <a
-          href="/pandas_hello_world/load_num_csv?types=true"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP jjMzhC"
-          >
-            <span
-              className="bp3-icon bp3-icon-manual"
-              icon="manual"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="manual"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  manual
-                </desc>
-                <path
-                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Types
-          </div>
-        </a>
-      </div>
-      <div>
-        <div
-          className="sc-kgoBCf igxmqw"
-        >
-          Pipeline
-        </div>
-        <h3
-          className="sc-kAzzGY jYDBGE"
-        >
-          pandas_hello_world
-        </h3>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Description
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              />
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            className="sc-kpOJdX goxjbg"
-            onClick={[Function]}
-          >
-            Contexts
-            <span
-              className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-          </div>
-          <div
-            className="bp3-collapse"
-            style={
-              Object {
-                "height": "auto",
-                "overflowY": "visible",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              aria-hidden={false}
-              className="bp3-collapse-body"
-              style={
-                Object {
-                  "transform": "translateY(0)",
-                  "transition": "none",
-                }
-              }
-            >
-              <div
-                className="sc-dxgOiQ dPbrCh"
-              >
-                <div
-                  className="sc-kGXeez eAvgrC"
-                >
-                  <h4
-                    className="sc-chPdSV bzfSHL"
-                  >
-                    default
-                  </h4>
-                  <code
-                    className="sc-VigVT dhvbCT"
-                  >
-                    <div
-                      className="sc-jzJRlG jDBHIi"
-                    >
-                      /* A configuration dictionary with typed fields */
-                    </div>
-                    {
-                    <div
-                      className="sc-jTzLTM eCMmlJ"
-                    >
-                        
-                      <span
-                        className="sc-fjdhpX bNrcsK"
-                      >
-                        log_level
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "color": "#BF7326",
-                            "fontWeight": 500,
-                          }
-                        }
-                      >
-                        ?
-                      </span>
-                      : 
-                      <span>
-                        String
-                      </span>
-                    </div>
-                    }
-                  </code>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
+      title="Connecting..."
+    />
+    <span
+      className="sc-ktHwxA doWHPT"
+    />
+  </div>
+</div>
 `;
 
 exports[`renders type page 2`] = `
-Array [
+<div
+  className="bp3-navbar"
+>
   <div
-    className="bp3-navbar"
+    className="bp3-navbar-group bp3-align-left"
   >
     <div
-      className="bp3-navbar-group bp3-align-left"
+      className="bp3-navbar-heading"
+      onClick={[Function]}
     >
-      <div
-        className="bp3-navbar-heading"
-        onClick={[Function]}
-      >
-        <img
-          style={
-            Object {
-              "height": 34,
-            }
+      <img
+        style={
+          Object {
+            "height": 34,
           }
-        />
-      </div>
+        }
+      />
+    </div>
+    <div
+      className="bp3-navbar-divider"
+    />
+    <div
+      className="sc-cIShpX iWIiAw"
+    >
+      <span
+        className="bp3-popover-wrapper"
+      >
+        <span
+          className="bp3-popover-target"
+          onClick={[Function]}
+        >
+          <div
+            className=""
+            onKeyDown={[Function]}
+          >
+            <button
+              className="bp3-button"
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              type="button"
+            >
+              <span
+                className="bp3-button-text"
+              >
+                pandas_hello_world
+              </span>
+              <span
+                className="bp3-icon bp3-icon-double-caret-vertical"
+                icon="double-caret-vertical"
+              >
+                <svg
+                  data-icon="double-caret-vertical"
+                  height={16}
+                  viewBox="0 0 16 16"
+                  width={16}
+                >
+                  <desc>
+                    double-caret-vertical
+                  </desc>
+                  <path
+                    d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </span>
+      </span>
       <div
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-kafWEX dOcLVX"
       >
-        <span
-          className="bp3-popover-wrapper"
+        <a
+          className="active sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/explore"
+          onClick={[Function]}
         >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  pandas_hello_world
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <div
-          className="bp3-navbar-divider"
-        />
-        <div
-          className="sc-kafWEX dOcLVX"
+          Explore
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/execute"
+          onClick={[Function]}
         >
-          <a
-            className="active sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/explore"
-            onClick={[Function]}
-          >
-            Explore
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/execute"
-            onClick={[Function]}
-          >
-            Execute
-          </a>
-          <a
-            className="sc-feJyhm kTrNTW"
-            href="/pandas_hello_world/runs"
-            onClick={[Function]}
-          >
-            Runs
-          </a>
-        </div>
+          Execute
+        </a>
+        <a
+          className="sc-feJyhm kTrNTW"
+          href="/pandas_hello_world/runs"
+          onClick={[Function]}
+        >
+          Runs
+        </a>
       </div>
     </div>
-    <div
-      className="bp3-navbar-group bp3-align-right"
-    >
-      <div
-        className="sc-bRBYWo jpDyyc"
-        style={
-          Object {
-            "background": "#3DCC91",
-          }
-        }
-        title="Connecting..."
-      />
-      <span
-        className="sc-ktHwxA doWHPT"
-      />
-    </div>
-  </div>,
+  </div>
   <div
-    className="sc-brqgnP kbTxLu"
+    className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-cMljjf bkQPOZ"
+      className="sc-bRBYWo jpDyyc"
       style={
         Object {
-          "width": "70vw",
+          "background": "#3DCC91",
         }
       }
-    >
-      <div
-        className="sc-jDwBTQ bSCVyv"
-      >
-        <span
-          className="bp3-popover-wrapper"
-        >
-          <span
-            className="bp3-popover-target"
-            onClick={[Function]}
-          >
-            <div
-              className=""
-              onKeyDown={[Function]}
-            >
-              <button
-                className="bp3-button"
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                type="button"
-              >
-                <span
-                  className="bp3-button-text"
-                >
-                  Select a Solid...
-                </span>
-                <span
-                  className="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height={16}
-                    viewBox="0 0 16 16"
-                    width={16}
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </span>
-        </span>
-        <input
-          className="sc-gPEVay ldPQtW"
-          onChange={[Function]}
-          placeholder="Filter..."
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        onWheel={[Function]}
-        style={
-          Object {
-            "backgroundColor": "#F5F8FA",
-            "height": "100%",
-            "overflow": "hidden",
-            "position": "relative",
-            "userSelect": "none",
-            "width": "100%",
-          }
-        }
-        tabIndex={-1}
-      >
-        <div
-          style={
-            Object {
-              "transform": "matrix(0.39, 0, 0, 0.39, 378.125, 399.77)",
-              "transformOrigin": "top left",
-            }
-          }
-        >
-          <svg
-            className="sc-gzVnrw gBGkHq"
-            height={514}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            width={625}
-          >
-            <g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.2,
-                  }
-                }
-              >
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <path
-                    className="vx-link-vertical sc-htoDjs jbckmQ"
-                    d="M115,214C115,257,115,257,115,300"
-                  >
-                    <title>
-                      sum_solid - sum_sq_solid
-                    </title>
-                  </path>
-                </g>
-              </g>
-              <g
-                style={
-                  Object {
-                    "opacity": 0.75,
-                  }
-                }
-              />
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={130}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={167.4}
-                  x={112}
-                  y={151}
-                >
-                  sum_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    num: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={100}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={118}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={196}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-dnqmqq gDcGMW"
-    >
-      <div
-        className="sc-gZMcBi bksKfm"
-        onMouseDown={[Function]}
-      />
-    </div>
-    <div
-      className="sc-jAaTju cVRbSZ"
-      style={
-        Object {
-          "width": "30vw",
-        }
-      }
-    >
-      <div
-        className="sc-cvbbAY eJUIRn"
-      >
-        <a
-          href="/pandas_hello_world/load_num_csv"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP jjMzhC"
-          >
-            <span
-              className="bp3-icon bp3-icon-diagram-tree"
-              icon="diagram-tree"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="diagram-tree"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  diagram-tree
-                </desc>
-                <path
-                  d="M15 8v3h-2V9H9v2H7V9H3v2H1V8a1 1 0 0 1 1-1h5V5h2v2h5a1 1 0 0 1 1 1zM1 12h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm12 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zm-6 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1zM7 0h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Info
-          </div>
-        </a>
-        <a
-          href="/pandas_hello_world/load_num_csv?types=true"
-          onClick={[Function]}
-        >
-          <div
-            className="sc-jWBwVP hPUXXS"
-          >
-            <span
-              className="bp3-icon bp3-icon-manual"
-              icon="manual"
-              style={
-                Object {
-                  "marginRight": 5,
-                }
-              }
-            >
-              <svg
-                data-icon="manual"
-                height={16}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <desc>
-                  manual
-                </desc>
-                <path
-                  d="M15.99 1.13c-.02-.41-.33-.77-.78-.87C12.26-.36 9.84.13 8 1.7 6.16.13 3.74-.36.78.26.33.35.03.72.01 1.13H0v12c0 .08 0 .17.02.26.12.51.65.82 1.19.71 2.63-.55 4.59-.04 6.01 1.57.02.03.06.04.08.06.02.02.03.04.05.06.04.03.09.04.13.07.05.03.09.05.14.07.11.04.23.07.35.07h.04c.12 0 .24-.03.35-.07.05-.02.09-.05.14-.07.04-.02.09-.04.13-.07.02-.02.03-.04.05-.06.03-.02.06-.03.08-.06 1.42-1.6 3.39-2.12 6.01-1.57.54.11 1.07-.21 1.19-.71.04-.09.04-.18.04-.26l-.01-12zM7 12.99c-1.4-.83-3.07-1.14-5-.93V1.96c2.11-.28 3.75.2 5 1.46v9.57zm7-.92c-1.93-.21-3.6.1-5 .93V3.42c1.25-1.26 2.89-1.74 5-1.46v10.11z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </span>
-            Types
-          </div>
-        </a>
-      </div>
-      <div
-        className="sc-kgoBCf igxmqw"
-      />
-      <h3
-        className="sc-kAzzGY jYDBGE"
-      >
-        Pipeline Types
-      </h3>
-      <div>
-        <div
-          className="sc-kpOJdX goxjbg"
-          onClick={[Function]}
-        >
-          Custom
-          <span
-            className="bp3-icon bp3-icon-chevron-down sc-cSHVUG fvtgDa"
-            icon="chevron-down"
-          >
-            <svg
-              data-icon="chevron-down"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-            >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0 0 12 5z"
-                fillRule="evenodd"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          className="bp3-collapse"
-          style={
-            Object {
-              "height": "auto",
-              "overflowY": "visible",
-              "transition": "none",
-            }
-          }
-        >
-          <div
-            aria-hidden={false}
-            className="bp3-collapse-body"
-            style={
-              Object {
-                "transform": "translateY(0)",
-                "transition": "none",
-              }
-            }
-          >
-            <div
-              className="sc-dxgOiQ dPbrCh"
-            >
-              <ul
-                className="bp3-list"
-              >
-                <li
-                  className="sc-jKJlTe hLXNeg"
-                >
-                  <a
-                    href="/?typeExplorer=PandasDataFrame"
-                    onClick={[Function]}
-                  >
-                    <code
-                      className="sc-ckVGcZ iRVuvl"
-                    >
-                      PandasDataFrame
-                    </code>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <div
-          className="sc-kpOJdX goxjbg"
-          onClick={[Function]}
-        >
-          Built-in
-          <span
-            className="bp3-icon bp3-icon-chevron-up sc-cSHVUG fvtgDa"
-            icon="chevron-up"
-          >
-            <svg
-              data-icon="chevron-up"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-            >
-              <desc>
-                chevron-up
-              </desc>
-              <path
-                d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 0 0 1.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71z"
-                fillRule="evenodd"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          className="bp3-collapse"
-          style={
-            Object {
-              "height": undefined,
-              "overflowY": undefined,
-              "transition": undefined,
-            }
-          }
-        >
-          <div
-            aria-hidden={false}
-            className="bp3-collapse-body"
-            style={
-              Object {
-                "transform": "translateY(-undefinedpx)",
-                "transition": undefined,
-              }
-            }
-          />
-        </div>
-      </div>
-      <h3
-        className="bp3-heading"
-      />
-    </div>
-  </div>,
-]
+      title="Connecting..."
+    />
+    <span
+      className="sc-ktHwxA doWHPT"
+    />
+  </div>
+</div>
 `;
 
 exports[`renders without error 1`] = `

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -2875,7 +2875,8 @@ E   AttributeError: module 'dagster.core.types' has no attribute 'ConfigDictiona
 ```
 
 First, we can discouraging the use of the `types` namespace. Instead just `from dagster import Dict` (or whatever class directly).
-Second, `ConfigDictionary` is now just `Dict`.
+Second, `ConfigDictionary` is now just `NamedDict`. If the name of the type wasn't particularily relevant
+you can also eliminate that and just use `Dict`.
 Third, you do not have to name it. The net result is much nicer:
 
 Before:
@@ -21653,7 +21654,8 @@ snapshots['test_build_all_docs 57'] = '''
 </pre></div>
 </div>
 <p>First, we can discouraging the use of the <code class="docutils literal notranslate"><span class="pre">types</span></code> namespace. Instead just <code class="docutils literal notranslate"><span class="pre">from</span> <span class="pre">dagster</span> <span class="pre">import</span> <span class="pre">Dict</span></code> (or whatever class directly).
-Second, <code class="docutils literal notranslate"><span class="pre">ConfigDictionary</span></code> is now just <code class="docutils literal notranslate"><span class="pre">Dict</span></code>.
+Second, <code class="docutils literal notranslate"><span class="pre">ConfigDictionary</span></code> is now just <code class="docutils literal notranslate"><span class="pre">NamedDict</span></code>. If the name of the type wasn’t particularily relevant
+you can also eliminate that and just use <code class="docutils literal notranslate"><span class="pre">Dict</span></code>.
 Third, you do not have to name it. The net result is much nicer:</p>
 <p>Before:</p>
 <div class="highlight-py notranslate"><div class="highlight"><pre><span></span><span class="n">types</span><span class="o">.</span><span class="n">ConfigDictionary</span><span class="p">(</span>


### PR DESCRIPTION
Looks like https://github.com/dagster-io/dagster/commit/02b1d07b6b00407c9533d4d718efc6195620961a broke navigation to solids by generating urls with /explore but not matching on them in the router.

Also updating snapshots I did not update when I pushed a minor documentation change to master.

There's some dubious JS in here but this fixes this in the short term. Assigned https://github.com/dagster-io/dagster/issues/1070 to @bengotow to follow up with more coherent fix.