### PR TITLE
Truncate step names as necessary in the execution plan view, add tooltips

### DIFF
--- a/js_modules/dagit/src/ExecutionPlanBox.tsx
+++ b/js_modules/dagit/src/ExecutionPlanBox.tsx
@@ -122,7 +122,7 @@ export class ExecutionPlanBox extends React.Component<
                 />
               )}
             </ExeuctionStateWrap>
-            <ExecutionPlanBoxName>{name}</ExecutionPlanBoxName>
+            <ExecutionPlanBoxName title={name}>{name}</ExecutionPlanBoxName>
             {elapsed !== undefined && <ExecutionTime elapsed={elapsed} />}
           </ExecutionPlanBoxContainer>
           {onReexecuteStep &&
@@ -191,7 +191,7 @@ const ExecutionTime = ({ elapsed }: { elapsed: number }) => {
 const ReExecuteContainer = styled.div`
   display: inline-block;
   border: 1px solid white;
-  margin-left: 5px;
+  margin: 0 5px 0 3px;
   border-radius: 13px;
   width: 19px;
   height: 19px;
@@ -206,6 +206,8 @@ const ExecutionTimeContainer = styled.div`
 
 const ExecutionPlanBoxName = styled.div`
   font-weight: 500;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 const ExecutionFinishedFlash = styled.div<{ success: boolean }>`

--- a/js_modules/dagit/src/ExecutionPlanBox.tsx
+++ b/js_modules/dagit/src/ExecutionPlanBox.tsx
@@ -118,6 +118,7 @@ export class ExecutionPlanBox extends React.Component<
               ) : (
                 <ExecutionStateDot
                   state={state}
+                  title={`${state[0].toUpperCase()}${state.substr(1)}`}
                   style={{ transitionDelay: `${delay}ms` }}
                 />
               )}
@@ -129,6 +130,7 @@ export class ExecutionPlanBox extends React.Component<
             [IStepState.FAILED, IStepState.SUCCEEDED].includes(state) && (
               <ReExecuteContainer
                 className="reexecute"
+                title="Re-run just this step with existing configuration."
                 onClick={() => onReexecuteStep(name)}
               >
                 <Icon icon={IconNames.PLAY} iconSize={15} />


### PR DESCRIPTION
Tiny PR that causes the steps to ellipsis nicely here. You can hover over them to get the full text in a tooltip.

Edit: I also added #1221 to this PR.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/1037212/56008126-f6128b80-5c8f-11e9-959f-fd310135b4b3.png">
