### PR TITLE
Rework the Run UI so that there is no fullscreen loading state

### DIFF
--- a/js_modules/dagit/src/App.tsx
+++ b/js_modules/dagit/src/App.tsx
@@ -14,7 +14,10 @@ import PipelineRunsRoot from "./runs/PipelineRunsRoot";
 import PipelineExplorerRoot from "./PipelineExplorerRoot";
 import { NonIdealState } from "@blueprintjs/core";
 
-function extractData(result: RootPipelinesQuery) {
+function extractData(result?: RootPipelinesQuery) {
+  if (!result || !result.pipelinesOrError) {
+    return { pipelines: [], error: null };
+  }
   if (result.pipelinesOrError.__typename === "PipelineConnection") {
     return { pipelines: result.pipelinesOrError.nodes, error: null };
   } else {
@@ -51,30 +54,26 @@ export default class App extends React.Component {
     return (
       <BrowserRouter>
         <Query query={ROOT_PIPELINES_QUERY} fetchPolicy="cache-and-network">
-          {(queryResult: QueryResult<RootPipelinesQuery, any>) => (
-            <Loading queryResult={queryResult}>
-              {result => {
-                const { pipelines, error } = extractData(result);
-                return (
-                  <>
-                    <TopNav pipelines={pipelines} />
-                    {error ? (
-                      <PythonErrorInfo
-                        contextMsg={`${
-                          error.__typename
-                        } encountered when loading pipelines:`}
-                        error={error}
-                        centered={true}
-                      />
-                    ) : (
-                      <AppRoutes />
-                    )}
-                    <CustomAlertProvider />
-                  </>
-                );
-              }}
-            </Loading>
-          )}
+          {(queryResult: QueryResult<RootPipelinesQuery, any>) => {
+            const { pipelines, error } = extractData(queryResult.data);
+            return (
+              <>
+                <TopNav pipelines={pipelines} />
+                {error ? (
+                  <PythonErrorInfo
+                    contextMsg={`${
+                      error.__typename
+                    } encountered when loading pipelines:`}
+                    error={error}
+                    centered={true}
+                  />
+                ) : (
+                  <AppRoutes />
+                )}
+                <CustomAlertProvider />
+              </>
+            );
+          }}
         </Query>
       </BrowserRouter>
     );

--- a/js_modules/dagit/src/Loading.tsx
+++ b/js_modules/dagit/src/Loading.tsx
@@ -15,7 +15,6 @@ export default class Loading<TData> extends React.Component<
     const { error, data } = this.props.queryResult;
 
     if (!data || Object.keys(data).length === 0) {
-      console.log("here", this, data);
       return (
         <LoadingContainer>
           <LoadingCentering>

--- a/js_modules/dagit/src/Loading.tsx
+++ b/js_modules/dagit/src/Loading.tsx
@@ -15,6 +15,7 @@ export default class Loading<TData> extends React.Component<
     const { error, data } = this.props.queryResult;
 
     if (!data || Object.keys(data).length === 0) {
+      console.log("here", this, data);
       return (
         <LoadingContainer>
           <LoadingCentering>

--- a/js_modules/dagit/src/PipelineJumpComponents.tsx
+++ b/js_modules/dagit/src/PipelineJumpComponents.tsx
@@ -126,6 +126,7 @@ export class PipelineJumpBar extends React.Component<IPipelineJumpBarProps> {
           onItemSelect={onItemSelect}
         >
           <Button
+            style={{ minWidth: 230, justifyContent: "space-between" }}
             text={
               selectedPipeline ? selectedPipeline.name : "Select a Pipeline..."
             }

--- a/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/js_modules/dagit/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -46,6 +46,12 @@ Array [
                 className="bp3-button"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "space-between",
+                    "minWidth": 230,
+                  }
+                }
                 type="button"
               >
                 <span
@@ -80,24 +86,24 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-ifAKCX fZwGXo"
+          className="sc-htpNat dMCWdO"
         >
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
             Explore
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
             Execute
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/runs"
             onClick={[Function]}
           >
@@ -110,7 +116,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-htpNat eBXEsV"
+        className="sc-bdVaJa cgCJAY"
         style={
           Object {
             "background": "#3DCC91",
@@ -119,7 +125,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-bxivhb cvIdVt"
+        className="sc-bwzfXH bRRDrI"
       />
     </div>
   </div>,
@@ -184,6 +190,12 @@ Array [
                 className="bp3-button"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "space-between",
+                    "minWidth": 230,
+                  }
+                }
                 type="button"
               >
                 <span
@@ -220,7 +232,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-htpNat eBXEsV"
+        className="sc-bdVaJa cgCJAY"
         style={
           Object {
             "background": "#3DCC91",
@@ -229,7 +241,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-bxivhb cvIdVt"
+        className="sc-bwzfXH bRRDrI"
       />
     </div>
   </div>,
@@ -294,6 +306,12 @@ Array [
                 className="bp3-button"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "space-between",
+                    "minWidth": 230,
+                  }
+                }
                 type="button"
               >
                 <span
@@ -328,24 +346,24 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-ifAKCX fZwGXo"
+          className="sc-htpNat dMCWdO"
         >
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
             Explore
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
             Execute
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/runs"
             onClick={[Function]}
           >
@@ -358,7 +376,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-htpNat eBXEsV"
+        className="sc-bdVaJa cgCJAY"
         style={
           Object {
             "background": "#3DCC91",
@@ -367,7 +385,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-bxivhb cvIdVt"
+        className="sc-bwzfXH bRRDrI"
       />
     </div>
   </div>,
@@ -432,6 +450,12 @@ Array [
                 className="bp3-button"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "space-between",
+                    "minWidth": 230,
+                  }
+                }
                 type="button"
               >
                 <span
@@ -466,24 +490,24 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-ifAKCX fZwGXo"
+          className="sc-htpNat dMCWdO"
         >
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
             Explore
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
             Execute
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/runs"
             onClick={[Function]}
           >
@@ -496,7 +520,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-htpNat eBXEsV"
+        className="sc-bdVaJa cgCJAY"
         style={
           Object {
             "background": "#3DCC91",
@@ -505,7 +529,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-bxivhb cvIdVt"
+        className="sc-bwzfXH bRRDrI"
       />
     </div>
   </div>,
@@ -570,6 +594,12 @@ Array [
                 className="bp3-button"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "space-between",
+                    "minWidth": 230,
+                  }
+                }
                 type="button"
               >
                 <span
@@ -604,24 +634,24 @@ Array [
           className="bp3-navbar-divider"
         />
         <div
-          className="sc-ifAKCX fZwGXo"
+          className="sc-htpNat dMCWdO"
         >
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/explore"
             onClick={[Function]}
           >
             Explore
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/execute"
             onClick={[Function]}
           >
             Execute
           </a>
           <a
-            className="sc-EHOje dyRDtw"
+            className="sc-bxivhb cpwKZw"
             href="/pandas_hello_world/runs"
             onClick={[Function]}
           >
@@ -634,7 +664,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-htpNat eBXEsV"
+        className="sc-bdVaJa cgCJAY"
         style={
           Object {
             "background": "#3DCC91",
@@ -643,7 +673,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-bxivhb cvIdVt"
+        className="sc-bwzfXH bRRDrI"
       />
     </div>
   </div>,
@@ -708,6 +738,12 @@ Array [
                 className="bp3-button"
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                style={
+                  Object {
+                    "justifyContent": "space-between",
+                    "minWidth": 230,
+                  }
+                }
                 type="button"
               >
                 <span
@@ -744,7 +780,7 @@ Array [
       className="bp3-navbar-group bp3-align-right"
     >
       <div
-        className="sc-htpNat eBXEsV"
+        className="sc-bdVaJa cgCJAY"
         style={
           Object {
             "background": "#3DCC91",
@@ -753,7 +789,7 @@ Array [
         title="Connecting..."
       />
       <span
-        className="sc-bxivhb cvIdVt"
+        className="sc-bwzfXH bRRDrI"
       />
     </div>
   </div>,

--- a/js_modules/dagit/src/runs/LogsFilterProvider.tsx
+++ b/js_modules/dagit/src/runs/LogsFilterProvider.tsx
@@ -28,12 +28,15 @@ export interface ILogFilter {
 
 interface ILogsFilterProviderProps<T> {
   filter: ILogFilter;
-  nodes: T[];
-  children: (props: { filteredNodes: T[]; busy: boolean }) => React.ReactChild;
+  nodes: T[] | undefined;
+  children: (props: {
+    filteredNodes: T[] | undefined;
+    busy: boolean;
+  }) => React.ReactChild;
 }
 
 interface ILogsFilterProviderState<T> {
-  results: T[];
+  results: T[] | undefined;
 }
 
 export default class LogsFilterProvider<
@@ -77,7 +80,7 @@ export default class LogsFilterProvider<
   runFilter = () => {
     const { nodes, filter } = this.props;
 
-    if (isEqual(filter, DefaultLogFilter)) {
+    if (nodes === undefined || isEqual(filter, DefaultLogFilter)) {
       this.setState({ results: nodes });
       return;
     }

--- a/js_modules/dagit/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/src/runs/LogsScrollingTable.tsx
@@ -16,7 +16,7 @@ import { IconNames } from "@blueprintjs/icons";
 import { showCustomAlert } from "../CustomAlertProvider";
 
 interface ILogsScrollingTableProps {
-  nodes: LogsScrollingTableMessageFragment[];
+  nodes?: LogsScrollingTableMessageFragment[];
 }
 
 interface ILogsScrollingTableSizedProps extends ILogsScrollingTableProps {
@@ -106,7 +106,7 @@ class LogsScrollingTableSized extends React.Component<
     defaultHeight: 30,
     fixedWidth: true,
     keyMapper: (rowIndex: number, columnIndex: number) =>
-      `${this.props.nodes[rowIndex].message}:${columnIndex}`
+      `${this.props.nodes && this.props.nodes[rowIndex].message}:${columnIndex}`
   });
 
   isAtBottomOrZero: boolean = true;
@@ -177,6 +177,8 @@ class LogsScrollingTableSized extends React.Component<
     key,
     style
   }: GridCellProps) => {
+    if (!this.props.nodes) return;
+
     const node = this.props.nodes[rowIndex];
     const width = this.columnWidth({ index: columnIndex });
 
@@ -217,9 +219,12 @@ class LogsScrollingTableSized extends React.Component<
   };
 
   noContentRenderer = () => {
-    return (
-      <NonIdealState icon={IconNames.CONSOLE} title="No logs to display" />
-    );
+    if (this.props.nodes) {
+      return (
+        <NonIdealState icon={IconNames.CONSOLE} title="No logs to display" />
+      );
+    }
+    return <span />;
   };
 
   columnWidth = ({ index }: { index: number }) => {
@@ -248,7 +253,7 @@ class LogsScrollingTableSized extends React.Component<
           autoContainerWidth={true}
           deferredMeasurementCache={this.cache}
           rowHeight={this.cache.rowHeight}
-          rowCount={this.props.nodes.length}
+          rowCount={this.props.nodes ? this.props.nodes.length : 0}
           noContentRenderer={this.noContentRenderer}
           overscanColumnCount={0}
           overscanRowCount={20}

--- a/js_modules/dagit/src/runs/PipelineRun.tsx
+++ b/js_modules/dagit/src/runs/PipelineRun.tsx
@@ -171,7 +171,7 @@ export class PipelineRun extends React.Component<
     const { client, run } = this.props;
     const { logsFilter, logsVW, highlightedError } = this.state;
 
-    const logs = run ? run.logs.nodes : [];
+    const logs = run ? run.logs.nodes : undefined;
     const executionPlan: PipelineRunFragment_executionPlan = run
       ? run.executionPlan
       : { __typename: "ExecutionPlan", steps: [] };
@@ -204,7 +204,7 @@ export class PipelineRun extends React.Component<
           mutation={REEXECUTE_STEP_MUTATION}
         >
           {reexecuteMutation => (
-            <RunMetadataProvider logs={logs}>
+            <RunMetadataProvider logs={logs || []}>
               {metadata => (
                 <ExecutionPlan
                   runMetadata={metadata}

--- a/js_modules/dagit/src/runs/PipelineRun.tsx
+++ b/js_modules/dagit/src/runs/PipelineRun.tsx
@@ -10,23 +10,28 @@ import LogsFilterProvider, {
 import LogsScrollingTable from "./LogsScrollingTable";
 import {
   PipelineRunFragment,
-  PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent
+  PipelineRunFragment_logs_nodes_ExecutionStepFailureEvent,
+  PipelineRunFragment_executionPlan
 } from "./types/PipelineRunFragment";
 import { PanelDivider } from "../PanelDivider";
 import PythonErrorInfo from "../PythonErrorInfo";
 import ExecutionPlan from "../ExecutionPlan";
 import RunMetadataProvider from "../RunMetadataProvider";
 import LogsToolbar from "./LogsToolbar";
-import { Mutation, MutationFn } from "react-apollo";
+import { Mutation, MutationFn, ApolloConsumer } from "react-apollo";
 import {
   HANDLE_START_EXECUTION_FRAGMENT,
   handleStartExecutionResult
 } from "./RunUtils";
 import { ReexecuteStep, ReexecuteStepVariables } from "./types/ReexecuteStep";
 import { ReexecutionConfig } from "src/types/globalTypes";
+import RunSubscriptionProvider from "./RunSubscriptionProvider";
+import { RunStatusToPageAttributes } from "./RunStatusToPageAttributes";
+import ApolloClient from "apollo-client";
 
 interface IPipelineRunProps {
-  run: PipelineRunFragment;
+  client: ApolloClient<any>;
+  run?: PipelineRunFragment;
 }
 
 interface IPipelineRunState {
@@ -42,6 +47,9 @@ export class PipelineRun extends React.Component<
   static fragments = {
     PipelineRunFragment: gql`
       fragment PipelineRunFragment on PipelineRun {
+        ...RunStatusPipelineRunFragment
+        ...RunSubscriptionPipelineRunFragment
+
         config
         runId
         pipeline {
@@ -82,10 +90,12 @@ export class PipelineRun extends React.Component<
         }
       }
 
-      ${RunMetadataProvider.fragments.RunMetadataProviderMessageFragment}
       ${ExecutionPlan.fragments.ExecutionPlanFragment}
       ${LogsFilterProvider.fragments.LogsFilterProviderMessageFragment}
       ${LogsScrollingTable.fragments.LogsScrollingTableMessageFragment}
+      ${RunStatusToPageAttributes.fragments.RunStatusPipelineRunFragment}
+      ${RunMetadataProvider.fragments.RunMetadataProviderMessageFragment}
+      ${RunSubscriptionProvider.fragments.RunSubscriptionPipelineRunFragment}
     `,
     PipelineRunPipelineRunEventFragment: gql`
       fragment PipelineRunPipelineRunEventFragment on PipelineRunEvent {
@@ -107,7 +117,10 @@ export class PipelineRun extends React.Component<
   };
 
   onShowStateDetails = (step: string) => {
-    const errorNode = this.props.run.logs.nodes.find(
+    const { run } = this.props;
+    if (!run) return;
+
+    const errorNode = run.logs.nodes.find(
       node =>
         node.__typename === "ExecutionStepFailureEvent" &&
         node.step != null &&
@@ -124,7 +137,7 @@ export class PipelineRun extends React.Component<
     stepName: string
   ) => {
     const { run } = this.props;
-
+    if (!run) return;
     const step = run.executionPlan.steps.find(s => s.key === stepName);
     if (!step) return;
 
@@ -155,13 +168,21 @@ export class PipelineRun extends React.Component<
   };
 
   render() {
+    const { client, run } = this.props;
     const { logsFilter, logsVW, highlightedError } = this.state;
-    const { logs } = this.props.run;
+
+    const logs = run ? run.logs.nodes : [];
+    const executionPlan: PipelineRunFragment_executionPlan = run
+      ? run.executionPlan
+      : { __typename: "ExecutionPlan", steps: [] };
 
     return (
       <PipelineRunWrapper>
+        {run && <RunSubscriptionProvider client={client} run={run} />}
+        {run && <RunStatusToPageAttributes run={run} />}
+
         <LogsContainer style={{ width: `${logsVW}vw` }}>
-          <LogsFilterProvider filter={logsFilter} nodes={logs.nodes}>
+          <LogsFilterProvider filter={logsFilter} nodes={logs}>
             {({ filteredNodes, busy }) => (
               <>
                 <LogsToolbar
@@ -183,11 +204,11 @@ export class PipelineRun extends React.Component<
           mutation={REEXECUTE_STEP_MUTATION}
         >
           {reexecuteMutation => (
-            <RunMetadataProvider logs={logs.nodes}>
+            <RunMetadataProvider logs={logs}>
               {metadata => (
                 <ExecutionPlan
                   runMetadata={metadata}
-                  executionPlan={this.props.run.executionPlan}
+                  executionPlan={executionPlan}
                   onShowStateDetails={this.onShowStateDetails}
                   onReexecuteStep={stepName =>
                     this.onReexecuteStep(reexecuteMutation, stepName)
@@ -249,4 +270,43 @@ const REEXECUTE_STEP_MUTATION = gql`
   }
 
   ${HANDLE_START_EXECUTION_FRAGMENT}
+`;
+
+export const PIPELINE_RUN_LOGS_UPDATE_FRAGMENT = gql`
+  fragment PipelineRunLogsUpdateFragment on PipelineRun {
+    runId
+    status
+    ...PipelineRunFragment
+    logs {
+      nodes {
+        ...PipelineRunPipelineRunEventFragment
+      }
+    }
+  }
+
+  ${PipelineRun.fragments.PipelineRunFragment}
+  ${PipelineRun.fragments.PipelineRunPipelineRunEventFragment}
+`;
+
+export const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
+  subscription PipelineRunLogsSubscription($runId: ID!, $after: Cursor) {
+    pipelineRunLogs(runId: $runId, after: $after) {
+      __typename
+      ... on PipelineRunLogsSubscriptionSuccess {
+        messages {
+          ... on MessageEvent {
+            run {
+              runId
+            }
+          }
+          ...PipelineRunPipelineRunEventFragment
+        }
+      }
+      ... on PipelineRunLogsSubscriptionMissingRunIdFailure {
+        missingRunId
+      }
+    }
+  }
+
+  ${PipelineRun.fragments.PipelineRunPipelineRunEventFragment}
 `;

--- a/js_modules/dagit/src/runs/RunStatusToPageAttributes.tsx
+++ b/js_modules/dagit/src/runs/RunStatusToPageAttributes.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { PipelineRunStatus } from "../types/globalTypes";
+import { RunStatusPipelineRunFragment } from "./types/RunStatusPipelineRunFragment";
+import gql from "graphql-tag";
 
 const link = (document.querySelector("link[rel*='icon']") ||
   document.createElement("link")) as HTMLLinkElement;
@@ -16,11 +18,21 @@ const FaviconsForStatus = {
   [PipelineRunStatus.SUCCESS]: "/favicon_success.ico"
 };
 
-export class PipelineStatusToPageAttributes extends React.Component<{
-  pipelineName: string;
-  runId: string;
-  status: PipelineRunStatus;
+export class RunStatusToPageAttributes extends React.Component<{
+  run: RunStatusPipelineRunFragment;
 }> {
+  static fragments = {
+    RunStatusPipelineRunFragment: gql`
+      fragment RunStatusPipelineRunFragment on PipelineRun {
+        runId
+        status
+        pipeline {
+          name
+        }
+      }
+    `
+  };
+
   componentDidMount() {
     this.updatePageAttributes();
   }
@@ -35,10 +47,10 @@ export class PipelineStatusToPageAttributes extends React.Component<{
   }
 
   updatePageAttributes() {
-    const { status, pipelineName, runId } = this.props;
+    const { status, pipeline, runId } = this.props.run;
 
-    title.textContent = `${pipelineName} ${runId} [${status}]`;
-    link.href = FaviconsForStatus[this.props.status] || "/favicon.ico";
+    title.textContent = `${pipeline.name} ${runId} [${status}]`;
+    link.href = FaviconsForStatus[status] || "/favicon.ico";
   }
 
   render() {

--- a/js_modules/dagit/src/runs/types/PipelineRunFragment.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { LogLevel, StepKind } from "./../../types/globalTypes";
+import { PipelineRunStatus, LogLevel, StepKind } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: PipelineRunFragment
@@ -11,6 +11,11 @@ import { LogLevel, StepKind } from "./../../types/globalTypes";
 export interface PipelineRunFragment_pipeline {
   __typename: "Pipeline";
   name: string;
+}
+
+export interface PipelineRunFragment_logs_pageInfo {
+  __typename: "PageInfo";
+  lastCursor: any | null;
 }
 
 export interface PipelineRunFragment_logs_nodes_LogMessageEvent_step {
@@ -99,6 +104,7 @@ export type PipelineRunFragment_logs_nodes = PipelineRunFragment_logs_nodes_LogM
 
 export interface PipelineRunFragment_logs {
   __typename: "LogMessageConnection";
+  pageInfo: PipelineRunFragment_logs_pageInfo;
   nodes: PipelineRunFragment_logs_nodes[];
 }
 
@@ -145,9 +151,10 @@ export interface PipelineRunFragment_executionPlan {
 
 export interface PipelineRunFragment {
   __typename: "PipelineRun";
-  config: string;
   runId: string;
+  status: PipelineRunStatus;
   pipeline: PipelineRunFragment_pipeline;
   logs: PipelineRunFragment_logs;
+  config: string;
   executionPlan: PipelineRunFragment_executionPlan;
 }

--- a/js_modules/dagit/src/runs/types/PipelineRunLogsUpdateFragment.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunLogsUpdateFragment.ts
@@ -13,6 +13,11 @@ export interface PipelineRunLogsUpdateFragment_pipeline {
   name: string;
 }
 
+export interface PipelineRunLogsUpdateFragment_logs_pageInfo {
+  __typename: "PageInfo";
+  lastCursor: any | null;
+}
+
 export interface PipelineRunLogsUpdateFragment_logs_nodes_LogMessageEvent_step {
   __typename: "ExecutionStep";
   name: string;
@@ -99,6 +104,7 @@ export type PipelineRunLogsUpdateFragment_logs_nodes = PipelineRunLogsUpdateFrag
 
 export interface PipelineRunLogsUpdateFragment_logs {
   __typename: "LogMessageConnection";
+  pageInfo: PipelineRunLogsUpdateFragment_logs_pageInfo;
   nodes: PipelineRunLogsUpdateFragment_logs_nodes[];
 }
 
@@ -147,8 +153,8 @@ export interface PipelineRunLogsUpdateFragment {
   __typename: "PipelineRun";
   runId: string;
   status: PipelineRunStatus;
-  config: string;
   pipeline: PipelineRunLogsUpdateFragment_pipeline;
   logs: PipelineRunLogsUpdateFragment_logs;
+  config: string;
   executionPlan: PipelineRunLogsUpdateFragment_executionPlan;
 }

--- a/js_modules/dagit/src/runs/types/PipelineRunRootQuery.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunRootQuery.ts
@@ -12,6 +12,11 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRunNotFoundErro
   __typename: "PipelineRunNotFoundError";
 }
 
+export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_pipeline {
+  __typename: "Pipeline";
+  name: string;
+}
+
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs_pageInfo {
   __typename: "PageInfo";
   lastCursor: any | null;
@@ -107,11 +112,6 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs {
   nodes: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs_nodes[];
 }
 
-export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_pipeline {
-  __typename: "Pipeline";
-  name: string;
-}
-
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps_solid {
   __typename: "Solid";
   name: string;
@@ -157,9 +157,9 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun {
   __typename: "PipelineRun";
   runId: string;
   status: PipelineRunStatus;
+  pipeline: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_pipeline;
   logs: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_logs;
   config: string;
-  pipeline: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_pipeline;
   executionPlan: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan;
 }
 

--- a/js_modules/dagit/src/runs/types/RunStatusPipelineRunFragment.ts
+++ b/js_modules/dagit/src/runs/types/RunStatusPipelineRunFragment.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { PipelineRunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: RunStatusPipelineRunFragment
+// ====================================================
+
+export interface RunStatusPipelineRunFragment_pipeline {
+  __typename: "Pipeline";
+  name: string;
+}
+
+export interface RunStatusPipelineRunFragment {
+  __typename: "PipelineRun";
+  runId: string;
+  status: PipelineRunStatus;
+  pipeline: RunStatusPipelineRunFragment_pipeline;
+}

--- a/js_modules/dagit/src/runs/types/RunSubscriptionPipelineRunFragment.ts
+++ b/js_modules/dagit/src/runs/types/RunSubscriptionPipelineRunFragment.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: RunSubscriptionPipelineRunFragment
+// ====================================================
+
+export interface RunSubscriptionPipelineRunFragment_logs_pageInfo {
+  __typename: "PageInfo";
+  lastCursor: any | null;
+}
+
+export interface RunSubscriptionPipelineRunFragment_logs {
+  __typename: "LogMessageConnection";
+  pageInfo: RunSubscriptionPipelineRunFragment_logs_pageInfo;
+}
+
+export interface RunSubscriptionPipelineRunFragment {
+  __typename: "PipelineRun";
+  runId: string;
+  logs: RunSubscriptionPipelineRunFragment_logs;
+}


### PR DESCRIPTION
This PR allows the PipelineRunContainer to display with `run=undefined` before the run has been loaded. This means that the UI shows immediately and there aren't any full-screen loading indicators when opening a run.

Videos below are intentionally running ~6x slower than normal. The right sidebar width changing is just when the video loops. Unfortunately we can't get rid of the initial flicker when the tab is opened and the page hasn't loaded yet, but this makes it a lot less 'jumpy'

Edit: I've also removed the "No logs to display" loading state that appears briefly in the `After` video. Ideally dagit will be reliably fast enough that no loading state should be necessary there and having it be blank while the data is fetched should be fine. (And then subsequently it'd show "No logs" if the result was `[]`)

Before:
![Before-660](https://user-images.githubusercontent.com/1037212/56007550-00cc2100-5c8e-11e9-93d5-35547f759827.gif)

After:
![After-650](https://user-images.githubusercontent.com/1037212/56007567-06296b80-5c8e-11e9-92cc-8a95c41dcad2.gif)