### PR TITLE
 Allow jumping between solids by clicking connection nodes, expand tooltips

### DIFF
--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -481,6 +481,96 @@ Array [
                   strokeWidth={1}
                   width={350}
                   x={100}
+                  y={312}
+                />
+                <text
+                  dominantBaseline="hanging"
+                  fill="#222"
+                  style={
+                    Object {
+                      "font": "30px \\"Source Code Pro\\", monospace",
+                      "pointerEvents": "none",
+                    }
+                  }
+                  width={223.2}
+                  x={112}
+                  y={333}
+                >
+                  sum_sq_solid
+                </text>
+                <g
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    sum_df: PandasDataFrame
+
+From:
+sum_solid: result
+                  </title>
+                  <rect
+                    fill="#00B3A4"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={282}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={300}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+                <g
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <title>
+                    result: PandasDataFrame
+
+Used By:
+
+                  </title>
+                  <rect
+                    fill="#137CBD"
+                    height={36}
+                    stroke="#979797"
+                    strokeWidth={1}
+                    width={30}
+                    x={100}
+                    y={378}
+                  />
+                  <ellipse
+                    cx={115}
+                    cy={396}
+                    fill="rgba(0, 0, 0, 0.3)"
+                    rx={7}
+                    ry={7}
+                    stroke="white"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              </g>
+              <g
+                onClick={[Function]}
+                onDoubleClick={[Function]}
+                opacity={1}
+              >
+                <rect
+                  fill="#DBE6EE"
+                  height={72}
+                  stroke="#979797"
+                  strokeWidth={1}
+                  width={350}
+                  x={100}
                   y={130}
                 />
                 <text
@@ -499,6 +589,7 @@ Array [
                   sum_solid
                 </text>
                 <g
+                  onClick={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -525,11 +616,15 @@ Array [
                   />
                 </g>
                 <g
+                  onClick={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
                   <title>
                     result: PandasDataFrame
+
+Used By:
+sum_sq_solid sum_df
                   </title>
                   <rect
                     fill="#137CBD"
@@ -543,88 +638,6 @@ Array [
                   <ellipse
                     cx={115}
                     cy={214}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-              </g>
-              <g
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                opacity={1}
-              >
-                <rect
-                  fill="#DBE6EE"
-                  height={72}
-                  stroke="#979797"
-                  strokeWidth={1}
-                  width={350}
-                  x={100}
-                  y={312}
-                />
-                <text
-                  dominantBaseline="hanging"
-                  fill="#222"
-                  style={
-                    Object {
-                      "font": "30px \\"Source Code Pro\\", monospace",
-                      "pointerEvents": "none",
-                    }
-                  }
-                  width={223.2}
-                  x={112}
-                  y={333}
-                >
-                  sum_sq_solid
-                </text>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    sum_df: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#00B3A4"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={282}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={300}
-                    fill="rgba(0, 0, 0, 0.3)"
-                    rx={7}
-                    ry={7}
-                    stroke="white"
-                    strokeWidth={1.5}
-                  />
-                </g>
-                <g
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <title>
-                    result: PandasDataFrame
-                  </title>
-                  <rect
-                    fill="#137CBD"
-                    height={36}
-                    stroke="#979797"
-                    strokeWidth={1}
-                    width={30}
-                    x={100}
-                    y={378}
-                  />
-                  <ellipse
-                    cx={115}
-                    cy={396}
                     fill="rgba(0, 0, 0, 0.3)"
                     rx={7}
                     ry={7}
@@ -876,7 +889,7 @@ Array [
                       </span>
                       : 
                       <span>
-                        String
+                        log_level
                       </span>
                     </div>
                     }

--- a/js_modules/dagit/src/__tests__/mockData.tsx
+++ b/js_modules/dagit/src/__tests__/mockData.tsx
@@ -5,340 +5,65 @@ import { TYPE_LIST_CONTAINER_QUERY } from "../typeexplorer/TypeListContainer";
 const MOCKS = [
   {
     request: {
-      operationName: "PipelineseContainerQuery",
-      queryVariableName: "APP_QUERY",
-      query: APP_QUERY,
-      variables: undefined
+      operationName: "TypeListContainerQuery",
+      queryVariableName: "TYPE_LIST_CONTAINER_QUERY",
+      query: TYPE_LIST_CONTAINER_QUERY,
+      variables: { pipelineName: "pandas_hello_world" }
     },
     result: {
       data: {
-        pipelinesOrError: {
-          __typename: "PipelineConnection",
-          nodes: [
+        pipelineOrError: {
+          __typename: "Pipeline",
+          runtimeTypes: [
             {
-              name: "input_transform_test_pipeline",
+              name: "Any",
+              isBuiltin: true,
+              displayName: "Any",
               description: null,
-              contexts: [
-                {
-                  name: "default",
-                  description: null,
-                  __typename: "PipelineContext",
-                  config: {
-                    configType: {
-                      key: "Dict.32",
-                      name: null,
-                      description:
-                        "A configuration dictionary with typed fields",
-                      isList: false,
-                      isNullable: false,
-                      isSelector: false,
-                      innerTypes: [
-                        {
-                          key: "String",
-                          __typename: "RegularConfigType",
-                          name: "String",
-                          description: "",
-                          isList: false,
-                          isNullable: false,
-                          isSelector: false,
-                          innerTypes: []
-                        }
-                      ],
-                      fields: [
-                        {
-                          name: "log_level",
-                          description: null,
-                          isOptional: true,
-                          configType: {
-                            key: "String",
-                            __typename: "RegularConfigType"
-                          },
-                          __typename: "ConfigTypeField"
-                        }
-                      ],
-                      __typename: "CompositeConfigType"
-                    },
-                    __typename: "ConfigTypeField"
-                  },
-                  resources: []
-                }
-              ],
-              solids: [
-                {
-                  name: "pandas_source_test",
-                  definition: {
-                    metadata: [
-                      {
-                        key: "notebook_path",
-                        value:
-                          "/Users/bengotow/Work/F376/Projects/dagster/python_modules/dagster-pandas/dagster_pandas/examples/notebooks/pandas_source_test.ipynb",
-                        __typename: "SolidMetadataItemDefinition"
-                      },
-                      {
-                        key: "kind",
-                        value: "ipynb",
-                        __typename: "SolidMetadataItemDefinition"
-                      }
-                    ],
-                    configDefinition: null,
-                    __typename: "SolidDefinition",
-                    description:
-                      "This solid is backed by the notebook at /Users/bengotow/Work/F376/Projects/dagster/python_modules/dagster-pandas/dagster_pandas/examples/notebooks/pandas_source_test.ipynb"
-                  },
-                  inputs: [
-                    {
-                      definition: {
-                        name: "df",
-                        type: {
-                          name: "PandasDataFrame",
-                          displayName: "PandasDataFrame",
-                          __typename: "RegularRuntimeType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
-                        },
-                        __typename: "InputDefinition",
-                        description: null,
-                        expectations: []
-                      },
-                      dependsOn: {
-                        definition: {
-                          name: "result",
-                          __typename: "OutputDefinition"
-                        },
-                        solid: { name: "load_num_csv", __typename: "Solid" },
-                        __typename: "Output"
-                      },
-                      __typename: "Input"
-                    }
-                  ],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          name: "PandasDataFrame",
-                          displayName: "PandasDataFrame",
-                          __typename: "RegularRuntimeType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                },
-                {
-                  name: "load_num_csv",
-                  definition: {
-                    metadata: [],
-                    configDefinition: null,
-                    __typename: "SolidDefinition",
-                    description: null
-                  },
-                  inputs: [],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          name: "Any",
-                          displayName: "Any",
-                          __typename: "RegularRuntimeType",
-                          description: null
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [
-                        {
-                          solid: {
-                            name: "pandas_source_test",
-                            __typename: "Solid"
-                          },
-                          __typename: "Input"
-                        }
-                      ],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                }
-              ],
-              __typename: "Pipeline",
-              environmentType: {
-                name: "InputTransformTestPipeline.Environment",
-                __typename: "CompositeConfigType"
-              }
+              __typename: "RegularRuntimeType"
             },
             {
-              name: "pandas_hello_world",
+              name: "Bool",
+              isBuiltin: true,
+              displayName: "Bool",
               description: null,
-              contexts: [
-                {
-                  name: "default",
-                  description: null,
-                  __typename: "PipelineContext",
-                  config: {
-                    configType: {
-                      key: "Dict.29",
-                      name: null,
-                      description:
-                        "A configuration dictionary with typed fields",
-                      isList: false,
-                      isNullable: false,
-                      isSelector: false,
-                      innerTypes: [
-                        {
-                          key: "String",
-                          __typename: "RegularConfigType",
-                          name: "String",
-                          description: "",
-                          isList: false,
-                          isNullable: false,
-                          isSelector: false,
-                          innerTypes: []
-                        }
-                      ],
-                      fields: [
-                        {
-                          name: "log_level",
-                          description: null,
-                          isOptional: true,
-                          configType: {
-                            key: "String",
-                            __typename: "RegularConfigType"
-                          },
-                          __typename: "ConfigTypeField"
-                        }
-                      ],
-                      __typename: "CompositeConfigType"
-                    },
-                    __typename: "ConfigTypeField"
-                  },
-                  resources: []
-                }
-              ],
-              solids: [
-                {
-                  name: "sum_solid",
-                  definition: {
-                    metadata: [],
-                    configDefinition: null,
-                    __typename: "SolidDefinition",
-                    description: null
-                  },
-                  inputs: [
-                    {
-                      definition: {
-                        name: "num",
-                        type: {
-                          name: "PandasDataFrame",
-                          displayName: "PandasDataFrame",
-                          __typename: "RegularRuntimeType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
-                        },
-                        __typename: "InputDefinition",
-                        description: null,
-                        expectations: []
-                      },
-                      dependsOn: null,
-                      __typename: "Input"
-                    }
-                  ],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          name: "PandasDataFrame",
-                          displayName: "PandasDataFrame",
-                          __typename: "RegularRuntimeType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [
-                        {
-                          solid: { name: "sum_sq_solid", __typename: "Solid" },
-                          __typename: "Input"
-                        }
-                      ],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                },
-                {
-                  name: "sum_sq_solid",
-                  definition: {
-                    metadata: [],
-                    configDefinition: null,
-                    __typename: "SolidDefinition",
-                    description: null
-                  },
-                  inputs: [
-                    {
-                      definition: {
-                        name: "sum_df",
-                        type: {
-                          name: "PandasDataFrame",
-                          displayName: "PandasDataFrame",
-                          __typename: "RegularRuntimeType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
-                        },
-                        __typename: "InputDefinition",
-                        description: null,
-                        expectations: []
-                      },
-                      dependsOn: {
-                        definition: {
-                          name: "result",
-                          __typename: "OutputDefinition"
-                        },
-                        solid: { name: "sum_solid", __typename: "Solid" },
-                        __typename: "Output"
-                      },
-                      __typename: "Input"
-                    }
-                  ],
-                  outputs: [
-                    {
-                      definition: {
-                        name: "result",
-                        type: {
-                          displayName: "PandasDataFrame",
-                          name: "PandasDataFrame",
-                          __typename: "RegularRuntimeType",
-                          description:
-                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
-                        },
-                        expectations: [],
-                        __typename: "OutputDefinition",
-                        description: null
-                      },
-                      dependedBy: [],
-                      __typename: "Output"
-                    }
-                  ],
-                  __typename: "Solid"
-                }
-              ],
-              __typename: "Pipeline",
-              environmentType: {
-                name: "PandasHelloWorld.Environment",
-                __typename: "CompositeConfigType"
-              }
+              __typename: "RegularRuntimeType"
+            },
+            {
+              name: "Float",
+              isBuiltin: true,
+              displayName: "Float",
+              description: null,
+              __typename: "RegularRuntimeType"
+            },
+            {
+              name: "Int",
+              isBuiltin: true,
+              displayName: "Int",
+              description: null,
+              __typename: "RegularRuntimeType"
+            },
+            {
+              name: "PandasDataFrame",
+              isBuiltin: false,
+              displayName: "PandasDataFrame",
+              description:
+                "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/",
+              __typename: "RegularRuntimeType"
+            },
+            {
+              name: "Path",
+              isBuiltin: true,
+              displayName: "Path",
+              description: null,
+              __typename: "RegularRuntimeType"
+            },
+            {
+              name: "String",
+              isBuiltin: true,
+              displayName: "String",
+              description: null,
+              __typename: "RegularRuntimeType"
             }
           ]
         }
@@ -360,7 +85,6 @@ const MOCKS = [
       data: {
         runtimeTypeOrError: {
           __typename: "RegularRuntimeType",
-          displayName: "PandasDataFrame",
           name: "PandasDataFrame",
           description:
             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/",
@@ -372,26 +96,6 @@ const MOCKS = [
             isNullable: false,
             isSelector: true,
             innerTypes: [
-              {
-                key: "Path",
-                __typename: "RegularConfigType",
-                name: "Path",
-                description: "",
-                isList: false,
-                isNullable: false,
-                isSelector: false,
-                innerTypes: []
-              },
-              {
-                key: "String",
-                __typename: "RegularConfigType",
-                name: "String",
-                description: "",
-                isList: false,
-                isNullable: false,
-                isSelector: false,
-                innerTypes: []
-              },
               {
                 key: "Dict.28",
                 __typename: "CompositeConfigType",
@@ -448,6 +152,26 @@ const MOCKS = [
                     __typename: "ConfigTypeField"
                   }
                 ]
+              },
+              {
+                key: "Path",
+                __typename: "RegularConfigType",
+                name: "Path",
+                description: "",
+                isList: false,
+                isNullable: false,
+                isSelector: false,
+                innerTypes: []
+              },
+              {
+                key: "String",
+                __typename: "RegularConfigType",
+                name: "String",
+                description: "",
+                isList: false,
+                isNullable: false,
+                isSelector: false,
+                innerTypes: []
               },
               {
                 key: "Dict.27",
@@ -515,17 +239,24 @@ const MOCKS = [
             isSelector: true,
             innerTypes: [
               {
-                key: "Dict.23",
+                key: "Path",
+                __typename: "RegularConfigType",
+                name: "Path",
+                description: "",
+                isList: false,
+                isNullable: false,
+                isSelector: false,
+                innerTypes: []
+              },
+              {
+                key: "Dict.25",
                 __typename: "CompositeConfigType",
                 name: null,
                 description: "A configuration dictionary with typed fields",
                 isList: false,
                 isNullable: false,
                 isSelector: false,
-                innerTypes: [
-                  { key: "String", __typename: "RegularConfigType" },
-                  { key: "Path", __typename: "RegularConfigType" }
-                ],
+                innerTypes: [{ key: "Path", __typename: "RegularConfigType" }],
                 fields: [
                   {
                     name: "path",
@@ -536,28 +267,8 @@ const MOCKS = [
                       __typename: "RegularConfigType"
                     },
                     __typename: "ConfigTypeField"
-                  },
-                  {
-                    name: "sep",
-                    description: null,
-                    isOptional: true,
-                    configType: {
-                      key: "String",
-                      __typename: "RegularConfigType"
-                    },
-                    __typename: "ConfigTypeField"
                   }
                 ]
-              },
-              {
-                key: "Path",
-                __typename: "RegularConfigType",
-                name: "Path",
-                description: "",
-                isList: false,
-                isNullable: false,
-                isSelector: false,
-                innerTypes: []
               },
               {
                 key: "String",
@@ -592,14 +303,17 @@ const MOCKS = [
                 ]
               },
               {
-                key: "Dict.25",
+                key: "Dict.23",
                 __typename: "CompositeConfigType",
                 name: null,
                 description: "A configuration dictionary with typed fields",
                 isList: false,
                 isNullable: false,
                 isSelector: false,
-                innerTypes: [{ key: "Path", __typename: "RegularConfigType" }],
+                innerTypes: [
+                  { key: "String", __typename: "RegularConfigType" },
+                  { key: "Path", __typename: "RegularConfigType" }
+                ],
                 fields: [
                   {
                     name: "path",
@@ -607,6 +321,16 @@ const MOCKS = [
                     isOptional: false,
                     configType: {
                       key: "Path",
+                      __typename: "RegularConfigType"
+                    },
+                    __typename: "ConfigTypeField"
+                  },
+                  {
+                    name: "sep",
+                    description: null,
+                    isOptional: true,
+                    configType: {
+                      key: "String",
                       __typename: "RegularConfigType"
                     },
                     __typename: "ConfigTypeField"
@@ -655,65 +379,308 @@ const MOCKS = [
 
   {
     request: {
-      operationName: "TypeListContainerQuery",
-      queryVariableName: "TYPE_LIST_CONTAINER_QUERY",
-      query: TYPE_LIST_CONTAINER_QUERY,
-      variables: { pipelineName: "pandas_hello_world" }
+      operationName: "PipelineseContainerQuery",
+      queryVariableName: "APP_QUERY",
+      query: APP_QUERY,
+      variables: undefined
     },
     result: {
       data: {
-        pipelineOrError: {
-          __typename: "Pipeline",
-          runtimeTypes: [
+        pipelinesOrError: {
+          __typename: "PipelineConnection",
+          nodes: [
             {
-              name: "Any",
-              displayName: "Any",
-              isBuiltin: true,
+              name: "pandas_hello_world",
               description: null,
-              __typename: "RegularRuntimeType"
+              contexts: [
+                {
+                  name: "default",
+                  description: null,
+                  __typename: "PipelineContext",
+                  config: {
+                    configType: {
+                      key: "Dict.32",
+                      name: null,
+                      description:
+                        "A configuration dictionary with typed fields",
+                      isList: false,
+                      isNullable: false,
+                      isSelector: false,
+                      innerTypes: [
+                        {
+                          key: "log_level",
+                          __typename: "EnumConfigType",
+                          name: "log_level",
+                          description: null,
+                          isList: false,
+                          isNullable: false,
+                          isSelector: false,
+                          innerTypes: []
+                        }
+                      ],
+                      fields: [
+                        {
+                          name: "log_level",
+                          description: null,
+                          isOptional: true,
+                          configType: {
+                            key: "log_level",
+                            __typename: "EnumConfigType"
+                          },
+                          __typename: "ConfigTypeField"
+                        }
+                      ],
+                      __typename: "CompositeConfigType"
+                    },
+                    __typename: "ConfigTypeField"
+                  },
+                  resources: []
+                }
+              ],
+              solids: [
+                {
+                  name: "sum_sq_solid",
+                  definition: {
+                    metadata: [],
+                    configDefinition: null,
+                    __typename: "SolidDefinition",
+                    description: null
+                  },
+                  inputs: [
+                    {
+                      definition: {
+                        name: "sum_df",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularRuntimeType",
+                          displayName: "PandasDataFrame",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
+                        },
+                        __typename: "InputDefinition",
+                        description: null,
+                        expectations: []
+                      },
+                      dependsOn: {
+                        definition: {
+                          name: "result",
+                          type: {
+                            name: "PandasDataFrame",
+                            __typename: "RegularRuntimeType"
+                          },
+                          __typename: "OutputDefinition"
+                        },
+                        solid: { name: "sum_solid", __typename: "Solid" },
+                        __typename: "Output"
+                      },
+                      __typename: "Input"
+                    }
+                  ],
+                  outputs: [
+                    {
+                      definition: {
+                        name: "result",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularRuntimeType",
+                          displayName: "PandasDataFrame",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
+                        },
+                        expectations: [],
+                        __typename: "OutputDefinition",
+                        description: null
+                      },
+                      dependedBy: [],
+                      __typename: "Output"
+                    }
+                  ],
+                  __typename: "Solid"
+                },
+                {
+                  name: "sum_solid",
+                  definition: {
+                    metadata: [],
+                    configDefinition: null,
+                    __typename: "SolidDefinition",
+                    description: null
+                  },
+                  inputs: [
+                    {
+                      definition: {
+                        name: "num",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularRuntimeType",
+                          displayName: "PandasDataFrame",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
+                        },
+                        __typename: "InputDefinition",
+                        description: null,
+                        expectations: []
+                      },
+                      dependsOn: null,
+                      __typename: "Input"
+                    }
+                  ],
+                  outputs: [
+                    {
+                      definition: {
+                        name: "result",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularRuntimeType",
+                          displayName: "PandasDataFrame",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
+                        },
+                        expectations: [],
+                        __typename: "OutputDefinition",
+                        description: null
+                      },
+                      dependedBy: [
+                        {
+                          solid: { name: "sum_sq_solid", __typename: "Solid" },
+                          definition: {
+                            name: "sum_df",
+                            type: {
+                              name: "PandasDataFrame",
+                              __typename: "RegularRuntimeType"
+                            },
+                            __typename: "InputDefinition"
+                          },
+                          __typename: "Input"
+                        }
+                      ],
+                      __typename: "Output"
+                    }
+                  ],
+                  __typename: "Solid"
+                }
+              ],
+              __typename: "Pipeline",
+              environmentType: {
+                name: "PandasHelloWorld.Environment",
+                __typename: "CompositeConfigType"
+              }
             },
             {
-              name: "Bool",
-              displayName: "Bool",
-              isBuiltin: true,
+              name: "papermill_pandas_hello_world_pipeline",
               description: null,
-              __typename: "RegularRuntimeType"
-            },
-            {
-              name: "Float",
-              displayName: "Float",
-              isBuiltin: true,
-              description: null,
-              __typename: "RegularRuntimeType"
-            },
-            {
-              name: "Int",
-              displayName: "Int",
-              isBuiltin: true,
-              description: null,
-              __typename: "RegularRuntimeType"
-            },
-            {
-              name: "PandasDataFrame",
-              displayName: "PandasDataFrame",
-              isBuiltin: false,
-              description:
-                "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/",
-              __typename: "RegularRuntimeType"
-            },
-            {
-              name: "Path",
-              displayName: "Path",
-              isBuiltin: true,
-              description: null,
-              __typename: "RegularRuntimeType"
-            },
-            {
-              name: "String",
-              displayName: "String",
-              isBuiltin: true,
-              description: null,
-              __typename: "RegularRuntimeType"
+              contexts: [
+                {
+                  name: "default",
+                  description: null,
+                  __typename: "PipelineContext",
+                  config: {
+                    configType: {
+                      key: "Dict.29",
+                      name: null,
+                      description:
+                        "A configuration dictionary with typed fields",
+                      isList: false,
+                      isNullable: false,
+                      isSelector: false,
+                      innerTypes: [
+                        {
+                          key: "log_level",
+                          __typename: "EnumConfigType",
+                          name: "log_level",
+                          description: null,
+                          isList: false,
+                          isNullable: false,
+                          isSelector: false,
+                          innerTypes: []
+                        }
+                      ],
+                      fields: [
+                        {
+                          name: "log_level",
+                          description: null,
+                          isOptional: true,
+                          configType: {
+                            key: "log_level",
+                            __typename: "EnumConfigType"
+                          },
+                          __typename: "ConfigTypeField"
+                        }
+                      ],
+                      __typename: "CompositeConfigType"
+                    },
+                    __typename: "ConfigTypeField"
+                  },
+                  resources: []
+                }
+              ],
+              solids: [
+                {
+                  name: "papermill_pandas_hello_world",
+                  definition: {
+                    metadata: [
+                      {
+                        key: "notebook_path",
+                        value:
+                          "/Users/bengotow/Work/F376/Projects/dagster/python_modules/dagster-pandas/dagster_pandas/examples/notebooks/papermill_pandas_hello_world.ipynb",
+                        __typename: "SolidMetadataItemDefinition"
+                      },
+                      {
+                        key: "kind",
+                        value: "ipynb",
+                        __typename: "SolidMetadataItemDefinition"
+                      }
+                    ],
+                    configDefinition: null,
+                    __typename: "SolidDefinition",
+                    description:
+                      "This solid is backed by the notebook at /Users/bengotow/Work/F376/Projects/dagster/python_modules/dagster-pandas/dagster_pandas/examples/notebooks/papermill_pandas_hello_world.ipynb"
+                  },
+                  inputs: [
+                    {
+                      definition: {
+                        name: "df",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularRuntimeType",
+                          displayName: "PandasDataFrame",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
+                        },
+                        __typename: "InputDefinition",
+                        description: null,
+                        expectations: []
+                      },
+                      dependsOn: null,
+                      __typename: "Input"
+                    }
+                  ],
+                  outputs: [
+                    {
+                      definition: {
+                        name: "result",
+                        type: {
+                          name: "PandasDataFrame",
+                          __typename: "RegularRuntimeType",
+                          displayName: "PandasDataFrame",
+                          description:
+                            "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
+                        },
+                        expectations: [],
+                        __typename: "OutputDefinition",
+                        description: null
+                      },
+                      dependedBy: [],
+                      __typename: "Output"
+                    }
+                  ],
+                  __typename: "Solid"
+                }
+              ],
+              __typename: "Pipeline",
+              environmentType: {
+                name: "PapermillPandasHelloWorldPipeline.Environment",
+                __typename: "CompositeConfigType"
+              }
             }
           ]
         }

--- a/js_modules/dagit/src/execute/types/SolidSelectorQuery.ts
+++ b/js_modules/dagit/src/execute/types/SolidSelectorQuery.ts
@@ -40,9 +40,15 @@ export interface SolidSelectorQuery_pipeline_solids_inputs_definition {
   type: SolidSelectorQuery_pipeline_solids_inputs_definition_type;
 }
 
+export interface SolidSelectorQuery_pipeline_solids_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface SolidSelectorQuery_pipeline_solids_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: SolidSelectorQuery_pipeline_solids_inputs_dependsOn_definition_type;
 }
 
 export interface SolidSelectorQuery_pipeline_solids_inputs_dependsOn_solid {
@@ -85,9 +91,21 @@ export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy_solid {
   name: string;
 }
 
+export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: SolidSelectorQuery_pipeline_solids_outputs_dependedBy_definition_type;
+}
+
 export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy {
   __typename: "Input";
   solid: SolidSelectorQuery_pipeline_solids_outputs_dependedBy_solid;
+  definition: SolidSelectorQuery_pipeline_solids_outputs_dependedBy_definition;
 }
 
 export interface SolidSelectorQuery_pipeline_solids_outputs {

--- a/js_modules/dagit/src/graph/SolidNode.tsx
+++ b/js_modules/dagit/src/graph/SolidNode.tsx
@@ -6,8 +6,7 @@ import { IFullSolidLayout, ILayout } from "./getFullSolidLayout";
 import {
   SolidNodeFragment,
   SolidNodeFragment_inputs,
-  SolidNodeFragment_outputs,
-  SolidNodeFragment_inputs_dependsOn
+  SolidNodeFragment_outputs
 } from "./types/SolidNodeFragment";
 import {
   SVGEllipseInRect,
@@ -58,6 +57,9 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
           dependsOn {
             definition {
               name
+              type {
+                name
+              }
             }
             solid {
               name
@@ -78,6 +80,12 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
           dependedBy {
             solid {
               name
+            }
+            definition {
+              name
+              type {
+                name
+              }
             }
           }
         }
@@ -119,11 +127,14 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
       const { name, type } = item.definition;
 
       const connections: Array<{ a: string; b: string }> = [];
-
-      let title = `${name}: ${type.name}`;
+      let title = `${item.definition.name}: ${item.definition.type.name}`;
+      let clickTarget: string | null = null;
 
       if ("dependsOn" in item && item.dependsOn) {
-        title += `\n\nFrom:\n${item.dependsOn.solid.name}`;
+        title += `\n\nFrom:\n${item.dependsOn.solid.name}: ${
+          item.dependsOn.definition.name
+        }`;
+        clickTarget = item.dependsOn.solid.name;
         connections.push({
           a: item.dependsOn.solid.name,
           b: this.props.solid.name
@@ -131,7 +142,13 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
       }
       if ("dependedBy" in item) {
         title +=
-          "\n\nUsed By:\n" + item.dependedBy.map(o => o.solid.name).join("\n");
+          "\n\nUsed By:\n" +
+          item.dependedBy
+            .map(o => `${o.solid.name} ${o.definition.name}`)
+            .join("\n");
+        clickTarget =
+          item.dependedBy.length === 1 ? item.dependedBy[0].solid.name : null;
+
         connections.push(
           ...item.dependedBy.map(o => ({
             a: o.solid.name,
@@ -152,6 +169,7 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
           key={i}
           onMouseEnter={() => this.props.onHighlightConnections(connections)}
           onMouseLeave={() => this.props.onHighlightConnections([])}
+          onClick={() => clickTarget && this.props.onDoubleClick(clickTarget)}
         >
           <title>{title}</title>
           <SVGFlowLayoutRect

--- a/js_modules/dagit/src/graph/SolidNode.tsx
+++ b/js_modules/dagit/src/graph/SolidNode.tsx
@@ -120,13 +120,18 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
 
       const connections: Array<{ a: string; b: string }> = [];
 
+      let title = `${name}: ${type.name}`;
+
       if ("dependsOn" in item && item.dependsOn) {
+        title += `\n\nFrom:\n${item.dependsOn.solid.name}`;
         connections.push({
           a: item.dependsOn.solid.name,
           b: this.props.solid.name
         });
       }
       if ("dependedBy" in item) {
+        title +=
+          "\n\nUsed By:\n" + item.dependedBy.map(o => o.solid.name).join("\n");
         connections.push(
           ...item.dependedBy.map(o => ({
             a: o.solid.name,
@@ -148,7 +153,7 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
           onMouseEnter={() => this.props.onHighlightConnections(connections)}
           onMouseLeave={() => this.props.onHighlightConnections([])}
         >
-          <title>{`${name}: ${type.name}`}</title>
+          <title>{title}</title>
           <SVGFlowLayoutRect
             x={x}
             y={y}

--- a/js_modules/dagit/src/graph/types/PipelineGraphFragment.ts
+++ b/js_modules/dagit/src/graph/types/PipelineGraphFragment.ts
@@ -40,9 +40,15 @@ export interface PipelineGraphFragment_solids_inputs_definition {
   type: PipelineGraphFragment_solids_inputs_definition_type;
 }
 
+export interface PipelineGraphFragment_solids_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface PipelineGraphFragment_solids_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: PipelineGraphFragment_solids_inputs_dependsOn_definition_type;
 }
 
 export interface PipelineGraphFragment_solids_inputs_dependsOn_solid {
@@ -85,9 +91,21 @@ export interface PipelineGraphFragment_solids_outputs_dependedBy_solid {
   name: string;
 }
 
+export interface PipelineGraphFragment_solids_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineGraphFragment_solids_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: PipelineGraphFragment_solids_outputs_dependedBy_definition_type;
+}
+
 export interface PipelineGraphFragment_solids_outputs_dependedBy {
   __typename: "Input";
   solid: PipelineGraphFragment_solids_outputs_dependedBy_solid;
+  definition: PipelineGraphFragment_solids_outputs_dependedBy_definition;
 }
 
 export interface PipelineGraphFragment_solids_outputs {

--- a/js_modules/dagit/src/graph/types/PipelineGraphSolidFragment.ts
+++ b/js_modules/dagit/src/graph/types/PipelineGraphSolidFragment.ts
@@ -40,9 +40,15 @@ export interface PipelineGraphSolidFragment_inputs_definition {
   type: PipelineGraphSolidFragment_inputs_definition_type;
 }
 
+export interface PipelineGraphSolidFragment_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface PipelineGraphSolidFragment_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: PipelineGraphSolidFragment_inputs_dependsOn_definition_type;
 }
 
 export interface PipelineGraphSolidFragment_inputs_dependsOn_solid {
@@ -85,9 +91,21 @@ export interface PipelineGraphSolidFragment_outputs_dependedBy_solid {
   name: string;
 }
 
+export interface PipelineGraphSolidFragment_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineGraphSolidFragment_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: PipelineGraphSolidFragment_outputs_dependedBy_definition_type;
+}
+
 export interface PipelineGraphSolidFragment_outputs_dependedBy {
   __typename: "Input";
   solid: PipelineGraphSolidFragment_outputs_dependedBy_solid;
+  definition: PipelineGraphSolidFragment_outputs_dependedBy_definition;
 }
 
 export interface PipelineGraphSolidFragment_outputs {

--- a/js_modules/dagit/src/graph/types/SolidNodeFragment.ts
+++ b/js_modules/dagit/src/graph/types/SolidNodeFragment.ts
@@ -40,9 +40,15 @@ export interface SolidNodeFragment_inputs_definition {
   type: SolidNodeFragment_inputs_definition_type;
 }
 
+export interface SolidNodeFragment_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface SolidNodeFragment_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: SolidNodeFragment_inputs_dependsOn_definition_type;
 }
 
 export interface SolidNodeFragment_inputs_dependsOn_solid {
@@ -85,9 +91,21 @@ export interface SolidNodeFragment_outputs_dependedBy_solid {
   name: string;
 }
 
+export interface SolidNodeFragment_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface SolidNodeFragment_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: SolidNodeFragment_outputs_dependedBy_definition_type;
+}
+
 export interface SolidNodeFragment_outputs_dependedBy {
   __typename: "Input";
   solid: SolidNodeFragment_outputs_dependedBy_solid;
+  definition: SolidNodeFragment_outputs_dependedBy_definition;
 }
 
 export interface SolidNodeFragment_outputs {

--- a/js_modules/dagit/src/types/AppQuery.ts
+++ b/js_modules/dagit/src/types/AppQuery.ts
@@ -484,9 +484,15 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_input
   expectations: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_inputs_definition_expectations[];
 }
 
+export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_inputs_dependsOn_definition_type;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_inputs_dependsOn_solid {
@@ -532,9 +538,21 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outpu
   name: string;
 }
 
+export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_dependedBy_definition_type;
+}
+
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_dependedBy {
   __typename: "Input";
   solid: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_dependedBy_solid;
+  definition: AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_dependedBy_definition;
 }
 
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs {

--- a/js_modules/dagit/src/types/PipelineExplorerFragment.ts
+++ b/js_modules/dagit/src/types/PipelineExplorerFragment.ts
@@ -333,9 +333,15 @@ export interface PipelineExplorerFragment_solids_inputs_definition {
   type: PipelineExplorerFragment_solids_inputs_definition_type;
 }
 
+export interface PipelineExplorerFragment_solids_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface PipelineExplorerFragment_solids_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: PipelineExplorerFragment_solids_inputs_dependsOn_definition_type;
 }
 
 export interface PipelineExplorerFragment_solids_inputs_dependsOn_solid {
@@ -378,9 +384,21 @@ export interface PipelineExplorerFragment_solids_outputs_dependedBy_solid {
   name: string;
 }
 
+export interface PipelineExplorerFragment_solids_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineExplorerFragment_solids_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: PipelineExplorerFragment_solids_outputs_dependedBy_definition_type;
+}
+
 export interface PipelineExplorerFragment_solids_outputs_dependedBy {
   __typename: "Input";
   solid: PipelineExplorerFragment_solids_outputs_dependedBy_solid;
+  definition: PipelineExplorerFragment_solids_outputs_dependedBy_definition;
 }
 
 export interface PipelineExplorerFragment_solids_outputs {

--- a/js_modules/dagit/src/types/PipelineExplorerSolidFragment.ts
+++ b/js_modules/dagit/src/types/PipelineExplorerSolidFragment.ts
@@ -179,9 +179,15 @@ export interface PipelineExplorerSolidFragment_inputs_definition {
   expectations: PipelineExplorerSolidFragment_inputs_definition_expectations[];
 }
 
+export interface PipelineExplorerSolidFragment_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface PipelineExplorerSolidFragment_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: PipelineExplorerSolidFragment_inputs_dependsOn_definition_type;
 }
 
 export interface PipelineExplorerSolidFragment_inputs_dependsOn_solid {
@@ -227,9 +233,21 @@ export interface PipelineExplorerSolidFragment_outputs_dependedBy_solid {
   name: string;
 }
 
+export interface PipelineExplorerSolidFragment_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineExplorerSolidFragment_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: PipelineExplorerSolidFragment_outputs_dependedBy_definition_type;
+}
+
 export interface PipelineExplorerSolidFragment_outputs_dependedBy {
   __typename: "Input";
   solid: PipelineExplorerSolidFragment_outputs_dependedBy_solid;
+  definition: PipelineExplorerSolidFragment_outputs_dependedBy_definition;
 }
 
 export interface PipelineExplorerSolidFragment_outputs {

--- a/js_modules/dagit/src/types/PipelinePageFragment.ts
+++ b/js_modules/dagit/src/types/PipelinePageFragment.ts
@@ -484,9 +484,15 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_inputs_def
   expectations: PipelinePageFragment_PipelineConnection_nodes_solids_inputs_definition_expectations[];
 }
 
+export interface PipelinePageFragment_PipelineConnection_nodes_solids_inputs_dependsOn_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
+  type: PipelinePageFragment_PipelineConnection_nodes_solids_inputs_dependsOn_definition_type;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_inputs_dependsOn_solid {
@@ -532,9 +538,21 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_outputs_de
   name: string;
 }
 
+export interface PipelinePageFragment_PipelineConnection_nodes_solids_outputs_dependedBy_definition_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelinePageFragment_PipelineConnection_nodes_solids_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: PipelinePageFragment_PipelineConnection_nodes_solids_outputs_dependedBy_definition_type;
+}
+
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_outputs_dependedBy {
   __typename: "Input";
   solid: PipelinePageFragment_PipelineConnection_nodes_solids_outputs_dependedBy_solid;
+  definition: PipelinePageFragment_PipelineConnection_nodes_solids_outputs_dependedBy_definition;
 }
 
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_outputs {


### PR DESCRIPTION
This is a small PR that makes the solid "input" and "output" boxes clickable. Clicking them jumps to the other side of the connection.

The tooltips also show information about the other end of the connection as well as the box you're hovering over.