### PR TITLE
Bind the start button to Ctrl-Enter

### DIFF
--- a/python_modules/dagster/docs/sections/community/release_notes.rst
+++ b/python_modules/dagster/docs/sections/community/release_notes.rst
@@ -53,7 +53,8 @@ milestones in the framework's capability.
   more salient.
 - Dagit no longer offers to open materializations on your machine. Clicking an on-disk
   materialization now copies the path to your clipboard.
- 
+- Pressing Ctrl-Enter now starts execution in Dagit's Execute tab.
+
 **Dagster-Airflow**
 
 - Dagster-Airflow includes functions to dynamically generate containerized (``DockerOperator``-based)


### PR DESCRIPTION
Nuff said! This is added as a document-level keyboard event and not a React component event handler so the button doesn't need to be the focused element. 