### PR TITLE
Presets example command line had wrong python file pipeline name

### DIFF
--- a/docs/sections/learn/tutorial/resources.rst
+++ b/docs/sections/learn/tutorial/resources.rst
@@ -183,7 +183,7 @@ From the CLI, use ``-p`` or ``--preset``:
 
 .. code-block:: shell
 
-    $ dagster pipeline execute -f modes.py -n modes_pipeline -p unittest
+    $ dagster pipeline execute -f presets.py -n presets_pipeline -p unittest
 
 From Python, you can use :py:func:`execute_pipeline_with_preset <dagster.execute_pipeline_with_preset>`:
 


### PR DESCRIPTION
The `dagster` command line example had the wrong python file (`modes.py`) and pipeline name (`modes_pipeline`).   Should be `presets.py` and `presets_pipeline` respectively.