### PR TITLE
Fix strftime incorrect format in advanced scheduling doc

### DIFF
--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/scheduling/scheduler.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/scheduling/scheduler.py
@@ -33,7 +33,7 @@ def good_morning_schedule(date):
     return {
         'solids': {
             'hello_cereal': {
-                'inputs': {'date': {'value': date.strftime('YYYY-mm-dd')}}
+                'inputs': {'date': {'value': date.strftime('%Y-%m-%d')}}
             }
         }
     }
@@ -60,7 +60,7 @@ def good_weekday_morning_schedule(date):
     return {
         'solids': {
             'hello_cereal': {
-                'inputs': {'date': {'value': date.strftime('YYYY-mm-dd')}}
+                'inputs': {'date': {'value': date.strftime('%Y-%m-%d')}}
             }
         }
     }


### PR DESCRIPTION
Use `%Y-%m-%d` to produce date in string format. Not `YYYY-mm-dd`, which
produces "YYYY-mm-dd".