### PR TITLE
Update "Basics of Solids" Tutorial to use `-c` argument

### DIFF
--- a/docs/next/src/pages/tutorial/basics_solids.mdx
+++ b/docs/next/src/pages/tutorial/basics_solids.mdx
@@ -102,15 +102,15 @@ file:/docs_snippets/docs_snippets/intro_tutorial/basics/e02_solids/inputs_env.ya
 dedent:4
 ```
 
-We can pass config files in this format to the Dagster CLI tool with the `-e` flag.
+We can pass config files in this format to the Dagster CLI tool with the `-c` flag.
 
 ```bash
-dagster pipeline execute -f inputs.py -e inputs_env.yaml
+dagster pipeline execute -f inputs.py -c inputs_env.yaml
 ```
 
 In practice, you might have different sections of your run config in different yaml files&mdash;if,
 for instance, some sections change more often (e.g. in test and prod) while other are more static.
-In this case, you can set multiple instances of the `-e` flag on CLI invocations, and the CLI tools
+In this case, you can set multiple instances of the `-c` flag on CLI invocations, and the CLI tools
 will assemble the YAML fragments into a single run config.
 
 </details>


### PR DESCRIPTION
Hello Dagster Team,

I was following the Basics of Solids Tutorial and reached this warning when running `dagster pipeline execute -f inputs.py -e inputs_env.yaml`:
```
UserWarning: "--env" is deprecated and will be removed in 0.9.0, use "--config" instead.
```
This PR fixes that command to use the `-c` argument instead.