### PR TITLE
[Docs][Minor] Replace reference to deprecated Slack method in `sensors.mdx`

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -255,7 +255,7 @@ For example, you can write an "alert" pipeline that sends a slack message when i
 @solid(required_resource_keys={"slack"})
 def slack_message_on_failure_solid(context):
     message = f"Solid {context.solid.name} failed"
-    context.resources.slack.chat.post_message(channel="#foo", text=message)
+    context.resources.slack.chat_postMessage(channel="#foo", text=message)
 
 
 @pipeline(


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
It looks like the Slack WebClient was refactored at some point since this documentation was written. It appears the correct method to post a message is `.post_chatMessage`. This is also what the hooks reference in the `dagster-slack` package: https://github.com/dagster-io/dagster/blob/c071ca413dc18e9efcb3bc95c06227c37688ca7d/python_modules/libraries/dagster-slack/dagster_slack/hooks.py#L71



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack-->
<!--- channel #contributors: https://app.slack.com/client/TCDGQDUKF/C01K91YP0TF. We're here to answer any questions!-->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.