### PR TITLE
[docs] detect broken anchor links, assets, and links to apidocs

### DIFF
--- a/docs/next/package.json
+++ b/docs/next/package.json
@@ -71,5 +71,11 @@
     "prettier": "^2.0.5",
     "tailwindcss": "^1.4.0",
     "typescript": "^3.8.3"
+  },
+  "jest": {
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ]
   }
 }

--- a/docs/next/src/__tests__/mdxInternalLinks.test.ts
+++ b/docs/next/src/__tests__/mdxInternalLinks.test.ts
@@ -3,16 +3,20 @@ import path from 'path';
 
 import glob from 'glob';
 import { createCompiler } from '@mdx-js/mdx';
+import { getAnchorLinkFromHeadingContent } from 'components/AnchorHeading';
 
 const { parse: parseMdxContent } = createCompiler();
 
 const DOCS_ROOT = path.resolve(__dirname, '..', 'pages');
+
+type MdxAstNode = any;
 
 test('no dead links', async () => {
   const allMdxFilePaths = (await findAllMdxFileRelativePaths()).filter(
     (i) => !i.endsWith('versions/index.mdx'),
   );
 
+  const astStore: { [filePath: string]: MdxAstNode } = {};
   const allInternalLinksStore: { [filePath: string]: Array<string> } = {};
 
   // parse mdx files to find all internal links and populate the store
@@ -20,13 +24,14 @@ test('no dead links', async () => {
     allMdxFilePaths.map(async (relativeFilePath) => {
       const absolutePath = path.resolve(DOCS_ROOT, relativeFilePath);
       const fileContent = await fs.promises.readFile(absolutePath, 'utf-8');
-
-      const rootAstNode = parseMdxContent(fileContent);
-      const internalLinks = collectInternalLinks(rootAstNode);
-
-      allInternalLinksStore[relativeFilePath] = internalLinks;
+      astStore[relativeFilePath] = parseMdxContent(fileContent);
     }),
   );
+
+  for (const filePath in astStore) {
+    const internalLinks = collectInternalLinks(astStore[filePath], filePath);
+    allInternalLinksStore[filePath] = internalLinks;
+  }
 
   const allMdxFileSet = new Set(allMdxFilePaths);
   const deadLinks: Array<{ sourceFile: string; deadLink: string }> = [];
@@ -38,9 +43,9 @@ test('no dead links', async () => {
 
     for (const link of linkList) {
       linkCount++;
-      if (!isLinkLegit(link, allMdxFileSet)) {
+      if (!isLinkLegit(link, allMdxFileSet, astStore)) {
         deadLinks.push({
-          sourceFile: source,
+          sourceFile: path.resolve(DOCS_ROOT, source),
           deadLink: link,
         });
       }
@@ -53,29 +58,36 @@ test('no dead links', async () => {
   expect(deadLinks).toEqual([]);
 });
 
-function isLinkLegit(rawTarget: string, allMdxFileSet: Set<string>): boolean {
+function getMatchCandidates(targetPath: string): Array<string> {
+  return [`${targetPath}.mdx`, `${targetPath}/index.mdx`];
+}
+
+function isLinkLegit(
+  rawTarget: string,
+  allMdxFileSet: Set<string>,
+  astStore: { [filePath: string]: MdxAstNode },
+): boolean {
   if (rawTarget.startsWith('_apidocs/')) {
     // TODO: handle dynamic routes (which can also have "#" headings)
     return true;
   }
 
   if (!rawTarget.includes('#')) {
-    // the link target doesn't have a specific "#" heading/slug
-    const candidates = [`${rawTarget}.mdx`, `${rawTarget}/index.mdx`];
-    return candidates.some((name) => allMdxFileSet.has(name));
+    // the link target doesn't have a "#" anchor
+    return getMatchCandidates(rawTarget).some((name) =>
+      allMdxFileSet.has(name),
+    );
   }
 
-  const [target, headingName] = rawTarget.split(/#+/);
-  const headingLevel = (rawTarget.match(/#/g) || []).length;
+  const [target, anchor] = rawTarget.split('#');
 
-  const targetFilePath = [`${target}.mdx`, `${target}/index.mdx`].find((name) =>
+  const targetFilePath = getMatchCandidates(target).find((name) =>
     allMdxFileSet.has(name),
   );
 
   if (targetFilePath) {
-    // TODO: can read the mdx ast again and check if the heading/slug actually exists
-    // (using the `headingName` and `headingLevel` above)
-    return true;
+    const allAnchors = collectHeadingsAsAnchors(astStore[targetFilePath]);
+    return allAnchors.includes(`#${anchor}`);
   }
 
   return false;
@@ -100,39 +112,72 @@ function findAllMdxFileRelativePaths(): Promise<Array<string>> {
 }
 
 // traverse the mdx ast to find all internal links
-function collectInternalLinks(rootAstNode: any): Array<string> {
-  const externalLinkRegex = /^http/;
+function collectInternalLinks(
+  rootAstNode: MdxAstNode,
+  currentFilePath: string,
+): Array<string> {
+  const externalLinkRegex = /^https?:\/\//;
 
   const queue = [rootAstNode];
-  const result = [];
+  const result: Array<string> = [];
 
   while (queue.length > 0) {
     const node = queue.shift();
-
     if (!node) {
       continue;
     }
-
-    if (node.type === 'link' && node.url) {
-      const { url } = node;
-      if (!url.match(externalLinkRegex)) {
-        if (url.startsWith('#')) {
-          // TODO: handle self # heading links
-        } else if (url.startsWith('/assets/')) {
-          // TODO: handle assets
-        } else if (url.startsWith('/')) {
-          result.push(url.substr(1));
-        } else {
-          // disallow relative references
-          result.push(
-            `Do not use relative references ('${url}'). All links should start with '/'`,
-          );
-        }
-      }
-    }
-
     if (Array.isArray(node.children)) {
       queue.push(...node.children);
+    }
+
+    if (!(node.type === 'link' && node.url)) {
+      continue;
+    }
+
+    const { url } = node;
+    if (url.match(externalLinkRegex)) {
+      continue;
+    }
+
+    if (url.startsWith('#')) {
+      // is a self-referencing anchor link
+      result.push(`${currentFilePath.replace(/\.mdx$/, '')}${url}`);
+    } else if (!url.startsWith('/')) {
+      throw new Error(
+        `Do not use relative references ('${url}'). All links should start with '/'`,
+      );
+    } else if (url.startsWith('/assets/')) {
+      // TODO: handle assets
+    } else {
+      // remove the leading `/` from the link target
+      result.push(url.substr(1));
+    }
+  }
+
+  return result;
+}
+
+function collectHeadingsAsAnchors(rootAstNode: MdxAstNode): Array<string> {
+  const queue = [rootAstNode];
+  const result: Array<string> = [];
+
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (!node) {
+      continue;
+    }
+    if (Array.isArray(node.children)) {
+      queue.push(...node.children);
+    }
+
+    // NOTE: this matches the current behavior of <AnchorHeading />
+    // where the children get flattened and only plain text is recognized
+    if (
+      node.type === 'heading' &&
+      node.children.length === 1 &&
+      node.children[0].type === 'text'
+    ) {
+      result.push(getAnchorLinkFromHeadingContent(node.children[0].value));
     }
   }
 

--- a/docs/next/src/__tests__/mdxInternalLinks.test.ts
+++ b/docs/next/src/__tests__/mdxInternalLinks.test.ts
@@ -71,18 +71,17 @@ function isLinkLegit(
   if (rawTarget.startsWith('_apidocs/')) {
     // NOTE: this currently fails all anchored links to `_apidocs`
     // (e.g. `_apidocs/foo#bar`)
-    try {
-      fs.statSync(
-        path.resolve(
-          ROOT_DIR,
-          '../sections/api/apidocs',
-          `${rawTarget.replace(/^_apidocs\//, '')}.rst`,
-        ),
-      );
-      return true;
-    } catch (_) {
-      return false;
-    }
+    return fileExists(
+      path.resolve(
+        ROOT_DIR,
+        '../sections/api/apidocs',
+        `${rawTarget.replace(/^_apidocs\//, '')}.rst`,
+      ),
+    );
+  }
+
+  if (rawTarget.startsWith('assets/')) {
+    return fileExists(path.resolve(ROOT_DIR, 'public', rawTarget));
   }
 
   if (!rawTarget.includes('#')) {
@@ -143,7 +142,7 @@ function collectInternalLinks(
       queue.push(...node.children);
     }
 
-    if (!(node.type === 'link' && node.url)) {
+    if (!((node.type === 'link' || node.type === 'image') && node.url)) {
       continue;
     }
 
@@ -159,8 +158,6 @@ function collectInternalLinks(
       throw new Error(
         `Do not use relative references ('${url}'). All links should start with '/'`,
       );
-    } else if (url.startsWith('/assets/')) {
-      // TODO: handle assets
     } else {
       // remove the leading `/` from the link target
       result.push(url.substr(1));
@@ -195,4 +192,13 @@ function collectHeadingsAsAnchors(rootAstNode: MdxAstNode): Array<string> {
   }
 
   return result;
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    fs.statSync(filePath);
+    return true;
+  } catch (_) {
+    return false;
+  }
 }

--- a/docs/next/src/components/AnchorHeading.tsx
+++ b/docs/next/src/components/AnchorHeading.tsx
@@ -26,13 +26,7 @@ const AnchorHeading: React.FC<AnchorHeadingProps> = ({
   let localHref: string = '#';
   if (href) localHref = href;
   else if (typeof children === 'string')
-    localHref = `#${(children as string)
-      .toLowerCase()
-      .trim()
-      // Remove special characters
-      .replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '')
-      .split(' ')
-      .join('-')}`;
+    localHref = getAnchorLinkFromHeadingContent(children);
 
   useEffect(() => {
     const title =
@@ -58,5 +52,16 @@ const AnchorHeading: React.FC<AnchorHeadingProps> = ({
     </Tag>
   );
 };
+
+export function getAnchorLinkFromHeadingContent(content: string): string {
+  return `#${content
+    .trim()
+    .toLowerCase()
+    // Remove special characters
+    .replace(/[^a-zA-Z0-9 ]/g, '')
+    .split(' ')
+    .filter(Boolean)
+    .join('-')}`;
+}
 
 export default AnchorHeading;

--- a/docs/next/src/pages/_apidocs/index.mdx
+++ b/docs/next/src/pages/_apidocs/index.mdx
@@ -93,7 +93,7 @@ functionality:
   with Microsoft Azure resources.
 
 - [Celery](/_apidocs/libraries/dagster_celery) (`dagster_celery`) Provides an executor built on
-  top of the popular [Celery task queue](http:/www.celeryproject.org/), and an executor with support
+  top of the popular [Celery task queue](http://www.celeryproject.org/), and an executor with support
   for using Celery on Kubernetes.
 
 - [Celery+Docker](/_apidocs/libraries/dagster_celery_docker) (`dagster_celery_docker`) Provides an
@@ -103,7 +103,7 @@ functionality:
   implementation built on system cron.
 
 - [Dask](/_apidocs/libraries/dagster_dask) (`dagster_dask`) Provides an executor built on top of
-  [dask.distributed](https:/distributed.dask.org/en/latest/).
+  [dask.distributed](https://distributed.dask.org/en/latest/).
 
 - [Flyte](/_apidocs/libraries/dagster_flyte) (`dagster_flyte`) (experimental) Provides an
   integration for runninig Dagster pipelines on [Flyte](https://flyte.org/).

--- a/docs/next/src/pages/overview/packages/dagstermill.mdx
+++ b/docs/next/src/pages/overview/packages/dagstermill.mdx
@@ -147,7 +147,7 @@ iris = pd.read_csv(
 We need to make one more change to our notebook so that the `path`
 parameter is injected by the Dagstermill machinery at runtime.
 
-Dagstermill is built on Papermill ([3](#3)), which uses Jupyter cell tags to identify the cell into
+Dagstermill is built on Papermill ([3](#references)), which uses Jupyter cell tags to identify the cell into
 which it should inject parameters at runtime. You will need to be
 running Jupyter 5.0 or later and may need to turn the display of cell
 tags on (select _View \> Cell Toolbar \> Tags_ from the Jupyter menu).

--- a/docs/next/src/pages/tutorial/basics_solids.mdx
+++ b/docs/next/src/pages/tutorial/basics_solids.mdx
@@ -66,7 +66,7 @@ displayText="execute_pipeline()" />function. Pipeline run config is specified by
 argument to this function, which must be a dict.
 
 This dict contains all of the user-provided configuration with which to execute a pipeline. As such,
-it can have [a lot of sections](/_apidocs/execution####config_schema), but we'll only use one of
+it can have [a lot of sections](/_apidocs/execution), but we'll only use one of
 them here: per-solid configuration, which is specified under the key `solids`:
 
 ```python literalinclude showLines startLine=41 caption=inputs.py

--- a/docs/next/src/pages/tutorial/testable.mdx
+++ b/docs/next/src/pages/tutorial/testable.mdx
@@ -22,7 +22,7 @@ talk about how you can build maintainable and testable data applications with Da
 
 ## Testing solids and pipelines
 
-Let's go back to our first solid and pipeline in [`hello_cereal.py`](#execute-our-first-pipeline)
+Let's go back to our first solid and pipeline in [`hello_cereal.py`](/tutorial/execute#executing-our-first-pipeline)
 and ensure they're working as expected by writing some tests. We'll use <PyObject module="dagster" object="execute_pipeline" displayText="execute_pipeline()" />
 to test our pipeline, as well as <PyObject module="dagster" object="execute_solid" displayText="execute_solid()" />
 to test our solid in isolation.


### PR DESCRIPTION
Continuation of #2448. It might be easier to review commit by commit (they are stacked).

Test Plan:
1. `yarn test` is green
2. Manually break some links and they are caught by the test