### PR TITLE
[Issue-1813] - Fix Types documentation in 0.6.0 Release

### DIFF
--- a/docs/sections/learn/tutorial/types.rst
+++ b/docs/sections/learn/tutorial/types.rst
@@ -12,7 +12,7 @@ Basic Typing
 ^^^^^^^^^^^^
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 18,47-49
+   :lines: 16, 45-47
    :linenos:
 
 What this code doing is annotating/registering our new ``Sauce`` class as a dagster type. Now
@@ -22,7 +22,7 @@ typecheck to ensure that the object is of type ``Sauce``.
 Now one can use it to define a solid:
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 62-65
+   :lines: 60-63
    :linenos:
 
 
@@ -42,13 +42,13 @@ system to do so.
 Let us now add the input hydration config:
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 23-26
+   :lines: 21-24
    :linenos:
 
 Then insert this into the original declaration:
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 36-37,46-49
+   :lines: 34-35,44-47
    :emphasize-lines: 2
    :linenos:
 
@@ -69,7 +69,7 @@ whereas inputs *must* be provided for a computation to proceed. You will likely 
 a pipeline to be useful it should produce some materialization that outlives the computation.
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 29-32
+   :lines: 27-31
    :linenos:
 
 This has a similar aesthetic to an input hydration config but performs a different function. Notice that
@@ -80,7 +80,7 @@ how to materialize the value.
 One connects the output materialization config to the type as follows:
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 36-38,46-49
+   :lines: 34-36,44-47
    :emphasize-lines: 3
    :linenos:
 
@@ -101,6 +101,6 @@ object containing metadata entries about an instance of the type when it success
 We will use this to emit some summary statistics about our DataFrame type:
 
 .. literalinclude:: ../../../../examples/dagster_examples/intro_tutorial/custom_types.py
-   :lines: 36-49
+   :lines: 34-47
    :emphasize-lines: 4-10
    :linenos:


### PR DESCRIPTION
**Issue**: https://github.com/dagster-io/dagster/issues/1813

**Observation**

- Noticed that docs were a bit skewed in the 0.6.0 docs release. 

<img width="955" alt="Screen Shot 2019-10-06 at 11 56 54 AM" src="https://user-images.githubusercontent.com/56212213/66274158-88a37a00-e830-11e9-97da-99d8c3d941a2.png">

- This is what 0.5.9 looked like. 

<img width="959" alt="Screen Shot 2019-10-06 at 11 58 34 AM" src="https://user-images.githubusercontent.com/56212213/66274172-a53fb200-e830-11e9-80d6-ae03b7bf21db.png">

**Solution**

- Updated the lines to match up with the original mental model. 

**Proof this works**

This is the output I am getting when I do `make livehtml`. 

<img width="1680" alt="Screen Shot 2019-10-06 at 12 02 45 PM" src="https://user-images.githubusercontent.com/56212213/66274239-3f9ff580-e831-11e9-8cde-4e1348023b34.png">


⚠️ **Call out for reviewer**: I noticed the following line in the documentation under Type Metadata.

```We will use this to emit some summary statistics about our DataFrame type:```

I am unsure where the dataframe type came from. It made me wonder if there was a mental model mismatch between 0.5.9 and 0.6.0 that I didn't catch when looking at the examples in `examples/dagster_examples/intro_tutorial/custom_types.py`


