### PR TITLE
Add wrapper for Python enums in Dagster configs.

### DIFF
--- a/python_modules/dagster/dagster/core/types/config/config_type.py
+++ b/python_modules/dagster/dagster/core/types/config/config_type.py
@@ -330,6 +330,34 @@ class Enum(ConfigType):
             ).format(config_value=config_value)
         )
 
+    @classmethod
+    def from_python_enum(cls, enum, name=None):
+        '''
+        Create a Dagster enum corresponding to an existing Python enum.
+
+        Args:
+            enum (enum.EnumMeta):
+                The class representing the enum.
+            name (Optional[str]):
+                The name for the enum. If not present, `enum.__name__` will be used.
+
+        Example:
+            .. code-block:: python
+                class Color(enum.Enum):
+                    RED = enum.auto()
+                    GREEN = enum.auto()
+                    BLUE = enum.auto()
+
+                @solid(
+                    config={"color": Field(Enum.from_python_enum(Color))}
+                )
+                def select_color(context):
+                    # ...
+        '''
+        if name is None:
+            name = enum.__name__
+        return cls(name, [EnumValue(v.name, python_value=v) for v in enum])
+
 
 ConfigAnyInstance = Any()
 ConfigBoolInstance = Bool()

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_enums.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_enums.py
@@ -95,3 +95,27 @@ def test_native_enum_dagster_enum():
     result = execute_pipeline(pipeline_def, {'solids': {'dagster_enum_me': {'config': 'BAR'}}})
     assert result.success
     assert called['yup']
+
+
+def test_native_enum_dagster_enum_from_classmethod():
+    dagster_enum = Enum.from_python_enum(NativeEnum)
+    called = {}
+
+    @solid(config=dagster_enum)
+    def dagster_enum_me(context):
+        assert context.solid_config == NativeEnum.BAR
+        called['yup'] = True
+
+    pipeline_def = PipelineDefinition(
+        name='native_enum_dagster_pipeline', solid_defs=[dagster_enum_me]
+    )
+
+    result = execute_pipeline(pipeline_def, {'solids': {'dagster_enum_me': {'config': 'BAR'}}})
+    assert result.success
+    assert called['yup']
+
+
+def test_native_enum_classmethod_creates_all_values():
+    dagster_enum = Enum.from_python_enum(NativeEnum)
+    for enum_value in NativeEnum:
+        assert enum_value is dagster_enum.to_python_value(enum_value.name)


### PR DESCRIPTION
This adds `Enum.from_python_enum` which takes a Python enum (i.e.
something inheriting from EnumMeta) and builds a Dagster Enum from it.

Each value is represented by its name on config level but the
corresponding python_value is the enum value itself.

Also adds two tests:

 - Test that Enum created from this method can be used in a solid
 config.
 - Test for comprehensiveness: all enum values actually have a
 corresponding EnumValue.