### PR TITLE
Suggest deploying dagster with the name "dagster"

### DIFF
--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
@@ -197,7 +197,7 @@ To enable Dagster to connect to S3, provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_
 
 ### Install the Dagster Helm Chart
 
-Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` will be modified:
+Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` release will be modified:
 
     helm upgrade --install dagster dagster/dagster -f /path/to/values.yaml \
       --set runLauncher.type=CeleryK8sRunLauncher \

--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
@@ -194,6 +194,7 @@ We assume that you've followed the initial steps in the [previous walkthrough](/
 We need to configure persistent object storage so that data can be serialized and passed between steps. To run the Dagster User Code example, create a S3 bucket named "dagster-test".
 
 To enable Dagster to connect to S3, provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables via the `env`, `envConfigMaps`, or `envSecrets` fields under `dagster-user-deployments` in `values.yaml` or (not recommended) by setting these variables directly in the User Code Deployment image.
+
 ### Install the Dagster Helm Chart
 
 Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` will be modified:

--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
@@ -194,12 +194,11 @@ We assume that you've followed the initial steps in the [previous walkthrough](/
 We need to configure persistent object storage so that data can be serialized and passed between steps. To run the Dagster User Code example, create a S3 bucket named "dagster-test".
 
 To enable Dagster to connect to S3, provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables via the `env`, `envConfigMaps`, or `envSecrets` fields under `dagster-user-deployments` in `values.yaml` or (not recommended) by setting these variables directly in the User Code Deployment image.
-
 ### Install the Dagster Helm Chart
 
-Install the Helm chart and create a release. Below, we've named our release `dagster-release`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster-release` will be modified:
+Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` will be modified:
 
-    helm upgrade --install dagster-release dagster/dagster -f /path/to/values.yaml \
+    helm upgrade --install dagster dagster/dagster -f /path/to/values.yaml \
       --set runLauncher.type=CeleryK8sRunLauncher \
       --set dagsterDaemon.queuedRunCoordinator.enabled=true \
       --set rabbitmq.enabled=true

--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
@@ -184,7 +184,7 @@ The `dagsterApiGrpcArgs` field expects a list of arguments for `dagster api grpc
 
 ### Install the Dagster Helm chart
 
-Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` will be modified:
+Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` release will be modified:
 
     helm upgrade --install dagster dagster/dagster -f /path/to/values.yaml
 

--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
@@ -184,9 +184,9 @@ The `dagsterApiGrpcArgs` field expects a list of arguments for `dagster api grpc
 
 ### Install the Dagster Helm chart
 
-Install the Helm chart and create a release. Below, we've named our release `dagster-release`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster-release` will be modified:
+Install the Helm chart and create a release. Below, we've named our release `dagster`. We use `helm upgrade --install` to create the release if it does not exist; otherwise, the existing `dagster` will be modified:
 
-    helm upgrade --install dagster-release dagster/dagster -f /path/to/values.yaml
+    helm upgrade --install dagster dagster/dagster -f /path/to/values.yaml
 
 Helm will launch several pods including PostgreSQL. You can check the status of the installation with `kubectl`. If everything worked correctly, you should see output like the following:
 


### PR DESCRIPTION
## Summary

Immediately after setting up Dagster with helm, the example workflows fail because it expects to find a configmap called `dagster-pipeline-env` and the helm chart creates it as `dagster-release-pipeline-env`. This is unintuitive - it should work out of the box for people trying deployments with helm.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.