### PR TITLE
Basic re-execution via a new "play" button beside finished / failed steps

### DIFF
--- a/js_modules/dagit/src/ExecutionPlan.tsx
+++ b/js_modules/dagit/src/ExecutionPlan.tsx
@@ -16,6 +16,7 @@ interface IExecutionPlanProps {
   runMetadata?: IRunMetadataDict;
   onApplyStepFilter?: (step: string) => void;
   onShowStateDetails?: (step: string) => void;
+  onReexecuteStep?: (step: string) => void;
 }
 
 const EMPTY_RUN_METADATA: IRunMetadataDict = {
@@ -52,6 +53,7 @@ export default class ExecutionPlan extends React.PureComponent<
     const {
       onApplyStepFilter,
       onShowStateDetails,
+      onReexecuteStep,
       runMetadata = EMPTY_RUN_METADATA,
       executionPlan
     } = this.props;
@@ -120,6 +122,7 @@ export default class ExecutionPlan extends React.PureComponent<
                 materializations={metadata.materializations}
                 onShowStateDetails={onShowStateDetails}
                 onApplyStepFilter={onApplyStepFilter}
+                onReexecuteStep={onReexecuteStep}
                 delay={delay}
               />
             );

--- a/js_modules/dagit/src/ExecutionPlanBox.tsx
+++ b/js_modules/dagit/src/ExecutionPlanBox.tsx
@@ -148,6 +148,7 @@ const ExecutionStateDot = styled.div<{ state: IStepState }>`
       [IStepState.WAITING]: Colors.GRAY1,
       [IStepState.RUNNING]: Colors.GRAY3,
       [IStepState.SUCCEEDED]: Colors.GREEN2,
+      [IStepState.SKIPPED]: Colors.GOLD3,
       [IStepState.FAILED]: Colors.RED3
     }[state])};
   &:hover {
@@ -156,6 +157,7 @@ const ExecutionStateDot = styled.div<{ state: IStepState }>`
         [IStepState.WAITING]: Colors.GRAY1,
         [IStepState.RUNNING]: Colors.GRAY3,
         [IStepState.SUCCEEDED]: Colors.GREEN2,
+        [IStepState.SKIPPED]: Colors.GOLD3,
         [IStepState.FAILED]: Colors.RED5
       }[state])};
   }

--- a/js_modules/dagit/src/ExecutionPlanBox.tsx
+++ b/js_modules/dagit/src/ExecutionPlanBox.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import styled from "styled-components";
-import { Colors, Spinner, Intent } from "@blueprintjs/core";
+import { Colors, Spinner, Intent, Icon } from "@blueprintjs/core";
 import { IStepState, IStepMaterialization } from "./RunMetadataProvider";
 import { Materialization } from "./Materialization";
 import { formatElapsedTime } from "./Util";
+import { IconNames } from "@blueprintjs/icons";
 
 interface IExecutionPlanBoxProps {
   state: IStepState;
@@ -14,6 +15,7 @@ interface IExecutionPlanBoxProps {
   materializations: IStepMaterialization[];
   onShowStateDetails?: (stepName: string) => void;
   onApplyStepFilter?: (stepName: string) => void;
+  onReexecuteStep?: (stepName: string) => void;
 }
 
 interface IExecutionPlanBoxState {
@@ -86,6 +88,7 @@ export class ExecutionPlanBox extends React.Component<
       delay,
       materializations,
       onApplyStepFilter,
+      onReexecuteStep,
       onShowStateDetails
     } = this.props;
 
@@ -96,31 +99,42 @@ export class ExecutionPlanBox extends React.Component<
 
     return (
       <>
-        <ExecutionPlanBoxContainer
-          state={state}
-          className={state}
-          style={{ transitionDelay: `${delay}ms` }}
-          onClick={() => onApplyStepFilter && onApplyStepFilter(name)}
-        >
-          <ExecutionFinishedFlash
+        <ExecutionPlanRowContainer>
+          <ExecutionPlanBoxContainer
+            state={state}
+            className={state}
             style={{ transitionDelay: `${delay}ms` }}
-            success={state === IStepState.SUCCEEDED}
-          />
-          <ExeuctionStateWrap
-            onClick={() => onShowStateDetails && onShowStateDetails(name)}
+            onClick={() => onApplyStepFilter && onApplyStepFilter(name)}
           >
-            {state === IStepState.RUNNING ? (
-              <Spinner intent={Intent.NONE} size={11} />
-            ) : (
-              <ExecutionStateDot
-                state={state}
-                style={{ transitionDelay: `${delay}ms` }}
-              />
+            <ExecutionFinishedFlash
+              style={{ transitionDelay: `${delay}ms` }}
+              success={state === IStepState.SUCCEEDED}
+            />
+            <ExeuctionStateWrap
+              onClick={() => onShowStateDetails && onShowStateDetails(name)}
+            >
+              {state === IStepState.RUNNING ? (
+                <Spinner intent={Intent.NONE} size={11} />
+              ) : (
+                <ExecutionStateDot
+                  state={state}
+                  style={{ transitionDelay: `${delay}ms` }}
+                />
+              )}
+            </ExeuctionStateWrap>
+            <ExecutionPlanBoxName>{name}</ExecutionPlanBoxName>
+            {elapsed !== undefined && <ExecutionTime elapsed={elapsed} />}
+          </ExecutionPlanBoxContainer>
+          {onReexecuteStep &&
+            [IStepState.FAILED, IStepState.SUCCEEDED].includes(state) && (
+              <ReExecuteContainer
+                className="reexecute"
+                onClick={() => onReexecuteStep(name)}
+              >
+                <Icon icon={IconNames.PLAY} iconSize={15} />
+              </ReExecuteContainer>
             )}
-          </ExeuctionStateWrap>
-          <ExecutionPlanBoxName>{name}</ExecutionPlanBoxName>
-          {elapsed !== undefined && <ExecutionTime elapsed={elapsed} />}
-        </ExecutionPlanBoxContainer>
+        </ExecutionPlanRowContainer>
         {(materializations || []).map(mat => (
           <Materialization
             fileLocation={mat.fileLocation}
@@ -174,6 +188,16 @@ const ExecutionTime = ({ elapsed }: { elapsed: number }) => {
   );
 };
 
+const ReExecuteContainer = styled.div`
+  display: inline-block;
+  border: 1px solid white;
+  margin-left: 5px;
+  border-radius: 13px;
+  width: 19px;
+  height: 19px;
+  padding: 1px 2px;
+`;
+
 const ExecutionTimeContainer = styled.div`
   opacity: 0.7;
   font-size: 0.9em;
@@ -203,6 +227,24 @@ const ExecutionFinishedFlash = styled.div<{ success: boolean }>`
   pointer-events: none;
   transition: ${({ success }) =>
     success ? "400ms background-position-x linear" : ""};
+`;
+
+const ExecutionPlanRowContainer = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+
+  .reexecute {
+    opacity: 0;
+  }
+  &:hover {
+    .reexecute {
+      opacity: 0.5;
+    }
+    .reexecute:hover {
+      opacity: 1;
+    }
+  }
 `;
 
 const ExecutionPlanBoxContainer = styled.div<{ state: IStepState }>`

--- a/js_modules/dagit/src/RunMetadataProvider.tsx
+++ b/js_modules/dagit/src/RunMetadataProvider.tsx
@@ -8,6 +8,7 @@ export enum IStepState {
   WAITING = "waiting",
   RUNNING = "running",
   SUCCEEDED = "succeeded",
+  SKIPPED = "skipped",
   FAILED = "failed"
 }
 
@@ -83,6 +84,10 @@ function extractMetadataFromLogs(
             step.transitionedAt = timestamp;
             step.elapsed = timestamp - step.start;
           }
+        });
+      } else if (log.__typename === "ExecutionStepSkippedEvent") {
+        metadata.steps[name] = produce(metadata.steps[name] || {}, step => {
+          step.state = IStepState.SKIPPED;
         });
       } else if (log.__typename === "StepMaterializationEvent") {
         metadata.steps[name] = produce(metadata.steps[name] || {}, step => {

--- a/js_modules/dagit/src/Util.tsx
+++ b/js_modules/dagit/src/Util.tsx
@@ -48,7 +48,9 @@ function twoDigit(v: number) {
 export function formatElapsedTime(elapsed: number) {
   let text = "";
 
-  if (elapsed < 1000) {
+  if (elapsed < 0) {
+    text = `0 msec`;
+  } else if (elapsed < 1000) {
     // < 1 second, show "X msec"
     text = `${Math.ceil(elapsed)} msec`;
   } else {

--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`renders execution 1`] = `
       className="bp3-navbar-divider"
     />
     <div
-      className="sc-cIShpX iWIiAw"
+      className="sc-feJyhm ehvwQP"
     >
       <span
         className="bp3-popover-wrapper"
@@ -74,24 +74,24 @@ exports[`renders execution 1`] = `
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-iELTvK gedWkH"
       >
         <a
-          className="active sc-feJyhm kTrNTW"
+          className="active sc-cmTdod iaXaIC"
           href="/pandas_hello_world/explore"
           onClick={[Function]}
         >
           Explore
         </a>
         <a
-          className="sc-feJyhm kTrNTW"
+          className="sc-cmTdod iaXaIC"
           href="/pandas_hello_world/execute"
           onClick={[Function]}
         >
           Execute
         </a>
         <a
-          className="sc-feJyhm kTrNTW"
+          className="sc-cmTdod iaXaIC"
           href="/pandas_hello_world/runs"
           onClick={[Function]}
         >
@@ -104,7 +104,7 @@ exports[`renders execution 1`] = `
     className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-Rmtcm gvepfF"
       style={
         Object {
           "background": "#3DCC91",
@@ -113,7 +113,7 @@ exports[`renders execution 1`] = `
       title="Connecting..."
     />
     <span
-      className="sc-ktHwxA doWHPT"
+      className="sc-kafWEX ixdkCC"
     />
   </div>
 </div>
@@ -143,7 +143,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-feJyhm ehvwQP"
       >
         <span
           className="bp3-popover-wrapper"
@@ -196,7 +196,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-bRBYWo jpDyyc"
+        className="sc-Rmtcm gvepfF"
         style={
           Object {
             "background": "#3DCC91",
@@ -205,7 +205,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-ktHwxA doWHPT"
+        className="sc-kafWEX ixdkCC"
       />
     </div>
   </div>,
@@ -248,7 +248,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-feJyhm ehvwQP"
       >
         <span
           className="bp3-popover-wrapper"
@@ -299,24 +299,24 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-kafWEX dOcLVX"
+          className="sc-iELTvK gedWkH"
         >
           <a
-            className="active sc-feJyhm kTrNTW"
+            className="active sc-cmTdod iaXaIC"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
             Explore
           </a>
           <a
-            className="sc-feJyhm kTrNTW"
+            className="sc-cmTdod iaXaIC"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
             Execute
           </a>
           <a
-            className="sc-feJyhm kTrNTW"
+            className="sc-cmTdod iaXaIC"
             href="/pandas_hello_world/runs"
             onClick={[Function]}
           >
@@ -329,7 +329,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-bRBYWo jpDyyc"
+        className="sc-Rmtcm gvepfF"
         style={
           Object {
             "background": "#3DCC91",
@@ -338,7 +338,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-ktHwxA doWHPT"
+        className="sc-kafWEX ixdkCC"
       />
     </div>
   </div>,
@@ -928,7 +928,7 @@ exports[`renders type page 1`] = `
       className="bp3-navbar-divider"
     />
     <div
-      className="sc-cIShpX iWIiAw"
+      className="sc-feJyhm ehvwQP"
     >
       <span
         className="bp3-popover-wrapper"
@@ -979,24 +979,24 @@ exports[`renders type page 1`] = `
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-iELTvK gedWkH"
       >
         <a
-          className="active sc-feJyhm kTrNTW"
+          className="active sc-cmTdod iaXaIC"
           href="/pandas_hello_world/explore"
           onClick={[Function]}
         >
           Explore
         </a>
         <a
-          className="sc-feJyhm kTrNTW"
+          className="sc-cmTdod iaXaIC"
           href="/pandas_hello_world/execute"
           onClick={[Function]}
         >
           Execute
         </a>
         <a
-          className="sc-feJyhm kTrNTW"
+          className="sc-cmTdod iaXaIC"
           href="/pandas_hello_world/runs"
           onClick={[Function]}
         >
@@ -1009,7 +1009,7 @@ exports[`renders type page 1`] = `
     className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-Rmtcm gvepfF"
       style={
         Object {
           "background": "#3DCC91",
@@ -1018,7 +1018,7 @@ exports[`renders type page 1`] = `
       title="Connecting..."
     />
     <span
-      className="sc-ktHwxA doWHPT"
+      className="sc-kafWEX ixdkCC"
     />
   </div>
 </div>
@@ -1047,7 +1047,7 @@ exports[`renders type page 2`] = `
       className="bp3-navbar-divider"
     />
     <div
-      className="sc-cIShpX iWIiAw"
+      className="sc-feJyhm ehvwQP"
     >
       <span
         className="bp3-popover-wrapper"
@@ -1098,24 +1098,24 @@ exports[`renders type page 2`] = `
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-kafWEX dOcLVX"
+        className="sc-iELTvK gedWkH"
       >
         <a
-          className="active sc-feJyhm kTrNTW"
+          className="active sc-cmTdod iaXaIC"
           href="/pandas_hello_world/explore"
           onClick={[Function]}
         >
           Explore
         </a>
         <a
-          className="sc-feJyhm kTrNTW"
+          className="sc-cmTdod iaXaIC"
           href="/pandas_hello_world/execute"
           onClick={[Function]}
         >
           Execute
         </a>
         <a
-          className="sc-feJyhm kTrNTW"
+          className="sc-cmTdod iaXaIC"
           href="/pandas_hello_world/runs"
           onClick={[Function]}
         >
@@ -1128,7 +1128,7 @@ exports[`renders type page 2`] = `
     className="bp3-navbar-group bp3-align-right"
   >
     <div
-      className="sc-bRBYWo jpDyyc"
+      className="sc-Rmtcm gvepfF"
       style={
         Object {
           "background": "#3DCC91",
@@ -1137,7 +1137,7 @@ exports[`renders type page 2`] = `
       title="Connecting..."
     />
     <span
-      className="sc-ktHwxA doWHPT"
+      className="sc-kafWEX ixdkCC"
     />
   </div>
 </div>
@@ -1167,7 +1167,7 @@ Array [
         className="bp3-navbar-divider"
       />
       <div
-        className="sc-cIShpX iWIiAw"
+        className="sc-feJyhm ehvwQP"
       >
         <span
           className="bp3-popover-wrapper"
@@ -1220,7 +1220,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-bRBYWo jpDyyc"
+        className="sc-Rmtcm gvepfF"
         style={
           Object {
             "background": "#3DCC91",
@@ -1229,7 +1229,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-ktHwxA doWHPT"
+        className="sc-kafWEX ixdkCC"
       />
     </div>
   </div>,

--- a/js_modules/dagit/src/execute/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execute/PipelineExecutionContainer.tsx
@@ -6,8 +6,8 @@ import { Colors, Spinner } from "@blueprintjs/core";
 import { ApolloConsumer, Mutation, MutationFn } from "react-apollo";
 
 import TabBar from "./TabBar";
-import { showCustomAlert } from "../CustomAlertProvider";
 import ExecutionStartButton from "./ExecutionStartButton";
+import { handleStartExecutionResult } from "../runs/RunUtils";
 import { RunPreview } from "./RunPreview";
 import { PanelDivider } from "../PanelDivider";
 import SolidSelector from "./SolidSelector";
@@ -137,28 +137,7 @@ export default class PipelineExecutionContainer extends React.Component<
     if (!variables) return;
 
     const result = await startPipelineExecution({ variables });
-    if (!result || !result.data) {
-      alert("No data was returned.");
-      return;
-    }
-
-    const obj = result.data.startPipelineExecution;
-
-    if (obj.__typename === "StartPipelineExecutionSuccess") {
-      window.open(`/${pipeline.name}/runs/${obj.run.runId}`, "_blank");
-    } else {
-      let message = `${
-        pipeline.name
-      } cannot not be executed with the provided config.`;
-
-      if ("errors" in obj) {
-        message += ` Please fix the following errors:\n\n${obj.errors
-          .map(error => error.message)
-          .join("\n\n")}`;
-      }
-
-      showCustomAlert({ message });
-    }
+    handleStartExecutionResult(pipeline.name, result);
   };
 
   buildExecutionVariables = () => {

--- a/js_modules/dagit/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/src/runs/RunUtils.tsx
@@ -1,11 +1,42 @@
 import * as React from "react";
 import styled from "styled-components";
 import { Colors, Spinner } from "@blueprintjs/core";
+import gql from "graphql-tag";
+import { HandleStartExecutionFragment } from "./types/HandleStartExecutionFragment";
+import { showCustomAlert } from "../CustomAlertProvider";
 
 export type IRunStatus = "SUCCESS" | "NOT_STARTED" | "FAILURE" | "STARTED";
 
 export function titleForRun(run: { runId: string }) {
   return run.runId.split("-").shift();
+}
+
+export function handleStartExecutionResult(
+  pipelineName: string,
+  result: void | {
+    data?: { startPipelineExecution?: HandleStartExecutionFragment };
+  }
+) {
+  if (!result || !result.data || !result.data.startPipelineExecution) {
+    alert("No data was returned.");
+    return;
+  }
+
+  const obj = result.data.startPipelineExecution;
+
+  if (obj.__typename === "StartPipelineExecutionSuccess") {
+    window.open(`/${pipelineName}/runs/${obj.run.runId}`, "_blank");
+  } else {
+    let message = `${pipelineName} cannot not be executed with the provided config.`;
+
+    if ("errors" in obj) {
+      message += ` Please fix the following errors:\n\n${obj.errors
+        .map(error => error.message)
+        .join("\n\n")}`;
+    }
+
+    showCustomAlert({ message });
+  }
 }
 
 export const RunStatus: React.SFC<{ status: IRunStatus }> = ({ status }) => {
@@ -39,5 +70,25 @@ const RunStatusDot = styled.div<{
         SUCCESS: Colors.GREEN2,
         FAILURE: Colors.RED5
       }[status])};
+  }
+`;
+
+export const HANDLE_START_EXECUTION_FRAGMENT = gql`
+  fragment HandleStartExecutionFragment on StartPipelineExecutionResult {
+    __typename
+
+    ... on StartPipelineExecutionSuccess {
+      run {
+        runId
+      }
+    }
+    ... on PipelineNotFoundError {
+      message
+    }
+    ... on PipelineConfigValidationInvalid {
+      errors {
+        message
+      }
+    }
   }
 `;

--- a/js_modules/dagit/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/src/runs/RunUtils.tsx
@@ -14,11 +14,11 @@ export function titleForRun(run: { runId: string }) {
 export function handleStartExecutionResult(
   pipelineName: string,
   result: void | {
-    data?: { startPipelineExecution?: HandleStartExecutionFragment };
+    data?: { startPipelineExecution: HandleStartExecutionFragment };
   }
 ) {
-  if (!result || !result.data || !result.data.startPipelineExecution) {
-    alert("No data was returned.");
+  if (!result || !result.data) {
+    showCustomAlert({ message: `No data was returned. Did Dagit crash?` });
     return;
   }
 

--- a/js_modules/dagit/src/runs/types/HandleStartExecutionFragment.ts
+++ b/js_modules/dagit/src/runs/types/HandleStartExecutionFragment.ts
@@ -1,0 +1,38 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: HandleStartExecutionFragment
+// ====================================================
+
+export interface HandleStartExecutionFragment_InvalidStepError {
+  __typename: "InvalidStepError" | "InvalidOutputError";
+}
+
+export interface HandleStartExecutionFragment_StartPipelineExecutionSuccess_run {
+  __typename: "PipelineRun";
+  runId: string;
+}
+
+export interface HandleStartExecutionFragment_StartPipelineExecutionSuccess {
+  __typename: "StartPipelineExecutionSuccess";
+  run: HandleStartExecutionFragment_StartPipelineExecutionSuccess_run;
+}
+
+export interface HandleStartExecutionFragment_PipelineNotFoundError {
+  __typename: "PipelineNotFoundError";
+  message: string;
+}
+
+export interface HandleStartExecutionFragment_PipelineConfigValidationInvalid_errors {
+  __typename: "FieldNotDefinedConfigError" | "FieldsNotDefinedConfigError" | "MissingFieldConfigError" | "MissingFieldsConfigError" | "RuntimeMismatchConfigError" | "SelectorTypeConfigError";
+  message: string;
+}
+
+export interface HandleStartExecutionFragment_PipelineConfigValidationInvalid {
+  __typename: "PipelineConfigValidationInvalid";
+  errors: HandleStartExecutionFragment_PipelineConfigValidationInvalid_errors[];
+}
+
+export type HandleStartExecutionFragment = HandleStartExecutionFragment_InvalidStepError | HandleStartExecutionFragment_StartPipelineExecutionSuccess | HandleStartExecutionFragment_PipelineNotFoundError | HandleStartExecutionFragment_PipelineConfigValidationInvalid;

--- a/js_modules/dagit/src/runs/types/PipelineRunFragment.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunFragment.ts
@@ -8,6 +8,11 @@ import { LogLevel, StepKind } from "./../../types/globalTypes";
 // GraphQL fragment: PipelineRunFragment
 // ====================================================
 
+export interface PipelineRunFragment_pipeline {
+  __typename: "Pipeline";
+  name: string;
+}
+
 export interface PipelineRunFragment_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -102,11 +107,35 @@ export interface PipelineRunFragment_executionPlan_steps_solid {
   name: string;
 }
 
+export interface PipelineRunFragment_executionPlan_steps_inputs_dependsOn_outputs_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineRunFragment_executionPlan_steps_inputs_dependsOn_outputs {
+  __typename: "ExecutionStepOutput";
+  name: string;
+  type: PipelineRunFragment_executionPlan_steps_inputs_dependsOn_outputs_type;
+}
+
+export interface PipelineRunFragment_executionPlan_steps_inputs_dependsOn {
+  __typename: "ExecutionStep";
+  key: string;
+  outputs: PipelineRunFragment_executionPlan_steps_inputs_dependsOn_outputs[];
+}
+
+export interface PipelineRunFragment_executionPlan_steps_inputs {
+  __typename: "ExecutionStepInput";
+  dependsOn: PipelineRunFragment_executionPlan_steps_inputs_dependsOn;
+}
+
 export interface PipelineRunFragment_executionPlan_steps {
   __typename: "ExecutionStep";
   name: string;
   solid: PipelineRunFragment_executionPlan_steps_solid;
   kind: StepKind;
+  key: string;
+  inputs: PipelineRunFragment_executionPlan_steps_inputs[];
 }
 
 export interface PipelineRunFragment_executionPlan {
@@ -116,6 +145,9 @@ export interface PipelineRunFragment_executionPlan {
 
 export interface PipelineRunFragment {
   __typename: "PipelineRun";
+  config: string;
+  runId: string;
+  pipeline: PipelineRunFragment_pipeline;
   logs: PipelineRunFragment_logs;
   executionPlan: PipelineRunFragment_executionPlan;
 }

--- a/js_modules/dagit/src/runs/types/PipelineRunLogsUpdateFragment.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunLogsUpdateFragment.ts
@@ -8,6 +8,11 @@ import { PipelineRunStatus, LogLevel, StepKind } from "./../../types/globalTypes
 // GraphQL fragment: PipelineRunLogsUpdateFragment
 // ====================================================
 
+export interface PipelineRunLogsUpdateFragment_pipeline {
+  __typename: "Pipeline";
+  name: string;
+}
+
 export interface PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -102,11 +107,35 @@ export interface PipelineRunLogsUpdateFragment_executionPlan_steps_solid {
   name: string;
 }
 
+export interface PipelineRunLogsUpdateFragment_executionPlan_steps_inputs_dependsOn_outputs_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineRunLogsUpdateFragment_executionPlan_steps_inputs_dependsOn_outputs {
+  __typename: "ExecutionStepOutput";
+  name: string;
+  type: PipelineRunLogsUpdateFragment_executionPlan_steps_inputs_dependsOn_outputs_type;
+}
+
+export interface PipelineRunLogsUpdateFragment_executionPlan_steps_inputs_dependsOn {
+  __typename: "ExecutionStep";
+  key: string;
+  outputs: PipelineRunLogsUpdateFragment_executionPlan_steps_inputs_dependsOn_outputs[];
+}
+
+export interface PipelineRunLogsUpdateFragment_executionPlan_steps_inputs {
+  __typename: "ExecutionStepInput";
+  dependsOn: PipelineRunLogsUpdateFragment_executionPlan_steps_inputs_dependsOn;
+}
+
 export interface PipelineRunLogsUpdateFragment_executionPlan_steps {
   __typename: "ExecutionStep";
   name: string;
   solid: PipelineRunLogsUpdateFragment_executionPlan_steps_solid;
   kind: StepKind;
+  key: string;
+  inputs: PipelineRunLogsUpdateFragment_executionPlan_steps_inputs[];
 }
 
 export interface PipelineRunLogsUpdateFragment_executionPlan {
@@ -118,6 +147,8 @@ export interface PipelineRunLogsUpdateFragment {
   __typename: "PipelineRun";
   runId: string;
   status: PipelineRunStatus;
+  config: string;
+  pipeline: PipelineRunLogsUpdateFragment_pipeline;
   logs: PipelineRunLogsUpdateFragment_logs;
   executionPlan: PipelineRunLogsUpdateFragment_executionPlan;
 }

--- a/js_modules/dagit/src/runs/types/PipelineRunRootQuery.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunRootQuery.ts
@@ -107,9 +107,36 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs {
   nodes: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs_nodes[];
 }
 
+export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_pipeline {
+  __typename: "Pipeline";
+  name: string;
+}
+
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_solid {
   __typename: "Solid";
   name: string;
+}
+
+export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs_dependsOn_outputs_type {
+  __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
+  name: string | null;
+}
+
+export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs_dependsOn_outputs {
+  __typename: "ExecutionStepOutput";
+  name: string;
+  type: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs_dependsOn_outputs_type;
+}
+
+export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs_dependsOn {
+  __typename: "ExecutionStep";
+  key: string;
+  outputs: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs_dependsOn_outputs[];
+}
+
+export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs {
+  __typename: "ExecutionStepInput";
+  dependsOn: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs_dependsOn;
 }
 
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps {
@@ -117,6 +144,8 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPl
   name: string;
   solid: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_solid;
   kind: StepKind;
+  key: string;
+  inputs: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_inputs[];
 }
 
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan {
@@ -129,6 +158,8 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun {
   runId: string;
   status: PipelineRunStatus;
   logs: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs;
+  config: string;
+  pipeline: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_pipeline;
   executionPlan: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan;
 }
 

--- a/js_modules/dagit/src/runs/types/ReexecuteStep.ts
+++ b/js_modules/dagit/src/runs/types/ReexecuteStep.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { ExecutionSelector, ReexecutionConfig } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ReexecuteStep
+// ====================================================
+
+export interface ReexecuteStep_startPipelineExecution_InvalidStepError {
+  __typename: "InvalidStepError" | "InvalidOutputError";
+}
+
+export interface ReexecuteStep_startPipelineExecution_StartPipelineExecutionSuccess_run {
+  __typename: "PipelineRun";
+  runId: string;
+}
+
+export interface ReexecuteStep_startPipelineExecution_StartPipelineExecutionSuccess {
+  __typename: "StartPipelineExecutionSuccess";
+  run: ReexecuteStep_startPipelineExecution_StartPipelineExecutionSuccess_run;
+}
+
+export interface ReexecuteStep_startPipelineExecution_PipelineNotFoundError {
+  __typename: "PipelineNotFoundError";
+  message: string;
+}
+
+export interface ReexecuteStep_startPipelineExecution_PipelineConfigValidationInvalid_errors {
+  __typename: "FieldNotDefinedConfigError" | "FieldsNotDefinedConfigError" | "MissingFieldConfigError" | "MissingFieldsConfigError" | "RuntimeMismatchConfigError" | "SelectorTypeConfigError";
+  message: string;
+}
+
+export interface ReexecuteStep_startPipelineExecution_PipelineConfigValidationInvalid {
+  __typename: "PipelineConfigValidationInvalid";
+  errors: ReexecuteStep_startPipelineExecution_PipelineConfigValidationInvalid_errors[];
+}
+
+export type ReexecuteStep_startPipelineExecution = ReexecuteStep_startPipelineExecution_InvalidStepError | ReexecuteStep_startPipelineExecution_StartPipelineExecutionSuccess | ReexecuteStep_startPipelineExecution_PipelineNotFoundError | ReexecuteStep_startPipelineExecution_PipelineConfigValidationInvalid;
+
+export interface ReexecuteStep {
+  startPipelineExecution: ReexecuteStep_startPipelineExecution;
+}
+
+export interface ReexecuteStepVariables {
+  pipeline: ExecutionSelector;
+  config: any;
+  stepKeys?: string[] | null;
+  reexecutionConfig?: ReexecutionConfig | null;
+}

--- a/js_modules/dagit/src/types/globalTypes.ts
+++ b/js_modules/dagit/src/types/globalTypes.ts
@@ -47,6 +47,16 @@ export interface ExecutionSelector {
   solidSubset?: string[] | null;
 }
 
+export interface ReexecutionConfig {
+  previousRunId: string;
+  stepOutputHandles: StepOutputHandle[];
+}
+
+export interface StepOutputHandle {
+  stepKey: string;
+  outputName: string;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import yaml
 
 from dagster import check
 from dagster.core.events.logging import EventRecord
@@ -44,7 +45,7 @@ class DauphinPipelineRun(dauphin.ObjectType):
         )
 
     def resolve_config(self, _graphene_info):
-        return self._pipeline_run.config
+        return yaml.dump(self._pipeline_run.config, default_flow_style=False)
 
 
 class DauphinLogLevel(dauphin.Enum):


### PR DESCRIPTION
This PR adds a small play button that appears when you hover over a step that has succeeded or failed:

<img width="345" alt="image" src="https://user-images.githubusercontent.com/1037212/55909969-19efa780-5b92-11e9-8c2d-2c2cae8fd340.png">

When you click it, it starts a new execution of the pipeline with the same config and all of the outputs of steps used by the selected step captured in the `reexecutionConfig`.

In order to make this work on the demo pipeline, I needed to specify persistent run storage in my pipeline config explicitly. Otherwise it says it can't find the previous run once it's started:

```
storage:
  filesystem:
    base_dir: "~/Desktop"
```

The new run opens in a new tab similar to the way fresh runs work.