### PR TITLE
Fix typo in '--config' help message

### DIFF
--- a/python_modules/dagster/dagster/cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/cli/workspace/cli_target.py
@@ -363,7 +363,7 @@ def target_with_config_option(command_name):
             "\n\nYou can also specify multiple files:"
             "\n\nExample: "
             "dagster pipeline {name} -f hello_world.py -p pandas_hello_world "
-            "-c pandas_hello_world/solids.yaml -e pandas_hello_world/env.yaml"
+            "-c pandas_hello_world/solids.yaml -c pandas_hello_world/env.yaml"
         ).format(name=command_name),
     )
 


### PR DESCRIPTION
## Summary
Hi!

I believe I found a small typo in the docs / help message and wanted to fix it : )

## Checklist
- [] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.