### PR TITLE
[Issue-1841] Wipe command gate on user prompt

### DIFF
--- a/python_modules/dagster/dagster/cli/run.py
+++ b/python_modules/dagster/dagster/cli/run.py
@@ -18,8 +18,16 @@ def run_list_command():
         click.echo('     Pipeline: {}'.format(run.pipeline_name))
 
 
-@click.command(name='wipe', help='Eliminate all run history. Warning: Cannot be undone')
+@click.command(
+    name='wipe', help='Eliminate all run history and event logs. Warning: Cannot be undone'
+)
 def run_wipe_command():
-    instance = DagsterInstance.get()
-    instance.wipe()
-    click.echo('Deleted all run history')
+    confirmation = click.prompt(
+        'Are you sure you want to delete all run history and event logs? Type DELETE'
+    )
+    if confirmation == 'DELETE':
+        instance = DagsterInstance.get()
+        instance.wipe()
+        click.echo('Deleted all run history and event logs')
+    else:
+        click.echo('Exiting without deleting all run history and event logs')

--- a/python_modules/dagster/dagster/cli/schedule.py
+++ b/python_modules/dagster/dagster/cli/schedule.py
@@ -399,7 +399,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
         )
 
 
-@click.command(name='wipe', help="Deletes all schedules and crontabs.")
+@click.command(name='wipe', help="Deletes all schedules and schedule cron jobs.")
 @repository_target_argument
 def schedule_wipe_command(**kwargs):
     return execute_wipe_command(kwargs, click.echo)
@@ -418,7 +418,12 @@ def execute_wipe_command(cli_args, print_fn):
         print_fn("Scheduler not defined for repository {name}".format(name=repository.name))
         return
 
-    scheduler = schedule_handle.get_scheduler()
-    scheduler.wipe()
-
-    print_fn("Wiped all schedules")
+    confirmation = click.prompt(
+        'Are you sure you want to delete all schedules and schedule cron jobs? Type DELETE'
+    )
+    if confirmation == 'DELETE':
+        scheduler = schedule_handle.get_scheduler()
+        scheduler.wipe()
+        print_fn("Wiped all schedules and schedule cron jobs")
+    else:
+        click.echo('Exiting without deleting all schedules and schedule cron jobs')


### PR DESCRIPTION
The wipe commands are pretty dangerous commands. A verification step allows the user to type `DELETE` to confirm they want to execute the command. I have applied this to both the run and schedule commands where wipe can be run. I also updated the tests respectively. This PR is based on what was mentioned in #1841 

**Before:** 
![image](https://user-images.githubusercontent.com/6476594/67038930-575b6180-f0ee-11e9-81dd-01864a2b934a.png)

**After:**
![image](https://user-images.githubusercontent.com/6476594/67038988-7b1ea780-f0ee-11e9-9315-b61645ca62ff.png)

![image](https://user-images.githubusercontent.com/6476594/67039267-fa13e000-f0ee-11e9-97d1-609342cf3a82.png)

