### PR TITLE
Revert "[dagster-airflow] upgraded airflow dep"

### DIFF
--- a/python_modules/dagster-airflow/setup.py
+++ b/python_modules/dagster-airflow/setup.py
@@ -51,7 +51,7 @@ def _do_setup(name='dagster-airflow'):
             'future>=0.16.0, <0.17.0a0',  # pin to range for Airflow compat
             'six>=1.11.0',
             # airflow
-            'apache-airflow==1.10.3',
+            'apache-airflow==1.10.2',
             # dagster
             'dagster>=0.2.0',
             # docker api


### PR DESCRIPTION
Reverts dagster-io/dagster#1271, per discussion -- we want to target the oldest compatible Airflow.