### PR TITLE
parameterize dagster s3 prefix

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/intermediate_store.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/intermediate_store.py
@@ -6,14 +6,22 @@ from .object_store import S3ObjectStore
 
 
 class S3IntermediateStore(IntermediateStore):
-    def __init__(self, s3_bucket, run_id, s3_session=None, type_storage_plugin_registry=None):
+    def __init__(
+        self,
+        s3_bucket,
+        run_id,
+        s3_session=None,
+        type_storage_plugin_registry=None,
+        s3_prefix='dagster',
+    ):
         check.str_param(s3_bucket, 's3_bucket')
+        check.str_param(s3_prefix, 's3_prefix')
         check.str_param(run_id, 'run_id')
 
         object_store = S3ObjectStore(s3_bucket, s3_session=s3_session)
 
         def root_for_run_id(r_id):
-            return object_store.key_for_paths(['dagster', 'storage', r_id])
+            return object_store.key_for_paths([s3_prefix, 'storage', r_id])
 
         super(S3IntermediateStore, self).__init__(
             object_store,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_intermediate_store.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_intermediate_store.py
@@ -263,6 +263,27 @@ def test_s3_intermediate_store_with_custom_serializer(s3_bucket):
 
 
 @nettest
+def test_s3_intermediate_store_with_custom_prefix(s3_bucket):
+    run_id = str(uuid.uuid4())
+
+    intermediate_store = S3IntermediateStore(
+        run_id=run_id, s3_bucket=s3_bucket, s3_prefix="custom_prefix"
+    )
+    assert intermediate_store.root == '/'.join(['custom_prefix', 'storage', run_id])
+
+    try:
+        with yield_empty_pipeline_context(run_id=run_id) as context:
+
+            intermediate_store.set_object(True, context, RuntimeBool.inst(), ['true'])
+
+            assert intermediate_store.has_object(context, ['true'])
+            assert intermediate_store.uri_for_paths(['true']).startswith('s3://')
+
+    finally:
+        intermediate_store.rm_object(context, ['true'])
+
+
+@nettest
 def test_s3_intermediate_store(s3_bucket):
     run_id = str(uuid.uuid4())
     run_id_2 = str(uuid.uuid4())


### PR DESCRIPTION
## Use case

My dags exist in a separate lifecycle from my airflow cluster and I'd like to cleanup or expire backing metadata/files when I destroy the dags that create them. I don't really want to create a bucket for every dag lifecycle that exists.


