### PR TITLE
Hide `Nothing` dag text, use new type.displayName attribute

### DIFF
--- a/js_modules/dagit/src/execute/types/SolidSelectorQuery.ts
+++ b/js_modules/dagit/src/execute/types/SolidSelectorQuery.ts
@@ -31,7 +31,8 @@ export interface SolidSelectorQuery_pipeline_solids_definition {
 
 export interface SolidSelectorQuery_pipeline_solids_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface SolidSelectorQuery_pipeline_solids_inputs_definition {
@@ -42,7 +43,7 @@ export interface SolidSelectorQuery_pipeline_solids_inputs_definition {
 
 export interface SolidSelectorQuery_pipeline_solids_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface SolidSelectorQuery_pipeline_solids_inputs_dependsOn_definition {
@@ -70,7 +71,8 @@ export interface SolidSelectorQuery_pipeline_solids_inputs {
 
 export interface SolidSelectorQuery_pipeline_solids_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface SolidSelectorQuery_pipeline_solids_outputs_definition_expectations {
@@ -93,7 +95,7 @@ export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy_solid {
 
 export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface SolidSelectorQuery_pipeline_solids_outputs_dependedBy_definition {

--- a/js_modules/dagit/src/graph/SolidNode.tsx
+++ b/js_modules/dagit/src/graph/SolidNode.tsx
@@ -52,14 +52,15 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
           definition {
             name
             type {
-              name
+              displayName
+              isNothing
             }
           }
           dependsOn {
             definition {
               name
               type {
-                name
+                displayName
               }
             }
             solid {
@@ -71,7 +72,8 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
           definition {
             name
             type {
-              name
+              displayName
+              isNothing
             }
             expectations {
               name
@@ -85,7 +87,7 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
             definition {
               name
               type {
-                name
+                displayName
               }
             }
           }
@@ -125,17 +127,19 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
     items: Array<SolidNodeFragment_inputs | SolidNodeFragment_outputs>,
     layout: { [ioName: string]: { layout: ILayout } }
   ) {
+    const { solid, minified, highlightedConnections } = this.props;
+
     return Object.keys(layout).map((key, i) => {
       const { x, y, width, height } = layout[key].layout;
 
       const item = items.find(o => o.definition.name === key);
       if (!item) return <g key={i} />;
 
-      const showText = width == 0 && !this.props.minified;
       const { name, type } = item.definition;
+      const showText = width == 0 && !minified && !type.isNothing;
 
       const connections: Array<{ a: string; b: string }> = [];
-      let title = `${item.definition.name}: ${item.definition.type.name}`;
+      let title = `${name}: ${type.displayName}`;
       let clickTarget: string | null = null;
 
       if ("dependsOn" in item && item.dependsOn) {
@@ -145,7 +149,7 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
         clickTarget = item.dependsOn.solid.name;
         connections.push({
           a: item.dependsOn.solid.name,
-          b: this.props.solid.name
+          b: solid.name
         });
       }
       if ("dependedBy" in item) {
@@ -160,14 +164,14 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
         connections.push(
           ...item.dependedBy.map(o => ({
             a: o.solid.name,
-            b: this.props.solid.name
+            b: solid.name
           }))
         );
       }
 
       const highlighted = connections.some(
         ({ a, b }) =>
-          !!this.props.highlightedConnections.find(
+          !!highlightedConnections.find(
             h => (h.a === a || h.a === b) && (h.b === a || h.b === b)
           )
       );
@@ -205,7 +209,7 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
             {showText && name !== DEFAULT_RESULT_NAME && (
               <SVGMonospaceText text={`${name}:`} fill="#FFF" size={14} />
             )}
-            {showText && type.name && (
+            {showText && type.displayName && (
               <SVGFlowLayoutRect
                 rx={4}
                 ry={4}
@@ -216,7 +220,11 @@ export default class SolidNode extends React.Component<ISolidNodeProps> {
                 spacing={0}
                 padding={4}
               >
-                <SVGMonospaceText text={type.name} size={14} fill="#222" />
+                <SVGMonospaceText
+                  text={type.displayName}
+                  size={14}
+                  fill="#222"
+                />
               </SVGFlowLayoutRect>
             )}
           </SVGFlowLayoutRect>

--- a/js_modules/dagit/src/graph/types/PipelineGraphFragment.ts
+++ b/js_modules/dagit/src/graph/types/PipelineGraphFragment.ts
@@ -31,7 +31,8 @@ export interface PipelineGraphFragment_solids_definition {
 
 export interface PipelineGraphFragment_solids_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface PipelineGraphFragment_solids_inputs_definition {
@@ -42,7 +43,7 @@ export interface PipelineGraphFragment_solids_inputs_definition {
 
 export interface PipelineGraphFragment_solids_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineGraphFragment_solids_inputs_dependsOn_definition {
@@ -70,7 +71,8 @@ export interface PipelineGraphFragment_solids_inputs {
 
 export interface PipelineGraphFragment_solids_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface PipelineGraphFragment_solids_outputs_definition_expectations {
@@ -93,7 +95,7 @@ export interface PipelineGraphFragment_solids_outputs_dependedBy_solid {
 
 export interface PipelineGraphFragment_solids_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineGraphFragment_solids_outputs_dependedBy_definition {

--- a/js_modules/dagit/src/graph/types/PipelineGraphSolidFragment.ts
+++ b/js_modules/dagit/src/graph/types/PipelineGraphSolidFragment.ts
@@ -31,7 +31,8 @@ export interface PipelineGraphSolidFragment_definition {
 
 export interface PipelineGraphSolidFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface PipelineGraphSolidFragment_inputs_definition {
@@ -42,7 +43,7 @@ export interface PipelineGraphSolidFragment_inputs_definition {
 
 export interface PipelineGraphSolidFragment_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineGraphSolidFragment_inputs_dependsOn_definition {
@@ -70,7 +71,8 @@ export interface PipelineGraphSolidFragment_inputs {
 
 export interface PipelineGraphSolidFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface PipelineGraphSolidFragment_outputs_definition_expectations {
@@ -93,7 +95,7 @@ export interface PipelineGraphSolidFragment_outputs_dependedBy_solid {
 
 export interface PipelineGraphSolidFragment_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineGraphSolidFragment_outputs_dependedBy_definition {

--- a/js_modules/dagit/src/graph/types/SolidNodeFragment.ts
+++ b/js_modules/dagit/src/graph/types/SolidNodeFragment.ts
@@ -31,7 +31,8 @@ export interface SolidNodeFragment_definition {
 
 export interface SolidNodeFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface SolidNodeFragment_inputs_definition {
@@ -42,7 +43,7 @@ export interface SolidNodeFragment_inputs_definition {
 
 export interface SolidNodeFragment_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface SolidNodeFragment_inputs_dependsOn_definition {
@@ -70,7 +71,8 @@ export interface SolidNodeFragment_inputs {
 
 export interface SolidNodeFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface SolidNodeFragment_outputs_definition_expectations {
@@ -93,7 +95,7 @@ export interface SolidNodeFragment_outputs_dependedBy_solid {
 
 export interface SolidNodeFragment_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface SolidNodeFragment_outputs_dependedBy_definition {

--- a/js_modules/dagit/src/types/PipelineExplorerFragment.ts
+++ b/js_modules/dagit/src/types/PipelineExplorerFragment.ts
@@ -324,7 +324,8 @@ export interface PipelineExplorerFragment_solids_definition {
 
 export interface PipelineExplorerFragment_solids_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface PipelineExplorerFragment_solids_inputs_definition {
@@ -335,7 +336,7 @@ export interface PipelineExplorerFragment_solids_inputs_definition {
 
 export interface PipelineExplorerFragment_solids_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineExplorerFragment_solids_inputs_dependsOn_definition {
@@ -363,7 +364,8 @@ export interface PipelineExplorerFragment_solids_inputs {
 
 export interface PipelineExplorerFragment_solids_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
+  isNothing: boolean;
 }
 
 export interface PipelineExplorerFragment_solids_outputs_definition_expectations {
@@ -386,7 +388,7 @@ export interface PipelineExplorerFragment_solids_outputs_dependedBy_solid {
 
 export interface PipelineExplorerFragment_solids_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineExplorerFragment_solids_outputs_dependedBy_definition {

--- a/js_modules/dagit/src/types/PipelineExplorerRootQuery.ts
+++ b/js_modules/dagit/src/types/PipelineExplorerRootQuery.ts
@@ -453,9 +453,9 @@ export interface PipelineExplorerRootQuery_pipeline_solids_definition {
 
 export interface PipelineExplorerRootQuery_pipeline_solids_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
-  isNothing: boolean;
   displayName: string;
+  isNothing: boolean;
+  name: string | null;
   description: string | null;
 }
 
@@ -475,7 +475,7 @@ export interface PipelineExplorerRootQuery_pipeline_solids_inputs_definition {
 
 export interface PipelineExplorerRootQuery_pipeline_solids_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineExplorerRootQuery_pipeline_solids_inputs_dependsOn_definition {
@@ -503,9 +503,9 @@ export interface PipelineExplorerRootQuery_pipeline_solids_inputs {
 
 export interface PipelineExplorerRootQuery_pipeline_solids_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
-  isNothing: boolean;
   displayName: string;
+  isNothing: boolean;
+  name: string | null;
   description: string | null;
 }
 
@@ -530,7 +530,7 @@ export interface PipelineExplorerRootQuery_pipeline_solids_outputs_dependedBy_so
 
 export interface PipelineExplorerRootQuery_pipeline_solids_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineExplorerRootQuery_pipeline_solids_outputs_dependedBy_definition {

--- a/js_modules/dagit/src/types/PipelineExplorerSolidFragment.ts
+++ b/js_modules/dagit/src/types/PipelineExplorerSolidFragment.ts
@@ -160,9 +160,9 @@ export interface PipelineExplorerSolidFragment_definition {
 
 export interface PipelineExplorerSolidFragment_inputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
-  isNothing: boolean;
   displayName: string;
+  isNothing: boolean;
+  name: string | null;
   description: string | null;
 }
 
@@ -182,7 +182,7 @@ export interface PipelineExplorerSolidFragment_inputs_definition {
 
 export interface PipelineExplorerSolidFragment_inputs_dependsOn_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineExplorerSolidFragment_inputs_dependsOn_definition {
@@ -210,9 +210,9 @@ export interface PipelineExplorerSolidFragment_inputs {
 
 export interface PipelineExplorerSolidFragment_outputs_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
-  isNothing: boolean;
   displayName: string;
+  isNothing: boolean;
+  name: string | null;
   description: string | null;
 }
 
@@ -237,7 +237,7 @@ export interface PipelineExplorerSolidFragment_outputs_dependedBy_solid {
 
 export interface PipelineExplorerSolidFragment_outputs_dependedBy_definition_type {
   __typename: "RegularRuntimeType" | "ListRuntimeType" | "NullableRuntimeType";
-  name: string | null;
+  displayName: string;
 }
 
 export interface PipelineExplorerSolidFragment_outputs_dependedBy_definition {

--- a/python_modules/dagster/docs/sections/community/release_notes.rst
+++ b/python_modules/dagster/docs/sections/community/release_notes.rst
@@ -54,6 +54,7 @@ milestones in the framework's capability.
 - Dagit no longer offers to open materializations on your machine. Clicking an on-disk
   materialization now copies the path to your clipboard.
 - Pressing Ctrl-Enter now starts execution in Dagit's Execute tab.
+- Dagit properly shows List and Nullable types in the DAG view.
 
 **Dagster-Airflow**
 


### PR DESCRIPTION
Addresses both #1218 and #1256.

(Notice that the snowflake_load output type is shown, and the input is just a dot without any description. We're not collapsing multiple "nothing" inputs yet - I think that'll take a bit more work and incorporation into the actual flow algorithm, but this hides the names + content similar to the way the solid type signature works.)

<img width="449" alt="image" src="https://user-images.githubusercontent.com/1037212/56262971-b2ac8880-60a6-11e9-9ba2-83fffe5dc41c.png">
