### PR TITLE
Fixed a simple Typo in 'solid' decorator

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators.py
@@ -289,7 +289,7 @@ def solid(
         name (str): Name of solid. Must be unique within any :py:class:`PipelineDefinition`
             using the solid.
         description (str): Human-readable description of this solid.
-        input_defs (Optiona[List[InputDefinition]]):
+        input_defs (Optional[List[InputDefinition]]):
             List of input definitions. Inferred from typehints if not provided.
         output_defs (Optional[List[OutputDefinition]]):
             List of output definitions. Inferred from typehints if not provided.


### PR DESCRIPTION
Fixed a Typo in solid decorator. Fixed "Optiona" to be "Optional".