### PR TITLE
Mock S3

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/conftest.py
@@ -1,6 +1,14 @@
+import boto3
 import pytest
+from moto import mock_s3
 
 
-@pytest.fixture(scope="session")
-def s3_bucket():
-    yield "dagster-scratch-80542c2"
+@pytest.fixture
+def s3():
+    with mock_s3():
+        yield boto3.resource("s3")
+
+
+@pytest.fixture
+def bucket(s3):  # pylint: disable=redefined-outer-name
+    yield s3.create_bucket(Bucket="test-bucket")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import boto3
 import six
 from dagster import DagsterEventType, execute_pipeline, pipeline, seven, solid
 from dagster.core.instance import DagsterInstance, InstanceType
@@ -12,7 +11,6 @@ from dagster.core.storage.event_log import SqliteEventLogStorage
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import SqliteRunStorage
 from dagster_aws.s3 import S3ComputeLogManager
-from moto import mock_s3
 
 HELLO_WORLD = "Hello World"
 SEPARATOR = os.linesep if (os.name == "nt" and sys.version_info < (3,)) else "\n"
@@ -23,8 +21,7 @@ EXPECTED_LOGS = [
 ]
 
 
-@mock_s3
-def test_compute_log_manager(s3_bucket):
+def test_compute_log_manager(bucket):
     @pipeline
     def simple():
         @solid
@@ -35,14 +32,10 @@ def test_compute_log_manager(s3_bucket):
 
         easy()
 
-    # Uses mock S3
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket=s3_bucket)
-
     with seven.TemporaryDirectory() as temp_dir:
         run_store = SqliteRunStorage.from_local(temp_dir)
         event_store = SqliteEventLogStorage(temp_dir)
-        manager = S3ComputeLogManager(bucket=s3_bucket, prefix="my_prefix", local_dir=temp_dir)
+        manager = S3ComputeLogManager(bucket=bucket.name, prefix="my_prefix", local_dir=temp_dir)
         instance = DagsterInstance(
             instance_type=InstanceType.PERSISTENT,
             local_artifact_storage=LocalArtifactStorage(temp_dir),
@@ -69,13 +62,12 @@ def test_compute_log_manager(s3_bucket):
             assert expected in stderr.data
 
         # Check S3 directly
-        s3_object = s3.get_object(
-            Bucket=s3_bucket,
-            Key="{prefix}/storage/{run_id}/compute_logs/easy.compute.err".format(
+        s3_object = bucket.Object(
+            key="{prefix}/storage/{run_id}/compute_logs/easy.compute.err".format(
                 prefix="my_prefix", run_id=result.run_id
             ),
         )
-        stderr_s3 = six.ensure_str(s3_object["Body"].read())
+        stderr_s3 = six.ensure_str(s3_object.get()["Body"].read())
         for expected in EXPECTED_LOGS:
             assert expected in stderr_s3
 
@@ -92,8 +84,7 @@ def test_compute_log_manager(s3_bucket):
             assert expected in stderr.data
 
 
-@mock_s3
-def test_compute_log_manager_from_config(s3_bucket):
+def test_compute_log_manager_from_config(bucket):
     s3_prefix = "foobar"
 
     dagster_yaml = """
@@ -105,7 +96,7 @@ compute_logs:
     local_dir: "/tmp/cool"
     prefix: "{s3_prefix}"
 """.format(
-        s3_bucket=s3_bucket, s3_prefix=s3_prefix
+        s3_bucket=bucket.name, s3_prefix=s3_prefix
     )
 
     with seven.TemporaryDirectory() as tempdir:
@@ -113,5 +104,7 @@ compute_logs:
             f.write(six.ensure_binary(dagster_yaml))
 
         instance = DagsterInstance.from_config(tempdir)
-    assert instance.compute_log_manager._s3_bucket == s3_bucket  # pylint: disable=protected-access
+    assert (
+        instance.compute_log_manager._s3_bucket == bucket.name  # pylint: disable=protected_access
+    )
     assert instance.compute_log_manager._s3_prefix == s3_prefix  # pylint: disable=protected-access

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -105,6 +105,6 @@ compute_logs:
 
         instance = DagsterInstance.from_config(tempdir)
     assert (
-        instance.compute_log_manager._s3_bucket == bucket.name  # pylint: disable=protected_access
+        instance.compute_log_manager._s3_bucket == bucket.name  # pylint: disable=protected-access
     )
     assert instance.compute_log_manager._s3_prefix == s3_prefix  # pylint: disable=protected-access

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
@@ -1,53 +1,43 @@
 import boto3
 from dagster import ModeDefinition, ResourceDefinition, execute_pipeline, pipeline, solid
 from dagster.utils.test import get_temp_file_handle_with_data
-from dagster_aws.s3 import file_handle_to_s3
-from moto import mock_s3
+from dagster_aws.s3 import file_handle_to_s3, s3_resource
 
 
-def create_file_handle_pipeline(temp_file_handle, s3_resource):
+def create_file_handle_pipeline(temp_file_handle):
     @solid
     def emit_temp_handle(_):
         return temp_file_handle
 
-    @pipeline(
-        mode_defs=[
-            ModeDefinition(resource_defs={"s3": ResourceDefinition.hardcoded_resource(s3_resource)})
-        ]
-    )
+    @pipeline(mode_defs=[ModeDefinition(resource_defs={"s3": s3_resource})])
     def test():
         return file_handle_to_s3(emit_temp_handle())
 
     return test
 
 
-@mock_s3
-def test_successful_file_handle_to_s3():
+def test_successful_file_handle_to_s3(bucket):
     foo_bytes = "foo".encode()
     with get_temp_file_handle_with_data(foo_bytes) as temp_file_handle:
-        # Uses mock S3
-        s3 = boto3.client("s3")
-        s3.create_bucket(Bucket="some-bucket")
-
         result = execute_pipeline(
-            create_file_handle_pipeline(temp_file_handle, s3),
+            create_file_handle_pipeline(temp_file_handle),
             run_config={
                 "solids": {
-                    "file_handle_to_s3": {"config": {"Bucket": "some-bucket", "Key": "some-key"}}
+                    "file_handle_to_s3": {"config": {"Bucket": bucket.name, "Key": "some-key"}}
                 }
             },
         )
 
         assert result.success
 
-        assert s3.get_object(Bucket="some-bucket", Key="some-key")["Body"].read() == foo_bytes
+        assert bucket.Object(key="some-key").get()["Body"].read() == foo_bytes
 
         materializations = result.result_for_solid(
             "file_handle_to_s3"
         ).materializations_during_compute
         assert len(materializations) == 1
         assert len(materializations[0].metadata_entries) == 1
-        assert (
-            materializations[0].metadata_entries[0].entry_data.path == "s3://some-bucket/some-key"
-        )
+        assert materializations[0].metadata_entries[
+            0
+        ].entry_data.path == "s3://{bucket}/some-key".format(bucket=bucket.name)
         assert materializations[0].metadata_entries[0].label == "some-key"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
@@ -1,5 +1,4 @@
-import boto3
-from dagster import ModeDefinition, ResourceDefinition, execute_pipeline, pipeline, solid
+from dagster import ModeDefinition, execute_pipeline, pipeline, solid
 from dagster.utils.test import get_temp_file_handle_with_data
 from dagster_aws.s3 import file_handle_to_s3, s3_resource
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_object_store.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_object_store.py
@@ -1,20 +1,14 @@
 import boto3
 from dagster.core.storage.object_store import DEFAULT_SERIALIZATION_STRATEGY
 from dagster_aws.s3 import S3ObjectStore
-from moto import mock_s3
 
 
-@mock_s3
-def test_s3_object_store(s3_bucket, caplog):
-    # Uses mock S3
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket=s3_bucket)
-
+def test_s3_object_store(bucket, caplog):
     key = "foo"
 
-    s3_obj_store = S3ObjectStore(s3_bucket)
+    s3_obj_store = S3ObjectStore(bucket.name)
     res_key = s3_obj_store.set_object(key, True, DEFAULT_SERIALIZATION_STRATEGY)
-    assert res_key == "s3://{s3_bucket}/{key}".format(s3_bucket=s3_bucket, key=key)
+    assert res_key == "s3://{s3_bucket}/{key}".format(s3_bucket=bucket.name, key=key)
 
     s3_obj_store.set_object(key, True, DEFAULT_SERIALIZATION_STRATEGY)
     assert "Removing existing S3 key" in caplog.text
@@ -29,5 +23,5 @@ def test_s3_object_store(s3_bucket, caplog):
     assert not s3_obj_store.has_object(key)
 
     assert s3_obj_store.uri_for_key(key) == "s3://{s3_bucket}/{key}".format(
-        s3_bucket=s3_bucket, key=key
+        s3_bucket=bucket.name, key=key
     )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_object_store.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_object_store.py
@@ -1,4 +1,3 @@
-import boto3
 from dagster.core.storage.object_store import DEFAULT_SERIALIZATION_STRATEGY
 from dagster_aws.s3 import S3ObjectStore
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_cache.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_cache.py
@@ -1,27 +1,19 @@
 import io
 
-import boto3
 from dagster_aws.s3 import S3FileCache, S3FileHandle
-from moto import mock_s3
 
 
-@mock_s3
-def test_s3_file_cache_file_not_present():
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="some-bucket")
+def test_s3_file_cache_file_not_present(s3, bucket):
     file_store = S3FileCache(
-        s3_bucket="some-bucket", s3_key="some-key", s3_session=s3, overwrite=False
+        s3_bucket=bucket.name, s3_key="some-key", s3_session=s3.meta.client, overwrite=False
     )
 
     assert not file_store.has_file_object("foo")
 
 
-@mock_s3
-def test_s3_file_cache_file_present():
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="some-bucket")
+def test_s3_file_cache_file_present(s3, bucket):
     file_store = S3FileCache(
-        s3_bucket="some-bucket", s3_key="some-key", s3_session=s3, overwrite=False
+        s3_bucket=bucket.name, s3_key="some-key", s3_session=s3.meta.client, overwrite=False
     )
 
     assert not file_store.has_file_object("foo")
@@ -31,23 +23,17 @@ def test_s3_file_cache_file_present():
     assert file_store.has_file_object("foo")
 
 
-@mock_s3
-def test_s3_file_cache_correct_handle():
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="some-bucket")
+def test_s3_file_cache_correct_handle(s3, bucket):
     file_store = S3FileCache(
-        s3_bucket="some-bucket", s3_key="some-key", s3_session=s3, overwrite=False
+        s3_bucket=bucket.name, s3_key="some-key", s3_session=s3.meta.client, overwrite=False
     )
 
     assert isinstance(file_store.get_file_handle("foo"), S3FileHandle)
 
 
-@mock_s3
-def test_s3_file_cache_write_file_object():
-    s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="some-bucket")
+def test_s3_file_cache_write_file_object(s3, bucket):
     file_store = S3FileCache(
-        s3_bucket="some-bucket", s3_key="some-key", s3_session=s3, overwrite=False
+        s3_bucket=bucket.name, s3_key="some-key", s3_session=s3.meta.client, overwrite=False
     )
 
     stream = io.BytesIO("content".encode())


### PR DESCRIPTION
Previously, most of the tests in [test_intermediate_storage.py](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_intermediate_storage.py) failed when run locally because they [relied on credentials with access to a bucket called `dagster-scratch-80542c2`](https://dagster.phacility.com/D786). Similarly to #3221, I've updated the pytest fixture to instead yield a mock bucket so tests can run locally while leaving all the actual S3 implementations untouched. I also:

- removed the nettest marks from these tests becuase they no longer cross network boundaries.
- refactored tests slightly to use an S3 resource instead of an S3 client. I find the higher level api for resources to be more user-friendly.
- used the real `dagster_aws.s3.s3_resource` instead of providing a hardcoded resource.
- removed an unused check for AWS credentials

I didn't standardize the use of mocks outside of this directory - but I think there remains opportunity to pull this `bucket` fixture up a few levels to make the use of mock S3 consistent throughout dagster-aws.

If merged, https://github.com/dagster-io/dagster/issues/2302 will be _almost_ to ready to close - only the ECS and EMR tests still need to be mocked.