### PR TITLE
feat: Enable TLS in Helm chart

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
@@ -11,9 +11,14 @@ class IngressPath(BaseModel):
     serviceName: str
     servicePort: Union[str, int]
 
+class IngressTLSConfiguration(BaseModel):
+    secretName: str
+
 
 class DagitIngressConfiguration(BaseModel):
     host: str
+    path: str
+    tls: IngressTLSConfiguration
     precedingPaths: List[IngressPath]
     succeedingPaths: List[IngressPath]
 
@@ -21,6 +26,7 @@ class DagitIngressConfiguration(BaseModel):
 class FlowerIngressConfiguration(BaseModel):
     host: str
     path: str
+    tls: IngressTLSConfiguration
     precedingPaths: List[IngressPath]
     succeedingPaths: List[IngressPath]
 

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -11,6 +11,17 @@ metadata:
     {{- end }}
 spec:
   # See: https://github.com/helm/charts/blob/master/stable/airflow/templates/ingress-web.yaml
+  tls:
+    {{- if .Values.ingress.dagit.tls.enabled }}
+    - hosts:
+        - {{ .Values.ingress.dagit.host }}
+      secretName: {{ .Values.ingress.dagit.tls.secretName }}
+    {{- end }}
+    {{- if .Values.ingress.flower.tls.enabled }}
+    - hosts:
+        - {{ .Values.ingress.flower.host }}
+      secretName: {{ .Values.ingress.flower.tls.secretName }}
+    {{- end }}
   rules:
     - host: {{ .Values.ingress.dagit.host }}
       http:
@@ -21,7 +32,7 @@ spec:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
           {{- end }}
-          - path: "/*"
+          - path: {{ .Values.ingress.dagit.path | default "/*" }}
             backend:
               serviceName: {{ include "dagster.dagit.fullname" . }}
               servicePort: {{ .Values.dagit.service.port | default 80 }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -678,6 +678,19 @@
                 "startupProbe"
             ]
         },
+        "IngressTLSConfiguration": {
+            "title": "IngressTLSConfiguration",
+            "type": "object",
+            "properties": {
+                "secretName": {
+                    "title": "Secretname",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "secretName"
+            ]
+        },
         "IngressPath": {
             "title": "IngressPath",
             "type": "object",
@@ -716,38 +729,12 @@
                     "title": "Host",
                     "type": "string"
                 },
-                "precedingPaths": {
-                    "title": "Precedingpaths",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IngressPath"
-                    }
-                },
-                "succeedingPaths": {
-                    "title": "Succeedingpaths",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IngressPath"
-                    }
-                }
-            },
-            "required": [
-                "host",
-                "precedingPaths",
-                "succeedingPaths"
-            ]
-        },
-        "FlowerIngressConfiguration": {
-            "title": "FlowerIngressConfiguration",
-            "type": "object",
-            "properties": {
-                "host": {
-                    "title": "Host",
-                    "type": "string"
-                },
                 "path": {
                     "title": "Path",
                     "type": "string"
+                },
+                "tls": {
+                    "$ref": "#/definitions/IngressTLSConfiguration"
                 },
                 "precedingPaths": {
                     "title": "Precedingpaths",
@@ -767,6 +754,45 @@
             "required": [
                 "host",
                 "path",
+                "tls",
+                "precedingPaths",
+                "succeedingPaths"
+            ]
+        },
+        "FlowerIngressConfiguration": {
+            "title": "FlowerIngressConfiguration",
+            "type": "object",
+            "properties": {
+                "host": {
+                    "title": "Host",
+                    "type": "string"
+                },
+                "path": {
+                    "title": "Path",
+                    "type": "string"
+                },
+                "tls": {
+                    "$ref": "#/definitions/IngressTLSConfiguration"
+                },
+                "precedingPaths": {
+                    "title": "Precedingpaths",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IngressPath"
+                    }
+                },
+                "succeedingPaths": {
+                    "title": "Succeedingpaths",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IngressPath"
+                    }
+                }
+            },
+            "required": [
+                "host",
+                "path",
+                "tls",
                 "precedingPaths",
                 "succeedingPaths"
             ]

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -653,9 +653,14 @@ ingress:
 
   dagit:
     # Ingress hostname for Dagit e.g. dagit.mycompany.com
+    host: ""
     # NOTE: Dagit doesn't yet support hosting on a path, e.g. mycompany.com/dagit
     # See: https://github.com/dagster-io/dagster/issues/2073
-    host: ""
+    path: ""
+
+    tls:
+      enabled: false
+      secretName: ""
 
     # Different http paths to add to the ingress before the default dagit path
     # Example:
@@ -681,6 +686,10 @@ ingress:
     # if path is '/flower', Flower will be accessible at 'mycompany.com/flower'
     # NOTE: do NOT keep trailing slash. For root configuration, set as empty string
     path: ""
+
+    tls:
+      enabled: false
+      secretName: ""
 
     # Different http paths to add to the ingress before the default flower path
     # Example:


### PR DESCRIPTION
## Summary
Enables TLS option in Helm chart for ingress - resolves https://github.com/dagster-io/dagster/issues/4006

## Test Plan
Testing was done on Azure K8s cluster

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.