### PR TITLE
Only add flower to the k8s ingress resource if enabled

### DIFF
--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -31,6 +31,7 @@ spec:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
           {{- end }}
+    {{- if .Values.flower.enabled -}}
     - host: {{ .Values.ingress.flower.host }}
       http:
         paths:
@@ -50,4 +51,5 @@ spec:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
           {{- end }}
+    {{end}}
 {{end}}


### PR DESCRIPTION
When flower is disabled, k8s chokes on the ingress resource since it
refers to a non-existent service.