### PR TITLE
Don't pass instance to launch_run

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1316,7 +1316,7 @@ class DagsterInstance:
         run = self.get_run_by_id(run_id)
 
         try:
-            self._run_launcher.launch_run(self, run, external_pipeline=external_pipeline)
+            self._run_launcher.launch_run(run, external_pipeline=external_pipeline)
         except:
             error = serializable_error_info_from_exc_info(sys.exc_info())
             self.report_engine_event(

--- a/python_modules/dagster/dagster/core/launcher/base.py
+++ b/python_modules/dagster/dagster/core/launcher/base.py
@@ -5,7 +5,7 @@ from dagster.core.instance import MayHaveInstanceWeakref
 
 class RunLauncher(ABC, MayHaveInstanceWeakref):
     @abstractmethod
-    def launch_run(self, instance, run, external_pipeline):
+    def launch_run(self, run, external_pipeline):
         """Launch a run.
 
         This method should begin the execution of the specified run, and may emit engine events.
@@ -15,7 +15,6 @@ class RunLauncher(ABC, MayHaveInstanceWeakref):
         not be invoked directly, but should be invoked through ``DagsterInstance.launch_run()``.
 
         Args:
-            instance (DagsterInstance): The instance in which the run has been created.
             run (PipelineRun): The PipelineRun to launch.
             external_pipeline (ExternalPipeline): The pipeline that is being launched (currently
              optional during migration)

--- a/python_modules/dagster/dagster/core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/core/launcher/default_run_launcher.py
@@ -50,7 +50,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return DefaultRunLauncher(inst_data=inst_data)
 
-    def launch_run(self, instance, run, external_pipeline):
+    def launch_run(self, run, external_pipeline):
         check.inst_param(run, "run", PipelineRun)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
 

--- a/python_modules/dagster/dagster/core/launcher/sync_in_memory_run_launcher.py
+++ b/python_modules/dagster/dagster/core/launcher/sync_in_memory_run_launcher.py
@@ -31,7 +31,7 @@ class SyncInMemoryRunLauncher(RunLauncher, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return SyncInMemoryRunLauncher(inst_data=inst_data)
 
-    def launch_run(self, instance, run, external_pipeline):
+    def launch_run(self, run, external_pipeline):
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         recon_pipeline = recon_pipeline_from_origin(external_pipeline.get_python_origin())
         execute_run(recon_pipeline, run, self._instance)

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -272,7 +272,7 @@ class ExplodingRunLauncher(RunLauncher, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return ExplodingRunLauncher(inst_data=inst_data)
 
-    def launch_run(self, instance, run, external_pipeline):
+    def launch_run(self, run, external_pipeline):
         raise NotImplementedError("The entire purpose of this is to throw on launch")
 
     def join(self, timeout=30):
@@ -292,8 +292,7 @@ class MockedRunLauncher(RunLauncher, ConfigurableClass):
 
         super().__init__()
 
-    def launch_run(self, instance, run, external_pipeline):
-        check.inst_param(instance, "instance", DagsterInstance)
+    def launch_run(self, run, external_pipeline):
         check.inst_param(run, "run", PipelineRun)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         check.invariant(run.status == PipelineRunStatus.STARTING)

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -148,8 +148,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
     def inst_data(self):
         return self._inst_data
 
-    def launch_run(self, instance, run, external_pipeline):
-        check.inst_param(instance, "instance", DagsterInstance)
+    def launch_run(self, run, external_pipeline):
         check.inst_param(run, "run", PipelineRun)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -7,7 +7,6 @@ from dagster.config.validate import process_config
 from dagster.core.events import EngineEventData
 from dagster.core.execution.retries import RetryMode
 from dagster.core.host_representation import ExternalPipeline
-from dagster.core.instance import DagsterInstance
 from dagster.core.launcher import RunLauncher
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster.serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -173,7 +173,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             run_config=run_config,
             tags=tags,
         )
-        celery_k8s_run_launcher.launch_run(instance, run, fake_external_pipeline)
+        celery_k8s_run_launcher.launch_run(run, fake_external_pipeline)
 
     # Check that user defined k8s config was passed down to the k8s job.
     mock_method_calls = mock_k8s_client_batch_api.method_calls

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -81,7 +81,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             )
         return client
 
-    def launch_run(self, instance, run, external_pipeline):
+    def launch_run(self, run, external_pipeline):
         check.inst_param(run, "run", PipelineRun)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
 
@@ -107,7 +107,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             ExecuteRunArgs(
                 pipeline_origin=external_pipeline.get_python_origin(),
                 pipeline_run_id=run.run_id,
-                instance_ref=instance.get_ref(),
+                instance_ref=_instance.get_ref(),
             )
         )
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -107,7 +107,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             ExecuteRunArgs(
                 pipeline_origin=external_pipeline.get_python_origin(),
                 pipeline_run_id=run.run_id,
-                instance_ref=_instance.get_ref(),
+                instance_ref=self._instance.get_ref(),
             )
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -211,7 +211,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             env_secrets=check.opt_list_param(self._env_secrets, "env_secrets", of_type=str),
         )
 
-    def launch_run(self, instance, run, external_pipeline):
+    def launch_run(self, run, external_pipeline):
         check.inst_param(run, "run", PipelineRun)
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -55,7 +55,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
         pipeline_name = "demo_pipeline"
         run = create_run_for_test(instance, pipeline_name=pipeline_name, tags=tags)
         k8s_run_launcher.register_instance(instance)
-        k8s_run_launcher.launch_run(None, run, fake_external_pipeline)
+        k8s_run_launcher.launch_run(run, fake_external_pipeline)
 
     # Check that user defined k8s config was passed down to the k8s job.
     mock_method_calls = mock_k8s_client_batch_api.method_calls


### PR DESCRIPTION
The `RunLauncher` abstract base class requires implementing classes to pass `instance` to `.launch_run()`. Few of them do anything with the argument (other than the occasional type check) because they've mostly been updated to instead reference `._instance` that gets set during `RunLauncher.initialize()`.

This leads to a number of confusing tests where `None` is passed for the `instance`. I've started implementing a new `RunLauncher` for ECS and I think it makes sense to simplify the interface rather than to introduce another place where the argument is passed but unused.

The only `RunLauncher` with a functional change in this commit should be to `DockerRunLauncher`; previously it was the only one still using `instance` but now it has been updated to instead use `._instance`.