### PR TITLE
remove aws cli entry_point and unused terminaltables dependency

### DIFF
--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -43,10 +43,8 @@ def _do_setup(name='dagster-aws'):
             'dagster',
             'psycopg2-binary',
             'requests',
-            'terminaltables',
         ],
         extras_require={'pyspark': ['dagster-pyspark']},
-        entry_points={'console_scripts': ['dagster-aws = dagster_aws.cli.cli:main']},
         zip_safe=False,
     )
 


### PR DESCRIPTION
Hi, thanks for dagster!

Trying to finish up our somewhat convoluted build over on https://github.com/conda-forge/dagster-feedstock/pull/39: it looks like the `dagster-aws 0.8.x` cli has left the building, taking `terminaltables` with it.

This PR removes the `entry_point`, as well as the no-longer-used dependency.