### PR TITLE
Convert to_sql dtype values to SQLAlchemy types

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -499,7 +499,8 @@ def dataframe_materializer(_context, config, dask_df):
         to_kwargs = to_options
         
         # Specifically for to_sql, attempt to convert dtype values into SQLAlchemy types
-        if to_type == "sql" and dtype := to_options.get("dtype", None):
+        if to_type == "sql" and "dtype" in to_options:
+            dtype = to_options["dtype"]
             import sqlalchemy.types as st
                 
             if isinstance(dtype, str):


### PR DESCRIPTION
For the Dask DataFrame materializer to_sql option, try to convert string value references to SQLAlchemy types. SQLAlchemy expects to receive concrete type classes, but they’re impossible to specify using plain YAML only.

This conversion is designed to work only for the standard types defined in `sqlalchemy.types`. No conversion is done for engine specific types or customized types.

Closes #3104