### PR TITLE
Add utility options to Dask DataFrame type loader/materializer

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -1,6 +1,8 @@
 import contextlib
 import warnings
 
+import dask.dataframe as dd
+
 from dagster import (
     Any,
     AssetMaterialization,
@@ -21,10 +23,8 @@ from dagster import (
     dagster_type_loader,
     dagster_type_materializer,
 )
-import dask.dataframe as dd
 
 from .utils import DataFrameUtilities, apply_utilities_to_df
-
 
 WriteCompressionTextOptions = Enum(
     "WriteCompressionText", [EnumValue("gzip"), EnumValue("bz2"), EnumValue("xz"),],

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -14,6 +14,7 @@ from dagster import (
     Int,
     Permissive,
     Selector,
+    Shape,
     String,
     TypeCheck,
     check,
@@ -381,16 +382,25 @@ def _dataframe_loader_config():
         for read_from, read_opts in DataFrameReadTypes.items()
     }
 
-    return Selector(
-        {
-            "read": Field(Selector(read_fields), is_required=False,),
-            # https://github.com/dagster-io/dagster/issues/2872
-            **{
-                field_name: Field(field_config, is_required=False,)
-                for field_name, field_config in read_fields.items()
-            },
-        }
-    )
+    return Shape({
+        "read": Field(
+            Selector(read_fields),
+            is_required=False,
+        ),
+        ** {
+            util_name: util_spec["options"]
+            for util_name, util_spec in DataFrameUtilities.items()
+        },
+
+        # https://github.com/dagster-io/dagster/issues/2872
+        **{
+            field_name: Field(
+                field_config,
+                is_required=False,
+            )
+            for field_name, field_config in read_fields.items()
+        },
+    })
 
 
 @dagster_type_loader(_dataframe_loader_config())
@@ -444,16 +454,25 @@ def _dataframe_materializer_config():
         for write_to, to_opts in DataFrameToTypes.items()
     }
 
-    return Selector(
-        {
-            "to": Field(Selector(to_fields), is_required=False,),
-            # https://github.com/dagster-io/dagster/issues/2872
-            **{
-                field_name: Field(field_config, is_required=False,)
-                for field_name, field_config in to_fields.items()
-            },
-        }
-    )
+    return Shape({
+        "to": Field(
+            Selector(to_fields),
+            is_required=False,
+        ),
+        ** {
+            util_name: util_spec["options"]
+            for util_name, util_spec in DataFrameUtilities.items()
+        },
+
+        # https://github.com/dagster-io/dagster/issues/2872
+        **{
+            field_name: Field(
+                field_config,
+                is_required=False,
+            )
+            for field_name, field_config in to_fields.items()
+        },
+    })
 
 
 @dagster_type_materializer(_dataframe_materializer_config())

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -353,25 +353,20 @@ def _dataframe_loader_config():
         for read_from, read_opts in DataFrameReadTypes.items()
     }
 
-    return Shape({
-        "read": Field(
-            Selector(read_fields),
-            is_required=False,
-        ),
-        ** {
-            util_name: util_spec["options"]
-            for util_name, util_spec in DataFrameUtilities.items()
-        },
-
-        # https://github.com/dagster-io/dagster/issues/2872
-        **{
-            field_name: Field(
-                field_config,
-                is_required=False,
-            )
-            for field_name, field_config in read_fields.items()
-        },
-    })
+    return Shape(
+        {
+            "read": Field(Selector(read_fields), is_required=False,),
+            **{
+                util_name: util_spec["options"]
+                for util_name, util_spec in DataFrameUtilities.items()
+            },
+            # https://github.com/dagster-io/dagster/issues/2872
+            **{
+                field_name: Field(field_config, is_required=False,)
+                for field_name, field_config in read_fields.items()
+            },
+        }
+    )
 
 
 @dagster_type_loader(_dataframe_loader_config())
@@ -428,25 +423,20 @@ def _dataframe_materializer_config():
         for write_to, to_opts in DataFrameToTypes.items()
     }
 
-    return Shape({
-        "to": Field(
-            Selector(to_fields),
-            is_required=False,
-        ),
-        ** {
-            util_name: util_spec["options"]
-            for util_name, util_spec in DataFrameUtilities.items()
-        },
-
-        # https://github.com/dagster-io/dagster/issues/2872
-        **{
-            field_name: Field(
-                field_config,
-                is_required=False,
-            )
-            for field_name, field_config in to_fields.items()
-        },
-    })
+    return Shape(
+        {
+            "to": Field(Selector(to_fields), is_required=False,),
+            **{
+                util_name: util_spec["options"]
+                for util_name, util_spec in DataFrameUtilities.items()
+            },
+            # https://github.com/dagster-io/dagster/issues/2872
+            **{
+                field_name: Field(field_config, is_required=False,)
+                for field_name, field_config in to_fields.items()
+            },
+        }
+    )
 
 
 @dagster_type_materializer(_dataframe_materializer_config())

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -23,7 +23,7 @@ from dagster import (
 )
 import dask.dataframe as dd
 
-from .utils import sanitize_column_names
+from .utils import DataFrameUtilities
 
 
 WriteCompressionTextOptions = Enum(
@@ -337,35 +337,6 @@ DataFrameToTypes = {
             ),
         },
     },
-}
-
-
-DataFrameUtilities = {
-    "sample": {
-        "function": dd.DataFrame.sample,
-        "options": Field(Float, is_required=False, description="Sample a random fraction of items.")
-    },
-    "repartition": {
-        "function": dd.DataFrame.repartition,
-        "options": Field(
-            Selector(
-                {
-                    "npartitions": Field(Int, description="Number of partitions of output."),
-                    "partition_size": Field(Any, description="Max number of bytes of memory for each partition."),
-                }
-            ),
-            is_required=False,
-            description="Repartition dataframe along new divisions.",
-        )  
-    },
-    "reset_index": {
-        "function": dd.DataFrame.reset_index,
-        "options": Field(Bool, is_required=False, description="Reset the index to the default index."),
-    },
-    "sanitize_column_names": {
-        "function": sanitize_column_names,
-        "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),   
-    }
 }
 
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -1,8 +1,6 @@
 import contextlib
 import warnings
 
-import dask.dataframe as dd
-
 from dagster import (
     Any,
     AssetMaterialization,
@@ -22,6 +20,10 @@ from dagster import (
     dagster_type_loader,
     dagster_type_materializer,
 )
+import dask.dataframe as dd
+
+from .utils import sanitize_column_names
+
 
 WriteCompressionTextOptions = Enum(
     "WriteCompressionText", [EnumValue("gzip"), EnumValue("bz2"), EnumValue("xz"),],
@@ -334,6 +336,35 @@ DataFrameToTypes = {
             ),
         },
     },
+}
+
+
+DataFrameUtilities = {
+    "sample": {
+        "function": dd.DataFrame.sample,
+        "options": Field(Float, is_required=False, description="Sample a random fraction of items.")
+    },
+    "repartition": {
+        "function": dd.DataFrame.repartition,
+        "options": Field(
+            Selector(
+                {
+                    "npartitions": Field(Int, description="Number of partitions of output."),
+                    "partition_size": Field(Any, description="Max number of bytes of memory for each partition."),
+                }
+            ),
+            is_required=False,
+            description="Repartition dataframe along new divisions.",
+        )  
+    },
+    "reset_index": {
+        "function": dd.DataFrame.reset_index,
+        "options": Field(Bool, is_required=False, description="Reset the index to the default index."),
+    },
+    "sanitize_column_names": {
+        "function": sanitize_column_names,
+        "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),   
+    }
 }
 
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -1,3 +1,12 @@
+from dagster import (
+    Any, 
+    Bool,
+    Field,
+    Int,
+    Permissive,
+    Selector,
+    String,
+)
 import dask.dataframe as dd
 
 
@@ -5,3 +14,32 @@ def sanitize_column_names(df: dd.DataFrame) -> dd.DataFrame:
     df.columns = map(str.lower, df.columns)
     
     return df
+
+
+DataFrameUtilities = {
+    "sample": {
+        "function": dd.DataFrame.sample,
+        "options": Field(Float, is_required=False, description="Sample a random fraction of items.")
+    },
+    "repartition": {
+        "function": dd.DataFrame.repartition,
+        "options": Field(
+            Selector(
+                {
+                    "npartitions": Field(Int, description="Number of partitions of output."),
+                    "partition_size": Field(Any, description="Max number of bytes of memory for each partition."),
+                }
+            ),
+            is_required=False,
+            description="Repartition dataframe along new divisions.",
+        )  
+    },
+    "reset_index": {
+        "function": dd.DataFrame.reset_index,
+        "options": Field(Bool, is_required=False, description="Reset the index to the default index."),
+    },
+    "sanitize_column_names": {
+        "function": sanitize_column_names,
+        "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),   
+    }
+}

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -12,7 +12,7 @@ from dagster import (
 import dask.dataframe as dd
 
 
-def sanitize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
+def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
     if enabled:
         df.columns = map(str.lower, df.columns)
     
@@ -69,9 +69,9 @@ DataFrameUtilities = {
             description="Repartition dataframe along new divisions.",
         ),
     },
-    "sanitize_column_names": {
-        "function": sanitize_column_names,
-        "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),
+    "normalize_column_names": {
+        "function": normalize_column_names,
+        "options": Field(Bool, is_required=False, description="Lowercase column names and convert CamelCase to snake_case for interoperability."),
     },
 }
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -16,16 +16,22 @@ import dask.dataframe as dd
 
 def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
     if enabled:
-        # Based on https://stackoverflow.com/a/1176023
-        camel_to_snake1 = re.compile('(.)([A-Z][a-z]+)')
-        camel_to_snake2 = re.compile('([a-z0-9])([A-Z])')
-        def normalize(name):
-            name = camel_to_snake1.sub(r'\1_\2', name)
-            return camel_to_snake2.sub(r'\1_\2', name).lower()
-            
-        df.columns = map(normalize, df.columns)
+        df.columns = normalize_names(df.columns)
     
     return df
+
+
+def normalize_names(names):
+    # Based on https://stackoverflow.com/a/1176023
+    camel_to_snake1 = re.compile('(.)([A-Z][a-z]+)')
+    camel_to_snake2 = re.compile('([a-z0-9])([A-Z])')
+    def normalize(name):
+        if not name:
+            return name
+        name = camel_to_snake1.sub(r'\1_\2', name)
+        return camel_to_snake2.sub(r'\1_\2', name).lower()
+    
+    return map(normalize, names)
 
 
 DataFrameUtilities = {

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -1,7 +1,7 @@
 import re
 
 from dagster import (
-    Any, 
+    Any,
     Bool,
     Field,
     Float,
@@ -17,20 +17,21 @@ import dask.dataframe as dd
 def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
     if enabled:
         df.columns = normalize_names(df.columns)
-    
+
     return df
 
 
 def normalize_names(names):
     # Based on https://stackoverflow.com/a/1176023
-    camel_to_snake1 = re.compile('(.)([A-Z][a-z]+)')
-    camel_to_snake2 = re.compile('([a-z0-9])([A-Z])')
+    camel_to_snake1 = re.compile("(.)([A-Z][a-z]+)")
+    camel_to_snake2 = re.compile("([a-z0-9])([A-Z])")
+
     def normalize(name):
         if not name:
             return name
-        name = camel_to_snake1.sub(r'\1_\2', name)
-        return camel_to_snake2.sub(r'\1_\2', name).lower()
-    
+        name = camel_to_snake1.sub(r"\1_\2", name)
+        return camel_to_snake2.sub(r"\1_\2", name).lower()
+
     return map(normalize, names)
 
 
@@ -38,12 +39,30 @@ DataFrameUtilities = {
     "drop": {
         "function": dd.DataFrame.drop,
         "options": Field(
-            Shape({
-                "labels": Field(Any, is_required=False, description="Index or column labels to drop."),
-                "axis": Field(Any, is_required=False, description="Drop labesl from index or columns."),
-                "columns": Field(Any, is_required=False, description="Equivalent to labels with axis=1."),
-                "errors": Field(String, is_required=False, description="If \"ignore\", supress errors."),
-            }),
+            Shape(
+                {
+                    "labels": Field(
+                        Any,
+                        is_required=False,
+                        description="Index or column labels to drop.",
+                    ),
+                    "axis": Field(
+                        Any,
+                        is_required=False,
+                        description="Drop labesl from index or columns.",
+                    ),
+                    "columns": Field(
+                        Any,
+                        is_required=False,
+                        description="Equivalent to labels with axis=1.",
+                    ),
+                    "errors": Field(
+                        String,
+                        is_required=False,
+                        description='If "ignore", supress errors.',
+                    ),
+                }
+            ),
             is_required=False,
             description="Drop specified labels from rows or columns.",
         ),
@@ -51,11 +70,25 @@ DataFrameUtilities = {
     "sample": {
         "function": dd.DataFrame.sample,
         "options": Field(
-            Shape({
-                "frac": Field(Float, is_required=False, description="Fraction of axis items to return."),
-                "replace": Field(Bool, is_required=False, description="Sample with or without replacement."),
-                "random_state": Field(Int, is_required=False, description="Create RandomState with this as the seed."),
-            }),
+            Shape(
+                {
+                    "frac": Field(
+                        Float,
+                        is_required=False,
+                        description="Fraction of axis items to return.",
+                    ),
+                    "replace": Field(
+                        Bool,
+                        is_required=False,
+                        description="Sample with or without replacement.",
+                    ),
+                    "random_state": Field(
+                        Int,
+                        is_required=False,
+                        description="Create RandomState with this as the seed.",
+                    ),
+                }
+            ),
             is_required=False,
             description="Random sample of items.",
         ),
@@ -63,9 +96,15 @@ DataFrameUtilities = {
     "reset_index": {
         "function": dd.DataFrame.reset_index,
         "options": Field(
-            Shape({
-                "drop": Field(Bool, is_required=False, description="Do not try to insert index into dataframe columns."),
-            }),
+            Shape(
+                {
+                    "drop": Field(
+                        Bool,
+                        is_required=False,
+                        description="Do not try to insert index into dataframe columns.",
+                    ),
+                }
+            ),
             is_required=False,
             description="Reset the index to the default index.",
         ),
@@ -73,12 +112,30 @@ DataFrameUtilities = {
     "set_index": {
         "function": dd.DataFrame.set_index,
         "options": Field(
-            Permissive({
-                "other": Field(String, is_required=True, description="Set index to specified column."),
-                "drop": Field(Bool, is_required=False, description="Delete columns to be used as the new index."),
-                "sorted": Field(Bool, is_required=False, description="If the index column is already sorted in increasing order."),
-                "divisions": Field(Any, is_required=False, description="Known values on which to separate index values of the partitions."),   
-            }),
+            Permissive(
+                {
+                    "other": Field(
+                        String,
+                        is_required=True,
+                        description="Set index to specified column.",
+                    ),
+                    "drop": Field(
+                        Bool,
+                        is_required=False,
+                        description="Delete columns to be used as the new index.",
+                    ),
+                    "sorted": Field(
+                        Bool,
+                        is_required=False,
+                        description="If the index column is already sorted in increasing order.",
+                    ),
+                    "divisions": Field(
+                        Any,
+                        is_required=False,
+                        description="Known values on which to separate index values of the partitions.",
+                    ),
+                }
+            ),
             is_required=False,
             description="Set the DataFrame index using an existing column.",
         ),
@@ -86,20 +143,46 @@ DataFrameUtilities = {
     "repartition": {
         "function": dd.DataFrame.repartition,
         "options": Field(
-            Shape({
-                "divisions": Field(Any, is_required=False, description="List of partitions to be used."),
-                "npartitions": Field(Int, is_required=False, description="Number of partitions of output."),
-                "partition_size": Field(Any, is_required=False, description="Max number of bytes of memory for each partition."),
-                "freq": Field(String, is_required=False, description="A period on which to partition timeseries data."),
-                "force": Field(Bool, is_required=False, description="Allows the expansion of the existing divisions."),
-            }),
+            Shape(
+                {
+                    "divisions": Field(
+                        Any,
+                        is_required=False,
+                        description="List of partitions to be used.",
+                    ),
+                    "npartitions": Field(
+                        Int,
+                        is_required=False,
+                        description="Number of partitions of output.",
+                    ),
+                    "partition_size": Field(
+                        Any,
+                        is_required=False,
+                        description="Max number of bytes of memory for each partition.",
+                    ),
+                    "freq": Field(
+                        String,
+                        is_required=False,
+                        description="A period on which to partition timeseries data.",
+                    ),
+                    "force": Field(
+                        Bool,
+                        is_required=False,
+                        description="Allows the expansion of the existing divisions.",
+                    ),
+                }
+            ),
             is_required=False,
             description="Repartition dataframe along new divisions.",
         ),
     },
     "normalize_column_names": {
         "function": normalize_column_names,
-        "options": Field(Bool, is_required=False, description="Lowercase and convert CamelCase to snake_case on column names."),
+        "options": Field(
+            Bool,
+            is_required=False,
+            description="Lowercase and convert CamelCase to snake_case on column names.",
+        ),
     },
 }
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -33,9 +33,9 @@ DataFrameUtilities = {
         "function": dd.DataFrame.sample,
         "options": Field(
             Shape({
-            "frac": Field(Float, is_required=False, description="Fraction of axis items to return."),
-            "replace": Field(Bool, is_required=False, description="Sample with or without replacement."),
-            "random_state": Field(Int, is_required=False, description="Create RandomState with this as the seed."),
+                "frac": Field(Float, is_required=False, description="Fraction of axis items to return."),
+                "replace": Field(Bool, is_required=False, description="Sample with or without replacement."),
+                "random_state": Field(Int, is_required=False, description="Create RandomState with this as the seed."),
             }),
             is_required=False,
             description="Random sample of items.",

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -21,39 +21,55 @@ def sanitize_column_names(df: dd.DataFrame) -> dd.DataFrame:
 DataFrameUtilities = {
     "sample": {
         "function": dd.DataFrame.sample,
-        "options": Shape({
+        "options": Field(
+            Shape({
             "frac": Field(Float, is_required=False, description="Fraction of axis items to return."),
             "replace": Field(Bool, is_required=False, description="Sample with or without replacement."),
             "random_state": Field(Int, is_required=False, description="Create RandomState with this as the seed."),
-        }),
+            }),
+            is_required=False,
+            description="Random sample of items.",
+        ),
     },
     "set_index": {
         "function": dd.DataFrame.set_index,
-        "options": Permissive({
-            "other": Field(String, is_required=True, description="Set index to specified column."),
-            "drop": Field(Bool, is_required=False, description="Delete columns to be used as the new index."),
-            "sorted": Field(Bool, is_required=False, description="If the index column is already sorted in increasing order."),
-            "divisions": Field(Any, is_required=False, description="Known values on which to separate index values of the partitions."),   
-        }),
+        "options": Field(
+            Permissive({
+                "other": Field(String, is_required=True, description="Set index to specified column."),
+                "drop": Field(Bool, is_required=False, description="Delete columns to be used as the new index."),
+                "sorted": Field(Bool, is_required=False, description="If the index column is already sorted in increasing order."),
+                "divisions": Field(Any, is_required=False, description="Known values on which to separate index values of the partitions."),   
+            }),
+            is_required=False,
+            description="Set the DataFrame index using an existing column.",
+        ),
     },
     "repartition": {
         "function": dd.DataFrame.repartition,
-        "options": Shape({
-            "divisions": Field(Any, is_required=False, description="List of partitions to be used."),
-            "npartitions": Field(Int, is_required=False, description="Number of partitions of output."),
-            "partition_size": Field(Any, is_required=False, description="Max number of bytes of memory for each partition."),
-            "freq": Field(String, is_required=False, description="A period on which to partition timeseries data."),
-            "force": Field(Bool, is_required=False, description="Allows the expansion of the existing divisions."),
-        })
+        "options": Field(
+            Shape({
+                "divisions": Field(Any, is_required=False, description="List of partitions to be used."),
+                "npartitions": Field(Int, is_required=False, description="Number of partitions of output."),
+                "partition_size": Field(Any, is_required=False, description="Max number of bytes of memory for each partition."),
+                "freq": Field(String, is_required=False, description="A period on which to partition timeseries data."),
+                "force": Field(Bool, is_required=False, description="Allows the expansion of the existing divisions."),
+            }),
+            is_required=False,
+            description="Repartition dataframe along new divisions.",
+        ),
     },
     "reset_index": {
         "function": dd.DataFrame.reset_index,
-        "options": Shape({
-            "drop": Field(Bool, is_required=False, description="Do not try to insert index into dataframe columns."),
-        })
+        "options": Field(
+            Shape({
+                "drop": Field(Bool, is_required=False, description="Do not try to insert index into dataframe columns."),
+            }),
+            is_required=False,
+            description="Reset the index to the default index.",
+        ),
     },
     "sanitize_column_names": {
         "function": sanitize_column_names,
-        "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),   
+        "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),
     },
 }

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -80,7 +80,7 @@ DataFrameUtilities = {
     },
     "normalize_column_names": {
         "function": normalize_column_names,
-        "options": Field(Bool, is_required=False, description="Lowercase column names and convert CamelCase to snake_case for interoperability."),
+        "options": Field(Bool, is_required=False, description="Lowercase and convert CamelCase to snake_case on column names."),
     },
 }
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -31,6 +31,16 @@ DataFrameUtilities = {
             description="Random sample of items.",
         ),
     },
+    "reset_index": {
+        "function": dd.DataFrame.reset_index,
+        "options": Field(
+            Shape({
+                "drop": Field(Bool, is_required=False, description="Do not try to insert index into dataframe columns."),
+            }),
+            is_required=False,
+            description="Reset the index to the default index.",
+        ),
+    },
     "set_index": {
         "function": dd.DataFrame.set_index,
         "options": Field(
@@ -56,16 +66,6 @@ DataFrameUtilities = {
             }),
             is_required=False,
             description="Repartition dataframe along new divisions.",
-        ),
-    },
-    "reset_index": {
-        "function": dd.DataFrame.reset_index,
-        "options": Field(
-            Shape({
-                "drop": Field(Bool, is_required=False, description="Do not try to insert index into dataframe columns."),
-            }),
-            is_required=False,
-            description="Reset the index to the default index.",
         ),
     },
     "sanitize_column_names": {

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -42,24 +42,16 @@ DataFrameUtilities = {
             Shape(
                 {
                     "labels": Field(
-                        Any,
-                        is_required=False,
-                        description="Index or column labels to drop.",
+                        Any, is_required=False, description="Index or column labels to drop.",
                     ),
                     "axis": Field(
-                        Any,
-                        is_required=False,
-                        description="Drop labesl from index or columns.",
+                        Any, is_required=False, description="Drop labesl from index or columns.",
                     ),
                     "columns": Field(
-                        Any,
-                        is_required=False,
-                        description="Equivalent to labels with axis=1.",
+                        Any, is_required=False, description="Equivalent to labels with axis=1.",
                     ),
                     "errors": Field(
-                        String,
-                        is_required=False,
-                        description='If "ignore", supress errors.',
+                        String, is_required=False, description='If "ignore", supress errors.',
                     ),
                 }
             ),
@@ -73,14 +65,10 @@ DataFrameUtilities = {
             Shape(
                 {
                     "frac": Field(
-                        Float,
-                        is_required=False,
-                        description="Fraction of axis items to return.",
+                        Float, is_required=False, description="Fraction of axis items to return.",
                     ),
                     "replace": Field(
-                        Bool,
-                        is_required=False,
-                        description="Sample with or without replacement.",
+                        Bool, is_required=False, description="Sample with or without replacement.",
                     ),
                     "random_state": Field(
                         Int,
@@ -115,9 +103,7 @@ DataFrameUtilities = {
             Permissive(
                 {
                     "other": Field(
-                        String,
-                        is_required=True,
-                        description="Set index to specified column.",
+                        String, is_required=True, description="Set index to specified column.",
                     ),
                     "drop": Field(
                         Bool,
@@ -146,14 +132,10 @@ DataFrameUtilities = {
             Shape(
                 {
                     "divisions": Field(
-                        Any,
-                        is_required=False,
-                        description="List of partitions to be used.",
+                        Any, is_required=False, description="List of partitions to be used.",
                     ),
                     "npartitions": Field(
-                        Int,
-                        is_required=False,
-                        description="Number of partitions of output.",
+                        Int, is_required=False, description="Number of partitions of output.",
                     ),
                     "partition_size": Field(
                         Any,

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -1,0 +1,7 @@
+import dask.dataframe as dd
+
+
+def sanitize_column_names(df: dd.DataFrame) -> dd.DataFrame:
+    df.columns = map(str.lower, df.columns)
+    
+    return df

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -12,8 +12,9 @@ from dagster import (
 import dask.dataframe as dd
 
 
-def sanitize_column_names(df: dd.DataFrame) -> dd.DataFrame:
-    df.columns = map(str.lower, df.columns)
+def sanitize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
+    if enabled:
+        df.columns = map(str.lower, df.columns)
     
     return df
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -1,17 +1,8 @@
 import re
 
-from dagster import (
-    Any,
-    Bool,
-    Field,
-    Float,
-    Int,
-    Permissive,
-    Selector,
-    Shape,
-    String,
-)
 import dask.dataframe as dd
+
+from dagster import Any, Bool, Field, Float, Int, Permissive, Selector, Shape, String
 
 
 def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -35,6 +35,19 @@ def normalize_names(names):
 
 
 DataFrameUtilities = {
+    "drop": {
+        "function": dd.DataFrame.drop,
+        "options": Field(
+            Shape({
+                "labels": Field(Any, is_required=False, description="Index or column labels to drop."),
+                "axis": Field(Any, is_required=False, description="Drop labesl from index or columns."),
+                "columns": Field(Any, is_required=False, description="Equivalent to labels with axis=1."),
+                "errors": Field(String, is_required=False, description="If \"ignore\", supress errors."),
+            }),
+            is_required=False,
+            description="Drop specified labels from rows or columns.",
+        ),
+    },
     "sample": {
         "function": dd.DataFrame.sample,
         "options": Field(

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -19,7 +19,18 @@ def sanitize_column_names(df: dd.DataFrame) -> dd.DataFrame:
 DataFrameUtilities = {
     "sample": {
         "function": dd.DataFrame.sample,
-        "options": Field(Float, is_required=False, description="Sample a random fraction of items.")
+        "options": Field(Float, is_required=False, description="Sample a random fraction of items."),
+    },
+    "set_index": {
+        "function": dd.DataFrame.set_index,
+        "options": Permissive(
+            {
+                "other": Field(String, is_required=True, description="Set index to specified column."),
+                "drop": Field(Bool, is_required=False, description="Delete columns to be used as the new index."),
+                "sorted": Field(Bool, is_required=False, description="If the index column is already sorted in increasing order."),
+                "divisions": Field(Any, is_required=False, description="Known values on which to separate index values of the partitions."),
+            }
+        ),
     },
     "repartition": {
         "function": dd.DataFrame.repartition,

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -2,9 +2,11 @@ from dagster import (
     Any, 
     Bool,
     Field,
+    Float,
     Int,
     Permissive,
     Selector,
+    Shape,
     String,
 )
 import dask.dataframe as dd
@@ -19,38 +21,39 @@ def sanitize_column_names(df: dd.DataFrame) -> dd.DataFrame:
 DataFrameUtilities = {
     "sample": {
         "function": dd.DataFrame.sample,
-        "options": Field(Float, is_required=False, description="Sample a random fraction of items."),
+        "options": Shape({
+            "frac": Field(Float, is_required=False, description="Fraction of axis items to return."),
+            "replace": Field(Bool, is_required=False, description="Sample with or without replacement."),
+            "random_state": Field(Int, is_required=False, description="Create RandomState with this as the seed."),
+        }),
     },
     "set_index": {
         "function": dd.DataFrame.set_index,
-        "options": Permissive(
-            {
-                "other": Field(String, is_required=True, description="Set index to specified column."),
-                "drop": Field(Bool, is_required=False, description="Delete columns to be used as the new index."),
-                "sorted": Field(Bool, is_required=False, description="If the index column is already sorted in increasing order."),
-                "divisions": Field(Any, is_required=False, description="Known values on which to separate index values of the partitions."),
-            }
-        ),
+        "options": Permissive({
+            "other": Field(String, is_required=True, description="Set index to specified column."),
+            "drop": Field(Bool, is_required=False, description="Delete columns to be used as the new index."),
+            "sorted": Field(Bool, is_required=False, description="If the index column is already sorted in increasing order."),
+            "divisions": Field(Any, is_required=False, description="Known values on which to separate index values of the partitions."),   
+        }),
     },
     "repartition": {
         "function": dd.DataFrame.repartition,
-        "options": Field(
-            Selector(
-                {
-                    "npartitions": Field(Int, description="Number of partitions of output."),
-                    "partition_size": Field(Any, description="Max number of bytes of memory for each partition."),
-                }
-            ),
-            is_required=False,
-            description="Repartition dataframe along new divisions.",
-        )  
+        "options": Shape({
+            "divisions": Field(Any, is_required=False, description="List of partitions to be used."),
+            "npartitions": Field(Int, is_required=False, description="Number of partitions of output."),
+            "partition_size": Field(Any, is_required=False, description="Max number of bytes of memory for each partition."),
+            "freq": Field(String, is_required=False, description="A period on which to partition timeseries data."),
+            "force": Field(Bool, is_required=False, description="Allows the expansion of the existing divisions."),
+        })
     },
     "reset_index": {
         "function": dd.DataFrame.reset_index,
-        "options": Field(Bool, is_required=False, description="Reset the index to the default index."),
+        "options": Shape({
+            "drop": Field(Bool, is_required=False, description="Do not try to insert index into dataframe columns."),
+        })
     },
     "sanitize_column_names": {
         "function": sanitize_column_names,
         "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),   
-    }
+    },
 }

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -73,3 +73,19 @@ DataFrameUtilities = {
         "options": Field(Bool, is_required=False, description="Modify column names for greater compatibility."),
     },
 }
+
+
+def apply_utilities_to_df(df, config):
+    for util_name, util_spec in DataFrameUtilities.items():
+        if util_name in config:
+            util_func = util_spec["function"]
+            util_opts = config[util_name]
+
+            if isinstance(util_opts, dict):
+                df = util_func(df, **util_opts)
+            elif isinstance(util_opts, list):
+                df = util_func(df, *util_opts)
+            else:
+                df = util_func(df, util_opts)
+
+    return df

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from dagster import (
     Any, 
     Bool,
@@ -14,7 +16,14 @@ import dask.dataframe as dd
 
 def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
     if enabled:
-        df.columns = map(str.lower, df.columns)
+        # Based on https://stackoverflow.com/a/1176023
+        camel_to_snake1 = re.compile('(.)([A-Z][a-z]+)')
+        camel_to_snake2 = re.compile('([a-z0-9])([A-Z])')
+        def normalize(name):
+            name = camel_to_snake1.sub(r'\1_\2', name)
+            return camel_to_snake2.sub(r'\1_\2', name).lower()
+            
+        df.columns = map(normalize, df.columns)
     
     return df
 

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/canada.csv
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/canada.csv
@@ -1,0 +1,17 @@
+ID,provinceOrTerritory,country,current
+4122,Alberta,Canada,1
+4235,Saskatchewan,Canada,1
+4691,New Brunswick,Canada,1
+4029,British Columbia,Canada,1
+4518,Quebec,Canada,1
+4395,Manitoba,Canada,1
+4455,Ontario,Canada,1
+4973,Newfoundland and Labrador,Canada,1
+4867,Nova Scotia,Canada,1
+4749,Prince Edward Island,Canada,1
+5033,Yukon,Canada,1
+5165,Northwest Territories,Canada,1
+5245,Nunavut,Canada,1
+6001,Placeholder 1,Canada,0
+6002,Placeholder 2,Canada,0
+6003,Placeholder 3,Canada,0

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -4,6 +4,8 @@ import shutil
 import dask.dataframe as dd
 import pytest
 from dagster_dask import DataFrame
+from dagster_dask.data_frame import DataFrameReadTypes, DataFrameToTypes
+from dagster_dask.utils import DataFrameUtilities
 from dask.dataframe.utils import assert_eq
 
 from dagster import InputDefinition, OutputDefinition, execute_solid, file_relative_path, solid
@@ -94,3 +96,27 @@ def test_dataframe_outputs(file_type, read, kwargs):
             assert result.success
             actual = read(f"{temp_path}/*")
             assert assert_eq(actual, df)
+
+
+def test_dataframe_loader_config_keys_dont_overlap():
+    """
+    Test that the read_keys, which are deprecated, do not overlap with
+    the normal loader config_keys.
+    """
+    config_keys = set(DataFrameUtilities.keys())
+    config_keys.add("read")
+    read_keys = set(DataFrameReadTypes.keys())
+    
+    assert len(config_keys.intersection(read_keys)) == 0
+
+
+def test_dataframe_materializer_config_keys_dont_overlap():
+    """
+    Test that the to_keys, which are deprecated, do not overlap with
+    the normal materializer config_keys.
+    """
+    config_keys = set(DataFrameUtilities.keys())
+    config_keys.add("to")
+    to_keys = set(DataFrameToTypes.keys())
+    
+    assert len(config_keys.intersection(to_keys)) == 0

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -33,6 +33,20 @@ def generate_config(path, **df_opts):
     }
 
 
+def test_drop():
+    path = file_relative_path(__file__, "canada.csv")
+    col = "current"
+
+    input_df = dd.read_csv(path)
+    assert col in input_df.columns
+
+    # Drop the "current" column.
+    run_config = generate_config(path, drop={"columns": col})
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert col not in output_df.columns
+
+
 def test_sample():
     path = file_relative_path(__file__, "canada.csv")
     frac = 0.25

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -4,6 +4,7 @@ from dagster import (
     file_relative_path,
     solid,
 )
+import dask.dataframe as dd
 
 from dagster_dask import DataFrame
 
@@ -13,29 +14,33 @@ def passthrough(_, input_df: DataFrame) -> DataFrame:
     return input_df
 
 
-def test_single_utilities():
-    file_name = file_relative_path(__file__, "num.csv")
-    
-    def generate_config(**df_opts):
-        return {
-            "solids": {
-                "passthrough": {
-                    "inputs": {
-                        "input_df": {
-                            "read": {
-                                "csv": {
-                                    "path": file_name,
-                                },
+def generate_config(path, **df_opts):
+    return {
+        "solids": {
+            "passthrough": {
+                "inputs": {
+                    "input_df": {
+                        "read": {
+                            "csv": {
+                                "path": path,
                             },
-                            **df_opts,
                         },
+                        **df_opts,
                     },
                 },
             },
-        }
+        },
+    }
 
-    run_config = generate_config(sample={"frac": 0.5})
+
+def test_sample_utility():
+    path = file_relative_path(__file__, "num.csv")
+    frac = 0.5
+
+    input_df = dd.read_csv(path)
+
+    run_config = generate_config(path, sample={"frac": 0.5})
     result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
 
-    df = result.output_value()
-    assert len(df) == 1
+    assert len(input_df) * frac == len(output_df)

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -94,20 +94,20 @@ def test_repartition():
     assert output_df.npartitions == npartitions
 
 
-def test_sanitize_column_names():
+def test_normalize_column_names():
     path = file_relative_path(__file__, "canada.csv")
 
     input_df = dd.read_csv(path)
     assert all(col in input_df.columns for col in ("ID", "provinceOrTerritory", "country"))
 
-    # Set sanitize_column_names=False to not modify the column names
-    run_config = generate_config(path, sanitize_column_names=False)
+    # Set normalize_column_names=False to not modify the column names
+    run_config = generate_config(path, normalize_column_names=False)
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
     assert all(col in output_df.columns for col in ("ID", "provinceOrTerritory", "country"))
 
-    # Set sanitize_column_names=True to modify the column names
-    run_config = generate_config(path, sanitize_column_names=True)
+    # Set normalize_column_names=True to modify the column names
+    run_config = generate_config(path, normalize_column_names=True)
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
     assert all(col in output_df.columns for col in ("id", "provinceorterritory", "country"))
@@ -121,10 +121,10 @@ def test_utilities_combo():
 
     # Apply multiple utilities at once. The utilities are expected to
     # apply in the following order, regardless of config order:
-    #   sample, reset_index, set_index, repartition, sanitize_column_names
+    #   sample, reset_index, set_index, repartition, normalize_column_names
     run_config = generate_config(
         path,
-        sanitize_column_names=True,
+        normalize_column_names=True,
         set_index={"other": "ID", "drop": True},
         repartition={"npartitions": 3},
         sample={"frac": 0.5},
@@ -148,7 +148,7 @@ def test_utilities_combo():
     assert input_df.npartitions == 1
     assert output_df.npartitions == 3
     
-    # sanitize_column_names(true)
+    # normalize_column_names(true)
     # No id due to it being set to the index and dropped.
     assert all(col in input_df.columns for col in ("ID", "provinceOrTerritory", "country"))
     assert all(col in output_df.columns for col in ("provinceorterritory", "country"))

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -18,16 +18,7 @@ def generate_config(path, **df_opts):
     return {
         "solids": {
             "passthrough": {
-                "inputs": {
-                    "input_df": {
-                        "read": {
-                            "csv": {
-                                "path": path,
-                            },
-                        },
-                        **df_opts,
-                    },
-                },
+                "inputs": {"input_df": {"read": {"csv": {"path": path,},}, **df_opts,},},
             },
         },
     }

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -1,0 +1,41 @@
+from dagster import (
+    InputDefinition,
+    execute_solid,
+    file_relative_path,
+    solid,
+)
+
+from dagster_dask import DataFrame
+
+
+@solid(input_defs=[InputDefinition(dagster_type=DataFrame, name="input_df")])
+def passthrough(_, input_df: DataFrame) -> DataFrame:
+    return input_df
+
+
+def test_single_utilities():
+    file_name = file_relative_path(__file__, "num.csv")
+    
+    def generate_config(**df_opts):
+        return {
+            "solids": {
+                "passthrough": {
+                    "inputs": {
+                        "input_df": {
+                            "read": {
+                                "csv": {
+                                    "path": file_name,
+                                },
+                            },
+                            **df_opts,
+                        },
+                    },
+                },
+            },
+        }
+
+    run_config = generate_config(sample={"frac": 0.5})
+    result = execute_solid(passthrough, run_config=run_config)
+
+    df = result.output_value()
+    assert len(df) == 1

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -77,10 +77,10 @@ def test_reset_index():
 def test_set_index():
     path = file_relative_path(__file__, "canada.csv")
     col = "ID"
-    
+
     input_df = dd.read_csv(path)
     assert col in input_df.columns
-    
+
     # Set index to ID. We expect the column to be dropped by default.
     run_config = generate_config(path, set_index={"other": col})
     result = execute_solid(passthrough, run_config=run_config)
@@ -161,7 +161,7 @@ def test_utilities_combo():
     # repartition(npartitions=3)
     assert input_df.npartitions == 1
     assert output_df.npartitions == 3
-    
+
     # normalize_column_names(true)
     # No id due to it being set to the index and dropped.
     assert all(col in input_df.columns for col in ("ID", "provinceOrTerritory", "country"))

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -33,14 +33,81 @@ def generate_config(path, **df_opts):
     }
 
 
-def test_sample_utility():
-    path = file_relative_path(__file__, "num.csv")
-    frac = 0.5
+def test_sample():
+    path = file_relative_path(__file__, "canada.csv")
+    frac = 0.25
 
     input_df = dd.read_csv(path)
 
-    run_config = generate_config(path, sample={"frac": 0.5})
+    run_config = generate_config(path, sample={"frac": frac})
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
 
     assert len(input_df) * frac == len(output_df)
+
+
+def test_reset_index():
+    path = file_relative_path(__file__, "canada.csv")
+
+    input_df = dd.read_csv(path)
+
+    # Reset the index without dropping. We expect the index to be moved
+    # to the columns, as a column named "index".
+    run_config = generate_config(path, reset_index={})
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert "index" in output_df.columns
+    assert len(output_df.columns) == len(input_df.columns) + 1
+
+
+def test_set_index():
+    path = file_relative_path(__file__, "canada.csv")
+    col = "ID"
+    
+    input_df = dd.read_csv(path)
+    assert col in input_df.columns
+    
+    # Set index to ID. We expect the column to be dropped by default.
+    run_config = generate_config(path, set_index={"other": col})
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert col not in output_df.columns
+
+    # Set index to ID without dropping the column.
+    run_config = generate_config(path, set_index={"other": col, "drop": False})
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert col in output_df.columns
+
+
+def test_repartition():
+    path = file_relative_path(__file__, "canada.csv")
+    npartitions = 2
+
+    input_df = dd.read_csv(path)
+    assert input_df.npartitions == 1
+
+    # Repartition from 1 to 2 partitions.
+    run_config = generate_config(path, repartition={"npartitions": npartitions})
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert output_df.npartitions == npartitions
+
+
+def test_sanitize_column_names():
+    path = file_relative_path(__file__, "canada.csv")
+
+    input_df = dd.read_csv(path)
+    assert all(col in input_df.columns for col in ("ID", "provinceOrTerritory", "country"))
+
+    # Set sanitize_column_names=False to not modify the column names
+    run_config = generate_config(path, sanitize_column_names=False)
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert all(col in output_df.columns for col in ("ID", "provinceOrTerritory", "country"))
+
+    # Set sanitize_column_names=True to modify the column names
+    run_config = generate_config(path, sanitize_column_names=True)
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert all(col in output_df.columns for col in ("id", "provinceorterritory", "country"))

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -1,12 +1,7 @@
-from dagster import (
-    InputDefinition,
-    execute_solid,
-    file_relative_path,
-    solid,
-)
 import dask.dataframe as dd
-
 from dagster_dask import DataFrame
+
+from dagster import InputDefinition, execute_solid, file_relative_path, solid
 
 
 @solid(input_defs=[InputDefinition(dagster_type=DataFrame, name="input_df")])

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -110,7 +110,7 @@ def test_normalize_column_names():
     run_config = generate_config(path, normalize_column_names=True)
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
-    assert all(col in output_df.columns for col in ("id", "provinceorterritory", "country"))
+    assert all(col in output_df.columns for col in ("id", "province_or_territory", "country"))
 
 
 def test_utilities_combo():
@@ -151,4 +151,4 @@ def test_utilities_combo():
     # normalize_column_names(true)
     # No id due to it being set to the index and dropped.
     assert all(col in input_df.columns for col in ("ID", "provinceOrTerritory", "country"))
-    assert all(col in output_df.columns for col in ("provinceorterritory", "country"))
+    assert all(col in output_df.columns for col in ("province_or_territory", "country"))


### PR DESCRIPTION
This PR contains the other half of #2809, and is meant to be merged after #2811.

Add configuration options to the Dask DataFrame loader and materializer configs to perform some common operations on DataFrames. The operations are:

* drop
* sample
* reset_index
* set_index
* repartition
* normalize_column_names

The first five correspond directly to methods of the same name on DataFrame objects. Multiple utilities can be set simultaneously. They are evaluated in the order of the list, above.

While solids can directly perform these operations on DataFrames themselves, incorporating them into the DataFrame type loader and materializer helps keep solids focussed on their main business logic and be adaptable to common data conditions. Here's a few example scenarios.

1. Systems like Amazon Athena do not support upper case column names. Materialize datasets with broadly compatible column names by setting `normalize_column_names: true` to lowercase names and convert CamelCase to snake_case.

```yaml
solids:
  df_solid:
    outputs:
      - output_df:
          to:
            parquet:
              path: s3://bucket/dataset
          normalize_column_names: true
```

2. The number of partitions in a DataFrame influences how much Dask can scale an operation across workers. A CSV file that is read as 1 partition can be easily repartitioned to 12 by setting `repartition: {"n_partitions": 12}`.

```yaml
solids:
  df_solid:
    inputs:
      input_df:
        from:
          csv:
            path: /project/data.csv
        repartition:
          npartitions: 12
```

3. Running a complex pipeline can take a long time. Sample 0.1% of the input as a quick preview by setting `sample: {"frac": 0.011}` before running the pipeline on a full dataset.

```yaml
solids:
  df_solid:
    inputs:
      input_df:
        from:
          csv:
            path: /project/data.csv
        sample:
          frac: 0.001
```

These utilities are meant to cover common needs during loading and materialization, only. They are not a replacement for more complex operations in solids.