### PR TITLE
Check that the environment is production before logging a pageview

### DIFF
--- a/docs/next/pages/_app.tsx
+++ b/docs/next/pages/_app.tsx
@@ -50,7 +50,9 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   useEffect(() => {
     const handleRouteChange = (url) => {
-      gtag.pageview(url);
+      if (process.env.NODE_ENV === "production") {
+        gtag.pageview(url);
+      }
     };
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => {


### PR DESCRIPTION
## Summary
Fixes https://github.com/dagster-io/dagster/issues/3821

When running the docs site and navigating, an error is thrown showing the following error:
![image](https://user-images.githubusercontent.com/225131/110753112-1cc50c80-8281-11eb-9f57-2297a7813fd8.png)

```
Uncaught (in promise) TypeError: window.gtag is not a function
    at Module.pageview (gtag.js?99a7:5)
    at handleRouteChange (_app.tsx?7216:53)
    at eval (mitt.ts?f4ec:42)
    at Array.map (<anonymous>)
    at Object.emit (mitt.ts?f4ec:41)
    at Router._callee$ (router.ts?35b8:1121)
    at tryCatch (runtime.js?96cf:63)
    at Generator.invoke [as _invoke] (runtime.js?96cf:293)
    at Generator.eval [as next] (runtime.js?96cf:118)
    at asyncGeneratorStep (asyncToGenerator.js?a954:3)
    at _next (asyncToGenerator.js?a954:25)
```

I believe it's because of https://github.com/dagster-io/dagster/blob/master/docs/next/pages/_document.js#L10 , where it's checking it's running in production.

## Reproduction
1. Run the docs site as per instructions
2. Access a page


## Test Plan
1. I have tested in development mode and it seems to work, not sure how to test properly in a production setting? Should I turn it on and see if the event is logged?

## Checklist
1. Check that the documentation site works in dev
2. Check that the documentation site works in production (todo)

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.