### PR TITLE
Fix fs_file_cache not passing overwrite config value

### DIFF
--- a/python_modules/dagster/dagster/core/storage/file_cache.py
+++ b/python_modules/dagster/dagster/core/storage/file_cache.py
@@ -65,7 +65,9 @@ class FSFileCache(FileCache):
 def fs_file_cache(init_context):
     target_folder = init_context.resource_config["target_folder"]
 
+    overwrite = init_context.resource_config["overwrite"]
+
     if not os.path.exists(target_folder):
         mkdir_p(target_folder)
 
-    return FSFileCache(target_folder=target_folder, overwrite=False)
+    return FSFileCache(target_folder=target_folder, overwrite=overwrite)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_file_cache.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_file_cache.py
@@ -1,8 +1,8 @@
 import io
 import os
 
-from dagster import LocalFileHandle
-from dagster.core.storage.file_cache import FSFileCache
+from dagster import LocalFileHandle, ModeDefinition, execute_solid, solid
+from dagster.core.storage.file_cache import FSFileCache, fs_file_cache
 from dagster.utils.temp_file import get_temp_dir
 
 
@@ -31,3 +31,32 @@ def test_empty_file_cache():
     with get_temp_dir() as temp_dir:
         file_cache = FSFileCache(temp_dir)
         assert not file_cache.has_file_object("kjdfkd")
+
+
+def test_file_cache_overwrite():
+    """Test changing overwrite config from default (False) value is propogated"""
+
+    @solid(
+        required_resource_keys={"file_cache"},
+    )
+    def file_cache_overwrite(context):
+        return context.resources.file_cache.overwrite
+
+    result = execute_solid(
+        file_cache_overwrite,
+        ModeDefinition(resource_defs={"file_cache": fs_file_cache}),
+        run_config={
+            "solids": {"file_cache_overwrite": {}},
+            "resources": {
+                "file_cache": {
+                    "config": {
+                        "overwrite": True,
+                        "target_folder": "test_folder",
+                    }
+                }
+            },
+        },
+    )
+
+    assert result.success
+    assert result.output_value()


### PR DESCRIPTION
The file_cache does not pass through the overwrite value set in the resource config at present: it only defaults to False.  

This fix allows the overwrite value to be set correctly within a solid's file_cache resource config

Signed-off-by: Richard Whitefoot <mouseholdonline@gmail.com>