### PR TITLE
Fix: typo in link to Papermill library

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Dagster works with the tools and systems that you're already using with your dat
 			&nbsp;/&nbsp; <img style="vertical-align:middle" src="https://user-images.githubusercontent.com/609349/57987827-fa268b80-7a3b-11e9-8a18-b675d76c19aa.png">
 			</td>
 			<td style="border-left: 0px"> <b>Jupyter / Papermill</b></td>
-			<td><a href="https://github.com/dagster-io/dagster/tree/master/python_modules/dagstermill" />dagstermill</a><br />Built on the <a href=https://github.com/nteract/papermill">papermill library</a>, dagstermill is meant for integrating productionized Jupyter notebooks into dagster pipelines.</td>
+			<td><a href="https://github.com/dagster-io/dagster/tree/master/python_modules/dagstermill" />dagstermill</a><br />Built on the <a href="https://github.com/nteract/papermill">papermill library</a>, dagstermill is meant for integrating productionized Jupyter notebooks into dagster pipelines.</td>
 		</tr>
 		<tr>
 			<td align="center" style="border-right: 0px"><img style="vertical-align:middle"  src="https://user-images.githubusercontent.com/609349/57988016-f431aa00-7a3d-11e9-8cb6-1309d4246b27.png"></td>


### PR DESCRIPTION
I found this issue when I clicked the link and got a 404

**STOP!** Did you remember to make changes to the release notes reflecting any changes to public
APIs or new user-facing functionality introduced in this diff?
