### PR TITLE
Fix docs logo placement

### DIFF
--- a/python_modules/dagster/docs/_templates/layout.html
+++ b/python_modules/dagster/docs/_templates/layout.html
@@ -63,11 +63,12 @@
             {% endblock %}
 
             {% if pagename == 'index' %}
-            <div class="logo_img">
-                <img
-                    src="https://user-images.githubusercontent.com/28738937/44878798-b6e17e00-ac5c-11e8-8d25-2e47e5a53418.png" />
-            </div>
             <div class="dagster">
+                <div class="logo_img">
+                    <img
+                        src="https://user-images.githubusercontent.com/28738937/44878798-b6e17e00-ac5c-11e8-8d25-2e47e5a53418.png" />
+                </div>
+
                 <div class="why_dagster">
                     <h1>Why Dagster?</h1>
                     Dagster is a system for building modern data applications. Combining
@@ -83,29 +84,29 @@
                     <div class="value_prop_block">
                         <h1>Elegant Programming Model</h1>
                         <div class="value_prop_detail">
-                          Dagster is a set of abstractions for building self-describing,
-                          testable, and reliable data applications. It embraces the
-                          principles of functional data programming; gradual, optional
-                          typing; and testability as a first-class value. 
+                            Dagster is a set of abstractions for building self-describing,
+                            testable, and reliable data applications. It embraces the
+                            principles of functional data programming; gradual, optional
+                            typing; and testability as a first-class value.
                         </div>
                     </div>
 
                     <div class="value_prop_block">
                         <h1>Beautiful Tools</h1>
                         <div class="value_prop_detail">
-                          Dagster's development environment, dagit — designed for data
-                          engineers, machine learning engineers, data scientists — enables
-                          astoundingly productive local development. 
+                            Dagster's development environment, dagit — designed for data
+                            engineers, machine learning engineers, data scientists — enables
+                            astoundingly productive local development.
                         </div>
                     </div>
 
                     <div class="value_prop_block">
                         <h1>Flexible and Incremental</h1>
                         <div class="value_prop_detail">
-                          Dagster integrates with your existing tools and infrastructure.
-                          Dagster can invoke any computation — whether it be Spark, a
-                          Python, a Jupyter notebook, or SQL — and is designed to deploy to
-                          any workflow engine, such as Airflow.
+                            Dagster integrates with your existing tools and infrastructure.
+                            Dagster can invoke any computation — whether it be Spark, a
+                            Python, a Jupyter notebook, or SQL — and is designed to deploy to
+                            any workflow engine, such as Airflow.
                         </div>
                     </div>
                 </div>

--- a/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
+++ b/python_modules/dagster/docs/snapshots/snap_test_doc_build.py
@@ -1042,11 +1042,12 @@ snapshots['test_build_all_docs 4'] = '''
             
 
             
-            <div class="logo_img">
-                <img
-                    src="https://user-images.githubusercontent.com/28738937/44878798-b6e17e00-ac5c-11e8-8d25-2e47e5a53418.png" />
-            </div>
             <div class="dagster">
+                <div class="logo_img">
+                    <img
+                        src="https://user-images.githubusercontent.com/28738937/44878798-b6e17e00-ac5c-11e8-8d25-2e47e5a53418.png" />
+                </div>
+
                 <div class="why_dagster">
                     <h1>Why Dagster?</h1>
                     Dagster is a system for building modern data applications. Combining
@@ -1062,29 +1063,29 @@ snapshots['test_build_all_docs 4'] = '''
                     <div class="value_prop_block">
                         <h1>Elegant Programming Model</h1>
                         <div class="value_prop_detail">
-                          Dagster is a set of abstractions for building self-describing,
-                          testable, and reliable data applications. It embraces the
-                          principles of functional data programming; gradual, optional
-                          typing; and testability as a first-class value. 
+                            Dagster is a set of abstractions for building self-describing,
+                            testable, and reliable data applications. It embraces the
+                            principles of functional data programming; gradual, optional
+                            typing; and testability as a first-class value.
                         </div>
                     </div>
 
                     <div class="value_prop_block">
                         <h1>Beautiful Tools</h1>
                         <div class="value_prop_detail">
-                          Dagster's development environment, dagit — designed for data
-                          engineers, machine learning engineers, data scientists — enables
-                          astoundingly productive local development. 
+                            Dagster's development environment, dagit — designed for data
+                            engineers, machine learning engineers, data scientists — enables
+                            astoundingly productive local development.
                         </div>
                     </div>
 
                     <div class="value_prop_block">
                         <h1>Flexible and Incremental</h1>
                         <div class="value_prop_detail">
-                          Dagster integrates with your existing tools and infrastructure.
-                          Dagster can invoke any computation — whether it be Spark, a
-                          Python, a Jupyter notebook, or SQL — and is designed to deploy to
-                          any workflow engine, such as Airflow.
+                            Dagster integrates with your existing tools and infrastructure.
+                            Dagster can invoke any computation — whether it be Spark, a
+                            Python, a Jupyter notebook, or SQL — and is designed to deploy to
+                            any workflow engine, such as Airflow.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The dagster logo was placed horizontally different than the text below it because it was outside of the enclosing div. Moved it inside which fixes the issue (also my editor cleaned up some whitespace)