### PR TITLE
fix user_facing_error processing

### DIFF
--- a/examples/error_monster/pipeline.py
+++ b/examples/error_monster/pipeline.py
@@ -19,6 +19,8 @@ from dagster import (
     ExecutionContext,
 )
 
+from dagster.core.errors import DagsterUserError
+
 
 class ErrorableResource:
     pass
@@ -106,13 +108,13 @@ if __name__ == '__main__':
                 'errorable_context': {
                     'config': {'throw_on_context_init': False},
                     'resources': {
-                        'errorable_resource': {'config': {'throw_on_resource_init': True}}
+                        'errorable_resource': {'config': {'throw_on_resource_init': False}}
                     },
                 }
             },
             'solids': {
                 'start': {'config': {'throw_in_solid': False}},
-                'middle': {'config': {'throw_in_solid': False}},
+                'middle': {'config': {'throw_in_solid': True}},
                 'end': {'config': {'throw_in_solid': False}},
             },
         },

--- a/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
+++ b/python_modules/dagster-airflow/dagster_airflow_tests/test_run_airflow_dag.py
@@ -145,5 +145,7 @@ def test_run_airflow_error_dag(scaffold_error_dag):
         ti = TaskInstance(task=task, execution_date=execution_date)
         context = ti.get_template_context()
         context['dag_run'] = namedtuple('_', 'run_id')(run_id=run_id)
-        with pytest.raises(AirflowException, match='Unusual error'):
+        with pytest.raises(
+            AirflowException, match='Error occured during step error_solid.transform'
+        ):
             task.execute(context)

--- a/python_modules/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
+++ b/python_modules/dagster-pandas/dagster_pandas_tests/pandas_hello_world/test_pandas_hello_world.py
@@ -5,6 +5,7 @@ import pytest
 from dagster.core.execution import execute_pipeline
 from dagster.utils import script_relative_path
 from dagster.cli.pipeline import do_execute_command, print_pipeline
+from dagster.core.errors import DagsterExecutionStepExecutionError
 
 from dagster_pandas.examples.pandas_hello_world.pipeline import (
     define_success_pipeline,
@@ -65,7 +66,7 @@ def test_cli_execute_failure():
 
     # currently paths in env files have to be relative to where the
     # script has launched so we have to simulate that
-    with pytest.raises(Exception, match='I am a programmer and I make error'):
+    with pytest.raises(DagsterExecutionStepExecutionError) as e_info:
         cwd = os.getcwd()
         try:
 
@@ -79,6 +80,7 @@ def test_cli_execute_failure():
         finally:
             # restore cwd
             os.chdir(cwd)
+    assert 'I am a programmer and I make error' in str(e_info.value.__cause__)
 
 
 def test_cli_print():

--- a/python_modules/dagster/dagster/core/execution.py
+++ b/python_modules/dagster/dagster/core/execution.py
@@ -21,7 +21,6 @@ import inspect
 import itertools
 import time
 import sys
-import six
 
 from contextlib2 import ExitStack
 from dagster import check
@@ -539,7 +538,7 @@ def _pipeline_execution_context_manager(
         )
 
         if run_config.executor_config.throw_on_user_error:
-            six.reraise(*user_facing_exc_info)
+            raise dagster_error
 
         error_info = serializable_error_info_from_exc_info(user_facing_exc_info)
         yield DagsterEvent.pipeline_init_failure(

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -1,7 +1,6 @@
 import sys
 
 from future.utils import raise_from
-import six
 
 from dagster import check
 
@@ -169,6 +168,8 @@ def execute_step_in_memory(step_context, inputs, intermediates_manager):
                 )
             yield step_event
     except DagsterError as dagster_error:
+        if step_context.executor_config.throw_on_user_error:
+            raise dagster_error
 
         user_facing_exc_info = (
             # pylint does not know original_exc_info exists is is_user_code_error is true
@@ -177,9 +178,6 @@ def execute_step_in_memory(step_context, inputs, intermediates_manager):
             if dagster_error.is_user_code_error
             else sys.exc_info()
         )
-
-        if step_context.executor_config.throw_on_user_error:
-            six.reraise(*user_facing_exc_info)
 
         error_info = serializable_error_info_from_exc_info(user_facing_exc_info)
 

--- a/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_configuration_schemas.py
+++ b/python_modules/dagster/dagster_tests/tutorial_tests/intro_tutorial/test_configuration_schemas.py
@@ -8,6 +8,7 @@ from dagster.tutorials.intro_tutorial.configuration_schemas import (
 )
 from dagster.utils import script_relative_path
 from dagster.utils.yaml_utils import load_yaml_from_path
+from dagster.core.errors import DagsterExecutionStepExecutionError
 
 
 def intro_tutorial_path(path):
@@ -30,11 +31,13 @@ def test_demo_configuration_schema_pipeline_correct_yaml():
 
 
 def test_demo_configuration_schema_pipeline_runtime_error():
-    with pytest.raises(TypeError):
+    with pytest.raises(DagsterExecutionStepExecutionError) as e_info:
         execute_pipeline(
             define_demo_configuration_schema_pipeline(),
             load_yaml_from_path(intro_tutorial_path('configuration_schemas_runtime_error.yml')),
         )
+
+    assert isinstance(e_info.value.__cause__, TypeError)
 
 
 def test_demo_configuration_schema_pipeline_wrong_field():

--- a/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_solid_isolation.py
@@ -16,6 +16,7 @@ from dagster import (
 )
 
 from dagster.utils.test import execute_solid
+from dagster.core.errors import DagsterExecutionStepExecutionError
 
 
 def test_single_solid_in_isolation():
@@ -143,8 +144,10 @@ def test_single_solid_error():
 
     pipeline_def = PipelineDefinition(solids=[throw_error])
 
-    with pytest.raises(SomeError):
+    with pytest.raises(DagsterExecutionStepExecutionError) as e_info:
         execute_solid(pipeline_def, 'throw_error')
+
+    assert isinstance(e_info.value.__cause__, SomeError)
 
 
 def test_single_solid_type_checking_output_error():
@@ -168,5 +171,7 @@ def test_failing_solid_execute_solid():
 
     pipeline_def = PipelineDefinition(solids=[throw_an_error])
 
-    with pytest.raises(ThisException):
+    with pytest.raises(DagsterExecutionStepExecutionError) as e_info:
         execute_solid(pipeline_def, 'throw_an_error')
+
+    assert isinstance(e_info.value.__cause__, ThisException)


### PR DESCRIPTION
fix misattribution of solid level exception from my previous diff
stop using reraise to preserve the chaining from `raise_from` in user code error boundary
explicitly add the inner exception to the message for python 2