### PR TITLE
skip checking stdout for windows / py36+

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/test_stdout.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_stdout.py
@@ -1,7 +1,10 @@
 import os
 import sys
 
+import pytest
+
 from dagster import DagsterEventType, execute_pipeline, lambda_solid, pipeline
+from dagster.core.execution.compute_logs import should_disable_io_stream_redirect
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.compute_log_manager import ComputeIOType
 
@@ -21,6 +24,9 @@ HELLO_WORLD = 'Hello World'
 SEPARATOR = os.linesep if (os.name == 'nt' and sys.version_info < (3,)) else '\n'
 
 
+@pytest.mark.skipif(
+    should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
+)
 def test_stdout():
     instance = DagsterInstance.local_temp()
     manager = instance.compute_log_manager
@@ -47,6 +53,9 @@ def test_stdout():
     assert not manager.is_compute_completed('not_a_run_id', step_key)
 
 
+@pytest.mark.skipif(
+    should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
+)
 def test_stdout_subscriptions():
     instance = DagsterInstance.local_temp()
     step_key = 'spew.compute'

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -37,7 +37,7 @@ def _do_setup(name='dagster-snowflake'):
             'Operating System :: OS Independent',
         ],
         packages=find_packages(exclude=['test']),
-        install_requires=['dagster', 'snowflake-connector-python==1.7.*'],
+        install_requires=['dagster', 'snowflake-connector-python>=2.0.1'],
         zip_safe=False,
     )
 


### PR DESCRIPTION
azure test are failing because we skip compute logging when we are on windows with py36+