### PR TITLE
Update Dask docs about sharing environment vars to workers

### DIFF
--- a/docs/sections/deploying/dask.rst
+++ b/docs/sections/deploying/dask.rst
@@ -72,12 +72,17 @@ Since Dask will invoke your pipeline code on the cluster workers, you must ensur
 version of your Python code is available to all of the Dask workers. Ideally, you'll package this as
 a Python module, and target your ``repository.yaml`` at this module.
 
-If you want Dask to share the `DAGSTER_HOME` environment variable with spawned workers, then you can 
-edit the `dask_jobqueue` configuration file:
+If you want Dask to share the ``DAGSTER_HOME`` environment variable with spawned workers, then you can 
+edit Dask's ``jobqueue.yaml`` configuration file:
 
-.. literalinclude:: dask_jobqueue_config.yaml
-  :caption: jobqueue.yaml
-  :langauge: YAML
+.. code-block:: YAML
+
+  jobqueue:
+    sge:  # your resource manager
+      name: dask-worker
+      ...
+      job-extra: ['-v DAGSTER_HOME=/path/to/dagster']
+
 
 Managing compute resources with Dask
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sections/deploying/dask.rst
+++ b/docs/sections/deploying/dask.rst
@@ -80,7 +80,7 @@ edit Dask's ``jobqueue.yaml`` configuration file. Using SGE as an example:
   jobqueue:
     sge:
       name: dask-worker
-      ...
+      # ...
       job-extra: ['-v DAGSTER_HOME=/path/to/dagster']
 
 

--- a/docs/sections/deploying/dask.rst
+++ b/docs/sections/deploying/dask.rst
@@ -73,12 +73,12 @@ version of your Python code is available to all of the Dask workers. Ideally, yo
 a Python module, and target your ``repository.yaml`` at this module.
 
 If you want Dask to share the ``DAGSTER_HOME`` environment variable with spawned workers, then you can 
-edit Dask's ``jobqueue.yaml`` configuration file:
+edit Dask's ``jobqueue.yaml`` configuration file. Using SGE as an example:
 
 .. code-block:: YAML
 
   jobqueue:
-    sge:  # your resource manager
+    sge:
       name: dask-worker
       ...
       job-extra: ['-v DAGSTER_HOME=/path/to/dagster']

--- a/docs/sections/deploying/dask.rst
+++ b/docs/sections/deploying/dask.rst
@@ -59,7 +59,7 @@ on which the Dask scheduler is running.
 
 You'll also need a persistent shared storage, which should be attached to a pipeline
 :py:class:`~dagster.ModeDefinition` along with any resources on which it depends. (Here, we use the
-:py:data:`~dagster_aws.s3_system_storage`)
+:py:data:`~dagster_aws.s3_system_storage`) 
 
 For distributing task execution on a Dask cluster, you must provide a config block that includes the
 address/port of the Dask scheduler:
@@ -71,6 +71,13 @@ address/port of the Dask scheduler:
 Since Dask will invoke your pipeline code on the cluster workers, you must ensure that the latest
 version of your Python code is available to all of the Dask workers. Ideally, you'll package this as
 a Python module, and target your ``repository.yaml`` at this module.
+
+If you want Dask to share the `DAGSTER_HOME` environment variable with spawned workers, then you can 
+edit the `dask_jobqueue` configuration file:
+
+.. literalinclude:: dask_jobqueue_config.yaml
+  :caption: jobqueue.yaml
+  :langauge: YAML
 
 Managing compute resources with Dask
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sections/deploying/dask_jobqueue_config.yaml
+++ b/docs/sections/deploying/dask_jobqueue_config.yaml
@@ -1,0 +1,5 @@
+jobqueue:
+  sge:  # your resource manager
+    name: dask-worker
+    ...
+    job-extra: ['-v DAGSTER_HOME=/path/to/dagster']

--- a/docs/sections/deploying/dask_jobqueue_config.yaml
+++ b/docs/sections/deploying/dask_jobqueue_config.yaml
@@ -1,5 +1,0 @@
-jobqueue:
-  sge:  # your resource manager
-    name: dask-worker
-    ...
-    job-extra: ['-v DAGSTER_HOME=/path/to/dagster']


### PR DESCRIPTION
Hi there! In an attempt to run my Dagster pipelines on a distributed Dask cluster, I noticed that spawned dask-workers did not have the `DAGSTER_HOME` environment variable set (even when the original shell used to start them did). In my case, Dask is running on top of a CfnCluster with the SGE resource manager. SGE has a `qsub -v` option that lets you pass individual environment variables to the jobs. This PR adds a bit of information to the "Deploying on Dask" docs about how to configure Dask to do this automatically.