### PR TITLE
int for EventMetadataEntry

### DIFF
--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types_4.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types_4.py
@@ -66,6 +66,11 @@ def less_simple_data_frame_type_check(_, value):
                 "column_names",
                 "Keys of columns seen in the data frame",
             ),
+            EventMetadataEntry.int(  # TODO remove this test example
+                24.3,
+                "random_int",
+                "testing int EventMetadataEntry"
+            )
         ],
     )
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types_4.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types_4.py
@@ -66,11 +66,6 @@ def less_simple_data_frame_type_check(_, value):
                 "column_names",
                 "Keys of columns seen in the data frame",
             ),
-            EventMetadataEntry.int(  # TODO remove this test example
-                24.3,
-                "random_int",
-                "testing int EventMetadataEntry"
-            )
         ],
     )
 

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -228,7 +228,7 @@ class EventMetadataEntry(
         :py:class:`IntMetadataEntryData`.
 
         Args:
-            value (Optional[int]): The int value contained by this metadata entry.
+            value (Optional[int]): The int value contained by this metadata entry. 
             label (str): Short display label for this metadata entry.
             description (Optional[str]): A human-readable description of this metadata entry.
         """

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -339,7 +339,7 @@ EntryDataUnion = (
     MarkdownMetadataEntryData,
     PythonArtifactMetadataEntryData,
     FloatMetadataEntryData,
-    IntMetadataEntryData
+    IntMetadataEntryData,
 )
 
 

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -220,8 +220,19 @@ class EventMetadataEntry(
             label (str): Short display label for this metadata entry.
             description (Optional[str]): A human-readable description of this metadata entry.
         """
-        check.opt_float_param(value, "value")
         return EventMetadataEntry(label, description, FloatMetadataEntryData(value))
+
+    @staticmethod
+    def int(value, label, description=None):
+        """Static constructor for a metadata entry containing int as
+        :py:class:`IntMetadataEntryData`.
+
+        Args:
+            value (Optional[int]): The int value contained by this metadata entry.
+            label (str): Short display label for this metadata entry.
+            description (Optional[str]): A human-readable description of this metadata entry.
+        """
+        return EventMetadataEntry(label, description, IntMetadataEntryData(value))
 
 
 @whitelist_for_persistence
@@ -307,9 +318,16 @@ class PythonArtifactMetadataEntryData(
 @whitelist_for_persistence
 class FloatMetadataEntryData(namedtuple("_FloatMetadataEntryData", "value"), Persistable):
     def __new__(cls, value):
-        check.opt_float_param(value, "value")
         return super(FloatMetadataEntryData, cls).__new__(
             cls, check.opt_float_param(value, "value")
+        )
+
+
+@whitelist_for_persistence
+class IntMetadataEntryData(namedtuple("_IntMetadataEntryData", "value"), Persistable):
+    def __new__(cls, value):
+        return super(IntMetadataEntryData, cls).__new__(
+            cls, check.opt_int_param(value, "value")
         )
 
 
@@ -321,6 +339,7 @@ EntryDataUnion = (
     MarkdownMetadataEntryData,
     PythonArtifactMetadataEntryData,
     FloatMetadataEntryData,
+    IntMetadataEntryData
 )
 
 

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -326,9 +326,7 @@ class FloatMetadataEntryData(namedtuple("_FloatMetadataEntryData", "value"), Per
 @whitelist_for_persistence
 class IntMetadataEntryData(namedtuple("_IntMetadataEntryData", "value"), Persistable):
     def __new__(cls, value):
-        return super(IntMetadataEntryData, cls).__new__(
-            cls, check.opt_int_param(value, "value")
-        )
+        return super(IntMetadataEntryData, cls).__new__(cls, check.opt_int_param(value, "value"))
 
 
 EntryDataUnion = (

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -515,7 +515,8 @@ def test_asset_materialization(conn_string):
             metadata_entries=[
                 EventMetadataEntry.text("hello", "text"),
                 EventMetadataEntry.json({"hello": "world"}, "json"),
-                EventMetadataEntry.float(1.0, "one"),
+                EventMetadataEntry.float(1.0, "one_float"),
+                EventMetadataEntry.int(1, "one_int"),
             ],
         )
         yield Output(1)


### PR DESCRIPTION
fixes issue #2783 
* created IntMetadataEntryData and added it to the collection of EntryDataUnion to accept the int metadata type as valid.
