### PR TITLE
Handle "invalid subset" to prevent user from getting stuck when selected solid is removed

### DIFF
--- a/js_modules/dagit/src/configeditor/codemirror-yaml/mode.tsx
+++ b/js_modules/dagit/src/configeditor/codemirror-yaml/mode.tsx
@@ -412,6 +412,11 @@ function findAutocompletionContext(
   parents = parents.filter(({ indent }) => currentIndent > indent);
   const immediateParent = parents[parents.length - 1];
 
+  if (!pipeline) {
+    // Pipeline may still be loading
+    return;
+  }
+
   let type = pipeline.configTypes.find(
     t => t.key === pipeline.environmentType.key
   );

--- a/js_modules/dagit/src/execute/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execute/PipelineExecutionContainer.tsx
@@ -182,13 +182,14 @@ export default class PipelineExecutionContainer extends React.Component<
               onRemoveSession={this.onRemoveSession}
               onSaveSession={this.onSaveSession}
             >
-              {!this.state.preview ? (
-                <Spinner size={17} />
-              ) : (
-                <ExecutionStartButton
-                  onClick={() => this.onExecute(startPipelineExecution)}
-                />
-              )}
+              {pipeline &&
+                (!this.state.preview ? (
+                  <Spinner size={17} />
+                ) : (
+                  <ExecutionStartButton
+                    onClick={() => this.onExecute(startPipelineExecution)}
+                  />
+                ))}
             </TabBar>
           )}
         </Mutation>

--- a/js_modules/dagit/src/execute/PipelineExecutionContainer.tsx
+++ b/js_modules/dagit/src/execute/PipelineExecutionContainer.tsx
@@ -43,6 +43,7 @@ interface IPipelineExecutionContainerProps {
   data: IStorageData;
   onSave: (data: IStorageData) => void;
   pipeline?: PipelineExecutionContainerFragment;
+  pipelineName: string;
   currentSession: IExecutionSession;
 }
 
@@ -164,7 +165,7 @@ export default class PipelineExecutionContainer extends React.Component<
   };
 
   render() {
-    const { currentSession, pipeline } = this.props;
+    const { currentSession, pipeline, pipelineName } = this.props;
     const { preview } = this.state;
 
     return (
@@ -230,15 +231,11 @@ export default class PipelineExecutionContainer extends React.Component<
                 )}
               </ApolloConsumer>
               <SessionSettingsFooter className="bp3-dark">
-                {!pipeline ? (
-                  <span />
-                ) : (
-                  <SolidSelector
-                    pipelineName={pipeline.name}
-                    value={currentSession.solidSubset || null}
-                    onChange={this.onSolidSubsetChange}
-                  />
-                )}
+                <SolidSelector
+                  pipelineName={pipelineName}
+                  value={currentSession.solidSubset || null}
+                  onChange={this.onSolidSubsetChange}
+                />
               </SessionSettingsFooter>
             </Split>
             <PanelDivider

--- a/js_modules/dagit/src/execute/PipelineExecutionRoot.tsx
+++ b/js_modules/dagit/src/execute/PipelineExecutionRoot.tsx
@@ -39,6 +39,7 @@ export default class PipelineExecutionRoot extends React.Component<
                   data={data}
                   onSave={onSave}
                   pipeline={result.data ? result.data.pipeline : undefined}
+                  pipelineName={pipelineName}
                   currentSession={data.sessions[data.current]}
                 />
               )}

--- a/js_modules/dagit/src/execute/SolidSelector.tsx
+++ b/js_modules/dagit/src/execute/SolidSelector.tsx
@@ -160,7 +160,11 @@ class SolidSelector extends React.PureComponent<
   // The equivalent solidSubset is `null`, not `[]`, so we do some conversion here.
 
   handleOpen = () => {
-    this.setState({ open: true, highlighted: this.props.value || [] });
+    const { value, pipeline } = this.props;
+    const valid = (value || []).filter(
+      name => !!pipeline.solids.find(s => s.name === name)
+    );
+    this.setState({ open: true, highlighted: valid });
   };
 
   handleSave = () => {

--- a/js_modules/dagit/src/execute/SolidSelector.tsx
+++ b/js_modules/dagit/src/execute/SolidSelector.tsx
@@ -1,4 +1,4 @@
-import { Colors, Button, Classes, Dialog } from "@blueprintjs/core";
+import { Colors, Button, Classes, Dialog, Intent } from "@blueprintjs/core";
 import * as React from "react";
 import gql from "graphql-tag";
 import PipelineGraph from "../graph/PipelineGraph";
@@ -173,6 +173,12 @@ class SolidSelector extends React.PureComponent<
     const { pipeline } = this.props;
     const { open, highlighted, toolRectEnd, toolRectStart } = this.state;
 
+    const valid =
+      !this.props.value ||
+      this.props.value.every(
+        name => !!pipeline.solids.find(s => s.name === name)
+      );
+
     return (
       <div>
         <Dialog
@@ -234,8 +240,14 @@ class SolidSelector extends React.PureComponent<
             </div>
           </div>
         </Dialog>
-        <Button icon={IconNames.SEARCH_AROUND} onClick={this.handleOpen}>
-          {subsetDescription(this.props.value, this.props.pipeline)}
+        <Button
+          icon={valid ? IconNames.SEARCH_AROUND : IconNames.WARNING_SIGN}
+          intent={valid ? Intent.NONE : Intent.WARNING}
+          onClick={this.handleOpen}
+        >
+          {valid
+            ? subsetDescription(this.props.value, this.props.pipeline)
+            : "Invalid Solid Selection"}
         </Button>
       </div>
     );


### PR DESCRIPTION
Resolves #1180

This PR makes it so the solid selector is 1) still visible when the pipeline cannot be loaded due to an invalid solid subset and 2) loud and orange when the selection is invalid and needs to be fixed.

We could try to automatically fix the selection, but I'm not sure that's preferable because the user might then be confused as to why things weren't executing (if they slightly renamed a solid for example and we just removed it from the subset). Completely clearing the subset also seems non-ideal.

When you open the picker, the invalid solid is removed from the subset and just clicking "Save" will get you back on a happy path.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/1037212/55987097-9eefc500-5c55-11e9-92cd-b467604d3321.png">
