### PR TITLE
dagster.yaml dagster_postgres.event_log_storage should be dagster_postgres.event_log

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -295,7 +295,7 @@ event_log_storage:
 
 # this config manually sets the Postgres credentials
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_db:
@@ -307,7 +307,7 @@ event_log_storage:
 
 # and this config grabs the database credentials from environment variables
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_db:
@@ -323,14 +323,14 @@ event_log_storage:
 
 # and this config sets the credentials via DB connection string / url:
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_url: { PG_DB_CONN_STRING }
 
 # This config gets the DB connection string / url via environment variables:
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_url:

--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -168,7 +168,7 @@ event_log_storage:
 
 # this config manually sets the Postgres credentials
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_db:
@@ -180,7 +180,7 @@ event_log_storage:
 
 # and this config grabs the database credentials from environment variables
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_db:
@@ -196,14 +196,14 @@ event_log_storage:
 
 # and this config sets the credentials via DB connection string / url:
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_url: { PG_DB_CONN_STRING }
 
 # This config gets the DB connection string / url via environment variables:
 event_log_storage:
-  module: dagster_postgres.event_log_storage
+  module: dagster_postgres.event_log
   class: PostgresEventLogStorage
   config:
     postgres_url:


### PR DESCRIPTION
Correction to docs: https://docs.dagster.io/deployment/dagster-instance#postgreseventlogstorage

Otherwise the following error is thrown on startup:

```
dagster.check.CheckError: Failure condition: Couldn't import module dagster_postgres.event_log_storage when attempting to load the configurable class dagster_postgres.event_log_storage.PostgresEventLogStorage
```
