### PR TITLE
Better error message for a selector with multiple fields where no field is specified.

### DIFF
--- a/python_modules/dagster/dagster/core/types/evaluator.py
+++ b/python_modules/dagster/dagster/core/types/evaluator.py
@@ -384,8 +384,9 @@ def validate_selector_config_value(selector_type, config_value, stack):
                 stack=stack,
                 reason=DagsterEvaluationErrorReason.SELECTOR_FIELD_ERROR,
                 message=(
-                    'Must specify a field if more one defined. Defined fields: {defined_fields}'
-                ).format(defined_fields=defined_fields),
+                    'Must specify a field {path_msg} if more than one field is defined. '
+                    'Defined fields: {defined_fields}'
+                ).format(defined_fields=defined_fields, path_msg=_get_friendly_path_msg(stack)),
                 error_data=SelectorTypeErrorData(dagster_type=selector_type, incoming_fields=[]),
             )
             return

--- a/python_modules/dagster/dagster_tests/core_tests/types_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/types_tests/test_evaluator.py
@@ -356,6 +356,18 @@ def test_example_selector_multiple_fields():
     assert result.errors[0].reason == DagsterEvaluationErrorReason.SELECTOR_FIELD_ERROR
 
 
+def test_selector_within_dict_no_subfields():
+    result = eval_config_value_from_dagster_type(
+        Dict({'selector': Field(ExampleSelector)}), {'selector': {}}
+    )
+    assert not result.success
+    assert len(result.errors) == 1
+    assert result.errors[0].message == (
+        "Must specify a field at path root:selector if more than one field "
+        "is defined. Defined fields: ['option_one', 'option_two']"
+    )
+
+
 SelectorWithDefaults = Selector({'default': Field(String, is_optional=True, default_value='foo')})
 
 


### PR DESCRIPTION
Resolves https://github.com/dagster-io/dagster/issues/1074

Including path is now much more important with the error pane on the right hand side.