### PR TITLE
Have spark solid use step execution metadata

### DIFF
--- a/python_modules/libraries/dagster-spark/dagster_spark/solids.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/solids.py
@@ -8,6 +8,64 @@ from .types import SparkSolidError
 from .utils import run_spark_subprocess, parse_spark_config
 
 
+def create_spark_shell_cmd(solid_config, main_class):
+    # Extract parameters from config
+    (master_url, deploy_mode, application_jar, spark_conf, application_arguments, spark_home) = [
+        solid_config.get(k)
+        for k in (
+            'master_url',
+            'deploy_mode',
+            'application_jar',
+            'spark_conf',
+            'application_arguments',
+            'spark_home',
+        )
+    ]
+
+    # Let the user use env vars in the jar path
+    application_jar = os.path.expandvars(application_jar)
+
+    if not os.path.exists(application_jar):
+        raise SparkSolidError(
+            (
+                'Application jar {} does not exist. A valid jar must be '
+                'built before running this solid.'.format(application_jar)
+            )
+        )
+
+    spark_home = spark_home if spark_home else os.environ.get('SPARK_HOME')
+
+    if spark_home is None:
+        raise SparkSolidError(
+            (
+                'No spark home set. You must either pass spark_home in config or '
+                'set $SPARK_HOME in your environment (got None).'
+            )
+        )
+
+    deploy_mode = ['--deploy-mode', '{}'.format(deploy_mode)] if deploy_mode else []
+
+    spark_shell_cmd = (
+        ['{}/bin/spark-submit'.format(spark_home), '--class', main_class, '--master', master_url]
+        + deploy_mode
+        + parse_spark_config(spark_conf)
+        + [application_jar]
+        + ([application_arguments] if application_arguments else [])
+    )
+    return spark_shell_cmd
+
+
+def create_step_metadata_fn(solid_name, main_class):
+    def step_metadata_fn(environment_config):
+        return {
+            'spark_submit_command': ' '.join(
+                create_spark_shell_cmd(environment_config.solids[solid_name].config, main_class)
+            )
+        }
+
+    return step_metadata_fn
+
+
 class SparkSolidDefinition(SolidDefinition):
     '''This solid is a generic representation of a parameterized Spark job.
 
@@ -32,64 +90,7 @@ class SparkSolidDefinition(SolidDefinition):
             This function defines how we'll execute the Spark job and invokes spark-submit.
             '''
 
-            # Extract parameters from config
-            (
-                master_url,
-                deploy_mode,
-                application_jar,
-                spark_conf,
-                application_arguments,
-                spark_home,
-                spark_outputs,
-            ) = [
-                context.solid_config.get(k)
-                for k in (
-                    'master_url',
-                    'deploy_mode',
-                    'application_jar',
-                    'spark_conf',
-                    'application_arguments',
-                    'spark_home',
-                    'spark_outputs',
-                )
-            ]
-
-            # Let the user use env vars in the jar path
-            application_jar = os.path.expandvars(application_jar)
-
-            if not os.path.exists(application_jar):
-                raise SparkSolidError(
-                    (
-                        'Application jar {} does not exist. A valid jar must be '
-                        'built before running this solid.'.format(application_jar)
-                    )
-                )
-
-            spark_home = spark_home if spark_home else os.environ.get('SPARK_HOME')
-
-            if spark_home is None:
-                raise SparkSolidError(
-                    (
-                        'No spark home set. You must either pass spark_home in config or '
-                        'set $SPARK_HOME in your environment (got None).'
-                    )
-                )
-
-            deploy_mode = ['--deploy-mode', '{}'.format(deploy_mode)] if deploy_mode else []
-
-            spark_shell_cmd = (
-                [
-                    '{}/bin/spark-submit'.format(spark_home),
-                    '--class',
-                    main_class,
-                    '--master',
-                    master_url,
-                ]
-                + deploy_mode
-                + parse_spark_config(spark_conf)
-                + [application_jar]
-                + ([application_arguments] if application_arguments else [])
-            )
+            spark_shell_cmd = create_spark_shell_cmd(context.solid_config, main_class)
 
             context.log.info("Running spark-submit: " + ' '.join(spark_shell_cmd))
             retcode = run_spark_subprocess(spark_shell_cmd, context.log)
@@ -97,7 +98,7 @@ class SparkSolidDefinition(SolidDefinition):
             if retcode != 0:
                 raise SparkSolidError('Spark job failed. Please consult your logs.')
 
-            yield Result(spark_outputs, 'paths')
+            yield Result(context.solid_config.get('spark_outputs'), 'paths')
 
         super(SparkSolidDefinition, self).__init__(
             name=name,
@@ -107,4 +108,5 @@ class SparkSolidDefinition(SolidDefinition):
             transform_fn=_spark_transform_fn,
             config_field=define_spark_config(),
             metadata={'kind': 'spark', 'main_class': main_class},
+            step_metadata_fn=create_step_metadata_fn(name, main_class),
         )


### PR DESCRIPTION
This will allow the dagit to display the fully executable spark-submit command in the UI