### PR TITLE
Kill iterate_over_pipelines

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/repository.py
@@ -89,14 +89,6 @@ class RepositoryDefinition(object):
 
         return pipeline
 
-    def iterate_over_pipelines(self):
-        '''Returns list of pipelines. Exists for backwards compat. The name lies.
-
-        Returns:
-            List[PipelineDefinition]:
-        '''
-        return self.get_all_pipelines()
-
     def get_all_pipelines(self):
         '''Return all pipelines as a list
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -90,27 +90,6 @@ def test_dupe_solid_repo_definition():
         repo.get_all_pipelines()
 
 
-def test_dupe_solid_repo_definition_iterate():
-    @lambda_solid(name='same')
-    def noop():
-        pass
-
-    @lambda_solid(name='same')
-    def noop2():
-        pass
-
-    repo = RepositoryDefinition(
-        'error_repo',
-        pipeline_dict={
-            'first': lambda: PipelineDefinition(name='first', solids=[noop]),
-            'second': lambda: PipelineDefinition(name='second', solids=[noop2]),
-        },
-    )
-
-    with pytest.raises(DagsterInvalidDefinitionError):
-        list(repo.iterate_over_pipelines())
-
-
 def test_dupe_solid_repo_definition_unforced():
     @lambda_solid(name='same')
     def noop():

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -743,8 +743,6 @@ snapshots['test_build_all_docs 3'] = '''
 </li>
       <li><a href="sections/api/apidocs/definitions.html#dagster.OutputDefinition.is_optional">is_optional (dagster.OutputDefinition attribute)</a>
 </li>
-      <li><a href="sections/api/apidocs/definitions.html#dagster.RepositoryDefinition.iterate_over_pipelines">iterate_over_pipelines() (dagster.RepositoryDefinition method)</a>
-</li>
   </ul></td>
 </tr></table>
 
@@ -19965,22 +19963,6 @@ name of the pipeline are the same.</p>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of PipelineDefinition with that name.</td>
 </tr>
 <tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#dagster.PipelineDefinition" title="dagster.PipelineDefinition">PipelineDefinition</a></td>
-</tr>
-</tbody>
-</table>
-</dd></dl>
-
-<dl class="method">
-<dt id="dagster.RepositoryDefinition.iterate_over_pipelines">
-<code class="descname">iterate_over_pipelines</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#dagster.RepositoryDefinition.iterate_over_pipelines" title="Permalink to this definition">¶</a></dt>
-<dd><p>Returns list of pipelines. Exists for backwards compat. The name lies.</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body"></td>
-</tr>
-<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body">List[<a class="reference internal" href="#dagster.PipelineDefinition" title="dagster.PipelineDefinition">PipelineDefinition</a>]</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
This only has a single caller, in a SC test, which will be replaced by a call to get_all_pipelines.