### PR TITLE
Add support for datetime64[ns, UTC] via PandasColumn.datetime_column(..., tz='UTC')

### DIFF
--- a/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from dagster import DagsterInvariantViolationError, check
 from dagster_pandas.constraints import (
     CategoricalColumnConstraint,
@@ -256,7 +258,7 @@ class PandasColumn:
         unique=False,
         ignore_missing_vals=False,
         is_required=None,
-        utc=False,
+        tz=None,
     ):
         """
         Simple constructor for PandasColumns that expresses datetime constraints on 'datetime64[ns]' dtypes.
@@ -275,17 +277,23 @@ class PandasColumn:
                 only evaluate non-null data. Ignore_missing_vals and non_nullable cannot both be True.
             is_required (Optional[bool]): Flag indicating the optional/required presence of the column.
                 If the column exists the validate function will validate the column. Default to True.
-            utc (Optional[bool]): Flag indicating whether datetime should have UTC timezone
-                If the column exists the validate function will validate the column. Default to False.
+            tz (Optional[str]): Required timezone for values eg: tz='UTC', tz='Europe/Dublin', tz='US/Eastern'.
+                Defaults to None, meaning naive datetime values.
         """
-        if utc:
-            datetime_constraint = ColumnDTypeInSetConstraint({"datetime64[ns, UTC]"})
-            if Timestamp(min_datetime).tz is None:
-                min_datetime = Timestamp(min_datetime).tz_localize("UTC")
-            if Timestamp(max_datetime).tz is None:
-                max_datetime = Timestamp(max_datetime).tz_localize("UTC")
-        else:
+        if tz is None:
             datetime_constraint = ColumnDTypeInSetConstraint({"datetime64[ns]"})
+        else:
+            datetime_constraint = ColumnDTypeInSetConstraint({f"datetime64[ns, {tz}]"})
+            # One day more/less than absolute min/max to prevent OutOfBoundsDatetime errors
+            if min_datetime == Timestamp.min:
+                min_datetime = Timestamp("1677-09-22 00:12:43.145225Z")
+            if max_datetime == Timestamp.max:
+                max_datetime = Timestamp("2262-04-10 23:47:16.854775807Z")
+            # Convert bounds to same tz
+            if Timestamp(min_datetime).tz is None:
+                min_datetime = Timestamp(min_datetime).tz_localize(tz)
+            if Timestamp(max_datetime).tz is None:
+                max_datetime = Timestamp(max_datetime).tz_localize(tz)
 
         return PandasColumn(
             name=check.str_param(name, "name"),

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from dagster import DagsterInvariantViolationError, check
 from dagster_pandas.constraints import (
     CategoricalColumnConstraint,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
@@ -282,10 +282,10 @@ class PandasColumn:
             datetime_constraint = ColumnDTypeInSetConstraint({"datetime64[ns]"})
         else:
             datetime_constraint = ColumnDTypeInSetConstraint({f"datetime64[ns, {tz}]"})
-            # One day more/less than absolute min/max to prevent OutOfBoundsDatetime errors
-            if min_datetime == Timestamp.min:
+            # One day more/less than absolute min/max to prevent OutOfBoundsDatetime errors when converting min/max to be tz aware
+            if min_datetime.replace(tzinfo=None) == Timestamp.min:
                 min_datetime = Timestamp("1677-09-22 00:12:43.145225Z")
-            if max_datetime == Timestamp.max:
+            if max_datetime.replace(tzinfo=None) == Timestamp.max:
                 max_datetime = Timestamp("2262-04-10 23:47:16.854775807Z")
             # Convert bounds to same tz
             if Timestamp(min_datetime).tz is None:

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_validation.py
@@ -168,11 +168,41 @@ def test_datetime_column_with_tz_validation_ok():
                 PandasColumn.datetime_column("datetime_dublin", tz="Europe/Dublin"),
                 PandasColumn.datetime_column("datetime_est", tz="US/Eastern"),
                 PandasColumn.datetime_column("datetime_chatham", tz="Pacific/Chatham"),
+            ],
+        )
+        is None
+    )
+
+
+def test_datetime_column_with_min_max_constraints_ok():
+    assert (
+        validate_constraints(
+            DataFrame(
+                {
+                    "datetime": [Timestamp("2021-03-14T12:34:56")],
+                    "datetime_utc_min_max_no_tz": [Timestamp("2021-03-14T12:34:56Z")],
+                    "datetime_utc_min_max_same_tz": [Timestamp("2021-03-14T12:34:56Z")],
+                    "datetime_utc_min_max_from_different_tz": [Timestamp("2021-03-14T12:34:56Z")],
+                }
+            ),
+            pandas_columns=[
                 PandasColumn.datetime_column(
-                    "datetime_utc_with_min_max",
+                    "datetime_utc_min_max_no_tz",
                     tz="UTC",
-                    min_datetime=datetime(2021, 3, 1),
-                    max_datetime=Timestamp("2021-04-01T00:00:00Z"),
+                    min_datetime=Timestamp.min,
+                    max_datetime=Timestamp.max,
+                ),
+                PandasColumn.datetime_column(
+                    "datetime_utc_min_max_same_tz",
+                    tz="UTC",
+                    min_datetime=Timestamp("2021-01-01T00:00:00Z"),
+                    max_datetime=Timestamp("2021-12-01T00:00:00Z"),
+                ),
+                PandasColumn.datetime_column(
+                    "datetime_utc_min_max_from_different_tz",
+                    tz="UTC",
+                    min_datetime=Timestamp("2021-01-01T00:00:00Z", tz="US/Eastern"),
+                    max_datetime=Timestamp("2021-12-01T00:00:00Z"),
                 ),
             ],
         )

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_validation.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import pytest
 from dagster_pandas.constraints import (
     CategoricalColumnConstraint,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_validation.py
@@ -10,7 +10,8 @@ from dagster_pandas.constraints import (
     UniqueColumnConstraint,
 )
 from dagster_pandas.validation import PandasColumn, validate_constraints
-from pandas import DataFrame
+from pandas import DataFrame, Timestamp
+from datetime import datetime
 
 
 def test_validate_constraints_ok():
@@ -145,3 +146,16 @@ def test_datetime_column_composition(composer, composer_args, expected_constrain
     for constraint in ignore_column.constraints:
         if hasattr(constraint, "ignore_missing_vals"):
             assert constraint.ignore_missing_vals
+
+def test_datetime_column_utc_ok():
+    assert (
+        validate_constraints(
+            DataFrame({"datetime": [Timestamp('2021-03-14T12:34:56')],"datetime_utc": [Timestamp('2021-03-14T12:34:56Z')],"datetime_utc_with_min_max": [Timestamp('2021-03-14T12:34:56Z')]}),
+            pandas_columns=[
+                PandasColumn.datetime_column("datetime"),
+                PandasColumn.datetime_column("datetime_utc", utc=True),
+                PandasColumn.datetime_column("datetime_utc_with_min_max", utc=True, min_datetime=datetime(2021,3,1), max_datetime=Timestamp('2021-04-01T00:00:00Z')),
+            ]
+        )
+        is None
+    )


### PR DESCRIPTION
From [#dagster-support thread](https://dagster.slack.com/archives/C01U954MEER/p1618916606441300):

> @mrdavidling:
> I have a PandasColumn.datetime_column that I'd like to constrain to only contain dates in UTC.
> Is this possible?
> Currently, if I define the column like this:
> `PandasColumn.datetime_column("at_date", non_nullable=True, is_required=True)`
and pass it a dataframe with a the column of type `datetime64[ns, UTC]` (from `pandas.to_datetime(my_dates, utc=True)` ) I get the following error:
> `Warning! Type check failed. Violated "ColumnDTypeInSetConstraint" for column "at_date" - Column dtype must be in the following set {'datetime64[ns]'}.. DTypes received: datetime64[ns, UTC]`
>Which is pretty much the exact opposite of the constraint I'm trying to place on the column :slightly_smiling_face:
>
>@catherinewu:
>Hi @mrdavidlaing :wave: that change would be very appreciated! feel free to tag me in the PR


## Summary
Extends the `PandasColumn.datetime_column()` with a tz param (defaulted to `None` to preserve existing behaviour).

When `tz='UTC'` the column must have values with a UTC timezone


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Added [`test_datetime_column_utc_ok()`](https://github.com/dagster-io/dagster/compare/master...mrdavidlaing:pandas_column_datetime_utc?expand=1#diff-d4b6c9483e6fafec33f7ca6da99ae5fbee7a8f541bd9152433765a71dcaecd9aR150) to unit test suite



## Checklist
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.