### PR TITLE
PresetDefinition.with_additional_config bugfix

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/preset.py
+++ b/python_modules/dagster/dagster/core/definitions/preset.py
@@ -199,10 +199,11 @@ class PresetDefinition(
         if run_config is None:
             return self
         else:
+            initial_config = self.run_config or {}
             return PresetDefinition(
                 name=self.name,
                 solid_selection=self.solid_selection,
                 mode=self.mode,
                 tags=self.tags,
-                run_config=deep_merge_dicts(self.run_config, run_config),
+                run_config=deep_merge_dicts(initial_config, run_config),
             )

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_preset_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_preset_definition.py
@@ -237,3 +237,22 @@ def test_tags():
     # preset overwrites pipeline def
     assert "defs" in pipeline_run.tags
     assert pipeline_run.tags["defs"] == "preset"
+
+
+@pytest.mark.parametrize("initial_run_config", [{"foo": "bar"}, None])
+def test_with_additional_config(initial_run_config):
+    # Given: an initial preset with a run config or no run config
+    preset_def = PresetDefinition("example_with_config", run_config=initial_run_config)
+
+    # And: new config to be added
+    new_config = {"fizz": "buzz"}
+
+    # When: additional config is added
+    new_preset_def = preset_def.with_additional_config(new_config)
+
+    # Then: the new preset is a new preset object
+    assert id(preset_def) != id(new_preset_def)
+
+    # And: the preset has the expected new config
+    new_full_config = {"foo": "bar", "fizz": "buzz"} if initial_run_config else new_config
+    assert new_preset_def == PresetDefinition("example_with_config", run_config=new_full_config)


### PR DESCRIPTION
Replacing self.run_config with {} pre merge_dicts if self.run_config is falsey

## Summary
Bugfix.
Related ticket has all info on context: https://github.com/dagster-io/dagster/issues/3985

I found minimal change to be to add 
`initial_config = self.run_config or {}`
This will also ensure that the new config is a new dict (rather than the same dict object that was passed in).

Happy for alternative suggestions.

## Test Plan
Added happy path test to assert that even if initial run_config is None, the with_additional_config won't fail and that a new object will be returned and that it will have expected config.

Have considered also adding test case permutations where the config-to-be-added is a dict vs None - however there would be a problem with the assertion that the object is always a new object (which atm would not be the case if the new_runconfig is None). This test would align with docstring - but it would require more code changes and would also change current behaviour. 

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.