### PR TITLE
Perform flake8 tests for syntax errors and undefined names

### DIFF
--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
 
 import os
+try:
+    from typing import Any, Dict
+except ImportError:
+    pass
 
 from six import text_type
 

--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -90,9 +90,7 @@ def vendor_view(path, file):
 
 def index_view(_path):
     try:
-        return send_file(
-            os.path.join(os.path.dirname(__file__), './webapp/build/index.html')
-        )
+        return send_file(os.path.join(os.path.dirname(__file__), './webapp/build/index.html'))
     except seven.FileNotFoundError:
         text = '''<p>Can't find webapp files. Probably webapp isn't built. If you are using
         dagit, then probably it's a corrupted installation or a bug. However, if you are
@@ -124,9 +122,7 @@ def notebook_view(request_args):
 def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=False):
     check.inst_param(handle, 'handle', ExecutionTargetHandle)
     check.inst_param(pipeline_run_storage, 'pipeline_run_storage', PipelineRunStorage)
-    check.bool_param(
-        use_synchronous_execution_manager, 'use_synchronous_execution_manager'
-    )
+    check.bool_param(use_synchronous_execution_manager, 'use_synchronous_execution_manager')
 
     app = Flask('dagster-ui')
     sockets = Sockets(app)
@@ -163,9 +159,7 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
         ),
     )
     sockets.add_url_rule(
-        '/graphql',
-        'graphql',
-        dagster_graphql_subscription_view(subscription_server, context),
+        '/graphql', 'graphql', dagster_graphql_subscription_view(subscription_server, context),
     )
 
     # these routes are specifically for the Dagit UI and are not part of the graphql

--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -159,7 +159,7 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
         ),
     )
     sockets.add_url_rule(
-        '/graphql', 'graphql', dagster_graphql_subscription_view(subscription_server, context),
+        '/graphql', 'graphql', dagster_graphql_subscription_view(subscription_server, context)
     )
 
     # these routes are specifically for the Dagit UI and are not part of the graphql

--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -38,19 +38,19 @@ def format_error_with_stack_trace(error):
 
     # type: (Exception) -> Dict[str, Any]
 
-    formatted_error = {"message": text_type(error)}  # type: Dict[str, Any]
+    formatted_error = {'message': text_type(error)}  # type: Dict[str, Any]
     if isinstance(error, GraphQLError):
         if error.locations is not None:
-            formatted_error["locations"] = [
-                {"line": loc.line, "column": loc.column} for loc in error.locations
+            formatted_error['locations'] = [
+                {'line': loc.line, 'column': loc.column} for loc in error.locations
             ]
         if error.path is not None:
-            formatted_error["path"] = error.path
+            formatted_error['path'] = error.path
 
         # this is what is different about this implementation
         # we print out stack traces to ease debugging
-        if hasattr(error, "original_error") and error.original_error:
-            formatted_error["stack_trace"] = get_stack_trace_array(error.original_error)
+        if hasattr(error, 'original_error') and error.original_error:
+            formatted_error['stack_trace'] = get_stack_trace_array(error.original_error)
 
     return formatted_error
 
@@ -58,7 +58,7 @@ def format_error_with_stack_trace(error):
 class DagsterGraphQLView(GraphQLView):
     def __init__(self, context, **kwargs):
         super(DagsterGraphQLView, self).__init__(**kwargs)
-        self.context = check.inst_param(context, "context", DagsterGraphQLContext)
+        self.context = check.inst_param(context, 'context', DagsterGraphQLContext)
 
     def get_context(self):
         return self.context
@@ -67,7 +67,7 @@ class DagsterGraphQLView(GraphQLView):
 
 
 def dagster_graphql_subscription_view(subscription_server, context):
-    context = check.inst_param(context, "context", DagsterGraphQLContext)
+    context = check.inst_param(context, 'context', DagsterGraphQLContext)
 
     def view(ws):
         subscription_server.handle(ws, request_context=context)
@@ -78,59 +78,59 @@ def dagster_graphql_subscription_view(subscription_server, context):
 
 def static_view(path, file):
     return send_from_directory(
-        os.path.join(os.path.dirname(__file__), "./webapp/build/static/", path), file
+        os.path.join(os.path.dirname(__file__), './webapp/build/static/', path), file
     )
 
 
 def vendor_view(path, file):
     return send_from_directory(
-        os.path.join(os.path.dirname(__file__), "./webapp/build/vendor/", path), file
+        os.path.join(os.path.dirname(__file__), './webapp/build/vendor/', path), file
     )
 
 
 def index_view(_path):
     try:
         return send_file(
-            os.path.join(os.path.dirname(__file__), "./webapp/build/index.html")
+            os.path.join(os.path.dirname(__file__), './webapp/build/index.html')
         )
     except seven.FileNotFoundError:
-        text = """<p>Can't find webapp files. Probably webapp isn't built. If you are using
+        text = '''<p>Can't find webapp files. Probably webapp isn't built. If you are using
         dagit, then probably it's a corrupted installation or a bug. However, if you are
         developing dagit locally, your problem can be fixed as follows:</p>
 
 <pre>cd ./python_modules/
-make rebuild_dagit</pre>"""
+make rebuild_dagit</pre>'''
         return text, 500
 
 
 def notebook_view(request_args):
-    check.dict_param(request_args, "request_args")
+    check.dict_param(request_args, 'request_args')
 
     # This currently provides open access to your file system - the very least we can
     # do is limit it to notebook files until we create a more permanent solution.
-    path = request_args["path"]
-    if not path.endswith(".ipynb"):
-        return "Invalid Path", 400
+    path = request_args['path']
+    if not path.endswith('.ipynb'):
+        return 'Invalid Path', 400
 
     with open(os.path.abspath(path)) as f:
         read_data = f.read()
         notebook = nbformat.reads(read_data, as_version=4)
         html_exporter = HTMLExporter()
-        html_exporter.template_file = "basic"
+        html_exporter.template_file = 'basic'
         (body, resources) = html_exporter.from_notebook_node(notebook)
-        return "<style>" + resources["inlining"]["css"][0] + "</style>" + body, 200
+        return '<style>' + resources['inlining']['css'][0] + '</style>' + body, 200
 
 
 def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=False):
-    check.inst_param(handle, "handle", ExecutionTargetHandle)
-    check.inst_param(pipeline_run_storage, "pipeline_run_storage", PipelineRunStorage)
+    check.inst_param(handle, 'handle', ExecutionTargetHandle)
+    check.inst_param(pipeline_run_storage, 'pipeline_run_storage', PipelineRunStorage)
     check.bool_param(
-        use_synchronous_execution_manager, "use_synchronous_execution_manager"
+        use_synchronous_execution_manager, 'use_synchronous_execution_manager'
     )
 
-    app = Flask("dagster-ui")
+    app = Flask('dagster-ui')
     sockets = Sockets(app)
-    app.app_protocol = lambda environ_path_info: "graphql-ws"
+    app.app_protocol = lambda environ_path_info: 'graphql-ws'
 
     schema = create_schema()
     subscription_server = DagsterSubscriptionServer(schema=schema)
@@ -140,7 +140,7 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
     else:
         execution_manager = MultiprocessingExecutionManager()
 
-    print("Loading repository...")
+    print('Loading repository...')
 
     context = DagsterGraphQLContext(
         handle=handle,
@@ -150,10 +150,10 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
     )
 
     app.add_url_rule(
-        "/graphql",
-        "graphql",
+        '/graphql',
+        'graphql',
         DagsterGraphQLView.as_view(
-            "graphql",
+            'graphql',
             schema=schema,
             graphiql=True,
             # XXX(freiksenet): Pass proper ws url
@@ -163,20 +163,20 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
         ),
     )
     sockets.add_url_rule(
-        "/graphql",
-        "graphql",
+        '/graphql',
+        'graphql',
         dagster_graphql_subscription_view(subscription_server, context),
     )
 
     # these routes are specifically for the Dagit UI and are not part of the graphql
     # API that we want other people to consume, so they're separate for now.
-    # Also grabbing the magic glabl request args dict so that notebook_view is testable
-    app.add_url_rule("/dagit/notebook", "notebook", lambda: notebook_view(request.args))
+    # Also grabbing the magic global request args dict so that notebook_view is testable
+    app.add_url_rule('/dagit/notebook', 'notebook', lambda: notebook_view(request.args))
 
-    app.add_url_rule("/static/<path:path>/<string:file>", "static_view", static_view)
-    app.add_url_rule("/vendor/<path:path>/<string:file>", "vendor_view", vendor_view)
-    app.add_url_rule("/<path:_path>", "index_catchall", index_view)
-    app.add_url_rule("/", "index", index_view, defaults={"_path": ""})
+    app.add_url_rule('/static/<path:path>/<string:file>', 'static_view', static_view)
+    app.add_url_rule('/vendor/<path:path>/<string:file>', 'vendor_view', vendor_view)
+    app.add_url_rule('/<path:_path>', 'index_catchall', index_view)
+    app.add_url_rule('/', 'index', index_view, defaults={'_path': ''})
 
     CORS(app)
 

--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+
 try:
     from typing import Any, Dict
 except ImportError:
@@ -37,19 +38,19 @@ def format_error_with_stack_trace(error):
 
     # type: (Exception) -> Dict[str, Any]
 
-    formatted_error = {'message': text_type(error)}  # type: Dict[str, Any]
+    formatted_error = {"message": text_type(error)}  # type: Dict[str, Any]
     if isinstance(error, GraphQLError):
         if error.locations is not None:
-            formatted_error['locations'] = [
-                {'line': loc.line, 'column': loc.column} for loc in error.locations
+            formatted_error["locations"] = [
+                {"line": loc.line, "column": loc.column} for loc in error.locations
             ]
         if error.path is not None:
-            formatted_error['path'] = error.path
+            formatted_error["path"] = error.path
 
         # this is what is different about this implementation
         # we print out stack traces to ease debugging
-        if hasattr(error, 'original_error') and error.original_error:
-            formatted_error['stack_trace'] = get_stack_trace_array(error.original_error)
+        if hasattr(error, "original_error") and error.original_error:
+            formatted_error["stack_trace"] = get_stack_trace_array(error.original_error)
 
     return formatted_error
 
@@ -57,7 +58,7 @@ def format_error_with_stack_trace(error):
 class DagsterGraphQLView(GraphQLView):
     def __init__(self, context, **kwargs):
         super(DagsterGraphQLView, self).__init__(**kwargs)
-        self.context = check.inst_param(context, 'context', DagsterGraphQLContext)
+        self.context = check.inst_param(context, "context", DagsterGraphQLContext)
 
     def get_context(self):
         return self.context
@@ -66,7 +67,7 @@ class DagsterGraphQLView(GraphQLView):
 
 
 def dagster_graphql_subscription_view(subscription_server, context):
-    context = check.inst_param(context, 'context', DagsterGraphQLContext)
+    context = check.inst_param(context, "context", DagsterGraphQLContext)
 
     def view(ws):
         subscription_server.handle(ws, request_context=context)
@@ -77,35 +78,37 @@ def dagster_graphql_subscription_view(subscription_server, context):
 
 def static_view(path, file):
     return send_from_directory(
-        os.path.join(os.path.dirname(__file__), './webapp/build/static/', path), file
+        os.path.join(os.path.dirname(__file__), "./webapp/build/static/", path), file
     )
 
 
 def vendor_view(path, file):
     return send_from_directory(
-        os.path.join(os.path.dirname(__file__), './webapp/build/vendor/', path), file
+        os.path.join(os.path.dirname(__file__), "./webapp/build/vendor/", path), file
     )
 
 
 def index_view(_path):
     try:
-        return send_file(os.path.join(os.path.dirname(__file__), './webapp/build/index.html'))
+        return send_file(
+            os.path.join(os.path.dirname(__file__), "./webapp/build/index.html")
+        )
     except seven.FileNotFoundError:
-        text = '''<p>Can't find webapp files. Probably webapp isn't built. If you are using
+        text = """<p>Can't find webapp files. Probably webapp isn't built. If you are using
         dagit, then probably it's a corrupted installation or a bug. However, if you are
         developing dagit locally, your problem can be fixed as follows:</p>
 
 <pre>cd ./python_modules/
-make rebuild_dagit</pre>'''
+make rebuild_dagit</pre>"""
         return text, 500
 
 
 def notebook_view(request_args):
-    check.dict_param(request_args, 'request_args')
+    check.dict_param(request_args, "request_args")
 
     # This currently provides open access to your file system - the very least we can
     # do is limit it to notebook files until we create a more permanent solution.
-    path = request_args['path']
+    path = request_args["path"]
     if not path.endswith(".ipynb"):
         return "Invalid Path", 400
 
@@ -113,19 +116,21 @@ def notebook_view(request_args):
         read_data = f.read()
         notebook = nbformat.reads(read_data, as_version=4)
         html_exporter = HTMLExporter()
-        html_exporter.template_file = 'basic'
+        html_exporter.template_file = "basic"
         (body, resources) = html_exporter.from_notebook_node(notebook)
-        return "<style>" + resources['inlining']['css'][0] + "</style>" + body, 200
+        return "<style>" + resources["inlining"]["css"][0] + "</style>" + body, 200
 
 
 def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=False):
-    check.inst_param(handle, 'handle', ExecutionTargetHandle)
-    check.inst_param(pipeline_run_storage, 'pipeline_run_storage', PipelineRunStorage)
-    check.bool_param(use_synchronous_execution_manager, 'use_synchronous_execution_manager')
+    check.inst_param(handle, "handle", ExecutionTargetHandle)
+    check.inst_param(pipeline_run_storage, "pipeline_run_storage", PipelineRunStorage)
+    check.bool_param(
+        use_synchronous_execution_manager, "use_synchronous_execution_manager"
+    )
 
-    app = Flask('dagster-ui')
+    app = Flask("dagster-ui")
     sockets = Sockets(app)
-    app.app_protocol = lambda environ_path_info: 'graphql-ws'
+    app.app_protocol = lambda environ_path_info: "graphql-ws"
 
     schema = create_schema()
     subscription_server = DagsterSubscriptionServer(schema=schema)
@@ -135,7 +140,7 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
     else:
         execution_manager = MultiprocessingExecutionManager()
 
-    print('Loading repository...')
+    print("Loading repository...")
 
     context = DagsterGraphQLContext(
         handle=handle,
@@ -145,10 +150,10 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
     )
 
     app.add_url_rule(
-        '/graphql',
-        'graphql',
+        "/graphql",
+        "graphql",
         DagsterGraphQLView.as_view(
-            'graphql',
+            "graphql",
             schema=schema,
             graphiql=True,
             # XXX(freiksenet): Pass proper ws url
@@ -158,18 +163,20 @@ def create_app(handle, pipeline_run_storage, use_synchronous_execution_manager=F
         ),
     )
     sockets.add_url_rule(
-        '/graphql', 'graphql', dagster_graphql_subscription_view(subscription_server, context)
+        "/graphql",
+        "graphql",
+        dagster_graphql_subscription_view(subscription_server, context),
     )
 
     # these routes are specifically for the Dagit UI and are not part of the graphql
     # API that we want other people to consume, so they're separate for now.
     # Also grabbing the magic glabl request args dict so that notebook_view is testable
-    app.add_url_rule('/dagit/notebook', 'notebook', lambda: notebook_view(request.args))
+    app.add_url_rule("/dagit/notebook", "notebook", lambda: notebook_view(request.args))
 
-    app.add_url_rule('/static/<path:path>/<string:file>', 'static_view', static_view)
-    app.add_url_rule('/vendor/<path:path>/<string:file>', 'vendor_view', vendor_view)
-    app.add_url_rule('/<path:_path>', 'index_catchall', index_view)
-    app.add_url_rule('/', 'index', index_view, defaults={'_path': ''})
+    app.add_url_rule("/static/<path:path>/<string:file>", "static_view", static_view)
+    app.add_url_rule("/vendor/<path:path>/<string:file>", "vendor_view", vendor_view)
+    app.add_url_rule("/<path:_path>", "index_catchall", index_view)
+    app.add_url_rule("/", "index", index_view, defaults={"_path": ""})
 
     CORS(app)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_composites.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_composites.py
@@ -80,6 +80,6 @@ def test_composites(snapshot):
     #            (/4)
     #           /
     #       (/2)
-    assert len(handle_map) is 10
+    assert len(handle_map) == 10
 
     snapshot.assert_match(result.data)

--- a/python_modules/dagster/dagster_tests/core_tests/test_composites.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_composites.py
@@ -81,7 +81,7 @@ def test_composite_config():
     @solid(config_field=Field(String))
     def configured(context):
         called['configured'] = True
-        assert context.solid_config is 'yes'
+        assert context.solid_config == 'yes'
 
     @composite_solid
     def inner():
@@ -109,7 +109,7 @@ def test_composite_config_input():
     @solid(input_defs=[InputDefinition('one')])
     def node_a(_context, one):
         called['node_a'] = True
-        assert one is 1
+        assert one == 1
 
     @composite_solid
     def inner():
@@ -143,7 +143,7 @@ def test_mapped_composite_config_input():
     @solid(input_defs=[InputDefinition('one')])
     def node_a(_context, one):
         called['node_a'] = True
-        assert one is 1
+        assert one == 1
 
     @composite_solid
     def inner(inner_one):

--- a/python_modules/dagster/dev-requirements.txt
+++ b/python_modules/dagster/dev-requirements.txt
@@ -1,4 +1,5 @@
 black==18.9b0; python_version >= '3.6'
+flake8>=3.7.8
 nbsphinx==0.4.2
 pylint>=2.3.0; python_version >= '3.6'
 pytest==4.6.3

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -9,7 +9,7 @@ deps =
   -r dev-requirements.txt
 commands =
   coverage erase
-  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  flake8 . --count --exclude=./python_modules/dagster/dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
   pytest -vv ./dagster_tests --junitxml=test_results.xml --cov=dagster --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -9,7 +9,7 @@ deps =
   -r dev-requirements.txt
 commands =
   coverage erase
-  flake8 . --count --exclude=./.*,./python_modules/dagster/dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
+  flake8 . --count --exclude=./.*,dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
   pytest -vv ./dagster_tests --junitxml=test_results.xml --cov=dagster --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -9,7 +9,7 @@ deps =
   -r dev-requirements.txt
 commands =
   coverage erase
-  flake8 . --count --exclude=./python_modules/dagster/dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
+  flake8 . --count --exclude=./.*,./python_modules/dagster/dagster/seven/__init__.py --select=E9,F63,F7,F82 --show-source --statistics
   pytest -vv ./dagster_tests --junitxml=test_results.xml --cov=dagster --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -9,6 +9,7 @@ deps =
   -r dev-requirements.txt
 commands =
   coverage erase
+  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   pytest -vv ./dagster_tests --junitxml=test_results.xml --cov=dagster --cov-append --cov-report=
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
**STOP!** Did you remember to make changes to the release notes reflecting any changes to public
APIs or new user-facing functionality introduced in this diff?

[flake8](http://flake8.pycqa.org) testing of https://github.com/dagster-io/dagster on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./python_modules/dagit/dagit/app.py:34:5: F821 undefined name 'Dict'
    # type: (Exception) -> Dict[str, Any]
    ^
./python_modules/dagit/dagit/app.py:34:5: F821 undefined name 'Any'
    # type: (Exception) -> Dict[str, Any]
    ^
./python_modules/dagit/dagit/app.py:36:54: F821 undefined name 'Dict'
    formatted_error = {'message': text_type(error)}  # type: Dict[str, Any]
                                                     ^
./python_modules/dagit/dagit/app.py:36:54: F821 undefined name 'Any'
    formatted_error = {'message': text_type(error)}  # type: Dict[str, Any]
                                                     ^
./python_modules/dagster/dagster/seven/__init__.py:64:12: F821 undefined name 'reload'
    return reload(module)  # pylint: disable=undefined-variable
           ^
./python_modules/dagster/dagster_tests/core_tests/test_composites.py:84:16: F632 use ==/!= to compare str, bytes, and int literals
        assert context.solid_config is 'yes'
               ^
./python_modules/dagster/dagster_tests/core_tests/test_composites.py:112:16: F632 use ==/!= to compare str, bytes, and int literals
        assert one is 1
               ^
./python_modules/dagster/dagster_tests/core_tests/test_composites.py:146:16: F632 use ==/!= to compare str, bytes, and int literals
        assert one is 1
               ^
./python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_composites.py:83:12: F632 use ==/!= to compare str, bytes, and int literals
    assert len(handle_map) is 10
           ^
4     F632 use ==/!= to compare str, bytes, and int literals
5     F821 undefined name 'Dict'
9
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
