### PR TITLE
Disable alter_sys_path on background threads.

### DIFF
--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -474,6 +474,11 @@ def find_free_port():
 
 @contextlib.contextmanager
 def alter_sys_path(to_add, to_remove):
+    # If this is a non-main thread, bail out because global mutation of sys.path causes race conditions.
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
     to_restore = [path for path in sys.path]
 
     # remove paths


### PR DESCRIPTION
This prevents issues in threaded launchers because sys.path is a global value so changing it on one thread changes it for all. This leads to race conditions.

I've been running it for a week now and things seem to be much more stable. There isn't a threaded launcher in Dagster itself, so this should have no impact for normal users.