### PR TITLE
Update pipelines.mdx

### DIFF
--- a/docs/content/tutorial/advanced-tutorial/pipelines.mdx
+++ b/docs/content/tutorial/advanced-tutorial/pipelines.mdx
@@ -243,7 +243,7 @@ Each of the ways we can invoke a Dagster pipeline lets us select which mode we'd
 From the command line, we can set `-d` or `--mode` and select the name of the mode:
 
 ```bash
-dagster pipeline execute -f modes.py -e resources.yaml -d unittest
+dagster pipeline execute -f modes.py -c resources.yaml --mode unittest
 ```
 
 Or, from the Python API:

--- a/docs/content/tutorial/advanced-tutorial/pipelines.mdx
+++ b/docs/content/tutorial/advanced-tutorial/pipelines.mdx
@@ -240,7 +240,7 @@ def modes_pipeline():
 
 Each of the ways we can invoke a Dagster pipeline lets us select which mode we'd like to run it in.
 
-From the command line, we can set `-d` or `--mode` and select the name of the mode:
+From the command line, we can set `--mode` and select the name of the mode:
 
 ```bash
 dagster pipeline execute -f modes.py -c resources.yaml --mode unittest


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
I received a message that said "no such option: -e"

Instead, when using version 0.11.0, I found that this worked instead:
dagster pipeline execute -f modes.py -c resources.yaml --mode unittest

-e and -d switches did not work. I was able to run this instead with -c or--config and --mode, respectively.
Screenshot of running original documented code:
![image](https://user-images.githubusercontent.com/7647726/111885125-c304c680-8993-11eb-8aff-cea74b431111.png)




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.