### PR TITLE
new-project: dynamically insert Dagster and Dagit versions

### DIFF
--- a/python_modules/dagster/dagster/generate/generate.py
+++ b/python_modules/dagster/dagster/generate/generate.py
@@ -2,6 +2,8 @@ import os
 import posixpath
 
 import jinja2
+from dagit.version import __version__ as dagit_version
+from dagster.version import __version__ as dagster_version
 
 NEW_PROJECT_PLACEHOLDER = "new_project"
 NEW_PROJECT_PATH = os.path.join(os.path.dirname(__file__), NEW_PROJECT_PLACEHOLDER)
@@ -59,7 +61,13 @@ def generate_new_project(path: str):
                 # Jinja template names must use the POSIX path separator "/".
                 template_name = src_relative_file_path.replace(os.sep, posixpath.sep)
                 template = env.get_template(name=template_name)
-                f.write(template.render(repo_name=repo_name))
+                f.write(
+                    template.render(
+                        repo_name=repo_name,
+                        dagster_version=dagster_version,
+                        dagit_version=dagit_version,
+                    )
+                )
                 f.write("\n")
 
 

--- a/python_modules/dagster/dagster/generate/generate.py
+++ b/python_modules/dagster/dagster/generate/generate.py
@@ -2,7 +2,6 @@ import os
 import posixpath
 
 import jinja2
-from dagit.version import __version__ as dagit_version
 from dagster.version import __version__ as dagster_version
 
 NEW_PROJECT_PLACEHOLDER = "new_project"
@@ -65,7 +64,6 @@ def generate_new_project(path: str):
                     template.render(
                         repo_name=repo_name,
                         dagster_version=dagster_version,
-                        dagit_version=dagit_version,
                     )
                 )
                 f.write("\n")

--- a/python_modules/dagster/dagster/generate/new_project/setup.py
+++ b/python_modules/dagster/dagster/generate/new_project/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["{{ repo_name }}_tests"]),
     install_requires=[
         "dagster=={{ dagster_version }}",
-        "dagit=={{ dagit_version }}",
+        "dagit=={{ dagster_version }}",
         "pytest",
     ],
 )

--- a/python_modules/dagster/dagster/generate/new_project/setup.py
+++ b/python_modules/dagster/dagster/generate/new_project/setup.py
@@ -4,8 +4,8 @@ setuptools.setup(
     name="{{ repo_name }}",
     packages=setuptools.find_packages(exclude=["{{ repo_name }}_tests"]),
     install_requires=[
-        "dagster==0.10.2",
-        "dagit==0.10.2",
+        "dagster=={{ dagster_version }}",
+        "dagit=={{ dagit_version }}",
         "pytest",
     ],
 )


### PR DESCRIPTION
## Summary
`dagster new-project PROJECT_NAME` always generated a fixed requirement for 0.10.2.
I changed it to use the current version of Dagster (that was used to run the command) instead of the fixed version.




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.