### PR TITLE
Skip timing tests on windows for now

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_expectations.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_expectations.py
@@ -1,4 +1,6 @@
+import sys
 import time
+
 import pytest
 
 from dagster import (
@@ -12,6 +14,9 @@ from dagster import (
 )
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='https://github.com/dagster-io/dagster/issues/1421'
+)
 def test_event_timing_before_yield():
     @solid
     def before_yield_solid(_context):
@@ -24,6 +29,9 @@ def test_event_timing_before_yield():
     assert success_event.event_specific_data.duration_ms >= 10.0
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='https://github.com/dagster-io/dagster/issues/1421'
+)
 def test_event_timing_after_yield():
     @solid
     def after_yield_solid(_context):
@@ -36,6 +44,9 @@ def test_event_timing_after_yield():
     assert success_event.event_specific_data.duration_ms >= 10.0
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='https://github.com/dagster-io/dagster/issues/1421'
+)
 def test_event_timing_direct_return():
     @solid
     def direct_return_solid(_context):


### PR DESCRIPTION
Summary:
These timing tests broke windows. Disabling them until we figure out a fix and put windows under buildkite

See https://github.com/dagster-io/dagster/issues/1421

Test Plan: Unit test

Reviewers: natekupp, max, alangenfeld

Differential Revision: https://dagster.phacility.com/D282

**STOP!** Did you remember to make changes to the release notes reflecting any changes to public
APIs or new user-facing functionality introduced in this diff?
