### PR TITLE
Improve error messages with Field arguments

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/context.py
+++ b/python_modules/dagster/dagster/core/definitions/context.py
@@ -83,7 +83,7 @@ class PipelineContextDefinition(object):
             context_fn = _default_context_fn
 
         self.config_field = check_user_facing_opt_field_param(
-            config_field, 'config_field', 'PipelineContextDefinition'
+            config_field, 'config_field', 'of a PipelineContextDefinition'
         )
         self.context_fn = check.opt_callable_param(
             context_fn, 'context_fn', lambda *args, **kwargs: ExecutionContext()

--- a/python_modules/dagster/dagster/core/definitions/context.py
+++ b/python_modules/dagster/dagster/core/definitions/context.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from dagster import check
 
 from dagster.core.types import Field, Dict
-from dagster.core.types.field_utils import check_opt_field_param
+from dagster.core.types.field_utils import check_user_facing_opt_field_param
 from dagster.core.user_context import ExecutionContext
 from dagster.core.system_config.objects import DEFAULT_CONTEXT_NAME
 
@@ -82,7 +82,9 @@ class PipelineContextDefinition(object):
             config_field = _default_config_field()
             context_fn = _default_context_fn
 
-        self.config_field = check_opt_field_param(config_field, 'config_field')
+        self.config_field = check_user_facing_opt_field_param(
+            config_field, 'config_field', 'PipelineContextDefinition'
+        )
         self.context_fn = check.opt_callable_param(
             context_fn, 'context_fn', lambda *args, **kwargs: ExecutionContext()
         )

--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -6,7 +6,7 @@ from dagster import check
 
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 
-from dagster.core.types.field_utils import check_opt_field_param
+# from dagster.core.types.field_utils import check_user_facing_opt_field_param
 
 from . import InputDefinition, OutputDefinition, Result, SolidDefinition
 
@@ -113,7 +113,11 @@ class _Solid(object):
         outputs = outputs or ([OutputDefinition()] if outputs is None else [])
         self.outputs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
-        self.config_field = check_opt_field_param(config_field, 'config_field')
+        # config_field will be checked within SolidDefinition
+        self.config_field = config_field
+        # self.config_field = check_user_facing_opt_field_param(
+        #     config_field, 'config_field', 'solid definition named {name}'.format(name=name)
+        # )
 
     def __call__(self, fn):
         check.callable_param(fn, 'fn')

--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -6,8 +6,6 @@ from dagster import check
 
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 
-# from dagster.core.types.field_utils import check_user_facing_opt_field_param
-
 from . import InputDefinition, OutputDefinition, Result, SolidDefinition
 
 if hasattr(inspect, 'signature'):
@@ -115,9 +113,6 @@ class _Solid(object):
         self.description = check.opt_str_param(description, 'description')
         # config_field will be checked within SolidDefinition
         self.config_field = config_field
-        # self.config_field = check_user_facing_opt_field_param(
-        #     config_field, 'config_field', 'solid definition named {name}'.format(name=name)
-        # )
 
     def __call__(self, fn):
         check.callable_param(fn, 'fn')

--- a/python_modules/dagster/dagster/core/definitions/resource.py
+++ b/python_modules/dagster/dagster/core/definitions/resource.py
@@ -8,7 +8,7 @@ class ResourceDefinition(object):
     def __init__(self, resource_fn, config_field=None, description=None):
         self.resource_fn = check.callable_param(resource_fn, 'resource_fn')
         self.config_field = check_user_facing_opt_field_param(
-            config_field, 'config_field', 'ResourceDefinition or @resource'
+            config_field, 'config_field', 'of a ResourceDefinition or @resource'
         )
         self.description = check.opt_str_param(description, 'description')
 

--- a/python_modules/dagster/dagster/core/definitions/resource.py
+++ b/python_modules/dagster/dagster/core/definitions/resource.py
@@ -1,13 +1,15 @@
 from dagster import check
 
 from dagster.core.types import Field, String
-from dagster.core.types.field_utils import check_opt_field_param
+from dagster.core.types.field_utils import check_user_facing_opt_field_param
 
 
 class ResourceDefinition(object):
     def __init__(self, resource_fn, config_field=None, description=None):
         self.resource_fn = check.callable_param(resource_fn, 'resource_fn')
-        self.config_field = check_opt_field_param(config_field, 'config_field')
+        self.config_field = check_user_facing_opt_field_param(
+            config_field, 'config_field', 'ResourceDefinition or @resource'
+        )
         self.description = check.opt_str_param(description, 'description')
 
     @staticmethod

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -76,7 +76,7 @@ class SolidDefinition(object):
         self.config_field = check_user_facing_opt_field_param(
             config_field,
             'config_field',
-            'SolidDefinition or @solid named "{name}"'.format(name=name),
+            'of a SolidDefinition or @solid named "{name}"'.format(name=name),
         )
         self.metadata = check.opt_dict_param(metadata, 'metadata', key_type=str)
         self._input_dict = {inp.name: inp for inp in inputs}

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.core.types.field_utils import check_opt_field_param
+from dagster.core.types.field_utils import check_user_facing_opt_field_param
 
 from .input import InputDefinition
 
@@ -73,7 +73,9 @@ class SolidDefinition(object):
         self.transform_fn = check.callable_param(transform_fn, 'transform_fn')
         self.output_defs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
-        self.config_field = check_opt_field_param(config_field, 'config_field')
+        self.config_field = check_user_facing_opt_field_param(
+            config_field, 'config_field', 'solid definition named "{name}"'.format(name=name)
+        )
         self.metadata = check.opt_dict_param(metadata, 'metadata', key_type=str)
         self._input_dict = {inp.name: inp for inp in inputs}
         self._output_dict = {output.name: output for output in outputs}

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -74,7 +74,9 @@ class SolidDefinition(object):
         self.output_defs = check.list_param(outputs, 'outputs', OutputDefinition)
         self.description = check.opt_str_param(description, 'description')
         self.config_field = check_user_facing_opt_field_param(
-            config_field, 'config_field', 'solid definition named "{name}"'.format(name=name)
+            config_field,
+            'config_field',
+            'SolidDefinition or @solid named "{name}"'.format(name=name),
         )
         self.metadata = check.opt_dict_param(metadata, 'metadata', key_type=str)
         self._input_dict = {inp.name: inp for inp in inputs}

--- a/python_modules/dagster/dagster/core/types/field.py
+++ b/python_modules/dagster/dagster/core/types/field.py
@@ -1,4 +1,5 @@
 from dagster import check
+from dagster.core.errors import DagsterInvalidDefinitionError
 from .builtin_enum import BuiltinEnum
 from .config import Any, ConfigType, List, Nullable
 from .field_utils import FieldImpl, FIELD_NO_DEFAULT_PROVIDED, INFER_OPTIONAL_COMPOSITE_FIELD
@@ -36,4 +37,12 @@ def Field(
     is_optional=INFER_OPTIONAL_COMPOSITE_FIELD,
     description=None,
 ):
+    config_type = resolve_to_config_type(dagster_type)
+    if not config_type:
+        raise DagsterInvalidDefinitionError(
+            (
+                'Attempted to pass {value_repr} to a Field that expects a valid '
+                'dagster type usable in config (e.g. Dict, NamedDict, Int, String et al).'
+            ).format(value_repr=repr(dagster_type))
+        )
     return FieldImpl(resolve_to_config_type(dagster_type), default_value, is_optional, description)

--- a/python_modules/dagster/dagster/core/types/field.py
+++ b/python_modules/dagster/dagster/core/types/field.py
@@ -20,15 +20,14 @@ def resolve_to_config_type(dagster_type):
         return Any.inst()
     if isinstance(dagster_type, BuiltinEnum):
         return ConfigType.from_builtin_enum(dagster_type)
-    ## TODO need to check for runtime type. e.g. List(DataFrame)
     if isinstance(dagster_type, WrappingListType):
         return resolve_to_config_list(dagster_type).inst()
     if isinstance(dagster_type, WrappingNullableType):
         return resolve_to_config_nullable(dagster_type).inst()
-    if issubclass(dagster_type, ConfigType):
+    if isinstance(dagster_type, type) and issubclass(dagster_type, ConfigType):
         return dagster_type.inst()
 
-    check.failed('should not reach')
+    return None
 
 
 def Field(

--- a/python_modules/dagster/dagster/core/types/field_utils.py
+++ b/python_modules/dagster/dagster/core/types/field_utils.py
@@ -41,8 +41,8 @@ def check_using_facing_field_param(obj, param_name, error_context_str):
         if config_type:
             raise DagsterInvalidDefinitionError(
                 (
-                    'You have passed a config type "{printed_type}" as parameter '
-                    '"{param_name}" of a {error_context_str} that expects a '
+                    'You have passed a config type "{printed_type}" in the parameter '
+                    '"{param_name}" {error_context_str} that expects a '
                     'Field. You have likely forgot to wrap this type in a Field.'
                 ).format(
                     printed_type=print_config_type_to_string(config_type, with_lines=False),
@@ -53,9 +53,9 @@ def check_using_facing_field_param(obj, param_name, error_context_str):
         else:
             raise DagsterInvalidDefinitionError(
                 (
-                    'You have passed an object {value_repr} of incorrect type "{type_name}" as '
-                    'parameter "{param_name}" of a {error_context_str} where a '
-                    'Field was expected.'
+                    'You have passed an object {value_repr} of incorrect type '
+                    '"{type_name}" in the parameter "{param_name}" '
+                    '{error_context_str} where a Field was expected.'
                 ).format(
                     error_context_str=error_context_str,
                     param_name=param_name,
@@ -224,6 +224,18 @@ def NamedDict(name, fields, description=None, type_attributes=DEFAULT_TYPE_ATTRI
 
 
 def Dict(fields):
+    type_name = 'Dict'
+    check.dict_param(fields, 'fields', key_type=str)
+    for field_name, potential_field in fields.items():
+        check_using_facing_field_param(
+            potential_field,
+            'fields',
+            (
+                'It is in the "{field_name}" entry of the field dict of a {type_name} '
+                'with field names {field_names}'
+            ).format(type_name=type_name, field_name=field_name, field_names=list(fields.keys())),
+        )
+
     class _Dict(_ConfigComposite):
         def __init__(self):
             key = 'Dict.' + str(DictCounter.get_next_count())

--- a/python_modules/dagster/dagster/core/types/field_utils.py
+++ b/python_modules/dagster/dagster/core/types/field_utils.py
@@ -209,6 +209,25 @@ class DictCounter:
         return DictCounter._count
 
 
+def check_user_facing_fields_dict(fields, type_name_msg):
+    check.dict_param(fields, 'fields', key_type=str)
+    check.str_param(type_name_msg, 'type_name_msg')
+
+    for field_name, potential_field in fields.items():
+        check_using_facing_field_param(
+            potential_field,
+            'fields',
+            (
+                'and it is in the "{field_name}" entry of that dict. It is from '
+                'a {type_name_msg} with fields {field_names}'
+            ).format(
+                type_name_msg=type_name_msg,
+                field_name=field_name,
+                field_names=sorted(list(fields.keys())),
+            ),
+        )
+
+
 def NamedDict(name, fields, description=None, type_attributes=DEFAULT_TYPE_ATTRIBUTES):
     check_user_facing_fields_dict(fields, 'NamedDict named "{}"'.format(name))
 
@@ -240,25 +259,6 @@ def Dict(fields):
             )
 
     return _Dict
-
-
-def check_user_facing_fields_dict(fields, type_name_msg):
-    check.dict_param(fields, 'fields', key_type=str)
-    check.str_param(type_name_msg, 'type_name_msg')
-
-    for field_name, potential_field in fields.items():
-        check_using_facing_field_param(
-            potential_field,
-            'fields',
-            (
-                'and it is in the "{field_name}" entry of that dict. It is from '
-                'a {type_name_msg} with fields {field_names}'
-            ).format(
-                type_name_msg=type_name_msg,
-                field_name=field_name,
-                field_names=sorted(list(fields.keys())),
-            ),
-        )
 
 
 def PermissiveDict(fields=None):

--- a/python_modules/dagster/dagster/core/types/field_utils.py
+++ b/python_modules/dagster/dagster/core/types/field_utils.py
@@ -41,9 +41,9 @@ def check_using_facing_field_param(obj, param_name, error_context_str):
         if config_type:
             raise DagsterInvalidDefinitionError(
                 (
-                    'You have passed a config type {printed_type} as parameter {param_name} of a '
-                    '{error_context_str} that expects a Field. You have likely forgot '
-                    'to wrap this type in a Field.'
+                    'You have passed a config type "{printed_type}" as parameter '
+                    '"{param_name}" of a {error_context_str} that expects a '
+                    'Field. You have likely forgot to wrap this type in a Field.'
                 ).format(
                     printed_type=print_config_type_to_string(config_type, with_lines=False),
                     error_context_str=error_context_str,
@@ -54,7 +54,7 @@ def check_using_facing_field_param(obj, param_name, error_context_str):
             raise DagsterInvalidDefinitionError(
                 (
                     'You have passed an object {value_repr} of incorrect type "{type_name}" as '
-                    'parameter {param_name} of a {error_context_str} where a '
+                    'parameter "{param_name}" of a {error_context_str} where a '
                     'Field was expected.'
                 ).format(
                     error_context_str=error_context_str,

--- a/python_modules/dagster/dagster/core/types/field_utils.py
+++ b/python_modules/dagster/dagster/core/types/field_utils.py
@@ -33,38 +33,38 @@ def check_using_facing_field_param(obj, param_name, error_context_str):
     check.str_param(param_name, 'param_name')
     check.str_param(error_context_str, 'error_context_str')
 
-    if not isinstance(obj, FieldImpl):
-        from dagster.core.types.field import resolve_to_config_type
-        from .type_printer import print_config_type_to_string
+    if isinstance(obj, FieldImpl):
+        return obj
 
-        config_type = resolve_to_config_type(obj)
-        if config_type:
-            raise DagsterInvalidDefinitionError(
-                (
-                    'You have passed a config type "{printed_type}" in the parameter '
-                    '"{param_name}" {error_context_str}. '
-                    'You have likely forgot to wrap this type in a Field.'
-                ).format(
-                    printed_type=print_config_type_to_string(config_type, with_lines=False),
-                    error_context_str=error_context_str,
-                    param_name=param_name,
-                )
-            )
-        else:
-            raise DagsterInvalidDefinitionError(
-                (
-                    'You have passed an object {value_repr} of incorrect type '
-                    '"{type_name}" in the parameter "{param_name}" '
-                    '{error_context_str} where a Field was expected.'
-                ).format(
-                    error_context_str=error_context_str,
-                    param_name=param_name,
-                    value_repr=repr(obj),
-                    type_name=type(obj).__name__,
-                )
-            )
+    from dagster.core.types.field import resolve_to_config_type
+    from .type_printer import print_config_type_to_string
 
-    return check.inst_param(obj, param_name, FieldImpl)
+    config_type = resolve_to_config_type(obj)
+    if config_type:
+        raise DagsterInvalidDefinitionError(
+            (
+                'You have passed a config type "{printed_type}" in the parameter '
+                '"{param_name}" {error_context_str}. '
+                'You have likely forgot to wrap this type in a Field.'
+            ).format(
+                printed_type=print_config_type_to_string(config_type, with_lines=False),
+                error_context_str=error_context_str,
+                param_name=param_name,
+            )
+        )
+    else:
+        raise DagsterInvalidDefinitionError(
+            (
+                'You have passed an object {value_repr} of incorrect type '
+                '"{type_name}" in the parameter "{param_name}" '
+                '{error_context_str} where a Field was expected.'
+            ).format(
+                error_context_str=error_context_str,
+                param_name=param_name,
+                value_repr=repr(obj),
+                type_name=type(obj).__name__,
+            )
+        )
 
 
 def check_user_facing_opt_field_param(obj, param_name, error_context_str):

--- a/python_modules/dagster/dagster/core/types/field_utils.py
+++ b/python_modules/dagster/dagster/core/types/field_utils.py
@@ -29,9 +29,9 @@ FIELD_NO_DEFAULT_PROVIDED = __FieldValueSentinel
 INFER_OPTIONAL_COMPOSITE_FIELD = __InferOptionalCompositeFieldSentinel
 
 
-def check_using_facing_field_param(obj, param_name, error_context_str=None):
+def check_using_facing_field_param(obj, param_name, error_context_str):
     check.str_param(param_name, 'param_name')
-    check.opt_str_param(error_context_str, 'error_context_str')
+    check.str_param(error_context_str, 'error_context_str')
 
     if not isinstance(obj, FieldImpl):
         from dagster.core.types.field import resolve_to_config_type
@@ -67,9 +67,9 @@ def check_using_facing_field_param(obj, param_name, error_context_str=None):
     return check.inst_param(obj, param_name, FieldImpl)
 
 
-def check_user_facing_opt_field_param(obj, param_name, error_context_str=None):
+def check_user_facing_opt_field_param(obj, param_name, error_context_str):
     check.str_param(param_name, 'param_name')
-    check.opt_str_param(error_context_str, 'error_context_str')
+    check.str_param(error_context_str, 'error_context_str')
     if obj is None:
         return None
     return check_using_facing_field_param(obj, param_name, error_context_str)

--- a/python_modules/dagster/dagster/core/types/field_utils.py
+++ b/python_modules/dagster/dagster/core/types/field_utils.py
@@ -213,6 +213,7 @@ def check_user_facing_fields_dict(fields, type_name_msg):
     check.dict_param(fields, 'fields', key_type=str)
     check.str_param(type_name_msg, 'type_name_msg')
 
+    sorted_field_names = sorted(list(fields.keys()))
     for field_name, potential_field in fields.items():
         check_using_facing_field_param(
             potential_field,
@@ -221,9 +222,7 @@ def check_user_facing_fields_dict(fields, type_name_msg):
                 'and it is in the "{field_name}" entry of that dict. It is from '
                 'a {type_name_msg} with fields {field_names}'
             ).format(
-                type_name_msg=type_name_msg,
-                field_name=field_name,
-                field_names=sorted(list(fields.keys())),
+                type_name_msg=type_name_msg, field_name=field_name, field_names=sorted_field_names
             ),
         )
 
@@ -267,6 +266,9 @@ def PermissiveDict(fields=None):
     will be ignored by the type checker.
     '''
 
+    if fields:
+        check_user_facing_fields_dict(fields, 'PermissiveDict')
+
     class _PermissiveDict(_ConfigComposite):
         def __init__(self):
             key = 'PermissiveDict.' + str(DictCounter.get_next_count())
@@ -293,6 +295,8 @@ def Selector(fields):
     Note that in other type systems this might be called an "input union."
     '''
 
+    check_user_facing_fields_dict(fields, 'Selector')
+
     class _Selector(_ConfigSelector):
         def __init__(self):
             key = 'Selector.' + str(DictCounter.get_next_count())
@@ -309,6 +313,7 @@ def Selector(fields):
 
 def NamedSelector(name, fields, description=None, type_attributes=DEFAULT_TYPE_ATTRIBUTES):
     check.str_param(name, 'name')
+    check_user_facing_fields_dict(fields, 'NamedSelector named "{}"'.format(name))
 
     class _NamedSelector(_ConfigSelector):
         def __init__(self):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -306,4 +306,3 @@ def test_invalid_named_selector_field():
         '"some_selector" with fields [\'val\']. You '
         'have likely forgot to wrap this type in a Field.'
     )
-

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -11,10 +11,13 @@ from dagster import (
     InputDefinition,
     Int,
     NamedDict,
+    # NamedSelector,
     OutputDefinition,
+    # PermissiveDict,
     PipelineContextDefinition,
     PipelineDefinition,
     ResourceDefinition,
+    # Selector,
     SolidDefinition,
     String,
     solid,
@@ -160,7 +163,7 @@ def test_pass_config_type_to_field_error_context_definition():
         )
 
     assert str(exc_info.value) == (
-        'You have passed a config type "{ val: Int }" as parameter "config_field" of a '
+        'You have passed a config type "{ val: Int }" in the parameter "config_field" of a '
         'PipelineContextDefinition that expects a Field. You have likely forgot to '
         'wrap this type in a Field.'
     )
@@ -175,7 +178,7 @@ def test_pass_unrelated_type_to_field_error_context_definition():
         )
 
     assert str(exc_info.value) == (
-        'You have passed an object \'wut\' of incorrect type "str" as parameter '
+        'You have passed an object \'wut\' of incorrect type "str" in the parameter '
         '"config_field" of a PipelineContextDefinition where a Field was expected.'
     )
 
@@ -191,7 +194,7 @@ def test_pass_config_type_to_field_error_solid_definition():
         assert a_solid  # fool lint
 
     assert str(exc_info.value) == (
-        'You have passed a config type "{ val: Int }" as parameter "config_field" '
+        'You have passed a config type "{ val: Int }" in the parameter "config_field" '
         'of a SolidDefinition or @solid named "a_solid" that expects a Field. You have '
         'likely forgot to wrap this type in a Field.'
     )
@@ -208,7 +211,7 @@ def test_pass_unrelated_type_to_field_error_solid_definition():
         assert a_solid  # fool lint
 
     assert str(exc_info.value) == (
-        'You have passed an object \'nope\' of incorrect type "str" as parameter '
+        'You have passed an object \'nope\' of incorrect type "str" in the parameter '
         '"config_field" of a SolidDefinition or @solid named "a_solid" where a Field '
         'was expected.'
     )
@@ -219,7 +222,7 @@ def test_pass_config_type_to_field_error_resource_definition():
         ResourceDefinition(resource_fn=lambda: None, config_field=Dict({'val': Field(Int)}))
 
     assert str(exc_info.value) == (
-        'You have passed a config type "{ val: Int }" as parameter "config_field" of a '
+        'You have passed a config type "{ val: Int }" in the parameter "config_field" of a '
         'ResourceDefinition or @resource that expects a Field. You have likely forgot to '
         'wrap this type in a Field.'
     )
@@ -230,7 +233,7 @@ def test_pass_unrelated_type_to_field_error_resource_definition():
         ResourceDefinition(resource_fn=lambda: None, config_field='wut')
 
     assert str(exc_info.value) == (
-        'You have passed an object \'wut\' of incorrect type "str" as parameter '
+        'You have passed an object \'wut\' of incorrect type "str" in the parameter '
         '"config_field" of a ResourceDefinition or @resource where a Field was expected.'
     )
 
@@ -245,11 +248,26 @@ def test_pass_incorrect_thing_to_field():
     )
 
 
-# TODO
-# def test_invalid_dict_field():
-#     Dict({'val': Int})
+def test_invalid_dict_field():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        Dict({'val': Int, 'another_val': Field(Int)})
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "Int" in the parameter "fields" It is '
+        'in the "val" entry of the field dict of a Dict with field names '
+        '[\'val\', \'another_val\'] that expects a Field. You have likely '
+        'forgot to wrap this type in a Field.'
+    )
 
 
-# TODO
 # def test_invalid_named_dict_field():
+#     NamedDict('some_dict', {'val': Int})
+
+# def test_invalid_permissive_dict_field():
+#     NamedDict('some_dict', {'val': Int})
+
+# def test_invalid_selector_field():
+#     NamedDict('some_dict', {'val': Int})
+
+# def test_invalid_named_selector_field():
 #     NamedDict('some_dict', {'val': Int})

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -177,3 +177,13 @@ def test_pass_unrelated_type_to_field_error_context_definition():
         'You have passed an object \'wut\' of incorrect type "str" as parameter '
         'config_field of a PipelineContextDefinition where a Field was expected.'
     )
+
+
+def test_pass_incorrect_thing_to_field():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        Field('nope')
+
+    assert str(exc_info.value) == (
+        'Attempted to pass \'nope\' to a Field that expects a valid dagster type '
+        'usable in config (e.g. Dict, NamedDict, Int, String et al).'
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -198,18 +198,18 @@ def test_pass_config_type_to_field_error_solid_definition():
 
 def test_pass_unrelated_type_to_field_error_solid_definition():
 
-    # with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
 
-    @solid(config_field='nope')
-    def a_solid(_context):
-        pass
+        @solid(config_field='nope')
+        def a_solid(_context):
+            pass
 
-    assert a_solid  # fool lint
+        assert a_solid  # fool lint
 
     assert str(exc_info.value) == (
-        'You have passed a config type "{ val: Int }" as parameter "config_field" '
-        'of a solid definition named "a_solid" that expects a Field. You have '
-        'likely forgot to wrap this type in a Field.'
+        'You have passed an object \'nope\' of incorrect type "str" as parameter '
+        '"config_field" of a solid definition named "a_solid" where a Field '
+        'was expected.'
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -11,13 +11,13 @@ from dagster import (
     InputDefinition,
     Int,
     NamedDict,
-    # NamedSelector,
+    NamedSelector,
     OutputDefinition,
-    # PermissiveDict,
+    PermissiveDict,
     PipelineContextDefinition,
     PipelineDefinition,
     ResourceDefinition,
-    # Selector,
+    Selector,
     SolidDefinition,
     String,
     solid,
@@ -272,11 +272,38 @@ def test_invalid_named_dict_field():
     )
 
 
-# def test_invalid_permissive_dict_field():
-#     NamedDict('some_dict', {'val': Int})
+def test_invalid_permissive_dict_field():
 
-# def test_invalid_selector_field():
-#     NamedDict('some_dict', {'val': Int})
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        PermissiveDict({'val': Int, 'another_val': Field(Int)})
 
-# def test_invalid_named_selector_field():
-#     NamedDict('some_dict', {'val': Int})
+    assert str(exc_info.value) == (
+        'You have passed a config type "Int" in the parameter "fields" and it is '
+        'in the "val" entry of that dict. It is from a PermissiveDict with fields '
+        '[\'another_val\', \'val\']. You have likely '
+        'forgot to wrap this type in a Field.'
+    )
+
+
+def test_invalid_selector_field():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        Selector({'val': Int})
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "Int" in the parameter "fields" and it is '
+        'in the "val" entry of that dict. It is from a Selector with fields '
+        '[\'val\']. You have likely forgot to wrap this type in a Field.'
+    )
+
+
+def test_invalid_named_selector_field():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        NamedSelector('some_selector', {'val': Int})
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "Int" in the parameter "fields" and it is '
+        'in the "val" entry of that dict. It is from a NamedSelector named '
+        '"some_selector" with fields [\'val\']. You '
+        'have likely forgot to wrap this type in a Field.'
+    )
+

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -164,7 +164,7 @@ def test_pass_config_type_to_field_error_context_definition():
 
     assert str(exc_info.value) == (
         'You have passed a config type "{ val: Int }" in the parameter "config_field" of a '
-        'PipelineContextDefinition that expects a Field. You have likely forgot to '
+        'PipelineContextDefinition. You have likely forgot to '
         'wrap this type in a Field.'
     )
 
@@ -195,7 +195,7 @@ def test_pass_config_type_to_field_error_solid_definition():
 
     assert str(exc_info.value) == (
         'You have passed a config type "{ val: Int }" in the parameter "config_field" '
-        'of a SolidDefinition or @solid named "a_solid" that expects a Field. You have '
+        'of a SolidDefinition or @solid named "a_solid". You have '
         'likely forgot to wrap this type in a Field.'
     )
 
@@ -223,7 +223,7 @@ def test_pass_config_type_to_field_error_resource_definition():
 
     assert str(exc_info.value) == (
         'You have passed a config type "{ val: Int }" in the parameter "config_field" of a '
-        'ResourceDefinition or @resource that expects a Field. You have likely forgot to '
+        'ResourceDefinition or @resource. You have likely forgot to '
         'wrap this type in a Field.'
     )
 
@@ -253,15 +253,24 @@ def test_invalid_dict_field():
         Dict({'val': Int, 'another_val': Field(Int)})
 
     assert str(exc_info.value) == (
-        'You have passed a config type "Int" in the parameter "fields" It is '
-        'in the "val" entry of the field dict of a Dict with field names '
-        '[\'val\', \'another_val\'] that expects a Field. You have likely '
+        'You have passed a config type "Int" in the parameter "fields" and it is '
+        'in the "val" entry of that dict. It is from a Dict with fields '
+        '[\'another_val\', \'val\']. You have likely '
         'forgot to wrap this type in a Field.'
     )
 
 
-# def test_invalid_named_dict_field():
-#     NamedDict('some_dict', {'val': Int})
+def test_invalid_named_dict_field():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        NamedDict('some_named_dict', {'val': Int, 'another_val': Field(Int)})
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "Int" in the parameter "fields" and it is '
+        'in the "val" entry of that dict. It is from a NamedDict named '
+        '"some_named_dict" with fields [\'another_val\', \'val\']. You '
+        'have likely forgot to wrap this type in a Field.'
+    )
+
 
 # def test_invalid_permissive_dict_field():
 #     NamedDict('some_dict', {'val': Int})

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -159,7 +159,7 @@ def test_pass_config_type_to_field_error_context_definition():
         )
 
     assert str(exc_info.value) == (
-        'You have passed a config type { val: Int } as parameter config_field of a '
+        'You have passed a config type "{ val: Int }" as parameter "config_field" of a '
         'PipelineContextDefinition that expects a Field. You have likely forgot to '
         'wrap this type in a Field.'
     )
@@ -175,7 +175,41 @@ def test_pass_unrelated_type_to_field_error_context_definition():
 
     assert str(exc_info.value) == (
         'You have passed an object \'wut\' of incorrect type "str" as parameter '
-        'config_field of a PipelineContextDefinition where a Field was expected.'
+        '"config_field" of a PipelineContextDefinition where a Field was expected.'
+    )
+
+
+def test_pass_config_type_to_field_error_solid_definition():
+
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+
+        @solid(config_field=Dict({'val': Field(Int)}))
+        def a_solid(_context):
+            pass
+
+        assert a_solid  # fool lint
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "{ val: Int }" as parameter "config_field" '
+        'of a solid definition named "a_solid" that expects a Field. You have '
+        'likely forgot to wrap this type in a Field.'
+    )
+
+
+def test_pass_unrelated_type_to_field_error_solid_definition():
+
+    # with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+
+    @solid(config_field='nope')
+    def a_solid(_context):
+        pass
+
+    assert a_solid  # fool lint
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "{ val: Int }" as parameter "config_field" '
+        'of a solid definition named "a_solid" that expects a Field. You have '
+        'likely forgot to wrap this type in a Field.'
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -14,6 +14,7 @@ from dagster import (
     OutputDefinition,
     PipelineContextDefinition,
     PipelineDefinition,
+    ResourceDefinition,
     SolidDefinition,
     String,
     solid,
@@ -191,7 +192,7 @@ def test_pass_config_type_to_field_error_solid_definition():
 
     assert str(exc_info.value) == (
         'You have passed a config type "{ val: Int }" as parameter "config_field" '
-        'of a solid definition named "a_solid" that expects a Field. You have '
+        'of a SolidDefinition or @solid named "a_solid" that expects a Field. You have '
         'likely forgot to wrap this type in a Field.'
     )
 
@@ -208,8 +209,29 @@ def test_pass_unrelated_type_to_field_error_solid_definition():
 
     assert str(exc_info.value) == (
         'You have passed an object \'nope\' of incorrect type "str" as parameter '
-        '"config_field" of a solid definition named "a_solid" where a Field '
+        '"config_field" of a SolidDefinition or @solid named "a_solid" where a Field '
         'was expected.'
+    )
+
+
+def test_pass_config_type_to_field_error_resource_definition():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        ResourceDefinition(resource_fn=lambda: None, config_field=Dict({'val': Field(Int)}))
+
+    assert str(exc_info.value) == (
+        'You have passed a config type "{ val: Int }" as parameter "config_field" of a '
+        'ResourceDefinition or @resource that expects a Field. You have likely forgot to '
+        'wrap this type in a Field.'
+    )
+
+
+def test_pass_unrelated_type_to_field_error_resource_definition():
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        ResourceDefinition(resource_fn=lambda: None, config_field='wut')
+
+    assert str(exc_info.value) == (
+        'You have passed an object \'wut\' of incorrect type "str" as parameter '
+        '"config_field" of a ResourceDefinition or @resource where a Field was expected.'
     )
 
 
@@ -221,3 +243,13 @@ def test_pass_incorrect_thing_to_field():
         'Attempted to pass \'nope\' to a Field that expects a valid dagster type '
         'usable in config (e.g. Dict, NamedDict, Int, String et al).'
     )
+
+
+# TODO
+# def test_invalid_dict_field():
+#     Dict({'val': Int})
+
+
+# TODO
+# def test_invalid_named_dict_field():
+#     NamedDict('some_dict', {'val': Int})


### PR DESCRIPTION
Where we expect Fields (such as in config_field parameters or the values of a field dict) we currently communicate pretty awful error messages as evidenced by https://github.com/dagster-io/dagster/issues/1071

This is because of some of the API shenanigans we are forced to do to map the dagster type system into our two different type systems (config and runtime).

This now produces errors messages of the form:

```
You have passed a config type "Int" in the parameter "fields" 
and it is in the "val" entry of that dict. 
It is from a NamedSelector named "some_selector" 
with fields ['another_val', 'val']. You have likely forgot to wrap
this type in a Field.
```

If you have forgot to specify a field like so:

```py
 NamedSelector('some_selector', {'val': Int})
```
and the fix is:

```py
 NamedSelector('some_selector', {'val': Field(Int)})
```
