### PR TITLE
No longer require context spinup to create execution plan

### DIFF
--- a/python_modules/dagit/dagit/schema/model.py
+++ b/python_modules/dagit/dagit/schema/model.py
@@ -430,11 +430,9 @@ def _execute_plan_chain_actual_execute_or_error(
         None if 'storage' in execute_plan_args.environment_dict else RunStorageMode.FILESYSTEM
     )
 
-    run_config = RunConfig(run_id=run_id, tags=tags, storage_mode=run_storage_mode)
     execution_plan = create_execution_plan(
         pipeline=dauphin_pipeline.get_dagster_pipeline(),
         environment_dict=execute_plan_args.environment_dict,
-        run_config=run_config,
     )
 
     if execute_plan_args.step_keys:
@@ -443,6 +441,8 @@ def _execute_plan_chain_actual_execute_or_error(
                 return execute_plan_args.graphene_info.schema.type_named('InvalidStepError')(
                     invalid_step_key=step_key
                 )
+
+    run_config = RunConfig(run_id=run_id, tags=tags, storage_mode=run_storage_mode)
 
     step_events = list(
         execute_plan(

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -278,7 +278,6 @@ def create_execution_plan(pipeline, environment_dict=None, run_config=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict', key_type=str)
     run_config = check_run_config_param(run_config)
-    check.inst_param(run_config, 'run_config', RunConfig)
 
     with yield_pipeline_execution_context(
         pipeline, environment_dict, run_config

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -274,18 +274,11 @@ def check_run_config_param(run_config):
     )
 
 
-def create_execution_plan(pipeline, environment_dict=None, run_config=None):
+def create_execution_plan(pipeline, environment_dict=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict', key_type=str)
-    run_config = check_run_config_param(run_config)
     environment_config = create_environment_config(pipeline, environment_dict)
     return create_execution_plan_core(pipeline, environment_config)
-    # with yield_pipeline_execution_context(
-    #     pipeline, environment_dict, run_config
-    # ) as pipeline_context:
-    #     return create_execution_plan_core(
-    #         pipeline_context.pipeline_def, pipeline_context.environment_config
-    #     )
 
 
 def get_tags(user_context_params, run_config, pipeline):

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -278,11 +278,14 @@ def create_execution_plan(pipeline, environment_dict=None, run_config=None):
     check.inst_param(pipeline, 'pipeline', PipelineDefinition)
     environment_dict = check.opt_dict_param(environment_dict, 'environment_dict', key_type=str)
     run_config = check_run_config_param(run_config)
-
-    with yield_pipeline_execution_context(
-        pipeline, environment_dict, run_config
-    ) as pipeline_context:
-        return create_execution_plan_core(pipeline_context)
+    environment_config = create_environment_config(pipeline, environment_dict)
+    return create_execution_plan_core(pipeline, environment_config)
+    # with yield_pipeline_execution_context(
+    #     pipeline, environment_dict, run_config
+    # ) as pipeline_context:
+    #     return create_execution_plan_core(
+    #         pipeline_context.pipeline_def, pipeline_context.environment_config
+    #     )
 
 
 def get_tags(user_context_params, run_config, pipeline):
@@ -599,7 +602,9 @@ def _execute_pipeline_iterator(pipeline_context):
     check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     yield DagsterEvent.pipeline_start(pipeline_context)
 
-    execution_plan = create_execution_plan_core(pipeline_context)
+    execution_plan = create_execution_plan_core(
+        pipeline_context.pipeline_def, pipeline_context.environment_config
+    )
 
     steps = execution_plan.topological_steps()
 

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -1,11 +1,12 @@
 from dagster import check
 
 from dagster.core.definitions import (
-    solids_in_topological_order,
     InputDefinition,
     OutputDefinition,
+    PipelineDefinition,
     Solid,
     SolidOutputHandle,
+    solids_in_topological_order,
 )
 
 from dagster.core.errors import DagsterInvariantViolationError
@@ -69,18 +70,22 @@ def create_execution_plan_core(pipeline_context):
 
         for output_def in solid.definition.output_defs:
             subplan = create_subplan_for_output(
-                pipeline_context, solid, solid_transform_step, output_def
+                pipeline_context.pipeline_def,
+                pipeline_context.environment_config,
+                solid,
+                solid_transform_step,
+                output_def,
             )
             plan_builder.steps.extend(subplan.steps)
 
             output_handle = solid.output_handle(output_def.name)
             plan_builder.step_output_map[output_handle] = subplan.terminal_step_output_handle
 
-    return create_execution_plan_from_steps(pipeline_context, plan_builder.steps)
+    return create_execution_plan_from_steps(pipeline_context.pipeline_def, plan_builder.steps)
 
 
-def create_execution_plan_from_steps(pipeline_context, steps):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def create_execution_plan_from_steps(pipeline_def, steps):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.list_param(steps, 'steps', of_type=ExecutionStep)
 
     step_dict = {step.key: step for step in steps}
@@ -100,7 +105,7 @@ def create_execution_plan_from_steps(pipeline_context, steps):
         for step_input in step.step_inputs:
             deps[step.key].add(step_input.prev_output_handle.step_key)
 
-    return ExecutionPlan(pipeline_context.pipeline_def, step_dict, deps)
+    return ExecutionPlan(pipeline_def, step_dict, deps)
 
 
 def create_subplan_for_input(
@@ -118,19 +123,25 @@ def create_subplan_for_input(
         return ExecutionValueSubplan.empty(prev_step_output_handle)
 
 
-def create_subplan_for_output(pipeline_context, solid, solid_transform_step, output_def):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def create_subplan_for_output(
+    pipeline_def, environment_config, solid, solid_transform_step, output_def
+):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(solid_transform_step, 'solid_transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)
 
-    subplan = decorate_with_expectations(pipeline_context, solid, solid_transform_step, output_def)
+    subplan = decorate_with_expectations(
+        pipeline_def, environment_config, solid, solid_transform_step, output_def
+    )
 
-    return decorate_with_output_materializations(pipeline_context, solid, output_def, subplan)
+    return decorate_with_output_materializations(
+        pipeline_def, environment_config, solid, output_def, subplan
+    )
 
 
 def get_input_source_step_handle(pipeline_def, environment_config, plan_builder, solid, input_def):
-    # check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
@@ -160,7 +171,7 @@ def get_input_source_step_handle(pipeline_def, environment_config, plan_builder,
 
 
 def create_step_inputs(pipeline_def, environment_config, plan_builder, solid):
-    # check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
 

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -106,6 +106,8 @@ def create_execution_plan_from_steps(pipeline_def, steps):
 def create_subplan_for_input(
     pipeline_def, environment_config, solid, prev_step_output_handle, input_def
 ):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
     check.inst_param(input_def, 'input_def', InputDefinition)
@@ -137,6 +139,7 @@ def create_subplan_for_output(
 
 def get_input_source_step_handle(pipeline_def, environment_config, plan_builder, solid, input_def):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
@@ -167,6 +170,7 @@ def get_input_source_step_handle(pipeline_def, environment_config, plan_builder,
 
 def create_step_inputs(pipeline_def, environment_config, plan_builder, solid):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
     check.inst_param(plan_builder, 'plan_builder', PlanBuilder)
     check.inst_param(solid, 'solid', Solid)
 

--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -12,6 +12,8 @@ from dagster.core.execution_context import SystemStepExecutionContext
 
 from dagster.core.errors import DagsterExpectationFailedError
 
+from dagster.core.system_config.objects import EnvironmentConfig
+
 from dagster.core.user_context import ExpectationExecutionContext
 
 from .objects import (
@@ -133,6 +135,7 @@ def create_expectation_step(
 
 def decorate_with_expectations(pipeline_def, environment_config, solid, transform_step, output_def):
     check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
+    check.inst_param(environment_config, 'environment_config', EnvironmentConfig)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(transform_step, 'transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)

--- a/python_modules/dagster/dagster/core/execution_plan/expectations.py
+++ b/python_modules/dagster/dagster/core/execution_plan/expectations.py
@@ -1,15 +1,18 @@
 from dagster import check
 
-from dagster.core.execution_context import (
-    SystemStepExecutionContext,
-    SystemPipelineExecutionContext,
+from dagster.core.definitions import (
+    ExpectationDefinition,
+    InputDefinition,
+    OutputDefinition,
+    PipelineDefinition,
+    Solid,
 )
 
-from dagster.core.user_context import ExpectationExecutionContext
-
-from dagster.core.definitions import ExpectationDefinition, InputDefinition, OutputDefinition, Solid
+from dagster.core.execution_context import SystemStepExecutionContext
 
 from dagster.core.errors import DagsterExpectationFailedError
+
+from dagster.core.user_context import ExpectationExecutionContext
 
 from .objects import (
     ExecutionStep,
@@ -40,7 +43,6 @@ def _create_expectation_lambda(solid, inout_def, expectation_def, internal_outpu
         expt_result = expectation_def.expectation_fn(
             ExpectationExecutionContext(expectation_context), value
         )
-        # step_context,  value)
         if expt_result.success:
             expectation_context.log.debug(
                 'Expectation {key} succeeded on {value}.'.format(
@@ -59,8 +61,8 @@ def _create_expectation_lambda(solid, inout_def, expectation_def, internal_outpu
     return _do_expectation
 
 
-def create_expectations_subplan(pipeline_context, solid, inout_def, prev_step_output_handle, kind):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def create_expectations_subplan(pipeline_def, solid, inout_def, prev_step_output_handle, kind):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(inout_def, 'inout_def', (InputDefinition, OutputDefinition))
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
@@ -69,7 +71,7 @@ def create_expectations_subplan(pipeline_context, solid, inout_def, prev_step_ou
     input_expect_steps = []
     for expectation_def in inout_def.expectations:
         expect_step = create_expectation_step(
-            pipeline_context=pipeline_context,
+            pipeline_def=pipeline_def,
             solid=solid,
             expectation_def=expectation_def,
             key='{solid}.{desc_key}.{inout_name}.expectation.{expectation_name}'.format(
@@ -85,7 +87,7 @@ def create_expectations_subplan(pipeline_context, solid, inout_def, prev_step_ou
         input_expect_steps.append(expect_step)
 
     return create_joining_subplan(
-        pipeline_context,
+        pipeline_def,
         solid,
         '{solid}.{desc_key}.{inout_name}.expectations.join'.format(
             solid=solid.name, desc_key=inout_def.descriptive_key, inout_name=inout_def.name
@@ -96,9 +98,9 @@ def create_expectations_subplan(pipeline_context, solid, inout_def, prev_step_ou
 
 
 def create_expectation_step(
-    pipeline_context, solid, expectation_def, key, kind, prev_step_output_handle, inout_def
+    pipeline_def, solid, expectation_def, key, kind, prev_step_output_handle, inout_def
 ):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(expectation_def, 'input_expct_def', ExpectationDefinition)
     check.inst_param(prev_step_output_handle, 'prev_step_output_handle', StepOutputHandle)
@@ -107,7 +109,7 @@ def create_expectation_step(
     value_type = inout_def.runtime_type
 
     return ExecutionStep(
-        pipeline_context=pipeline_context,
+        pipeline_name=pipeline_def.name,
         key=key,
         step_inputs=[
             StepInput(
@@ -129,15 +131,15 @@ def create_expectation_step(
     )
 
 
-def decorate_with_expectations(pipeline_context, solid, transform_step, output_def):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def decorate_with_expectations(pipeline_def, environment_config, solid, transform_step, output_def):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(transform_step, 'transform_step', ExecutionStep)
     check.inst_param(output_def, 'output_def', OutputDefinition)
 
-    if pipeline_context.environment_config.expectations.evaluate and output_def.expectations:
+    if environment_config.expectations.evaluate and output_def.expectations:
         return create_expectations_subplan(
-            pipeline_context,
+            pipeline_def,
             solid,
             output_def,
             StepOutputHandle.from_step(transform_step, output_def.name),

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -28,7 +28,7 @@ def _create_input_thunk_execution_step(pipeline_context, solid, input_def, input
         yield StepOutputValue(output_name=INPUT_THUNK_OUTPUT, value=value)
 
     return ExecutionStep(
-        pipeline_context=pipeline_context,
+        pipeline_name=pipeline_context.pipeline_def.name,
         key=solid.name + '.' + input_def.name + '.input_thunk',
         step_inputs=[],
         step_outputs=[

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -1,6 +1,6 @@
 from dagster import check
 
-from dagster.core.definitions import InputDefinition, Solid
+from dagster.core.definitions import InputDefinition, Solid, PipelineDefinition
 
 from dagster.core.errors import DagsterInvariantViolationError
 
@@ -16,7 +16,7 @@ INPUT_THUNK_OUTPUT = 'input_thunk_output'
 
 
 def _create_input_thunk_execution_step(pipeline_def, solid, input_def, input_spec):
-    # check.inst_param(pipeline_def, 'pipeline_context', SystemPipelineExecutionContext)
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
@@ -41,7 +41,7 @@ def _create_input_thunk_execution_step(pipeline_def, solid, input_def, input_spe
 
 
 def create_input_thunk_execution_step(pipeline_def, solid, input_def, input_spec):
-    # check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 

--- a/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/input_thunk.py
@@ -1,6 +1,5 @@
 from dagster import check
 
-from dagster.core.execution_context import SystemPipelineExecutionContext
 from dagster.core.definitions import InputDefinition, Solid
 
 from dagster.core.errors import DagsterInvariantViolationError
@@ -16,8 +15,8 @@ from .objects import (
 INPUT_THUNK_OUTPUT = 'input_thunk_output'
 
 
-def _create_input_thunk_execution_step(pipeline_context, solid, input_def, input_spec):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def _create_input_thunk_execution_step(pipeline_def, solid, input_def, input_spec):
+    # check.inst_param(pipeline_def, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
@@ -28,7 +27,7 @@ def _create_input_thunk_execution_step(pipeline_context, solid, input_def, input
         yield StepOutputValue(output_name=INPUT_THUNK_OUTPUT, value=value)
 
     return ExecutionStep(
-        pipeline_name=pipeline_context.pipeline_def.name,
+        pipeline_name=pipeline_def.name,
         key=solid.name + '.' + input_def.name + '.input_thunk',
         step_inputs=[],
         step_outputs=[
@@ -41,12 +40,12 @@ def _create_input_thunk_execution_step(pipeline_context, solid, input_def, input
     )
 
 
-def create_input_thunk_execution_step(pipeline_context, solid, input_def, input_spec):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def create_input_thunk_execution_step(pipeline_def, solid, input_def, input_spec):
+    # check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.inst_param(input_def, 'input_def', InputDefinition)
 
-    dependency_structure = pipeline_context.pipeline_def.dependency_structure
+    dependency_structure = pipeline_def.dependency_structure
     input_handle = solid.input_handle(input_def.name)
 
     if dependency_structure.has_dep(input_handle):
@@ -57,11 +56,9 @@ def create_input_thunk_execution_step(pipeline_context, solid, input_def, input_
                 'a dependency. Either remove the dependency, specify a subdag '
                 'to execute, or remove the inputs specification in the environment.'
             ).format(
-                pipeline_name=pipeline_context.pipeline.name,
-                solid_name=solid.name,
-                input_name=input_def.name,
+                pipeline_name=pipeline_def.name, solid_name=solid.name, input_name=input_def.name
             )
         )
 
-    input_thunk = _create_input_thunk_execution_step(pipeline_context, solid, input_def, input_spec)
+    input_thunk = _create_input_thunk_execution_step(pipeline_def, solid, input_def, input_spec)
     return SingleOutputStepCreationData(input_thunk, INPUT_THUNK_OUTPUT)

--- a/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
@@ -1,7 +1,6 @@
 from dagster import check
 
 from dagster.core.definitions import Solid, OutputDefinition, PipelineDefinition
-from dagster.core.execution_context import SystemPipelineExecutionContext
 
 from dagster.core.types.runtime import RuntimeType
 

--- a/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
+++ b/python_modules/dagster/dagster/core/execution_plan/materialization_thunk.py
@@ -57,7 +57,7 @@ def decorate_with_output_materializations(pipeline_context, solid, output_def, s
     for mat_count, output_spec in enumerate(configs_for_output(solid, solid_config, output_def)):
         new_steps.append(
             ExecutionStep(
-                pipeline_context=pipeline_context,
+                pipeline_name=pipeline_context.pipeline_def.name,
                 key='{solid}.materialization.output.{output}.{mat_count}'.format(
                     solid=solid.name, output=output_def.name, mat_count=mat_count
                 ),

--- a/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/multiprocessing_engine.py
@@ -31,7 +31,9 @@ class InProcessExecutorChildProcessCommand(ChildProcessCommand):
             pipeline, self.environment_dict, self.run_config.with_tags(pid=str(os.getpid()))
         ) as pipeline_context:
 
-            execution_plan = create_execution_plan_core(pipeline_context)
+            execution_plan = create_execution_plan_core(
+                pipeline_context.pipeline_def, pipeline_context.environment_config
+            )
 
             for step_event in start_inprocess_executor(
                 pipeline_context,

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -147,7 +147,11 @@ class ExecutionStep(
     def solid_definition_name(self):
         return self.solid.definition.name
 
-    # TODO I believe we can remove this
+    # TODO I believe we can remove this. This was only here
+    # so that we could pickle this stuff in the currently unused
+    # and untested dagma project. This object is not really reliably
+    # pickleable anyways since it contains references to solid definitions
+    # and lambdas: https://github.com/dagster-io/dagster/issues/1111
     def __getnewargs__(self):
         return (
             self.key,

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -4,7 +4,6 @@ from enum import Enum
 
 from dagster import check
 from dagster.core.definitions import Solid, PipelineDefinition
-from dagster.core.execution_context import SystemPipelineExecutionContext
 from dagster.core.intermediates_manager import StepOutputHandle, RunStorageMode
 from dagster.core.types.runtime import RuntimeType
 from dagster.core.utils import toposort

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -16,7 +16,7 @@ def create_transform_step(pipeline_context, solid, step_inputs):
     check.list_param(step_inputs, 'step_inputs', of_type=StepInput)
 
     return ExecutionStep(
-        pipeline_context=pipeline_context,
+        pipeline_name=pipeline_context.pipeline_def.name,
         key='{solid.name}.transform'.format(solid=solid),
         step_inputs=step_inputs,
         step_outputs=[

--- a/python_modules/dagster/dagster/core/execution_plan/transform.py
+++ b/python_modules/dagster/dagster/core/execution_plan/transform.py
@@ -1,22 +1,19 @@
 from dagster import check
-from dagster.core.definitions import Result, Solid, Materialization
+from dagster.core.definitions import Result, Solid, Materialization, PipelineDefinition
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.user_context import TransformExecutionContext
-from dagster.core.execution_context import (
-    SystemTransformExecutionContext,
-    SystemPipelineExecutionContext,
-)
+from dagster.core.execution_context import SystemTransformExecutionContext
 
 from .objects import ExecutionStep, StepInput, StepKind, StepOutput, StepOutputValue
 
 
-def create_transform_step(pipeline_context, solid, step_inputs):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def create_transform_step(pipeline_def, solid, step_inputs):
+    check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition)
     check.inst_param(solid, 'solid', Solid)
     check.list_param(step_inputs, 'step_inputs', of_type=StepInput)
 
     return ExecutionStep(
-        pipeline_name=pipeline_context.pipeline_def.name,
+        pipeline_name=pipeline_def.name,
         key='{solid.name}.transform'.format(solid=solid),
         step_inputs=step_inputs,
         step_outputs=[

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -50,7 +50,7 @@ def create_join_step(pipeline_context, solid, step_key, prev_steps, prev_output_
         step_inputs.append(StepInput(prev_step.key, prev_step_output.runtime_type, output_handle))
 
     return ExecutionStep(
-        pipeline_context=pipeline_context,
+        pipeline_name=pipeline_context.pipeline_def.name,
         key=step_key,
         step_inputs=step_inputs,
         step_outputs=[StepOutput(JOIN_OUTPUT, seen_runtime_type, optional=seen_optionality)],
@@ -110,7 +110,7 @@ def create_value_thunk_step(pipeline_context, solid, runtime_type, step_key, val
 
     return SingleOutputStepCreationData(
         ExecutionStep(
-            pipeline_context=pipeline_context,
+            pipeline_name=pipeline_context.pipeline_def.name,
             key=step_key,
             step_inputs=[],
             step_outputs=[StepOutput(VALUE_OUTPUT, runtime_type, optional=False)],

--- a/python_modules/dagster/dagster/core/execution_plan/utility.py
+++ b/python_modules/dagster/dagster/core/execution_plan/utility.py
@@ -21,8 +21,8 @@ def __join_lambda(_context, inputs):
     yield StepOutputValue(output_name=JOIN_OUTPUT, value=list(inputs.values())[0])
 
 
-def create_join_step(pipeline_context, solid, step_key, prev_steps, prev_output_name):
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+def create_join_step(pipeline_def, solid, step_key, prev_steps, prev_output_name):
+    # check.inst_param(pipeline_def, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.str_param(step_key, 'step_key')
     check.list_param(prev_steps, 'prev_steps', of_type=ExecutionStep)
@@ -50,7 +50,7 @@ def create_join_step(pipeline_context, solid, step_key, prev_steps, prev_output_
         step_inputs.append(StepInput(prev_step.key, prev_step_output.runtime_type, output_handle))
 
     return ExecutionStep(
-        pipeline_name=pipeline_context.pipeline_def.name,
+        pipeline_name=pipeline_def.name,
         key=step_key,
         step_inputs=step_inputs,
         step_outputs=[StepOutput(JOIN_OUTPUT, seen_runtime_type, optional=seen_optionality)],
@@ -63,7 +63,7 @@ def create_join_step(pipeline_context, solid, step_key, prev_steps, prev_output_
 
 
 def create_joining_subplan(
-    pipeline_context, solid, join_step_key, parallel_steps, parallel_step_output
+    pipeline_def, solid, join_step_key, parallel_steps, parallel_step_output
 ):
     '''
     This captures a common pattern of fanning out a single value to N steps,
@@ -77,7 +77,7 @@ def create_joining_subplan(
     to be seen if there should be any work or verification done in this step, especially
     in multi-process environments that require persistence between steps.
     '''
-    check.inst_param(pipeline_context, 'pipeline_context', SystemPipelineExecutionContext)
+    # check.inst_param(pipeline_def, 'pipeline_context', SystemPipelineExecutionContext)
     check.inst_param(solid, 'solid', Solid)
     check.str_param(join_step_key, 'join_step_key')
     check.list_param(parallel_steps, 'parallel_steps', of_type=ExecutionStep)
@@ -87,7 +87,7 @@ def create_joining_subplan(
         check.invariant(parallel_step.has_step_output(parallel_step_output))
 
     join_step = create_join_step(
-        pipeline_context, solid, join_step_key, parallel_steps, parallel_step_output
+        pipeline_def, solid, join_step_key, parallel_steps, parallel_step_output
     )
 
     output_name = join_step.step_outputs[0].name

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -79,9 +79,7 @@ def test_execution_plan_reexecution():
         storage_mode=RunStorageMode.FILESYSTEM,
     )
 
-    execution_plan = create_execution_plan(
-        pipeline_def, environment_dict=environment_dict, run_config=run_config
-    )
+    execution_plan = create_execution_plan(pipeline_def, environment_dict=environment_dict)
 
     step_events = execute_plan(
         execution_plan,
@@ -103,11 +101,7 @@ def test_execution_plan_wrong_run_id():
     unrun_id = str(uuid.uuid4())
     environment_dict = {'solids': {'add_one': {'inputs': {'num': {'value': 3}}}}}
 
-    run_config = RunConfig(storage_mode=RunStorageMode.FILESYSTEM)
-
-    execution_plan = create_execution_plan(
-        pipeline_def, environment_dict=environment_dict, run_config=run_config
-    )
+    execution_plan = create_execution_plan(pipeline_def, environment_dict=environment_dict)
 
     with pytest.raises(DagsterRunNotFoundError) as exc_info:
         execute_plan(
@@ -151,9 +145,7 @@ def test_execution_plan_wrong_invalid_step_key():
         storage_mode=RunStorageMode.FILESYSTEM,
     )
 
-    execution_plan = create_execution_plan(
-        pipeline_def, environment_dict=environment_dict, run_config=run_config
-    )
+    execution_plan = create_execution_plan(pipeline_def, environment_dict=environment_dict)
 
     with pytest.raises(DagsterExecutionStepNotFoundError) as exc_info:
         execute_plan(
@@ -191,9 +183,7 @@ def test_execution_plan_wrong_invalid_output_name():
         storage_mode=RunStorageMode.FILESYSTEM,
     )
 
-    execution_plan = create_execution_plan(
-        pipeline_def, environment_dict=environment_dict, run_config=run_config
-    )
+    execution_plan = create_execution_plan(pipeline_def, environment_dict=environment_dict)
 
     with pytest.raises(DagsterStepOutputNotFoundError) as exc_info:
         execute_plan(
@@ -238,9 +228,7 @@ def test_execution_plan_reexecution_with_in_memory():
         storage_mode=RunStorageMode.IN_MEMORY,
     )
 
-    execution_plan = create_execution_plan(
-        pipeline_def, environment_dict=environment_dict, run_config=in_memory_run_config
-    )
+    execution_plan = create_execution_plan(pipeline_def, environment_dict=environment_dict)
 
     with pytest.raises(DagsterInvariantViolationError):
         execute_plan(


### PR DESCRIPTION
After this we can create an execution plan without having to do a potentially expensive context spinup. 

Resolves https://github.com/dagster-io/dagster/issues/1094

Confirmed the airline-demo is much better behaved in dagit when dealing with config errors.
