### PR TITLE
Use sqlalchemy with snowflake_resource

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/configs.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/configs.py
@@ -111,6 +111,28 @@ def define_snowflake_config():
         is_required=False,
     )
 
+    connector = Field(
+        StringSource,
+        description="""Indicate alternative database connection engine. Permissible option is
+        'sqlalchemy' otherwise defaults to use the Snowflake Connector for Python.""",
+        is_required=False,
+    )
+
+    cache_column_metadata = Field(
+        StringSource,
+        description="""Optional parameter when connector is set to sqlalchemy. Snowflake SQLAlchemy
+        takes a flag cache_column_metadata=True such that all of column metadata for all tables are
+        cached""",
+        is_required=False,
+    )
+
+    numpy = Field(
+        StringSource,
+        description="""Optional parameter when connector is set to sqlalchemy. To enable fetching
+        NumPy data types, add numpy=True to the connection parameters.""",
+        is_required=False,
+    )
+
     return {
         "account": account,
         "user": user,
@@ -128,4 +150,7 @@ def define_snowflake_config():
         "validate_default_parameters": validate_default_parameters,
         "paramstyle": paramstyle,
         "timezone": timezone,
+        "connector": connector,
+        "cache_column_metadata": cache_column_metadata,
+        "numpy": numpy,
     }

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -26,5 +26,6 @@ if __name__ == "__main__":
         ],
         packages=find_packages(exclude=["test"]),
         install_requires=["dagster", "snowflake-connector-python>=2.1.0"],
+        extras_require={"snowflake.sqlalchemy": ["sqlalchemy", "snowflake-sqlalchemy"]},
         zip_safe=False,
     )


### PR DESCRIPTION
### Summary

This PR introduces changes that allow users to use an sqlalchemy connection engine within Dagster's snowflake_resource rather than the default snowflake.connector (note, the Snowflake Python Connector is still being used under the hood, but wrapped as an sqlalchemy connection).

Additional dependencies introduced by this PR: `snowflake-sqlalchemy`, `sqlalchemy`

### Configuration

To use sqlalchemy, add the optional config param:
```
resources:
    snowflake:
        config:
            connector: sqlalchemy
```

### Testing

Execute queries the same as before:
```py
context.resources.snowflake.execute_query('select * from <TABLE_NAME>;', fetch_results=True)
```

### Usage with Pandas

The main motivation for this PR is that these changes allow us to use Dagster's `snowflake_resource` with Pandas sql utilities. To do this install the following:
```sh
pip install snowflake-connector-python[pandas]
```

Then you can write a Pandas DataFrame directly Snowflake like this:
```py
from snowflake.connector.pandas_tools import pd_writer

with context.resources.snowflake.get_connection(raw_conn=False) as con:
        df.to_sql(name=table_name, con=con, if_exists='replace', index=False, method=pd_writer)
```

The `pd_writer` from the pandas_tools extra uses the `write_pandas()` function internally. See docs:
https://docs.snowflake.com/en/user-guide/python-connector-pandas.html

Also note, the added parameter `raw_conn=False` is needed with `get_connection` because the `.to_sql` function won't accept a raw connection from sqlalchemy.  However, Dagster's `execute_query` function require the raw_connection to maintain existing default behavior.
