### PR TITLE
Fix dagster-postgres not copy alembic directory when packaging

### DIFF
--- a/python_modules/libraries/dagster-postgres/MANIFEST.in
+++ b/python_modules/libraries/dagster-postgres/MANIFEST.in
@@ -1,4 +1,2 @@
 include LICENSE
-graft dagster_postgres/event_log/alembic
-graft dagster_postgres/run_storage/alembic
-graft dagster_postgres/schedule_storage/alembic
+graft dagster_postgres/alembic


### PR DESCRIPTION
## Summary
In dagster 0.10.8, alembic directory doesn't copy to dagster-postgres
which's cause `dagster instance migrate` fail. Fixes by change
MANIFEST.in to include dagster-postgres/alembic directory.




## Test Plan
Run `python3 setup.py build` in `dagster-postgres` directory. It should see alembic in `build/lib/dagster-postgres` directory.




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.