### PR TITLE
Eliminating unnecessary repository_container arguments in dagster-graphql

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution.py
@@ -92,9 +92,7 @@ def start_pipeline_execution(
         config_or_error = _config_or_error_from_pipeline(graphene_info, pipeline, environment_dict)
         return config_or_error.chain(_start_execution)
 
-    pipeline_or_error = _pipeline_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container, selector
-    )
+    pipeline_or_error = _pipeline_or_error_from_container(graphene_info, selector)
     return pipeline_or_error.chain(get_config_and_start_execution).value()
 
 
@@ -130,9 +128,7 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
         )
 
     return (
-        _pipeline_or_error_from_container(
-            graphene_info, graphene_info.context.repository_container, run.selector
-        )
+        _pipeline_or_error_from_container(graphene_info, run.selector)
         .chain(get_observable)
         .value_or_raise()
     )
@@ -152,11 +148,7 @@ def do_execute_plan(graphene_info, pipeline_name, environment_dict, execution_me
         step_keys=step_keys,
     )
     return (
-        _pipeline_or_error_from_container(
-            graphene_info,
-            graphene_info.context.repository_container,
-            ExecutionSelector(pipeline_name),
-        )
+        _pipeline_or_error_from_container(graphene_info, ExecutionSelector(pipeline_name))
         .chain(
             lambda dauphin_pipeline: _execute_plan_resolve_config(
                 execute_plan_args, dauphin_pipeline

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
@@ -33,9 +33,7 @@ def get_pipelines_or_raise(graphene_info):
 def _get_pipeline(graphene_info, selector):
     check.inst_param(graphene_info, 'graphene_info', ResolveInfo)
     check.inst_param(selector, 'selector', ExecutionSelector)
-    return _pipeline_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container, selector
-    )
+    return _pipeline_or_error_from_container(graphene_info, selector)
 
 
 def _get_pipelines(graphene_info):
@@ -56,19 +54,18 @@ def _get_pipelines(graphene_info):
                 )
             )
 
-    repository_or_error = _repository_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container
-    )
+    repository_or_error = _repository_or_error_from_container(graphene_info)
     return repository_or_error.chain(process_pipelines)
 
 
-def _pipeline_or_error_from_container(graphene_info, container, selector):
-    return _repository_or_error_from_container(graphene_info, container).chain(
+def _pipeline_or_error_from_container(graphene_info, selector):
+    return _repository_or_error_from_container(graphene_info).chain(
         lambda repository: _pipeline_or_error_from_repository(graphene_info, repository, selector)
     )
 
 
-def _repository_or_error_from_container(graphene_info, container):
+def _repository_or_error_from_container(graphene_info):
+    container = graphene_info.context.repository_container
     error = container.error
     if error is not None:
         return EitherError(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -57,9 +57,7 @@ def validate_pipeline_config(graphene_info, selector, config):
             )
         )
 
-    pipeline_or_error = _pipeline_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container, selector
-    )
+    pipeline_or_error = _pipeline_or_error_from_container(graphene_info, selector)
     return pipeline_or_error.chain(do_validation).value()
 
 
@@ -76,7 +74,5 @@ def get_execution_plan(graphene_info, selector, config):
             )
         )
 
-    pipeline_or_error = _pipeline_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container, selector
-    )
+    pipeline_or_error = _pipeline_or_error_from_container(graphene_info, selector)
     return pipeline_or_error.chain(create_plan).value()

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_types.py
@@ -21,7 +21,7 @@ def _config_type_or_error(graphene_info, dauphin_pipeline, config_type_name):
 
 def get_config_type(graphene_info, pipeline_name, type_name):
     pipeline_or_error = _pipeline_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container, ExecutionSelector(pipeline_name)
+        graphene_info, ExecutionSelector(pipeline_name)
     )
 
     return pipeline_or_error.chain(
@@ -46,7 +46,7 @@ def _runtime_type_or_error(graphene_info, dauphin_pipeline, runtime_type_name):
 
 def get_runtime_type(graphene_info, pipeline_name, type_name):
     pipeline_or_error = _pipeline_or_error_from_container(
-        graphene_info, graphene_info.context.repository_container, ExecutionSelector(pipeline_name)
+        graphene_info, ExecutionSelector(pipeline_name)
     )
 
     return pipeline_or_error.chain(


### PR DESCRIPTION
This is available from the graphql info object which is threaded around everywhere so just using that