### PR TITLE
daemon launcher with subprocess

### DIFF
--- a/python_modules/dagster/dagster/core/launcher/__init__.py
+++ b/python_modules/dagster/dagster/core/launcher/__init__.py
@@ -1,24 +1,2 @@
-from abc import ABCMeta, abstractmethod
-
-import six
-
-
-class RunLauncher(six.with_metaclass(ABCMeta)):
-    @abstractmethod
-    def launch_run(self, instance, run):
-        '''Launch a run.
-
-        This method should begin the execution of the specified run, and may emit engine events.
-        Runs should be created in the instance (e.g., by calling
-        ``DagsterInstance.get_or_create_run()``) *before* this method is called, and
-        should be in the ``PipelineRunStatus.NOT_STARTED`` state. Typically, this method will not
-        be invoked directly, but should be invoked through ``DagsterInstance.launch_run()``.
-        
-        Args:
-            instance (DagsterInstance): The instance in which the run has been created.
-            run (PipelineRun): The PipelineRun to launch.
-
-        Returns:
-            PipelineRun: The launched run. This should be in the ``PipelineRunStatus.STARTED``
-                state, or, if a synchronous failure occurs, the ``PipelineRunStatus.FAILURE`` state.
-        '''
+from .launcher_base import RunLauncher
+from .launcher_daemon import DaemonRunLauncher

--- a/python_modules/dagster/dagster/core/launcher/launcher_base.py
+++ b/python_modules/dagster/dagster/core/launcher/launcher_base.py
@@ -1,0 +1,24 @@
+from abc import ABCMeta, abstractmethod
+
+import six
+
+
+class RunLauncher(six.with_metaclass(ABCMeta)):
+    @abstractmethod
+    def launch_run(self, instance, run):
+        '''Launch a run.
+
+        This method should begin the execution of the specified run, and may emit engine events.
+        Runs should be created in the instance (e.g., by calling
+        ``DagsterInstance.get_or_create_run()``) *before* this method is called, and
+        should be in the ``PipelineRunStatus.NOT_STARTED`` state. Typically, this method will not
+        be invoked directly, but should be invoked through ``DagsterInstance.launch_run()``.
+
+        Args:
+            instance (DagsterInstance): The instance in which the run has been created.
+            run (PipelineRun): The PipelineRun to launch.
+
+        Returns:
+            PipelineRun: The launched run. This should be in the ``PipelineRunStatus.STARTED``
+                state, or, if a synchronous failure occurs, the ``PipelineRunStatus.FAILURE`` state.
+        '''

--- a/python_modules/dagster/dagster/core/launcher/launcher_daemon.py
+++ b/python_modules/dagster/dagster/core/launcher/launcher_daemon.py
@@ -5,7 +5,7 @@ from dagster import EventMetadataEntry, check, seven
 from dagster.core.events import EngineEventData
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import PipelineRun
-from dagster.serdes import ConfigurableClass
+from dagster.serdes import ConfigurableClass, ConfigurableClassData
 
 from .launcher_base import RunLauncher
 
@@ -23,10 +23,23 @@ class DaemonRunLauncher(RunLauncher, ConfigurableClass):
         run_launcher:
             module: dagster.core.launcher
             class: DaemonRunLauncher
+            config: {}
     '''
-    def __init__(self):
+    def __init__(self, inst_data=None):
         print('FOOOOOOO INIT')
-        super().__init__(self)
+        self._inst_data = check.opt_inst_param(inst_data, 'inst_data', ConfigurableClassData)
+
+    @classmethod
+    def config_type(cls):
+        return {}
+
+    @classmethod
+    def from_config_value(cls, inst_data, config_value):
+        return cls(inst_data=inst_data, **config_value)
+
+    @property
+    def inst_data(self):
+        return self._inst_data
 
     def launch_run(self, instance, run):
         check.inst_param(instance, 'instance', DagsterInstance)

--- a/python_modules/dagster/dagster/core/launcher/launcher_daemon.py
+++ b/python_modules/dagster/dagster/core/launcher/launcher_daemon.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+
+from dagster import EventMetadataEntry, check, seven
+from dagster.core.events import EngineEventData
+from dagster.core.instance import DagsterInstance
+from dagster.core.storage.pipeline_run import PipelineRun
+from dagster.serdes import ConfigurableClass
+
+from .launcher_base import RunLauncher
+
+
+class DaemonRunLauncher(RunLauncher, ConfigurableClass):
+    '''RunLauncher that starts daemon process for each pipeline run
+
+    Encapsulates each pipeline run in a separate, isolated invocation of ``dagster-graphql``.
+
+    You may configure a Dagster instance to use this RunLauncher by adding a section to your
+    ``dagster.yaml`` like the following:
+
+    .. code-block:: yaml
+
+        run_launcher:
+            module: dagster.core.launcher
+            class: DaemonRunLauncher
+    '''
+    def __init__(self):
+        print('FOOOOOOO INIT')
+        super().__init__(self)
+
+    def launch_run(self, instance, run):
+        check.inst_param(instance, 'instance', DagsterInstance)
+        check.inst_param(run, 'run', PipelineRun)
+
+        job_name = 'dagster-run-%s' % run.run_id
+
+        print('HIHIHIHIHIHIHIHI')
+
+        subprocess.Popen([
+            'dagster-graphql',
+            '-p', 'startPipelineExecutionForCreatedRun',
+            '-v', seven.json.dumps({'runId': run.run_id}),
+        ], env=os.environ)
+
+        instance.report_engine_event(
+            'Daemon job launched',
+            run,
+            EngineEventData(
+                [
+                    EventMetadataEntry.text(job_name, 'Daemon Job name'),
+                    EventMetadataEntry.text(run.run_id, 'Run ID'),
+                ]
+            ),
+            cls=DaemonRunLauncher,
+        )
+        return run


### PR DESCRIPTION
I've made a simple implementation of daemon-launcher as we discussed in slack and launched my dagit instance with this in dagster.yaml:

```
run_launcher:
  module: dagster.core.launcher
  class: DaemonRunLauncher
  config: {}
```

but when I run a pipeline it is instantiating (I see a couple of FOOOO INIT)
but it doesn't call launch_run (can't see HIHIHIHIHIHIHIHI)

what am I missing?