### PR TITLE
Add Schema param to BQ load config

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -4,7 +4,7 @@ See the BigQuery Python API documentation for reference:
     https://googleapis.github.io/google-cloud-python/latest/bigquery/reference.html
 """
 
-from dagster import Bool, Field, IntSource, String, StringSource, Array
+from dagster import Array, Bool, Field, IntSource, String, StringSource
 
 from .types import (
     BQCreateDisposition,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -335,11 +335,7 @@ def define_bigquery_load_config():
         is_required=False,
     )
 
-    schema = Field(
-        BQTableSchema,
-        description="Schema of the destination table.",
-        is_required=False
-    )
+    schema = Field(BQTableSchema, description="Schema of the destination table.", is_required=False)
 
     skip_leading_rows = Field(
         IntSource,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -4,7 +4,10 @@ See the BigQuery Python API documentation for reference:
     https://googleapis.github.io/google-cloud-python/latest/bigquery/reference.html
 """
 
+from typing import List
+
 from dagster import Bool, Field, IntSource, String, StringSource
+from google.cloud.bigquery.schema import SchemaField
 
 from .types import (
     BQCreateDisposition,
@@ -12,7 +15,6 @@ from .types import (
     BQPriority,
     BQSchemaUpdateOption,
     BQSourceFormat,
-    BQTableSchema,
     BQWriteDisposition,
     Dataset,
     Table,
@@ -335,7 +337,7 @@ def define_bigquery_load_config():
         is_required=False,
     )
 
-    schema = Field(BQTableSchema, description="Schema of the destination table.", is_required=False)
+    schema = Field(List[SchemaField], description="Schema of the destination table.", is_required=False)
 
     skip_leading_rows = Field(
         IntSource,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -4,10 +4,7 @@ See the BigQuery Python API documentation for reference:
     https://googleapis.github.io/google-cloud-python/latest/bigquery/reference.html
 """
 
-from typing import List
-
-from dagster import Bool, Field, IntSource, String, StringSource
-from google.cloud.bigquery.schema import SchemaField
+from dagster import Bool, Field, IntSource, String, StringSource, Array
 
 from .types import (
     BQCreateDisposition,
@@ -337,7 +334,9 @@ def define_bigquery_load_config():
         is_required=False,
     )
 
-    schema = Field(List[SchemaField], description="Schema of the destination table.", is_required=False)
+    schema = Field(
+        Array(inner_type=dict), description="Schema of the destination table.", is_required=False
+    )
 
     skip_leading_rows = Field(
         IntSource,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -12,6 +12,7 @@ from .types import (
     BQPriority,
     BQSchemaUpdateOption,
     BQSourceFormat,
+    BQTableSchema,
     BQWriteDisposition,
     Dataset,
     Table,
@@ -334,6 +335,12 @@ def define_bigquery_load_config():
         is_required=False,
     )
 
+    schema = Field(
+        BQTableSchema,
+        description="Schema of the destination table.",
+        is_required=False
+    )
+
     skip_leading_rows = Field(
         IntSource,
         description="Number of rows to skip when reading data (CSV only).",
@@ -366,7 +373,7 @@ def define_bigquery_load_config():
             "max_bad_records": max_bad_records,
             "null_marker": null_marker,
             "quote_character": quote_character,
-            # TODO: schema
+            "schema": schema,
             "schema_update_options": sf["schema_update_options"],
             "skip_leading_rows": skip_leading_rows,
             "source_format": source_format,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/types.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/types.py
@@ -1,8 +1,7 @@
 import re
 from enum import Enum as PyEnum
-from typing import Dict, List
 
-from dagster import DagsterType, Enum, EnumValue
+from dagster import Enum, EnumValue
 from dagster.config import ConfigScalar, ConfigScalarKind, PostProcessingError
 from google.cloud.bigquery.job import (
     CreateDisposition,
@@ -12,7 +11,6 @@ from google.cloud.bigquery.job import (
     SourceFormat,
     WriteDisposition,
 )
-from google.cloud.bigquery.schema import SchemaField
 
 
 class BigQueryLoadSource(PyEnum):
@@ -117,17 +115,6 @@ def _is_valid_table(config_value):
     )
 
 
-def _is_valid_table_schema(_, value) -> bool:
-    if not isinstance(value, list):
-        return False
-
-    for col in value:
-        if not isinstance(col, SchemaField):
-            return False
-
-    return True
-
-
 class _Dataset(ConfigScalar):
     def __init__(self):
         super(_Dataset, self).__init__(
@@ -169,10 +156,3 @@ Dataset = _Dataset()
 
 class BigQueryError(Exception):
     pass
-
-
-BQTableSchema = DagsterType(
-    name="BigQueryTableSchema",
-    description="A BigQuery table schema in the format described here - https://cloud.google.com/bigquery/docs/schemas#specifying_a_json_schema_file ",
-    type_check_fn=_is_valid_table_schema,
-)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/types.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/types.py
@@ -124,7 +124,8 @@ def _is_valid_table_schema(_, value) -> bool:
     for col in value:
         if not isinstance(col, SchemaField):
             return False
-        return True
+
+    return True
 
 
 class _Dataset(ConfigScalar):

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/types.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/types.py
@@ -172,7 +172,6 @@ class BigQueryError(Exception):
 
 BQTableSchema = DagsterType(
     name="BigQueryTableSchema",
-    description="A BigQuery table schema in the format described here - "
-                "https://cloud.google.com/bigquery/docs/schemas#specifying_a_json_schema_file ",
-    type_check_fn=_is_valid_table_schema
+    description="A BigQuery table schema in the format described here - https://cloud.google.com/bigquery/docs/schemas#specifying_a_json_schema_file ",
+    type_check_fn=_is_valid_table_schema,
 )


### PR DESCRIPTION
This PR adds the `schema` parameter to the BigQuery load job config, used by a few solids in the `dagster_gcp` library, allowing users to explicitly specify a table schema when loading data to BQ. 

Checks that the parameter is of type `Array(dict)` and leaves further validation of the schema to the `google-cloud-bigquery` library.