### PR TITLE
Upgrade Papermill to 1.0.0

### DIFF
--- a/python_modules/dagstermill/dagstermill/__init__.py
+++ b/python_modules/dagstermill/dagstermill/__init__.py
@@ -17,6 +17,7 @@ import six
 from future.utils import raise_from
 
 import papermill as pm
+from papermill.parameterize import _find_first_tagged_cell_index
 from papermill.translators import translate_parameters
 from papermill.iorw import load_notebook_node, write_ipynb
 
@@ -472,16 +473,6 @@ def get_papermill_parameters(transform_context, inputs, output_log_path):
     parameters['dm_context'] = seven.json.dumps(dm_context_dict)
 
     return parameters
-
-
-def _find_first_tagged_cell_index(nb, tag):
-    parameters_indices = []
-    for idx, cell in enumerate(nb.cells):
-        if tag in cell.metadata.tags:
-            parameters_indices.append(idx)
-    if not parameters_indices:
-        return -1
-    return parameters_indices[0]
 
 
 def replace_parameters(context, nb, parameters):

--- a/python_modules/dagstermill/requirements.txt
+++ b/python_modules/dagstermill/requirements.txt
@@ -1,4 +1,5 @@
 enum-compat==0.0.2
 future>=0.16.0, <0.17.0a0
 ipykernel>=4.9.0
-papermill==0.18.1
+nteract-scrapbook>=0.2.0
+papermill>=1.0.0

--- a/python_modules/dagstermill/setup.py
+++ b/python_modules/dagstermill/setup.py
@@ -44,12 +44,13 @@ def _do_setup(name='dagstermill'):
         ],
         install_requires=[
             # standard python 2/3 compatability things
+            'dagster-pandas',
             'enum-compat==0.0.2',
             'future>=0.16.0, <0.17.0a0',
             'ipykernel>=4.9.0',
-            'papermill==0.18.1',
+            'nteract-scrapbook>=0.2.0',
+            'papermill>=1.0.0',
             'scikit-learn>=0.20.2',
-            'dagster-pandas',
         ],
         entry_points={"console_scripts": ['dagstermill = dagstermill.cli:main']},
     )


### PR DESCRIPTION
Info from phab:

    Upgrade Papermill and Install Scrapbook

    Summary:
    Papermill just made a breaking change to 1.0.0. They actually moved all of their output reading capabilities.
    This changes the APIs to the new styles.

    Test Plan: Included unit tests

    Reviewers: max, alangenfeld

    Differential Revision: https://dagster.phacility.com/D19
