### PR TITLE
Fix pickling of frozenlist

### DIFF
--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -166,6 +166,18 @@ class frozenlist(list):
     def __readonly__(self, *args, **kwargs):
         raise RuntimeError("Cannot modify ReadOnlyList")
 
+    # https://docs.python.org/3/library/pickle.html#object.__reduce__
+    #
+    # Like frozendict, implement __reduce__ and __setstate__ to handle pickling.
+    # Otherwise, __setstate__ will be called to restore the frozenlist, causing
+    # a RuntimeError because frozenlist is not mutable.
+
+    def __reduce__(self):
+        return (frozenlist, (), list(self))
+
+    def __setstate__(self, state):
+        self.__init__(state)
+
     __setitem__ = __readonly__
     __delitem__ = __readonly__
     append = __readonly__

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozendict.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozendict.py
@@ -1,4 +1,5 @@
 import pickle
+
 import pytest
 
 from dagster.utils import frozendict

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozendict.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozendict.py
@@ -7,3 +7,11 @@ def test_frozendict():
     d = frozendict({"foo": "bar"})
     with pytest.raises(RuntimeError):
         d["zip"] = "zowie"
+
+
+def test_pickle_frozendict():
+    orig_dict = [{"foo": "bar"}]
+    data = pickle.dumps(orig_dict)
+    loaded_dict = pickle.loads(data)
+
+    assert orig_dict == loaded_dict

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozendict.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozendict.py
@@ -1,3 +1,4 @@
+import pickle
 import pytest
 
 from dagster.utils import frozendict

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozenlist.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozenlist.py
@@ -1,0 +1,12 @@
+import pickle
+import pytest
+
+from dagster.utils import frozendict
+
+
+def test_pickle_frozenlist():
+    orig_list = [1, "a", {}]
+    data = pickle.dumps(orig_list)
+    loaded_list = pickle.loads(data)
+
+    assert orig_list == loaded_list

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozenlist.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_frozenlist.py
@@ -1,5 +1,4 @@
 import pickle
-import pytest
 
 from dagster.utils import frozendict
 


### PR DESCRIPTION
Implement `__reduce__` and `__setstate__` on frozenlist so that it can be unpickled. Otherwise, `__setitem__` will be called to restore the frozenlist, causing a RuntimeError because frozenlist is not mutable.

Also add a couple of simple tests for pickling `frozenlist` and `frozendict`.

Fixes #2719.