### PR TITLE
Unify Dask cluster and client configuration and instantiation

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -131,7 +131,7 @@ def create_from_config(config):
         # Get the module and class information from DaskClusterTypes, and instantiate
         # the cluster object.
         else:
-            cluster_meta = DaskClusterType.get(cluster_type, None)
+            cluster_meta = DaskClusterTypes.get(cluster_type, None)
             if not cluster_meta:
                 raise ValueError(f'Unknown cluster type "{cluster_type}".')
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -1,4 +1,4 @@
-from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, check
+from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, StringSource, check
 from dask.distributed import Client
 
 # Map of the possible Dask cluster types and their associated classes.

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -125,6 +125,7 @@ def create_from_config(config):
 
         # Deprecated option for specifying an existing cluster by its scheduler address.
         if cluster_type == "existing":
+            cluster = None
             client_config["address"] = cluster_opts["address"]
 
         # Get the module and class information from DaskClusterTypes, and instantiate

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -88,12 +88,20 @@ DaskConfigSchema = {
     "cluster": Field(
         Selector(
             {
-                key: Field(
-                    Permissive(),
-                    is_required=False,
-                    description=f"{meta['name']} cluster config. Requires {meta['module']}.",
-                )
-                for key, meta in DaskClusterTypes.items()
+                **{
+                    key: Field(
+                        Permissive(),
+                        is_required=False,
+                        description=f"{meta['name']} cluster config. Requires {meta['module']}.",
+                    )
+                    for key, meta in DaskClusterTypes.items()
+                },
+                **{
+                    "existing": Field(
+                        {"address": StringSource},
+                        description="Connect to an existing scheduler (deprecated, use client address config).",
+                    )
+                },
             }
         ),
         description="Create a Dask cluster. Will be passed as the client address.",

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -1,0 +1,102 @@
+from dagster import Bool, Int, String
+from dagster import Field, Permissive, Selector, Shape
+
+
+# Map of the possible Dask cluster types and their associated classes.
+# Users must install the modules associated with the cluster types they
+# want to use (e.g., dask_cloudprovider for ecs).
+DaskClusterTypes = {
+    key: dict(zip(("name", "module", "class"), values))
+    for key, values in {
+        "local": ("Local", "dask.distributed", "LocalCluster"),
+        "yarn": ("YARN", "dask_yarn", "YarnCluster"),
+        "ssh": ("SSH", "dask.distributed", "SSHCluster"),
+        "pbs": ("PBS", "dask_jobqueue", "PBSCluster"),
+        "moab": ("Moab", "dask_jobqueue", "MoabCluster"),
+        "sge": ("SGE", "dask_jobqueue", "SGECluster"),
+        "lsf": ("LSF", "dask_jobqueue", "LSFCluster"),
+        "slurm": ("SLURM", "dask_jobqueue", "SLURMCluster"),
+        "oar": ("OAR", "dask_jobqueue", "OARCluster"),
+        "kube": ("Kubernetes", "dask_kubernetes", "KubeCluster"),
+        "azureml": ("Azure ML", "dask_cloudprovider", "AzureMLCluster"),
+        "ecs": ("AWS ECS", "dask_cloudprovider", "ECSCluster"),
+        "fargate": ("AWS ECS on Fargate", "dask_cloudprovider", "FargateCluster"),
+    }.items()
+}
+
+# Common config schema for specifying a Dask client and/or cluster.
+DaskConfigSchema = {
+    # The client config fields correspond to the init arguments for the Dask distributed.Client class.
+    # https://distributed.dask.org/en/latest/api.html#distributed.Client
+    "client": Field(
+        Permissive(
+            {
+                "address": Field(
+                    String,
+                    description="Address of a Scheduler server. A Cluster object will be passed in if a cluster config is provided.",
+                    is_required=False,
+                ),
+                "timeout": Field(
+                    Int,
+                    description="Timeout duration for initial connection to the scheduler.",
+                    is_required=False,
+                ),
+                "set_as_default": Field(
+                    Bool,
+                    description="Claim this scheduler as the global dask scheduler.",
+                    is_required=False,
+                ),
+                "scheduler_file": Field(
+                    String,
+                    description="Path to a file with scheduler information, if available.",
+                    is_required=False,
+                ),
+                "security": Field(
+                    Bool,
+                    description="Optional security information.",
+                    is_required=False,
+                ),
+                "asynchronous": Field(
+                    Bool,
+                    description="Set to True if using this client within async/await functions.",
+                    is_required=False,
+                ),
+                "name": Field(
+                    String,
+                    description="Gives the client a name that will be included in logs generated on the scheduler.",
+                    is_required=False,
+                ),
+                "direct_to_workers": Field(
+                    Bool,
+                    description="Whether or not to connect directly to the workers.",
+                    is_required=False,
+                ),
+                "heartbeat_interval": Field(
+                    Int,
+                    description="Time in milliseconds between heartbeats to scheduler.",
+                    is_required=False,
+                ),
+            }
+        ),
+        description="Dask distributed client options.",
+        is_required=False,
+    ),
+
+    # The cluster config fields consist of a cluster type keys and permissive dicts of key-values
+    # that will be passed in to the corresponding cluster class. Only a single cluster type may be
+    # specified at a time.
+    "cluster": Field(
+        Selector(
+            {
+                key: Field(
+                    Permissive(),
+                    is_required=False,
+                    description=f"{meta['name']} cluster config. Requires {meta['module']}.",
+                )
+                for key, meta in DaskClusterTypes.items()
+            }
+        ),
+        description="Create a Dask cluster. Will be passed as the client address.",
+        is_required=False,
+    ),
+}

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -123,10 +123,14 @@ def create_from_config(config):
         # of a single dict member because the `cluster` field is defined as a selector.
         cluster_type, cluster_opts = next(iter(cluster_config.items()))
 
-        # Deprecated option for specifying an existing cluster by its scheduler address.
+        # Specifying an "existing" cluster type is deprecated.
+        # https://github.com/dagster-io/dagster/issues/3854
         if cluster_type == "existing":
             cluster = None
             client_config["address"] = cluster_opts["address"]
+            warnings.warn(
+                "Specifying cluster:existing:address is deprecated. Use client:address: instead."
+            )
 
         # Get the module and class information from DaskClusterTypes, and instantiate
         # the cluster object.

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -1,3 +1,5 @@
+import warnings
+
 from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, StringSource, check
 from dask.distributed import Client
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/config.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/config.py
@@ -1,8 +1,5 @@
-from dagster import Bool, Int, String
-from dagster import Field, Permissive, Selector, Shape
-from dagster import check
+from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, check
 from dask.distributed import Client
-
 
 # Map of the possible Dask cluster types and their associated classes.
 # Users must install the modules associated with the cluster types they
@@ -84,7 +81,6 @@ DaskConfigSchema = {
         description="Dask distributed client options.",
         is_required=False,
     ),
-
     # The cluster config fields consist of a cluster type keys and permissive dicts of key-values
     # that will be passed in to the corresponding cluster class. Only a single cluster type may be
     # specified at a time.

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -1,6 +1,6 @@
 import dask
 import dask.distributed
-from dagster import Executor, Field, Permissive, Selector, StringSource, check, seven
+from dagster import Executor, check, seven
 from dagster.core.definitions.executor import check_cross_process_constraints, executor
 from dagster.core.errors import raise_execution_interrupts
 from dagster.core.events import DagsterEvent
@@ -11,56 +11,15 @@ from dagster.core.execution.retries import RetryMode
 from dagster.core.instance import DagsterInstance
 from dagster.utils import frozentags, iterate_with_context
 
+from .config import DaskConfigSchema
+
 # Dask resource requirements are specified under this key
 DASK_RESOURCE_REQUIREMENTS_KEY = "dagster-dask/resource_requirements"
 
 
 @executor(
     name="dask",
-    config_schema={
-        "cluster": Field(
-            Selector(
-                {
-                    "existing": Field(
-                        {"address": StringSource},
-                        description="Connect to an existing scheduler.",
-                    ),
-                    "local": Field(
-                        Permissive(), is_required=False, description="Local cluster configuration."
-                    ),
-                    "yarn": Field(
-                        Permissive(), is_required=False, description="YARN cluster configuration."
-                    ),
-                    "ssh": Field(
-                        Permissive(), is_required=False, description="SSH cluster configuration."
-                    ),
-                    "pbs": Field(
-                        Permissive(), is_required=False, description="PBS cluster configuration."
-                    ),
-                    "moab": Field(
-                        Permissive(), is_required=False, description="Moab cluster configuration."
-                    ),
-                    "sge": Field(
-                        Permissive(), is_required=False, description="SGE cluster configuration."
-                    ),
-                    "lsf": Field(
-                        Permissive(), is_required=False, description="LSF cluster configuration."
-                    ),
-                    "slurm": Field(
-                        Permissive(), is_required=False, description="SLURM cluster configuration."
-                    ),
-                    "oar": Field(
-                        Permissive(), is_required=False, description="OAR cluster configuration."
-                    ),
-                    "kube": Field(
-                        Permissive(),
-                        is_required=False,
-                        description="Kubernetes cluster configuration.",
-                    ),
-                }
-            )
-        )
-    },
+    config_schema=DaskConfigSchema,
 )
 def dask_executor(init_context):
     """Dask-based executor.

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -13,7 +13,6 @@ from dagster.utils import frozentags, iterate_with_context
 
 from .config import DaskConfigSchema, create_from_config
 
-
 # Dask resource requirements are specified under this key
 DASK_RESOURCE_REQUIREMENTS_KEY = "dagster-dask/resource_requirements"
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -1,24 +1,7 @@
-from dagster import Bool, Field, Int, Permissive, Selector, Shape, String, resource
+from dagster import resource
 from dask.distributed import Client
 
-DaskClusterTypes = {
-    key: dict(zip(("name", "module", "class"), values))
-    for key, values in {
-        "local": ("Local", "dask.distributed", "LocalCluster"),
-        "yarn": ("YARN", "dask_yarn", "YarnCluster"),
-        "ssh": ("SSH", "dask.distributed", "SSHCluster"),
-        "pbs": ("PBS", "dask_jobqueue", "PBSCluster"),
-        "moab": ("Moab", "dask_jobqueue", "MoabCluster"),
-        "sge": ("SGE", "dask_jobqueue", "SGECluster"),
-        "lsf": ("LSF", "dask_jobqueue", "LSFCluster"),
-        "slurm": ("SLURM", "dask_jobqueue", "SLURMCluster"),
-        "oar": ("OAR", "dask_jobqueue", "OARCluster"),
-        "kube": ("Kubernetes", "dask_kubernetes", "KubeCluster"),
-        "azureml": ("Azure ML", "dask_cloudprovider", "AzureMLCluster"),
-        "ecs": ("AWS ECS", "dask_cloudprovider", "ECSCluster"),
-        "fargate": ("AWS ECS on Fargate", "dask_cloudprovider", "FargateCluster"),
-    }.items()
-}
+from .config import DaskConfigSchema
 
 
 class DaskResource:
@@ -67,77 +50,7 @@ class DaskResource:
 
 @resource(
     description="Dask Client resource.",
-    config_schema=Shape(
-        {
-            "client": Field(
-                Permissive(
-                    {
-                        "address": Field(
-                            String,
-                            description="Address of a Scheduler server.",
-                            is_required=False,
-                        ),
-                        "timeout": Field(
-                            Int,
-                            description="Timeout duration for initial connection to the scheduler.",
-                            is_required=False,
-                        ),
-                        "set_as_default": Field(
-                            Bool,
-                            description="Claim this scheduler as the global dask scheduler.",
-                            is_required=False,
-                        ),
-                        "scheduler_file": Field(
-                            String,
-                            description="Path to a file with scheduler information, if available.",
-                            is_required=False,
-                        ),
-                        "security": Field(
-                            Bool,
-                            description="Optional security information.",
-                            is_required=False,
-                        ),
-                        "asynchronous": Field(
-                            Bool,
-                            description="Set to True if using this client within async/await functions.",
-                            is_required=False,
-                        ),
-                        "name": Field(
-                            String,
-                            description="Name of client that will be included in logs generated on the scheduler.",
-                            is_required=False,
-                        ),
-                        "direct_to_workers": Field(
-                            Bool,
-                            description="Whether to connect directly to the workers.",
-                            is_required=False,
-                        ),
-                        "heartbeat_interval": Field(
-                            Int,
-                            description="Time in milliseconds between heartbeats to scheduler.",
-                            is_required=False,
-                        ),
-                    }
-                ),
-                description="Dask distributed client options.",
-                is_required=False,
-            ),
-            "cluster": Field(
-                Selector(
-                    {
-                        key: Field(
-                            Permissive(),
-                            is_required=False,
-                            description=f"{meta['name']} cluster config. Requires {meta['module']}.",
-                        )
-                        for key, meta in DaskClusterTypes.items()
-                    }
-                ),
-                description="Create a Dask cluster. Will be passed as the client address.",
-                is_required=False,
-            ),
-        }
-    ),
+    config_schema=DaskConfigSchema,
 )
 def dask_resource(context):
     res = DaskResource(context)

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -1,36 +1,11 @@
 from dagster import resource
-from dask.distributed import Client
 
-from .config import DaskConfigSchema
+from .config import DaskConfigSchema, create_from_config
 
 
 class DaskResource:
     def __init__(self, context):
-        # Create a Dask cluster if a cluster config is specified.
-        # This will be passed as the address value to the Client.
-        cluster_config = context.resource_config.get("cluster", None)
-        if cluster_config:
-            from importlib import import_module
-
-            cluster_type, cluster_opts = next(iter(cluster_config.items()))
-            cluster_meta = DaskClusterTypes.get(cluster_type, None)
-            if not cluster_meta:
-                raise ValueError(f"Unknown cluster type “{cluster_type}”.")
-
-            # Import the cluster module by name, and get the cluster Class.
-            cluster_module = import_module(cluster_meta["module"])
-            cluster_class = getattr(cluster_module, cluster_meta["class"])
-
-            self._cluster = cluster_class(**cluster_opts)
-        else:
-            self._cluster = None
-
-        # Get the client config, and set `address` to a cluster obejct
-        # if one was created above. Then, instantiate a Client object.
-        client_config = dict(context.resource_config.get("client", {}))
-        if self.cluster:
-            client_config["address"] = self.cluster
-        self._client = Client(**client_config)
+        self._client, self._cluster = create_from_config(context.resource_config)
 
     @property
     def cluster(self):

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
@@ -264,9 +264,7 @@ def test_existing_scheduler_address():
             reconstructable(dask_engine_pipeline),
             run_config={
                 "intermediate_storage": {"filesystem": {}},
-                "execution": {
-                    "dask": {"config": {"client": {"address": scheduler_address}}}
-                },
+                "execution": {"dask": {"config": {"client": {"address": scheduler_address}}}},
             },
             instance=instance,
         )


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Unify the code paths in the Dask executor and resource in `dagster_dask` for configuring and instantiating Dask clusters and clients. This ensures that both are equally capable in their support of Dask. In particular, the Dask executor gains the ability to configure the Dask client, in addition to a Dask cluster.

The consolidation largely uses the resource's implementation. The executor's `existing` cluster config is deprecated. It is not a real cluster type. Users should replace it with a `client` config.

**Deprecated Executor "existing" Cluster Config**:

```yaml
config:
  cluster:
    existing:
      address: "tcp://127.0.0.1:8786"
```

**Replace with Client Config**:

```yaml
config:
  client:
    address: "tcp://127.0.0.1:8786"
```

This PR does not modify the actual execution strategy of either the executor or resource.

Closes #2901.

**Note:** There are no docs changes in this PR. Docs will be updated for the `dagster-dask` module as a whole in #3863.

## Test Plan

<!--- Please describe the tests you have added and your testing environment (if applicable). →

No tests were added or changed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.