### PR TITLE
Preserved the original function wrapped by @solid.

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid.py
@@ -53,6 +53,8 @@ class _Solid:
         if not self.name:
             self.name = fn.__name__
 
+        self._fn = fn
+
         input_defs = (
             self.input_defs
             if self.input_defs is not None


### PR DESCRIPTION
### Summary
The PR will preserve a reference to the original function that got wrapped by @solid.

### Background
Currently, Dagster does not support async functions & generators, and it is not in the roadmap in the near future (a quarter). For adopters (like me) who are trying to convert their existing asyncio func & gen into solids, the closest they can do is to implement their own executors and deal with the async func & gen within the executor. However, they do not have access to the original functions as all functions will be wrapped into a general generator. As a result, besides implementing a new executor, they also need to make another version of @solid decorator, which is really cumbersome.

### Solution
The easiest way to resolve this is to preserve a reference to the original function, and this adds more flexibility for the customized executor, not only for the async case I mentioned above but also potentially other use cases.
