### PR TITLE
Add build_composite_solid_definition method to Lakehouse

### DIFF
--- a/python_modules/libraries/lakehouse/lakehouse/house.py
+++ b/python_modules/libraries/lakehouse/lakehouse/house.py
@@ -3,8 +3,10 @@ from typing import List, Optional
 
 from dagster import (
     AssetMaterialization,
+    CompositeSolidDefinition,
     DependencyDefinition,
     InputDefinition,
+    Nothing,
     Output,
     OutputDefinition,
     PipelineDefinition,
@@ -95,10 +97,166 @@ class Lakehouse:
         self._assets = QueryableAssetSet(assets or [])
 
     def build_pipeline_definition(self, name, assets_to_update):
+        solid_defs, solid_deps = self._get_solid_deps_and_defs(assets_to_update)
+
+        return PipelineDefinition(
+            name=name,
+            solid_defs=list(solid_defs.values()),
+            mode_defs=self._mode_defs,
+            dependencies=solid_deps,
+            preset_defs=self._preset_defs,
+        )
+
+    def build_composite_solid_definition(self, name, assets_to_update, include_nothing_input=False):
+        """Build a composite solid definition for the assets in `assets_to_update`.
+
+        By default the composite solid will not accept any inputs. If you need to run this composite
+        _after_ other solids have run, pass `include_nothing_input=True`, which will add a single
+        input of type `Nothing` to the solid.
+
+        Examples:
+
+            .. code-block:: python
+
+            from pyspark.sql import DataFrame, Row
+
+            from dagster import InputDefinition, ModeDefinition, PresetDefinition, Nothing, StringSource, solid, lambda_solid, pipeline, resource
+            from dagster_pyspark import pyspark_resource
+            from lakehouse import AssetStorage, Lakehouse, source_asset, computed_asset
+
+            class LocalFileSystemStorage():
+                def __init__(self, root):
+                    self.root = root
+
+                def get_fs_path(self, path) -> str:
+                    return '/'.join((self.root,) + path)
+
+            local_filesystem_config_schema = {"root": StringSource}
+
+            @resource(config_schema=local_filesystem_config_schema)
+            def local_file_system_storage(init_context):
+                return LocalFileSystemStorage(init_context.resource_config["root"])
+
+
+            @resource(config_schema=local_filesystem_config_schema)
+            def spark_df_local_storage(init_context):
+                local_fs = LocalFileSystemStorage(init_context.resource_config["root"])
+
+                class Storage(AssetStorage):
+                    def save(self, obj, path, _resources):
+                        obj.write.format("csv").options(header="true").save(
+                            local_fs.get_fs_path(path), mode="overwrite"
+                        )
+
+                    def load(cls, _python_type, path, resources):
+                        return (
+                            resources.pyspark.spark_session.read.format("csv")
+                            .options(header="true")
+                            .load(local_fs.get_fs_path(path))
+                        )
+
+                return Storage()
+
+            mode_def = ModeDefinition(
+                name='default',
+                resource_defs={
+                    'filesystem': local_file_system_storage,
+                    'default_storage': spark_df_local_storage,
+                    'pyspark': pyspark_resource,
+                }
+            )
+
+            preset_def = PresetDefinition(
+                name='default',
+                mode='default',
+                run_config={'resources': {'filesystem': {'config': {'root': '.'}}}},
+                solid_selection=None,
+            )
+
+            lakehouse = Lakehouse(
+                preset_defs=[preset_def],
+                mode_defs=[mode_def],
+                in_memory_type_resource_keys={DataFrame: ["pyspark"]},
+            )
+
+            @solid(required_resource_keys={"filesystem", "pyspark"})
+            def save_orders(context) -> Nothing:
+                orders = context.resources.pyspark.spark_session.createDataFrame([
+                    Row(id=1, name="foo"), Row(id=2, name="bar"), Row(id=3, name="baz"),
+                ])
+                path = context.resources.filesystem.get_fs_path(("orders.csv",))
+                orders.write.format("csv").options(header="true").save(path, mode="overwrite")
+
+            orders_asset = source_asset(path="orders.csv")
+
+            @computed_asset(input_assets=[orders_asset])
+            def orders_top1_asset(orders: DataFrame) -> DataFrame:
+                return orders.limit(1)
+
+            run_lakehouse = lakehouse.build_composite_solid_definition(
+                name="lakehouse_solid",
+                assets_to_update=[orders_top1_asset],
+                include_nothing_input=True,
+            )
+
+            @pipeline(mode_defs=[mode_def], preset_defs=[preset_def])
+            def simple_pipeline():
+                run_lakehouse(save_orders())
+
+            # If you have multiple solids which need to run first:
+
+            @lambda_solid
+            def other_side_effect() -> Nothing:
+                # Perhaps this writes to a database or some other required source table.
+                pass
+
+            @lambda_solid(
+                input_defs=[InputDefinition("orders", Nothing), InputDefinition("other", Nothing)]
+            )
+            def wait_until_complete() -> Nothing:
+                pass
+
+            @pipeline(mode_defs=[mode_def], preset_defs=[preset_def])
+            def pipeline_multi_deps():
+                completed = wait_until_complete(orders=save_orders(), other=other_side_effect())
+                run_lakehouse(completed)
+
+        """
+        solid_defs, solid_deps = self._get_solid_deps_and_defs(
+            assets_to_update, include_nothing_input
+        )
+
+        if include_nothing_input:
+            # Map a single `InputDefinition`, of type `Nothing`, to every
+            # solid in the solid definitions we just created that have an input
+            # named 'nothing'.
+            # Ideally we'd do this based on something more explicit than the names and types
+            # of solid inputs, but it's vanishingly unlikely that users will return `Nothing`
+            # from an asset, since there would be nothing to save to the Lakehouse that way.
+            nothing_input = InputDefinition("nothing", Nothing)
+            input_mappings = [
+                nothing_input.mapping_to("__".join(solid_name), "nothing")
+                for solid_name, solid_def in solid_defs.items()
+                if solid_def.input_defs[0].name == "nothing"
+                and solid_def.input_defs[0].dagster_type.is_nothing
+            ]
+        else:
+            input_mappings = None
+
+        return CompositeSolidDefinition(
+            name=name,
+            solid_defs=list(solid_defs.values()),
+            dependencies=solid_deps,
+            input_mappings=input_mappings,
+        )
+
+    def _get_solid_deps_and_defs(self, assets_to_update, include_nothing_input=False):
         solid_defs = {}
         for asset in assets_to_update:
             if asset.computation:
-                solid_defs[asset.path] = self.get_computed_asset_solid_def(asset, assets_to_update)
+                solid_defs[asset.path] = self.get_computed_asset_solid_def(
+                    asset, assets_to_update, include_nothing_input
+                )
             else:
                 check.failed("All elements of assets_to_update must have computations")
 
@@ -113,16 +271,11 @@ class Lakehouse:
             for asset in assets_to_update
             if asset.computation
         }
+        return solid_defs, solid_deps
 
-        return PipelineDefinition(
-            name=name,
-            solid_defs=list(solid_defs.values()),
-            mode_defs=self._mode_defs,
-            dependencies=solid_deps,
-            preset_defs=self._preset_defs,
-        )
-
-    def get_computed_asset_solid_def(self, computed_asset, assets_in_pipeline):
+    def get_computed_asset_solid_def(
+        self, computed_asset, assets_in_pipeline, include_nothing_input=False
+    ):
         output_dagster_type = computed_asset.dagster_type
         output_def = OutputDefinition(output_dagster_type)
         input_defs = []
@@ -134,6 +287,10 @@ class Lakehouse:
                     name="__".join(dep.asset.path), dagster_type=input_dagster_type
                 )
                 input_defs.append(input_def)
+
+        # Add a `Nothing` input if requested and if this asset has no input definitions.
+        if include_nothing_input and not input_defs:
+            input_defs.append(InputDefinition(name="nothing", dagster_type=Nothing))
 
         required_resource_keys = set(
             [

--- a/python_modules/libraries/lakehouse/lakehouse/house.py
+++ b/python_modules/libraries/lakehouse/lakehouse/house.py
@@ -111,8 +111,10 @@ class Lakehouse:
         """Build a composite solid definition for the assets in `assets_to_update`.
 
         By default the composite solid will not accept any inputs. If you need to run this composite
-        _after_ other solids have run, pass `include_nothing_input=True`, which will add a single
-        input of type `Nothing` to the solid.
+        _after_ other solids have run, pass `include_nothing_input=True`, which will create a
+        single input of type `Nothing` to the composite solid, and a mapping to each 'source' asset
+        input (i.e. those assets without `compute_fn`s, such as those created by `source_asset` or
+        `source_table`).
 
         Examples:
 


### PR DESCRIPTION
This allows the execution of the tasks to create a Lakehouse to be
scheduled inside other pipelines and optionally after other work,
such as solids which ingest data into the Lakehouse.

This follows on from a conversation in the #lakehouse Slack channel on 2020-09-25.