### PR TITLE
Add Dask DataFrame type utility for normalizing index names

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -9,6 +9,13 @@ def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
         df.columns = map(normalize_name, df.columns)
 
     return df
+    
+    
+def normalize_index_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
+    if enabled:
+        df.index = df.index.rename(normalize_name(df.index.name))
+        
+    return df
 
 
 # Based on https://stackoverflow.com/a/1176023   
@@ -170,6 +177,14 @@ DataFrameUtilities = {
             Bool,
             is_required=False,
             description="Lowercase and convert CamelCase to snake_case on column names.",
+        ),
+    },
+    "normalize_index_names": {
+        "function": normalize_index_names,
+        "options": Field(
+            Bool,
+            is_required=False,
+            description="Lowercase and convert CamelCase to snake_case on index names.",
         ),
     },
 }

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -9,16 +9,16 @@ def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
         df.columns = map(normalize_name, df.columns)
 
     return df
-    
-    
+
+
 def normalize_index_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
     if enabled:
         df.index = df.index.rename(normalize_name(df.index.name))
-        
+
     return df
 
 
-# Based on https://stackoverflow.com/a/1176023   
+# Based on https://stackoverflow.com/a/1176023
 _camel_to_snake1 = re.compile("(.)([A-Z][a-z]+)")
 _camel_to_snake2 = re.compile("([a-z0-9])([A-Z])")
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/utils.py
@@ -6,23 +6,21 @@ from dagster import Any, Bool, Field, Float, Int, Permissive, Shape, String
 
 def normalize_column_names(df: dd.DataFrame, enabled) -> dd.DataFrame:
     if enabled:
-        df.columns = normalize_names(df.columns)
+        df.columns = map(normalize_name, df.columns)
 
     return df
 
 
-def normalize_names(names):
-    # Based on https://stackoverflow.com/a/1176023
-    camel_to_snake1 = re.compile("(.)([A-Z][a-z]+)")
-    camel_to_snake2 = re.compile("([a-z0-9])([A-Z])")
+# Based on https://stackoverflow.com/a/1176023   
+_camel_to_snake1 = re.compile("(.)([A-Z][a-z]+)")
+_camel_to_snake2 = re.compile("([a-z0-9])([A-Z])")
 
-    def normalize(name):
-        if not name:
-            return name
-        name = camel_to_snake1.sub(r"\1_\2", name)
-        return camel_to_snake2.sub(r"\1_\2", name).lower()
 
-    return map(normalize, names)
+def normalize_name(name):
+    if not name:
+        return name
+    name = _camel_to_snake1.sub(r"\1_\2", name)
+    return _camel_to_snake2.sub(r"\1_\2", name).lower()
 
 
 DataFrameUtilities = {

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -119,20 +119,20 @@ def test_normalize_column_names():
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
     assert all(col in output_df.columns for col in ("id", "province_or_territory", "country"))
-    
-    
+
+
 def test_normalize_index_names():
     path = file_relative_path(__file__, "canada.csv")
-    
+
     input_df = dd.read_csv(path)
     input_df = input_df.set_index("provinceOrTerritory")
-    
+
     # Set normalize_index_names=False to not modify the index names
     run_config = generate_config(path, normalize_index_names=False)
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
     assert output_df.index.name == "provinceOrTerritory"
-    
+
     # Set normalize_index_names=True to modify the index names
     run_config = generate_config(path, normalize_index_names=True)
     result = execute_solid(passthrough, run_config=run_config)

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -119,6 +119,25 @@ def test_normalize_column_names():
     result = execute_solid(passthrough, run_config=run_config)
     output_df = result.output_value()
     assert all(col in output_df.columns for col in ("id", "province_or_territory", "country"))
+    
+    
+def test_normalize_index_names():
+    path = file_relative_path(__file__, "canada.csv")
+    
+    input_df = dd.read_csv(path)
+    input_df = input_df.set_index("provinceOrTerritory")
+    
+    # Set normalize_index_names=False to not modify the index names
+    run_config = generate_config(path, normalize_index_names=False)
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert output_df.index.name == "provinceOrTerritory"
+    
+    # Set normalize_index_names=True to modify the index names
+    run_config = generate_config(path, normalize_index_names=True)
+    result = execute_solid(passthrough, run_config=run_config)
+    output_df = result.output_value()
+    assert output_df.index.name == "province_or_territory"
 
 
 def test_utilities_combo():


### PR DESCRIPTION
For the Dask DataFrame loader and materialize, add a utility to normalize index names, as a corollary to the existing option to normalize column names.