### PR TITLE
Add toggle to disable PostgreSQL secret generation

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/values.py
+++ b/helm/dagster/schema/schema/charts/dagster/values.py
@@ -15,6 +15,7 @@ class DagsterHelmValues(BaseModel):
     dagit: subschema.Dagit
     dagsterUserDeployments: UserDeployments = Field(..., alias="dagster-user-deployments")
     postgresql: subschema.PostgreSQL
+    generatePostgresqlPasswordSecret: bool
     rabbitmq: subschema.RabbitMQ
     redis: subschema.Redis
     flower: subschema.Flower

--- a/helm/dagster/templates/secret-postgres.yaml
+++ b/helm/dagster/templates/secret-postgres.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.generatePostresqlPasswordSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   {{- if not (empty .Values.postgresql) }}
   postgresql-password: "{{ .Values.postgresql.postgresqlPassword | b64enc }}"
   {{- end }}
+{{ end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -12,6 +12,10 @@
         "postgresql": {
             "$ref": "#/definitions/PostgreSQL"
         },
+        "generatePostgresqlPasswordSecret": {
+            "title": "Generatepostgresqlpasswordsecret",
+            "type": "boolean"
+        },
         "rabbitmq": {
             "$ref": "#/definitions/RabbitMQ"
         },

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -58,6 +58,7 @@
         "dagit",
         "dagster-user-deployments",
         "postgresql",
+        "generatePostgresqlPasswordSecret",
         "rabbitmq",
         "redis",
         "flower",

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -7,7 +7,6 @@
 
 global:
   postgresqlSecretName: "dagster-postgresql-secret"
-
   # The DAGSTER_HOME env var is set by default on all nodes from this value
   dagsterHome: "/opt/dagster/dagster_home"
 

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -7,6 +7,7 @@
 
 global:
   postgresqlSecretName: "dagster-postgresql-secret"
+
   # The DAGSTER_HOME env var is set by default on all nodes from this value
   dagsterHome: "/opt/dagster/dagster_home"
 
@@ -518,6 +519,10 @@ postgresql:
 
   service:
     port: 5432
+
+# Whether to generate a secret resource for the PostgreSQL password. Useful if
+# global.postgresqlSecretName is managed outside of this helm chart.
+generatePostgresqlPasswordSecret: true
 
 ####################################################################################################
 # RabbitMQ: Configuration values for rabbitmq. Only one of RabbitMQ / Redis should be enabled.


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This is useful when the PostgreSQL secret is managed outside of Helm.

Context: https://dagster.slack.com/archives/C014N0PK37E/p1616053327016800


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested by confirming `helmfile diff` shows no new Secret resource on our deployment



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.