### PR TITLE
Increase user deployment k8s probe timeout

### DIFF
--- a/helm/dagster/templates/deployment-user.yaml
+++ b/helm/dagster/templates/deployment-user.yaml
@@ -85,10 +85,12 @@ spec:
             exec:
               command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
             periodSeconds: 20
+            timeoutSeconds: 3
           startupProbe:
             exec:
               command: ["dagster", "api", "grpc-health-check", "-p",  "{{ $deployment.port }}"]
             periodSeconds: 10
+            timeoutSeconds: 3
       {{- with $deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
`grpc-health-check` takes a little over 2 seconds in my deployment; with
the defaut timeout of 1 second, the k8s deployment never becomes ready.