### PR TITLE
Remove unnecessary semicolon

### DIFF
--- a/docs/next/src/pages/tutorial/execute.mdx
+++ b/docs/next/src/pages/tutorial/execute.mdx
@@ -7,7 +7,6 @@ import PyObject from 'components/PyObject';
   title="Building pipelines with Dagster | Dagster"
   description="Tutoiral guide to executing data pipelines using Dagster."
 />
-;
 
 # Building Pipelines with Dagster
 


### PR DESCRIPTION
This removes the unnecessary semicolon at the start of [the execute page](https://docs.dagster.io/tutorial/execute).