### PR TITLE
Fix typo in code examples

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
@@ -89,10 +89,10 @@ def test_even_type_hydration_config():
             self.num = num
 
     @input_hydration_config(int)
-    def hydrate_event_type(_, cfg):
+    def hydrate_even_type(_, cfg):
         return EvenType(cfg)
 
-    EvenDagsterType = PythonObjectDagsterType(EvenType, input_hydration_config=hydrate_event_type)
+    EvenDagsterType = PythonObjectDagsterType(EvenType, input_hydration_config=hydrate_even_type)
 
     @solid
     def double_even(_, even_num: EvenDagsterType) -> EvenDagsterType:


### PR DESCRIPTION
This code example is used in the docs to explain basic concepts of Dagster types.        
The example defines a super simplest type called `EvenType` (an even number).

This PR fixes a small typo in the code - One helper function uses **`event` instead of `even`**.