### PR TITLE
try to remove legacy nbconvert pinning

### DIFF
--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
             # https://github.com/nteract/papermill/issues/519,
             # https://github.com/ipython/ipykernel/issues/568
             "ipykernel>=4.9.0,!=5.4.0,!=5.4.1",
-            "nbconvert>=5.4.0,<6.0.0",
+            "nbconvert>=5.4.0,<7.0.0",
             "nteract-scrapbook>=0.2.0",
             "papermill>=1.0.0,<2.0.0",
         ],


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
I wish to have latest nbconvert, so this is to see where it fails




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.