### PR TITLE
Allow setting of S3 endpoint through env variables

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -15,7 +15,7 @@ S3_SESSION_CONFIG = {
         str, description="Specifies a custom region for the S3 session", is_required=False
     ),
     "endpoint_url": Field(
-        str, description="Specifies a custom endpoint for the S3 session", is_required=False
+        StringSource, description="Specifies a custom endpoint for the S3 session", is_required=False
     ),
     "max_attempts": Field(
         int,


### PR DESCRIPTION
Useful for when mocking out S3 locally