### PR TITLE
(dagster-cli-api-run-launcher-2) Add cli api for execute_run (for test)

### DIFF
--- a/python_modules/dagster/dagster/api/execute_run.py
+++ b/python_modules/dagster/dagster/api/execute_run.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import uuid
+
+from dagster import check
+from dagster.core.instance import DagsterInstance
+from dagster.core.storage.pipeline_run import PipelineRun
+from dagster.serdes import serialize_dagster_namedtuple
+from dagster.serdes.ipc import ipc_read_event_stream
+from dagster.seven.temp_dir import get_system_temp_directory
+from dagster.utils.temp_file import get_temp_dir
+
+
+# mostly for test
+def sync_cli_api_execute_run(
+    instance, repo_yaml, pipeline_name, environment_dict, mode, solid_subset
+):
+    with get_temp_dir(in_directory=get_system_temp_directory()) as tmp_dir:
+        output_file_name = "{}.json".format(uuid.uuid4())
+        output_file = os.path.join(tmp_dir, output_file_name)
+        pipeline_run = instance.create_run(
+            pipeline_name=pipeline_name,
+            environment_dict=environment_dict,
+            mode=mode,
+            solid_subset=solid_subset,
+        )
+        process = cli_api_execute_run(output_file, instance, repo_yaml, pipeline_run)
+
+        _stdout, _stderr = process.communicate()
+        for message in ipc_read_event_stream(output_file):
+            yield message
+
+
+def cli_api_execute_run(output_file, instance, repo_yaml, pipeline_run):
+    check.str_param(output_file, 'output_file')
+    check.inst_param(instance, 'instance', DagsterInstance)
+    check.str_param(repo_yaml, 'repo_yaml')
+    check.inst_param(pipeline_run, 'pipeline_run', PipelineRun)
+
+    parts = [
+        'dagster',
+        'api',
+        'execute_run',
+        '-y',
+        repo_yaml,
+        output_file,
+        '--instance-ref={instance_ref}'.format(
+            instance_ref=serialize_dagster_namedtuple(instance.get_ref()),
+        ),
+        '--pipeline-run={pipeline_run}'.format(
+            pipeline_run=serialize_dagster_namedtuple(pipeline_run)
+        ),
+    ]
+
+    return subprocess.Popen(parts)

--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -7,7 +7,8 @@ import click
 
 from dagster.cli.load_handle import recon_pipeline_for_cli_args, recon_repo_for_cli_args
 from dagster.cli.pipeline import pipeline_target_command, repository_target_argument
-from dagster.core.execution.api import execute_pipeline_iterator
+from dagster.core.definitions.reconstructable import ReconstructableRepository
+from dagster.core.execution.api import execute_pipeline_iterator, execute_run_iterator
 from dagster.core.host_representation import (
     external_pipeline_data_from_def,
     external_repository_data_from_def,
@@ -101,10 +102,106 @@ def execute_pipeline_command(
             stream.send(event)
 
 
+def _subset(recon_pipeline, solid_subset):
+    return (
+        recon_pipeline.subset_for_execution(solid_subset.split(','))
+        if solid_subset
+        else recon_pipeline
+    )
+
+
+def _get_instance(stream, instance_ref_json):
+    try:
+        return DagsterInstance.from_ref(deserialize_json_to_dagster_namedtuple(instance_ref_json))
+
+    except:  # pylint: disable=bare-except
+        stream.send_error(
+            sys.exc_info(),
+            message='Could not deserialize instance-ref arg: {json_string}'.format(
+                json_string=instance_ref_json
+            ),
+        )
+        return
+
+
+def _get_instance(stream, instance_ref_json):
+    try:
+        return DagsterInstance.from_ref(deserialize_json_to_dagster_namedtuple(instance_ref_json))
+
+    except:  # pylint: disable=bare-except
+        stream.send_error(
+            sys.exc_info(),
+            message='Could not deserialize instance-ref arg: {json_string}'.format(
+                json_string=instance_ref_json
+            ),
+        )
+        return
+
+
+def _get_pipeline_run(stream, pipeline_run_json):
+    try:
+        return deserialize_json_to_dagster_namedtuple(pipeline_run_json)
+
+    except:  # pylint: disable=bare-except
+        stream.send_error(
+            sys.exc_info(),
+            message='Could not deserialize pipeline-run arg: {json_string}'.format(
+                json_string=pipeline_run_json
+            ),
+        )
+        return
+
+
+def _get_recon_pipeline(stream, yaml_path, pipeline_run):
+    try:
+        recon_repo = ReconstructableRepository.from_yaml(yaml_path)
+        return _subset(
+            recon_repo.get_reconstructable_pipeline(pipeline_run.pipeline_name),
+            pipeline_run.solid_subset,
+        )
+
+    except:  # pylint: disable=bare-except
+        stream.send_error(
+            sys.exc_info(),
+            message='Could not load pipeline with yaml_path {path} and name {name}'.format(
+                path=yaml_path, name=pipeline_run.pipeline_name
+            ),
+        )
+        return
+
+
+# Note: only allowing repository yaml for now until we stabilize
+# how we want to communicate pipeline targets
+@click.command(name='execute_run')
+@click.argument('output_file', type=click.Path())
+@click.option('--config-yaml', '-y')
+@click.option('--pipeline-run')
+@click.option('--instance-ref')
+def execute_run_command(output_file, config_yaml, pipeline_run, instance_ref):
+    return _execute_run_command_body(output_file, config_yaml, pipeline_run, instance_ref)
+
+
+def _execute_run_command_body(output_file, config_yaml, pipeline_run_json, instance_ref_json):
+    with ipc_write_stream(output_file) as stream:
+        pipeline_run = _get_pipeline_run(stream, pipeline_run_json)
+        if not pipeline_run:
+            return
+
+        instance = _get_instance(stream, instance_ref_json)
+        if not instance:
+            return
+
+        recon_pipeline = _get_recon_pipeline(stream, config_yaml, pipeline_run)
+
+        for event in execute_run_iterator(recon_pipeline, pipeline_run, instance):
+            stream.send(event)
+
+
 def create_api_cli_group():
     group = click.Group(name="api")
     group.add_command(snapshot_cli)
     group.add_command(execute_pipeline_command)
+    group.add_command(execute_run_command)
     return group
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_execute_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_execute_run.py
@@ -1,0 +1,24 @@
+from dagster import file_relative_path, seven
+from dagster.api.execute_run import sync_cli_api_execute_run
+from dagster.core.events import DagsterEventType
+from dagster.core.instance import DagsterInstance
+
+
+def test_execute_run_api():
+
+    with seven.TemporaryDirectory() as temp_dir:
+        instance = DagsterInstance.local_temp(temp_dir)
+        events = []
+        for event in sync_cli_api_execute_run(
+            instance=instance,
+            repo_yaml=file_relative_path(__file__, 'repository_file.yaml'),
+            pipeline_name='foo',
+            environment_dict={},
+            mode='default',
+            solid_subset=None,
+        ):
+            events.append(event)
+
+        assert len(events) == 11
+        assert events[0].event_type_value == DagsterEventType.PIPELINE_START.value
+        assert events[-1].event_type_value == DagsterEventType.PIPELINE_SUCCESS.value


### PR DESCRIPTION
Summary:
Execute run is actully the thing we are going to need,
as the host process is responsible for creating the run

Will delete the execute pipeline cli api later in stack unless there are
objections

Depends on D3008

Test Plan: BK

Reviewers: alangenfeld, sashank, max

Differential Revision: https://dagster.phacility.com/D3009