### PR TITLE
Copy materialization paths to clipboard rather than opening

### DIFF
--- a/js_modules/dagit/src/Materialization.tsx
+++ b/js_modules/dagit/src/Materialization.tsx
@@ -13,13 +13,10 @@ function isFilePath(url: string) {
   return url.startsWith("file://") || url.startsWith("/");
 }
 export class Materialization extends React.Component<MaterializationProps> {
-  onCopyPath = async (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault();
-
-    const url = event.currentTarget.getAttribute("href") || "";
+  onCopyPath = async (path: string) => {
     const el = document.createElement("input");
     document.body.appendChild(el);
-    el.value = url;
+    el.value = path;
     el.select();
     document.execCommand("copy");
     el.remove();
@@ -37,10 +34,13 @@ export class Materialization extends React.Component<MaterializationProps> {
     if (isFilePath(fileLocation)) {
       return (
         <MaterializationLink
-          onClick={this.onCopyPath}
           href={fileLocation}
           key={fileLocation}
           title={`Copy path to ${fileLocation}`}
+          onClick={e => {
+            e.preventDefault();
+            this.onCopyPath(fileLocation);
+          }}
         >
           {FileIcon} {fileName}
         </MaterializationLink>

--- a/js_modules/dagit/src/Materialization.tsx
+++ b/js_modules/dagit/src/Materialization.tsx
@@ -1,88 +1,59 @@
 import * as React from "react";
 import styled from "styled-components";
-import { ROOT_SERVER_URI } from "./Util";
-import { Colors, Spinner } from "@blueprintjs/core";
+import { Toaster, Colors, Position, Intent } from "@blueprintjs/core";
 
-function fileLocationToHref(location: string) {
-  if (location.startsWith("/")) {
-    return `file://${location}`;
-  }
-  return location;
-}
+const SharedToaster = Toaster.create({ position: Position.TOP }, document.body);
 
 interface MaterializationProps {
   fileLocation: string;
   fileName: string;
 }
-interface MaterializationState {
-  opening: boolean;
+
+function isFilePath(url: string) {
+  return url.startsWith("file://") || url.startsWith("/");
 }
+export class Materialization extends React.Component<MaterializationProps> {
+  onCopyPath = async (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
 
-export class Materialization extends React.Component<
-  MaterializationProps,
-  MaterializationState
-> {
-  state = {
-    opening: false
-  };
+    const url = event.currentTarget.getAttribute("href") || "";
+    const el = document.createElement("input");
+    document.body.appendChild(el);
+    el.value = url;
+    el.select();
+    document.execCommand("copy");
+    el.remove();
 
-  _openingTimeout?: NodeJS.Timeout;
-
-  componentWillUnmount() {
-    if (this._openingTimeout) {
-      clearTimeout(this._openingTimeout);
-    }
-  }
-
-  onOpenFileLink = async (event: React.MouseEvent<HTMLAnchorElement>) => {
-    const url = event.currentTarget.href;
-
-    // If the file's location is a path, tell dagit to open it on the machine.
-    if (url.startsWith("file://")) {
-      event.preventDefault();
-
-      // Display a loading spinner to give Dagit and the file handler (eg: jupyter notebooks)
-      // time to open the file. Otherwise the user might just think its not working. Just
-      // set to an arbitrary amount of time - jupyter is slow.
-      this.setState({ opening: true });
-      this._openingTimeout = setTimeout(() => {
-        this.setState({ opening: false });
-      }, 2000);
-
-      const path = url.replace("file://", "");
-      const result = await fetch(
-        `${ROOT_SERVER_URI}/dagit/open?path=${encodeURIComponent(path)}`
-      );
-
-      if (result.status !== 200) {
-        const error = await result.text();
-        this.setState({ opening: false });
-        alert(`Dagit was unable to open the file.\n\n${error}`);
-      }
-    } else {
-      // If the file's location is a URL, allow the browser to open it normally.
-    }
+    SharedToaster.show({
+      message: "File path copied to clipboard",
+      icon: "clipboard",
+      intent: Intent.NONE
+    });
   };
 
   render() {
     const { fileLocation, fileName } = this.props;
 
+    if (isFilePath(fileLocation)) {
+      return (
+        <MaterializationLink
+          onClick={this.onCopyPath}
+          href={fileLocation}
+          key={fileLocation}
+          title={`Copy path to ${fileLocation}`}
+        >
+          {FileIcon} {fileName}
+        </MaterializationLink>
+      );
+    }
     return (
       <MaterializationLink
-        onClick={this.onOpenFileLink}
-        href={fileLocationToHref(fileLocation)}
+        href={fileLocation}
         key={fileLocation}
-        title={fileLocation}
+        title={`Open ${fileLocation} in a new tab`}
         target="__blank"
       >
-        {this.state.opening ? (
-          <span style={{ paddingLeft: 3, paddingRight: 3 }}>
-            <Spinner size={14} />
-          </span>
-        ) : (
-          FileIcon
-        )}{" "}
-        {fileName}
+        {LinkIcon} {fileName}
       </MaterializationLink>
     );
   }
@@ -120,6 +91,17 @@ const FileIcon = (
         stroke={Colors.GRAY3}
         strokeWidth="15"
         strokeLinecap="square"
+      />
+    </g>
+  </svg>
+);
+
+const LinkIcon = (
+  <svg width="20px" height="14px" viewBox="-300 -100 1200 1200" version="1.1">
+    <g>
+      <path
+        fill={Colors.GRAY5}
+        d="M568.2,644.1c-54.4,0-108.7-20.7-150.1-62.1c-11.2-11.2-11.2-29.5,0-40.8c11.2-11.2,29.5-11.2,40.8,0c60.3,60.3,158.4,60.3,218.7,0l209.6-209.6c60.3-60.3,60.3-158.4,0-218.7c-60.3-60.3-158.4-60.3-218.7,0L491.6,289.7c-11.2,11.2-29.5,11.2-40.8,0c-11.2-11.2-11.2-29.5,0-40.8L627.7,72.1c82.8-82.8,217.5-82.8,300.2,0c82.7,82.8,82.8,217.5,0,300.2L718.3,582C676.9,623.4,622.5,644.1,568.2,644.1L568.2,644.1L568.2,644.1z M222.2,990c-54.4,0-108.7-20.7-150.1-62.1c-82.8-82.8-82.8-217.5,0-300.2L281.7,418c82.8-82.8,217.5-82.8,300.2,0c11.2,11.2,11.2,29.5,0,40.8c-11.2,11.2-29.5,11.2-40.8,0c-60.3-60.3-158.4-60.3-218.7,0L112.9,668.4c-60.3,60.3-60.3,158.4,0,218.7c60.3,60.3,158.4,60.3,218.7,0l176.9-176.9c11.2-11.2,29.5-11.2,40.8,0c11.2,11.2,11.2,29.5,0,40.8L372.3,927.9C330.9,969.3,276.6,990,222.2,990L222.2,990L222.2,990z"
       />
     </g>
   </svg>

--- a/python_modules/dagit/dagit_tests/test_smoke.py
+++ b/python_modules/dagit/dagit_tests/test_smoke.py
@@ -28,19 +28,6 @@ def test_smoke_app():
     assert len(data['errors']) == 1
     assert data['errors'][0]['message'] == 'Must provide query string.'
 
-    result = client.post('/dagit/open', data={'path': 'foo.bar'})
-    assert result.status_code == 405
-    assert '405 Method Not Allowed' in result.data.decode('utf-8')
-
-    result = client.get('/dagit/open', data={'path': 'foo.bar'})
-    assert result.status_code == 400
-    assert result.data.decode('utf-8') == 'Must provide path to a file.'
-
-    # FIXME this doesn't work on python 27
-    # result = client.get('/dagit/open?path=foo.bar')
-    # assert result.status_code == 400
-    # assert 'does not exist' in result.data.decode('utf-8')
-
     result = client.get('/dagit/notebook?path=foo.bar')
     assert result.status_code == 400
     assert result.data.decode('utf-8') == 'Invalid Path'

--- a/python_modules/dagster/docs/sections/community/release_notes.rst
+++ b/python_modules/dagster/docs/sections/community/release_notes.rst
@@ -51,7 +51,9 @@ milestones in the framework's capability.
 - The execute button is now greyed out when Dagit is offline.
 - The Dagit UI now includes more contextual cues to make the solid in focus and its connections
   more salient.
-
+- Dagit no longer offers to open materializations on your machine. Clicking an on-disk
+  materialization now copies the path to your clipboard.
+ 
 **Dagster-Airflow**
 
 - Dagster-Airflow includes functions to dynamically generate containerized (``DockerOperator``-based)


### PR DESCRIPTION
This PR removes the "use a subprocess to open the file" mess (#1210) so Dagit doesn't attempt to open files. Instead, we:

- For on disk materializations where a file path is provided with no scheme, or with a file:// scheme, we show a file icon and clicking it copies the path to the clipboard.

<img width="255" alt="Screen Shot 2019-04-16 at 12 42 33 AM" src="https://user-images.githubusercontent.com/1037212/56184876-56cbfc00-5fe1-11e9-82c6-afd2a26d3ac8.png">

<img width="402" alt="Screen Shot 2019-04-16 at 12 42 38 AM" src="https://user-images.githubusercontent.com/1037212/56184879-5af81980-5fe1-11e9-928c-4ed5e8d04cc8.png">

- For URL materializations (with https://, http://, ftp://, etc.), clicking the link opens it in a new tab. The icon is also a "link" icon now to differentiate the two click behaviors. (We could make this copy to the clibpoard as well if that's preferable. I figure we'll revisit this more soon.)

<img width="274" alt="Screen Shot 2019-04-16 at 12 42 27 AM" src="https://user-images.githubusercontent.com/1037212/56184873-55023880-5fe1-11e9-9dbb-cb66ed473f69.png">
