### PR TITLE
Implement Dagster-compatible version of KubernetesPodOperator

### DIFF
--- a/python_modules/dagster-airflow/dagster_airflow/factory.py
+++ b/python_modules/dagster-airflow/dagster_airflow/factory.py
@@ -265,7 +265,8 @@ def make_airflow_dag_kubernetized(
     if not IMPORTED_KUBERNETES:
         raise ImportError(
             "DagsterKubernetesPodOperator is not available"
-            " if the kubernetes module isn't installed")
+            " if the kubernetes module isn't installed"
+        )
 
     check.str_param(module_name, 'module_name')
 

--- a/python_modules/dagster-airflow/dagster_airflow/factory.py
+++ b/python_modules/dagster-airflow/dagster_airflow/factory.py
@@ -12,7 +12,8 @@ from .compile import coalesce_execution_steps
 
 IMPORTED_KUBERNETES = False
 try:
-    from .kubernetes_operator import DagsterKubernetesPodOperator
+    from .kubernetes_operators import DagsterKubernetesPodOperator
+
     IMPORTED_KUBERNETES = True
 except:
     pass

--- a/python_modules/dagster-airflow/dagster_airflow/factory.py
+++ b/python_modules/dagster-airflow/dagster_airflow/factory.py
@@ -255,6 +255,7 @@ def make_airflow_dag_kubernetized(
     module_name,
     pipeline_name,
     image,
+    namespace,
     environment_dict=None,
     mode=None,
     dag_id=None,
@@ -274,6 +275,9 @@ def make_airflow_dag_kubernetized(
 
     op_kwargs = check.opt_dict_param(op_kwargs, 'op_kwargs', key_type=str)
     op_kwargs['image'] = image
+    # TODO: It would probably be better to require a Kubernetes config section in the environment
+    # YAML, since there's multiple relevant settings
+    op_kwargs['namespace'] = namespace
     return _make_airflow_dag(
         handle=handle,
         pipeline_name=pipeline_name,

--- a/python_modules/dagster-airflow/dagster_airflow/factory.py
+++ b/python_modules/dagster-airflow/dagster_airflow/factory.py
@@ -15,7 +15,8 @@ try:
     from .kubernetes_operators import DagsterKubernetesPodOperator
 
     IMPORTED_KUBERNETES = True
-except:
+except ImportError:
+    # TODO: raise an appropriate warning here
     pass
 
 DEFAULT_ARGS = {

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -71,13 +71,13 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
         # TODO: Warn if the user tried to set this, since it won't work as expected
         kwargs["xcom_push"] = False
 
-        # TODO: don't blow away S3 creds on providing an env
-        if 'env_vars' not in kwargs:
-            kwargs['env_vars'] = self.default_environment
-
         super(DagsterKubernetesPodOperator, self).__init__(
             task_id=task_id, dag=dag, *args, **kwargs
         )
+
+        # Update environment with applicable defaults
+        for k, v in self.env_vars.items():
+            self.env_vars.setdefault(k, v)
 
     def execute(self, context):
         try:

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -144,6 +144,7 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
                 # fetch the last line independently of whether logs were read
                 # unbelievably, if you set tail_lines=1, the returned json has its double quotes
                 # turned into unparseable single quotes
+                # TODO: add retries - k8s log servers are _extremely_ flaky
                 raw_res = client.read_namespaced_pod_log(
                     name=pod.name, namespace=pod.namespace, container='base', tail_lines=5
                 )

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -1,4 +1,9 @@
+import json
+
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.contrib.kubernetes import kube_client, pod_generator, pod_launcher
+from airflow.exceptions import AirflowException
+from airflow.utils.state import State
 from dagster import check
 from .operators import DagsterSkipMixin, GenericExecMixin
 from .util import airflow_storage_exception
@@ -56,3 +61,92 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
         super(DagsterKubernetesPodOperator, self).__init__(
             task_id=task_id, dag=dag, *args, **kwargs
         )
+
+    def execute(self, context):
+        try:
+            from dagster_graphql.client.mutations import (
+                handle_start_pipeline_execution_errors,
+                handle_start_pipeline_execution_result,
+            )
+
+        except ImportError:
+            raise AirflowException(
+                'To use the DagsterKubernetesPodOperator, dagster and dagster_graphql must be'
+                ' installed in your Airflow environment.'
+            )
+        if 'run_id' in self.params:
+            self._run_id = self.params['run_id']
+        elif 'dag_run' in context and context['dag_run'] is not None:
+            self._run_id = context['dag_run'].run_id
+
+        # return to original execute code:
+        try:
+            client = kube_client.get_kube_client(
+                in_cluster=self.in_cluster,
+                cluster_context=self.cluster_context,
+                config_file=self.config_file,
+            )
+            gen = pod_generator.PodGenerator()
+
+            for mount in self.volume_mounts:
+                gen.add_mount(mount)
+            for volume in self.volumes:
+                gen.add_volume(volume)
+
+            pod = gen.make_pod(
+                namespace=self.namespace,
+                image=self.image,
+                pod_id=self.name,
+                cmds=self.cmds,
+                arguments=self.arguments,
+                labels=self.labels,
+            )
+
+            pod.service_account_name = self.service_account_name
+            pod.secrets = self.secrets
+            pod.envs = self.env_vars
+            pod.image_pull_policy = self.image_pull_policy
+            pod.image_pull_secrets = self.image_pull_secrets
+            pod.annotations = self.annotations
+            pod.resources = self.resources
+            pod.affinity = self.affinity
+            pod.node_selectors = self.node_selectors
+            pod.hostnetwork = self.hostnetwork
+            pod.tolerations = self.tolerations
+            pod.configmaps = self.configmaps
+            pod.security_context = self.security_context
+
+            launcher = pod_launcher.PodLauncher(kube_client=client, extract_xcom=self.xcom_push)
+            try:
+                # we won't use the "result", which is the returned pod object
+                (final_state, _) = launcher.run_pod(
+                    pod, startup_timeout=self.startup_timeout_seconds, get_logs=self.get_logs
+                )
+
+                # fetch the last line independently of whether logs were read
+                dagster_json_line = client.read_namespaced_pod_log(
+                    name=pod.name, namespace=pod.namespace, container='base', tail_lines=1
+                )
+
+                # read the last line directly as json
+                # TODO: handle bytes type?
+                # TODO: handle garbage API string responses
+                res = json.loads(dagster_json_line)
+                handle_start_pipeline_execution_errors(res)
+                events = handle_start_pipeline_execution_result(res)
+
+                self.skip_self_if_necessary(events, context['execution_date'], context['task'])
+
+                return events
+
+            finally:
+                self._run_id = None
+
+                if self.is_delete_operator_pod:
+                    launcher.delete_pod(pod)
+
+            if final_state != State.SUCCESS:
+                raise AirflowException('Pod returned a failure: {state}'.format(state=final_state))
+            # note the lack of returning the default xcom
+        except AirflowException as ex:
+            raise AirflowException('Pod Launching failed: {error}'.format(error=ex))

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -1,5 +1,3 @@
-import json
-
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow.contrib.kubernetes import kube_client, pod_generator, pod_launcher
 from airflow.exceptions import AirflowException

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -1,11 +1,10 @@
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from dagster import check
-from .operators import DagsterSkipMixin, GenericExec
-
+from .operators import DagsterSkipMixin, GenericExecMixin
 from .util import airflow_storage_exception
 
 
-class DagsterKubernetesPodOperator(GenericExec, KubernetesPodOperator, DagsterSkipMixin):
+class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, DagsterSkipMixin):
     def __init__(
         self,
         task_id,

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -137,7 +137,7 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
 
             launcher = pod_launcher.PodLauncher(kube_client=client, extract_xcom=self.xcom_push)
             try:
-                # we won't use the "result", which is the returned pod object
+                # we won't use the "result", which is the pod's xcom json file
                 (final_state, _) = launcher.run_pod(
                     pod, startup_timeout=self.startup_timeout_seconds, get_logs=self.get_logs
                 )

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -115,7 +115,9 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
                 image=self.image,
                 pod_id=self.name,
                 cmds=self.cmds,
-                arguments=self.arguments,
+                # TODO: should we even accept self.arguments?
+                # TODO: would it be better to expose dagster query vars as airflow template vars
+                arguments=self.query,
                 labels=self.labels,
             )
 

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -28,6 +28,9 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
         *args,
         **kwargs
     ):
+        # TODO: choose a better generated dns-compliant k8s pod name
+        kwargs["name"] = "dagster.{pipeline_name}.{task_id}".format(
+            pipeline_name=pipeline_name, task_id=task_id).replace("_", "--")
 
         # TODO: reduce boilerplate
         check.str_param(pipeline_name, 'pipeline_name')

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -62,6 +62,12 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
         kwargs.setdefault("labels", {})
         kwargs["labels"].setdefault("dagster_pipeline", self.pipeline_name)
 
+        # The xcom mechanism for the pod operator is very unlike that of the Docker operator:
+        # https://github.com/apache/airflow/blob/1.10.3/airflow/contrib/operators/kubernetes_pod_operator.py#L76
+        # We therefore need to disable it
+        # TODO: Warn if the user tried to set this, since it won't work as expected
+        kwargs["xcom_push"] = False
+
         # TODO: don't blow away S3 creds on providing an env
         if 'env_vars' not in kwargs:
             kwargs['env_vars'] = self.default_environment

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -1,0 +1,43 @@
+from airflow.contrib.operators.kubernetes_operator import KubernetesPodOperator
+from dagster import check
+from .operators import DagsterSkipMixin, GenericExec
+
+from .util import airflow_storage_exception
+
+
+class DagsterKubernetesPodOperator(KubernetesPodOperator, GenericExec, DagsterSkipMixin):
+    def __init__(
+        self,
+        task_id,
+        environment_dict=None,
+        pipeline_name=None,
+        mode=None,
+        step_keys=None,
+        dag=None,
+        *args,
+        **kwargs
+    ):
+
+        # TODO: reduce boilerplate
+        check.str_param(pipeline_name, 'pipeline_name')
+        step_keys = check.opt_list_param(step_keys, 'step_keys', of_type=str)
+        environment_dict = check.opt_dict_param(environment_dict, 'environment_dict', key_type=str)
+
+        if 'storage' not in environment_dict:
+            # TODO: there's no meaningful /tmp dir, but also, shared k8s vols don't exist
+            # without a significant amount of extra work
+            raise airflow_storage_exception("/path-to-your-shared-kubernetes-volume")
+
+        check.invariant(
+            'in_memory' not in environment_dict.get('storage', {}),
+            'Cannot use in-memory storage with Airflow, must use S3',
+        )
+
+        self.environment_dict = environment_dict
+        self.pipeline_name = pipeline_name
+        self.mode = mode
+        self.step_keys = step_keys
+        self._run_id = None
+
+        # Store Airflow DAG run timestamp so that we can pass along via execution metadata
+        self.airflow_ts = kwargs.get('ts')

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -54,6 +54,14 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
         # Store Airflow DAG run timestamp so that we can pass along via execution metadata
         self.airflow_ts = kwargs.get('ts')
 
+        # TODO: This should be moved into a general, non-Airflow class if native integration is
+        # implemented, in order to keep labels consistent
+        # TODO: add some common Kubernetes labels
+        # https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+        # TODO: may make sense to set these as env vars too
+        kwargs.setdefault("labels", {})
+        kwargs["labels"].setdefault("dagster_pipeline", self.pipeline_name)
+
         # TODO: don't blow away S3 creds on providing an env
         if 'env_vars' not in kwargs:
             kwargs['env_vars'] = self.default_environment

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -5,6 +5,13 @@ from .util import airflow_storage_exception
 
 
 class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, DagsterSkipMixin):
+    '''Dagster operator for Apache Airflow.
+
+    Wraps a modified KubernetesPodOperator.
+    '''
+
+    # py2 compat
+    # pylint: disable=keyword-arg-before-vararg
     def __init__(
         self,
         task_id,

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -33,6 +33,7 @@ class DagsterKubernetesPodOperator(GenericExec, KubernetesPodOperator, DagsterSk
             'Cannot use in-memory storage with Airflow, must use S3',
         )
 
+        # TODO: decide whether any of this CRUD can go into a base class too
         self.environment_dict = environment_dict
         self.pipeline_name = pipeline_name
         self.mode = mode
@@ -45,3 +46,7 @@ class DagsterKubernetesPodOperator(GenericExec, KubernetesPodOperator, DagsterSk
         # TODO: don't blow away S3 creds on providing an env
         if 'env_vars' not in kwargs:
             kwargs['env_vars'] = self.default_environment
+
+        super(DagsterKubernetesPodOperator, self).__init__(
+            task_id=task_id, dag=dag, *args, **kwargs
+        )

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -5,7 +5,7 @@ from .operators import DagsterSkipMixin, GenericExec
 from .util import airflow_storage_exception
 
 
-class DagsterKubernetesPodOperator(KubernetesPodOperator, GenericExec, DagsterSkipMixin):
+class DagsterKubernetesPodOperator(GenericExec, KubernetesPodOperator, DagsterSkipMixin):
     def __init__(
         self,
         task_id,
@@ -41,3 +41,7 @@ class DagsterKubernetesPodOperator(KubernetesPodOperator, GenericExec, DagsterSk
 
         # Store Airflow DAG run timestamp so that we can pass along via execution metadata
         self.airflow_ts = kwargs.get('ts')
+
+        # TODO: don't blow away S3 creds on providing an env
+        if 'env_vars' not in kwargs:
+            kwargs['env_vars'] = self.default_environment

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -30,7 +30,8 @@ class DagsterKubernetesPodOperator(GenericExecMixin, KubernetesPodOperator, Dags
     ):
         # TODO: choose a better generated dns-compliant k8s pod name
         kwargs["name"] = "dagster.{pipeline_name}.{task_id}".format(
-            pipeline_name=pipeline_name, task_id=task_id).replace("_", "--")
+            pipeline_name=pipeline_name, task_id=task_id
+        ).replace("_", "--")
 
         # TODO: reduce boilerplate
         check.str_param(pipeline_name, 'pipeline_name')

--- a/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/kubernetes_operators.py
@@ -1,4 +1,4 @@
-from airflow.contrib.operators.kubernetes_operator import KubernetesPodOperator
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from dagster import check
 from .operators import DagsterSkipMixin, GenericExec
 

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -163,6 +163,9 @@ class GenericExecMixin:
 
     @property
     def default_environment(self):
+        """
+        Return a default set of environment variables for Docker and Kubernetes execution.
+        """
         default_env = {}
 
         if self.propagate_aws_vars:

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -161,9 +161,11 @@ class GenericExecMixin:
             self.step_keys,
         )
 
-        return '-v \'{variables}\' \'{query}\''.format(
-            variables=seven.json.dumps(variables), query=START_PIPELINE_EXECUTION_QUERY
-        )
+        return [
+            '-v',
+            '{}'.format(seven.json.dumps(variables)),
+            '{}'.format(START_PIPELINE_EXECUTION_QUERY)
+        ]
 
     @property
     def default_environment(self):
@@ -279,7 +281,8 @@ class DagsterDockerOperator(GenericExecMixin, ModifiedDockerOperator, DagsterSki
         elif self.command is not None:
             commands = self.command
         else:
-            commands = self.query
+            # return a string-joined version of the query text
+            commands = " ".join(self.query)
         return commands
 
     def get_hook(self):

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -132,6 +132,8 @@ class GenericExecMixin:
     Base class for shared machinery for operators that will exec: Docker, Kubernetes, venvs, etc.
     """
 
+    # py2 compat
+    # pylint: disable=keyword-arg-before-vararg
     def __init__(self, propagate_aws_vars=True, *args, **kwargs):
         self.propagate_aws_vars = propagate_aws_vars
         super(GenericExecMixin, self).__init__(*args, **kwargs)

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -303,7 +303,7 @@ class DagsterDockerOperator(GenericExec, ModifiedDockerOperator, DagsterSkipMixi
 
         except ImportError:
             raise AirflowException(
-                'To use the DagsterPythonOperator, dagster and dagster_graphql must be installed '
+                'To use the DagsterDockerOperator, dagster and dagster_graphql must be installed '
                 'in your Airflow environment.'
             )
         if 'run_id' in self.params:

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -182,10 +182,13 @@ class GenericExecMixin:
 
             # The creds _also_ break if you only set one of them.
             if aws_access_key_id and aws_secret_access_key:
-                default_env.update({
-                    'AWS_ACCESS_KEY_ID': aws_access_key_id,
-                    'AWS_SECRET_ACCESS_KEY': aws_secret_access_key,
-                })
+                # TODO: also get region env var this way, since boto commands may fail without it
+                default_env.update(
+                    {
+                        'AWS_ACCESS_KEY_ID': aws_access_key_id,
+                        'AWS_SECRET_ACCESS_KEY': aws_secret_access_key,
+                    }
+                )
             elif aws_access_key_id or aws_secret_access_key:
                 # TODO: log warning, this'll fail at runtime
 

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -137,6 +137,10 @@ class GenericExecMixin:
         super(GenericExecMixin, self).__init__(*args, **kwargs)
 
     @property
+    def run_id(self):
+        return getattr(self, "_run_id", '')
+
+    @property
     def query(self):
         # TODO: https://github.com/dagster-io/dagster/issues/1342
         redacted = construct_variables(
@@ -268,12 +272,6 @@ class DagsterDockerOperator(GenericExecMixin, ModifiedDockerOperator, DagsterSki
             task_id=task_id, dag=dag, tmp_dir=tmp_dir, host_tmp_dir=host_tmp_dir, *args, **kwargs
         )
 
-    @property
-    def run_id(self):
-        if self._run_id is None:
-            return ''
-        else:
-            return self._run_id
 
     def get_command(self):
         if self.command is not None and self.command.strip().find('[') == 0:

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -132,7 +132,7 @@ class GenericExecMixin:
     Base class for shared machinery for operators that will exec: Docker, Kubernetes, venvs, etc.
     """
 
-    def __init__(self, propagate_aws_vars, *args, **kwargs):
+    def __init__(self, propagate_aws_vars=True, *args, **kwargs):
         self.propagate_aws_vars = propagate_aws_vars
         super(GenericExecMixin, self).__init__(*args, **kwargs)
 
@@ -190,8 +190,10 @@ class GenericExecMixin:
                     }
                 )
             elif aws_access_key_id or aws_secret_access_key:
-                # TODO: log warning, this'll fail at runtime
-
+                raise ValueError(
+                    "If `propagate_aws_vars=True`, must provide either both of AWS_ACCESS_KEY_ID"
+                    " and AWS_SECRET_ACCESS_KEY env vars, or neither."
+                )
         return default_env
 
 

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -21,15 +21,6 @@ from dagster_graphql.client.query import START_PIPELINE_EXECUTION_QUERY
 
 from .util import airflow_storage_exception, construct_variables, parse_raw_res
 
-# Importing this will crash if Kubernetes libraries aren't installed.
-IMPORTED_KUBERNETES = False
-try:
-    from airflow.contrib.operators.kubernetes_operator import KubernetesPodOperator
-    from .kubernetes_operator import DagsterKubernetesPodOperator
-    IMPORTED_KUBERNETES = True
-except ImportError:
-    pass
-
 
 DOCKER_TEMPDIR = '/tmp'
 

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -127,13 +127,14 @@ class ModifiedDockerOperator(DockerOperator):
         return super(ModifiedDockerOperator, self)._DockerOperator__get_tls_config()
 
 
-class GenericExec:
+class GenericExecMixin:
     """
     Base class for shared machinery for operators that will exec: Docker, Kubernetes, venvs, etc.
     """
+
     def __init__(self, propagate_aws_vars, *args, **kwargs):
         self.propagate_aws_vars = propagate_aws_vars
-        super(GenericExec, self).__init__(*args, **kwargs)
+        super(GenericExecMixin, self).__init__(*args, **kwargs)
 
     @property
     def query(self):
@@ -188,7 +189,7 @@ class GenericExec:
         return default_env
 
 
-class DagsterDockerOperator(GenericExec, ModifiedDockerOperator, DagsterSkipMixin):
+class DagsterDockerOperator(GenericExecMixin, ModifiedDockerOperator, DagsterSkipMixin):
     '''Dagster operator for Apache Airflow.
 
     Wraps a modified DockerOperator incorporating https://github.com/apache/airflow/pull/4315.

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -265,13 +265,13 @@ class DagsterDockerOperator(GenericExecMixin, ModifiedDockerOperator, DagsterSki
         # Store Airflow DAG run timestamp so that we can pass along via execution metadata
         self.airflow_ts = kwargs.get('ts')
 
-        if 'environment' not in kwargs:
-            kwargs['environment'] = self.default_environment
-
         super(DagsterDockerOperator, self).__init__(
             task_id=task_id, dag=dag, tmp_dir=tmp_dir, host_tmp_dir=host_tmp_dir, *args, **kwargs
         )
 
+        # Update environment with applicable defaults
+        for k, v in self.default_environment.items():
+            self.environment.setdefault(k, v)
 
     def get_command(self):
         if self.command is not None and self.command.strip().find('[') == 0:

--- a/python_modules/dagster-airflow/dagster_airflow/operators.py
+++ b/python_modules/dagster-airflow/dagster_airflow/operators.py
@@ -164,7 +164,7 @@ class GenericExecMixin:
         return [
             '-v',
             '{}'.format(seven.json.dumps(variables)),
-            '{}'.format(START_PIPELINE_EXECUTION_QUERY)
+            '{}'.format(START_PIPELINE_EXECUTION_QUERY),
         ]
 
     @property


### PR DESCRIPTION
Following the example of the Docker operator, I've made a subclass of Airflow's KubernetesPodOperator that works with `dagster-graphql`. Where possible I tried not to "vendor" too many code paths since that will make this operator much harder to maintain with multiple Airflow versions. I also tried to pull out code that would be shared by any `exec`-like process launcher (so the Docker operator too, but also perhaps subprocess-based operators like Python venv).

It's not quite mergeable yet, as I haven't had time to learn the test suite. I also left a lot of TODO comments with further points of work - either places where it wasn't clear how to best handle user experience, or cases places I've seen this operator fail before and which might benefit from extra safety code.

For reference, my current testing env looks like:

- Ubuntu 18.04.2 (via Windows 10 WSL2)
- Airflow 1.10.3 running via `docker-compose`
- Minikube (no RBAC)
- A public S3 bucket (due to previous issues with boto auth)

Some of the setup code (like the pipeline code and DAG factory) are available here though it's not a totally reproducible setup. https://github.com/Eronarn/dagster-consulting
(If you need access, let me know)