### PR TITLE
:bug: replace merge_dicts with deep_merge_dicts in PresetDefinition's…

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/preset.py
+++ b/python_modules/dagster/dagster/core/definitions/preset.py
@@ -8,8 +8,8 @@ from dagster import check
 from dagster.core.definitions.utils import config_from_files, config_from_yaml_strings
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.seven import FileNotFoundError, ModuleNotFoundError  # pylint:disable=redefined-builtin
-from dagster.utils import merge_dicts
 from dagster.utils.backcompat import canonicalize_backcompat_args
+from dagster.utils.merger import deep_merge_dicts
 
 from .mode import DEFAULT_MODE_NAME
 
@@ -210,5 +210,5 @@ class PresetDefinition(
                 solid_selection=self.solid_selection,
                 mode=self.mode,
                 tags=self.tags,
-                run_config=merge_dicts(self.run_config, run_config),
+                run_config=deep_merge_dicts(self.run_config, run_config),
             )


### PR DESCRIPTION
… with_additional_config method

This brings the `with_additional_config` method in line with the other run config yaml combination functions found in `python_modules/dagster/dagster/utils/yaml_utils.py`.