### PR TITLE
Add orient field to JSON materializer config

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -602,6 +602,11 @@ def dataframe_materializer(_context, config, dask_df):
                         is_required=False,
                         description="how to respond to errors in the conversion (see str.encode()).",
                     ),
+                    'orient': Field(
+                        String,
+                        is_required=False,
+                        description="The JSON string format."
+                    ),
                     'storage_option': Field(
                         Permissive(),
                         is_required=False,


### PR DESCRIPTION
Add [`orient`](https://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.to_json) to the config options when materializing a Dask DataFrame to `json`.