### PR TITLE
Fix for the example (access to ADL client)

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -37,7 +37,7 @@ def adls2_resource(context):
 
             @solid(required_resource_keys={'adls2'})
             def example_adls2_solid(context):
-                return list(context.resources.adls2.list_file_systems())
+                return list(context.resources.adls2.adls2_client.list_file_systems())
 
             result = execute_solid(
                 example_adls2_solid,


### PR DESCRIPTION
There was a missing step in the provided example for being able to list the files on ADL. Maybe an example showing adls2_file_manage would be useful?