### PR TITLE
[Docs] Links to docs.dagster.io in example folder, fall back to legacy site pre-0.11.0

### DIFF
--- a/examples/conditional_execution/README.md
+++ b/examples/conditional_execution/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/conditional_execution.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/conditional_execution.

--- a/examples/conditional_execution/README.md
+++ b/examples/conditional_execution/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/conditional_execution.
+View this example in the Dagster docs at https://docs.dagster.io/examples/conditional_execution.

--- a/examples/deploy_docker/README.md
+++ b/examples/deploy_docker/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/deploy_docker.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/deploy_docker.

--- a/examples/deploy_docker/README.md
+++ b/examples/deploy_docker/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/deploy_docker.
+View this example in the Dagster docs at https://docs.dagster.io/examples/deploy_docker.

--- a/examples/memoized_development/README.md
+++ b/examples/memoized_development/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/memoized_development.
+View this example in the Dagster docs at https://docs.dagster.io/examples/memoized_development.

--- a/examples/memoized_development/README.md
+++ b/examples/memoized_development/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/memoized_development.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/memoized_development.

--- a/examples/multi_type_lakehouse/README.md
+++ b/examples/multi_type_lakehouse/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/multi_type_lakehouse.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/multi_type_lakehouse.

--- a/examples/multi_type_lakehouse/README.md
+++ b/examples/multi_type_lakehouse/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/multi_type_lakehouse.
+View this example in the Dagster docs at https://docs.dagster.io/examples/multi_type_lakehouse.

--- a/examples/nothing/README.md
+++ b/examples/nothing/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/nothing.
+View this example in the Dagster docs at https://docs.dagster.io/examples/nothing.

--- a/examples/nothing/README.md
+++ b/examples/nothing/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/nothing.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/nothing.

--- a/examples/simple_lakehouse/README.md
+++ b/examples/simple_lakehouse/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/simple_lakehouse.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/simple_lakehouse.

--- a/examples/simple_lakehouse/README.md
+++ b/examples/simple_lakehouse/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/simple_lakehouse.
+View this example in the Dagster docs at https://docs.dagster.io/examples/simple_lakehouse.

--- a/examples/trigger_pipeline/README.md
+++ b/examples/trigger_pipeline/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/trigger_pipeline.
+View this example in the Dagster docs at https://docs.dagster.io/examples/trigger_pipeline.

--- a/examples/trigger_pipeline/README.md
+++ b/examples/trigger_pipeline/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/trigger_pipeline.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/trigger_pipeline.

--- a/examples/user_in_loop/README.md
+++ b/examples/user_in_loop/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/user_in_loop.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/user_in_loop.

--- a/examples/user_in_loop/README.md
+++ b/examples/user_in_loop/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/user_in_loop.
+View this example in the Dagster docs at https://docs.dagster.io/examples/user_in_loop.

--- a/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/README.md
+++ b/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://docs.dagster.io/docs/examples/{{EXAMPLE_NAME}}.
+View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/{{EXAMPLE_NAME}}.

--- a/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/README.md
+++ b/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/README.md
@@ -1,1 +1,1 @@
-View this example in the Dagster docs at https://legacy-docs.dagster.io/examples/{{EXAMPLE_NAME}}.
+View this example in the Dagster docs at https://docs.dagster.io/examples/{{EXAMPLE_NAME}}.


### PR DESCRIPTION
## Summary
[Docs] Links to docs.dagster.io in example folder, fall back to legacy site pre-0.11.0

No actual code change, just links in .MD files.

Seems after the new release of 0.11.0, existing links in `examples` folder is pointing to latest version while `docs.dagster.io` is not redirecting properly.

`Note`: this is just a tmp fix, and root cause fixing should be fixing the docs generation (which I'm not familiar with yet, sorry)

## Test Plan
Manual test.

### Example with `examples/conditional_execution`
### Before change: broken link with 404
https://docs.dagster.io/docs/examples/conditional_execution
![Screen Shot 2021-03-23 at 10 57 53 PM](https://user-images.githubusercontent.com/3925641/112262643-3bd18000-8c2b-11eb-9b21-2bb7af6366ba.png)

### After change: showing me some example details
https://legacy-docs.dagster.io/examples/conditional_execution
![Screen Shot 2021-03-23 at 10 59 18 PM](https://user-images.githubusercontent.com/3925641/112262838-85ba6600-8c2b-11eb-8f44-e28e0e77da65.png)
