### PR TITLE
issue-2042 :: Convert calls to yaml.load

### DIFF
--- a/python_modules/dagster-airflow/dagster_airflow/cli.py
+++ b/python_modules/dagster-airflow/dagster_airflow/cli.py
@@ -3,12 +3,12 @@ from datetime import datetime, timedelta
 
 import click
 import six
-import yaml
 
 from dagster import check, seven
 from dagster.cli.load_handle import handle_for_pipeline_cli_args
 from dagster.utils import load_yaml_from_glob_list
 from dagster.utils.indenting_printer import IndentingStringIoPrinter
+from dagster.seven import yaml
 
 
 def construct_environment_yaml(preset_name, env, pipeline_name, module_name):
@@ -57,7 +57,7 @@ def construct_scaffolded_file_contents(module_name, pipeline_name, environment_d
     printer.line('\'\'\'')
     printer.line('import datetime')
     printer.blank_line()
-    printer.line('import yaml')
+    printer.line('from dagster.seven import yaml')
     printer.line('from dagster_airflow.factory import make_airflow_dag')
     printer.blank_line()
     printer.line('#' * 80)

--- a/python_modules/dagster-celery/dagster_celery/cli.py
+++ b/python_modules/dagster-celery/dagster_celery/cli.py
@@ -3,12 +3,13 @@ import subprocess
 import uuid
 
 import click
-import yaml
+
 from celery.utils.nodenames import default_nodename, host_format
 
 from dagster import check, seven
 from dagster.core.instance import DagsterInstance
 from dagster.core.types.config.evaluator.validate import validate_config
+from dagster.seven import yaml
 from dagster.utils import load_yaml_from_path, mkdir_p
 from dagster.utils.indenting_printer import IndentingPrinter
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -1,4 +1,3 @@
-import yaml
 from dagster_graphql import dauphin
 from dagster_graphql.schema.errors import (
     DauphinPartitionSetNotFoundError,
@@ -8,6 +7,7 @@ from dagster_graphql.schema.errors import (
 
 from dagster import check
 from dagster.core.definitions.partition import Partition, PartitionSetDefinition
+from dagster.seven import yaml
 
 
 class DauphinPartition(dauphin.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 
-import yaml
 from dagster_graphql import dauphin
 from dagster_graphql.implementation.fetch_pipelines import get_pipeline_reference_or_raise
 from dagster_graphql.implementation.fetch_runs import get_stats
@@ -27,6 +26,7 @@ from dagster.core.storage.pipeline_run import (
     PipelineRunStatsSnapshot,
     PipelineRunStatus,
 )
+from dagster.seven import yaml
 
 from .pipelines import DauphinPipeline
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules.py
@@ -2,7 +2,6 @@ import heapq
 import json
 import os
 
-import yaml
 from dagster_graphql import dauphin
 from dagster_graphql.implementation.fetch_schedules import (
     get_dagster_schedule_def,
@@ -16,6 +15,7 @@ from dagster_graphql.schema.errors import (
 from dagster import check, seven
 from dagster.core.definitions import ScheduleDefinition
 from dagster.core.scheduler import Schedule
+from dagster.seven import yaml
 
 
 class DauphinScheduleStatus(dauphin.Enum):

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -10,7 +10,6 @@ import time
 
 import click
 import six
-import yaml
 
 from dagster import (
     PipelineDefinition,
@@ -26,7 +25,7 @@ from dagster.core.definitions.pipeline import ExecutionSelector
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster.core.utils import make_new_run_id
-from dagster.seven import IS_WINDOWS
+from dagster.seven import IS_WINDOWS, yaml
 from dagster.utils import DEFAULT_REPOSITORY_YAML_FILENAME, load_yaml_from_glob_list, merge_dicts
 from dagster.utils.indenting_printer import IndentingPrinter
 from dagster.visualize import build_graphviz_graph

--- a/python_modules/dagster/dagster/core/definitions/preset.py
+++ b/python_modules/dagster/dagster/core/definitions/preset.py
@@ -3,10 +3,10 @@ from collections import namedtuple
 from glob import glob
 
 import six
-import yaml
 
 from dagster import check
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+from dagster.seven import yaml
 from dagster.utils.yaml_utils import merge_yamls
 
 from .mode import DEFAULT_MODE_NAME

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -5,7 +5,6 @@ from collections import defaultdict, namedtuple
 from enum import Enum
 
 import six
-import yaml
 from rx import Observable
 
 from dagster import check, seven
@@ -15,6 +14,7 @@ from dagster.core.serdes import ConfigurableClass, whitelist_for_serdes
 from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.core.types import String
 from dagster.core.types.config import Field, PermissiveDict
+from dagster.seven import yaml
 from dagster.utils.yaml_utils import load_yaml_from_globs
 
 from .config import DAGSTER_CONFIG_YAML_FILENAME

--- a/python_modules/dagster/dagster/core/instance/ref.py
+++ b/python_modules/dagster/dagster/core/instance/ref.py
@@ -1,10 +1,10 @@
 import os
 from collections import namedtuple
 
-import yaml
 
 from dagster import check
 from dagster.core.serdes import ConfigurableClassData, whitelist_for_serdes
+from dagster.seven import yaml
 
 from .config import DAGSTER_CONFIG_YAML_FILENAME, dagster_instance_config
 

--- a/python_modules/dagster/dagster/core/serdes/__init__.py
+++ b/python_modules/dagster/dagster/core/serdes/__init__.py
@@ -19,9 +19,9 @@ from collections import namedtuple
 from enum import Enum
 
 import six
-import yaml
 
 from dagster import check, seven
+from dagster.seven import yaml
 
 _WHITELISTED_TUPLE_MAP = {}
 _WHITELISTED_ENUM_MAP = {}

--- a/python_modules/dagster/dagster/seven/yaml.py
+++ b/python_modules/dagster/dagster/seven/yaml.py
@@ -1,11 +1,8 @@
 # pylint: disable=unused-import
 from __future__ import absolute_import
 
-from functools import partial
-
 from yaml import dump as dump_
-from yaml import load as load_
-from yaml import FullLoader
+from yaml import safe_load
 
 try:
     from yaml import YAMLError
@@ -14,4 +11,4 @@ except ImportError:
 
 dump = dump_
 
-load = partial(load_, Loader=FullLoader)
+load = safe_load

--- a/python_modules/dagster/dagster/seven/yaml.py
+++ b/python_modules/dagster/dagster/seven/yaml.py
@@ -1,0 +1,17 @@
+# pylint: disable=unused-import
+from __future__ import absolute_import
+
+from functools import partial
+
+from yaml import dump as dump_
+from yaml import load as load_
+from yaml import FullLoader
+
+try:
+    from yaml import YAMLError
+except ImportError:
+    YAMLError = ValueError
+
+dump = dump_
+
+load = partial(load_, Loader=FullLoader)

--- a/python_modules/dagster/dagster/utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/utils/yaml_utils.py
@@ -1,10 +1,10 @@
 import glob
 
-import yaml
 
 from dagster import check
 
 from .merger import dict_merge
+from ..seven import yaml
 
 
 def load_yaml_from_globs(*globs):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-import yaml
 
 from dagster import (
     DagsterEventType,
@@ -19,6 +18,7 @@ from dagster.core.storage.local_compute_log_manager import LocalComputeLogManage
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
+from dagster.seven import yaml
 
 
 def test_fs_stores():

--- a/python_modules/libraries/dagster-aws/dagster_aws/cli/config.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cli/config.py
@@ -3,9 +3,9 @@ from collections import namedtuple
 
 import six
 import terminaltables
-import yaml
 
 from dagster import check
+from dagster.seven import yaml
 
 from .term import Term
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/cli_tests/test_config.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/cli_tests/test_config.py
@@ -1,10 +1,10 @@
 import os
 import uuid
 
-import yaml
 from dagster_aws.cli.config import HOST_CONFIG_FILE, EC2Config, RDSConfig
 
 from dagster import seven
+from dagster.seven import yaml
 
 
 def test_write_configs():

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/test_launcher.py
@@ -1,9 +1,8 @@
 import os
 import uuid
 
-import yaml
-
 from dagster.core.storage.pipeline_run import PipelineRun
+from dagster.seven import yaml
 from dagster.utils import load_yaml_from_path
 
 from .conftest import docker_image, environments_path  # pylint: disable=unused-import

--- a/python_modules/libraries/dagster-spark/dagster_spark_tests/test_error.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark_tests/test_error.py
@@ -2,11 +2,12 @@ import os
 import uuid
 
 import pytest
-import yaml
+
 from dagster_spark import SparkSolidDefinition, SparkSolidError
 
 from dagster import PipelineDefinition, execute_pipeline
 from dagster.core.execution.api import create_execution_plan
+from dagster.seven import yaml
 from dagster.utils import script_relative_path
 
 CONFIG_FILE = '''

--- a/python_modules/libraries/dagster-spark/dagster_spark_tests/test_solids.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark_tests/test_solids.py
@@ -1,10 +1,11 @@
 import os
 
 import pytest
-import yaml
+
 from dagster_spark import create_spark_solid, spark_resource
 
 from dagster import ModeDefinition, execute_pipeline, pipeline
+from dagster.seven import yaml
 
 CONFIG = '''
 solids:


### PR DESCRIPTION
I repeated the pattern I saw for `json.py`. 

I only saw three usages of the `yaml` package:

- `yaml.load`
- `yaml.dump`
- `yaml.YAMLError`