### PR TITLE
Package new project skeleton on build

### DIFF
--- a/python_modules/dagster/MANIFEST.in
+++ b/python_modules/dagster/MANIFEST.in
@@ -3,4 +3,4 @@ include LICENSE
 recursive-include dagster/core/storage/event_log/sqlite/alembic *
 recursive-include dagster/core/storage/runs/sqlite/alembic *
 recursive-include dagster/core/storage/schedules/sqlite/alembic *
-recursive-include dagster/generate/new_repo *
+recursive-include dagster/generate/new_project *


### PR DESCRIPTION
This seems to have been left out in 7a3f7f10f673038856bcdf6923921236c3ae125b. `dagster new-project ..` is not functional on `0.11.0`:

```
~ % dagster --version
dagster, version 0.11.0
~ % dagster new-project testing
Creating a new Dagster repository in testing...
Done.
~ % ls -la testing
total 0
drwxr-xr-x    2 sg  staff    64 Mar 20 11:37 .
drwxr-xr-x+ 122 sg  staff  3904 Mar 20 11:37 ..
```

## Test Plan
No tests added. Tested locally by trying to build `dagster` package and generator skeleton was included after this change.

## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.