### PR TITLE
Add the ECSClient methods that will be needed to create an ECSRunLauncher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/client.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/client.py
@@ -25,6 +25,18 @@ class ECSClient:
         self.max_polls = max_polls
         self.polling_interval = polling_interval
 
+    def set_task(self, **kwargs):
+        """Set an ECS Task Definition.
+
+        Args:
+
+        https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html
+
+        Returns:
+            str: The Task Definition ARN
+        """
+        return self.client.register_task_definition(**kwargs)["taskDefinition"]["taskDefinitionArn"]
+
     def run_task(self, task_definition):
         """Synchronously run a task definition on ECS.
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/client.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/client.py
@@ -64,6 +64,47 @@ class ECSClient:
         """
         task_arn = self._start_task(task_definition)
 
+        tasks = self._poll_until_stopped(task_arn)
+
+        stop_codes = [task.get("stopCode") for task in tasks]
+        errors = [stop_code for stop_code in stop_codes if stop_code != "EssentialContainerExited"]
+        if any(errors):
+            raise ECSError(";".join(errors))
+
+    def stop_task(self, task_arn):
+        """Synchronously stop a running task. This method will call ECS StopTask and then
+            poll until the task reaches a STOPPED status.
+
+        Args:
+            task_arn (str): The Task ARN.
+
+        Returns:
+            bool: True if the task stops; False if the task was already stopped.
+        """
+        try:
+            response = self.client.stop_task(cluster=self.cluster, task=task_arn)
+        except Exception as e:
+            raise ECSError(e)
+
+        if response["task"]["lastStatus"] == "STOPPED":
+            return False
+
+        self._poll_until_stopped(task_arn)
+        return True
+
+    def _start_task(self, task_definition):
+        response = self.client.run_task(
+            count=1,
+            launchType="FARGATE",
+            taskDefinition=task_definition,
+            cluster=self.cluster,
+            networkConfiguration={
+                "awsvpcConfiguration": {"subnets": self.subnets, "assignPublicIp": "ENABLED"}
+            },
+        )
+        return response["tasks"][0]["taskArn"]
+
+    def _poll_until_stopped(self, task_arn):
         retries = self.max_polls
         while retries > 0:
             response = self.client.describe_tasks(cluster=self.cluster, tasks=[task_arn])
@@ -78,22 +119,7 @@ class ECSClient:
         if retries <= 0:
             raise ECSTimeout()
 
-        stop_codes = [task.get("stopCode") for task in tasks]
-        errors = [stop_code for stop_code in stop_codes if stop_code != "EssentialContainerExited"]
-        if any(errors):
-            raise ECSError(";".join(errors))
-
-    def _start_task(self, task_definition):
-        response = self.client.run_task(
-            count=1,
-            launchType="FARGATE",
-            taskDefinition=task_definition,
-            cluster=self.cluster,
-            networkConfiguration={
-                "awsvpcConfiguration": {"subnets": self.subnets, "assignPublicIp": "ENABLED"}
-            },
-        )
-        return response["tasks"][0]["taskArn"]
+        return tasks
 
 
 class FakeECSClient(ECSClient):
@@ -150,6 +176,43 @@ class FakeECSClient(ECSClient):
 
         self.stubber.deactivate()
         self.stubber.assert_no_pending_responses()
+
+    def stop_task(self, task_arn, expected_statuses=None):  # pylint: disable=arguments-differ
+        """Fake for stop; stubs the expected ECS endpoints and polls against
+        the provided expected container statuses until all containers are STOPPED.
+
+        Args:
+            task_arn (str): The Task ARN.
+            expected_statuses (list[str]): The expected container satuses:
+                https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html
+                Defaults to initially RUNNING and then STOPPED.
+
+        Returns:
+            bool: True if the task stops; False if the task was already stopped.
+        """
+        if not expected_statuses:
+            expected_statuses = ["RUNNING", "STOPPED"]
+        self.stubber.activate()
+
+        self.stubber.add_response(
+            method="stop_task",
+            service_response={"task": {"lastStatus": expected_statuses.pop(0)}},
+            expected_params={"task": task_arn, "cluster": self.cluster},
+        )
+
+        for status in expected_statuses:
+            self.stubber.add_response(
+                method="describe_tasks",
+                service_response={"tasks": [{"lastStatus": status}]},
+                expected_params={"cluster": self.cluster, "tasks": [task_arn]},
+            )
+
+        result = super().stop_task(task_arn)
+
+        self.stubber.deactivate()
+        self.stubber.assert_no_pending_responses()
+
+        return result
 
     def _stub_start_task(self, task_definition):
         task = f"arn:aws:ecs:us-east-2:0123456789:task/{uuid.uuid4()}"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_client.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_client.py
@@ -1,7 +1,7 @@
 # pylint: disable=redefined-outer-name
 import boto3
 import pytest
-from dagster_aws.ecs.client import ECSError, ECSTimeout, FakeECSClient
+from dagster_aws.ecs.client import ECSClient, ECSError, ECSTimeout, FakeECSClient
 from moto import mock_ec2, mock_ecs
 
 
@@ -99,3 +99,25 @@ def test_run_task_fails(mock_ecs_client, mock_ecs_cluster, mock_ecs_task_definit
     client = FakeECSClient(cluster=mock_ecs_cluster, subnets=mock_subnets, client=mock_ecs_client)
     with pytest.raises(ECSError, match="OutOfMemoryError"):
         client.run_task(mock_ecs_task_definition, expected_stop_code="OutOfMemoryError")
+
+
+def test_stop_task(mock_ecs_client, mock_ecs_cluster, mock_subnets):
+    client = FakeECSClient(cluster=mock_ecs_cluster, subnets=mock_subnets, client=mock_ecs_client)
+
+    assert client.stop_task("running task arn")
+    assert not client.stop_task("already stopped task arn", expected_statuses=["STOPPED"])
+
+
+def test_stop_task_timeout(mock_ecs_client, mock_ecs_cluster, mock_subnets):
+    client = FakeECSClient(
+        cluster=mock_ecs_cluster, client=mock_ecs_client, subnets=mock_subnets, max_polls=1
+    )
+    with pytest.raises(ECSTimeout):
+        client.stop_task("task arn", expected_statuses=["RUNNING", "RUNNING"])
+
+
+def test_stop_task_does_not_exist(mock_ecs_client, mock_ecs_cluster, mock_subnets):
+    # Use a real ECSClient so the response stubs aren't added
+    client = ECSClient(cluster=mock_ecs_cluster, subnets=mock_subnets, client=mock_ecs_client)
+    with pytest.raises(ECSError):
+        client.stop_task("task arn")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_client.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_client.py
@@ -44,6 +44,22 @@ def mock_ecs_task_definition(mock_ecs_client):
     return task_definition.get("taskDefinition").get("taskDefinitionArn")
 
 
+def test_set_task(mock_ecs_client, mock_ecs_cluster, mock_subnets):
+    client = FakeECSClient(cluster=mock_ecs_cluster, client=mock_ecs_client, subnets=mock_subnets)
+    definition = dict(
+        family="dagster",
+        requiresCompatibilities=["FARGATE"],
+        containerDefinitions=[{"name": "HelloWorld", "image": "hello-world:latest", "cpu": 256},],
+        networkMode="awsvpc",
+        cpu="256",
+        memory="512",
+    )
+
+    assert not mock_ecs_client.list_task_definitions()["taskDefinitionArns"]
+    task_definition_arn = client.set_task(**definition)
+    assert mock_ecs_client.list_task_definitions()["taskDefinitionArns"] == [task_definition_arn]
+
+
 @pytest.mark.parametrize(
     "expected_statuses",
     [

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_client.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_client.py
@@ -60,6 +60,12 @@ def test_set_task(mock_ecs_client, mock_ecs_cluster, mock_subnets):
     assert mock_ecs_client.list_task_definitions()["taskDefinitionArns"] == [task_definition_arn]
 
 
+def test_start_task(mock_ecs_client, mock_ecs_cluster, mock_ecs_task_definition, mock_subnets):
+    client = FakeECSClient(cluster=mock_ecs_cluster, client=mock_ecs_client, subnets=mock_subnets)
+    task_arn = client.start_task(mock_ecs_task_definition)
+    assert client.start_task(mock_ecs_task_definition) != task_arn
+
+
 @pytest.mark.parametrize(
     "expected_statuses",
     [


### PR DESCRIPTION
These additional methods represent the changes to ECSClient that we'll likely need to create a simple ECSRunLauncher (particularly the ability to launch a run and to terminate a run).