### PR TITLE
Allow overriding the dagit ingress path in the helm chart

### DIFF
--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
           {{- end }}
-          - path: "/*"
+          - path: {{ .Values.ingress.dagit.path | default "/*" }}
             backend:
               serviceName: {{ include "dagster.dagit.fullname" . }}
               servicePort: {{ .Values.dagit.service.port | default 80 }}


### PR DESCRIPTION
## Summary
Not many k8s ingress controllers support `/*` as a rule, usually it's a prefix match like `/`. In our case, using Traefik, we would need to use something like `/{route:.*}` rather than just `/*`.

This PR allows us to configure the ingress route, which means we can set it to `/`. I didn't change it to be `/` by default as this would be a breaking change. 


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

It works, trust the force.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.