### PR TITLE
Move Dask DataFrame read/to options under read/to keys

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -35,355 +35,6 @@ def dict_without_keys(ddict, *keys):
     return {key: value for key, value in ddict.items() if key not in set(keys)}
 
 
-@dagster_type_materializer(
-    Shape({
-        "to": {
-            "csv": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="str or list, Path glob indicating the naming scheme for the output files",
-                    ),
-                    "single_file": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether to save everything into a single CSV file.
-                            Under the single file mode, each partition is appended at the end of the specified CSV file.
-                            Note that not all filesystems support the append mode and thus the single file mode,
-                            especially on cloud storage systems such as S3 or GCS.
-                            A warning will be issued when writing to a file that is not backed by a local filesystem.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            A string representing the encoding to use in the output file,
-                            defaults to "ascii" on Python 2 and "utf-8" on Python 3.
-                        """,
-                    ),
-                    "mode": Field(
-                        String, is_required=False, description="Python write mode, default "w"",
-                    ),
-                    "compression": Field(
-                        WriteCompressionTextOptions,
-                        is_required=False,
-                        description="""
-                            a string representing the compression to use in the output file,
-                            allowed values are "gzip", "bz2", "xz".
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Parameters passed on to the backend filesystem class.",
-                    ),
-                    "header_first_partition_only": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If set to `True`, only write the header row in the first output file.
-                            By default, headers are written to all partitions
-                            under the multiple file mode (`single_file` is `False`)
-                            and written only once under the single file mode (`single_file` is `True`).
-                            It must not be `False` under the single file mode.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                }
-            ),
-            "parquet": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Destination directory for data.
-                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
-                        """,
-                    ),
-                    "engine": Field(
-                        EngineParquetOptions,
-                        is_required=False,
-                        description="""
-                            {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
-                            If only one library is installed, it will use that one; if both, it will use "fastparquet".
-                        """,
-                    ),
-                    "compression": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                        str or dict, optional Either a string like ``"snappy"``
-                        or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
-                        The default is ``"default"``, which uses the default compression for whichever engine is selected.
-                        """,
-                    ),
-                    "write_index": Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether or not to write the index. Defaults to True.",
-                    ),
-                    "append": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default), construct data-set from scratch.
-                            If True, add new row-group(s) to an existing data-set.
-                            In the latter case, the data-set must exist, and the schema must match the input data.
-                        """,
-                    ),
-                    "ignore_divisions": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default) raises error when previous divisions overlap with the new appended divisions.
-                            Ignored if append=False.
-                        """,
-                    ),
-                    "partition_on": Field(
-                        list,
-                        is_required=False,
-                        description="""
-                            Construct directory-based partitioning by splitting on these fields values.
-                            Each dask partition will result in one or more datafiles, there will be no global groupby.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Key/value pairs to be passed on to the file-system backend, if any.",
-                    ),
-                    "write_metadata_file": Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether to write the special "_metadata" file.",
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True (default) then the result is computed immediately.
-                            If False then a ``dask.delayed`` object is returned for future computation.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method.",
-                    ),
-                }
-            ),
-            "hdf": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Path to a target filename.
-                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
-                            May contain a ``*`` to denote many filenames.
-                        """,
-                    ),
-                    "key": Field(
-                        String,
-                        is_required=True,
-                        description="""
-                            Datapath within the files.
-                            May contain a ``*`` to denote many locations.
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether or not to execute immediately.
-                            If False then this returns a ``dask.Delayed`` value.
-                        """,
-                    ),
-                    "scheduler": Field(
-                        String,
-                        is_required=False,
-                        description="The scheduler to use, like "threads" or "processes".",
-                    ),
-                }
-            ),
-            "json": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Location to write to.
-                            If a string, and there are more than one partitions in df,
-                            should include a glob character to expand into a set of file names,
-                            or provide a ``name_function=`` parameter.
-                            Supports protocol specifications such as ``"s3://"``.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
-                    ),
-                    "errors": Field(
-                        String,
-                        is_required=False,
-                        description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Passed to backend file-system implementation",
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                    "compression": Field(
-                        String, is_required=False, description="String like "gzip" or "xz".",
-                    ),
-                },
-            ),
-            "sql": Permissive(
-                {
-                    "name": Field(String, is_required=True, description="Name of SQL table",),
-                    "uri": Field(
-                        String,
-                        is_required=True,
-                        description="Full sqlalchemy URI for the database connection",
-                    ),
-                    "schema": Field(
-                        String,
-                        is_required=False,
-                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
-                    ),
-                    "if_exists": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {"fail", "replace", "append"}, default "fail""
-                            How to behave if the table already exists.
-                            * fail: Raise a ValueError.
-                            * replace: Drop the table before inserting new values.
-                            * append: Insert new values to the existing table.
-                        """,
-                    ),
-                    "index": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, Write DataFrame index as a column.
-                            Uses `index_label` as the column name in the table.
-                        """,
-                    ),
-                    "index_label": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or sequence, default None Column label for index column(s).
-                            If None is given (default) and `index` is True, then the index names are used.
-                            A sequence should be given if the DataFrame uses MultiIndex.
-                        """,
-                    ),
-                    "chunksize": Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            Specify the number of rows in each batch to be written at a time.
-                            By default, all rows will be written at once.
-                        """,
-                    ),
-                    "dtype": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            dict or scalar, Specifying the datatype for columns.
-                            If a dictionary is used, the keys should be the column names
-                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
-                            If a scalar is provided, it will be applied to all columns.
-                        """,
-                    ),
-                    "method": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {None, "multi", callable}, default None
-                            Controls the SQL insertion clause used:
-                            * None : Uses standard SQL ``INSERT`` clause (one per row).
-                            * "multi": Pass multiple values in a single ``INSERT`` clause.
-                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
-                            Details and a sample callable implementation can be found in the
-                            section :ref:`insert method <io.sql.method>`.
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, When true, call dask.compute and perform the load into SQL;
-                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
-                        """,
-                    ),
-                    "parallel": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is False, When true, have each block append itself to the DB table concurrently.
-                            This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
-                            When false, load each block into the SQL DB in sequence.
-                        """,
-                    ),
-                },
-            ),
-        },
-    })
-)
-def dataframe_materializer(_context, config, dask_df):
-    check.inst_param(dask_df, "dask_df", dd.DataFrame)
-
-    for to_type, to_options in config["to"].items():
-        path = to_options.get("path")
-
-        if to_type == "csv":
-            dask_df.to_csv(path, **dict_without_keys(to_options, "path"))
-        elif to_type == "parquet":
-            dask_df.to_parquet(path, **dict_without_keys(to_options, "path"))
-        elif to_type == "hdf":
-            dask_df.to_hdf(path, **dict_without_keys(to_options, "path"))
-        elif to_type == "json":
-            dask_df.to_json(path, **dict_without_keys(to_options, "path"))
-        elif to_type == "sql":
-            dask_df.to_sql(**to_options)
-        else:
-            check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
-
-        yield AssetMaterialization.file(path)
-
-
 @dagster_type_loader(
     Shape({
         "read": Selector(
@@ -876,6 +527,355 @@ def dataframe_loader(_context, config):
         raise DagsterInvariantViolationError(
             "Unsupported read_type {read_type}".format(read_type=read_type)
         )
+
+
+@dagster_type_materializer(
+    Shape({
+        "to": {
+            "csv": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="str or list, Path glob indicating the naming scheme for the output files",
+                    ),
+                    "single_file": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            Whether to save everything into a single CSV file.
+                            Under the single file mode, each partition is appended at the end of the specified CSV file.
+                            Note that not all filesystems support the append mode and thus the single file mode,
+                            especially on cloud storage systems such as S3 or GCS.
+                            A warning will be issued when writing to a file that is not backed by a local filesystem.
+                        """,
+                    ),
+                    "encoding": Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            A string representing the encoding to use in the output file,
+                            defaults to "ascii" on Python 2 and "utf-8" on Python 3.
+                        """,
+                    ),
+                    "mode": Field(
+                        String, is_required=False, description="Python write mode, default "w"",
+                    ),
+                    "compression": Field(
+                        WriteCompressionTextOptions,
+                        is_required=False,
+                        description="""
+                            a string representing the compression to use in the output file,
+                            allowed values are "gzip", "bz2", "xz".
+                        """,
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If true, immediately executes.
+                            If False, returns a set of delayed objects, which can be computed at a later time.
+                        """,
+                    ),
+                    "storage_options": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Parameters passed on to the backend filesystem class.",
+                    ),
+                    "header_first_partition_only": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If set to `True`, only write the header row in the first output file.
+                            By default, headers are written to all partitions
+                            under the multiple file mode (`single_file` is `False`)
+                            and written only once under the single file mode (`single_file` is `True`).
+                            It must not be `False` under the single file mode.
+                        """,
+                    ),
+                    "compute_kwargs": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method",
+                    ),
+                }
+            ),
+            "parquet": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or pathlib.Path, Destination directory for data.
+                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+                        """,
+                    ),
+                    "engine": Field(
+                        EngineParquetOptions,
+                        is_required=False,
+                        description="""
+                            {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
+                            If only one library is installed, it will use that one; if both, it will use "fastparquet".
+                        """,
+                    ),
+                    "compression": Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                        str or dict, optional Either a string like ``"snappy"``
+                        or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
+                        The default is ``"default"``, which uses the default compression for whichever engine is selected.
+                        """,
+                    ),
+                    "write_index": Field(
+                        Bool,
+                        is_required=False,
+                        description="Whether or not to write the index. Defaults to True.",
+                    ),
+                    "append": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If False (default), construct data-set from scratch.
+                            If True, add new row-group(s) to an existing data-set.
+                            In the latter case, the data-set must exist, and the schema must match the input data.
+                        """,
+                    ),
+                    "ignore_divisions": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If False (default) raises error when previous divisions overlap with the new appended divisions.
+                            Ignored if append=False.
+                        """,
+                    ),
+                    "partition_on": Field(
+                        list,
+                        is_required=False,
+                        description="""
+                            Construct directory-based partitioning by splitting on these fields values.
+                            Each dask partition will result in one or more datafiles, there will be no global groupby.
+                        """,
+                    ),
+                    "storage_options": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Key/value pairs to be passed on to the file-system backend, if any.",
+                    ),
+                    "write_metadata_file": Field(
+                        Bool,
+                        is_required=False,
+                        description="Whether to write the special "_metadata" file.",
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If True (default) then the result is computed immediately.
+                            If False then a ``dask.delayed`` object is returned for future computation.
+                        """,
+                    ),
+                    "compute_kwargs": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method.",
+                    ),
+                }
+            ),
+            "hdf": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or pathlib.Path, Path to a target filename.
+                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
+                            May contain a ``*`` to denote many filenames.
+                        """,
+                    ),
+                    "key": Field(
+                        String,
+                        is_required=True,
+                        description="""
+                            Datapath within the files.
+                            May contain a ``*`` to denote many locations.
+                        """,
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            Whether or not to execute immediately.
+                            If False then this returns a ``dask.Delayed`` value.
+                        """,
+                    ),
+                    "scheduler": Field(
+                        String,
+                        is_required=False,
+                        description="The scheduler to use, like "threads" or "processes".",
+                    ),
+                }
+            ),
+            "json": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or list, Location to write to.
+                            If a string, and there are more than one partitions in df,
+                            should include a glob character to expand into a set of file names,
+                            or provide a ``name_function=`` parameter.
+                            Supports protocol specifications such as ``"s3://"``.
+                        """,
+                    ),
+                    "encoding": Field(
+                        String,
+                        is_required=False,
+                        description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
+                    ),
+                    "errors": Field(
+                        String,
+                        is_required=False,
+                        description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
+                    ),
+                    "storage_options": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Passed to backend file-system implementation",
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If true, immediately executes.
+                            If False, returns a set of delayed objects, which can be computed at a later time.
+                        """,
+                    ),
+                    "compute_kwargs": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method",
+                    ),
+                    "compression": Field(
+                        String, is_required=False, description="String like "gzip" or "xz".",
+                    ),
+                },
+            ),
+            "sql": Permissive(
+                {
+                    "name": Field(String, is_required=True, description="Name of SQL table",),
+                    "uri": Field(
+                        String,
+                        is_required=True,
+                        description="Full sqlalchemy URI for the database connection",
+                    ),
+                    "schema": Field(
+                        String,
+                        is_required=False,
+                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
+                    ),
+                    "if_exists": Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            {"fail", "replace", "append"}, default "fail""
+                            How to behave if the table already exists.
+                            * fail: Raise a ValueError.
+                            * replace: Drop the table before inserting new values.
+                            * append: Insert new values to the existing table.
+                        """,
+                    ),
+                    "index": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is True, Write DataFrame index as a column.
+                            Uses `index_label` as the column name in the table.
+                        """,
+                    ),
+                    "index_label": Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                            str or sequence, default None Column label for index column(s).
+                            If None is given (default) and `index` is True, then the index names are used.
+                            A sequence should be given if the DataFrame uses MultiIndex.
+                        """,
+                    ),
+                    "chunksize": Field(
+                        Int,
+                        is_required=False,
+                        description="""
+                            Specify the number of rows in each batch to be written at a time.
+                            By default, all rows will be written at once.
+                        """,
+                    ),
+                    "dtype": Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                            dict or scalar, Specifying the datatype for columns.
+                            If a dictionary is used, the keys should be the column names
+                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
+                            If a scalar is provided, it will be applied to all columns.
+                        """,
+                    ),
+                    "method": Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            {None, "multi", callable}, default None
+                            Controls the SQL insertion clause used:
+                            * None : Uses standard SQL ``INSERT`` clause (one per row).
+                            * "multi": Pass multiple values in a single ``INSERT`` clause.
+                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
+                            Details and a sample callable implementation can be found in the
+                            section :ref:`insert method <io.sql.method>`.
+                        """,
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is True, When true, call dask.compute and perform the load into SQL;
+                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
+                        """,
+                    ),
+                    "parallel": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is False, When true, have each block append itself to the DB table concurrently.
+                            This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
+                            When false, load each block into the SQL DB in sequence.
+                        """,
+                    ),
+                },
+            ),
+        },
+    })
+)
+def dataframe_materializer(_context, config, dask_df):
+    check.inst_param(dask_df, "dask_df", dd.DataFrame)
+
+    for to_type, to_options in config["to"].items():
+        path = to_options.get("path")
+
+        if to_type == "csv":
+            dask_df.to_csv(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "parquet":
+            dask_df.to_parquet(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "hdf":
+            dask_df.to_hdf(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "json":
+            dask_df.to_json(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "sql":
+            dask_df.to_sql(**to_options)
+        else:
+            check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
+
+        yield AssetMaterialization.file(path)
 
 
 def df_type_check(_, value):

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -12,11 +12,9 @@ from dagster import (
     EnumValue,
     EventMetadataEntry,
     Field,
-    Float,
     Int,
     Permissive,
     Selector,
-    Shape,
     String,
     TypeCheck,
     check,
@@ -224,7 +222,7 @@ def _dataframe_loader_config():
         for read_from, read_opts in DataFrameReadTypes.items()
     }
 
-    return Shape({
+    return Selector({
         "read": Field(
             Selector(read_fields),
             is_required=False,
@@ -283,7 +281,7 @@ def _dataframe_materializer_config():
         for write_to, to_opts in DataFrameToTypes.items()
     }
 
-    return Shape({
+    return Selector({
         "to": Field(
             Selector(to_fields),
             is_required=False,

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -366,21 +366,21 @@ def dict_without_keys(ddict, *keys):
 )
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, "dask_df", dd.DataFrame)
-    file_type, file_options = list(config["to"].items())[0]
-    path = file_options.get("path")
+    to_type, to_options = list(config["to"].items())[0]
+    path = to_options.get("path")
 
-    if file_type == "csv":
-        dask_df.to_csv(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "parquet":
-        dask_df.to_parquet(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "hdf":
-        dask_df.to_hdf(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "json":
-        dask_df.to_json(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "sql":
-        dask_df.to_sql(**file_options)
+    if to_type == "csv":
+        dask_df.to_csv(path, **dict_without_keys(to_options, "path"))
+    elif to_type == "parquet":
+        dask_df.to_parquet(path, **dict_without_keys(to_options, "path"))
+    elif to_type == "hdf":
+        dask_df.to_hdf(path, **dict_without_keys(to_options, "path"))
+    elif to_type == "json":
+        dask_df.to_json(path, **dict_without_keys(to_options, "path"))
+    elif to_type == "sql":
+        dask_df.to_sql(**to_options)
     else:
-        check.failed("Unsupported file_type {file_type}".format(file_type=file_type))
+        check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
 
     return AssetMaterialization.file(path)
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -257,7 +257,7 @@ def dict_without_keys(ddict, *keys):
                             is_required=False,
                             description="how to respond to errors in the conversion (see str.encode()).",
                         ),
-                        "storage_option": Field(
+                        "storage_options": Field(
                             Permissive(),
                             is_required=False,
                             description="Passed to backend file-system implementation.",

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -31,10 +31,6 @@ EngineParquetOptions = Enum(
 )
 
 
-def dict_without_keys(ddict, *keys):
-    return {key: value for key, value in ddict.items() if key not in set(keys)}
-
-
 DataFrameReadTypes = {
     "csv": {
         "function": dd.read_csv,

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -215,10 +215,10 @@ DataFrameToTypes = {
 
 def _dataframe_loader_config():
     read_fields = {
-        read_from: {
+        read_from: Permissive({
             option_name: Field(option_args[0], is_required=option_args[1], description=option_args[2])
             for option_name, option_args in read_opts["options"].items()
-        }
+        })
         for read_from, read_opts in DataFrameReadTypes.items()
     }
 
@@ -273,10 +273,10 @@ def dataframe_loader(_context, config):
 
 def _dataframe_materializer_config():
     to_fields = {
-        write_to: {
+        write_to: Permissive({
             option_name: Field(option_args[0], is_required=option_args[1], description=option_args[2])
             for option_name, option_args in to_opts["options"].items()
-        }
+        })
         for write_to, to_opts in DataFrameToTypes.items()
     }
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -36,335 +36,337 @@ def dict_without_keys(ddict, *keys):
 
 
 @dagster_type_materializer(
-    Selector(
-        {
-            "csv": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="str or list, Path glob indicating the naming scheme for the output files",
-                    ),
-                    "single_file": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether to save everything into a single CSV file.
-                            Under the single file mode, each partition is appended at the end of the specified CSV file.
-                            Note that not all filesystems support the append mode and thus the single file mode,
-                            especially on cloud storage systems such as S3 or GCS.
-                            A warning will be issued when writing to a file that is not backed by a local filesystem.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            A string representing the encoding to use in the output file,
-                            defaults to "ascii" on Python 2 and "utf-8" on Python 3.
-                        """,
-                    ),
-                    "mode": Field(
-                        String, is_required=False, description="Python write mode, default "w"",
-                    ),
-                    "compression": Field(
-                        WriteCompressionTextOptions,
-                        is_required=False,
-                        description="""
-                            a string representing the compression to use in the output file,
-                            allowed values are "gzip", "bz2", "xz".
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Parameters passed on to the backend filesystem class.",
-                    ),
-                    "header_first_partition_only": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If set to `True`, only write the header row in the first output file.
-                            By default, headers are written to all partitions
-                            under the multiple file mode (`single_file` is `False`)
-                            and written only once under the single file mode (`single_file` is `True`).
-                            It must not be `False` under the single file mode.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                }
-            ),
-            "parquet": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Destination directory for data.
-                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
-                        """,
-                    ),
-                    "engine": Field(
-                        EngineParquetOptions,
-                        is_required=False,
-                        description="""
-                            {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
-                            If only one library is installed, it will use that one; if both, it will use "fastparquet".
-                        """,
-                    ),
-                    "compression": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                        str or dict, optional Either a string like ``"snappy"``
-                        or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
-                        The default is ``"default"``, which uses the default compression for whichever engine is selected.
-                        """,
-                    ),
-                    "write_index": Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether or not to write the index. Defaults to True.",
-                    ),
-                    "append": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default), construct data-set from scratch.
-                            If True, add new row-group(s) to an existing data-set.
-                            In the latter case, the data-set must exist, and the schema must match the input data.
-                        """,
-                    ),
-                    "ignore_divisions": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default) raises error when previous divisions overlap with the new appended divisions.
-                            Ignored if append=False.
-                        """,
-                    ),
-                    "partition_on": Field(
-                        list,
-                        is_required=False,
-                        description="""
-                            Construct directory-based partitioning by splitting on these fields values.
-                            Each dask partition will result in one or more datafiles, there will be no global groupby.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Key/value pairs to be passed on to the file-system backend, if any.",
-                    ),
-                    "write_metadata_file": Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether to write the special "_metadata" file.",
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True (default) then the result is computed immediately.
-                            If False then a ``dask.delayed`` object is returned for future computation.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method.",
-                    ),
-                }
-            ),
-            "hdf": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Path to a target filename.
-                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
-                            May contain a ``*`` to denote many filenames.
-                        """,
-                    ),
-                    "key": Field(
-                        String,
-                        is_required=True,
-                        description="""
-                            Datapath within the files.
-                            May contain a ``*`` to denote many locations.
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether or not to execute immediately.
-                            If False then this returns a ``dask.Delayed`` value.
-                        """,
-                    ),
-                    "scheduler": Field(
-                        String,
-                        is_required=False,
-                        description="The scheduler to use, like "threads" or "processes".",
-                    ),
-                }
-            ),
-            "json": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Location to write to.
-                            If a string, and there are more than one partitions in df,
-                            should include a glob character to expand into a set of file names,
-                            or provide a ``name_function=`` parameter.
-                            Supports protocol specifications such as ``"s3://"``.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
-                    ),
-                    "errors": Field(
-                        String,
-                        is_required=False,
-                        description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Passed to backend file-system implementation",
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                    "compression": Field(
-                        String, is_required=False, description="String like "gzip" or "xz".",
-                    ),
-                },
-            ),
-            "sql": Permissive(
-                {
-                    "name": Field(String, is_required=True, description="Name of SQL table",),
-                    "uri": Field(
-                        String,
-                        is_required=True,
-                        description="Full sqlalchemy URI for the database connection",
-                    ),
-                    "schema": Field(
-                        String,
-                        is_required=False,
-                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
-                    ),
-                    "if_exists": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {"fail", "replace", "append"}, default "fail""
-                            How to behave if the table already exists.
-                            * fail: Raise a ValueError.
-                            * replace: Drop the table before inserting new values.
-                            * append: Insert new values to the existing table.
-                        """,
-                    ),
-                    "index": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, Write DataFrame index as a column.
-                            Uses `index_label` as the column name in the table.
-                        """,
-                    ),
-                    "index_label": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or sequence, default None Column label for index column(s).
-                            If None is given (default) and `index` is True, then the index names are used.
-                            A sequence should be given if the DataFrame uses MultiIndex.
-                        """,
-                    ),
-                    "chunksize": Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            Specify the number of rows in each batch to be written at a time.
-                            By default, all rows will be written at once.
-                        """,
-                    ),
-                    "dtype": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            dict or scalar, Specifying the datatype for columns.
-                            If a dictionary is used, the keys should be the column names
-                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
-                            If a scalar is provided, it will be applied to all columns.
-                        """,
-                    ),
-                    "method": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {None, "multi", callable}, default None
-                            Controls the SQL insertion clause used:
-                            * None : Uses standard SQL ``INSERT`` clause (one per row).
-                            * "multi": Pass multiple values in a single ``INSERT`` clause.
-                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
-                            Details and a sample callable implementation can be found in the
-                            section :ref:`insert method <io.sql.method>`.
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, When true, call dask.compute and perform the load into SQL;
-                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
-                        """,
-                    ),
-                    "parallel": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is False, When true, have each block append itself to the DB table concurrently.
-                            This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
-                            When false, load each block into the SQL DB in sequence.
-                        """,
-                    ),
-                },
-            ),
-        },
-    )
+    Shape({
+        "to": Selector(
+            {
+                "csv": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="str or list, Path glob indicating the naming scheme for the output files",
+                        ),
+                        "single_file": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                Whether to save everything into a single CSV file.
+                                Under the single file mode, each partition is appended at the end of the specified CSV file.
+                                Note that not all filesystems support the append mode and thus the single file mode,
+                                especially on cloud storage systems such as S3 or GCS.
+                                A warning will be issued when writing to a file that is not backed by a local filesystem.
+                            """,
+                        ),
+                        "encoding": Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                A string representing the encoding to use in the output file,
+                                defaults to "ascii" on Python 2 and "utf-8" on Python 3.
+                            """,
+                        ),
+                        "mode": Field(
+                            String, is_required=False, description="Python write mode, default "w"",
+                        ),
+                        "compression": Field(
+                            WriteCompressionTextOptions,
+                            is_required=False,
+                            description="""
+                                a string representing the compression to use in the output file,
+                                allowed values are "gzip", "bz2", "xz".
+                            """,
+                        ),
+                        "compute": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If true, immediately executes.
+                                If False, returns a set of delayed objects, which can be computed at a later time.
+                            """,
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Parameters passed on to the backend filesystem class.",
+                        ),
+                        "header_first_partition_only": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If set to `True`, only write the header row in the first output file.
+                                By default, headers are written to all partitions
+                                under the multiple file mode (`single_file` is `False`)
+                                and written only once under the single file mode (`single_file` is `True`).
+                                It must not be `False` under the single file mode.
+                            """,
+                        ),
+                        "compute_kwargs": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Options to be passed in to the compute method",
+                        ),
+                    }
+                ),
+                "parquet": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or pathlib.Path, Destination directory for data.
+                                Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+                            """,
+                        ),
+                        "engine": Field(
+                            EngineParquetOptions,
+                            is_required=False,
+                            description="""
+                                {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
+                                If only one library is installed, it will use that one; if both, it will use "fastparquet".
+                            """,
+                        ),
+                        "compression": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                            str or dict, optional Either a string like ``"snappy"``
+                            or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
+                            The default is ``"default"``, which uses the default compression for whichever engine is selected.
+                            """,
+                        ),
+                        "write_index": Field(
+                            Bool,
+                            is_required=False,
+                            description="Whether or not to write the index. Defaults to True.",
+                        ),
+                        "append": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If False (default), construct data-set from scratch.
+                                If True, add new row-group(s) to an existing data-set.
+                                In the latter case, the data-set must exist, and the schema must match the input data.
+                            """,
+                        ),
+                        "ignore_divisions": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If False (default) raises error when previous divisions overlap with the new appended divisions.
+                                Ignored if append=False.
+                            """,
+                        ),
+                        "partition_on": Field(
+                            list,
+                            is_required=False,
+                            description="""
+                                Construct directory-based partitioning by splitting on these fields values.
+                                Each dask partition will result in one or more datafiles, there will be no global groupby.
+                            """,
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Key/value pairs to be passed on to the file-system backend, if any.",
+                        ),
+                        "write_metadata_file": Field(
+                            Bool,
+                            is_required=False,
+                            description="Whether to write the special "_metadata" file.",
+                        ),
+                        "compute": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If True (default) then the result is computed immediately.
+                                If False then a ``dask.delayed`` object is returned for future computation.
+                            """,
+                        ),
+                        "compute_kwargs": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Options to be passed in to the compute method.",
+                        ),
+                    }
+                ),
+                "hdf": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or pathlib.Path, Path to a target filename.
+                                Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
+                                May contain a ``*`` to denote many filenames.
+                            """,
+                        ),
+                        "key": Field(
+                            String,
+                            is_required=True,
+                            description="""
+                                Datapath within the files.
+                                May contain a ``*`` to denote many locations.
+                            """,
+                        ),
+                        "compute": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                Whether or not to execute immediately.
+                                If False then this returns a ``dask.Delayed`` value.
+                            """,
+                        ),
+                        "scheduler": Field(
+                            String,
+                            is_required=False,
+                            description="The scheduler to use, like "threads" or "processes".",
+                        ),
+                    }
+                ),
+                "json": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Location to write to.
+                                If a string, and there are more than one partitions in df,
+                                should include a glob character to expand into a set of file names,
+                                or provide a ``name_function=`` parameter.
+                                Supports protocol specifications such as ``"s3://"``.
+                            """,
+                        ),
+                        "encoding": Field(
+                            String,
+                            is_required=False,
+                            description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
+                        ),
+                        "errors": Field(
+                            String,
+                            is_required=False,
+                            description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Passed to backend file-system implementation",
+                        ),
+                        "compute": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If true, immediately executes.
+                                If False, returns a set of delayed objects, which can be computed at a later time.
+                            """,
+                        ),
+                        "compute_kwargs": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Options to be passed in to the compute method",
+                        ),
+                        "compression": Field(
+                            String, is_required=False, description="String like "gzip" or "xz".",
+                        ),
+                    },
+                ),
+                "sql": Permissive(
+                    {
+                        "name": Field(String, is_required=True, description="Name of SQL table",),
+                        "uri": Field(
+                            String,
+                            is_required=True,
+                            description="Full sqlalchemy URI for the database connection",
+                        ),
+                        "schema": Field(
+                            String,
+                            is_required=False,
+                            description="Specify the schema (if database flavor supports this). If None, use default schema.",
+                        ),
+                        "if_exists": Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                {"fail", "replace", "append"}, default "fail""
+                                How to behave if the table already exists.
+                                * fail: Raise a ValueError.
+                                * replace: Drop the table before inserting new values.
+                                * append: Insert new values to the existing table.
+                            """,
+                        ),
+                        "index": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is True, Write DataFrame index as a column.
+                                Uses `index_label` as the column name in the table.
+                            """,
+                        ),
+                        "index_label": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                str or sequence, default None Column label for index column(s).
+                                If None is given (default) and `index` is True, then the index names are used.
+                                A sequence should be given if the DataFrame uses MultiIndex.
+                            """,
+                        ),
+                        "chunksize": Field(
+                            Int,
+                            is_required=False,
+                            description="""
+                                Specify the number of rows in each batch to be written at a time.
+                                By default, all rows will be written at once.
+                            """,
+                        ),
+                        "dtype": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                dict or scalar, Specifying the datatype for columns.
+                                If a dictionary is used, the keys should be the column names
+                                and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
+                                If a scalar is provided, it will be applied to all columns.
+                            """,
+                        ),
+                        "method": Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                {None, "multi", callable}, default None
+                                Controls the SQL insertion clause used:
+                                * None : Uses standard SQL ``INSERT`` clause (one per row).
+                                * "multi": Pass multiple values in a single ``INSERT`` clause.
+                                * callable with signature ``(pd_table, conn, keys, data_iter)``.
+                                Details and a sample callable implementation can be found in the
+                                section :ref:`insert method <io.sql.method>`.
+                            """,
+                        ),
+                        "compute": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is True, When true, call dask.compute and perform the load into SQL;
+                                otherwise, return a Dask object (or array of per-block objects when parallel=True).
+                            """,
+                        ),
+                        "parallel": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is False, When true, have each block append itself to the DB table concurrently.
+                                This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
+                                When false, load each block into the SQL DB in sequence.
+                            """,
+                        ),
+                    },
+                ),
+            },
+        ),
+    })
 )
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, "dask_df", dd.DataFrame)
-    file_type, file_options = list(config.items())[0]
+    file_type, file_options = list(config["to"].items())[0]
     path = file_options.get("path")
 
     if file_type == "csv":

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -50,6 +50,7 @@ DataFrameReadTypes = {
         "options": {
             "path": (Any, True, "Absolute or relative filepath(s)."),
             "columns": (Any, False, "Field name(s) to read in as columns in the output."),
+            "filters": (Any, False, "List of filters to apply."),
             "index": (Any, False, "Field name(s) to use as the output frame index."),
             "categories": (Any, False, "For any fields listed here, if the parquet encoding is Dictionary, the column will be created with dtype category."),
             "storage_options": (Permissive(), False, "Key/value pairs to be passed on to the file-system backend, if any."),

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -37,352 +37,351 @@ def dict_without_keys(ddict, *keys):
 
 @dagster_type_materializer(
     Shape({
-        "to": Selector(
-            {
-                "csv": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="str or list, Path glob indicating the naming scheme for the output files",
-                        ),
-                        "single_file": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                Whether to save everything into a single CSV file.
-                                Under the single file mode, each partition is appended at the end of the specified CSV file.
-                                Note that not all filesystems support the append mode and thus the single file mode,
-                                especially on cloud storage systems such as S3 or GCS.
-                                A warning will be issued when writing to a file that is not backed by a local filesystem.
-                            """,
-                        ),
-                        "encoding": Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                A string representing the encoding to use in the output file,
-                                defaults to "ascii" on Python 2 and "utf-8" on Python 3.
-                            """,
-                        ),
-                        "mode": Field(
-                            String, is_required=False, description="Python write mode, default "w"",
-                        ),
-                        "compression": Field(
-                            WriteCompressionTextOptions,
-                            is_required=False,
-                            description="""
-                                a string representing the compression to use in the output file,
-                                allowed values are "gzip", "bz2", "xz".
-                            """,
-                        ),
-                        "compute": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If true, immediately executes.
-                                If False, returns a set of delayed objects, which can be computed at a later time.
-                            """,
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Parameters passed on to the backend filesystem class.",
-                        ),
-                        "header_first_partition_only": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If set to `True`, only write the header row in the first output file.
-                                By default, headers are written to all partitions
-                                under the multiple file mode (`single_file` is `False`)
-                                and written only once under the single file mode (`single_file` is `True`).
-                                It must not be `False` under the single file mode.
-                            """,
-                        ),
-                        "compute_kwargs": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Options to be passed in to the compute method",
-                        ),
-                    }
-                ),
-                "parquet": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or pathlib.Path, Destination directory for data.
-                                Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
-                            """,
-                        ),
-                        "engine": Field(
-                            EngineParquetOptions,
-                            is_required=False,
-                            description="""
-                                {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
-                                If only one library is installed, it will use that one; if both, it will use "fastparquet".
-                            """,
-                        ),
-                        "compression": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                            str or dict, optional Either a string like ``"snappy"``
-                            or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
-                            The default is ``"default"``, which uses the default compression for whichever engine is selected.
-                            """,
-                        ),
-                        "write_index": Field(
-                            Bool,
-                            is_required=False,
-                            description="Whether or not to write the index. Defaults to True.",
-                        ),
-                        "append": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If False (default), construct data-set from scratch.
-                                If True, add new row-group(s) to an existing data-set.
-                                In the latter case, the data-set must exist, and the schema must match the input data.
-                            """,
-                        ),
-                        "ignore_divisions": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If False (default) raises error when previous divisions overlap with the new appended divisions.
-                                Ignored if append=False.
-                            """,
-                        ),
-                        "partition_on": Field(
-                            list,
-                            is_required=False,
-                            description="""
-                                Construct directory-based partitioning by splitting on these fields values.
-                                Each dask partition will result in one or more datafiles, there will be no global groupby.
-                            """,
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Key/value pairs to be passed on to the file-system backend, if any.",
-                        ),
-                        "write_metadata_file": Field(
-                            Bool,
-                            is_required=False,
-                            description="Whether to write the special "_metadata" file.",
-                        ),
-                        "compute": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If True (default) then the result is computed immediately.
-                                If False then a ``dask.delayed`` object is returned for future computation.
-                            """,
-                        ),
-                        "compute_kwargs": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Options to be passed in to the compute method.",
-                        ),
-                    }
-                ),
-                "hdf": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or pathlib.Path, Path to a target filename.
-                                Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
-                                May contain a ``*`` to denote many filenames.
-                            """,
-                        ),
-                        "key": Field(
-                            String,
-                            is_required=True,
-                            description="""
-                                Datapath within the files.
-                                May contain a ``*`` to denote many locations.
-                            """,
-                        ),
-                        "compute": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                Whether or not to execute immediately.
-                                If False then this returns a ``dask.Delayed`` value.
-                            """,
-                        ),
-                        "scheduler": Field(
-                            String,
-                            is_required=False,
-                            description="The scheduler to use, like "threads" or "processes".",
-                        ),
-                    }
-                ),
-                "json": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Location to write to.
-                                If a string, and there are more than one partitions in df,
-                                should include a glob character to expand into a set of file names,
-                                or provide a ``name_function=`` parameter.
-                                Supports protocol specifications such as ``"s3://"``.
-                            """,
-                        ),
-                        "encoding": Field(
-                            String,
-                            is_required=False,
-                            description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
-                        ),
-                        "errors": Field(
-                            String,
-                            is_required=False,
-                            description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Passed to backend file-system implementation",
-                        ),
-                        "compute": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If true, immediately executes.
-                                If False, returns a set of delayed objects, which can be computed at a later time.
-                            """,
-                        ),
-                        "compute_kwargs": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Options to be passed in to the compute method",
-                        ),
-                        "compression": Field(
-                            String, is_required=False, description="String like "gzip" or "xz".",
-                        ),
-                    },
-                ),
-                "sql": Permissive(
-                    {
-                        "name": Field(String, is_required=True, description="Name of SQL table",),
-                        "uri": Field(
-                            String,
-                            is_required=True,
-                            description="Full sqlalchemy URI for the database connection",
-                        ),
-                        "schema": Field(
-                            String,
-                            is_required=False,
-                            description="Specify the schema (if database flavor supports this). If None, use default schema.",
-                        ),
-                        "if_exists": Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                {"fail", "replace", "append"}, default "fail""
-                                How to behave if the table already exists.
-                                * fail: Raise a ValueError.
-                                * replace: Drop the table before inserting new values.
-                                * append: Insert new values to the existing table.
-                            """,
-                        ),
-                        "index": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is True, Write DataFrame index as a column.
-                                Uses `index_label` as the column name in the table.
-                            """,
-                        ),
-                        "index_label": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                str or sequence, default None Column label for index column(s).
-                                If None is given (default) and `index` is True, then the index names are used.
-                                A sequence should be given if the DataFrame uses MultiIndex.
-                            """,
-                        ),
-                        "chunksize": Field(
-                            Int,
-                            is_required=False,
-                            description="""
-                                Specify the number of rows in each batch to be written at a time.
-                                By default, all rows will be written at once.
-                            """,
-                        ),
-                        "dtype": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                dict or scalar, Specifying the datatype for columns.
-                                If a dictionary is used, the keys should be the column names
-                                and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
-                                If a scalar is provided, it will be applied to all columns.
-                            """,
-                        ),
-                        "method": Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                {None, "multi", callable}, default None
-                                Controls the SQL insertion clause used:
-                                * None : Uses standard SQL ``INSERT`` clause (one per row).
-                                * "multi": Pass multiple values in a single ``INSERT`` clause.
-                                * callable with signature ``(pd_table, conn, keys, data_iter)``.
-                                Details and a sample callable implementation can be found in the
-                                section :ref:`insert method <io.sql.method>`.
-                            """,
-                        ),
-                        "compute": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is True, When true, call dask.compute and perform the load into SQL;
-                                otherwise, return a Dask object (or array of per-block objects when parallel=True).
-                            """,
-                        ),
-                        "parallel": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is False, When true, have each block append itself to the DB table concurrently.
-                                This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
-                                When false, load each block into the SQL DB in sequence.
-                            """,
-                        ),
-                    },
-                ),
-            },
-        ),
+        "to": {
+            "csv": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="str or list, Path glob indicating the naming scheme for the output files",
+                    ),
+                    "single_file": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            Whether to save everything into a single CSV file.
+                            Under the single file mode, each partition is appended at the end of the specified CSV file.
+                            Note that not all filesystems support the append mode and thus the single file mode,
+                            especially on cloud storage systems such as S3 or GCS.
+                            A warning will be issued when writing to a file that is not backed by a local filesystem.
+                        """,
+                    ),
+                    "encoding": Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            A string representing the encoding to use in the output file,
+                            defaults to "ascii" on Python 2 and "utf-8" on Python 3.
+                        """,
+                    ),
+                    "mode": Field(
+                        String, is_required=False, description="Python write mode, default "w"",
+                    ),
+                    "compression": Field(
+                        WriteCompressionTextOptions,
+                        is_required=False,
+                        description="""
+                            a string representing the compression to use in the output file,
+                            allowed values are "gzip", "bz2", "xz".
+                        """,
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If true, immediately executes.
+                            If False, returns a set of delayed objects, which can be computed at a later time.
+                        """,
+                    ),
+                    "storage_options": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Parameters passed on to the backend filesystem class.",
+                    ),
+                    "header_first_partition_only": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If set to `True`, only write the header row in the first output file.
+                            By default, headers are written to all partitions
+                            under the multiple file mode (`single_file` is `False`)
+                            and written only once under the single file mode (`single_file` is `True`).
+                            It must not be `False` under the single file mode.
+                        """,
+                    ),
+                    "compute_kwargs": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method",
+                    ),
+                }
+            ),
+            "parquet": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or pathlib.Path, Destination directory for data.
+                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
+                        """,
+                    ),
+                    "engine": Field(
+                        EngineParquetOptions,
+                        is_required=False,
+                        description="""
+                            {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
+                            If only one library is installed, it will use that one; if both, it will use "fastparquet".
+                        """,
+                    ),
+                    "compression": Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                        str or dict, optional Either a string like ``"snappy"``
+                        or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
+                        The default is ``"default"``, which uses the default compression for whichever engine is selected.
+                        """,
+                    ),
+                    "write_index": Field(
+                        Bool,
+                        is_required=False,
+                        description="Whether or not to write the index. Defaults to True.",
+                    ),
+                    "append": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If False (default), construct data-set from scratch.
+                            If True, add new row-group(s) to an existing data-set.
+                            In the latter case, the data-set must exist, and the schema must match the input data.
+                        """,
+                    ),
+                    "ignore_divisions": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If False (default) raises error when previous divisions overlap with the new appended divisions.
+                            Ignored if append=False.
+                        """,
+                    ),
+                    "partition_on": Field(
+                        list,
+                        is_required=False,
+                        description="""
+                            Construct directory-based partitioning by splitting on these fields values.
+                            Each dask partition will result in one or more datafiles, there will be no global groupby.
+                        """,
+                    ),
+                    "storage_options": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Key/value pairs to be passed on to the file-system backend, if any.",
+                    ),
+                    "write_metadata_file": Field(
+                        Bool,
+                        is_required=False,
+                        description="Whether to write the special "_metadata" file.",
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If True (default) then the result is computed immediately.
+                            If False then a ``dask.delayed`` object is returned for future computation.
+                        """,
+                    ),
+                    "compute_kwargs": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method.",
+                    ),
+                }
+            ),
+            "hdf": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or pathlib.Path, Path to a target filename.
+                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
+                            May contain a ``*`` to denote many filenames.
+                        """,
+                    ),
+                    "key": Field(
+                        String,
+                        is_required=True,
+                        description="""
+                            Datapath within the files.
+                            May contain a ``*`` to denote many locations.
+                        """,
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            Whether or not to execute immediately.
+                            If False then this returns a ``dask.Delayed`` value.
+                        """,
+                    ),
+                    "scheduler": Field(
+                        String,
+                        is_required=False,
+                        description="The scheduler to use, like "threads" or "processes".",
+                    ),
+                }
+            ),
+            "json": Permissive(
+                {
+                    "path": Field(
+                        Any,
+                        is_required=True,
+                        description="""
+                            str or list, Location to write to.
+                            If a string, and there are more than one partitions in df,
+                            should include a glob character to expand into a set of file names,
+                            or provide a ``name_function=`` parameter.
+                            Supports protocol specifications such as ``"s3://"``.
+                        """,
+                    ),
+                    "encoding": Field(
+                        String,
+                        is_required=False,
+                        description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
+                    ),
+                    "errors": Field(
+                        String,
+                        is_required=False,
+                        description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
+                    ),
+                    "storage_options": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Passed to backend file-system implementation",
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            If true, immediately executes.
+                            If False, returns a set of delayed objects, which can be computed at a later time.
+                        """,
+                    ),
+                    "compute_kwargs": Field(
+                        Permissive(),
+                        is_required=False,
+                        description="Options to be passed in to the compute method",
+                    ),
+                    "compression": Field(
+                        String, is_required=False, description="String like "gzip" or "xz".",
+                    ),
+                },
+            ),
+            "sql": Permissive(
+                {
+                    "name": Field(String, is_required=True, description="Name of SQL table",),
+                    "uri": Field(
+                        String,
+                        is_required=True,
+                        description="Full sqlalchemy URI for the database connection",
+                    ),
+                    "schema": Field(
+                        String,
+                        is_required=False,
+                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
+                    ),
+                    "if_exists": Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            {"fail", "replace", "append"}, default "fail""
+                            How to behave if the table already exists.
+                            * fail: Raise a ValueError.
+                            * replace: Drop the table before inserting new values.
+                            * append: Insert new values to the existing table.
+                        """,
+                    ),
+                    "index": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is True, Write DataFrame index as a column.
+                            Uses `index_label` as the column name in the table.
+                        """,
+                    ),
+                    "index_label": Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                            str or sequence, default None Column label for index column(s).
+                            If None is given (default) and `index` is True, then the index names are used.
+                            A sequence should be given if the DataFrame uses MultiIndex.
+                        """,
+                    ),
+                    "chunksize": Field(
+                        Int,
+                        is_required=False,
+                        description="""
+                            Specify the number of rows in each batch to be written at a time.
+                            By default, all rows will be written at once.
+                        """,
+                    ),
+                    "dtype": Field(
+                        Any,
+                        is_required=False,
+                        description="""
+                            dict or scalar, Specifying the datatype for columns.
+                            If a dictionary is used, the keys should be the column names
+                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
+                            If a scalar is provided, it will be applied to all columns.
+                        """,
+                    ),
+                    "method": Field(
+                        String,
+                        is_required=False,
+                        description="""
+                            {None, "multi", callable}, default None
+                            Controls the SQL insertion clause used:
+                            * None : Uses standard SQL ``INSERT`` clause (one per row).
+                            * "multi": Pass multiple values in a single ``INSERT`` clause.
+                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
+                            Details and a sample callable implementation can be found in the
+                            section :ref:`insert method <io.sql.method>`.
+                        """,
+                    ),
+                    "compute": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is True, When true, call dask.compute and perform the load into SQL;
+                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
+                        """,
+                    ),
+                    "parallel": Field(
+                        Bool,
+                        is_required=False,
+                        description="""
+                            default is False, When true, have each block append itself to the DB table concurrently.
+                            This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
+                            When false, load each block into the SQL DB in sequence.
+                        """,
+                    ),
+                },
+            ),
+        },
     })
 )
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, "dask_df", dd.DataFrame)
-    to_type, to_options = list(config["to"].items())[0]
-    path = to_options.get("path")
 
-    if to_type == "csv":
-        dask_df.to_csv(path, **dict_without_keys(to_options, "path"))
-    elif to_type == "parquet":
-        dask_df.to_parquet(path, **dict_without_keys(to_options, "path"))
-    elif to_type == "hdf":
-        dask_df.to_hdf(path, **dict_without_keys(to_options, "path"))
-    elif to_type == "json":
-        dask_df.to_json(path, **dict_without_keys(to_options, "path"))
-    elif to_type == "sql":
-        dask_df.to_sql(**to_options)
-    else:
-        check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
+    for to_type, to_options in config["to"].items():
+        path = to_options.get("path")
 
-    return AssetMaterialization.file(path)
+        if to_type == "csv":
+            dask_df.to_csv(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "parquet":
+            dask_df.to_parquet(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "hdf":
+            dask_df.to_hdf(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "json":
+            dask_df.to_json(path, **dict_without_keys(to_options, "path"))
+        elif to_type == "sql":
+            dask_df.to_sql(**to_options)
+        else:
+            check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
+
+        yield AssetMaterialization.file(path)
 
 
 @dagster_type_loader(

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -189,7 +189,7 @@ def dict_without_keys(ddict, *keys):
                                 Can contain wildcards.
                             """,
                         ),
-                        "Key": Field(
+                        "key": Field(
                             Any,
                             is_required=True,
                             description="group identifier in the store. Can contain wildcards.",

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -1,3 +1,5 @@
+import warnings
+
 import dask.dataframe as dd
 
 from dagster import (
@@ -246,6 +248,7 @@ def dataframe_loader(_context, config):
         for key in DataFrameReadTypes:
             if key in config:
                 read_type, read_options = key, config[key]
+                warnings.warn("Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=key))
     if not read_type:
         raise DagsterInvariantViolationError(
             "No read_type found. Expected read key in config."
@@ -307,6 +310,9 @@ def dataframe_materializer(_context, config, dask_df):
             for to_type, to_options in config.items()
             if to_type in DataFrameToTypes
         }
+        for key in to_specs.keys():
+            warnings.warn("Specifying {key}: is deprecated. Use to:{key}: instead.".format(key=key))
+
 
     for to_type, to_options in to_specs.items():
         if not to_type in DataFrameToTypes:

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -142,6 +142,80 @@ DataFrameReadTypes = {
 }
 
 
+DataFrameToTypes = {
+    "csv": {
+        "function": dd.DataFrame.to_csv,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Path glob indicating the naming scheme for the output files"),
+            "single_file": (Bool, False, "Whether to save everything into a single CSV file."),
+            "encoding": (String, False, "A string representing the encoding to use in the output file."),
+            "mode": (String, False, "Python write mode."),
+            "compression": (WriteCompressionTextOptions, False, "A string representing the compression to use in the output file."),
+            "compute": (Bool, False, "If true, immediate executes."),
+            "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
+        },
+    },
+    "parquet": {
+        "function": dd.DataFrame.to_parquet,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Destination directory for data."),
+            "engine": (EngineParquetOptions, False, "Parquet library to use."),
+            "compression": (Any, False, "Either a string like ``"snappy"`` or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``."),
+            "write_index": (Bool, False, "Whether or not to write the index."),
+            "append": (Bool, False, "Whether to add new row-group(s) to an existing data-set."),
+            "ignore_divisions": (Bool, False, "If False (default) raises error when previous divisions overlap with the new appended divisions."),
+            "partition_on": (list, False, "onstruct directory-based partitioning by splitting on these fields values."),
+            "storage_options": (Permissive(), False, "Key/value pairs to be passed on to the file-system backend, if any."),
+            "write_metadata_file": (Bool, False, "Whether to write the special ``_metadata`` file."),
+            "compute": (Bool, False, "If true, immediate executes."),
+            "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
+        },
+    },
+    "hdf": {
+        "function": dd.DataFrame.to_hdf,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Path to a target filename."),
+            "key": (String, True, "Datapath within the files."),
+            "compute": (Bool, False, "Whether or not to execute immediately."),
+            "scheduler": (String, False, "The scheduler to use, like "threads" or "processes"."),
+        },
+    },
+    "json": {
+        "function": dd.DataFrame.to_json,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Location to write to."),
+            "encoding": (String, False, "The text encoding to implement."),
+            "errors": (String, False, "How to respond to errors in the conversion."),
+            "storage_options": (Permissive(), False, "Passed to backend file-system implementation."),
+            "compute": (Bool, False, "If true, immediate executes."),
+            "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
+            "compression": (String, False, "String like "gzip" or "xz"."),
+        },
+    },
+    "sql": {
+        "function": dd.DataFrame.to_sql,
+        "is_path_based": False,
+        "options": {
+            "name": (String, True, "Name of SQL table."),
+            "uri": (String, True, "Full sqlalchemy URI for the database connection."),
+            "schema": (String, False, "Specify the schema (if database flavor supports this)."),
+            "if_exists": (String, False, "How to behave if the table already exists."),
+            "index": (Bool, False, "Write DataFrame index as a column."),
+            "index_label": (Any, False, "Column label for index column(s)."),
+            "chunksize": (Int, False, "Specify the number of rows in each batch to be written at a time."),
+            "dtype": (Any, False, "Specifying the datatype for columns."),
+            "method": (String, False, "Controls the SQL insertion clause used."),
+            "compute": (Bool, False, "When true, call dask.compute and perform the load into SQL."),
+            "parallel": (Bool, False, "When true, have each block append itself to the DB table concurrently."),
+        }
+    }
+}
+
+
 def _dataframe_loader_config():
     read_fields = {
         read_from: {
@@ -152,7 +226,7 @@ def _dataframe_loader_config():
     }
 
     return Shape({
-        'read': Field(
+        "read": Field(
             Selector(read_fields),
             is_required=False,
         ),
@@ -191,8 +265,8 @@ def dataframe_loader(_context, config):
     read_options = dict(read_options)
     
     # Get the read function and prepare its arguments.
-    read_function = read_meta['function']
-    read_args = [read_options.pop('path')] if read_meta.get('is_path_based', False) else []
+    read_function = read_meta["function"]
+    read_args = [read_options.pop("path")] if read_meta.get("is_path_based", False) else []
     read_kwargs = read_options
     
     df = read_function(*read_args, **read_kwargs)
@@ -200,333 +274,31 @@ def dataframe_loader(_context, config):
     return df
 
 
-@dagster_type_materializer(
-    Shape({
-        "to": {
-            "csv": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="str or list, Path glob indicating the naming scheme for the output files",
-                    ),
-                    "single_file": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether to save everything into a single CSV file.
-                            Under the single file mode, each partition is appended at the end of the specified CSV file.
-                            Note that not all filesystems support the append mode and thus the single file mode,
-                            especially on cloud storage systems such as S3 or GCS.
-                            A warning will be issued when writing to a file that is not backed by a local filesystem.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            A string representing the encoding to use in the output file,
-                            defaults to "ascii" on Python 2 and "utf-8" on Python 3.
-                        """,
-                    ),
-                    "mode": Field(
-                        String, is_required=False, description="Python write mode, default "w"",
-                    ),
-                    "compression": Field(
-                        WriteCompressionTextOptions,
-                        is_required=False,
-                        description="""
-                            a string representing the compression to use in the output file,
-                            allowed values are "gzip", "bz2", "xz".
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Parameters passed on to the backend filesystem class.",
-                    ),
-                    "header_first_partition_only": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If set to `True`, only write the header row in the first output file.
-                            By default, headers are written to all partitions
-                            under the multiple file mode (`single_file` is `False`)
-                            and written only once under the single file mode (`single_file` is `True`).
-                            It must not be `False` under the single file mode.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                }
-            ),
-            "parquet": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Destination directory for data.
-                            Prepend with protocol like ``s3://`` or ``hdfs://`` for remote data.
-                        """,
-                    ),
-                    "engine": Field(
-                        EngineParquetOptions,
-                        is_required=False,
-                        description="""
-                            {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
-                            If only one library is installed, it will use that one; if both, it will use "fastparquet".
-                        """,
-                    ),
-                    "compression": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                        str or dict, optional Either a string like ``"snappy"``
-                        or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
-                        The default is ``"default"``, which uses the default compression for whichever engine is selected.
-                        """,
-                    ),
-                    "write_index": Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether or not to write the index. Defaults to True.",
-                    ),
-                    "append": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default), construct data-set from scratch.
-                            If True, add new row-group(s) to an existing data-set.
-                            In the latter case, the data-set must exist, and the schema must match the input data.
-                        """,
-                    ),
-                    "ignore_divisions": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If False (default) raises error when previous divisions overlap with the new appended divisions.
-                            Ignored if append=False.
-                        """,
-                    ),
-                    "partition_on": Field(
-                        list,
-                        is_required=False,
-                        description="""
-                            Construct directory-based partitioning by splitting on these fields values.
-                            Each dask partition will result in one or more datafiles, there will be no global groupby.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Key/value pairs to be passed on to the file-system backend, if any.",
-                    ),
-                    "write_metadata_file": Field(
-                        Bool,
-                        is_required=False,
-                        description="Whether to write the special "_metadata" file.",
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True (default) then the result is computed immediately.
-                            If False then a ``dask.delayed`` object is returned for future computation.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method.",
-                    ),
-                }
-            ),
-            "hdf": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path, Path to a target filename.
-                            Supports strings, ``pathlib.Path``, or any object implementing the ``__fspath__`` protocol.
-                            May contain a ``*`` to denote many filenames.
-                        """,
-                    ),
-                    "key": Field(
-                        String,
-                        is_required=True,
-                        description="""
-                            Datapath within the files.
-                            May contain a ``*`` to denote many locations.
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            Whether or not to execute immediately.
-                            If False then this returns a ``dask.Delayed`` value.
-                        """,
-                    ),
-                    "scheduler": Field(
-                        String,
-                        is_required=False,
-                        description="The scheduler to use, like "threads" or "processes".",
-                    ),
-                }
-            ),
-            "json": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Location to write to.
-                            If a string, and there are more than one partitions in df,
-                            should include a glob character to expand into a set of file names,
-                            or provide a ``name_function=`` parameter.
-                            Supports protocol specifications such as ``"s3://"``.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
-                    ),
-                    "errors": Field(
-                        String,
-                        is_required=False,
-                        description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Passed to backend file-system implementation",
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If true, immediately executes.
-                            If False, returns a set of delayed objects, which can be computed at a later time.
-                        """,
-                    ),
-                    "compute_kwargs": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Options to be passed in to the compute method",
-                    ),
-                    "compression": Field(
-                        String, is_required=False, description="String like "gzip" or "xz".",
-                    ),
-                },
-            ),
-            "sql": Permissive(
-                {
-                    "name": Field(String, is_required=True, description="Name of SQL table",),
-                    "uri": Field(
-                        String,
-                        is_required=True,
-                        description="Full sqlalchemy URI for the database connection",
-                    ),
-                    "schema": Field(
-                        String,
-                        is_required=False,
-                        description="Specify the schema (if database flavor supports this). If None, use default schema.",
-                    ),
-                    "if_exists": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {"fail", "replace", "append"}, default "fail""
-                            How to behave if the table already exists.
-                            * fail: Raise a ValueError.
-                            * replace: Drop the table before inserting new values.
-                            * append: Insert new values to the existing table.
-                        """,
-                    ),
-                    "index": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, Write DataFrame index as a column.
-                            Uses `index_label` as the column name in the table.
-                        """,
-                    ),
-                    "index_label": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or sequence, default None Column label for index column(s).
-                            If None is given (default) and `index` is True, then the index names are used.
-                            A sequence should be given if the DataFrame uses MultiIndex.
-                        """,
-                    ),
-                    "chunksize": Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            Specify the number of rows in each batch to be written at a time.
-                            By default, all rows will be written at once.
-                        """,
-                    ),
-                    "dtype": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            dict or scalar, Specifying the datatype for columns.
-                            If a dictionary is used, the keys should be the column names
-                            and the values should be the SQLAlchemy types or strings for the sqlite3 legacy mode.
-                            If a scalar is provided, it will be applied to all columns.
-                        """,
-                    ),
-                    "method": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {None, "multi", callable}, default None
-                            Controls the SQL insertion clause used:
-                            * None : Uses standard SQL ``INSERT`` clause (one per row).
-                            * "multi": Pass multiple values in a single ``INSERT`` clause.
-                            * callable with signature ``(pd_table, conn, keys, data_iter)``.
-                            Details and a sample callable implementation can be found in the
-                            section :ref:`insert method <io.sql.method>`.
-                        """,
-                    ),
-                    "compute": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is True, When true, call dask.compute and perform the load into SQL;
-                            otherwise, return a Dask object (or array of per-block objects when parallel=True).
-                        """,
-                    ),
-                    "parallel": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is False, When true, have each block append itself to the DB table concurrently.
-                            This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
-                            When false, load each block into the SQL DB in sequence.
-                        """,
-                    ),
-                },
-            ),
+def _dataframe_materializer_config():
+    to_fields = {
+        write_to: {
+            option_name: Field(option_args[0], is_required=option_args[1], description=option_args[2])
+            for option_name, option_args in to_opts["options"].items()
+        }
+        for write_to, to_opts in DataFrameToTypes.items()
+    }
+
+    return Shape({
+        "to": Field(
+            Selector(to_fields),
+            is_required=False,
+        ),
+        **{
+            field_name: Field(
+                field_config,
+                is_required=False,
+            )
+            for field_name, field_config in to_fields.items()
         },
     })
-)
+
+
+@dagster_type_materializer(_dataframe_materializer_config())
 def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, "dask_df", dd.DataFrame)
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -23,11 +23,21 @@ from dagster import (
 )
 
 WriteCompressionTextOptions = Enum(
-    "WriteCompressionText", [EnumValue("gzip"), EnumValue("bz2"), EnumValue("xz"),],
+    "WriteCompressionText",
+    [
+        EnumValue("gzip"),
+        EnumValue("bz2"),
+        EnumValue("xz"),
+    ],
 )
 
 EngineParquetOptions = Enum(
-    "EngineParquet", [EnumValue("auto"), EnumValue("fastparquet"), EnumValue("pyarrow"),],
+    "EngineParquet",
+    [
+        EnumValue("auto"),
+        EnumValue("fastparquet"),
+        EnumValue("pyarrow"),
+    ],
 )
 
 
@@ -39,9 +49,21 @@ DataFrameReadTypes = {
             "path": (Any, True, "Absolute or relative filepath(s)."),
             "blocksize": (Any, False, "Number of bytes by which to cut up larger files."),
             "sample": (Int, False, "Number of bytes to use when determining dtypes."),
-            "assume_missing": (Bool, False, "If True, all integer columns that aren’t specified in `dtype` are assumed to contain missing values, and are converted to floats."),
-            "storage_options": (Permissive(), False, "Extra options that make sense for a particular storage connection."),
-            "include_path_column": (Any, False, "Whether or not to include the path to each particular file."),
+            "assume_missing": (
+                Bool,
+                False,
+                "If True, all integer columns that aren’t specified in `dtype` are assumed to contain missing values, and are converted to floats.",
+            ),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Extra options that make sense for a particular storage connection.",
+            ),
+            "include_path_column": (
+                Any,
+                False,
+                "Whether or not to include the path to each particular file.",
+            ),
         },
     },
     "parquet": {
@@ -52,11 +74,23 @@ DataFrameReadTypes = {
             "columns": (Any, False, "Field name(s) to read in as columns in the output."),
             "filters": (Any, False, "List of filters to apply."),
             "index": (Any, False, "Field name(s) to use as the output frame index."),
-            "categories": (Any, False, "For any fields listed here, if the parquet encoding is Dictionary, the column will be created with dtype category."),
-            "storage_options": (Permissive(), False, "Key/value pairs to be passed on to the file-system backend, if any."),
+            "categories": (
+                Any,
+                False,
+                "For any fields listed here, if the parquet encoding is Dictionary, the column will be created with dtype category.",
+            ),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Key/value pairs to be passed on to the file-system backend, if any.",
+            ),
             "engine": (EngineParquetOptions, False, "Parquet reader library to use."),
             "gather_statistics": (Bool, False, "Gather the statistics for each dataset partition."),
-            "split_row_groups": (Bool, False, "If True (default) then output dataframe partitions will correspond to parquet-file row-groups."),
+            "split_row_groups": (
+                Bool,
+                False,
+                "If True (default) then output dataframe partitions will correspond to parquet-file row-groups.",
+            ),
             "chunksize": (Any, False, "The target task partition size."),
         },
     },
@@ -70,7 +104,11 @@ DataFrameReadTypes = {
             "stop": (Int, False, "Row number to stop selection."),
             "columns": (list, False, "A list of columns names to return."),
             "chunksize": (Any, False, "Maximal number of rows per partition."),
-            "sorted_index": (Bool, False, "Option to specify whether or not the input hdf files have a sorted index."),
+            "sorted_index": (
+                Bool,
+                False,
+                "Option to specify whether or not the input hdf files have a sorted index.",
+            ),
             "lock": (Bool, False, "Option to use a lock to prevent concurrency issues."),
             "mode": (String, False, "Mode to use when opening file(s)."),
         },
@@ -82,9 +120,17 @@ DataFrameReadTypes = {
             "path": (Any, True, "Absolute or relative filepath(s)."),
             "encoding": (String, False, "The text encoding to implement."),
             "errors": (String, False, "How to respond to errors in the conversion."),
-            "storage_options": (Permissive(), False, "Passed to backend file-system implementation."),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Passed to backend file-system implementation.",
+            ),
             "blocksize": (Int, False, "Each partition will be approximately this size in bytes."),
-            "sample": (Int, False, "Number of bytes to pre-load, to provide an empty dataframe structure to any blocks without data."),
+            "sample": (
+                Int,
+                False,
+                "Number of bytes to pre-load, to provide an empty dataframe structure to any blocks without data.",
+            ),
             "compression": (String, False, "String like ‘gzip’ or ‘xz’."),
         },
     },
@@ -94,13 +140,25 @@ DataFrameReadTypes = {
         "options": {
             "table": (Any, True, "Select columns from here."),
             "uri": (String, True, "Full sqlalchemy URI for the database connection."),
-            "index_col": (String, True, "Column which becomes the index, and defines the partitioning."),
+            "index_col": (
+                String,
+                True,
+                "Column which becomes the index, and defines the partitioning.",
+            ),
             "divisions": (Any, False, "Values of the index column to split the table by."),
             "npartitions": (Int, False, "Number of partitions, if divisions is not given."),
             "columns": (Any, False, "Which columns to select."),
             "bytes_per_chunk": (Any, False, "The target size of each partition, in bytes."),
-            "head_rows": (Int, False, "How many rows to load for inferring the data-types, unless passing meta."),
-            "schema": (String, False, "If using a table name, pass this to sqlalchemy to select which DB schema to use within the URI connection."),
+            "head_rows": (
+                Int,
+                False,
+                "How many rows to load for inferring the data-types, unless passing meta.",
+            ),
+            "schema": (
+                String,
+                False,
+                "If using a table name, pass this to sqlalchemy to select which DB schema to use within the URI connection.",
+            ),
         },
     },
     "table": {
@@ -110,9 +168,21 @@ DataFrameReadTypes = {
             "path": (Any, True, "Absolute or relative filepath(s)."),
             "blocksize": (Any, False, "Number of bytes by which to cut up larger files."),
             "sample": (Int, False, "Number of bytes to use when determining dtypes."),
-            "assume_missing": (Bool, False, "If True, all integer columns that aren’t specified in dtype are assumed to contain missing values, and are converted to floats."),
-            "storage_options": (Permissive(), False, "Extra options that make sense for a particular storage connection."),
-            "include_path_column": (Any, False, "Whether or not to include the path to each particular file."),
+            "assume_missing": (
+                Bool,
+                False,
+                "If True, all integer columns that aren’t specified in dtype are assumed to contain missing values, and are converted to floats.",
+            ),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Extra options that make sense for a particular storage connection.",
+            ),
+            "include_path_column": (
+                Any,
+                False,
+                "Whether or not to include the path to each particular file.",
+            ),
         },
     },
     "fwf": {
@@ -122,10 +192,22 @@ DataFrameReadTypes = {
             "path": (Any, True, "Absolute or relative filepath(s)."),
             "blocksize": (Any, False, "Number of bytes by which to cut up larger files."),
             "sample": (Int, False, "Number of bytes to use when determining dtypes."),
-            "assume_missing": (Bool, False, "If True, all integer columns that aren’t specified in dtype are assumed to contain missing values, and are converted to floats."),
-            "storage_options": (Permissive(), False, "Extra options that make sense for a particular storage connection."),
-            "include_path_column": (Any, False, "Whether or not to include the path to each particular file."),
-        }
+            "assume_missing": (
+                Bool,
+                False,
+                "If True, all integer columns that aren’t specified in dtype are assumed to contain missing values, and are converted to floats.",
+            ),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Extra options that make sense for a particular storage connection.",
+            ),
+            "include_path_column": (
+                Any,
+                False,
+                "Whether or not to include the path to each particular file.",
+            ),
+        },
     },
     "orc": {
         "function": dd.read_orc,
@@ -133,9 +215,13 @@ DataFrameReadTypes = {
         "options": {
             "path": (Any, True, "Absolute or relative filepath(s)."),
             "columns": (Any, False, "Columns to load."),
-            "storage_options": (Permissive(), False, "Further parameters to pass to the bytes backend."),
-        }
-    }
+            "storage_options": (
+                Permissive(),
+                False,
+                "Further parameters to pass to the bytes backend.",
+            ),
+        },
+    },
 }
 
 
@@ -146,11 +232,23 @@ DataFrameToTypes = {
         "options": {
             "path": (Any, True, "Path glob indicating the naming scheme for the output files"),
             "single_file": (Bool, False, "Whether to save everything into a single CSV file."),
-            "encoding": (String, False, "A string representing the encoding to use in the output file."),
+            "encoding": (
+                String,
+                False,
+                "A string representing the encoding to use in the output file.",
+            ),
             "mode": (String, False, "Python write mode."),
-            "compression": (WriteCompressionTextOptions, False, "A string representing the compression to use in the output file."),
+            "compression": (
+                WriteCompressionTextOptions,
+                False,
+                "A string representing the compression to use in the output file.",
+            ),
             "compute": (Bool, False, "If true, immediate executes."),
-            "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
+            "compute_kwargs": (
+                Permissive(),
+                False,
+                "Options to be passed in to the compute method.",
+            ),
         },
     },
     "parquet": {
@@ -159,15 +257,39 @@ DataFrameToTypes = {
         "options": {
             "path": (Any, True, "Destination directory for data."),
             "engine": (EngineParquetOptions, False, "Parquet library to use."),
-            "compression": (Any, False, "Either a string like ``\"snappy\"`` or a dictionary mapping column names to compressors like ``{\"name\": \"gzip\", \"values\": \"snappy\"}``."),
+            "compression": (
+                Any,
+                False,
+                'Either a string like ``"snappy"`` or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.',
+            ),
             "write_index": (Bool, False, "Whether or not to write the index."),
             "append": (Bool, False, "Whether to add new row-group(s) to an existing data-set."),
-            "ignore_divisions": (Bool, False, "If False (default) raises error when previous divisions overlap with the new appended divisions."),
-            "partition_on": (list, False, "onstruct directory-based partitioning by splitting on these fields values."),
-            "storage_options": (Permissive(), False, "Key/value pairs to be passed on to the file-system backend, if any."),
-            "write_metadata_file": (Bool, False, "Whether to write the special ``_metadata`` file."),
+            "ignore_divisions": (
+                Bool,
+                False,
+                "If False (default) raises error when previous divisions overlap with the new appended divisions.",
+            ),
+            "partition_on": (
+                list,
+                False,
+                "onstruct directory-based partitioning by splitting on these fields values.",
+            ),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Key/value pairs to be passed on to the file-system backend, if any.",
+            ),
+            "write_metadata_file": (
+                Bool,
+                False,
+                "Whether to write the special ``_metadata`` file.",
+            ),
             "compute": (Bool, False, "If true, immediate executes."),
-            "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
+            "compute_kwargs": (
+                Permissive(),
+                False,
+                "Options to be passed in to the compute method.",
+            ),
         },
     },
     "hdf": {
@@ -177,7 +299,7 @@ DataFrameToTypes = {
             "path": (Any, True, "Path to a target filename."),
             "key": (String, True, "Datapath within the files."),
             "compute": (Bool, False, "Whether or not to execute immediately."),
-            "scheduler": (String, False, "The scheduler to use, like \"threads\" or \"processes\"."),
+            "scheduler": (String, False, 'The scheduler to use, like "threads" or "processes".'),
         },
     },
     "json": {
@@ -187,10 +309,18 @@ DataFrameToTypes = {
             "path": (Any, True, "Location to write to."),
             "encoding": (String, False, "The text encoding to implement."),
             "errors": (String, False, "How to respond to errors in the conversion."),
-            "storage_options": (Permissive(), False, "Passed to backend file-system implementation."),
+            "storage_options": (
+                Permissive(),
+                False,
+                "Passed to backend file-system implementation.",
+            ),
             "compute": (Bool, False, "If true, immediate executes."),
-            "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
-            "compression": (String, False, "String like \"gzip\" or \"xz\"."),
+            "compute_kwargs": (
+                Permissive(),
+                False,
+                "Options to be passed in to the compute method.",
+            ),
+            "compression": (String, False, 'String like "gzip" or "xz".'),
         },
     },
     "sql": {
@@ -203,40 +333,53 @@ DataFrameToTypes = {
             "if_exists": (String, False, "How to behave if the table already exists."),
             "index": (Bool, False, "Write DataFrame index as a column."),
             "index_label": (Any, False, "Column label for index column(s)."),
-            "chunksize": (Int, False, "Specify the number of rows in each batch to be written at a time."),
+            "chunksize": (
+                Int,
+                False,
+                "Specify the number of rows in each batch to be written at a time.",
+            ),
             "dtype": (Any, False, "Specifying the datatype for columns."),
             "method": (String, False, "Controls the SQL insertion clause used."),
             "compute": (Bool, False, "When true, call dask.compute and perform the load into SQL."),
-            "parallel": (Bool, False, "When true, have each block append itself to the DB table concurrently."),
-        }
-    }
+            "parallel": (
+                Bool,
+                False,
+                "When true, have each block append itself to the DB table concurrently.",
+            ),
+        },
+    },
 }
 
 
 def _dataframe_loader_config():
     read_fields = {
-        read_from: Permissive({
-            option_name: Field(option_args[0], is_required=option_args[1], description=option_args[2])
-            for option_name, option_args in read_opts["options"].items()
-        })
+        read_from: Permissive(
+            {
+                option_name: Field(
+                    option_args[0], is_required=option_args[1], description=option_args[2]
+                )
+                for option_name, option_args in read_opts["options"].items()
+            }
+        )
         for read_from, read_opts in DataFrameReadTypes.items()
     }
 
-    return Selector({
-        "read": Field(
-            Selector(read_fields),
-            is_required=False,
-        ),
-
-        # https://github.com/dagster-io/dagster/issues/2872
-        **{
-            field_name: Field(
-                field_config,
+    return Selector(
+        {
+            "read": Field(
+                Selector(read_fields),
                 is_required=False,
-            )
-            for field_name, field_config in read_fields.items()
-        },
-    })
+            ),
+            # https://github.com/dagster-io/dagster/issues/2872
+            **{
+                field_name: Field(
+                    field_config,
+                    is_required=False,
+                )
+                for field_name, field_config in read_fields.items()
+            },
+        }
+    )
 
 
 @dagster_type_loader(_dataframe_loader_config())
@@ -244,18 +387,18 @@ def dataframe_loader(_context, config):
     read_type, read_options = None, None
     if "read" in config:
         read_type, read_options = next(iter(config["read"].items()))
-    
+
     # https://github.com/dagster-io/dagster/issues/2872
     else:
         for key in DataFrameReadTypes:
             if key in config:
                 read_type, read_options = key, config[key]
-                warnings.warn("Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=key))
-    
+                warnings.warn(
+                    "Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=key)
+                )
+
     if not read_type:
-        raise DagsterInvariantViolationError(
-            "No read_type found. Expected read key in config."
-        )
+        raise DagsterInvariantViolationError("No read_type found. Expected read key in config.")
     if not read_type in DataFrameReadTypes:
         raise DagsterInvariantViolationError(
             "Unsupported read_type {read_type}.".format(read_type=read_type)
@@ -266,12 +409,12 @@ def dataframe_loader(_context, config):
     # read_options mutable if we need to pop off a path argument.
     read_meta = DataFrameReadTypes[read_type]
     read_options = dict(read_options)
-    
+
     # Get the read function and prepare its arguments.
     read_function = read_meta["function"]
     read_args = [read_options.pop("path")] if read_meta.get("is_path_based", False) else []
     read_kwargs = read_options
-    
+
     df = read_function(*read_args, **read_kwargs)
 
     return df
@@ -279,28 +422,33 @@ def dataframe_loader(_context, config):
 
 def _dataframe_materializer_config():
     to_fields = {
-        write_to: Permissive({
-            option_name: Field(option_args[0], is_required=option_args[1], description=option_args[2])
-            for option_name, option_args in to_opts["options"].items()
-        })
+        write_to: Permissive(
+            {
+                option_name: Field(
+                    option_args[0], is_required=option_args[1], description=option_args[2]
+                )
+                for option_name, option_args in to_opts["options"].items()
+            }
+        )
         for write_to, to_opts in DataFrameToTypes.items()
     }
 
-    return Selector({
-        "to": Field(
-            Selector(to_fields),
-            is_required=False,
-        ),
-
-        # https://github.com/dagster-io/dagster/issues/2872
-        **{
-            field_name: Field(
-                field_config,
+    return Selector(
+        {
+            "to": Field(
+                Selector(to_fields),
                 is_required=False,
-            )
-            for field_name, field_config in to_fields.items()
-        },
-    })
+            ),
+            # https://github.com/dagster-io/dagster/issues/2872
+            **{
+                field_name: Field(
+                    field_config,
+                    is_required=False,
+                )
+                for field_name, field_config in to_fields.items()
+            },
+        }
+    )
 
 
 @dagster_type_materializer(_dataframe_materializer_config())
@@ -323,7 +471,7 @@ def dataframe_materializer(_context, config, dask_df):
     for to_type, to_options in to_specs.items():
         if not to_type in DataFrameToTypes:
             check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
-        
+
         # Get the metadata entry for the read_type in order to know which method
         # to call and whether it uses path as the first argument. And, make
         # to_options mutable if we need to pop off a path argument.

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -852,28 +852,28 @@ def dataframe_materializer(_context, config, dask_df):
     })
 )
 def dataframe_loader(_context, config):
-    file_type, file_options = next(iter(config["read"].items()))
-    path = file_options.get("path")
+    read_type, read_options = next(iter(config["read"].items()))
+    path = read_options.get("path")
 
-    if file_type == "csv":
-        return dd.read_csv(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "parquet":
-        return dd.read_parquet(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "hdf":
-        return dd.read_hdf(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "json":
-        return dd.read_json(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "sql_table":
-        return dd.read_sql_table(**file_options)
-    elif file_type == "table":
-        return dd.read_table(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "fwf":
-        return dd.read_fwf(path, **dict_without_keys(file_options, "path"))
-    elif file_type == "orc":
-        return dd.read_orc(path, **dict_without_keys(file_options, "path"))
+    if read_type == "csv":
+        return dd.read_csv(path, **dict_without_keys(read_options, "path"))
+    elif read_type == "parquet":
+        return dd.read_parquet(path, **dict_without_keys(read_options, "path"))
+    elif read_type == "hdf":
+        return dd.read_hdf(path, **dict_without_keys(read_options, "path"))
+    elif read_type == "json":
+        return dd.read_json(path, **dict_without_keys(read_options, "path"))
+    elif read_type == "sql_table":
+        return dd.read_sql_table(**read_options)
+    elif read_type == "table":
+        return dd.read_table(path, **dict_without_keys(read_options, "path"))
+    elif read_type == "fwf":
+        return dd.read_fwf(path, **dict_without_keys(read_options, "path"))
+    elif read_type == "orc":
+        return dd.read_orc(path, **dict_without_keys(read_options, "path"))
     else:
         raise DagsterInvariantViolationError(
-            "Unsupported file_type {file_type}".format(file_type=file_type)
+            "Unsupported read_type {read_type}".format(read_type=read_type)
         )
 
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -159,7 +159,7 @@ DataFrameToTypes = {
         "options": {
             "path": (Any, True, "Destination directory for data."),
             "engine": (EngineParquetOptions, False, "Parquet library to use."),
-            "compression": (Any, False, "Either a string like ``"snappy"`` or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``."),
+            "compression": (Any, False, "Either a string like ``\"snappy\"`` or a dictionary mapping column names to compressors like ``{\"name\": \"gzip\", \"values\": \"snappy\"}``."),
             "write_index": (Bool, False, "Whether or not to write the index."),
             "append": (Bool, False, "Whether to add new row-group(s) to an existing data-set."),
             "ignore_divisions": (Bool, False, "If False (default) raises error when previous divisions overlap with the new appended divisions."),
@@ -177,7 +177,7 @@ DataFrameToTypes = {
             "path": (Any, True, "Path to a target filename."),
             "key": (String, True, "Datapath within the files."),
             "compute": (Bool, False, "Whether or not to execute immediately."),
-            "scheduler": (String, False, "The scheduler to use, like "threads" or "processes"."),
+            "scheduler": (String, False, "The scheduler to use, like \"threads\" or \"processes\"."),
         },
     },
     "json": {
@@ -190,7 +190,7 @@ DataFrameToTypes = {
             "storage_options": (Permissive(), False, "Passed to backend file-system implementation."),
             "compute": (Bool, False, "If true, immediate executes."),
             "compute_kwargs": (Permissive(), False, "Options to be passed in to the compute method."),
-            "compression": (String, False, "String like "gzip" or "xz"."),
+            "compression": (String, False, "String like \"gzip\" or \"xz\"."),
         },
     },
     "sql": {

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -35,474 +35,128 @@ def dict_without_keys(ddict, *keys):
     return {key: value for key, value in ddict.items() if key not in set(keys)}
 
 
-@dagster_type_loader(
-    Shape({
-        "read": Selector(
-            {
-                "csv": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Absolute or relative filepath(s).
-                                Prefix with a protocol like `s3://` to read from alternative filesystems.
-                                To read from multiple files you can pass a globstring or a list of paths,
-                                with the caveat that they must all have the same protocol.
-                            """,
-                        ),
-                        "blocksize": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                            str or int or None, Number of bytes by which to cut up larger files.
-                            Default value is computed based on available physical memory and the number of cores, up to a maximum of 64MB.
-                            Can be a number like 64000000` or a string like ``"64MB". If None, a single block is used for each file.
-                            """,
-                        ),
-                        "sample": Field(
-                            Int,
-                            is_required=False,
-                            description="Number of bytes to use when determining dtypes.",
-                        ),
-                        "assume_missing": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If True, all integer columns that aren’t specified in `dtype` are assumed to contain missing values,
-                                and are converted to floats. Default is False.
-                            """,
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="""
-                                Extra options that make sense for a particular storage connection,
-                                e.g. host, port, username, password, etc.
-                            """,
-                        ),
-                        "include_path_column": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                bool or str, Whether or not to include the path to each particular file.
-                                If True a new column is added to the dataframe called path.
-                                If str, sets new column name. Default is False.
-                            """,
-                        ),
-                    }
-                ),
-                "parquet": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Source directory for data, or path(s) to individual parquet files.
-                                Prefix with a protocol like s3:// to read from alternative filesystems.
-                                To read from multiple files you can pass a globstring or a list of paths,
-                                with the caveat that they must all have the same protocol.
-                            """,
-                        ),
-                        "columns": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                str or list or None (default), Field name(s) to read in as columns in the output.
-                                By default all non-index fields will be read (as determined by the pandas parquet metadata, if present).
-                                Provide a single field name instead of a list to read in the data as a Series.
-                            """,
-                        ),
-                        "index": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                list or False or None (default), Field name(s) to use as the output frame index.
-                                By default will be inferred from the pandas parquet file metadata (if present).
-                                Use False to read all fields as columns.
-                            """,
-                        ),
-                        "categories": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                list or dict or None, For any fields listed here,
-                                if the parquet encoding is Dictionary, the column will be created with dtype category.
-                                Use only if it is guaranteed that the column is encoded as dictionary in all row-groups.
-                                If a list, assumes up to 2**16-1 labels; if a dict, specify the number of labels expected;
-                                if None, will load categories automatically for data written by dask/fastparquet, not otherwise.
-                            """,
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Key/value pairs to be passed on to the file-system backend, if any.",
-                        ),
-                        "engine": Field(
-                            EngineParquetOptions,
-                            is_required=False,
-                            description="""
-                                Parquet reader library to use.
-                                If only one library is installed, it will use that one;
-                                if both, it will use ‘fastparquet’.
-                            """,
-                        ),
-                        "gather_statistics": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                default is None, Gather the statistics for each dataset partition.
-                                By default, this will only be done if the _metadata file is available.
-                                Otherwise, statistics will only be gathered if True,
-                                because the footer of every file will be parsed (which is very slow on some systems).
-                            """,
-                        ),
-                        "split_row_groups:": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If True (default) then output dataframe partitions will correspond
-                                to parquet-file row-groups (when enough row-group metadata is available).
-                                Otherwise, partitions correspond to distinct files.
-                                Only the “pyarrow” engine currently supports this argument.
-                            """,
-                        ),
-                        "chunksize": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                int or string, The target task partition size.
-                                If set, consecutive row-groups from the same file will be aggregated
-                                into the same output partition until the aggregate size reaches this value.
-                            """,
-                        ),
-                    }
-                ),
-                "hdf": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or pathlib.Path or list,
-                                File pattern (string), pathlib.Path, buffer to read from, or list of file paths.
-                                Can contain wildcards.
-                            """,
-                        ),
-                        "key": Field(
-                            Any,
-                            is_required=True,
-                            description="group identifier in the store. Can contain wildcards.",
-                        ),
-                        "start": Field(
-                            Int,
-                            is_required=False,
-                            description="defaults to 0, row number to start at.",
-                        ),
-                        "stop": Field(
-                            Int,
-                            is_required=False,
-                            description="defaults to None (the last row), row number to stop at.",
-                        ),
-                        "columns": Field(
-                            list,
-                            is_required=False,
-                            description="A list of columns that if not None, will limit the return columns (default is None).",
-                        ),
-                        "chunksize": Field(
-                            Any,
-                            is_required=False,
-                            description="Maximal number of rows per partition (default is 1000000).",
-                        ),
-                        "sorted_index": Field(
-                            Bool,
-                            is_required=False,
-                            description="Option to specify whether or not the input hdf files have a sorted index (default is False).",
-                        ),
-                        "lock": Field(
-                            Bool,
-                            is_required=False,
-                            description="Option to use a lock to prevent concurrency issues (default is True).",
-                        ),
-                        "mode": Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                {‘a’, ‘r’, ‘r+’}, default ‘a’. Mode to use when opening file(s).
-                                ‘r’ - Read-only; no data can be modified.
-                                ‘a’ - Append; an existing file is opened for reading and writing, and if the file does not exist it is created.
-                                ‘r+’ - It is similar to ‘a’, but the file must already exist.
-                            """,
-                        ),
-                    }
-                ),
-                "json": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Location to read from.
-                                If a string, can include a glob character to find a set of file names.
-                                Supports protocol specifications such as "s3://".
-                            """,
-                        ),
-                        "encoding": Field(
-                            String,
-                            is_required=False,
-                            description="The text encoding to implement, e.g., “utf-8”.",
-                        ),
-                        "errors": Field(
-                            String,
-                            is_required=False,
-                            description="how to respond to errors in the conversion (see str.encode()).",
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Passed to backend file-system implementation.",
-                        ),
-                        "blocksize": Field(
-                            Int,
-                            is_required=False,
-                            description="""
-                                default is None, If None, files are not blocked, and you get one partition per input file.
-                                If int, which can only be used for line-delimited JSON files,
-                                each partition will be approximately this size in bytes, to the nearest newline character.
-                            """,
-                        ),
-                        "sample": Field(
-                            Int,
-                            is_required=False,
-                            description="""
-                                Number of bytes to pre-load,
-                                to provide an empty dataframe structure to any blocks without data.
-                                Only relevant is using blocksize.
-                            """,
-                        ),
-                        "compression": Field(
-                            String,
-                            is_required=False,
-                            description="default is None, String like ‘gzip’ or ‘xz’.",
-                        ),
-                    }
-                ),
-                "sql_table": Permissive(
-                    {
-                        "table": Field(
-                            Any,
-                            is_required=True,
-                            description="str or sqlalchemy expression, Select columns from here.",
-                        ),
-                        "uri": Field(
-                            String,
-                            is_required=True,
-                            description="Full sqlalchemy URI for the database connection.",
-                        ),
-                        "index_col": Field(
-                            String,
-                            is_required=True,
-                            description="""
-                            Column which becomes the index, and defines the partitioning.
-                            Should be a indexed column in the SQL server, and any orderable type.
-                            If the type is number or time, then partition boundaries can be inferred from npartitions or bytes_per_chunk;
-                            otherwide must supply explicit divisions=.
-                            index_col could be a function to return a value, e.g., sql.func.abs(sql.column("value")).label("abs(value)").
-                            index_col=sql.func.abs(sql.column("value")).label("abs(value)"),
-                            or index_col=cast(sql.column("id"),types.BigInteger).label("id") to convert the textfield id to BigInteger.
-                            Note sql, cast, types methods comes frome sqlalchemy module.
-                            Labeling columns created by functions or arithmetic operations is required
-                            """,
-                        ),
-                        "divisions": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                sequence, Values of the index column to split the table by.
-                                If given, this will override npartitions and bytes_per_chunk.
-                                The divisions are the value boundaries of the index column used to define the partitions.
-                                For example, divisions=list("acegikmoqsuwz") could be used
-                                to partition a string column lexographically into 12 partitions,
-                                with the implicit assumption that each partition contains similar numbers of records.
-                            """,
-                        ),
-                        "npartitions": Field(
-                            Int,
-                            is_required=False,
-                            description="""
-                                Number of partitions, if divisions is not given.
-                                Will split the values of the index column linearly between limits, if given, or the column max/min.
-                                The index column must be numeric or time for this to work.
-                            """,
-                        ),
-                        "columns": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                list of strings or None, Which columns to select;
-                                if None, gets all; can include sqlalchemy functions,
-                                e.g., sql.func.abs(sql.column("value")).label("abs(value)").
-                                Labeling columns created by functions or arithmetic operations is recommended.
-                            """,
-                        ),
-                        "bytes_per_chunk": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                str or int, If both divisions and npartitions is None,
-                                this is the target size of each partition, in bytes.
-                            """,
-                        ),
-                        "head_rows": Field(
-                            Int,
-                            is_required=False,
-                            description="How many rows to load for inferring the data-types, unless passing meta.",
-                        ),
-                        "schema": Field(
-                            String,
-                            is_required=False,
-                            description="""
-                                If using a table name, pass this to sqlalchemy to select
-                                which DB schema to use within the URI connection.
-                            """,
-                        ),
-                    }
-                ),
-                "table": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Absolute or relative filepath(s).
-                                Prefix with a protocol like "s3://" to read from alternative filesystems.
-                                To read from multiple files you can pass a globstring or a list of paths,
-                                with the caveat that they must all have the same protocol.
-                            """,
-                        ),
-                        "blocksize": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                str or int or None, Number of bytes by which to cut up larger files.
-                                Default value is computed based on available physical memory and the number of cores,
-                                up to a maximum of 64MB. Can be a number like 64000000` or a string like ``"64MB".
-                                If None, a single block is used for each file.
-                            """,
-                        ),
-                        "sample": Field(
-                            Int,
-                            is_required=False,
-                            description="Number of bytes to use when determining dtypes.",
-                        ),
-                        "assume_missing": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If True, all integer columns that aren’t specified in dtype are assumed to contain missing values,
-                                and are converted to floats. Default is False.
-                            """,
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="""
-                                Extra options that make sense for a particular storage connection,
-                                e.g. host, port, username, password, etc.
-                            """,
-                        ),
-                        "include_path_column": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                bool or str, Whether or not to include the path to each particular file.
-                                If True a new column is added to the dataframe called path.
-                                If str, sets new column name. Default is False.
-                            """,
-                        ),
-                    }
-                ),
-                "fwf": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Absolute or relative filepath(s).
-                                Prefix with a protocol like "s3://" to read from alternative filesystems.
-                                To read from multiple files you can pass a globstring or a list of paths,
-                                with the caveat that they must all have the same protocol.
-                            """,
-                        ),
-                        "blocksize": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                str or int or None, Number of bytes by which to cut up larger files.
-                                Default value is computed based on available physical memory
-                                and the number of cores up to a maximum of 64MB.
-                                Can be a number like 64000000` or a string like ``"64MB".
-                                If None, a single block is used for each file.
-                            """,
-                        ),
-                        "sample": Field(
-                            Int,
-                            is_required=False,
-                            description="Number of bytes to use when determining dtypes.",
-                        ),
-                        "assume_missing": Field(
-                            Bool,
-                            is_required=False,
-                            description="""
-                                If True, all integer columns that aren’t specified in dtype are assumed
-                                to contain missing values, and are converted to floats.
-                                Default is False.
-                            """,
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="""
-                                Extra options that make sense for a particular storage connection,
-                                e.g. host, port, username, password, etc.
-                            """,
-                        ),
-                        "include_path_column": Field(
-                            Any,
-                            is_required=False,
-                            description="""
-                                bool or str, Whether or not to include the path to each particular file.
-                                If True a new column is added to the dataframe called path.
-                                If str, sets new column name. Default is False.
-                            """,
-                        ),
-                    }
-                ),
-                "orc": Permissive(
-                    {
-                        "path": Field(
-                            Any,
-                            is_required=True,
-                            description="""
-                                str or list, Location of file(s),
-                                which can be a full URL with protocol specifier,
-                                and may include glob character if a single string.
-                            """,
-                        ),
-                        "columns": Field(
-                            list, is_required=False, description="Columns to load. If None, loads all.",
-                        ),
-                        "storage_options": Field(
-                            Permissive(),
-                            is_required=False,
-                            description="Further parameters to pass to the bytes backend.",
-                        ),
-                    }
-                ),
-            },
-        ),
+DataFrameReadTypes = {
+    "csv": {
+        "function": dd.read_csv,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "blocksize": (Any, False, "Number of bytes by which to cut up larger files."),
+            "sample": (Int, False, "Number of bytes to use when determining dtypes."),
+            "assume_missing": (Bool, False, "If True, all integer columns that aren’t specified in `dtype` are assumed to contain missing values, and are converted to floats."),
+            "storage_options": (Permissive(), False, "Extra options that make sense for a particular storage connection."),
+            "include_path_column": (Any, False, "Whether or not to include the path to each particular file."),
+        },
+    },
+    "parquet": {
+        "function": dd.read_parquet,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "columns": (Any, False, "Field name(s) to read in as columns in the output."),
+            "index": (Any, False, "Field name(s) to use as the output frame index."),
+            "categories": (Any, False, "For any fields listed here, if the parquet encoding is Dictionary, the column will be created with dtype category."),
+            "storage_options": (Permissive(), False, "Key/value pairs to be passed on to the file-system backend, if any."),
+            "engine": (EngineParquetOptions, False, "Parquet reader library to use."),
+            "gather_statistics": (Bool, False, "Gather the statistics for each dataset partition."),
+            "split_row_groups": (Bool, False, "If True (default) then output dataframe partitions will correspond to parquet-file row-groups."),
+            "chunksize": (Any, False, "The target task partition size."),
+        },
+    },
+    "hdf": {
+        "function": dd.read_hdf,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "key": (Any, True, "The group identifier in the store."),
+            "start": (Int, False, "Row number to start selection."),
+            "stop": (Int, False, "Row number to stop selection."),
+            "columns": (list, False, "A list of columns names to return."),
+            "chunksize": (Any, False, "Maximal number of rows per partition."),
+            "sorted_index": (Bool, False, "Option to specify whether or not the input hdf files have a sorted index."),
+            "lock": (Bool, False, "Option to use a lock to prevent concurrency issues."),
+            "mode": (String, False, "Mode to use when opening file(s)."),
+        },
+    },
+    "json": {
+        "function": dd.read_json,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "encoding": (String, False, "The text encoding to implement."),
+            "errors": (String, False, "How to respond to errors in the conversion."),
+            "storage_options": (Permissive(), False, "Passed to backend file-system implementation."),
+            "blocksize": (Int, False, "Each partition will be approximately this size in bytes."),
+            "sample": (Int, False, "Number of bytes to pre-load, to provide an empty dataframe structure to any blocks without data."),
+            "compression": (String, False, "String like ‘gzip’ or ‘xz’."),
+        },
+    },
+    "sql_table": {
+        "function": dd.read_sql_table,
+        "is_path_based": False,
+        "options": {
+            "table": (Any, True, "Select columns from here."),
+            "uri": (String, True, "Full sqlalchemy URI for the database connection."),
+            "index_col": (String, True, "Column which becomes the index, and defines the partitioning."),
+            "divisions": (Any, False, "Values of the index column to split the table by."),
+            "npartitions": (Int, False, "Number of partitions, if divisions is not given."),
+            "columns": (Any, False, "Which columns to select."),
+            "bytes_per_chunk": (Any, False, "The target size of each partition, in bytes."),
+            "head_rows": (Int, False, "How many rows to load for inferring the data-types, unless passing meta."),
+            "schema": (String, False, "If using a table name, pass this to sqlalchemy to select which DB schema to use within the URI connection."),
+        },
+    },
+    "table": {
+        "function": dd.read_table,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "blocksize": (Any, False, "Number of bytes by which to cut up larger files."),
+            "sample": (Int, False, "Number of bytes to use when determining dtypes."),
+            "assume_missing": (Bool, False, "If True, all integer columns that aren’t specified in dtype are assumed to contain missing values, and are converted to floats."),
+            "storage_options": (Permissive(), False, "Extra options that make sense for a particular storage connection."),
+            "include_path_column": (Any, False, "Whether or not to include the path to each particular file."),
+        },
+    },
+    "fwf": {
+        "function": dd.read_fwf,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "blocksize": (Any, False, "Number of bytes by which to cut up larger files."),
+            "sample": (Int, False, "Number of bytes to use when determining dtypes."),
+            "assume_missing": (Bool, False, "If True, all integer columns that aren’t specified in dtype are assumed to contain missing values, and are converted to floats."),
+            "storage_options": (Permissive(), False, "Extra options that make sense for a particular storage connection."),
+            "include_path_column": (Any, False, "Whether or not to include the path to each particular file."),
+        }
+    },
+    "orc": {
+        "function": dd.read_orc,
+        "is_path_based": True,
+        "options": {
+            "path": (Any, True, "Absolute or relative filepath(s)."),
+            "columns": (Any, False, "Columns to load."),
+            "storage_options": (Permissive(), False, "Further parameters to pass to the bytes backend."),
+        }
+    }
+}
+
+
+def _dataframe_loader_config():
+    read_fields = Selector({
+        read_from: {
+            option_name: Field(option_args[0], is_required=option_args[1], description=option_args[2])
+            for option_name, option_args in read_opts["options"].items()
+        }
+        for read_from, read_opts in DataFrameReadTypes.items()
     })
-)
+
+    return Shape({
+        "read": read_fields
+    })
+
+
+@dagster_type_loader(_dataframe_loader_config())
 def dataframe_loader(_context, config):
     read_type, read_options = next(iter(config["read"].items()))
     path = read_options.get("path")

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -303,26 +303,34 @@ def dataframe_materializer(_context, config, dask_df):
     check.inst_param(dask_df, "dask_df", dd.DataFrame)
 
     if "to" in config:
-        for to_type, to_options in config["to"].items():
-            if not to_type in DataFrameToTypes:
-                check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
-            
-            # Get the metadata entry for the read_type in order to know which method
-            # to call and whether it uses path as the first argument. And, make
-            # to_options mutable if we need to pop off a path argument.
-            to_meta = DataFrameToTypes[to_type]
-            to_options = dict(to_options)
+        to_specs = config["to"]
+    else:
+        to_specs = {
+            to_type: to_options
+            for to_type, to_options in config.items()
+            if to_type in DataFrameToTypes
+        }
 
-            # Get the to function and prepare its arguments.
-            to_function = to_meta["function"]
-            to_path = to_options.pop("path") if to_meta.get("is_path_based", False) else None
-            to_args = [to_path] if to_path else []
-            to_kwargs = to_options
+    for to_type, to_options in to_specs.items():
+        if not to_type in DataFrameToTypes:
+            check.failed("Unsupported to_type {to_type}".format(to_type=to_type))
+        
+        # Get the metadata entry for the read_type in order to know which method
+        # to call and whether it uses path as the first argument. And, make
+        # to_options mutable if we need to pop off a path argument.
+        to_meta = DataFrameToTypes[to_type]
+        to_options = dict(to_options)
 
-            to_function(dask_df, *to_args, **to_kwargs)
+        # Get the to function and prepare its arguments.
+        to_function = to_meta["function"]
+        to_path = to_options.pop("path") if to_meta.get("is_path_based", False) else None
+        to_args = [to_path] if to_path else []
+        to_kwargs = to_options
 
-            if to_path:
-                yield AssetMaterialization.file(to_path)
+        to_function(dask_df, *to_args, **to_kwargs)
+
+        if to_path:
+            yield AssetMaterialization.file(to_path)
 
 
 def df_type_check(_, value):

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -10,15 +10,17 @@ from dagster import (
     EnumValue,
     EventMetadataEntry,
     Field,
+    Float,
     Int,
     Permissive,
+    Selector,
+    Shape,
     String,
     TypeCheck,
     check,
     dagster_type_loader,
     dagster_type_materializer,
 )
-from dagster.config.field_utils import Selector
 
 WriteCompressionTextOptions = Enum(
     "WriteCompressionText", [EnumValue("gzip"), EnumValue("bz2"), EnumValue("xz"),],
@@ -59,18 +61,18 @@ def dict_without_keys(ddict, *keys):
                         is_required=False,
                         description="""
                             A string representing the encoding to use in the output file,
-                            defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
+                            defaults to "ascii" on Python 2 and "utf-8" on Python 3.
                         """,
                     ),
                     "mode": Field(
-                        String, is_required=False, description="Python write mode, default 'w'",
+                        String, is_required=False, description="Python write mode, default "w"",
                     ),
                     "compression": Field(
                         WriteCompressionTextOptions,
                         is_required=False,
                         description="""
                             a string representing the compression to use in the output file,
-                            allowed values are 'gzip', 'bz2', 'xz'.
+                            allowed values are "gzip", "bz2", "xz".
                         """,
                     ),
                     "compute": Field(
@@ -118,17 +120,17 @@ def dict_without_keys(ddict, *keys):
                         EngineParquetOptions,
                         is_required=False,
                         description="""
-                            {'auto', 'fastparquet', 'pyarrow'}, default 'auto' Parquet library to use.
-                            If only one library is installed, it will use that one; if both, it will use 'fastparquet'.
+                            {"auto", "fastparquet", "pyarrow"}, default "auto" Parquet library to use.
+                            If only one library is installed, it will use that one; if both, it will use "fastparquet".
                         """,
                     ),
                     "compression": Field(
                         Any,
                         is_required=False,
                         description="""
-                        str or dict, optional Either a string like ``'snappy'``
-                        or a dictionary mapping column names to compressors like ``{'name': 'gzip', 'values': 'snappy'}``.
-                        The default is ``'default'``, which uses the default compression for whichever engine is selected.
+                        str or dict, optional Either a string like ``"snappy"``
+                        or a dictionary mapping column names to compressors like ``{"name": "gzip", "values": "snappy"}``.
+                        The default is ``"default"``, which uses the default compression for whichever engine is selected.
                         """,
                     ),
                     "write_index": Field(
@@ -169,7 +171,7 @@ def dict_without_keys(ddict, *keys):
                     "write_metadata_file": Field(
                         Bool,
                         is_required=False,
-                        description="Whether to write the special '_metadata' file.",
+                        description="Whether to write the special "_metadata" file.",
                     ),
                     "compute": Field(
                         Bool,
@@ -216,7 +218,7 @@ def dict_without_keys(ddict, *keys):
                     "scheduler": Field(
                         String,
                         is_required=False,
-                        description="The scheduler to use, like 'threads' or 'processes'.",
+                        description="The scheduler to use, like "threads" or "processes".",
                     ),
                 }
             ),
@@ -230,18 +232,18 @@ def dict_without_keys(ddict, *keys):
                             If a string, and there are more than one partitions in df,
                             should include a glob character to expand into a set of file names,
                             or provide a ``name_function=`` parameter.
-                            Supports protocol specifications such as ``'s3://'``.
+                            Supports protocol specifications such as ``"s3://"``.
                         """,
                     ),
                     "encoding": Field(
                         String,
                         is_required=False,
-                        description="default is 'utf-8', The text encoding to implement, e.g., 'utf-8'.",
+                        description="default is "utf-8", The text encoding to implement, e.g., "utf-8".",
                     ),
                     "errors": Field(
                         String,
                         is_required=False,
-                        description="default is 'strict', how to respond to errors in the conversion (see ``str.encode()``).",
+                        description="default is "strict", how to respond to errors in the conversion (see ``str.encode()``).",
                     ),
                     "storage_options": Field(
                         Permissive(),
@@ -262,7 +264,7 @@ def dict_without_keys(ddict, *keys):
                         description="Options to be passed in to the compute method",
                     ),
                     "compression": Field(
-                        String, is_required=False, description="String like 'gzip' or 'xz'.",
+                        String, is_required=False, description="String like "gzip" or "xz".",
                     ),
                 },
             ),
@@ -283,7 +285,7 @@ def dict_without_keys(ddict, *keys):
                         String,
                         is_required=False,
                         description="""
-                            {'fail', 'replace', 'append'}, default 'fail'"
+                            {"fail", "replace", "append"}, default "fail""
                             How to behave if the table already exists.
                             * fail: Raise a ValueError.
                             * replace: Drop the table before inserting new values.
@@ -329,10 +331,10 @@ def dict_without_keys(ddict, *keys):
                         String,
                         is_required=False,
                         description="""
-                            {None, 'multi', callable}, default None
+                            {None, "multi", callable}, default None
                             Controls the SQL insertion clause used:
                             * None : Uses standard SQL ``INSERT`` clause (one per row).
-                            * 'multi': Pass multiple values in a single ``INSERT`` clause.
+                            * "multi": Pass multiple values in a single ``INSERT`` clause.
                             * callable with signature ``(pd_table, conn, keys, data_iter)``.
                             Details and a sample callable implementation can be found in the
                             section :ref:`insert method <io.sql.method>`.
@@ -351,7 +353,7 @@ def dict_without_keys(ddict, *keys):
                         is_required=False,
                         description="""
                             default is False, When true, have each block append itself to the DB table concurrently.
-                            This can result in DB rows being in a different order than the source DataFrame's corresponding rows.
+                            This can result in DB rows being in a different order than the source DataFrame"s corresponding rows.
                             When false, load each block into the SQL DB in sequence.
                         """,
                     ),
@@ -382,476 +384,475 @@ def dataframe_materializer(_context, config, dask_df):
 
 
 @dagster_type_loader(
-    Selector(
-        {
-            "csv": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Absolute or relative filepath(s).
-                            Prefix with a protocol like `s3://` to read from alternative filesystems.
-                            To read from multiple files you can pass a globstring or a list of paths,
-                            with the caveat that they must all have the same protocol.
-                        """,
-                    ),
-                    "blocksize": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                        str or int or None, Number of bytes by which to cut up larger files.
-                        Default value is computed based on available physical memory and the number of cores, up to a maximum of 64MB.
-                        Can be a number like 64000000` or a string like ``'64MB'. If None, a single block is used for each file.
-                        """,
-                    ),
-                    "sample": Field(
-                        Int,
-                        is_required=False,
-                        description="Number of bytes to use when determining dtypes.",
-                    ),
-                    "assume_missing": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True, all integer columns that aren’t specified in `dtype` are assumed to contain missing values,
-                            and are converted to floats. Default is False.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="""
-                            Extra options that make sense for a particular storage connection,
-                            e.g. host, port, username, password, etc.
-                        """,
-                    ),
-                    "include_path_column": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            bool or str, Whether or not to include the path to each particular file.
-                            If True a new column is added to the dataframe called path.
-                            If str, sets new column name. Default is False.
-                        """,
-                    ),
-                }
-            ),
-            "parquet": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Source directory for data, or path(s) to individual parquet files.
-                            Prefix with a protocol like s3:// to read from alternative filesystems.
-                            To read from multiple files you can pass a globstring or a list of paths,
-                            with the caveat that they must all have the same protocol.
-                        """,
-                    ),
-                    "columns": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or list or None (default), Field name(s) to read in as columns in the output.
-                            By default all non-index fields will be read (as determined by the pandas parquet metadata, if present).
-                            Provide a single field name instead of a list to read in the data as a Series.
-                        """,
-                    ),
-                    "index": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            list or False or None (default), Field name(s) to use as the output frame index.
-                            By default will be inferred from the pandas parquet file metadata (if present).
-                            Use False to read all fields as columns.
-                        """,
-                    ),
-                    "categories": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            list or dict or None, For any fields listed here,
-                            if the parquet encoding is Dictionary, the column will be created with dtype category.
-                            Use only if it is guaranteed that the column is encoded as dictionary in all row-groups.
-                            If a list, assumes up to 2**16-1 labels; if a dict, specify the number of labels expected;
-                            if None, will load categories automatically for data written by dask/fastparquet, not otherwise.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Key/value pairs to be passed on to the file-system backend, if any.",
-                    ),
-                    "engine": Field(
-                        EngineParquetOptions,
-                        is_required=False,
-                        description="""
-                            Parquet reader library to use.
-                            If only one library is installed, it will use that one;
-                            if both, it will use ‘fastparquet’.
-                        """,
-                    ),
-                    "gather_statistics": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            default is None, Gather the statistics for each dataset partition.
-                            By default, this will only be done if the _metadata file is available.
-                            Otherwise, statistics will only be gathered if True,
-                            because the footer of every file will be parsed (which is very slow on some systems).
-                        """,
-                    ),
-                    "split_row_groups:": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True (default) then output dataframe partitions will correspond
-                            to parquet-file row-groups (when enough row-group metadata is available).
-                            Otherwise, partitions correspond to distinct files.
-                            Only the “pyarrow” engine currently supports this argument.
-                        """,
-                    ),
-                    "chunksize": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            int or string, The target task partition size.
-                            If set, consecutive row-groups from the same file will be aggregated
-                            into the same output partition until the aggregate size reaches this value.
-                        """,
-                    ),
-                }
-            ),
-            "hdf": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or pathlib.Path or list,
-                            File pattern (string), pathlib.Path, buffer to read from, or list of file paths.
-                            Can contain wildcards.
-                        """,
-                    ),
-                    "Key": Field(
-                        Any,
-                        is_required=True,
-                        description="group identifier in the store. Can contain wildcards.",
-                    ),
-                    "start": Field(
-                        Int,
-                        is_required=False,
-                        description="defaults to 0, row number to start at.",
-                    ),
-                    "stop": Field(
-                        Int,
-                        is_required=False,
-                        description="defaults to None (the last row), row number to stop at.",
-                    ),
-                    "columns": Field(
-                        list,
-                        is_required=False,
-                        description="A list of columns that if not None, will limit the return columns (default is None).",
-                    ),
-                    "chunksize": Field(
-                        Any,
-                        is_required=False,
-                        description="Maximal number of rows per partition (default is 1000000).",
-                    ),
-                    "sorted_index": Field(
-                        Bool,
-                        is_required=False,
-                        description="Option to specify whether or not the input hdf files have a sorted index (default is False).",
-                    ),
-                    "lock": Field(
-                        Bool,
-                        is_required=False,
-                        description="Option to use a lock to prevent concurrency issues (default is True).",
-                    ),
-                    "mode": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            {‘a’, ‘r’, ‘r+’}, default ‘a’. Mode to use when opening file(s).
-                            ‘r’ - Read-only; no data can be modified.
-                            ‘a’ - Append; an existing file is opened for reading and writing, and if the file does not exist it is created.
-                            ‘r+’ - It is similar to ‘a’, but the file must already exist.
-                        """,
-                    ),
-                }
-            ),
-            "json": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Location to read from.
-                            If a string, can include a glob character to find a set of file names.
-                            Supports protocol specifications such as 's3://'.
-                        """,
-                    ),
-                    "encoding": Field(
-                        String,
-                        is_required=False,
-                        description="The text encoding to implement, e.g., “utf-8”.",
-                    ),
-                    "errors": Field(
-                        String,
-                        is_required=False,
-                        description="how to respond to errors in the conversion (see str.encode()).",
-                    ),
-                    "orient": Field(
-                        String, is_required=False, description="The JSON string format."
-                    ),
-                    "storage_option": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Passed to backend file-system implementation.",
-                    ),
-                    "blocksize": Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            default is None, If None, files are not blocked, and you get one partition per input file.
-                            If int, which can only be used for line-delimited JSON files,
-                            each partition will be approximately this size in bytes, to the nearest newline character.
-                        """,
-                    ),
-                    "sample": Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            Number of bytes to pre-load,
-                            to provide an empty dataframe structure to any blocks without data.
-                            Only relevant is using blocksize.
-                        """,
-                    ),
-                    "compression": Field(
-                        String,
-                        is_required=False,
-                        description="default is None, String like ‘gzip’ or ‘xz’.",
-                    ),
-                }
-            ),
-            "sql_table": Permissive(
-                {
-                    "table": Field(
-                        Any,
-                        is_required=True,
-                        description="str or sqlalchemy expression, Select columns from here.",
-                    ),
-                    "uri": Field(
-                        String,
-                        is_required=True,
-                        description="Full sqlalchemy URI for the database connection.",
-                    ),
-                    "index_col": Field(
-                        String,
-                        is_required=True,
-                        description="""
-                        Column which becomes the index, and defines the partitioning.
-                        Should be a indexed column in the SQL server, and any orderable type.
-                        If the type is number or time, then partition boundaries can be inferred from npartitions or bytes_per_chunk;
-                        otherwide must supply explicit divisions=.
-                        index_col could be a function to return a value, e.g., sql.func.abs(sql.column('value')).label('abs(value)').
-                        index_col=sql.func.abs(sql.column("value")).label("abs(value)"),
-                        or index_col=cast(sql.column("id"),types.BigInteger).label("id") to convert the textfield id to BigInteger.
-                        Note sql, cast, types methods comes frome sqlalchemy module.
-                        Labeling columns created by functions or arithmetic operations is required
-                        """,
-                    ),
-                    "divisions": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            sequence, Values of the index column to split the table by.
-                            If given, this will override npartitions and bytes_per_chunk.
-                            The divisions are the value boundaries of the index column used to define the partitions.
-                            For example, divisions=list('acegikmoqsuwz') could be used
-                            to partition a string column lexographically into 12 partitions,
-                            with the implicit assumption that each partition contains similar numbers of records.
-                        """,
-                    ),
-                    "npartitions": Field(
-                        Int,
-                        is_required=False,
-                        description="""
-                            Number of partitions, if divisions is not given.
-                            Will split the values of the index column linearly between limits, if given, or the column max/min.
-                            The index column must be numeric or time for this to work.
-                        """,
-                    ),
-                    "columns": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            list of strings or None, Which columns to select;
-                            if None, gets all; can include sqlalchemy functions,
-                            e.g., sql.func.abs(sql.column('value')).label('abs(value)').
-                            Labeling columns created by functions or arithmetic operations is recommended.
-                        """,
-                    ),
-                    "bytes_per_chunk": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or int, If both divisions and npartitions is None,
-                            this is the target size of each partition, in bytes.
-                        """,
-                    ),
-                    "head_rows": Field(
-                        Int,
-                        is_required=False,
-                        description="How many rows to load for inferring the data-types, unless passing meta.",
-                    ),
-                    "schema": Field(
-                        String,
-                        is_required=False,
-                        description="""
-                            If using a table name, pass this to sqlalchemy to select
-                            which DB schema to use within the URI connection.
-                        """,
-                    ),
-                }
-            ),
-            "table": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Absolute or relative filepath(s).
-                            Prefix with a protocol like 's3://' to read from alternative filesystems.
-                            To read from multiple files you can pass a globstring or a list of paths,
-                            with the caveat that they must all have the same protocol.
-                        """,
-                    ),
-                    "blocksize": Field(
-                        Any,
-                        is_required=False,
-                        description="""
+    Shape({
+        "read": Selector(
+            {
+                "csv": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Absolute or relative filepath(s).
+                                Prefix with a protocol like `s3://` to read from alternative filesystems.
+                                To read from multiple files you can pass a globstring or a list of paths,
+                                with the caveat that they must all have the same protocol.
+                            """,
+                        ),
+                        "blocksize": Field(
+                            Any,
+                            is_required=False,
+                            description="""
                             str or int or None, Number of bytes by which to cut up larger files.
-                            Default value is computed based on available physical memory and the number of cores,
-                            up to a maximum of 64MB. Can be a number like 64000000` or a string like ``'64MB'.
-                            If None, a single block is used for each file.
-                        """,
-                    ),
-                    "sample": Field(
-                        Int,
-                        is_required=False,
-                        description="Number of bytes to use when determining dtypes.",
-                    ),
-                    "assume_missing": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True, all integer columns that aren’t specified in dtype are assumed to contain missing values,
-                            and are converted to floats. Default is False.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="""
-                            Extra options that make sense for a particular storage connection,
-                            e.g. host, port, username, password, etc.
-                        """,
-                    ),
-                    "include_path_column": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            bool or str, Whether or not to include the path to each particular file.
-                            If True a new column is added to the dataframe called path.
-                            If str, sets new column name. Default is False.
-                        """,
-                    ),
-                }
-            ),
-            "fwf": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Absolute or relative filepath(s).
-                            Prefix with a protocol like 's3://' to read from alternative filesystems.
-                            To read from multiple files you can pass a globstring or a list of paths,
-                            with the caveat that they must all have the same protocol.
-                        """,
-                    ),
-                    "blocksize": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            str or int or None, Number of bytes by which to cut up larger files.
-                            Default value is computed based on available physical memory
-                            and the number of cores up to a maximum of 64MB.
-                            Can be a number like 64000000` or a string like ``'64MB'.
-                            If None, a single block is used for each file.
-                        """,
-                    ),
-                    "sample": Field(
-                        Int,
-                        is_required=False,
-                        description="Number of bytes to use when determining dtypes.",
-                    ),
-                    "assume_missing": Field(
-                        Bool,
-                        is_required=False,
-                        description="""
-                            If True, all integer columns that aren’t specified in dtype are assumed
-                            to contain missing values, and are converted to floats.
-                            Default is False.
-                        """,
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="""
-                            Extra options that make sense for a particular storage connection,
-                            e.g. host, port, username, password, etc.
-                        """,
-                    ),
-                    "include_path_column": Field(
-                        Any,
-                        is_required=False,
-                        description="""
-                            bool or str, Whether or not to include the path to each particular file.
-                            If True a new column is added to the dataframe called path.
-                            If str, sets new column name. Default is False.
-                        """,
-                    ),
-                }
-            ),
-            "orc": Permissive(
-                {
-                    "path": Field(
-                        Any,
-                        is_required=True,
-                        description="""
-                            str or list, Location of file(s),
-                            which can be a full URL with protocol specifier,
-                            and may include glob character if a single string.
-                        """,
-                    ),
-                    "columns": Field(
-                        list, is_required=False, description="Columns to load. If None, loads all.",
-                    ),
-                    "storage_options": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Further parameters to pass to the bytes backend.",
-                    ),
-                }
-            ),
-        },
-    )
+                            Default value is computed based on available physical memory and the number of cores, up to a maximum of 64MB.
+                            Can be a number like 64000000` or a string like ``"64MB". If None, a single block is used for each file.
+                            """,
+                        ),
+                        "sample": Field(
+                            Int,
+                            is_required=False,
+                            description="Number of bytes to use when determining dtypes.",
+                        ),
+                        "assume_missing": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If True, all integer columns that aren’t specified in `dtype` are assumed to contain missing values,
+                                and are converted to floats. Default is False.
+                            """,
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="""
+                                Extra options that make sense for a particular storage connection,
+                                e.g. host, port, username, password, etc.
+                            """,
+                        ),
+                        "include_path_column": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                bool or str, Whether or not to include the path to each particular file.
+                                If True a new column is added to the dataframe called path.
+                                If str, sets new column name. Default is False.
+                            """,
+                        ),
+                    }
+                ),
+                "parquet": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Source directory for data, or path(s) to individual parquet files.
+                                Prefix with a protocol like s3:// to read from alternative filesystems.
+                                To read from multiple files you can pass a globstring or a list of paths,
+                                with the caveat that they must all have the same protocol.
+                            """,
+                        ),
+                        "columns": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                str or list or None (default), Field name(s) to read in as columns in the output.
+                                By default all non-index fields will be read (as determined by the pandas parquet metadata, if present).
+                                Provide a single field name instead of a list to read in the data as a Series.
+                            """,
+                        ),
+                        "index": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                list or False or None (default), Field name(s) to use as the output frame index.
+                                By default will be inferred from the pandas parquet file metadata (if present).
+                                Use False to read all fields as columns.
+                            """,
+                        ),
+                        "categories": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                list or dict or None, For any fields listed here,
+                                if the parquet encoding is Dictionary, the column will be created with dtype category.
+                                Use only if it is guaranteed that the column is encoded as dictionary in all row-groups.
+                                If a list, assumes up to 2**16-1 labels; if a dict, specify the number of labels expected;
+                                if None, will load categories automatically for data written by dask/fastparquet, not otherwise.
+                            """,
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Key/value pairs to be passed on to the file-system backend, if any.",
+                        ),
+                        "engine": Field(
+                            EngineParquetOptions,
+                            is_required=False,
+                            description="""
+                                Parquet reader library to use.
+                                If only one library is installed, it will use that one;
+                                if both, it will use ‘fastparquet’.
+                            """,
+                        ),
+                        "gather_statistics": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                default is None, Gather the statistics for each dataset partition.
+                                By default, this will only be done if the _metadata file is available.
+                                Otherwise, statistics will only be gathered if True,
+                                because the footer of every file will be parsed (which is very slow on some systems).
+                            """,
+                        ),
+                        "split_row_groups:": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If True (default) then output dataframe partitions will correspond
+                                to parquet-file row-groups (when enough row-group metadata is available).
+                                Otherwise, partitions correspond to distinct files.
+                                Only the “pyarrow” engine currently supports this argument.
+                            """,
+                        ),
+                        "chunksize": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                int or string, The target task partition size.
+                                If set, consecutive row-groups from the same file will be aggregated
+                                into the same output partition until the aggregate size reaches this value.
+                            """,
+                        ),
+                    }
+                ),
+                "hdf": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or pathlib.Path or list,
+                                File pattern (string), pathlib.Path, buffer to read from, or list of file paths.
+                                Can contain wildcards.
+                            """,
+                        ),
+                        "Key": Field(
+                            Any,
+                            is_required=True,
+                            description="group identifier in the store. Can contain wildcards.",
+                        ),
+                        "start": Field(
+                            Int,
+                            is_required=False,
+                            description="defaults to 0, row number to start at.",
+                        ),
+                        "stop": Field(
+                            Int,
+                            is_required=False,
+                            description="defaults to None (the last row), row number to stop at.",
+                        ),
+                        "columns": Field(
+                            list,
+                            is_required=False,
+                            description="A list of columns that if not None, will limit the return columns (default is None).",
+                        ),
+                        "chunksize": Field(
+                            Any,
+                            is_required=False,
+                            description="Maximal number of rows per partition (default is 1000000).",
+                        ),
+                        "sorted_index": Field(
+                            Bool,
+                            is_required=False,
+                            description="Option to specify whether or not the input hdf files have a sorted index (default is False).",
+                        ),
+                        "lock": Field(
+                            Bool,
+                            is_required=False,
+                            description="Option to use a lock to prevent concurrency issues (default is True).",
+                        ),
+                        "mode": Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                {‘a’, ‘r’, ‘r+’}, default ‘a’. Mode to use when opening file(s).
+                                ‘r’ - Read-only; no data can be modified.
+                                ‘a’ - Append; an existing file is opened for reading and writing, and if the file does not exist it is created.
+                                ‘r+’ - It is similar to ‘a’, but the file must already exist.
+                            """,
+                        ),
+                    }
+                ),
+                "json": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Location to read from.
+                                If a string, can include a glob character to find a set of file names.
+                                Supports protocol specifications such as "s3://".
+                            """,
+                        ),
+                        "encoding": Field(
+                            String,
+                            is_required=False,
+                            description="The text encoding to implement, e.g., “utf-8”.",
+                        ),
+                        "errors": Field(
+                            String,
+                            is_required=False,
+                            description="how to respond to errors in the conversion (see str.encode()).",
+                        ),
+                        "storage_option": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Passed to backend file-system implementation.",
+                        ),
+                        "blocksize": Field(
+                            Int,
+                            is_required=False,
+                            description="""
+                                default is None, If None, files are not blocked, and you get one partition per input file.
+                                If int, which can only be used for line-delimited JSON files,
+                                each partition will be approximately this size in bytes, to the nearest newline character.
+                            """,
+                        ),
+                        "sample": Field(
+                            Int,
+                            is_required=False,
+                            description="""
+                                Number of bytes to pre-load,
+                                to provide an empty dataframe structure to any blocks without data.
+                                Only relevant is using blocksize.
+                            """,
+                        ),
+                        "compression": Field(
+                            String,
+                            is_required=False,
+                            description="default is None, String like ‘gzip’ or ‘xz’.",
+                        ),
+                    }
+                ),
+                "sql_table": Permissive(
+                    {
+                        "table": Field(
+                            Any,
+                            is_required=True,
+                            description="str or sqlalchemy expression, Select columns from here.",
+                        ),
+                        "uri": Field(
+                            String,
+                            is_required=True,
+                            description="Full sqlalchemy URI for the database connection.",
+                        ),
+                        "index_col": Field(
+                            String,
+                            is_required=True,
+                            description="""
+                            Column which becomes the index, and defines the partitioning.
+                            Should be a indexed column in the SQL server, and any orderable type.
+                            If the type is number or time, then partition boundaries can be inferred from npartitions or bytes_per_chunk;
+                            otherwide must supply explicit divisions=.
+                            index_col could be a function to return a value, e.g., sql.func.abs(sql.column("value")).label("abs(value)").
+                            index_col=sql.func.abs(sql.column("value")).label("abs(value)"),
+                            or index_col=cast(sql.column("id"),types.BigInteger).label("id") to convert the textfield id to BigInteger.
+                            Note sql, cast, types methods comes frome sqlalchemy module.
+                            Labeling columns created by functions or arithmetic operations is required
+                            """,
+                        ),
+                        "divisions": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                sequence, Values of the index column to split the table by.
+                                If given, this will override npartitions and bytes_per_chunk.
+                                The divisions are the value boundaries of the index column used to define the partitions.
+                                For example, divisions=list("acegikmoqsuwz") could be used
+                                to partition a string column lexographically into 12 partitions,
+                                with the implicit assumption that each partition contains similar numbers of records.
+                            """,
+                        ),
+                        "npartitions": Field(
+                            Int,
+                            is_required=False,
+                            description="""
+                                Number of partitions, if divisions is not given.
+                                Will split the values of the index column linearly between limits, if given, or the column max/min.
+                                The index column must be numeric or time for this to work.
+                            """,
+                        ),
+                        "columns": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                list of strings or None, Which columns to select;
+                                if None, gets all; can include sqlalchemy functions,
+                                e.g., sql.func.abs(sql.column("value")).label("abs(value)").
+                                Labeling columns created by functions or arithmetic operations is recommended.
+                            """,
+                        ),
+                        "bytes_per_chunk": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                str or int, If both divisions and npartitions is None,
+                                this is the target size of each partition, in bytes.
+                            """,
+                        ),
+                        "head_rows": Field(
+                            Int,
+                            is_required=False,
+                            description="How many rows to load for inferring the data-types, unless passing meta.",
+                        ),
+                        "schema": Field(
+                            String,
+                            is_required=False,
+                            description="""
+                                If using a table name, pass this to sqlalchemy to select
+                                which DB schema to use within the URI connection.
+                            """,
+                        ),
+                    }
+                ),
+                "table": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Absolute or relative filepath(s).
+                                Prefix with a protocol like "s3://" to read from alternative filesystems.
+                                To read from multiple files you can pass a globstring or a list of paths,
+                                with the caveat that they must all have the same protocol.
+                            """,
+                        ),
+                        "blocksize": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                str or int or None, Number of bytes by which to cut up larger files.
+                                Default value is computed based on available physical memory and the number of cores,
+                                up to a maximum of 64MB. Can be a number like 64000000` or a string like ``"64MB".
+                                If None, a single block is used for each file.
+                            """,
+                        ),
+                        "sample": Field(
+                            Int,
+                            is_required=False,
+                            description="Number of bytes to use when determining dtypes.",
+                        ),
+                        "assume_missing": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If True, all integer columns that aren’t specified in dtype are assumed to contain missing values,
+                                and are converted to floats. Default is False.
+                            """,
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="""
+                                Extra options that make sense for a particular storage connection,
+                                e.g. host, port, username, password, etc.
+                            """,
+                        ),
+                        "include_path_column": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                bool or str, Whether or not to include the path to each particular file.
+                                If True a new column is added to the dataframe called path.
+                                If str, sets new column name. Default is False.
+                            """,
+                        ),
+                    }
+                ),
+                "fwf": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Absolute or relative filepath(s).
+                                Prefix with a protocol like "s3://" to read from alternative filesystems.
+                                To read from multiple files you can pass a globstring or a list of paths,
+                                with the caveat that they must all have the same protocol.
+                            """,
+                        ),
+                        "blocksize": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                str or int or None, Number of bytes by which to cut up larger files.
+                                Default value is computed based on available physical memory
+                                and the number of cores up to a maximum of 64MB.
+                                Can be a number like 64000000` or a string like ``"64MB".
+                                If None, a single block is used for each file.
+                            """,
+                        ),
+                        "sample": Field(
+                            Int,
+                            is_required=False,
+                            description="Number of bytes to use when determining dtypes.",
+                        ),
+                        "assume_missing": Field(
+                            Bool,
+                            is_required=False,
+                            description="""
+                                If True, all integer columns that aren’t specified in dtype are assumed
+                                to contain missing values, and are converted to floats.
+                                Default is False.
+                            """,
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="""
+                                Extra options that make sense for a particular storage connection,
+                                e.g. host, port, username, password, etc.
+                            """,
+                        ),
+                        "include_path_column": Field(
+                            Any,
+                            is_required=False,
+                            description="""
+                                bool or str, Whether or not to include the path to each particular file.
+                                If True a new column is added to the dataframe called path.
+                                If str, sets new column name. Default is False.
+                            """,
+                        ),
+                    }
+                ),
+                "orc": Permissive(
+                    {
+                        "path": Field(
+                            Any,
+                            is_required=True,
+                            description="""
+                                str or list, Location of file(s),
+                                which can be a full URL with protocol specifier,
+                                and may include glob character if a single string.
+                            """,
+                        ),
+                        "columns": Field(
+                            list, is_required=False, description="Columns to load. If None, loads all.",
+                        ),
+                        "storage_options": Field(
+                            Permissive(),
+                            is_required=False,
+                            description="Further parameters to pass to the bytes backend.",
+                        ),
+                    }
+                ),
+            },
+        ),
+    })
 )
 def dataframe_loader(_context, config):
-    file_type, file_options = list(config.items())[0]
+    file_type, file_options = next(iter(config["read"].items()))
     path = file_options.get("path")
 
     if file_type == "csv":

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -227,6 +227,8 @@ def _dataframe_loader_config():
             Selector(read_fields),
             is_required=False,
         ),
+
+        # https://github.com/dagster-io/dagster/issues/2872
         **{
             field_name: Field(
                 field_config,
@@ -242,11 +244,14 @@ def dataframe_loader(_context, config):
     read_type, read_options = None, None
     if "read" in config:
         read_type, read_options = next(iter(config["read"].items()))
+    
+    # https://github.com/dagster-io/dagster/issues/2872
     else:
         for key in DataFrameReadTypes:
             if key in config:
                 read_type, read_options = key, config[key]
                 warnings.warn("Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=key))
+    
     if not read_type:
         raise DagsterInvariantViolationError(
             "No read_type found. Expected read key in config."
@@ -286,6 +291,8 @@ def _dataframe_materializer_config():
             Selector(to_fields),
             is_required=False,
         ),
+
+        # https://github.com/dagster-io/dagster/issues/2872
         **{
             field_name: Field(
                 field_config,
@@ -302,6 +309,8 @@ def dataframe_materializer(_context, config, dask_df):
 
     if "to" in config:
         to_specs = config["to"]
+
+    # https://github.com/dagster-io/dagster/issues/2872
     else:
         to_specs = {
             to_type: to_options
@@ -310,7 +319,6 @@ def dataframe_materializer(_context, config, dask_df):
         }
         for key in to_specs.keys():
             warnings.warn("Specifying {key}: is deprecated. Use to:{key}: instead.".format(key=key))
-
 
     for to_type, to_options in to_specs.items():
         if not to_type in DataFrameToTypes:

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -28,6 +28,7 @@ def test_dataframe_inputs(file_type):
     def return_df(_, input_df):
         return input_df
 
+    # https://github.com/dagster-io/dagster/issues/2872
     with pytest.warns(
         UserWarning,
         match=re.escape("Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=file_type)),
@@ -67,6 +68,7 @@ def test_dataframe_outputs(file_type, read, kwargs):
     def return_df(_):
         return df
 
+    # https://github.com/dagster-io/dagster/issues/2872
     with pytest.warns(
         UserWarning,
         match=re.escape("Specifying {key}: is deprecated. Use to:{key}: instead.".format(key=file_type)),

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -37,6 +37,15 @@ def test_dataframe_inputs(file_type):
     assert result.success
     assert assert_eq(result.output_value(), create_dask_df())
 
+    read_result = execute_solid(
+        return_df,
+        run_config={
+            'solids': {'return_df': {'inputs': {'input_df': {'read': {file_type: {'path': file_name}}}}}}
+        },
+    )
+    assert read_result.success
+    assert assert_eq(result.output_value(), read_result.output_value())
+
 
 @pytest.mark.parametrize(
     "file_type,read,kwargs",

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -31,7 +31,9 @@ def test_dataframe_inputs(file_type):
     # https://github.com/dagster-io/dagster/issues/2872
     with pytest.warns(
         UserWarning,
-        match=re.escape("Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=file_type)),
+        match=re.escape(
+            "Specifying {key}: is deprecated. Use read:{key}: instead.".format(key=file_type)
+        ),
     ):
         file_name = file_relative_path(__file__, f"num.{file_type}")
         result = execute_solid(
@@ -46,7 +48,9 @@ def test_dataframe_inputs(file_type):
     read_result = execute_solid(
         return_df,
         run_config={
-            'solids': {'return_df': {'inputs': {'input_df': {'read': {file_type: {'path': file_name}}}}}}
+            "solids": {
+                "return_df": {"inputs": {"input_df": {"read": {file_type: {"path": file_name}}}}}
+            }
         },
     )
     assert read_result.success
@@ -71,7 +75,9 @@ def test_dataframe_outputs(file_type, read, kwargs):
     # https://github.com/dagster-io/dagster/issues/2872
     with pytest.warns(
         UserWarning,
-        match=re.escape("Specifying {key}: is deprecated. Use to:{key}: instead.".format(key=file_type)),
+        match=re.escape(
+            "Specifying {key}: is deprecated. Use to:{key}: instead.".format(key=file_type)
+        ),
     ):
         with get_temp_dir() as temp_path:
             shutil.rmtree(temp_path)


### PR DESCRIPTION
This PR replaces #2809.

This PR modifies the loader and materializer options for the Dask DataFrame DagsterType to place the options for reading and writing DataFrames under keys named `read` and `to`, respectively. Moving the keys in one level opens up room at the root of the type config for other options.

**Before:**

```yaml
solids:
  example:
    inputs:
      dataframe:
        parquet:
          path: s3://some_bucket/some_path
```

**After:**

```yaml
solids:
  example:
    inputs:
      dataframe:
        read:
          parquet:
            path: s3://some_bucket/some_path
```

`read` and `to` were chosen as the key names to match the underlying method names for reading and writing DataFrames (e.g., `read_parquet`, `to_json`).

Several typos in option names are also fixed.

* read_hdf: `Key` → `key`
* read_json: `storage_option` → `storage_options`