### PR TITLE
Link to new changelog and migration guide

### DIFF
--- a/docs/content/getting-started/releases.mdx
+++ b/docs/content/getting-started/releases.mdx
@@ -8,7 +8,7 @@ title: Releases and Changes | Dagster
 
 We currently publish two kinds of Dagster releases:
 
-- Minor releases, e.g. 0.7.0, 0.8.0. We publish a new minor release roughly every few months.
+- Minor releases, e.g. 0.7.0, 0.8.0. We publish a new minor release every few months.
 - Dot releases, e.g. 0.8.1, 0.8.2. We publish a new dot release at least once per week.
 
 ## Breaking Changes & Deprecations
@@ -23,4 +23,6 @@ We are in the 0.y.z of [SemVer](https://semver.org/). While technically this is 
 
 ## Following Along
 
-The best way to stay on top of what changes are included in each release is through the [changelog](https://github.com/dagster-io/dagster/blob/master/CHANGES.md). We call out breaking changes in “Breaking Changes” sections and deprecations in “Deprecations” sections.
+The best way to stay on top of what changes are included in each release is through the [changelog](https://docs.dagster.io/changelog). We call out breaking changes in “Breaking Changes” sections and deprecations in “Deprecations” sections.
+
+We also publish a [migration guide](https://docs.dagster.io/migration) with each minor release, which details changes you need to make to upgrade from the last minor release.


### PR DESCRIPTION
Add links to the changelog and migration guide hosted on the docs site.