### PR TITLE
Remove row_count metadata entry

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -879,7 +879,6 @@ def df_type_check(_, value):
     return TypeCheck(
         success=True,
         metadata_entries=[
-            EventMetadataEntry.text(str(len(value)), 'row_count', 'Number of rows in DataFrame'),
             # string cast columns since they may be things like datetime
             EventMetadataEntry.json({'columns': list(map(str, value.columns))}, 'metadata'),
         ],


### PR DESCRIPTION
Getting the length of a Dask dataframe forces computation, which may be very expensive. Remove the `row_count` metadata entry from the Dask DataFrame type check.