### PR TITLE
Allow user defined dbt target_path config for dbt run and test solids

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 Thank you for joining the Dasgter community!
 
 For more information, please see the guidelines in our [documentation](https://docs.dagster.io/community):
-- [Code of Conduct](https://docs.dagster.io/community/code_of_conduct)
+- [Code of Conduct](https://docs.dagster.io/community/code-of-conduct)
 - [Contributing](https://docs.dagster.io/community/contributing)
 - [Changing public APIs](https://docs.dagster.io/community/public-apis)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
@@ -21,6 +21,7 @@ from .types import DbtCliOutput
 from .utils import execute_cli, parse_run_results
 
 DEFAULT_DBT_EXECUTABLE = "dbt"
+DEFAULT_DBT_TARGET_PATH = "target"
 
 # The following config fields correspond to flags that apply to all dbt CLI commands. For details
 # on dbt CLI flags, see
@@ -112,13 +113,6 @@ def passthrough_flags_only(solid_config, additional_flags):
     }
 
 
-def __dbt_target_path(target_path_config: str):
-    if target_path_config is None:
-        return "target"
-    else:
-        target_path_config
-
-
 @solid(
     description="A solid to invoke dbt run via CLI.",
     input_defs=[InputDefinition(name="start_after", dagster_type=Nothing)],
@@ -182,10 +176,11 @@ def __dbt_target_path(target_path_config: str):
         "target-path": Field(
             config=StringSource,
             is_required=False,
+            default_value=DEFAULT_DBT_TARGET_PATH,
             description=(
                     "The directory path for target if different from the default `target-path` in "
                     "your dbt project configuration file."
-            )
+            ),
         ),
     },
     tags={"kind": "dbt"},
@@ -205,8 +200,8 @@ def dbt_cli_run(context) -> DbtCliOutput:
         warn_error=context.solid_config["warn-error"],
         ignore_handled_error=context.solid_config["ignore_handled_error"],
     )
-    target_path = __dbt_target_path(context.solid_config["target"])
-    run_results = parse_run_results(context.solid_config["project-dir"], target_path)
+    run_results = parse_run_results(context.solid_config["project-dir"],
+                                    context.solid_config["target-path"])
     cli_output_dict = {**run_results, **cli_output}
     cli_output = DbtCliOutput.from_dict(cli_output_dict)
 
@@ -282,6 +277,7 @@ def dbt_cli_run(context) -> DbtCliOutput:
         "target-path": Field(
             config=StringSource,
             is_required=False,
+            default_value=DEFAULT_DBT_TARGET_PATH,
             description=(
                     "The directory path for target if different from the default `target-path` in "
                     "your dbt project configuration file."
@@ -303,8 +299,8 @@ def dbt_cli_test(context) -> DbtCliOutput:
         warn_error=context.solid_config["warn-error"],
         ignore_handled_error=context.solid_config["ignore_handled_error"],
     )
-    target_path = __dbt_target_path(context.solid_config["target"])
-    run_results = parse_run_results(context.solid_config["project-dir"], target_path)
+    run_results = parse_run_results(context.solid_config["project-dir"],
+                                    context.solid_config["target-path"])
     cli_output = {**run_results, **cli_output}
 
     if context.solid_config["yield_materializations"]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
@@ -112,6 +112,13 @@ def passthrough_flags_only(solid_config, additional_flags):
     }
 
 
+def __dbt_target_path(target_path_config: str):
+    if target_path_config is None:
+        return "target"
+    else:
+        target_path_config
+
+
 @solid(
     description="A solid to invoke dbt run via CLI.",
     input_defs=[InputDefinition(name="start_after", dagster_type=Nothing)],
@@ -172,6 +179,14 @@ def passthrough_flags_only(solid_config, additional_flags):
                 "prefix the generated asset keys."
             ),
         ),
+        "target-path": Field(
+            config=StringSource,
+            is_required=False,
+            description=(
+                    "The directory path for target if different from the default `target-path` in "
+                    "your dbt project configuration file."
+            )
+        ),
     },
     tags={"kind": "dbt"},
 )
@@ -190,7 +205,8 @@ def dbt_cli_run(context) -> DbtCliOutput:
         warn_error=context.solid_config["warn-error"],
         ignore_handled_error=context.solid_config["ignore_handled_error"],
     )
-    run_results = parse_run_results(context.solid_config["project-dir"])
+    target_path = __dbt_target_path(context.solid_config["target"])
+    run_results = parse_run_results(context.solid_config["project-dir"], target_path)
     cli_output_dict = {**run_results, **cli_output}
     cli_output = DbtCliOutput.from_dict(cli_output_dict)
 
@@ -263,6 +279,14 @@ def dbt_cli_run(context) -> DbtCliOutput:
                 "be yielded when the solid executes. Default: True"
             ),
         ),
+        "target-path": Field(
+            config=StringSource,
+            is_required=False,
+            description=(
+                    "The directory path for target if different from the default `target-path` in "
+                    "your dbt project configuration file."
+            )
+        ),
     },
     tags={"kind": "dbt"},
 )
@@ -279,7 +303,8 @@ def dbt_cli_test(context) -> DbtCliOutput:
         warn_error=context.solid_config["warn-error"],
         ignore_handled_error=context.solid_config["ignore_handled_error"],
     )
-    run_results = parse_run_results(context.solid_config["project-dir"])
+    target_path = __dbt_target_path(context.solid_config["target"])
+    run_results = parse_run_results(context.solid_config["project-dir"], target_path)
     cli_output = {**run_results, **cli_output}
 
     if context.solid_config["yield_materializations"]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/solids.py
@@ -178,8 +178,8 @@ def passthrough_flags_only(solid_config, additional_flags):
             is_required=False,
             default_value=DEFAULT_DBT_TARGET_PATH,
             description=(
-                    "The directory path for target if different from the default `target-path` in "
-                    "your dbt project configuration file."
+                "The directory path for target if different from the default `target-path` in "
+                "your dbt project configuration file."
             ),
         ),
     },
@@ -200,8 +200,9 @@ def dbt_cli_run(context) -> DbtCliOutput:
         warn_error=context.solid_config["warn-error"],
         ignore_handled_error=context.solid_config["ignore_handled_error"],
     )
-    run_results = parse_run_results(context.solid_config["project-dir"],
-                                    context.solid_config["target-path"])
+    run_results = parse_run_results(
+        context.solid_config["project-dir"], context.solid_config["target-path"]
+    )
     cli_output_dict = {**run_results, **cli_output}
     cli_output = DbtCliOutput.from_dict(cli_output_dict)
 
@@ -279,9 +280,9 @@ def dbt_cli_run(context) -> DbtCliOutput:
             is_required=False,
             default_value=DEFAULT_DBT_TARGET_PATH,
             description=(
-                    "The directory path for target if different from the default `target-path` in "
-                    "your dbt project configuration file."
-            )
+                "The directory path for target if different from the default `target-path` in "
+                "your dbt project configuration file."
+            ),
         ),
     },
     tags={"kind": "dbt"},
@@ -299,8 +300,9 @@ def dbt_cli_test(context) -> DbtCliOutput:
         warn_error=context.solid_config["warn-error"],
         ignore_handled_error=context.solid_config["ignore_handled_error"],
     )
-    run_results = parse_run_results(context.solid_config["project-dir"],
-                                    context.solid_config["target-path"])
+    run_results = parse_run_results(
+        context.solid_config["project-dir"], context.solid_config["target-path"]
+    )
     cli_output = {**run_results, **cli_output}
 
     if context.solid_config["yield_materializations"]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -125,9 +125,9 @@ def extract_summary(logs: List[Dict[str, str]]):
     return dict(zip(SUMMARY_LABELS, summary))
 
 
-def parse_run_results(path: str) -> Dict[str, Any]:
+def parse_run_results(path: str, target_path: str = "target") -> Dict[str, Any]:
     """Parses the `target/run_results.json` artifact that is produced by a dbt process."""
-    run_results_path = os.path.join(path, "target", "run_results.json")
+    run_results_path = os.path.join(path, target_path, "run_results.json")
     try:
         with open(run_results_path) as file:
             return json.load(file)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
@@ -58,14 +58,19 @@ class TestDbtCliSolids:
         assert len(table_materializations) == 4
 
     def test_dbt_cli_run_with_extra_config(
-        self, dbt_seed, test_project_dir, dbt_config_dir
+        self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkeypatch
     ):  # pylint: disable=unused-argument
+
+        # specify dbt target dir
+        monkeypatch.setenv("DBT_TARGET_DIR", dbt_target_dir)
+
         test_solid = configured(dbt_cli_run, name="test_solid")(
             {
                 "project-dir": test_project_dir,
                 "profiles-dir": dbt_config_dir,
                 "threads": 1,
                 "models": ["least_caloric"],
+                "target-path": dbt_target_dir,
                 "fail-fast": True,
             }
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
@@ -62,7 +62,7 @@ class TestDbtCliSolids:
     ):  # pylint: disable=unused-argument
 
         # specify dbt target dir
-        monkeypatch.setenv("DBT_TARGET_DIR", dbt_target_dir)
+        monkeypatch.setenv("DBT_TARGET_PATH", dbt_target_dir)
 
         test_solid = configured(dbt_cli_run, name="test_solid")(
             {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
@@ -100,7 +100,7 @@ class TestDbtCliSolids:
                 "project-dir": test_project_dir,
                 "profiles-dir": dbt_config_dir,
                 "target-path:": dbt_target_dir,
-             }
+            }
         )
 
         result = execute_solid(test_solid)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
@@ -89,7 +89,7 @@ class TestDbtCliSolids:
         assert result.success
 
     def test_dbt_cli_test_with_extra_confg(
-        self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkypathc
+        self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkypatch
     ):  # pylint: disable=unused-argument
 
         # Specify dbt target path

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
@@ -61,7 +61,7 @@ class TestDbtCliSolids:
         self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkeypatch
     ):  # pylint: disable=unused-argument
 
-        # specify dbt target dir
+        # Specify dbt target path
         monkeypatch.setenv("DBT_TARGET_PATH", dbt_target_dir)
 
         test_solid = configured(dbt_cli_run, name="test_solid")(
@@ -83,6 +83,24 @@ class TestDbtCliSolids:
     ):  # pylint: disable=unused-argument
         test_solid = configured(dbt_cli_test, name="test_solid")(
             {"project-dir": test_project_dir, "profiles-dir": dbt_config_dir}
+        )
+
+        result = execute_solid(test_solid)
+        assert result.success
+
+    def test_dbt_cli_test_with_extra_confg(
+        self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkypathc
+    ):  # pylint: disable=unused-argument
+
+        # Specify dbt target path
+        monkeypatch.setenv("DBT_TARGET_PATH", dbt_target_dir)
+
+        test_solid = configured(dbt_cli_test, name="test_solid")(
+            {
+                "project-dir": test_project_dir,
+                "profiles-dir": dbt_config_dir,
+                "target-path:": dbt_target_dir,
+             }
         )
 
         result = execute_solid(test_solid)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_solids.py
@@ -89,7 +89,7 @@ class TestDbtCliSolids:
         assert result.success
 
     def test_dbt_cli_test_with_extra_confg(
-        self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkypatch
+        self, dbt_seed, test_project_dir, dbt_config_dir, dbt_target_dir, monkeypatch
     ):  # pylint: disable=unused-argument
 
         # Specify dbt target path
@@ -99,7 +99,7 @@ class TestDbtCliSolids:
             {
                 "project-dir": test_project_dir,
                 "profiles-dir": dbt_config_dir,
-                "target-path:": dbt_target_dir,
+                "target-path": dbt_target_dir,
             }
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -45,7 +45,7 @@ def conn_string():
         if not IS_BUILDKITE:
             os.environ["POSTGRES_TEST_DB_DBT_HOST"] = "localhost"
 
-        os.environ["DBT_TARGET_DIR"] = "target"
+        os.environ["DBT_TARGET_PATH"] = "target"
 
         with TestPostgresInstance.docker_service_up_or_skip(
             file_relative_path(__file__, "docker-compose.yml"),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -10,6 +10,7 @@ from dagster.utils.test.postgres_instance import TestPostgresInstance
 DBT_EXECUTABLE = "dbt"
 TEST_PROJECT_DIR = file_relative_path(__file__, "dagster_dbt_test_project")
 DBT_CONFIG_DIR = os.path.join(TEST_PROJECT_DIR, "dbt_config")
+TEST_DBT_TARGET_DIR = os.path.join(TEST_PROJECT_DIR, "target_test")
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
@@ -22,6 +23,11 @@ def test_project_dir():
 @pytest.fixture(scope="session")
 def dbt_config_dir():
     return DBT_CONFIG_DIR
+
+
+@pytest.fixture(scope="session")
+def dbt_target_dir():
+    return TEST_DBT_TARGET_DIR
 
 
 @pytest.fixture(scope="session")
@@ -38,6 +44,8 @@ def conn_string():
     try:
         if not IS_BUILDKITE:
             os.environ["POSTGRES_TEST_DB_DBT_HOST"] = "localhost"
+
+        os.environ["DBT_TARGET_DIR"] = "target"
 
         with TestPostgresInstance.docker_service_up_or_skip(
             file_relative_path(__file__, "docker-compose.yml"),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/.gitignore
@@ -1,5 +1,6 @@
 
 target/
+target_test/
 dbt_modules/
 logs/
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/dbt_project.yml
@@ -19,9 +19,9 @@ data-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-target-path: "target"  # directory which will store compiled SQL files
+target-path: "{{ env_var('DBT_TARGET_DIR') }}"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
-    - "target"
+    - "{{ env_var('DBT_TARGET_DIR') }}"
     - "dbt_modules"
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dagster_dbt_test_project/dbt_project.yml
@@ -19,9 +19,9 @@ data-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-target-path: "{{ env_var('DBT_TARGET_DIR') }}"  # directory which will store compiled SQL files
+target-path: "{{ env_var('DBT_TARGET_PATH') }}"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
-    - "{{ env_var('DBT_TARGET_DIR') }}"
+    - "{{ env_var('DBT_TARGET_PATH') }}"
     - "dbt_modules"
 
 

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
-passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_DBT_HOST DBT_TARGET_DIR
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_DBT_HOST DBT_TARGET_PATH
 deps =
   -e ../../dagster[test]
   -e ../dagster-pandas

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
-passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_DBT_HOST
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_DBT_HOST DBT_TARGET_DIR
 deps =
   -e ../../dagster[test]
   -e ../dagster-pandas


### PR DESCRIPTION
## Summary
Since dbt allows customization of `target_path` in your project file (`dbt_project.yml`), Dagster integration should allow customization of the path upon configuring dbt solids. This PR introduces a new configuration called `target_path` for `dbt_cli_test` and `dbt_cli_run`. 

The motivation behind this change was from being able to run dbt model and test on a clone of target database prior to deploying to the target database along with using [their state method](https://docs.getdbt.com/reference/node-selection/methods#the-state-method) to only run models that have been modified. (Need to keep the target directories separate for a test run and actual deployment to keep track of diffs)

[Original Slack thread](https://dagster.slack.com/archives/C01U954MEER/p1621363140015400)


## Test Plan
- Updated `libraries/dagster-dbt/dagster_dbt_tests/cli/test_slids.py` for `dbt run` and `dbt test`




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.