### PR TITLE
Unit tests of IPC interrupt machinery & interaction with compute logs

### DIFF
--- a/python_modules/dagster/dagster/seven/__init__.py
+++ b/python_modules/dagster/dagster/seven/__init__.py
@@ -63,6 +63,11 @@ if sys.version_info > (3,):
 else:
     from pathlib2 import Path  # pylint: disable=import-error
 
+if sys.version_info > (3,):
+    from contextlib import ExitStack  # pylint: disable=import-error
+else:
+    from contextlib2 import ExitStack  # pylint: disable=import-error
+
 IS_WINDOWS = os.name == 'nt'
 
 # TODO implement a generic import by name -- see https://stackoverflow.com/questions/301134/how-to-import-a-module-given-its-name

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -473,3 +473,17 @@ def restore_sys_modules():
         yield
     finally:
         sys.modules = sys_modules
+
+
+def process_is_alive(pid):
+    if IS_WINDOWS:
+        import psutil
+
+        return psutil.pid_exists(pid=pid)
+    else:
+        try:
+            subprocess.check_output(['ps', str(pid)])
+        except subprocess.CalledProcessError as exc:
+            assert exc.returncode == 1
+            return False
+        return True

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -477,7 +477,7 @@ def restore_sys_modules():
 
 def process_is_alive(pid):
     if IS_WINDOWS:
-        import psutil
+        import psutil  # pylint: disable=import-error
 
         return psutil.pid_exists(pid=pid)
     else:

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_grpc_run_launcher.py
@@ -333,7 +333,6 @@ def test_multi_solid_selection_execution():
 
 
 def test_engine_events():
-
     with temp_instance() as instance:
         repo_yaml = file_relative_path(__file__, 'repo.yaml')
 

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess.py
@@ -1,0 +1,31 @@
+'''Test that compute log tail processes go away when the parent is interrupted using
+IPC machinery.'''
+
+import sys
+import time
+
+from dagster.core.execution.compute_logs import mirror_stream_to_file
+from dagster.serdes.ipc import setup_interrupt_support
+
+if __name__ == '__main__':
+    stdout_filepath, stderr_filepath, opened_sentinel, interrupt_sentinel = (
+        sys.argv[1],
+        sys.argv[2],
+        sys.argv[3],
+        sys.argv[4],
+    )
+    setup_interrupt_support()
+    with open(opened_sentinel, 'w') as fd:
+        fd.write('opened_compute_log_subprocess')
+    with mirror_stream_to_file(sys.stdout, stdout_filepath) as stdout_pids:
+        with mirror_stream_to_file(sys.stderr, stderr_filepath) as stderr_pids:
+            sys.stdout.write('stdout pids: {pids}'.format(pids=str(stdout_pids)))
+            sys.stdout.flush()
+            sys.stderr.write('stderr pids: {pids}'.format(pids=str(stderr_pids)))
+            sys.stderr.flush()
+            try:
+                while True:
+                    time.sleep(0.1)
+            except KeyboardInterrupt:
+                with open(interrupt_sentinel, 'w') as fd:
+                    fd.write('compute_log_subprocess_interrupt')

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess_segfault.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/compute_log_subprocess_segfault.py
@@ -1,0 +1,16 @@
+'''Test that compute log tail processes go away when the parent hard crashes.'''
+
+import sys
+
+from dagster.core.execution.compute_logs import mirror_stream_to_file
+from dagster.utils import segfault
+
+if __name__ == '__main__':
+    stdout_pids_file, stderr_pids_file = (sys.argv[1], sys.argv[2])
+    with mirror_stream_to_file(sys.stdout, stdout_pids_file) as stdout_pids:
+        with mirror_stream_to_file(sys.stderr, stderr_pids_file) as stderr_pids:
+            sys.stdout.write('stdout pids: {pids}'.format(pids=str(stdout_pids)))
+            sys.stdout.flush()
+            sys.stderr.write('stderr pids: {pids}'.format(pids=str(stderr_pids)))
+            sys.stderr.flush()
+            segfault()

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/parent_compute_log_subprocess.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/parent_compute_log_subprocess.py
@@ -1,0 +1,41 @@
+'''Test a chain of child processes with compute log tails.'''
+
+import sys
+import time
+
+from dagster.serdes.ipc import (
+    interrupt_ipc_subprocess,
+    open_ipc_subprocess,
+    setup_interrupt_support,
+)
+from dagster.utils import file_relative_path
+
+if __name__ == '__main__':
+    setup_interrupt_support()
+    (
+        child_opened_sentinel,
+        parent_interrupt_sentinel,
+        child_started_sentinel,
+        stdout_pids_file,
+        stderr_pids_file,
+        child_interrupt_sentinel,
+    ) = (sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6])
+    child_process = open_ipc_subprocess(
+        [
+            sys.executable,
+            file_relative_path(__file__, 'compute_log_subprocess.py'),
+            stdout_pids_file,
+            stderr_pids_file,
+            child_started_sentinel,
+            child_interrupt_sentinel,
+        ]
+    )
+    with open(child_opened_sentinel, 'w') as fd:
+        fd.write('opened_ipc_subprocess')
+    try:
+        while True:
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        interrupt_ipc_subprocess(child_process)
+        with open(parent_interrupt_sentinel, 'w') as fd:
+            fd.write('parent_received_keyboard_interrupt')

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/parent_subprocess_with_interrupt_support.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/parent_subprocess_with_interrupt_support.py
@@ -1,0 +1,38 @@
+'''Test a chain of child processes with interrupt support, ensure that interrupts can be
+correctly propagated and handled.'''
+
+import sys
+import time
+
+from dagster.serdes.ipc import (
+    interrupt_ipc_subprocess,
+    open_ipc_subprocess,
+    setup_interrupt_support,
+)
+from dagster.utils import file_relative_path
+
+if __name__ == '__main__':
+    setup_interrupt_support()
+    (
+        child_opened_sentinel,
+        parent_interrupt_sentinel,
+        child_started_sentinel,
+        child_interrupt_sentinel,
+    ) = (sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+    child_process = open_ipc_subprocess(
+        [
+            sys.executable,
+            file_relative_path(__file__, 'subprocess_with_interrupt_support.py'),
+            child_started_sentinel,
+            child_interrupt_sentinel,
+        ]
+    )
+    with open(child_opened_sentinel, 'w') as fd:
+        fd.write('opened_ipc_subprocess')
+    try:
+        while True:
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        interrupt_ipc_subprocess(child_process)
+        with open(parent_interrupt_sentinel, 'w') as fd:
+            fd.write('parent_received_keyboard_interrupt')

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/subprocess_with_interrupt_support.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/subprocess_with_interrupt_support.py
@@ -1,0 +1,17 @@
+'''Test interrupt handling.'''
+import sys
+import time
+
+from dagster.serdes.ipc import setup_interrupt_support
+
+if __name__ == '__main__':
+    setup_interrupt_support()
+    started_sentinel, interrupt_sentinel = (sys.argv[1], sys.argv[2])
+    with open(started_sentinel, 'w') as fd:
+        fd.write('setup_interrupt_support')
+    try:
+        while True:
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        with open(interrupt_sentinel, 'w') as fd:
+            fd.write('received_keyboard_interrupt')

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
@@ -11,25 +11,7 @@ from dagster.serdes.ipc import (
     open_ipc_subprocess,
 )
 from dagster.seven import IS_WINDOWS, ExitStack
-from dagster.utils import file_relative_path, safe_tempfile_path
-
-
-def process_is_alive(pid):
-    if IS_WINDOWS:
-        import psutil
-
-        try:
-            psutil.Process(pid=pid)
-        except psutil.NoSuchProcess:
-            return False
-        return True
-    else:
-        try:
-            subprocess.check_output(['ps', str(pid)])
-        except subprocess.CalledProcessError as exc:
-            assert exc.returncode == 1
-            return False
-        return True
+from dagster.utils import file_relative_path, safe_tempfile_path, process_is_alive
 
 
 def wait_for_file(path, timeout=5):

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
@@ -40,7 +40,7 @@ def wait_for_file(path, timeout=5):
         total_time += interval
     if total_time >= timeout:
         raise Exception('wait_for_file: timeout')
-
+    time.sleep(interval)
 
 def wait_for_process(pid, timeout=5):
     interval = 0.1

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
@@ -10,8 +10,8 @@ from dagster.serdes.ipc import (
     interrupt_ipc_subprocess_pid,
     open_ipc_subprocess,
 )
-from dagster.seven import IS_WINDOWS, ExitStack
-from dagster.utils import file_relative_path, safe_tempfile_path, process_is_alive
+from dagster.seven import ExitStack
+from dagster.utils import file_relative_path, process_is_alive, safe_tempfile_path
 
 
 def wait_for_file(path, timeout=5):

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
@@ -1,0 +1,309 @@
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from dagster.serdes.ipc import (
+    interrupt_ipc_subprocess,
+    interrupt_ipc_subprocess_pid,
+    open_ipc_subprocess,
+)
+from dagster.seven import IS_WINDOWS, ExitStack
+from dagster.utils import file_relative_path, safe_tempfile_path
+
+
+def process_is_alive(pid):
+    if IS_WINDOWS:
+        import psutil
+
+        try:
+            psutil.Process(pid=pid)
+        except psutil.NoSuchProcess:
+            return False
+        return True
+    else:
+        try:
+            subprocess.check_output(['ps', str(pid)])
+        except subprocess.CalledProcessError as exc:
+            assert exc.returncode == 1
+            return False
+        return True
+
+
+def wait_for_file(path, timeout=5):
+    interval = 0.1
+    total_time = 0
+    while not os.path.exists(path) and total_time < timeout:
+        time.sleep(interval)
+        total_time += interval
+    if total_time >= timeout:
+        raise Exception('wait_for_file: timeout')
+
+
+def wait_for_process(pid, timeout=5):
+    interval = 0.1
+    total_time = 0
+    while process_is_alive(pid) and total_time < timeout:
+        time.sleep(interval)
+        total_time += interval
+    if total_time >= timeout:
+        raise Exception('wait_for_process: timeout')
+    time.sleep(interval)
+
+
+@pytest.fixture(scope='function')
+def windows_legacy_stdio_env():
+    old_env_value = os.getenv('PYTHONLEGACYWINDOWSSTDIO')
+    try:
+        os.environ['PYTHONLEGACYWINDOWSSTDIO'] = '1'
+        yield
+    finally:
+        if old_env_value is not None:
+            os.environ['PYTHONLEGACYWINDOWSSTDIO'] = old_env_value
+        else:
+            del os.environ['PYTHONLEGACYWINDOWSSTDIO']
+
+
+def test_interrupt_ipc_subprocess():
+    with safe_tempfile_path() as started_sentinel:
+        with safe_tempfile_path() as interrupt_sentinel:
+            sleepy_process = open_ipc_subprocess(
+                [
+                    sys.executable,
+                    file_relative_path(__file__, 'subprocess_with_interrupt_support.py'),
+                    started_sentinel,
+                    interrupt_sentinel,
+                ]
+            )
+            wait_for_file(started_sentinel)
+            interrupt_ipc_subprocess(sleepy_process)
+            wait_for_file(interrupt_sentinel)
+            with open(interrupt_sentinel, 'r') as fd:
+                assert fd.read().startswith('received_keyboard_interrupt')
+
+
+def test_interrupt_ipc_subprocess_by_pid():
+    with safe_tempfile_path() as started_sentinel:
+        with safe_tempfile_path() as interrupt_sentinel:
+            sleepy_process = open_ipc_subprocess(
+                [
+                    sys.executable,
+                    file_relative_path(__file__, 'subprocess_with_interrupt_support.py'),
+                    started_sentinel,
+                    interrupt_sentinel,
+                ]
+            )
+            wait_for_file(started_sentinel)
+            interrupt_ipc_subprocess_pid(sleepy_process.pid)
+            wait_for_file(interrupt_sentinel)
+            with open(interrupt_sentinel, 'r') as fd:
+                assert fd.read().startswith('received_keyboard_interrupt')
+
+
+def test_interrupt_ipc_subprocess_grandchild():
+    with ExitStack() as context_stack:
+        (
+            child_opened_sentinel,
+            parent_interrupt_sentinel,
+            child_started_sentinel,
+            child_interrupt_sentinel,
+        ) = [context_stack.enter_context(safe_tempfile_path()) for _ in range(4)]
+        child_process = open_ipc_subprocess(
+            [
+                sys.executable,
+                file_relative_path(__file__, 'parent_subprocess_with_interrupt_support.py'),
+                child_opened_sentinel,
+                parent_interrupt_sentinel,
+                child_started_sentinel,
+                child_interrupt_sentinel,
+            ]
+        )
+        wait_for_file(child_opened_sentinel)
+        wait_for_file(child_started_sentinel)
+        interrupt_ipc_subprocess(child_process)
+        wait_for_file(child_interrupt_sentinel)
+        with open(child_interrupt_sentinel, 'r') as fd:
+            assert fd.read().startswith('received_keyboard_interrupt')
+        wait_for_file(parent_interrupt_sentinel)
+        with open(parent_interrupt_sentinel, 'r') as fd:
+            assert fd.read().startswith('parent_received_keyboard_interrupt')
+
+
+def test_interrupt_compute_log_tail_child(
+    windows_legacy_stdio_env,  # pylint: disable=redefined-outer-name, unused-argument
+):
+    with ExitStack() as context_stack:
+        (stdout_pids_file, stderr_pids_file, opened_sentinel, interrupt_sentinel) = [
+            context_stack.enter_context(safe_tempfile_path()) for _ in range(4)
+        ]
+
+        child_process = open_ipc_subprocess(
+            [
+                sys.executable,
+                file_relative_path(__file__, 'compute_log_subprocess.py'),
+                stdout_pids_file,
+                stderr_pids_file,
+                opened_sentinel,
+                interrupt_sentinel,
+            ]
+        )
+        wait_for_file(opened_sentinel)
+        wait_for_file(stdout_pids_file)
+        wait_for_file(stderr_pids_file)
+
+        with open(opened_sentinel, 'r') as opened_sentinel_fd:
+            assert opened_sentinel_fd.read().startswith('opened_compute_log_subprocess')
+
+        with open(stdout_pids_file, 'r') as stdout_pids_fd:
+            stdout_pids_str = stdout_pids_fd.read()
+            assert stdout_pids_str.startswith('stdout pids:')
+            stdout_pids = list(
+                map(
+                    lambda x: int(x) if x != 'None' else None,
+                    [x.strip('(),') for x in stdout_pids_str.split(' ')[2:]],
+                )
+            )
+            print(stdout_pids)
+
+        with open(stderr_pids_file, 'r') as stderr_pids_fd:
+            stderr_pids_str = stderr_pids_fd.read()
+            assert stderr_pids_str.startswith('stderr pids:')
+            stderr_pids = list(
+                map(
+                    lambda x: int(x) if x != 'None' else None,
+                    [x.strip('(),') for x in stderr_pids_str.split(' ')[2:]],
+                )
+            )
+            print(stderr_pids)
+
+        interrupt_ipc_subprocess(child_process)
+
+        for stdout_pid in stdout_pids:
+            if stdout_pid is not None:
+                wait_for_process(stdout_pid)
+
+        for stderr_pid in stderr_pids:
+            if stderr_pid is not None:
+                wait_for_process(stderr_pid)
+
+        with open(interrupt_sentinel, 'r') as fd:
+            assert fd.read().startswith('compute_log_subprocess_interrupt')
+
+
+def test_segfault_compute_log_tail(
+    windows_legacy_stdio_env,  # pylint: disable=redefined-outer-name, unused-argument
+):
+    with safe_tempfile_path() as stdout_pids_file:
+        with safe_tempfile_path() as stderr_pids_file:
+            child_process = open_ipc_subprocess(
+                [
+                    sys.executable,
+                    file_relative_path(__file__, 'compute_log_subprocess_segfault.py'),
+                    stdout_pids_file,
+                    stderr_pids_file,
+                ]
+            )
+
+            child_process.wait()
+
+            wait_for_file(stdout_pids_file)
+            with open(stdout_pids_file, 'r') as stdout_pids_fd:
+                stdout_pids_str = stdout_pids_fd.read()
+                assert stdout_pids_str.startswith('stdout pids:')
+                stdout_pids = list(
+                    map(
+                        lambda x: int(x) if x != 'None' else None,
+                        stdout_pids_str.split(' ')[-1].strip('()').split(','),
+                    )
+                )
+
+            wait_for_file(stderr_pids_file)
+            with open(stderr_pids_file, 'r') as stderr_pids_fd:
+                stderr_pids_str = stderr_pids_fd.read()
+                assert stderr_pids_str.startswith('stderr pids:')
+                stderr_pids = list(
+                    map(
+                        lambda x: int(x) if x != 'None' else None,
+                        stderr_pids_str.split(' ')[-1].strip('()').split(','),
+                    )
+                )
+
+            for stdout_pid in stdout_pids:
+                if stdout_pid is not None:
+                    wait_for_process(stdout_pid)
+
+            for stderr_pid in stderr_pids:
+                if stderr_pid is not None:
+                    wait_for_process(stderr_pid)
+
+
+def test_interrupt_compute_log_tail_grandchild(
+    windows_legacy_stdio_env,  # pylint: disable=redefined-outer-name, unused-argument
+):
+    with ExitStack() as context_stack:
+        (
+            child_opened_sentinel,
+            parent_interrupt_sentinel,
+            child_started_sentinel,
+            stdout_pids_file,
+            stderr_pids_file,
+            child_interrupt_sentinel,
+        ) = [context_stack.enter_context(safe_tempfile_path()) for _ in range(6)]
+
+        parent_process = open_ipc_subprocess(
+            [
+                sys.executable,
+                file_relative_path(__file__, 'parent_compute_log_subprocess.py'),
+                child_opened_sentinel,
+                parent_interrupt_sentinel,
+                child_started_sentinel,
+                stdout_pids_file,
+                stderr_pids_file,
+                child_interrupt_sentinel,
+            ]
+        )
+
+        wait_for_file(child_opened_sentinel)
+        wait_for_file(child_started_sentinel)
+
+        wait_for_file(stdout_pids_file)
+        with open(stdout_pids_file, 'r') as stdout_pids_fd:
+            stdout_pids_str = stdout_pids_fd.read()
+            assert stdout_pids_str.startswith('stdout pids:')
+            stdout_pids = list(
+                map(
+                    lambda x: int(x) if x != 'None' else None,
+                    [x.strip('(),') for x in stdout_pids_str.split(' ')[2:]],
+                )
+            )
+
+        wait_for_file(stderr_pids_file)
+        with open(stderr_pids_file, 'r') as stderr_pids_fd:
+            stderr_pids_str = stderr_pids_fd.read()
+            assert stderr_pids_str.startswith('stderr pids:')
+            stderr_pids = list(
+                map(
+                    lambda x: int(x) if x != 'None' else None,
+                    [x.strip('(),') for x in stderr_pids_str.split(' ')[2:]],
+                )
+            )
+
+        interrupt_ipc_subprocess(parent_process)
+
+        wait_for_file(child_interrupt_sentinel)
+        with open(child_interrupt_sentinel, 'r') as fd:
+            assert fd.read().startswith('compute_log_subprocess_interrupt')
+
+        wait_for_file(parent_interrupt_sentinel)
+        with open(parent_interrupt_sentinel, 'r') as fd:
+            assert fd.read().startswith('parent_received_keyboard_interrupt')
+
+        for stdout_pid in stdout_pids:
+            if stdout_pid is not None:
+                wait_for_process(stdout_pid)
+
+        for stderr_pid in stderr_pids:
+            if stderr_pid is not None:
+                wait_for_process(stderr_pid)


### PR DESCRIPTION
Summary: Eliminate causes of suspicion for orphaned windows compute log processes.

Test Plan: Unit

Reviewers: prha

Differential Revision: https://dagster.phacility.com/D3881