### PR TITLE
Remove duplicate Pipelines reference

### DIFF
--- a/docs/content/concepts/solids-pipelines/solids.mdx
+++ b/docs/content/concepts/solids-pipelines/solids.mdx
@@ -20,7 +20,7 @@ Solids are the functional unit of work in Dagster. A solid's responsibility is t
 
 ## Overview
 
-Solids are used to define computations. Solids can later be assembled into Pipelines [Pipelines](/concepts/solids-pipelines/pipelines). Solids generally perform one specific action and are used for batch computations. For example, you can use a solid to:
+Solids are used to define computations. Solids can later be assembled into [Pipelines](/concepts/solids-pipelines/pipelines). Solids generally perform one specific action and are used for batch computations. For example, you can use a solid to:
 
 - Derive a data set from some other data sets.
 - Execute a database query.


### PR DESCRIPTION
## Summary
Looks like "Pipelines" was referenced twice in the docs in the Solids section.




## Test Plan
N/A




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.