### PR TITLE
block reexecution for when not persisting artifacts

### DIFF
--- a/js_modules/dagit/src/ExecutionPlan.tsx
+++ b/js_modules/dagit/src/ExecutionPlan.tsx
@@ -44,6 +44,7 @@ export default class ExecutionPlan extends React.PureComponent<
           }
           kind
         }
+        artifactsPersisted
       }
     `
   };
@@ -123,6 +124,7 @@ export default class ExecutionPlan extends React.PureComponent<
                 onShowStateDetails={onShowStateDetails}
                 onApplyStepFilter={onApplyStepFilter}
                 onReexecuteStep={onReexecuteStep}
+                executionArtifactsPersisted={executionPlan.artifactsPersisted}
                 delay={delay}
               />
             );

--- a/js_modules/dagit/src/execute/ExecutionStartButton.tsx
+++ b/js_modules/dagit/src/execute/ExecutionStartButton.tsx
@@ -49,7 +49,6 @@ export default class ExecutionStartButton extends React.Component<
     return (
       <WebsocketStatusContext.Consumer>
         {websocketStatus => {
-          console.log("rendering start button");
           if (websocketStatus !== WebSocket.OPEN) {
             return (
               <Wrapper

--- a/js_modules/dagit/src/execute/types/PreviewConfigQuery.ts
+++ b/js_modules/dagit/src/execute/types/PreviewConfigQuery.ts
@@ -67,6 +67,7 @@ export interface PreviewConfigQuery_executionPlan_ExecutionPlan_steps {
 export interface PreviewConfigQuery_executionPlan_ExecutionPlan {
   __typename: "ExecutionPlan";
   steps: PreviewConfigQuery_executionPlan_ExecutionPlan_steps[];
+  artifactsPersisted: boolean;
 }
 
 export interface PreviewConfigQuery_executionPlan_PipelineNotFoundError {

--- a/js_modules/dagit/src/execute/types/RunPreviewExecutionPlanResultFragment.ts
+++ b/js_modules/dagit/src/execute/types/RunPreviewExecutionPlanResultFragment.ts
@@ -27,6 +27,7 @@ export interface RunPreviewExecutionPlanResultFragment_ExecutionPlan_steps {
 export interface RunPreviewExecutionPlanResultFragment_ExecutionPlan {
   __typename: "ExecutionPlan";
   steps: RunPreviewExecutionPlanResultFragment_ExecutionPlan_steps[];
+  artifactsPersisted: boolean;
 }
 
 export interface RunPreviewExecutionPlanResultFragment_PipelineNotFoundError {

--- a/js_modules/dagit/src/runs/PipelineRun.tsx
+++ b/js_modules/dagit/src/runs/PipelineRun.tsx
@@ -174,7 +174,7 @@ export class PipelineRun extends React.Component<
     const logs = run ? run.logs.nodes : undefined;
     const executionPlan: PipelineRunFragment_executionPlan = run
       ? run.executionPlan
-      : { __typename: "ExecutionPlan", steps: [] };
+      : { __typename: "ExecutionPlan", steps: [], artifactsPersisted: false };
 
     return (
       <PipelineRunWrapper>

--- a/js_modules/dagit/src/runs/types/PipelineRunFragment.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunFragment.ts
@@ -147,6 +147,7 @@ export interface PipelineRunFragment_executionPlan_steps {
 export interface PipelineRunFragment_executionPlan {
   __typename: "ExecutionPlan";
   steps: PipelineRunFragment_executionPlan_steps[];
+  artifactsPersisted: boolean;
 }
 
 export interface PipelineRunFragment {

--- a/js_modules/dagit/src/runs/types/PipelineRunLogsUpdateFragment.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunLogsUpdateFragment.ts
@@ -147,6 +147,7 @@ export interface PipelineRunLogsUpdateFragment_executionPlan_steps {
 export interface PipelineRunLogsUpdateFragment_executionPlan {
   __typename: "ExecutionPlan";
   steps: PipelineRunLogsUpdateFragment_executionPlan_steps[];
+  artifactsPersisted: boolean;
 }
 
 export interface PipelineRunLogsUpdateFragment {

--- a/js_modules/dagit/src/runs/types/PipelineRunRootQuery.ts
+++ b/js_modules/dagit/src/runs/types/PipelineRunRootQuery.ts
@@ -151,6 +151,7 @@ export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPl
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan {
   __typename: "ExecutionPlan";
   steps: PipelineRunRootQuery_pipelineRunOrError_PipelineRun_executionPlan_steps[];
+  artifactsPersisted: boolean;
 }
 
 export interface PipelineRunRootQuery_pipelineRunOrError_PipelineRun {

--- a/js_modules/dagit/src/schema.graphql
+++ b/js_modules/dagit/src/schema.graphql
@@ -104,6 +104,7 @@ input ExecutionMetadata {
 type ExecutionPlan {
   steps: [ExecutionStep!]!
   pipeline: Pipeline!
+  artifactsPersisted: Boolean!
 }
 
 union ExecutionPlanResult = ExecutionPlan | PipelineConfigValidationInvalid | PipelineNotFoundError

--- a/js_modules/dagit/src/types/ExecutionPlanFragment.ts
+++ b/js_modules/dagit/src/types/ExecutionPlanFragment.ts
@@ -23,4 +23,5 @@ export interface ExecutionPlanFragment_steps {
 export interface ExecutionPlanFragment {
   __typename: "ExecutionPlan";
   steps: ExecutionPlanFragment_steps[];
+  artifactsPersisted: boolean;
 }

--- a/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
@@ -12,6 +12,7 @@ class DauphinExecutionPlan(dauphin.ObjectType):
 
     steps = dauphin.non_null_list('ExecutionStep')
     pipeline = dauphin.NonNull('Pipeline')
+    artifactsPersisted = dauphin.NonNull(dauphin.Boolean)
 
     def __init__(self, pipeline, execution_plan):
         super(DauphinExecutionPlan, self).__init__(pipeline=pipeline)
@@ -22,6 +23,9 @@ class DauphinExecutionPlan(dauphin.ObjectType):
             DauphinExecutionStep(self._execution_plan, step)
             for step in self._execution_plan.topological_steps()
         ]
+
+    def resolve_artifactsPersisted(self, _graphene_info):
+        return self._execution_plan.artifacts_persisted
 
 
 class DauphinExecutionStepOutput(dauphin.ObjectType):

--- a/python_modules/dagster/dagster/core/execution_plan/objects.py
+++ b/python_modules/dagster/dagster/core/execution_plan/objects.py
@@ -191,8 +191,10 @@ class ExecutionValueSubplan(
         return ExecutionValueSubplan([], terminal_step_output_handle)
 
 
-class ExecutionPlan(namedtuple('_ExecutionPlan', 'pipeline_def step_dict, deps, steps')):
-    def __new__(cls, pipeline_def, step_dict, deps):
+class ExecutionPlan(
+    namedtuple('_ExecutionPlan', 'pipeline_def step_dict deps steps artifacts_persisted')
+):
+    def __new__(cls, pipeline_def, step_dict, deps, artifacts_persisted):
         return super(ExecutionPlan, cls).__new__(
             cls,
             pipeline_def=check.inst_param(pipeline_def, 'pipeline_def', PipelineDefinition),
@@ -201,6 +203,7 @@ class ExecutionPlan(namedtuple('_ExecutionPlan', 'pipeline_def step_dict, deps, 
             ),
             deps=check.dict_param(deps, 'deps', key_type=str, value_type=set),
             steps=list(step_dict.values()),
+            artifacts_persisted=check.bool_param(artifacts_persisted, 'artifacts_persisted'),
         )
 
     def get_step_output(self, step_output_handle):

--- a/python_modules/dagster/dagster/core/runs.py
+++ b/python_modules/dagster/dagster/core/runs.py
@@ -54,6 +54,11 @@ class RunStorage(six.with_metaclass(ABCMeta)):  # pylint: disable=no-init
     def nuke(self):
         pass
 
+    @property
+    @abstractmethod
+    def is_persistent(self):
+        pass
+
 
 class FileSystemRunStorage(RunStorage):
     def __init__(self, base_dir=None):
@@ -105,6 +110,10 @@ class FileSystemRunStorage(RunStorage):
     def nuke(self):
         shutil.rmtree(self._base_dir)
 
+    @property
+    def is_persistent(self):
+        return True
+
 
 class InMemoryRunStorage(RunStorage):
     def __init__(self):
@@ -126,6 +135,10 @@ class InMemoryRunStorage(RunStorage):
 
     def nuke(self):
         self._run_metas = OrderedDict()
+
+    @property
+    def is_persistent(self):
+        return False
 
 
 class RunStorageMode(Enum):


### PR DESCRIPTION
add `artifactsPersisted` to `ExecutionPlan`
change `s3` storage mode to use `FileSystemRunStorage`
make dagit aware of this and disable reexecution with helpful tooltip

resolves #1209