### PR TITLE
[dagster] add "Nothing" IO type

### DIFF
--- a/examples/event-pipeline-demo/event_pipeline_demo/pipelines.py
+++ b/examples/event-pipeline-demo/event_pipeline_demo/pipelines.py
@@ -73,7 +73,7 @@ def define_event_ingest_pipeline():
             },
             SolidInstance('snowflake_load'): {
                 SnowflakeSolidDefinition.INPUT_READY: DependencyDefinition(
-                    'event_ingest', 'output_success'
+                    'event_ingest', 'paths'
                 )
             },
         },

--- a/js_modules/dagit/src/SidebarSolidInfo.tsx
+++ b/js_modules/dagit/src/SidebarSolidInfo.tsx
@@ -49,6 +49,7 @@ export default class SidebarSolidInfo extends React.Component<
             name
             description
             type {
+              isNothing
               ...RuntimeTypeWithTooltipFragment
             }
             expectations {
@@ -70,6 +71,7 @@ export default class SidebarSolidInfo extends React.Component<
             name
             description
             type {
+              isNothing
               ...RuntimeTypeWithTooltipFragment
             }
             expectations {
@@ -87,8 +89,9 @@ export default class SidebarSolidInfo extends React.Component<
   };
 
   renderInputs() {
-    return this.props.solid.inputs.map(
-      ({ definition, dependsOn }, i: number) => (
+    return this.props.solid.inputs
+      .filter(input => !input.definition.type.isNothing)
+      .map(({ definition, dependsOn }, i: number) => (
         <SectionItemContainer key={i}>
           <SectionItemHeader>{definition.name}</SectionItemHeader>
           <TypeWrapper>
@@ -119,31 +122,32 @@ export default class SidebarSolidInfo extends React.Component<
             </UL>
           ) : null}
         </SectionItemContainer>
-      )
-    );
+      ));
   }
 
   renderOutputs() {
-    return this.props.solid.outputs.map((output, i: number) => (
-      <SectionItemContainer key={i}>
-        <SectionItemHeader>{output.definition.name}</SectionItemHeader>
-        <TypeWrapper>
-          <TypeWithTooltip type={output.definition.type} />
-        </TypeWrapper>
-        <Description description={output.definition.description} />
-        {output.definition.expectations.length > 0 ? (
-          <H6>Expectations</H6>
-        ) : null}
-        <UL>
-          {output.definition.expectations.map((expectation, i) => (
-            <li key={i}>
-              {expectation.name}
-              <Description description={expectation.description} />
-            </li>
-          ))}
-        </UL>
-      </SectionItemContainer>
-    ));
+    return this.props.solid.outputs
+      .filter(output => !output.definition.type.isNothing)
+      .map((output, i: number) => (
+        <SectionItemContainer key={i}>
+          <SectionItemHeader>{output.definition.name}</SectionItemHeader>
+          <TypeWrapper>
+            <TypeWithTooltip type={output.definition.type} />
+          </TypeWrapper>
+          <Description description={output.definition.description} />
+          {output.definition.expectations.length > 0 ? (
+            <H6>Expectations</H6>
+          ) : null}
+          <UL>
+            {output.definition.expectations.map((expectation, i) => (
+              <li key={i}>
+                {expectation.name}
+                <Description description={expectation.description} />
+              </li>
+            ))}
+          </UL>
+        </SectionItemContainer>
+      ));
   }
 
   public render() {

--- a/js_modules/dagit/src/SolidTypeSignature.tsx
+++ b/js_modules/dagit/src/SolidTypeSignature.tsx
@@ -20,6 +20,7 @@ export default class SolidTypeSignature extends React.Component<
           definition {
             name
             type {
+              isNothing
               ...RuntimeTypeWithTooltipFragment
             }
           }
@@ -28,6 +29,7 @@ export default class SolidTypeSignature extends React.Component<
           definition {
             name
             type {
+              isNothing
               ...RuntimeTypeWithTooltipFragment
             }
           }
@@ -39,20 +41,24 @@ export default class SolidTypeSignature extends React.Component<
   };
 
   render() {
-    const inputSide = this.props.solid.inputs.map((input, i) => (
-      <span key={i}>
-        {input.definition.name}:{" "}
-        <TypeWithTooltip type={input.definition.type} />
-        {i < this.props.solid.inputs.length - 1 ? ", " : ""}
-      </span>
-    ));
-    const outputSide = this.props.solid.outputs.map((output, i) => (
-      <span key={i}>
-        {output.definition.name}:{" "}
-        <TypeWithTooltip type={output.definition.type} />
-        {i < this.props.solid.outputs.length - 1 ? ", " : ""}
-      </span>
-    ));
+    const inputSide = this.props.solid.inputs
+      .filter(input => !input.definition.type.isNothing)
+      .map((input, i) => (
+        <span key={i}>
+          {input.definition.name}:{" "}
+          <TypeWithTooltip type={input.definition.type} />
+          {i < this.props.solid.inputs.length - 1 ? ", " : ""}
+        </span>
+      ));
+    const outputSide = this.props.solid.outputs
+      .filter(output => !output.definition.type.isNothing)
+      .map((output, i) => (
+        <span key={i}>
+          {output.definition.name}:{" "}
+          <TypeWithTooltip type={output.definition.type} />
+          {i < this.props.solid.outputs.length - 1 ? ", " : ""}
+        </span>
+      ));
     return (
       <TypeSignature>
         ({inputSide}) ⇒ ({outputSide})

--- a/js_modules/dagit/src/__tests__/mockData.tsx
+++ b/js_modules/dagit/src/__tests__/mockData.tsx
@@ -453,6 +453,7 @@ const MOCKS = [
                         type: {
                           name: "PandasDataFrame",
                           __typename: "RegularRuntimeType",
+                          isNothing: false,
                           displayName: "PandasDataFrame",
                           description:
                             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
@@ -483,6 +484,7 @@ const MOCKS = [
                         type: {
                           name: "PandasDataFrame",
                           __typename: "RegularRuntimeType",
+                          isNothing: false,
                           displayName: "PandasDataFrame",
                           description:
                             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
@@ -512,6 +514,7 @@ const MOCKS = [
                         type: {
                           name: "PandasDataFrame",
                           __typename: "RegularRuntimeType",
+                          isNothing: false,
                           displayName: "PandasDataFrame",
                           description:
                             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
@@ -531,6 +534,7 @@ const MOCKS = [
                         type: {
                           name: "PandasDataFrame",
                           __typename: "RegularRuntimeType",
+                          isNothing: false,
                           displayName: "PandasDataFrame",
                           description:
                             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
@@ -642,6 +646,7 @@ const MOCKS = [
                         type: {
                           name: "PandasDataFrame",
                           __typename: "RegularRuntimeType",
+                          isNothing: false,
                           displayName: "PandasDataFrame",
                           description:
                             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
@@ -662,6 +667,7 @@ const MOCKS = [
                           name: "PandasDataFrame",
                           __typename: "RegularRuntimeType",
                           displayName: "PandasDataFrame",
+                          isNothing: false,
                           description:
                             "Two-dimensional size-mutable, potentially heterogeneous\n    tabular data structure with labeled axes (rows and columns).\n    See http://pandas.pydata.org/"
                         },

--- a/js_modules/dagit/src/schema.graphql
+++ b/js_modules/dagit/src/schema.graphql
@@ -253,6 +253,7 @@ type ListRuntimeType implements RuntimeType & WrappingRuntimeType {
   isNullable: Boolean!
   isList: Boolean!
   isBuiltin: Boolean!
+  isNothing: Boolean!
   inputSchemaType: ConfigType
   outputSchemaType: ConfigType
   innerTypes: [RuntimeType!]!
@@ -334,6 +335,7 @@ type NullableRuntimeType implements RuntimeType & WrappingRuntimeType {
   isNullable: Boolean!
   isList: Boolean!
   isBuiltin: Boolean!
+  isNothing: Boolean!
   inputSchemaType: ConfigType
   outputSchemaType: ConfigType
   innerTypes: [RuntimeType!]!
@@ -554,6 +556,7 @@ type RegularRuntimeType implements RuntimeType {
   isNullable: Boolean!
   isList: Boolean!
   isBuiltin: Boolean!
+  isNothing: Boolean!
   inputSchemaType: ConfigType
   outputSchemaType: ConfigType
   innerTypes: [RuntimeType!]!
@@ -582,6 +585,7 @@ interface RuntimeType {
   isNullable: Boolean!
   isList: Boolean!
   isBuiltin: Boolean!
+  isNothing: Boolean!
   inputSchemaType: ConfigType
   outputSchemaType: ConfigType
   innerTypes: [RuntimeType!]!

--- a/js_modules/dagit/src/types/AppQuery.ts
+++ b/js_modules/dagit/src/types/AppQuery.ts
@@ -466,6 +466,7 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_defin
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
   name: string | null;
+  isNothing: boolean;
   displayName: string;
   description: string | null;
 }
@@ -515,6 +516,7 @@ export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_input
 export interface AppQuery_pipelinesOrError_PipelineConnection_nodes_solids_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
   name: string | null;
+  isNothing: boolean;
   displayName: string;
   description: string | null;
 }

--- a/js_modules/dagit/src/types/PipelineExplorerSolidFragment.ts
+++ b/js_modules/dagit/src/types/PipelineExplorerSolidFragment.ts
@@ -161,6 +161,7 @@ export interface PipelineExplorerSolidFragment_definition {
 export interface PipelineExplorerSolidFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
   name: string | null;
+  isNothing: boolean;
   displayName: string;
   description: string | null;
 }
@@ -210,6 +211,7 @@ export interface PipelineExplorerSolidFragment_inputs {
 export interface PipelineExplorerSolidFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
   name: string | null;
+  isNothing: boolean;
   displayName: string;
   description: string | null;
 }

--- a/js_modules/dagit/src/types/PipelinePageFragment.ts
+++ b/js_modules/dagit/src/types/PipelinePageFragment.ts
@@ -466,6 +466,7 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_definition
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
   name: string | null;
+  isNothing: boolean;
   displayName: string;
   description: string | null;
 }
@@ -515,6 +516,7 @@ export interface PipelinePageFragment_PipelineConnection_nodes_solids_inputs {
 export interface PipelinePageFragment_PipelineConnection_nodes_solids_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
   name: string | null;
+  isNothing: boolean;
   displayName: string;
   description: string | null;
 }

--- a/js_modules/dagit/src/types/SidebarSolidInfoFragment.ts
+++ b/js_modules/dagit/src/types/SidebarSolidInfoFragment.ts
@@ -8,6 +8,7 @@
 
 export interface SidebarSolidInfoFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  isNothing: boolean;
   name: string | null;
   displayName: string;
   description: string | null;
@@ -34,6 +35,7 @@ export interface SidebarSolidInfoFragment_outputs {
 
 export interface SidebarSolidInfoFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  isNothing: boolean;
   name: string | null;
   displayName: string;
   description: string | null;

--- a/js_modules/dagit/src/types/SidebarTabbedContainerSolidFragment.ts
+++ b/js_modules/dagit/src/types/SidebarTabbedContainerSolidFragment.ts
@@ -8,6 +8,7 @@
 
 export interface SidebarTabbedContainerSolidFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  isNothing: boolean;
   name: string | null;
   displayName: string;
   description: string | null;
@@ -34,6 +35,7 @@ export interface SidebarTabbedContainerSolidFragment_outputs {
 
 export interface SidebarTabbedContainerSolidFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  isNothing: boolean;
   name: string | null;
   displayName: string;
   description: string | null;

--- a/js_modules/dagit/src/types/SolidTypeSignatureFragment.ts
+++ b/js_modules/dagit/src/types/SolidTypeSignatureFragment.ts
@@ -8,6 +8,7 @@
 
 export interface SolidTypeSignatureFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  isNothing: boolean;
   name: string | null;
   displayName: string;
   description: string | null;
@@ -26,6 +27,7 @@ export interface SolidTypeSignatureFragment_outputs {
 
 export interface SolidTypeSignatureFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  isNothing: boolean;
   name: string | null;
   displayName: string;
   description: string | null;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runtime_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runtime_types.py
@@ -20,6 +20,7 @@ def to_dauphin_runtime_type(runtime_type):
         is_builtin=runtime_type.is_builtin,
         is_nullable=runtime_type.is_nullable,
         is_list=runtime_type.is_list,
+        is_nothing=runtime_type.is_nothing,
         input_schema_type=config_type_for_schema(runtime_type.input_schema),
         output_schema_type=config_type_for_schema(runtime_type.output_schema),
         inner_types=_resolve_inner_types(runtime_type),
@@ -51,6 +52,7 @@ class DauphinRuntimeType(dauphin.Interface):
     is_nullable = dauphin.NonNull(dauphin.Boolean)
     is_list = dauphin.NonNull(dauphin.Boolean)
     is_builtin = dauphin.NonNull(dauphin.Boolean)
+    is_nothing = dauphin.NonNull(dauphin.Boolean)
 
     input_schema_type = dauphin.Field(DauphinConfigType)
     output_schema_type = dauphin.Field(DauphinConfigType)

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -70,6 +70,7 @@ from dagster.core.types import (
     PythonObjectType,
     Selector,
     String,
+    Nothing,
 )
 
 from dagster.core.types.decorator import dagster_type, as_dagster_type
@@ -142,6 +143,7 @@ __all__ = [
     'Selector',
     'String',
     'SerializationStrategy',
+    'Nothing',
     # type creation
     'as_dagster_type',
     'dagster_type',

--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -276,7 +276,9 @@ def _create_lambda_solid_transform_wrapper(fn, input_defs, output_def):
     check.list_param(input_defs, 'input_defs', of_type=InputDefinition)
     check.inst_param(output_def, 'output_def', OutputDefinition)
 
-    input_names = [input_def.name for input_def in input_defs]
+    input_names = [
+        input_def.name for input_def in input_defs if not input_def.runtime_type.is_nothing
+    ]
 
     @wraps(fn)
     def transform(_context, inputs):
@@ -295,7 +297,9 @@ def _create_solid_transform_wrapper(fn, input_defs, output_defs):
     check.list_param(input_defs, 'input_defs', of_type=InputDefinition)
     check.list_param(output_defs, 'output_defs', of_type=OutputDefinition)
 
-    input_names = [input_def.name for input_def in input_defs]
+    input_names = [
+        input_def.name for input_def in input_defs if not input_def.runtime_type.is_nothing
+    ]
 
     @wraps(fn)
     def transform(context, inputs):
@@ -367,7 +371,7 @@ def _validate_transform_fn(solid_name, transform_fn, inputs, expected_positional
         expected_positionals, 'expected_positionals', of_type=(str, tuple)
     )
 
-    names = set(inp.name for inp in inputs)
+    names = set(inp.name for inp in inputs if not inp.runtime_type.is_nothing)
     # Currently being super strict about naming. Might be a good idea to relax. Starting strict.
     try:
         _validate_decorated_fn(transform_fn, names, expected_positionals)

--- a/python_modules/dagster/dagster/core/execution_plan/create.py
+++ b/python_modules/dagster/dagster/core/execution_plan/create.py
@@ -156,6 +156,8 @@ def get_input_source_step_handle(pipeline_def, environment_config, plan_builder,
     elif dependency_structure.has_dep(input_handle):
         solid_output_handle = dependency_structure.get_dep(input_handle)
         return plan_builder.step_output_map[solid_output_handle]
+    elif input_def.runtime_type.is_nothing:
+        return None
     else:
         raise DagsterInvariantViolationError(
             (
@@ -180,6 +182,9 @@ def create_step_inputs(pipeline_def, environment_config, plan_builder, solid):
         prev_step_output_handle = get_input_source_step_handle(
             pipeline_def, environment_config, plan_builder, solid, input_def
         )
+
+        if not prev_step_output_handle:
+            continue
 
         subplan = create_subplan_for_input(
             pipeline_def, environment_config, solid, prev_step_output_handle, input_def

--- a/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
+++ b/python_modules/dagster/dagster/core/execution_plan/simple_engine.py
@@ -139,6 +139,9 @@ def _create_input_values(step_context, intermediates_manager):
 
     input_values = {}
     for step_input in step.step_inputs:
+        if step_input.runtime_type.is_nothing:
+            continue
+
         prev_output_handle = step_input.prev_output_handle
         input_value = intermediates_manager.get_intermediate(
             step_context, step_input.runtime_type, prev_output_handle

--- a/python_modules/dagster/dagster/core/types/__init__.py
+++ b/python_modules/dagster/dagster/core/types/__init__.py
@@ -16,6 +16,7 @@ Int = BuiltinEnum.INT
 Bool = BuiltinEnum.BOOL
 Path = BuiltinEnum.PATH
 Float = BuiltinEnum.FLOAT
+Nothing = BuiltinEnum.NOTHING
 
 
 # What sort of witchcraft is this?

--- a/python_modules/dagster/dagster/core/types/builtin_enum.py
+++ b/python_modules/dagster/dagster/core/types/builtin_enum.py
@@ -8,3 +8,4 @@ class BuiltinEnum(Enum):
     INT = 'Int'
     PATH = 'Path'
     STRING = 'String'
+    NOTHING = 'Nothing'

--- a/python_modules/dagster/dagster/core/types/runtime.py
+++ b/python_modules/dagster/dagster/core/types/runtime.py
@@ -117,6 +117,10 @@ class RuntimeType(object):
     def inner_types(self):
         return []
 
+    @property
+    def is_nothing(self):
+        return False
+
 
 class BuiltinScalarRuntimeType(RuntimeType):
     def __init__(self, *args, **kwargs):
@@ -217,6 +221,20 @@ def define_any_type(name, description=None):
             super(NamedAnyType, self).__init__(key=name, name=name, description=description)
 
     return NamedAnyType
+
+
+class Nothing(RuntimeType):
+    def __init__(self):
+        super(Nothing, self).__init__(
+            key='Nothing', name='Nothing', input_schema=None, output_schema=None, is_builtin=True
+        )
+
+    @property
+    def is_nothing(self):
+        return True
+
+    def coerce_runtime_value(self, value):
+        return self.throw_if_false(lambda v: v is None, value)
 
 
 class PythonObjectType(RuntimeType):
@@ -356,6 +374,7 @@ _RUNTIME_MAP = {
     BuiltinEnum.INT: Int.inst(),
     BuiltinEnum.PATH: Path.inst(),
     BuiltinEnum.STRING: String.inst(),
+    BuiltinEnum.NOTHING: Nothing.inst(),
 }
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
@@ -1,0 +1,161 @@
+import pytest
+
+from dagster import (
+    lambda_solid,
+    solid,
+    InputDefinition,
+    OutputDefinition,
+    Nothing,
+    Int,
+    PipelineDefinition,
+    execute_pipeline,
+    Result,
+    DependencyDefinition,
+    DagsterInvalidDefinitionError,
+    DagsterInvariantViolationError,
+    SolidInstance,
+)
+
+
+def _define_nothing_dep_pipeline():
+    @lambda_solid(output=OutputDefinition(Nothing, 'complete'))
+    def start_nothing():
+        pass
+
+    @lambda_solid(
+        inputs=[
+            InputDefinition('add_complete', Nothing),
+            InputDefinition('yield_complete', Nothing),
+        ]
+    )
+    def end_nothing():
+        pass
+
+    @lambda_solid(output=OutputDefinition(Int))
+    def emit_value():
+        return 1
+
+    @lambda_solid(
+        inputs=[InputDefinition('on_complete', Nothing), InputDefinition('num', Int)],
+        output=OutputDefinition(Int),
+    )
+    def add_value(num):
+        return 1 + num
+
+    @solid(
+        name='yield_values',
+        inputs=[InputDefinition('on_complete', Nothing)],
+        outputs=[
+            OutputDefinition(Int, 'num_1'),
+            OutputDefinition(Int, 'num_2'),
+            OutputDefinition(Nothing, 'complete'),
+        ],
+    )
+    def yield_values(_context):
+        yield Result(1, 'num_1')
+        yield Result(2, 'num_2')
+        yield Result(None, 'complete')
+
+    return PipelineDefinition(
+        name='simple_exc',
+        solids=[emit_value, add_value, start_nothing, end_nothing, yield_values],
+        dependencies={
+            'add_value': {
+                'on_complete': DependencyDefinition('start_nothing', 'complete'),
+                'num': DependencyDefinition('emit_value'),
+            },
+            'yield_values': {'on_complete': DependencyDefinition('start_nothing', 'complete')},
+            'end_nothing': {
+                'add_complete': DependencyDefinition('add_value'),
+                'yield_complete': DependencyDefinition('yield_values', 'complete'),
+            },
+        },
+    )
+
+
+def test_valid_nothing_dependencies():
+
+    result = execute_pipeline(_define_nothing_dep_pipeline())
+
+    assert result.success
+
+
+def test_invalid_input_dependency():
+    @lambda_solid(output=OutputDefinition(Nothing))
+    def do_nothing():
+        pass
+
+    @lambda_solid(inputs=[InputDefinition('num', Int)], output=OutputDefinition(Int))
+    def add_one(num):
+        return num + 1
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+        PipelineDefinition(
+            name='bad_dep',
+            solids=[do_nothing, add_one],
+            dependencies={'add_one': {'num': DependencyDefinition('do_nothing')}},
+        )
+
+
+def test_result_type_check():
+    @solid(outputs=[OutputDefinition(Nothing)])
+    def bad(_context):
+        yield Result('oops')
+
+    pipeline = PipelineDefinition(name='fail', solids=[bad])
+    with pytest.raises(DagsterInvariantViolationError):
+        execute_pipeline(pipeline)
+
+
+def test_nothing_inputs():
+    @lambda_solid(inputs=[InputDefinition('never_defined', Nothing)])
+    def emit_one():
+        return 1
+
+    @lambda_solid
+    def emit_two():
+        return 2
+
+    @lambda_solid
+    def emit_three():
+        return 3
+
+    @lambda_solid(output=OutputDefinition(Nothing))
+    def emit_nothing():
+        pass
+
+    @solid(
+        inputs=[
+            InputDefinition('_one', Nothing),
+            InputDefinition('one', Int),
+            InputDefinition('_two', Nothing),
+            InputDefinition('two', Int),
+            InputDefinition('_three', Nothing),
+            InputDefinition('three', Int),
+        ]
+    )
+    def adder(_context, one, two, three):
+        assert one == 1
+        assert two == 2
+        assert three == 3
+        return one + two + three
+
+    pipeline = PipelineDefinition(
+        name='input_test',
+        solids=[emit_one, emit_two, emit_three, emit_nothing, adder],
+        dependencies={
+            SolidInstance('emit_nothing', '_one'): {},
+            SolidInstance('emit_nothing', '_two'): {},
+            SolidInstance('emit_nothing', '_three'): {},
+            'adder': {
+                '_one': DependencyDefinition('_one'),
+                '_two': DependencyDefinition('_two'),
+                '_three': DependencyDefinition('_three'),
+                'one': DependencyDefinition('emit_one'),
+                'two': DependencyDefinition('emit_two'),
+                'three': DependencyDefinition('emit_three'),
+            },
+        },
+    )
+    result = execute_pipeline(pipeline)
+    assert result.success

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/solids.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/solids.py
@@ -6,7 +6,7 @@ import pandas as pd
 import snowflake.connector
 
 import dagster_pandas as dagster_pd
-from dagster import check, Bool, InputDefinition, List, OutputDefinition, Result, SolidDefinition
+from dagster import check, InputDefinition, List, OutputDefinition, Result, SolidDefinition, Nothing
 
 from .configs import define_snowflake_config
 
@@ -159,7 +159,7 @@ class SnowflakeSolidDefinition(SolidDefinition):
         super(SnowflakeSolidDefinition, self).__init__(
             name=name,
             description=description,
-            inputs=[InputDefinition(SnowflakeSolidDefinition.INPUT_READY, Bool)],
+            inputs=[InputDefinition(SnowflakeSolidDefinition.INPUT_READY, Nothing)],
             outputs=[OutputDefinition(List(dagster_pd.DataFrame))],
             transform_fn=_snowflake_transform_fn,
             config_field=define_snowflake_config(),

--- a/python_modules/libraries/dagster-spark/dagster_spark/configs.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/configs.py
@@ -9,7 +9,7 @@ import os
 
 from dagster import Dict, Field, List, Path, String
 
-from .types import SparkDeployMode, SparkSolidOutputMode, SparkSolidOutputModeSuccess
+from .types import SparkDeployMode
 from .configs_spark import spark_config
 
 
@@ -63,14 +63,6 @@ def define_spark_config():
 
     spark_outputs = Field(List(String), description='The outputs that this Spark job will produce')
 
-    solid_output_mode = Field(
-        SparkSolidOutputMode,
-        description='''Which output type to use for this Spark solid. Defaults to a success boolean
-        sentinel.''',
-        is_optional=True,
-        default_value=SparkSolidOutputModeSuccess.python_value,
-    )
-
     return Field(
         Dict(
             fields={
@@ -81,7 +73,6 @@ def define_spark_config():
                 'spark_home': spark_home,
                 'application_arguments': application_arguments,
                 'spark_outputs': spark_outputs,
-                'solid_output_mode': solid_output_mode,
             }
         )
     )

--- a/python_modules/libraries/dagster-spark/dagster_spark/solids.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/solids.py
@@ -2,18 +2,18 @@ import os
 
 from dagster import (
     check,
-    Bool,
     InputDefinition,
     List,
     OutputDefinition,
     Path,
     Result,
     SolidDefinition,
+    Nothing,
 )
 
 
 from .configs import define_spark_config
-from .types import SparkSolidError, SparkSolidOutputModeSuccess, SparkSolidOutputModePaths
+from .types import SparkSolidError
 from .utils import run_spark_subprocess, parse_spark_config
 
 
@@ -50,7 +50,6 @@ class SparkSolidDefinition(SolidDefinition):
                 application_arguments,
                 spark_home,
                 spark_outputs,
-                solid_output_mode,
             ) = [
                 context.solid_config.get(k)
                 for k in (
@@ -61,7 +60,6 @@ class SparkSolidDefinition(SolidDefinition):
                     'application_arguments',
                     'spark_home',
                     'spark_outputs',
-                    'solid_output_mode',
                 )
             ]
 
@@ -106,29 +104,13 @@ class SparkSolidDefinition(SolidDefinition):
             if retcode != 0:
                 raise SparkSolidError('Spark job failed. Please consult your logs.')
 
-            if solid_output_mode == SparkSolidOutputModeSuccess.python_value:
-                yield Result(True, SparkSolidOutputModeSuccess.python_value)
-            elif solid_output_mode == SparkSolidOutputModePaths.python_value:
-                yield Result(spark_outputs, SparkSolidOutputModePaths.python_value)
-            else:
-                raise SparkSolidError('should not reach')
+            yield Result(spark_outputs, 'paths')
 
         super(SparkSolidDefinition, self).__init__(
             name=name,
             description=description,
             inputs=[InputDefinition('spark_inputs', List(Path))],
-            outputs=[
-                OutputDefinition(
-                    dagster_type=Bool,
-                    name=SparkSolidOutputModeSuccess.python_value,
-                    is_optional=True,
-                ),
-                OutputDefinition(
-                    dagster_type=List(Path),
-                    name=SparkSolidOutputModePaths.python_value,
-                    is_optional=True,
-                ),
-            ],
+            outputs=[OutputDefinition(dagster_type=List(Path), name='paths')],
             transform_fn=_spark_transform_fn,
             config_field=define_spark_config(),
             metadata={'kind': 'spark', 'main_class': main_class},

--- a/python_modules/libraries/dagster-spark/dagster_spark/types.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/types.py
@@ -12,10 +12,3 @@ SparkDeployMode = Enum(
 
 class SparkSolidError(DagsterUserError):
     pass
-
-
-SparkSolidOutputModeSuccess = EnumValue('output_success')
-SparkSolidOutputModePaths = EnumValue('paths')
-SparkSolidOutputMode = Enum(
-    name='SparkOutputMode', enum_values=[SparkSolidOutputModeSuccess, SparkSolidOutputModePaths]
-)


### PR DESCRIPTION
This is a shortest path approach to adding a way to express execution order dependencies without input/output values. To do this a `Nothing` IO type is added, and special casing against this runtime type is used in various places. 
