### PR TITLE
Modifies contributing.rst: Adds the python environment path to the pytest

### DIFF
--- a/docs/sections/community/contributing.rst
+++ b/docs/sections/community/contributing.rst
@@ -36,7 +36,7 @@ the Python versions 2.7, 3.5, 3.6, and 3.7.
 
 .. code-block:: console
 
-    $ pytest python_modules/dagster/dagster_tests
+    $ python -m pytest python_modules/dagster/dagster_tests
 
 Have fun coding!
 


### PR DESCRIPTION
Fixes #1641 
I have modified the pytest command. The `sphinx-autobuild` change was already made in the repo.