### PR TITLE
Enable env variable references in yaml config files

### DIFF
--- a/python_modules/dagster/dagster/utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/utils/yaml_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import glob
 
 import yaml
@@ -33,4 +35,4 @@ def merge_yamls(file_list):
 def load_yaml_from_path(path):
     check.str_param(path, 'path')
     with open(path, 'r') as ff:
-        return yaml.safe_load(ff)
+        return yaml.safe_load(os.path.expandvars(ff.read()))


### PR DESCRIPTION
This PR would allow references to environment variables in yaml config files of the form $name and ${name} ([details](https://docs.python.org/3.7/library/os.path.html#os.path.expandvars)).

For example (`production.yaml`):
```sh
resources:
  postgres_db:
    config:
      username: $POSTGRES_USERNAME
      password: $POSTGRES_PASSWORD
      hostname: $POSTGRES_HOSTNAME
      db_name: $POSTGRES_DB_NAME
```

The implementation is similar to what is done by [Envyaml](https://github.com/thesimj/envyaml/blob/82b997edb439154e3471f0d74071d61568e7fcb0/envyaml/envyaml.py#L121)

My use cases is that this would allow for version controlling yaml config files without having to worry about committing secrets to my repository. 