### PR TITLE
Use literal em-dash (—) instead of (--) in landing page.

### DIFF
--- a/python_modules/dagster/docs/_templates/layout.html
+++ b/python_modules/dagster/docs/_templates/layout.html
@@ -93,8 +93,8 @@
                     <div class="value_prop_block">
                         <h1>Beautiful Tools</h1>
                         <div class="value_prop_detail">
-                          Dagster's development environment, dagit -- designed for data
-                          engineers, machine learning engineers, data scientists -- enables
+                          Dagster's development environment, dagit — designed for data
+                          engineers, machine learning engineers, data scientists — enables
                           astoundingly productive local development. 
                         </div>
                     </div>
@@ -103,8 +103,8 @@
                         <h1>Flexible and Incremental</h1>
                         <div class="value_prop_detail">
                           Dagster integrates with your existing tools and infrastructure.
-                          Dagster can invoke any computation -- whether it be Spark, a
-                          Python, a Jupyter notebook, or SQL -- and is designed to deploy to
+                          Dagster can invoke any computation — whether it be Spark, a
+                          Python, a Jupyter notebook, or SQL — and is designed to deploy to
                           any workflow engine, such as Airflow.
                         </div>
                     </div>


### PR DESCRIPTION
The page specifies `<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />` already, so we can just use the literal em-dash.

Currently it looks like:

<img width="514" alt="Screenshot 2019-04-23 14 00 36" src="https://user-images.githubusercontent.com/1121581/56615613-4a8f0280-65d0-11e9-8d1e-89abddea0fe7.png">
