### PR TITLE
Fix dep_dsl example

### DIFF
--- a/examples/dep_dsl/repo.py
+++ b/examples/dep_dsl/repo.py
@@ -57,5 +57,5 @@ def define_dep_dsl_pipeline():
 
 
 @repository
-def my_repository():
+def define_repository():
     return {'pipelines': {'some_example': define_dep_dsl_pipeline}}


### PR DESCRIPTION
The example was broken when the new `repository.yaml` was introduced. There is a mismatch in the expected function name that defines the pipeline and the actual function name.