### PR TITLE
Pin graphql-core to <3

### DIFF
--- a/python_modules/dagit/requirements.txt
+++ b/python_modules/dagit/requirements.txt
@@ -10,7 +10,8 @@ Flask==0.12.4
 future>=0.16.0, <0.17.0a0
 gevent-websocket==0.10.1
 gevent==1.3.7
-graphql-core>=2.1
+# graphql-core pinned to range for Python 2 compataibility
+graphql-core>=2.1,<3
 graphql-ws>=0.3.0
 nbconvert>=5.4.0
 # pyyaml pinned for compatibility with docker-compose

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -60,7 +60,7 @@ def _do_setup(name='dagit'):
             'dagster=={ver}'.format(ver=ver),
             'dagster-graphql=={ver}'.format(ver=ver),
             # graphql
-            'graphql-core>=2.1',
+            'graphql-core>=2.1,<3',
             # server
             'Flask-GraphQL>=2.0.0',
             'Flask-Sockets>=0.2.1',


### PR DESCRIPTION
We're planning on releasing a new major release of graphql-core with some breaking changes (dropping Python 2 support for example). This PR pins the version of graphql-core to be less than v3 so that nothing breaks when this happens.