### PR TITLE
Add clusters from dask_cloudprovider to Dask resource

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -15,6 +15,9 @@ DaskClusterTypes = {
         "slurm": ("SLURM", "dask_jobqueue", "SLURMCluster"),
         "oar": ("OAR", "dask_jobqueue", "OARCluster"),
         "kube": ("Kubernetes", "dask_kubernetes", "KubeCluster"),
+        "azureml": ("Azure ML", "dask_cloudprovider", "AzureMLCluster"),
+        "ecs": ("AWS ECS", "dask_cloudprovider", "ECSCluster"),
+        "fargate": ("AWS ECS on Fargate", "dask_cloudprovider", "FargateCluster"),
     }.items()
 }
 


### PR DESCRIPTION
Add AzureMLCluster, ECSCluster, and FargateCluster from the
dask_cloudprovider module to the list of Dask cluster types. They
provide support for launching Dask clusters on demand in Azure and AWS.

Closes #2941