### PR TITLE
Add Dask DataFrame options to loader and materializer configs

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -364,20 +364,22 @@ def dict_without_keys(ddict, *keys):
             is_required=False,
             description='Sample a random fraction of items.',
         ),
-        'repartition': Field(Selector(
-            {
-                'npartitions': Field(
-                    int,
-                    description='Number of partitions of output.',
-                ),
-                'partition_size': Field(
-                    Any,
-                    Description='Max number of bytes of memory for each partition.',
-                ),
-            },
+        'repartition': Field(
+            Selector(
+                {
+                    'npartitions': Field(
+                        int,
+                        description='Number of partitions of output.',
+                    ),
+                    'partition_size': Field(
+                        Any,
+                        description='Max number of bytes of memory for each partition.',
+                    ),
+                },
+            ),
             is_required=False,
             description='Repartition dataframe along new divisions.',
-        )),
+        ),
         'reset_index': Field(
             bool,
             is_required=False,
@@ -890,20 +892,22 @@ def dataframe_materializer(_context, config, dask_df):
             is_required=False,
             description='Sample a random fraction of items.',
         ),
-        'repartition': Field(Selector(
-            {
-                'npartitions': Field(
-                    int,
-                    description='Number of partitions of output.',
-                ),
-                'partition_size': Field(
-                    Any,
-                    Description='Max number of bytes of memory for each partition.',
-                ),
-            },
+        'repartition': Field(
+            Selector(
+                {
+                    'npartitions': Field(
+                        int,
+                        description='Number of partitions of output.',
+                    ),
+                    'partition_size': Field(
+                        Any,
+                        description='Max number of bytes of memory for each partition.',
+                    ),
+                },
+            ),
             is_required=False,
             description='Repartition dataframe along new divisions.',
-        )),
+        ),
         'lower_cols': Field(
             bool,
             is_required=False,

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -37,7 +37,7 @@ def dict_without_keys(ddict, *keys):
 @dagster_type_materializer(
     Shape({
         'to': {
-            'csv': Permissive(
+            'csv': Field(
                 {
                     'path': Field(
                         Any,
@@ -103,9 +103,10 @@ def dict_without_keys(ddict, *keys):
                         is_required=False,
                         description="Options to be passed in to the compute method",
                     ),
-                }
+                },
+                is_required=False,
             ),
-            'parquet': Permissive(
+            'parquet': Field(
                 {
                     'path': Field(
                         Any,
@@ -185,9 +186,10 @@ def dict_without_keys(ddict, *keys):
                         is_required=False,
                         description="Options to be passed in to the compute method.",
                     ),
-                }
+                },
+                is_required=False,
             ),
-            'hdf': Permissive(
+            'hdf': Field(
                 {
                     'path': Field(
                         Any,
@@ -219,9 +221,10 @@ def dict_without_keys(ddict, *keys):
                         is_required=False,
                         description="The scheduler to use, like 'threads' or 'processes'.",
                     ),
-                }
+                },
+                is_required=False,
             ),
-            'json': Permissive(
+            'json': Field(
                 {
                     'path': Field(
                         Any,
@@ -266,8 +269,9 @@ def dict_without_keys(ddict, *keys):
                         String, is_required=False, description="String like 'gzip' or 'xz'.",
                     ),
                 },
+                is_required=False,
             ),
-            'sql': Permissive(
+            'sql': Field(
                 {
                     'name': Field(String, is_required=True, description="Name of SQL table",),
                     'uri': Field(
@@ -357,6 +361,7 @@ def dict_without_keys(ddict, *keys):
                         """,
                     ),
                 },
+                is_required=False,
             ),
         },
         'sample': Field(

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -10,6 +10,7 @@ from dagster import (
     EnumValue,
     EventMetadataEntry,
     Field,
+    Float,
     Int,
     Permissive,
     Selector,
@@ -365,7 +366,7 @@ def dict_without_keys(ddict, *keys):
             ),
         },
         'sample': Field(
-            float,
+            Float,
             is_required=False,
             description='Sample a random fraction of items.',
         ),
@@ -386,7 +387,7 @@ def dict_without_keys(ddict, *keys):
             description='Repartition dataframe along new divisions.',
         ),
         'reset_index': Field(
-            bool,
+            Bool,
             is_required=False,
             description='Reset the index to the default index. If true, the index will be inserted into dataframe columns. Defaults to false.'
         ),
@@ -893,7 +894,7 @@ def dataframe_materializer(_context, config, dask_df):
             },
         ),
         'sample': Field(
-            float,
+            Float,
             is_required=False,
             description='Sample a random fraction of items.',
         ),
@@ -914,12 +915,12 @@ def dataframe_materializer(_context, config, dask_df):
             description='Repartition dataframe along new divisions.',
         ),
         'lower_cols': Field(
-            bool,
+            Bool,
             is_required=False,
             description='Lowercase column names.',
         ),
         'reset_index': Field(
-            bool,
+            Bool,
             is_required=False,
             description='Reset the index to the default index. If true, the index will be inserted into dataframe columns. Defaults to false.'
         )

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -423,7 +423,7 @@ def dataframe_materializer(_context, config, dask_df):
 
 @dagster_type_loader(
     Shape({
-        'from': Selector(
+        'read': Selector(
             {
                 'csv': Permissive(
                     {

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -35,335 +35,337 @@ def dict_without_keys(ddict, *keys):
 
 
 @dagster_type_materializer(
-    Selector(
-        {
-            'csv': Permissive(
-                {
-                    'path': Field(
-                        Any,
-                        is_required=True,
-                        description="str or list, Path glob indicating the naming scheme for the output files",
-                    ),
-                    'single_file': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether to save everything into a single CSV file.
-                            Under the single file mode, each partition is appended at the end of the specified CSV file.
-                            Note that not all filesystems support the append mode and thus the single file mode,
-                            especially on cloud storage systems such as S3 or GCS.
-                            A warning will be issued when writing to a file that is not backed by a local filesystem.
-                        """,
-                    ),
-                    'encoding': Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            A string representing the encoding to use in the output file,
-                            defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
-                        """,
-                    ),
-                    'mode': Field(
-                        String, is_required=False, description="Python write mode, default 'w'",
-                    ),
-                    'compression': Field(
-                        WriteCompressionTextOptions,
-                        is_required=False,
-                        description="""
-                            a string representing the compression to use in the output file,
-                            allowed values are 'gzip', 'bz2', 'xz'.
-                        """,
-                    ),
-                    'compute': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    'storage_options': Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Parameters passed on to the backend filesystem class.",
-                    ),
-                    'header_first_partition_only': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If set to `True`, only write the header row in the first output file.
-                            By default, headers are written to all partitions
-                            under the multiple file mode (`single_file` is `False`)
-                            and written only once under the single file mode (`single_file` is `True`).
-                            It must not be `False` under the single file mode.
-                        """,
-                    ),
-                    'compute_kwargs': Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                }
-            ),
-            'parquet': Permissive(
-                {
-                    'path': Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Destination directory for data.
-                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
-                        """,
-                    ),
-                    'engine': Field(
-                        EngineParquetOptions,
-                        is_required=False,
-                        description="""
-                            {'auto', 'fastparquet', 'pyarrow'}, default 'auto' Parquet library to use.
-                            If only one library is installed, it will use that one; if both, it will use 'fastparquet'.
-                        """,
-                    ),
-                    'compression': Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                        str or dict, optional Either a string like ``'snappy'``
-                        or a dictionary mapping column names to compressors like ``{'name': 'gzip', 'values': 'snappy'}``.
-                        The default is ``'default'``, which uses the default compression for whichever engine is selected.
-                        """,
-                    ),
-                    'write_index': Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether or not to write the index. Defaults to True.",
-                    ),
-                    'append': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default), construct data-set from scratch.
-                            If True, add new row-group(s) to an existing data-set.
-                            In the latter case, the data-set must exist, and the schema must match the input data.
-                        """,
-                    ),
-                    'ignore_divisions': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default) raises error when previous divisions overlap with the new appended divisions.
-                            Ignored if append=False.
-                        """,
-                    ),
-                    'partition_on': Field(
-                        list,
-                        is_required=False,
-                        description="""
-                            Construct directory-based partitioning by splitting on these fields values.
-                            Each dask partition will result in one or more datafiles, there will be no global groupby.
-                        """,
-                    ),
-                    'storage_options': Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Key/value pairs to be passed on to the file-system backend, if any.",
-                    ),
-                    'write_metadata_file': Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether to write the special '_metadata' file.",
-                    ),
-                    'compute': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True (default) then the result is computed immediately.
-                            If False then a ``dask.delayed`` object is returned for future computation.
-                        """,
-                    ),
-                    'compute_kwargs': Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method.",
-                    ),
-                }
-            ),
-            'hdf': Permissive(
-                {
-                    'path': Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Path to a target filename.
-                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
-                            May contain a ``*`` to denote many filenames.
-                        """,
-                    ),
-                    'key': Field(
-                        String,
-                        is_required=True,
-                        description="""
-                            Datapath within the files.
-                            May contain a ``*`` to denote many locations.
-                        """,
-                    ),
-                    'compute': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether or not to execute immediately.
-                            If False then this returns a ``dask.Delayed`` value.
-                        """,
-                    ),
-                    'scheduler': Field(
-                        String,
-                        is_required=False,
-                        description="The scheduler to use, like 'threads' or 'processes'.",
-                    ),
-                }
-            ),
-            'json': Permissive(
-                {
-                    'path': Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Location to write to.
-                            If a string, and there are more than one partitions in df,
-                            should include a glob character to expand into a set of file names,
-                            or provide a ``name_function=`` parameter.
-                            Supports protocol specifications such as ``'s3://'``.
-                        """,
-                    ),
-                    'encoding': Field(
-                        String,
-                        is_required=False,
-                        description="default is 'utf-8', The text encoding to implement, e.g., 'utf-8'.",
-                    ),
-                    'errors': Field(
-                        String,
-                        is_required=False,
-                        description="default is 'strict', how to respond to errors in the conversion (see ``str.encode()``).",
-                    ),
-                    'storage_options': Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Passed to backend file-system implementation",
-                    ),
-                    'compute': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    'compute_kwargs': Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                    'compression': Field(
-                        String, is_required=False, description="String like 'gzip' or 'xz'.",
-                    ),
-                },
-            ),
-            'sql': Permissive(
-                {
-                    'name': Field(String, is_required=True, description="Name of SQL table",),
-                    'uri': Field(
-                        String,
-                        is_required=True,
-                        description="Full sqlalchemy URI for the database connection",
-                    ),
-                    'schema': Field(
-                        String,
-                        is_required=False,
-                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
-                    ),
-                    'if_exists': Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {'fail', 'replace', 'append'}, default 'fail'"
-                            How to behave if the table already exists.
-                            * fail: Raise a ValueError.
-                            * replace: Drop the table before inserting new values.
-                            * append: Insert new values to the existing table.
-                        """,
-                    ),
-                    'index': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, Write DataFrame index as a column.
-                            Uses `index_label` as the column name in the table.
-                        """,
-                    ),
-                    'index_label': Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or sequence, default None Column label for index column(s).
-                            If None is given (default) and `index` is True, then the index names are used.
-                            A sequence should be given if the DataFrame uses MultiIndex.
-                        """,
-                    ),
-                    'chunksize': Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            Specify the number of rows in each batch to be written at a time.
-                            By default, all rows will be written at once.
-                        """,
-                    ),
-                    'dtype': Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            dict or scalar, Specifying the datatype for columns.
-                            If a dictionary is used, the keys should be the column names
-                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
-                            If a scalar is provided, it will be applied to all columns.
-                        """,
-                    ),
-                    'method': Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {None, 'multi', callable}, default None
-                            Controls the SQL insertion clause used:
-                            * None : Uses standard SQL ``INSERT`` clause (one per row).
-                            * 'multi': Pass multiple values in a single ``INSERT`` clause.
-                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
-                            Details and a sample callable implementation can be found in the
-                            section :ref:`insert method <io.sql.method>`.
-                        """,
-                    ),
-                    'compute': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, When true, call dask.compute and perform the load into SQL;
-                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
-                        """,
-                    ),
-                    'parallel': Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is False, When true, have each block append itself to the DB table concurrently.
-                            This can result in DB rows being in a different order than the source DataFrame's corresponding rows.
-                            When false, load each block into the SQL DB in sequence.
-                        """,
-                    ),
-                },
-            ),
-        },
-    )
+    Shape({
+        'to': Selector(
+            {
+                'csv': Permissive(
+                    {
+                        'path': Field(
+                            Any,
+                            is_required=True,
+                            description="str or list, Path glob indicating the naming scheme for the output files",
+                        ),
+                        'single_file': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                Whether to save everything into a single CSV file.
+                                Under the single file mode, each partition is appended at the end of the specified CSV file.
+                                Note that not all filesystems support the append mode and thus the single file mode,
+                                especially on cloud storage systems such as S3 or GCS.
+                                A warning will be issued when writing to a file that is not backed by a local filesystem.
+                            """,
+                        ),
+                        'encoding': Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                A string representing the encoding to use in the output file,
+                                defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
+                            """,
+                        ),
+                        'mode': Field(
+                            String, is_required=False, description="Python write mode, default 'w'",
+                        ),
+                        'compression': Field(
+                            WriteCompressionTextOptions,
+                            is_required=False,
+                            description="""
+                                a string representing the compression to use in the output file,
+                                allowed values are 'gzip', 'bz2', 'xz'.
+                            """,
+                        ),
+                        'compute': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If true, immediately executes.
+                                If False, returns a set of delayed objects, which can be computed at a later time.
+                            """,
+                        ),
+                        'storage_options': Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Parameters passed on to the backend filesystem class.",
+                        ),
+                        'header_first_partition_only': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If set to `True`, only write the header row in the first output file.
+                                By default, headers are written to all partitions
+                                under the multiple file mode (`single_file` is `False`)
+                                and written only once under the single file mode (`single_file` is `True`).
+                                It must not be `False` under the single file mode.
+                            """,
+                        ),
+                        'compute_kwargs': Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Options to be passed in to the compute method",
+                        ),
+                    }
+                ),
+                'parquet': Permissive(
+                    {
+                        'path': Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or pathlib.Path, Destination directory for data.
+                                Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+                            """,
+                        ),
+                        'engine': Field(
+                            EngineParquetOptions,
+                            is_required=False,
+                            description="""
+                                {'auto', 'fastparquet', 'pyarrow'}, default 'auto' Parquet library to use.
+                                If only one library is installed, it will use that one; if both, it will use 'fastparquet'.
+                            """,
+                        ),
+                        'compression': Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                            str or dict, optional Either a string like ``'snappy'``
+                            or a dictionary mapping column names to compressors like ``{'name': 'gzip', 'values': 'snappy'}``.
+                            The default is ``'default'``, which uses the default compression for whichever engine is selected.
+                            """,
+                        ),
+                        'write_index': Field(
+                            Bool,
+                            is_required=False,
+                            description="Whether or not to write the index. Defaults to True.",
+                        ),
+                        'append': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If False (default), construct data-set from scratch.
+                                If True, add new row-group(s) to an existing data-set.
+                                In the latter case, the data-set must exist, and the schema must match the input data.
+                            """,
+                        ),
+                        'ignore_divisions': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If False (default) raises error when previous divisions overlap with the new appended divisions.
+                                Ignored if append=False.
+                            """,
+                        ),
+                        'partition_on': Field(
+                            list,
+                            is_required=False,
+                            description="""
+                                Construct directory-based partitioning by splitting on these fields values.
+                                Each dask partition will result in one or more datafiles, there will be no global groupby.
+                            """,
+                        ),
+                        'storage_options': Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Key/value pairs to be passed on to the file-system backend, if any.",
+                        ),
+                        'write_metadata_file': Field(
+                            Bool,
+                            is_required=False,
+                            description="Whether to write the special '_metadata' file.",
+                        ),
+                        'compute': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If True (default) then the result is computed immediately.
+                                If False then a ``dask.delayed`` object is returned for future computation.
+                            """,
+                        ),
+                        'compute_kwargs': Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Options to be passed in to the compute method.",
+                        ),
+                    }
+                ),
+                'hdf': Permissive(
+                    {
+                        'path': Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or pathlib.Path, Path to a target filename.
+                                Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
+                                May contain a ``*`` to denote many filenames.
+                            """,
+                        ),
+                        'key': Field(
+                            String,
+                            is_required=True,
+                            description="""
+                                Datapath within the files.
+                                May contain a ``*`` to denote many locations.
+                            """,
+                        ),
+                        'compute': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                Whether or not to execute immediately.
+                                If False then this returns a ``dask.Delayed`` value.
+                            """,
+                        ),
+                        'scheduler': Field(
+                            String,
+                            is_required=False,
+                            description="The scheduler to use, like 'threads' or 'processes'.",
+                        ),
+                    }
+                ),
+                'json': Permissive(
+                    {
+                        'path': Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Location to write to.
+                                If a string, and there are more than one partitions in df,
+                                should include a glob character to expand into a set of file names,
+                                or provide a ``name_function=`` parameter.
+                                Supports protocol specifications such as ``'s3://'``.
+                            """,
+                        ),
+                        'encoding': Field(
+                            String,
+                            is_required=False,
+                            description="default is 'utf-8', The text encoding to implement, e.g., 'utf-8'.",
+                        ),
+                        'errors': Field(
+                            String,
+                            is_required=False,
+                            description="default is 'strict', how to respond to errors in the conversion (see ``str.encode()``).",
+                        ),
+                        'storage_options': Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Passed to backend file-system implementation",
+                        ),
+                        'compute': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If true, immediately executes.
+                                If False, returns a set of delayed objects, which can be computed at a later time.
+                            """,
+                        ),
+                        'compute_kwargs': Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Options to be passed in to the compute method",
+                        ),
+                        'compression': Field(
+                            String, is_required=False, description="String like 'gzip' or 'xz'.",
+                        ),
+                    },
+                ),
+                'sql': Permissive(
+                    {
+                        'name': Field(String, is_required=True, description="Name of SQL table",),
+                        'uri': Field(
+                            String,
+                            is_required=True,
+                            description="Full sqlalchemy URI for the database connection",
+                        ),
+                        'schema': Field(
+                            String,
+                            is_required=False,
+                            description="Specify the schema (if database flavor supports this). If None, use default schema.",
+                        ),
+                        'if_exists': Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                {'fail', 'replace', 'append'}, default 'fail'"
+                                How to behave if the table already exists.
+                                * fail: Raise a ValueError.
+                                * replace: Drop the table before inserting new values.
+                                * append: Insert new values to the existing table.
+                            """,
+                        ),
+                        'index': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is True, Write DataFrame index as a column.
+                                Uses `index_label` as the column name in the table.
+                            """,
+                        ),
+                        'index_label': Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                str or sequence, default None Column label for index column(s).
+                                If None is given (default) and `index` is True, then the index names are used.
+                                A sequence should be given if the DataFrame uses MultiIndex.
+                            """,
+                        ),
+                        'chunksize': Field(
+                            Int,
+                            is_required=False,
+                            description="""
+                                Specify the number of rows in each batch to be written at a time.
+                                By default, all rows will be written at once.
+                            """,
+                        ),
+                        'dtype': Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                dict or scalar, Specifying the datatype for columns.
+                                If a dictionary is used, the keys should be the column names
+                                and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
+                                If a scalar is provided, it will be applied to all columns.
+                            """,
+                        ),
+                        'method': Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                {None, 'multi', callable}, default None
+                                Controls the SQL insertion clause used:
+                                * None : Uses standard SQL ``INSERT`` clause (one per row).
+                                * 'multi': Pass multiple values in a single ``INSERT`` clause.
+                                * callable with signature ``(pd_table, conn, keys, data_iter)``.
+                                Details and a sample callable implementation can be found in the
+                                section :ref:`insert method <io.sql.method>`.
+                            """,
+                        ),
+                        'compute': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is True, When true, call dask.compute and perform the load into SQL;
+                                otherwise, return a Dask object (or array of per-block objects when parallel=True).
+                            """,
+                        ),
+                        'parallel': Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is False, When true, have each block append itself to the DB table concurrently.
+                                This can result in DB rows being in a different order than the source DataFrame's corresponding rows.
+                                When false, load each block into the SQL DB in sequence.
+                            """,
+                        ),
+                    },
+                ),
+            },
+        ),
+    })
 )
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, 'dask_df', dd.DataFrame)
-    file_type, file_options = list(config.items())[0]
+    file_type, file_options = list(config['to'].items())[0]
     path = file_options.get('path')
 
     if file_type == 'csv':

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -365,21 +365,21 @@ def dict_without_keys(ddict, *keys):
 )
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, 'dask_df', dd.DataFrame)
-    file_type, file_options = list(config['to'].items())[0]
-    path = file_options.get('path')
+    to_type, to_options = list(config['to'].items())[0]
+    path = to_options.get('path')
 
-    if file_type == 'csv':
-        dask_df.to_csv(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'parquet':
-        dask_df.to_parquet(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'hdf':
-        dask_df.to_hdf(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'json':
-        dask_df.to_json(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'sql':
-        dask_df.to_sql(**file_options)
+    if to_type == 'csv':
+        dask_df.to_csv(path, **dict_without_keys(to_options, 'path'))
+    elif to_type == 'parquet':
+        dask_df.to_parquet(path, **dict_without_keys(to_options, 'path'))
+    elif to_type == 'hdf':
+        dask_df.to_hdf(path, **dict_without_keys(to_options, 'path'))
+    elif to_type == 'json':
+        dask_df.to_json(path, **dict_without_keys(to_options, 'path'))
+    elif to_type == 'sql':
+        dask_df.to_sql(**to_options)
     else:
-        check.failed('Unsupported file_type {file_type}'.format(file_type=file_type))
+        check.failed('Unsupported to_type {to_type}'.format(to_type=to_type))
 
     return AssetMaterialization.file(path)
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -851,28 +851,28 @@ def dataframe_materializer(_context, config, dask_df):
     })
 )
 def dataframe_loader(_context, config):
-    file_type, file_options = next(iter(config['read'].items()))
-    path = file_options.get('path')
+    read_type, read_options = next(iter(config['read'].items()))
+    path = read_options.get('path')
 
-    if file_type == 'csv':
-        return dd.read_csv(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'parquet':
-        return dd.read_parquet(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'hdf':
-        return dd.read_hdf(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'json':
-        return dd.read_json(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'sql_table':
-        return dd.read_sql_table(**file_options)
-    elif file_type == 'table':
-        return dd.read_table(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'fwf':
-        return dd.read_fwf(path, **dict_without_keys(file_options, 'path'))
-    elif file_type == 'orc':
-        return dd.read_orc(path, **dict_without_keys(file_options, 'path'))
+    if read_type == 'csv':
+        return dd.read_csv(path, **dict_without_keys(read_options, 'path'))
+    elif read_type == 'parquet':
+        return dd.read_parquet(path, **dict_without_keys(read_options, 'path'))
+    elif read_type == 'hdf':
+        return dd.read_hdf(path, **dict_without_keys(read_options, 'path'))
+    elif read_type == 'json':
+        return dd.read_json(path, **dict_without_keys(read_options, 'path'))
+    elif read_type == 'sql_table':
+        return dd.read_sql_table(**read_options)
+    elif read_type == 'table':
+        return dd.read_table(path, **dict_without_keys(read_options, 'path'))
+    elif read_type == 'fwf':
+        return dd.read_fwf(path, **dict_without_keys(read_options, 'path'))
+    elif read_type == 'orc':
+        return dd.read_orc(path, **dict_without_keys(read_options, 'path'))
     else:
         raise DagsterInvariantViolationError(
-            'Unsupported file_type {file_type}'.format(file_type=file_type)
+            'Unsupported read_type {read_type}'.format(read_type=read_type)
         )
 
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -36,352 +36,351 @@ def dict_without_keys(ddict, *keys):
 
 @dagster_type_materializer(
     Shape({
-        'to': Selector(
-            {
-                'csv': Permissive(
-                    {
-                        'path': Field(
-                            Any,
-                            is_required=True,
-                            description="str or list, Path glob indicating the naming scheme for the output files",
-                        ),
-                        'single_file': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                Whether to save everything into a single CSV file.
-                                Under the single file mode, each partition is appended at the end of the specified CSV file.
-                                Note that not all filesystems support the append mode and thus the single file mode,
-                                especially on cloud storage systems such as S3 or GCS.
-                                A warning will be issued when writing to a file that is not backed by a local filesystem.
-                            """,
-                        ),
-                        'encoding': Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                A string representing the encoding to use in the output file,
-                                defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
-                            """,
-                        ),
-                        'mode': Field(
-                            String, is_required=False, description="Python write mode, default 'w'",
-                        ),
-                        'compression': Field(
-                            WriteCompressionTextOptions,
-                            is_required=False,
-                            description="""
-                                a string representing the compression to use in the output file,
-                                allowed values are 'gzip', 'bz2', 'xz'.
-                            """,
-                        ),
-                        'compute': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If true, immediately executes.
-                                If False, returns a set of delayed objects, which can be computed at a later time.
-                            """,
-                        ),
-                        'storage_options': Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Parameters passed on to the backend filesystem class.",
-                        ),
-                        'header_first_partition_only': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If set to `True`, only write the header row in the first output file.
-                                By default, headers are written to all partitions
-                                under the multiple file mode (`single_file` is `False`)
-                                and written only once under the single file mode (`single_file` is `True`).
-                                It must not be `False` under the single file mode.
-                            """,
-                        ),
-                        'compute_kwargs': Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Options to be passed in to the compute method",
-                        ),
-                    }
-                ),
-                'parquet': Permissive(
-                    {
-                        'path': Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or pathlib.Path, Destination directory for data.
-                                Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
-                            """,
-                        ),
-                        'engine': Field(
-                            EngineParquetOptions,
-                            is_required=False,
-                            description="""
-                                {'auto', 'fastparquet', 'pyarrow'}, default 'auto' Parquet library to use.
-                                If only one library is installed, it will use that one; if both, it will use 'fastparquet'.
-                            """,
-                        ),
-                        'compression': Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                            str or dict, optional Either a string like ``'snappy'``
-                            or a dictionary mapping column names to compressors like ``{'name': 'gzip', 'values': 'snappy'}``.
-                            The default is ``'default'``, which uses the default compression for whichever engine is selected.
-                            """,
-                        ),
-                        'write_index': Field(
-                            Bool,
-                            is_required=False,
-                            description="Whether or not to write the index. Defaults to True.",
-                        ),
-                        'append': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If False (default), construct data-set from scratch.
-                                If True, add new row-group(s) to an existing data-set.
-                                In the latter case, the data-set must exist, and the schema must match the input data.
-                            """,
-                        ),
-                        'ignore_divisions': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If False (default) raises error when previous divisions overlap with the new appended divisions.
-                                Ignored if append=False.
-                            """,
-                        ),
-                        'partition_on': Field(
-                            list,
-                            is_required=False,
-                            description="""
-                                Construct directory-based partitioning by splitting on these fields values.
-                                Each dask partition will result in one or more datafiles, there will be no global groupby.
-                            """,
-                        ),
-                        'storage_options': Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Key/value pairs to be passed on to the file-system backend, if any.",
-                        ),
-                        'write_metadata_file': Field(
-                            Bool,
-                            is_required=False,
-                            description="Whether to write the special '_metadata' file.",
-                        ),
-                        'compute': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If True (default) then the result is computed immediately.
-                                If False then a ``dask.delayed`` object is returned for future computation.
-                            """,
-                        ),
-                        'compute_kwargs': Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Options to be passed in to the compute method.",
-                        ),
-                    }
-                ),
-                'hdf': Permissive(
-                    {
-                        'path': Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or pathlib.Path, Path to a target filename.
-                                Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
-                                May contain a ``*`` to denote many filenames.
-                            """,
-                        ),
-                        'key': Field(
-                            String,
-                            is_required=True,
-                            description="""
-                                Datapath within the files.
-                                May contain a ``*`` to denote many locations.
-                            """,
-                        ),
-                        'compute': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                Whether or not to execute immediately.
-                                If False then this returns a ``dask.Delayed`` value.
-                            """,
-                        ),
-                        'scheduler': Field(
-                            String,
-                            is_required=False,
-                            description="The scheduler to use, like 'threads' or 'processes'.",
-                        ),
-                    }
-                ),
-                'json': Permissive(
-                    {
-                        'path': Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Location to write to.
-                                If a string, and there are more than one partitions in df,
-                                should include a glob character to expand into a set of file names,
-                                or provide a ``name_function=`` parameter.
-                                Supports protocol specifications such as ``'s3://'``.
-                            """,
-                        ),
-                        'encoding': Field(
-                            String,
-                            is_required=False,
-                            description="default is 'utf-8', The text encoding to implement, e.g., 'utf-8'.",
-                        ),
-                        'errors': Field(
-                            String,
-                            is_required=False,
-                            description="default is 'strict', how to respond to errors in the conversion (see ``str.encode()``).",
-                        ),
-                        'storage_options': Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Passed to backend file-system implementation",
-                        ),
-                        'compute': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If true, immediately executes.
-                                If False, returns a set of delayed objects, which can be computed at a later time.
-                            """,
-                        ),
-                        'compute_kwargs': Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Options to be passed in to the compute method",
-                        ),
-                        'compression': Field(
-                            String, is_required=False, description="String like 'gzip' or 'xz'.",
-                        ),
-                    },
-                ),
-                'sql': Permissive(
-                    {
-                        'name': Field(String, is_required=True, description="Name of SQL table",),
-                        'uri': Field(
-                            String,
-                            is_required=True,
-                            description="Full sqlalchemy URI for the database connection",
-                        ),
-                        'schema': Field(
-                            String,
-                            is_required=False,
-                            description="Specify the schema (if database flavor supports this). If None, use default schema.",
-                        ),
-                        'if_exists': Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                {'fail', 'replace', 'append'}, default 'fail'"
-                                How to behave if the table already exists.
-                                * fail: Raise a ValueError.
-                                * replace: Drop the table before inserting new values.
-                                * append: Insert new values to the existing table.
-                            """,
-                        ),
-                        'index': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is True, Write DataFrame index as a column.
-                                Uses `index_label` as the column name in the table.
-                            """,
-                        ),
-                        'index_label': Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                str or sequence, default None Column label for index column(s).
-                                If None is given (default) and `index` is True, then the index names are used.
-                                A sequence should be given if the DataFrame uses MultiIndex.
-                            """,
-                        ),
-                        'chunksize': Field(
-                            Int,
-                            is_required=False,
-                            description="""
-                                Specify the number of rows in each batch to be written at a time.
-                                By default, all rows will be written at once.
-                            """,
-                        ),
-                        'dtype': Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                dict or scalar, Specifying the datatype for columns.
-                                If a dictionary is used, the keys should be the column names
-                                and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
-                                If a scalar is provided, it will be applied to all columns.
-                            """,
-                        ),
-                        'method': Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                {None, 'multi', callable}, default None
-                                Controls the SQL insertion clause used:
-                                * None : Uses standard SQL ``INSERT`` clause (one per row).
-                                * 'multi': Pass multiple values in a single ``INSERT`` clause.
-                                * callable with signature ``(pd_table, conn, keys, data_iter)``.
-                                Details and a sample callable implementation can be found in the
-                                section :ref:`insert method <io.sql.method>`.
-                            """,
-                        ),
-                        'compute': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is True, When true, call dask.compute and perform the load into SQL;
-                                otherwise, return a Dask object (or array of per-block objects when parallel=True).
-                            """,
-                        ),
-                        'parallel': Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is False, When true, have each block append itself to the DB table concurrently.
-                                This can result in DB rows being in a different order than the source DataFrame's corresponding rows.
-                                When false, load each block into the SQL DB in sequence.
-                            """,
-                        ),
-                    },
-                ),
-            },
-        ),
+        'to': {
+            'csv': Permissive(
+                {
+                    'path': Field(
+                        Any,
+                        is_required=True,
+                        description="str or list, Path glob indicating the naming scheme for the output files",
+                    ),
+                    'single_file': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            Whether to save everything into a single CSV file.
+                            Under the single file mode, each partition is appended at the end of the specified CSV file.
+                            Note that not all filesystems support the append mode and thus the single file mode,
+                            especially on cloud storage systems such as S3 or GCS.
+                            A warning will be issued when writing to a file that is not backed by a local filesystem.
+                        """,
+                    ),
+                    'encoding': Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            A string representing the encoding to use in the output file,
+                            defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
+                        """,
+                    ),
+                    'mode': Field(
+                        String, is_required=False, description="Python write mode, default 'w'",
+                    ),
+                    'compression': Field(
+                        WriteCompressionTextOptions,
+                        is_required=False,
+                        description="""
+                            a string representing the compression to use in the output file,
+                            allowed values are 'gzip', 'bz2', 'xz'.
+                        """,
+                    ),
+                    'compute': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If true, immediately executes.
+                            If False, returns a set of delayed objects, which can be computed at a later time.
+                        """,
+                    ),
+                    'storage_options': Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Parameters passed on to the backend filesystem class.",
+                    ),
+                    'header_first_partition_only': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If set to `True`, only write the header row in the first output file.
+                            By default, headers are written to all partitions
+                            under the multiple file mode (`single_file` is `False`)
+                            and written only once under the single file mode (`single_file` is `True`).
+                            It must not be `False` under the single file mode.
+                        """,
+                    ),
+                    'compute_kwargs': Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method",
+                    ),
+                }
+            ),
+            'parquet': Permissive(
+                {
+                    'path': Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or pathlib.Path, Destination directory for data.
+                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+                        """,
+                    ),
+                    'engine': Field(
+                        EngineParquetOptions,
+                        is_required=False,
+                        description="""
+                            {'auto', 'fastparquet', 'pyarrow'}, default 'auto' Parquet library to use.
+                            If only one library is installed, it will use that one; if both, it will use 'fastparquet'.
+                        """,
+                    ),
+                    'compression': Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                        str or dict, optional Either a string like ``'snappy'``
+                        or a dictionary mapping column names to compressors like ``{'name': 'gzip', 'values': 'snappy'}``.
+                        The default is ``'default'``, which uses the default compression for whichever engine is selected.
+                        """,
+                    ),
+                    'write_index': Field(
+                        Bool,
+                        is_required=False,
+                        description="Whether or not to write the index. Defaults to True.",
+                    ),
+                    'append': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If False (default), construct data-set from scratch.
+                            If True, add new row-group(s) to an existing data-set.
+                            In the latter case, the data-set must exist, and the schema must match the input data.
+                        """,
+                    ),
+                    'ignore_divisions': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If False (default) raises error when previous divisions overlap with the new appended divisions.
+                            Ignored if append=False.
+                        """,
+                    ),
+                    'partition_on': Field(
+                        list,
+                        is_required=False,
+                        description="""
+                            Construct directory-based partitioning by splitting on these fields values.
+                            Each dask partition will result in one or more datafiles, there will be no global groupby.
+                        """,
+                    ),
+                    'storage_options': Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Key/value pairs to be passed on to the file-system backend, if any.",
+                    ),
+                    'write_metadata_file': Field(
+                        Bool,
+                        is_required=False,
+                        description="Whether to write the special '_metadata' file.",
+                    ),
+                    'compute': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If True (default) then the result is computed immediately.
+                            If False then a ``dask.delayed`` object is returned for future computation.
+                        """,
+                    ),
+                    'compute_kwargs': Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method.",
+                    ),
+                }
+            ),
+            'hdf': Permissive(
+                {
+                    'path': Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or pathlib.Path, Path to a target filename.
+                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
+                            May contain a ``*`` to denote many filenames.
+                        """,
+                    ),
+                    'key': Field(
+                        String,
+                        is_required=True,
+                        description="""
+                            Datapath within the files.
+                            May contain a ``*`` to denote many locations.
+                        """,
+                    ),
+                    'compute': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            Whether or not to execute immediately.
+                            If False then this returns a ``dask.Delayed`` value.
+                        """,
+                    ),
+                    'scheduler': Field(
+                        String,
+                        is_required=False,
+                        description="The scheduler to use, like 'threads' or 'processes'.",
+                    ),
+                }
+            ),
+            'json': Permissive(
+                {
+                    'path': Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or list, Location to write to.
+                            If a string, and there are more than one partitions in df,
+                            should include a glob character to expand into a set of file names,
+                            or provide a ``name_function=`` parameter.
+                            Supports protocol specifications such as ``'s3://'``.
+                        """,
+                    ),
+                    'encoding': Field(
+                        String,
+                        is_required=False,
+                        description="default is 'utf-8', The text encoding to implement, e.g., 'utf-8'.",
+                    ),
+                    'errors': Field(
+                        String,
+                        is_required=False,
+                        description="default is 'strict', how to respond to errors in the conversion (see ``str.encode()``).",
+                    ),
+                    'storage_options': Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Passed to backend file-system implementation",
+                    ),
+                    'compute': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If true, immediately executes.
+                            If False, returns a set of delayed objects, which can be computed at a later time.
+                        """,
+                    ),
+                    'compute_kwargs': Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method",
+                    ),
+                    'compression': Field(
+                        String, is_required=False, description="String like 'gzip' or 'xz'.",
+                    ),
+                },
+            ),
+            'sql': Permissive(
+                {
+                    'name': Field(String, is_required=True, description="Name of SQL table",),
+                    'uri': Field(
+                        String,
+                        is_required=True,
+                        description="Full sqlalchemy URI for the database connection",
+                    ),
+                    'schema': Field(
+                        String,
+                        is_required=False,
+                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
+                    ),
+                    'if_exists': Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            {'fail', 'replace', 'append'}, default 'fail'"
+                            How to behave if the table already exists.
+                            * fail: Raise a ValueError.
+                            * replace: Drop the table before inserting new values.
+                            * append: Insert new values to the existing table.
+                        """,
+                    ),
+                    'index': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is True, Write DataFrame index as a column.
+                            Uses `index_label` as the column name in the table.
+                        """,
+                    ),
+                    'index_label': Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                            str or sequence, default None Column label for index column(s).
+                            If None is given (default) and `index` is True, then the index names are used.
+                            A sequence should be given if the DataFrame uses MultiIndex.
+                        """,
+                    ),
+                    'chunksize': Field(
+                        Int,
+                        is_required=False,
+                        description="""
+                            Specify the number of rows in each batch to be written at a time.
+                            By default, all rows will be written at once.
+                        """,
+                    ),
+                    'dtype': Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                            dict or scalar, Specifying the datatype for columns.
+                            If a dictionary is used, the keys should be the column names
+                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
+                            If a scalar is provided, it will be applied to all columns.
+                        """,
+                    ),
+                    'method': Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            {None, 'multi', callable}, default None
+                            Controls the SQL insertion clause used:
+                            * None : Uses standard SQL ``INSERT`` clause (one per row).
+                            * 'multi': Pass multiple values in a single ``INSERT`` clause.
+                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
+                            Details and a sample callable implementation can be found in the
+                            section :ref:`insert method <io.sql.method>`.
+                        """,
+                    ),
+                    'compute': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is True, When true, call dask.compute and perform the load into SQL;
+                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
+                        """,
+                    ),
+                    'parallel': Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is False, When true, have each block append itself to the DB table concurrently.
+                            This can result in DB rows being in a different order than the source DataFrame's corresponding rows.
+                            When false, load each block into the SQL DB in sequence.
+                        """,
+                    ),
+                },
+            ),
+        },
     })
 )
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, 'dask_df', dd.DataFrame)
-    to_type, to_options = list(config['to'].items())[0]
-    path = to_options.get('path')
 
-    if to_type == 'csv':
-        dask_df.to_csv(path, **dict_without_keys(to_options, 'path'))
-    elif to_type == 'parquet':
-        dask_df.to_parquet(path, **dict_without_keys(to_options, 'path'))
-    elif to_type == 'hdf':
-        dask_df.to_hdf(path, **dict_without_keys(to_options, 'path'))
-    elif to_type == 'json':
-        dask_df.to_json(path, **dict_without_keys(to_options, 'path'))
-    elif to_type == 'sql':
-        dask_df.to_sql(**to_options)
-    else:
-        check.failed('Unsupported to_type {to_type}'.format(to_type=to_type))
+    for to_type, to_options in config['to'].items():
+        path = to_options.get('path')
 
-    return AssetMaterialization.file(path)
+        if to_type == 'csv':
+            dask_df.to_csv(path, **dict_without_keys(to_options, 'path'))
+        elif to_type == 'parquet':
+            dask_df.to_parquet(path, **dict_without_keys(to_options, 'path'))
+        elif to_type == 'hdf':
+            dask_df.to_hdf(path, **dict_without_keys(to_options, 'path'))
+        elif to_type == 'json':
+            dask_df.to_json(path, **dict_without_keys(to_options, 'path'))
+        elif to_type == 'sql':
+            dask_df.to_sql(**to_options)
+        else:
+            check.failed('Unsupported to_type {to_type}'.format(to_type=to_type))
+
+        yield AssetMaterialization.file(path)
 
 
 @dagster_type_loader(


### PR DESCRIPTION
This PR modifies the loader and materializer for the Dask DataFrame DagsterType to perform some common utility operations on DataFrames such as sampling or repartitioning dataframes. This allows pipelines to easily adjust loaded and stored dataframes, without introducing additional solids or custom code.

To accomplish this, the existing configs for specifying where to read dataframes from or write dataframes to are placed under `read` and `to` keys.

**Before:**

```yaml
solids:
  example:
    inputs:
      dataframe:
        parquet:
          path: s3://some_bucket/some_path
```

**After:**

```yaml
solids:
  example:
    inputs:
      dataframe:
        read:
          parquet:
            path: s3://some_bucket/some_path
```

Then, additional config keys can be added to perform common operations on dataframes being read or written. For example, the following config samples 0.1% of the rows in the dataset and repartitions the dataframe to one partition on load.

**Example:**

```
solids:
  example:
    inputs:
      dataframe:
        read:
          parquet:
            path: s3://some_bucket/some_path
          sample: 0.001
          repartition:
            npartitions: 1
```

In this implementation, the possible options are:

**Read**:

* sample
* repartition
* lower_cols (lowercase column names)
* reset_index

**Write**:

* sample
* repartition
* reset_index

Additionally, the  materializer now allows multiple output formats.