### PR TITLE
Pin alembic to <1.5.0

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
             "coloredlogs>=6.1, <=14.0",
             "PyYAML",
             # core (not explicitly expressed atm)
-            "alembic>=1.2.1",
+            "alembic>=1.2.1, <1.5.0",
             "croniter>=0.3.34",
             "grpcio>=1.32.0",  # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
             "grpcio-health-checking>=1.32.0",


### PR DESCRIPTION
Tests are passing on 1.4.3 but failing on 1.5.0:

Passing:

https://dev.azure.com/elementl/dagster/_build/results?buildId=10797&view=logs&j=cb0ea8d1-4def-53c9-8055-ed27ea3e056a&t=5edda9e6-5cdd-5945-c910-f5778afde426

Failing:

https://dev.azure.com/elementl/dagster/_build/results?buildId=10798&view=logs&j=cb0ea8d1-4def-53c9-8055-ed27ea3e056a&t=5edda9e6-5cdd-5945-c910-f5778afde426

I think this is the only reason #3551 is failing; I'm still trying to track down why that CI run picked up a newer version of alembic since both 1.4.3 and 1.5.0 are pretty old. In the meantime, this should hopefully keep CI green.