### PR TITLE
Fixed a spelling mistake

### DIFF
--- a/docs/next/src/pages/overview/configuration/run-config.mdx
+++ b/docs/next/src/pages/overview/configuration/run-config.mdx
@@ -42,7 +42,7 @@ The following simple example shows how **config_schema** can be used on a solid 
 file:/docs_snippets/docs_snippets/overview/configuration/example.py
 ```
 
-While the example above uses simple scalar config values, the config system supports strucutred types allowing for
+While the example above uses simple scalar config values, the config system supports structured types allowing for
 complex configuration. These are [documented in the API section with examples](/_apidocs/config).
 
 Notable entries include:


### PR DESCRIPTION
Corrected spelling of strucutred -> structured towards the bottom of the run_config docs - https://docs.dagster.io/overview/configuration/run-config