### PR TITLE
added resource to support AWS Profiles for s3

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
@@ -4,7 +4,7 @@ from .file_manager import S3FileHandle, S3FileManager
 from .intermediate_storage import S3IntermediateStorage
 from .io_manager import PickledObjectS3IOManager, s3_pickle_io_manager
 from .object_store import S3ObjectStore
-from .resources import s3_file_manager, s3_resource
+from .resources import s3_file_manager, s3_resource, s3_resource_for_profile
 from .s3_fake_resource import S3FakeSession, create_s3_fake_resource
 from .solids import S3Coordinate, file_handle_to_s3
 from .system_storage import s3_intermediate_storage, s3_plus_default_intermediate_storage_defs

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
@@ -4,7 +4,7 @@ from .file_manager import S3FileHandle, S3FileManager
 from .intermediate_storage import S3IntermediateStorage
 from .io_manager import PickledObjectS3IOManager, s3_pickle_io_manager
 from .object_store import S3ObjectStore
-from .resources import s3_file_manager, s3_resource, s3_resource_for_profile
+from .resources import s3_file_manager, s3_resource
 from .s3_fake_resource import S3FakeSession, create_s3_fake_resource
 from .solids import S3Coordinate, file_handle_to_s3
 from .system_storage import s3_intermediate_storage, s3_plus_default_intermediate_storage_defs

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -30,7 +30,6 @@ S3_SESSION_CONFIG = {
         str,
         description="Specifies a profile to connect that session",
         is_required=False,
-        default_value="default",
     ),
 }
 
@@ -97,7 +96,7 @@ def s3_resource(context):
         region_name=context.resource_config.get("region_name"),
         endpoint_url=context.resource_config.get("endpoint_url"),
         use_unsigned_session=context.resource_config["use_unsigned_session"],
-        profile_name=context.resource_config["profile_name"],
+        profile_name=context.resource_config.get("profile_name"),
     )
 
 
@@ -121,6 +120,7 @@ def s3_file_manager(context):
             region_name=context.resource_config.get("region_name"),
             endpoint_url=context.resource_config.get("endpoint_url"),
             use_unsigned_session=context.resource_config["use_unsigned_session"],
+            profile_name=context.resource_config.get("profile_name"),
         ),
         s3_bucket=context.resource_config["s3_bucket"],
         s3_base_key=context.resource_config["s3_prefix"],

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -38,7 +38,8 @@ S3_SESSION_CONFIG = {
 def s3_resource(context):
     """Resource that gives solids access to S3.
 
-    The underlying S3 session is created by calling :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
+    The underlying S3 session is created by calling
+    :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
     The returned resource object is an S3 client, an instance of `botocore.client.S3`.
 
     Attach this resource definition to a :py:class:`~dagster.ModeDefinition` in order to make it

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -2,7 +2,7 @@ from dagster import Field, StringSource, resource
 from dagster.utils.merger import merge_dicts
 
 from .file_manager import S3FileManager
-from .utils import construct_s3_client
+from .utils import construct_s3_client, construct_s3_client_for_profile
 
 S3_SESSION_CONFIG = {
     "use_unsigned_session": Field(
@@ -99,6 +99,21 @@ def s3_resource(context):
         profile_name=context.resource_config.get("profile_name"),
     )
 
+@resource(S3_SESSION_CONFIG)
+def s3_resource_for_profile(context):
+    """Resource that gives solids access to S3 for a specific profile.
+
+    The underlying S3 session is created by calling :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
+    The returned resource object is an S3 client fro specified profile_name, an instance of `botocore.client.S3`.
+
+    """
+    return construct_s3_client_for_profile(
+        max_attempts=context.resource_config["max_attempts"],
+        region_name=context.resource_config.get("region_name"),
+        endpoint_url=context.resource_config.get("endpoint_url"),
+        use_unsigned_session=context.resource_config["use_unsigned_session"],
+        profile_name=context.resource_config["profile_name"]
+    )
 
 @resource(
     merge_dicts(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -2,7 +2,7 @@ from dagster import Field, StringSource, resource
 from dagster.utils.merger import merge_dicts
 
 from .file_manager import S3FileManager
-from .utils import construct_s3_client
+from .utils import construct_s3_client, construct_s3_client_for_profile
 
 S3_SESSION_CONFIG = {
     "use_unsigned_session": Field(
@@ -25,6 +25,12 @@ S3_SESSION_CONFIG = {
         "where the initial call counts toward the max_attempts value that you provide",
         is_required=False,
         default_value=5,
+    ),
+    "profile_name": Field(
+        str,
+        description="TSpecifies a profile to connect that session",
+        is_required=False,
+        default_value="default",
     ),
 }
 
@@ -93,6 +99,21 @@ def s3_resource(context):
         use_unsigned_session=context.resource_config["use_unsigned_session"],
     )
 
+@resource(S3_SESSION_CONFIG)
+def s3_resource_for_profile(context):
+    """Resource that gives solids access to S3 for a specific profile.
+
+    The underlying S3 session is created by calling :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
+    The returned resource object is an S3 client fro specified profile_name, an instance of `botocore.client.S3`.
+
+    """
+    return construct_s3_client_for_profile(
+        max_attempts=context.resource_config["max_attempts"],
+        region_name=context.resource_config.get("region_name"),
+        endpoint_url=context.resource_config.get("endpoint_url"),
+        use_unsigned_session=context.resource_config["use_unsigned_session"],
+        profile_name=context.resource_config["profile_name"]
+    )
 
 @resource(
     merge_dicts(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -2,7 +2,7 @@ from dagster import Field, StringSource, resource
 from dagster.utils.merger import merge_dicts
 
 from .file_manager import S3FileManager
-from .utils import construct_s3_client, construct_s3_client_for_profile
+from .utils import construct_s3_client
 
 S3_SESSION_CONFIG = {
     "use_unsigned_session": Field(
@@ -99,21 +99,6 @@ def s3_resource(context):
         profile_name=context.resource_config.get("profile_name"),
     )
 
-@resource(S3_SESSION_CONFIG)
-def s3_resource_for_profile(context):
-    """Resource that gives solids access to S3 for a specific profile.
-
-    The underlying S3 session is created by calling :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
-    The returned resource object is an S3 client fro specified profile_name, an instance of `botocore.client.S3`.
-
-    """
-    return construct_s3_client_for_profile(
-        max_attempts=context.resource_config["max_attempts"],
-        region_name=context.resource_config.get("region_name"),
-        endpoint_url=context.resource_config.get("endpoint_url"),
-        use_unsigned_session=context.resource_config["use_unsigned_session"],
-        profile_name=context.resource_config["profile_name"]
-    )
 
 @resource(
     merge_dicts(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -90,6 +90,10 @@ def s3_resource(context):
               # Optional[bool]: Specifies whether to use an unsigned S3 session. Default: True
               endpoint_url: "http://localhost"
               # Optional[str]: Specifies a custom endpoint for the S3 session. Default is None.
+              profile_name: "dev"
+              # Optional[str]: Specifies a custom profile for S3 session. Default is default
+              # profile as specified in ~/.aws/credentials file
+
     """
     return construct_s3_client(
         max_attempts=context.resource_config["max_attempts"],

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -2,7 +2,7 @@ from dagster import Field, StringSource, resource
 from dagster.utils.merger import merge_dicts
 
 from .file_manager import S3FileManager
-from .utils import construct_s3_client, construct_s3_client_for_profile
+from .utils import construct_s3_client
 
 S3_SESSION_CONFIG = {
     "use_unsigned_session": Field(
@@ -28,7 +28,7 @@ S3_SESSION_CONFIG = {
     ),
     "profile_name": Field(
         str,
-        description="TSpecifies a profile to connect that session",
+        description="Specifies a profile to connect that session",
         is_required=False,
         default_value="default",
     ),
@@ -39,7 +39,7 @@ S3_SESSION_CONFIG = {
 def s3_resource(context):
     """Resource that gives solids access to S3.
 
-    The underlying S3 session is created by calling :py:func:`boto3.resource('s3') <boto3:boto3.resource>`.
+    The underlying S3 session is created by calling :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
     The returned resource object is an S3 client, an instance of `botocore.client.S3`.
 
     Attach this resource definition to a :py:class:`~dagster.ModeDefinition` in order to make it
@@ -97,23 +97,9 @@ def s3_resource(context):
         region_name=context.resource_config.get("region_name"),
         endpoint_url=context.resource_config.get("endpoint_url"),
         use_unsigned_session=context.resource_config["use_unsigned_session"],
+        profile_name=context.resource_config["profile_name"],
     )
 
-@resource(S3_SESSION_CONFIG)
-def s3_resource_for_profile(context):
-    """Resource that gives solids access to S3 for a specific profile.
-
-    The underlying S3 session is created by calling :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
-    The returned resource object is an S3 client fro specified profile_name, an instance of `botocore.client.S3`.
-
-    """
-    return construct_s3_client_for_profile(
-        max_attempts=context.resource_config["max_attempts"],
-        region_name=context.resource_config.get("region_name"),
-        endpoint_url=context.resource_config.get("endpoint_url"),
-        use_unsigned_session=context.resource_config["use_unsigned_session"],
-        profile_name=context.resource_config["profile_name"]
-    )
 
 @resource(
     merge_dicts(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -29,8 +29,7 @@ class S3Callback:
 
 
 def construct_s3_client(
-    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, 
-    profile_name=None
+    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, profile_name=None
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -29,8 +29,7 @@ class S3Callback:
 
 
 def construct_s3_client(
-    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, 
-    profile_name='default'
+    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, profile_name=None
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -48,6 +48,31 @@ def construct_s3_client(
         s3_client.meta.events.register("choose-signer.s3.*", disable_signing)
 
     return s3_client
+    
+    
+def construct_s3_client_for_profile(
+    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, 
+    profile_name='default'
+):
+    check.int_param(max_attempts, "max_attempts")
+    check.opt_str_param(region_name, "region_name")
+    check.opt_str_param(endpoint_url, "endpoint_url")
+    check.bool_param(use_unsigned_session, "use_unsigned_session")
+    check.opt_str_param(profile_name, "profile_name")
+
+    client_session = boto3.session.Session(profile_name=profile_name)
+    s3_client = client_session.resource(  # pylint:disable=C0103
+        "s3",
+        region_name=region_name,
+        use_ssl=True,
+        endpoint_url=endpoint_url,
+        config=construct_boto_client_retry_config(max_attempts),
+    ).meta.client
+
+    if use_unsigned_session:
+        s3_client.meta.events.register("choose-signer.s3.*", disable_signing)
+
+    return s3_client
 
 
 def construct_boto_client_retry_config(max_attempts):

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -29,28 +29,6 @@ class S3Callback:
 
 
 def construct_s3_client(
-    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False
-):
-    check.int_param(max_attempts, "max_attempts")
-    check.opt_str_param(region_name, "region_name")
-    check.opt_str_param(endpoint_url, "endpoint_url")
-    check.bool_param(use_unsigned_session, "use_unsigned_session")
-
-    s3_client = boto3.resource(
-        "s3",
-        region_name=region_name,
-        use_ssl=True,
-        endpoint_url=endpoint_url,
-        config=construct_boto_client_retry_config(max_attempts),
-    ).meta.client
-
-    if use_unsigned_session:
-        s3_client.meta.events.register("choose-signer.s3.*", disable_signing)
-
-    return s3_client
-    
-    
-def construct_s3_client_for_profile(
     max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, 
     profile_name='default'
 ):
@@ -61,7 +39,7 @@ def construct_s3_client_for_profile(
     check.opt_str_param(profile_name, "profile_name")
 
     client_session = boto3.session.Session(profile_name=profile_name)
-    s3_client = client_session.resource(  # pylint:disable=C0103
+    s3_client = client_session.resource(
         "s3",
         region_name=region_name,
         use_ssl=True,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -50,31 +50,6 @@ def construct_s3_client(
         s3_client.meta.events.register("choose-signer.s3.*", disable_signing)
 
     return s3_client
-    
-    
-def construct_s3_client_for_profile(
-    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, 
-    profile_name='default'
-):
-    check.int_param(max_attempts, "max_attempts")
-    check.opt_str_param(region_name, "region_name")
-    check.opt_str_param(endpoint_url, "endpoint_url")
-    check.bool_param(use_unsigned_session, "use_unsigned_session")
-    check.opt_str_param(profile_name, "profile_name")
-
-    client_session = boto3.session.Session(profile_name=profile_name)
-    s3_client = client_session.resource(  # pylint:disable=C0103
-        "s3",
-        region_name=region_name,
-        use_ssl=True,
-        endpoint_url=endpoint_url,
-        config=construct_boto_client_retry_config(max_attempts),
-    ).meta.client
-
-    if use_unsigned_session:
-        s3_client.meta.events.register("choose-signer.s3.*", disable_signing)
-
-    return s3_client
 
 
 def construct_boto_client_retry_config(max_attempts):

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -29,7 +29,8 @@ class S3Callback:
 
 
 def construct_s3_client(
-    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, profile_name=None
+    max_attempts, region_name=None, endpoint_url=None, use_unsigned_session=False, 
+    profile_name=None
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
@@ -154,7 +154,7 @@ def test_depends_on_s3_resource_file_manager(mock_s3_bucket):
     assert uuid.UUID(comps[-1])
 
 
-@mock.patch("boto3.resource")
+@mock.patch("boto3.session.Session.resource")
 @mock.patch("dagster_aws.s3.resources.S3FileManager")
 def test_s3_file_manager_resource(MockS3FileManager, mock_boto3_resource):
     did_it_run = dict(it_ran=False)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
@@ -212,10 +212,7 @@ def test_s3_file_manager_resource(MockS3FileManager, mock_boto3_resource):
     assert did_it_run["it_ran"]
 
 
-@mock.patch("boto3.session.Session.resource")
-@mock.patch("dagster_aws.s3.resources.S3FileManager")
-def test_s3_file_manager_resource_with_profile(MockS3FileManager, mock_boto3_resource):
-    did_it_run = dict(it_ran=False)
+def test_s3_file_manager_resource_with_profile():
 
     resource_config = {
         "use_unsigned_session": True,
@@ -226,12 +223,10 @@ def test_s3_file_manager_resource_with_profile(MockS3FileManager, mock_boto3_res
         "profile_name": "some-profile",
     }
 
-    mock_s3_session = mock_boto3_resource.return_value.meta.client
-
     @solid(required_resource_keys={"file_manager"})
     def test_solid(context):
         # placeholder function to test resource initialization
-        pass
+        return context.log.info("return from test_solid")
 
     @pipeline(
         mode_defs=[

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
@@ -1,9 +1,10 @@
 import uuid
 from unittest import mock
-from botocore import exceptions
-import pytest
 
+import pytest
+from botocore import exceptions
 from dagster import (
+    DagsterResourceFunctionError,
     InputDefinition,
     Int,
     ModeDefinition,
@@ -12,7 +13,6 @@ from dagster import (
     execute_pipeline,
     pipeline,
     solid,
-    DagsterResourceFunctionError,
 )
 from dagster_aws.s3 import (
     S3FileHandle,


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
Motivation/Context: 

I have implemented Dagster on one of our EC2 instances. We have s3 buckets on different clusters, which use separate AWS Profiles. We needed our pipelines to be able to access appropriate s3 buckets by using these profiles. Hence, I made some small updates to dagster_aws to support the use case.

This involves: 

 - Updating existing s3_resource to to use boto3.Session and accept profile_name as a config parameter

 - Appropriate changes in resources.py


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.