### PR TITLE
Dagster mlflow

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -388,6 +388,7 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
         extra_cmds_fn=k8s_extra_cmds_fn,
         depends_on_fn=test_image_depends_fn,
     ),
+    ModuleBuildSpec("python_modules/libraries/dagster-mlflow", upload_coverage=False),
     ModuleBuildSpec("python_modules/libraries/dagster-mysql", extra_cmds_fn=mysql_extra_cmds_fn),
     ModuleBuildSpec(
         "python_modules/libraries/dagster-postgres", extra_cmds_fn=postgres_extra_cmds_fn

--- a/python_modules/libraries/dagster-mlflow/.coveragerc
+++ b/python_modules/libraries/dagster-mlflow/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/python_modules/libraries/dagster-mlflow/LICENSE
+++ b/python_modules/libraries/dagster-mlflow/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python_modules/libraries/dagster-mlflow/MANIFEST.in
+++ b/python_modules/libraries/dagster-mlflow/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/python_modules/libraries/dagster-mlflow/README.md
+++ b/python_modules/libraries/dagster-mlflow/README.md
@@ -1,0 +1,4 @@
+# dagster-mlflow
+
+The docs for `dagster-mlflow` can be found
+[here](https://docs.dagster.io/_apidocs/libraries/dagster_mlflow).

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
@@ -1,0 +1,8 @@
+from dagster.core.utils import check_dagster_package_version
+
+from .resources import datadog_resource
+from .version import __version__
+
+check_dagster_package_version("dagster-datadog", __version__)
+
+__all__ = ["datadog_resource"]

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
@@ -1,8 +1,8 @@
 from dagster.core.utils import check_dagster_package_version
 
-from .resources import mlflow_tracking
+from .resources import mlflow_tracking, cleanup_on_success, cleanup_on_dagit_failure
 from .version import __version__
 
 check_dagster_package_version("dagster-mlflow", __version__)
 
-__all__ = ["mlflow_tracking"]
+__all__ = ["mlflow_tracking", "cleanup_on_success", "cleanup_on_dagit_failure"]

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
@@ -1,8 +1,9 @@
 from dagster.core.utils import check_dagster_package_version
 
-from .resources import mlflow_tracking, cleanup_on_success, cleanup_on_dagit_failure
+from .hooks import end_mlflow_run_on_pipeline_finished
+from .resources import mlflow_tracking
 from .version import __version__
 
 check_dagster_package_version("dagster-mlflow", __version__)
 
-__all__ = ["mlflow_tracking", "cleanup_on_success", "cleanup_on_dagit_failure"]
+__all__ = ["mlflow_tracking", "end_mlflow_run_on_pipeline_finished"]

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
@@ -1,8 +1,8 @@
 from dagster.core.utils import check_dagster_package_version
 
-from .resources import datadog_resource
+from .resources import mlflow_tracking
 from .version import __version__
 
-check_dagster_package_version("dagster-datadog", __version__)
+check_dagster_package_version("dagster-mlflow", __version__)
 
-__all__ = ["datadog_resource"]
+__all__ = ["mlflow_tracking"]

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/hooks.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/hooks.py
@@ -1,0 +1,25 @@
+from dagster.core.definitions.decorators.hook import event_list_hook
+from mlflow.entities.run_status import RunStatus
+
+
+@event_list_hook(required_resource_keys={"mlflow"})
+def end_mlflow_run_on_pipeline_finished(context, event_list):
+    for event in event_list:
+        if event.is_step_success:
+            _cleanup_on_success(context)
+        elif event.is_step_failure:
+            mlf = context.resources.mlflow
+            mlf.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+
+
+def _cleanup_on_success(context):
+    """
+    Checks if the current solid in the context is the last solid in the pipeline
+    and ends the mlflow run with a successful status when this is the case.
+    """
+    last_solid_name = context._step_execution_context.pipeline_def.solids_in_topological_order[  # pylint: disable=protected-access
+        -1
+    ].name
+
+    if context.solid.name == last_solid_name:
+        context.resources.mlflow.end_run()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -251,7 +251,9 @@ def _cleanup_on_success(context):
     Checks if the current solid in the context is the last solid in the pipeline
     and ends the mlflow run with a successful status when this is the case.
     """
-    last_solid_name = context.pipeline_def.solids_in_topological_order[-1].name
+    last_solid_name = context._step_execution_context.pipeline_def.solids_in_topological_order[
+        -1
+    ].name
 
     if context.solid.name == last_solid_name:
         context.resources.mlflow.end_run()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -1,0 +1,280 @@
+"""
+This module contains the mlflow resource provided by the MlFlow
+class. This resource provides an easy way to configure mlflow for logging various
+things from dagster runs.
+"""
+import atexit
+import sys
+from itertools import islice
+from os import environ
+from typing import Optional
+
+import mlflow
+from dagster import Field, Noneable, Permissive, failure_hook, resource
+from dagster.core.definitions.decorators.hook import success_hook
+from mlflow.entities.run_status import RunStatus
+
+CONFIG_SCHEMA = {
+    "experiment_name": Field(str, is_required=True, description="MlFlow experiment name."),
+    "mlflow_tracking_uri": Field(
+        Noneable(str),
+        default_value=None,
+        is_required=False,
+        description="MlFlow tracking server uri.",
+    ),
+    "parent_run_id": Field(
+        Noneable(str),
+        default_value=None,
+        is_required=False,
+        description="Mlflow run ID of parent run if this is a nested run.",
+    ),
+    "env": Field(Permissive(), description="Environment variables for mlflow setup."),
+    "env_to_tag": Field(
+        Noneable(list),
+        default_value=None,
+        is_required=False,
+        description="List of environment variables to log as tags in mlflow.",
+    ),
+    "extra_tags": Field(Permissive(), description="Any extra key-value tags to log to mlflow."),
+}
+
+
+class MlflowMeta(type):
+    """Mlflow Metaclass to create methods that "inherit" all of Mlflow's
+    methods. If the class has a method defined it is excluded from the
+    attribute setting from mlflow.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        class_cls = super(MlflowMeta, cls).__new__(cls, name, bases, attrs)
+        for attr in (attr for attr in dir(mlflow) if attr not in dir(class_cls)):
+            mlflow_attribute = getattr(mlflow, attr)
+            if callable(mlflow_attribute):
+                setattr(class_cls, attr, staticmethod(mlflow_attribute))
+            else:
+                setattr(class_cls, attr, mlflow_attribute)
+        return class_cls
+
+
+class MlFlow(metaclass=MlflowMeta):
+    """Class for setting up an mlflow resource for dagster runs.
+    This takes care of all the configuration required to use mlflow tracking and the complexities of
+    mlflow tracking dagster parallel runs.
+    """
+
+    def __init__(self, context):
+
+        # Context associated attributes
+        self.log = context.log
+        self.run_name = context.pipeline_run.pipeline_name
+        self.dagster_run_id = context.run_id
+
+        # resource config attributes
+        resource_config = context.resource_config
+        self.tracking_uri = resource_config.get("mlflow_tracking_uri")
+        if self.tracking_uri:
+            mlflow.set_tracking_uri(self.tracking_uri)
+        self.parent_run_id = resource_config.get("parent_run_id")
+        self.experiment_name = resource_config["experiment_name"]
+        self.env_tags_to_log = resource_config.get("env_to_tag") or []
+        self.extra_tags = resource_config.get("extra_tags")
+
+        # Update env variables if any are given
+        self.env_vars = resource_config.get("env", {})
+        if self.env_vars:
+            environ.update(self.env_vars)
+
+        # If the experiment exists then the set won't do anything
+        mlflow.set_experiment(self.experiment_name)
+        self.experiment = mlflow.get_experiment_by_name(self.experiment_name)
+
+        # Get the client object
+        self.tracking_client = mlflow.tracking.MlflowClient()
+
+        # Set up the active run and tags
+        self._setup()
+
+    def _setup(self):
+        """
+        Sets the active run and tags. If an Mlflow run_id exists then the
+        active run is set to it. This way a single Dagster run outputs data
+        to the same Mlflow run, even when multiprocess executors are used.
+        """
+        # Get the run id
+        run_id = self._get_current_run_id()
+        self._set_active_run(run_id=run_id)
+        self._set_all_tags()
+
+        # hack needed to stop mlflow from marking run as finished when
+        # a process exits in parallel runs
+        atexit.unregister(mlflow.end_run)
+
+    def _get_current_run_id(
+        self, experiment: Optional[str] = None, dagster_run_id: Optional[str] = None
+    ):
+        """Gets the run id of a specific dagster run and experiment id.
+        If it doesn't exist then it returns a None.
+
+        Args:
+            experiment (optional): Mlflow experiment.
+            When none is passed it fetches the experiment object set in
+            the constructor.  Defaults to None.
+            dagster_run_id (optional): The Dagster run id.
+            When none is passed it fetches the dagster_run_id object set in
+            the constructor.  Defaults to None.
+        Returns:
+            run_id (str or None): run_id if it is found else None
+        """
+        experiment = experiment or self.experiment
+        dagster_run_id = dagster_run_id or self.dagster_run_id
+        if experiment:
+            # Check if a run with this dagster run id has already been started
+            # in mlflow, will get an empty dataframe if not
+            current_run_df = mlflow.search_runs(
+                experiment_ids=[experiment.experiment_id],
+                filter_string=f"tags.dagster_run_id='{dagster_run_id}'",
+            )
+            if not current_run_df.empty:
+                return current_run_df.run_id.values[0]
+
+    def _set_active_run(self, run_id=None):
+        """
+        This method sets the active run to be that of the specified
+        run_id. If None is passed then a new run is started. The new run also
+        takes care of nested runs.
+
+        Args:
+            run_id (str, optional): Mlflow run_id. Defaults to None.
+        """
+        nested_run = False
+        if self.parent_run_id is not None:
+            self._start_run(run_id=self.parent_run_id, run_name=self.run_name)
+            nested_run = True
+        self._start_run(run_id=run_id, run_name=self.run_name, nested=nested_run)
+
+    def _start_run(self, **kwargs):
+        """
+        Catches the Mlflow exception if a run is already active.
+        """
+
+        try:
+            run = mlflow.start_run(**kwargs)
+            self.log.info(
+                f"Starting a new mlflow run with id {run.info.run_id} "
+                f"in experiment {self.experiment_name}"
+            )
+        except Exception as ex:
+            run = mlflow.active_run()
+            if f"is already active" not in str(ex):
+                raise (ex)
+            self.log.info(f"Run with id {run.info.run_id} is already active.")
+
+    def _set_all_tags(self):
+        """Method collects dagster_run_id plus all env variables/tags that have been
+            specified by the user in the config_schema and logs them as tags in mlflow.
+
+        Returns:
+            tags [dict]: Dictionary of all the tags
+        """
+        tags = {tag: environ.get(tag) for tag in self.env_tags_to_log}
+        tags["dagster_run_id"] = self.dagster_run_id
+        if self.extra_tags:
+            tags.update(self.extra_tags)
+
+        mlflow.set_tags(tags)
+
+    def cleanup_on_error(self):
+        """Method ends mlflow run with correct exit status for failed runs. Note that
+        this method does not work when a pipeline running in dagit fails, it seems
+        that in this case a different process runs the pipeline and when it fails
+        the stack trace is therefore not available. For this case we can use the
+        cleanup_on_failure hook defined below.
+        """
+        any_error = sys.exc_info()
+
+        if any_error[1]:
+            if isinstance(any_error[1], KeyboardInterrupt):
+                mlflow.end_run(status=RunStatus.to_string(RunStatus.KILLED))
+            else:
+                mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+
+    @staticmethod
+    def log_params(params: dict):
+        """Overload of the mlflow.log_params. If len(params) >100 then
+        params is sent to mlflow in chunks.
+
+        Args:
+            params (dict): Parameters to be logged
+        """
+        for param_chunk in MlFlow.chunks(params, 100):
+            mlflow.log_params(param_chunk)
+
+    @staticmethod
+    def chunks(params: dict, size: int = 100):
+        """Method that chunks a dictionary into batches of size.
+
+        Args:
+            params (dict): Dictionary set to be batched
+            size (int, optional): Number of batches. Defaults to 100.
+
+        Yields:
+            (dict): Batch of dictionary
+        """
+        it = iter(params)
+        for _ in range(0, len(params), size):
+            yield {k: params[k] for k in islice(it, size)}
+
+
+@failure_hook(required_resource_keys={"mlflow"})
+def cleanup_on_dagit_failure(context):
+    """When attached to a pipeline this hook will be called when a pipeline running
+    in dagit fails. Note that this hook is only called when the failing pipeline
+    has been launched through dagit. We therefore still need the cleanup_on_error
+    method above to cover all other cases.
+    """
+
+    mlf = context.resources.mlflow
+    mlf.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+
+
+@success_hook(required_resource_keys={"mlflow"})
+def cleanup_on_success(context):
+    """
+    When attached to a pipeline this hook will be called whenever a solid runs
+    successfully.
+    """
+    _cleanup_on_success(context)
+
+
+def _cleanup_on_success(context):
+    """
+    Checks if the current solid in the context is the last solid in the pipeline
+    and ends the mlflow run with a successful status when this is the case.
+    """
+    last_solid_name = context.pipeline_def.solids_in_topological_order[-1].name
+
+    if context.solid.name == last_solid_name:
+        context.resources.mlflow.end_run()
+
+
+@resource(config_schema=CONFIG_SCHEMA)
+def mlflow_tracking(context):
+    """
+    This resource provides access to all of mlflow's methods as well as the mlflow tracking client's
+    methods.
+
+    Usage:
+
+    1. Make sure to add the mlflow resource to the first solid in the pipeline to start
+       the mlflow run.
+    2. To use mlflow utilities inside a solid make sure to add the mlflow resource to
+       that solid and then get the mlflow instance like so
+       `mlflow = context.resources.mlflow`
+       then use as you would normally use mlflow,
+       e.g.; `mlflow.log_params(some_params)`
+    3. Add the success and failure hooks namely `cleanup_on_success` and `cleanup_on_dagit_failure`
+       to your pipeline to ensure the mlflow run is always stopped with the correct run status.
+    """
+    mlf = MlFlow(context)
+    yield mlf
+    mlf.cleanup_on_error()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -247,7 +247,7 @@ def mlflow_tracking(context):
             @solid(required_resource_keys={"mlflow"})
             def mlflow_solid(context):
                 mlflow.log_params(some_params)
-                mlflow.tracking_client.create_registered_model(some_model_name)
+                mlflow.tracking.MlflowClient().create_registered_model(some_model_name)
 
             @end_mlflow_run_on_pipeline_finished
             @pipeline(mode_defs=[ModeDefinition(resource_defs={"mlflow": mlflow_tracking})])

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/version.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/version.py
@@ -1,0 +1,1 @@
+__version__ = "dev"

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock
+
+from dagster_mlflow.hooks import _cleanup_on_success
+
+
+def test_cleanup_on_success():
+
+    # Given: - two mock solids
+    mock_solid_1 = Mock(name="solid_1")
+    mock_solid_2 = Mock(name="solid_2")
+
+    # - a mock context containing a list of these two solids and a current solid
+    mock_context = Mock()
+    step_execution_context = (
+        mock_context._step_execution_context  # pylint: disable=protected-access
+    )
+    step_execution_context.pipeline_def.solids_in_topological_order = [
+        mock_solid_1,
+        mock_solid_2,
+    ]
+    mock_context.solid = mock_solid_2
+
+    # When: the cleanup function is called with the mock context
+    _cleanup_on_success(mock_context)
+
+    # Then:
+    # - mlflow.end_run is called if solid is the last solid
+    mock_context.resources.mlflow.end_run.assert_called_once()
+
+    # - mlflow.end_run is not called when the solid in the context is not the last solid
+    mock_context.reset_mock()
+    mock_context.solid = mock_solid_1
+    _cleanup_on_success(mock_context)
+    mock_context.resources.mlflow.end_run.assert_not_called()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -1,18 +1,20 @@
 """
 Unit testing the Mlflow class
 """
+# pylint: disable=redefined-outer-name
 import logging
 import random
 import string
 import uuid
 from copy import deepcopy
 from typing import Any, Dict
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import mlflow
 import pandas as pd
 import pytest
-from dagster_mlflow.resources import MlFlow, _cleanup_on_success
+from dagster import ModeDefinition, execute_pipeline, pipeline, solid
+from dagster_mlflow.resources import MlFlow, mlflow_tracking
 
 
 @pytest.fixture
@@ -88,7 +90,7 @@ def child_context(basic_context, mlflow_run_config):
 def cleanup_mlflow_runs():
     yield
     while mlflow.active_run():
-        mlflow.end_run()
+        mlflow.end_run()  # pylint: disable=no-member
 
 
 @patch("os.environ.update")
@@ -105,57 +107,57 @@ def test_mlflow_constructor_basic(
     context,
 ):
     with patch.object(MlFlow, "_setup") as mock_setup:
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
-        ## Then:
-        ## the _setup() is called once
+        # Then:
+        # the _setup() is called once
         mock_setup.assert_called_once()
-    ## - the mlflow library methods & attributes have been added to the object
+    # - the mlflow library methods & attributes have been added to the object
     assert all(hasattr(mlf, attr) for attr in dir(MlFlow) if attr not in ("__name__"))
 
-    ## - the context associated attributes passed have been set
+    # - the context associated attributes passed have been set
     assert mlf.log == context.log
     assert mlf.run_name == context.pipeline_run.pipeline_name
     assert mlf.dagster_run_id == context.run_id
 
-    ## - the tracking URI is the same as what was passed
+    # - the tracking URI is the same as what was passed
     assert mlf.tracking_uri == context.resource_config.get("mlflow_tracking_uri")
-    ## - the tracking URI was set to mlflow
+    # - the tracking URI was set to mlflow
     if mlf.tracking_uri:
         mock_set_tracking_uri.assert_called_once_with(mlf.tracking_uri)
     else:
         mock_set_tracking_uri.assert_not_called()
-    ## - the resource config attributes have been set
+    # - the resource config attributes have been set
     assert mlf.parent_run_id == context.resource_config.get("parent_run_id")
     assert mlf.experiment_name == context.resource_config.get("experiment_name")
     assert mlf.env_tags_to_log == context.resource_config.get("env_to_tag", [])
     assert mlf.extra_tags == context.resource_config.get("extra_tags")
     assert mlf.env_vars == context.resource_config.get("env", {})
 
-    ## - the env vars that have been updated are set
+    # - the env vars that have been updated are set
     if mlf.env_vars:
         mock_environ_update.assert_called_once_with(mlf.env_vars)
     else:
         mock_environ_update.assert_not_called()
     mock_set_experiment.assert_called_once_with(mlf.experiment_name)
     mock_get_experiment_by_name(mlf.experiment_name)
-    ## - mlflow.tracking.MlflowClient has been called
+    # - mlflow.tracking.MlflowClient has been called
     mock_mlflowclient.assert_called_once()
 
 
-def test_mlflow_meta_not_overloading(context):
-    ## Given an MlFlow
-    ## And: a list of overloaded mlflow methods
+def test_mlflow_meta_not_overloading():
+    # Given an MlFlow
+    # And: a list of overloaded mlflow methods
     # TODO: find a way to get this list
     over_list = ["log_params"]
     for methods in over_list:
-        ## then: the function signature is not the same as the mlflow one
+        # then: the function signature is not the same as the mlflow one
         assert getattr(MlFlow, methods) != getattr(mlflow, methods)
 
 
-def test_mlflow_meta_overloading(context):
-    ## Given an MlFlow
-    ## And: a list of inherited mlflow methods
+def test_mlflow_meta_overloading():
+    # Given an MlFlow
+    # And: a list of inherited mlflow methods
     # TODO: find a way to get this list
     inherited_list = [
         method for method in dir(mlflow) if method not in ["log_params", "__name__", "__doc__"]
@@ -169,53 +171,54 @@ def test_mlflow_meta_overloading(context):
 def test_start_run(mock_start_run, context):
 
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
 
-    ## When: a run is started
+    # When: a run is started
     run_id_1 = str(uuid.uuid4())
-    mlf._start_run(run_id=run_id_1)
-    ## Then mlflow start_run is called
+    mlf._start_run(run_id=run_id_1)  # pylint: disable=protected-access
+    # Then mlflow start_run is called
     mock_start_run.assert_called_once_with(run_id=run_id_1)
 
-    ## And when start run is called with the same run_id no excpetion is raised
-    mlf._start_run(run_id=run_id_1)
+    # And when start run is called with the same run_id no excpetion is raised
+    mlf._start_run(run_id=run_id_1)  # pylint: disable=protected-access
 
 
 @patch("mlflow.end_run")
 @pytest.mark.parametrize("any_error", [KeyboardInterrupt(), OSError(), RuntimeError(), None])
-def test_cleanup_on_error(mock_mlflow_end_run, any_error, context, cleanup_mlflow_runs):
-
+def test_cleanup_on_error(
+    mock_mlflow_end_run, any_error, context, cleanup_mlflow_runs  # pylint: disable=unused-argument
+):
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
-    ## When: a run is started
-    mlf.start_run()
+    # When: a run is started
+    mlf.start_run()  # pylint: disable=no-member
 
     with patch("sys.exc_info", return_value=[0, any_error]):
-        ## When: cleanup_on_error is called
+        # When: cleanup_on_error is called
         mlf.cleanup_on_error()
-    ## Then:
+    # Then:
     if any_error:
         if isinstance(any_error, KeyboardInterrupt):
-            ## mlflow.end_run is called with status=KILLED if KeyboardInterrupt
+            # mlflow.end_run is called with status=KILLED if KeyboardInterrupt
             mock_mlflow_end_run.assert_called_once_with(status="KILLED")
         else:
-            ## mlflow.end_run is called with status=FAILED for all other errors
+            # mlflow.end_run is called with status=FAILED for all other errors
             mock_mlflow_end_run.assert_called_once_with(status="FAILED")
         assert True
     else:
-        ## mlflow.end_run is not called when no error is flagged
+        # mlflow.end_run is not called when no error is flagged
         mock_mlflow_end_run.assert_not_called()
 
 
 @patch("mlflow.set_tags")
 def test_set_all_tags(mock_mlflow_set_tags, context):
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
-    ## When all the tags are set
-    mlf._set_all_tags()
+    # When all the tags are set
+    mlf._set_all_tags()  # pylint: disable=protected-access
 
     # Given: the tags that should be set in mlflow
     tags = {
@@ -224,7 +227,7 @@ def test_set_all_tags(mock_mlflow_set_tags, context):
     tags["dagster_run_id"] = mlf.dagster_run_id
     if mlf.extra_tags:
         tags.update(mlf.extra_tags)
-    ## Then the Mlflow.set_tags is called with the set tags
+    # Then the Mlflow.set_tags is called with the set tags
     mock_mlflow_set_tags.assert_called_once_with(tags)
 
 
@@ -233,13 +236,13 @@ def test_set_all_tags(mock_mlflow_set_tags, context):
     "experiment", [None, MagicMock(experiment_id="1"), MagicMock(experiment_id="lol")]
 )
 def test_get_current_run_id(context, experiment, run_df):
-    ## Given: an initialization of the mlflow object
+    # Given: an initialization of the mlflow object
     mlf = MlFlow(context)
 
-    with patch("mlflow.search_runs", return_value=run_df) as mock_search_runs:
-        ## when: _get_current_run_id is called
-        run_id = mlf._get_current_run_id(experiment=experiment)
-    ## Then: the run_id id provided is the same as what was provided
+    with patch("mlflow.search_runs", return_value=run_df):
+        # when: _get_current_run_id is called
+        run_id = mlf._get_current_run_id(experiment=experiment)  # pylint: disable=protected-access
+    # Then: the run_id id provided is the same as what was provided
     if not run_df.empty:
         assert run_id == run_df.run_id.values[0]
     else:
@@ -250,7 +253,7 @@ def test_get_current_run_id(context, experiment, run_df):
 def test_setup(mock_atexit, context):
 
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
 
     with patch.object(
@@ -260,117 +263,131 @@ def test_setup(mock_atexit, context):
     ) as mock_set_active_run, patch.object(
         MlFlow, "_set_all_tags"
     ) as mock_set_all_tags:
-        ## When _setup is called
-        mlf._setup()
-        ## Then
-        ## - _get_current_run_id is called once with the experiment object
+        # When _setup is called
+        mlf._setup()  # pylint: disable=protected-access
+        # Then
+        # - _get_current_run_id is called once with the experiment object
         mock_get_current_run_id.assert_called()
-        ## - _set_active_run is called once with the run_id returned from _get_current_run_id
+        # - _set_active_run is called once with the run_id returned from _get_current_run_id
         mock_set_active_run.assert_called_once_with(run_id="run_id_mock")
-        ## - _set_all_tags is called once
+        # - _set_all_tags is called once
         mock_set_all_tags.assert_called_once()
-    ## - atexit.unregister is called with mlf.end_run as an argument
-    mock_atexit.assert_called_once_with(mlf.end_run)
+    # - atexit.unregister is called with mlf.end_run as an argument
+    mock_atexit.assert_called_once_with(mlf.end_run)  # pylint: disable=no-member
 
 
 @pytest.mark.parametrize("run_id", [None, 0, "12"])
 def test_set_active_run(context, run_id):
 
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
 
     with patch.object(MlFlow, "_start_run") as mock_start_run:
-        ## When _set_active_run is called
-        mlf._set_active_run(run_id=run_id)
+        # When _set_active_run is called
+        mlf._set_active_run(run_id=run_id)  # pylint: disable=protected-access
 
-    ## And: the run is nested
+    # And: the run is nested
     if mlf.parent_run_id is not None:
-        ## Then:
-        ## - the parent run is started if required
+        # Then:
+        # - the parent run is started if required
         mock_start_run.assert_any_call(run_id=mlf.parent_run_id, run_name=mlf.run_name)
-        ## - mlflow.start_run is called with nested=True
+        # - mlflow.start_run is called with nested=True
         mock_start_run.assert_any_call(run_id=run_id, run_name=mlf.run_name, nested=True)
-        ## - _start_run is called twice
-        mock_start_run.call_count == 2
-    ## And: the run is not nested
+        # - _start_run is called twice
+        assert mock_start_run.call_count == 2
+    # And: the run is not nested
     else:
-        ## Then:
+        # Then:
         mock_start_run.assert_called_once_with(run_id=run_id, run_name=mlf.run_name, nested=False)
 
 
 def test_set_active_run_parent_zero(child_context):
-    ## Given: a parent_run_id of zero
+    # Given: a parent_run_id of zero
     child_context.resource_config["parent_run_id"] = 0
-    ## : an initialization of the mlflow object
+    # : an initialization of the mlflow object
     mlf = MlFlow(child_context)
 
     with patch.object(MlFlow, "_start_run") as mock_start_run:
-        ## And _set_active_run is called with run_id
-        mlf._set_active_run(run_id="what-is-an-edge-case")
-        ## Then: _start_run_by_id is called with the parent_id
+        # And _set_active_run is called with run_id
+        mlf._set_active_run(run_id="what-is-an-edge-case")  # pylint: disable=protected-access
+        # Then: _start_run_by_id is called with the parent_id
         mock_start_run.assert_any_call(run_id=mlf.parent_run_id, run_name=mlf.run_name)
-        ## And: mlflow.start_run is called with the run_name and nested=True
+        # And: mlflow.start_run is called with the run_name and nested=True
         mock_start_run.assert_any_call(
             run_id="what-is-an-edge-case", run_name=mlf.run_name, nested=True
         )
-        ## And _start_run is called twice
-        mock_start_run.call_count == 2
+        # And _start_run is called twice
+        assert mock_start_run.call_count == 2
 
 
 @patch("mlflow.log_params")
 @pytest.mark.parametrize("num_of_params", (90, 101, 223))
 def test_log_params(mock_log_params, context, num_of_params, string_maker):
-    ## Given: init of MlFlow
+    # Given: init of MlFlow
     mlf = MlFlow(context)
-    ## And: a set of parameters
+    # And: a set of parameters
     param = {string_maker(5): string_maker(5) for _ in range(num_of_params)}
-    ## When: log_params is called
+    # When: log_params is called
     mlf.log_params(param)
-    ## Then mock_log_params is called the correct number of times
+    # Then mock_log_params is called the correct number of times
     assert mock_log_params.call_count == num_of_params // 100 + (1 if num_of_params % 100 else 0)
 
 
 @pytest.mark.parametrize("chunk", (10, 100))
 @pytest.mark.parametrize("num_of_params", (90, 200))
 def test_chunks(context, num_of_params, string_maker, chunk):
-    ## Given: init of MLFlow
+    # Given: init of MLFlow
     mlf = MlFlow(context)
-    ## And: a dictionary
+    # And: a dictionary
     D = {string_maker(5): string_maker(5) for _ in range(num_of_params)}
-    ## When: dictionary is chunked
+    # When: dictionary is chunked
     param_chunks_list = [param_chunk for param_chunk in mlf.chunks(D, chunk)]
 
-    ## Then
+    # Then
     # - the number of chunks is what is expected
     assert len(param_chunks_list) == num_of_params // chunk + (1 if num_of_params % chunk else 0)
     # - the unwrapped dictionary is the same as was set
     assert {k: v for d in param_chunks_list for k, v in d.items()} == D
 
 
-def test_cleanup_on_success():
+def test_execute_solid_with_mlflow_resource():
+    run_id_holder = {}
 
-    # Given: - two mock solids
-    mock_solid_1 = Mock(name="solid_1")
-    mock_solid_2 = Mock(name="solid_2")
+    params = {"learning_rate": "0.01", "n_estimators": "10"}
+    extra_tags = {"super": "experiment"}
 
-    # - a mock context containing a list of these two solids and a current solid
-    mock_context = Mock()
-    mock_context._step_execution_context.pipeline_def.solids_in_topological_order = [
-        mock_solid_1,
-        mock_solid_2,
-    ]
-    mock_context.solid = mock_solid_2
+    @solid(required_resource_keys={"mlflow"})
+    def solid1(_):
+        mlflow.log_params(params)
+        run_id_holder["solid1_run_id"] = mlflow.active_run().info.run_id
 
-    # When: the cleanup function is called with the mock context
-    _cleanup_on_success(mock_context)
+    @solid(required_resource_keys={"mlflow"})
+    def solid2(_, _arg1):
+        run_id_holder["solid2_run_id"] = mlflow.active_run().info.run_id
 
-    # Then:
-    # - mlflow.end_run is called if solid is the last solid
-    mock_context.resources.mlflow.end_run.assert_called_once()
+    @pipeline(mode_defs=[ModeDefinition(resource_defs={"mlflow": mlflow_tracking})])
+    def mlf_pipeline():
+        solid2(solid1())
 
-    # - mlflow.end_run is not called when the solid in the context is not the last solid
-    mock_context.reset_mock()
-    mock_context.solid = mock_solid_1
-    _cleanup_on_success(mock_context)
-    mock_context.resources.mlflow.end_run.assert_not_called()
+    result = execute_pipeline(
+        mlf_pipeline,
+        run_config={
+            "resources": {
+                "mlflow": {
+                    "config": {
+                        "experiment_name": "my_experiment",
+                        "extra_tags": extra_tags,
+                    }
+                }
+            }
+        },
+    )
+    assert result.success
+
+    assert run_id_holder["solid1_run_id"] == run_id_holder["solid2_run_id"]
+    run = mlflow.get_run(run_id_holder["solid1_run_id"])
+    assert run.data.params == params
+    assert set(extra_tags.items()).issubset(run.data.tags.items())
+
+    assert mlflow.get_experiment_by_name("my_experiment")

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -1,0 +1,477 @@
+"""
+Unit testing the Mlflow class
+"""
+import random
+import string
+
+from unittest.mock import MagicMock, patch, Mock
+
+import mlflow
+import pandas as pd
+import pytest
+
+from dagster_mlflow.resources import MlFlow, _cleanup_on_success
+
+
+import logging
+import uuid
+from copy import deepcopy
+from typing import Any, Dict
+
+
+from dagster import (
+    ModeDefinition,
+    DagsterInstance,
+    execute_pipeline,
+    fs_io_manager,
+    pipeline,
+    reconstructable,
+    solid,
+)
+
+from dagster_mlflow import mlflow_tracking
+
+
+@pytest.fixture
+def string_maker():
+    class Dummy:
+        def __call__(self, size=5):
+            return "".join(random.choice(string.ascii_letters) for _ in range(size))
+
+    return Dummy()
+
+
+@pytest.fixture
+def basic_run_config() -> Dict[str, Any]:
+    return {
+        "resources": {"mlflow": {"config": {"experiment_name": "testing"}}},
+        "solids": {},
+    }
+
+
+@pytest.fixture
+def mlflow_run_config(basic_run_config):
+    config = deepcopy(basic_run_config)
+    config["resources"]["mlflow"]["config"]["env"] = {
+        "what": "do we do with the drunken sailor?",
+        "early": "in the morning",
+        "put": "tag",
+    }
+    config["resources"]["mlflow"]["config"]["env_to_tag"] = ["what", "put"]
+    return config
+
+
+@pytest.fixture
+def multiprocess_mlflow_run_config(mlflow_run_config):
+    config = deepcopy(mlflow_run_config)
+    config["execution"] = {"multiprocess": {"config": {"max_concurrent": 2}}}
+    return config
+
+
+@pytest.fixture(params=["basic_context", "child_context"])
+def context(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def basic_context(mlflow_run_config, pipeline_run):
+    return MagicMock(
+        resource_config=mlflow_run_config["resources"]["mlflow"]["config"],
+        log=logging.getLogger(),
+        run_id=str(uuid.uuid4()),
+        pipeline_run=pipeline_run,
+    )
+
+
+@pytest.fixture
+def child_context(basic_context, mlflow_run_config):
+    resource_config = deepcopy(mlflow_run_config["resources"]["mlflow"]["config"])
+    resource_config["parent_run_id"] = basic_context.run_id
+    return MagicMock(
+        resource_config=resource_config,
+        log=basic_context.log,
+        run_id=str(uuid.uuid4()),
+        pipeline_run=basic_context.pipeline_run,
+        extra_tags={"wala": "lala"},
+    )
+
+
+# @pytest.fixture(params=[mlflow_tracking, mlflow_tracking_extra])
+# def testing_mode_mlflow_tracking(request):
+#     return ModeDefinition("testing_mode_mlflow_resource", resource_defs={"mlflow": request.param})
+
+
+# @pytest.fixture
+# def testing_mode_multiprocess_mlflow_tracking():
+#     return ModeDefinition(
+#         "testing_mode_mlflow_resource",
+#         resource_defs={"mlflow": mlflow_tracking},
+#         executor_defs=["multiprocess"],
+#     )
+
+
+# @pytest.fixture
+# def artifact_data():
+#     return {
+#         "science": {"experiment": "success"},
+#         "engineering": {"implementation": "issue"},
+#     }
+
+
+# @pytest.fixture
+# def log_params(request, string_maker):
+#     return {
+#         string_maker(3): string_maker(3),
+#         string_maker(request.param[0]): string_maker(request.param[1]),
+#         string_maker(request.param[1]): string_maker(request.param[0]),
+#     }
+
+
+@pytest.fixture
+def cleanup_mlflow_runs():
+    yield
+    while mlflow.active_run():
+        mlflow.end_run()
+
+
+@solid(required_resource_keys={"mlflow"})
+def dog(context):
+    mlf = context.resources.mlflow
+    mlf.set_tags({"dog": "pet"})
+
+
+@solid(required_resource_keys={"mlflow"})
+def potato(context):
+    mlf = context.resources.mlflow
+    mlf.set_tags({"potato": "food"})
+
+
+@pipeline(
+    mode_defs=[
+        ModeDefinition(
+            "testing_mode_mlflow_multiprocess",
+            resource_defs={"mlflow": mlflow_tracking, "io_manager": fs_io_manager},
+        )
+    ]
+)
+def multiprocess_pipeline():
+    dog()
+    potato()
+
+
+def test_multiprocess(multiprocess_mlflow_run_config, cleanup_mlflow_runs):
+    ## Given a pipeline with the MUltiproccess executor with three solids
+    res = execute_pipeline(
+        reconstructable(multiprocess_pipeline),
+        run_config=multiprocess_mlflow_run_config,
+        instance=DagsterInstance.local_temp(),
+    )
+
+    ## Then: the pipeline was executed successfully
+    assert res.success
+
+    ## And there is only one Mlfow run for the above run
+    experiment = mlflow.get_experiment_by_name(
+        multiprocess_mlflow_run_config["resources"]["mlflow"]["config"]["experiment_name"]
+    )
+    run_df = mlflow.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string=f"tags.dagster_run_id='{res.run_id}'",
+    )
+    assert run_df.shape[0] == 1
+
+
+@patch("os.environ.update")
+@patch("mlflow.set_tracking_uri")
+@patch("mlflow.get_experiment_by_name")
+@patch("mlflow.set_experiment")
+@patch("mlflow.tracking.MlflowClient")
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_mlflow_constructor_basic(
+    mock_mlflowclient,
+    mock_set_experiment,
+    mock_get_experiment_by_name,
+    mock_set_tracking_uri,
+    mock_environ_update,
+    context,
+    Mlflow_resource_class,
+):
+    with patch.object(Mlflow_resource_class, "_setup") as mock_setup:
+        ## Given: a context  passed into the __init__ for MlFlow
+        mlf = Mlflow_resource_class(context)
+        ## Then:
+        ## the _setup() is called once
+        mock_setup.assert_called_once()
+    ## - the mlflow library methods & attributes have been added to the object
+    assert all(hasattr(mlf, attr) for attr in dir(mlflow) if attr not in ("__name__"))
+
+    ## - the context associated attributes passed have been set
+    assert mlf.log == context.log
+    assert mlf.run_name == context.pipeline_run.pipeline_name
+    assert mlf.dagster_run_id == context.run_id
+
+    ## - the tracking URI is the same as what was passed
+    assert mlf.tracking_uri == context.resource_config.get("mlflow_tracking_uri")
+    ## - the tracking URI was set to mlflow
+    if mlf.tracking_uri:
+        mock_set_tracking_uri.assert_called_once_with(mlf.tracking_uri)
+    else:
+        mock_set_tracking_uri.assert_not_called()
+    ## - the resource config attributes have been set
+    assert mlf.parent_run_id == context.resource_config.get("parent_run_id")
+    assert mlf.experiment_name == context.resource_config.get("experiment_name")
+    assert mlf.env_tags_to_log == context.resource_config.get("env_to_tag", [])
+    assert mlf.extra_tags == context.resource_config.get("extra_tags")
+    assert mlf.env_vars == context.resource_config.get("env", {})
+
+    ## - the env vars that have been updated are set
+    if mlf.env_vars:
+        mock_environ_update.assert_called_once_with(mlf.env_vars)
+    else:
+        mock_environ_update.assert_not_called()
+    mock_set_experiment.assert_called_once_with(mlf.experiment_name)
+    mock_get_experiment_by_name(mlf.experiment_name)
+    ## - mlflow.tracking.MlflowClient has been called
+    mock_mlflowclient.assert_called_once()
+
+
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_mlflow_meta_not_overloading(context, Mlflow_resource_class):
+    ## Given an Mlflow_resource_class
+    ## And: a list of overloaded mlflow methods
+    # TODO: find a way to get this list
+    over_list = ["log_params"]
+    for methods in over_list:
+        ## then: the function signature is not the same as the mlflow one
+        assert getattr(Mlflow_resource_class, methods) != getattr(mlflow, methods)
+
+
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_mlflow_meta_overloading(context, Mlflow_resource_class):
+    ## Given an Mlflow_resource_class
+    ## And: a list of inherited mlflow methods
+    # TODO: find a way to get this list
+    inherited_list = [
+        method for method in dir(mlflow) if method not in ["log_params", "__name__", "__doc__"]
+    ]
+    for methods in inherited_list:
+        assert getattr(Mlflow_resource_class, methods) == getattr(mlflow, methods)
+
+
+@patch("mlflow.start_run")
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_start_run(mock_start_run, Mlflow_resource_class, context):
+
+    with patch.object(Mlflow_resource_class, "_setup"):
+        ## Given: a context  passed into the __init__ for MlFlow
+        mlf = Mlflow_resource_class(context)
+
+    ## When: a run is started
+    run_id_1 = str(uuid.uuid4())
+    mlf._start_run(run_id=run_id_1)
+    ## Then mlflow start_run is called
+    mock_start_run.assert_called_once_with(run_id=run_id_1)
+
+    ## And when start run is called with the same run_id no excpetion is raised
+    mlf._start_run(run_id=run_id_1)
+
+
+@patch("mlflow.end_run")
+@pytest.mark.parametrize("any_error", [KeyboardInterrupt(), OSError(), RuntimeError(), None])
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_cleanup_on_error(
+    mock_mlflow_end_run, any_error, Mlflow_resource_class, context, cleanup_mlflow_runs
+):
+
+    with patch.object(Mlflow_resource_class, "_setup"):
+        ## Given: a context  passed into the __init__ for MlFlow
+        mlf = Mlflow_resource_class(context)
+    ## When: a run is started
+    mlf.start_run()
+
+    with patch("sys.exc_info", return_value=[0, any_error]):
+        ## When: cleanup_on_error is called
+        mlf.cleanup_on_error()
+    ## Then:
+    if any_error:
+        if isinstance(any_error, KeyboardInterrupt):
+            ## mlflow.end_run is called with status=KILLED if KeyboardInterrupt
+            mock_mlflow_end_run.assert_called_once_with(status="KILLED")
+        else:
+            ## mlflow.end_run is called with status=FAILED for all other errors
+            mock_mlflow_end_run.assert_called_once_with(status="FAILED")
+        assert True
+    else:
+        ## mlflow.end_run is not called when no error is flagged
+        mock_mlflow_end_run.assert_not_called()
+
+
+@patch("mlflow.set_tags")
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_set_all_tags(mock_mlflow_set_tags, Mlflow_resource_class, context):
+    with patch.object(Mlflow_resource_class, "_setup"):
+        ## Given: a context  passed into the __init__ for MlFlow
+        mlf = Mlflow_resource_class(context)
+    ## When all the tags are set
+    mlf._set_all_tags()
+
+    # Given: the tags that should be set in mlflow
+    tags = {
+        tag: context.resource_config["env"][tag] for tag in context.resource_config["env_to_tag"]
+    }
+    tags["dagster_run_id"] = mlf.dagster_run_id
+    if mlf.extra_tags:
+        tags.update(mlf.extra_tags)
+    ## Then the Mlflow.set_tags is called with the set tags
+    mock_mlflow_set_tags.assert_called_once_with(tags)
+
+
+@pytest.mark.parametrize("run_df", [pd.DataFrame(), pd.DataFrame(data={"run_id": ["100"]})])
+@pytest.mark.parametrize(
+    "experiment", [None, MagicMock(experiment_id="1"), MagicMock(experiment_id="lol")]
+)
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_get_current_run_id(context, Mlflow_resource_class, experiment, run_df):
+    ## Given: an initialization of the mlflow object
+    mlf = Mlflow_resource_class(context)
+
+    with patch("mlflow.search_runs", return_value=run_df) as mock_search_runs:
+        ## when: _get_current_run_id is called
+        run_id = mlf._get_current_run_id(experiment=experiment)
+    ## Then: the run_id id provided is the same as what was provided
+    if not run_df.empty:
+        assert run_id == run_df.run_id.values[0]
+    else:
+        assert run_id is None
+
+
+@patch("atexit.unregister")
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_setup(mock_atexit, Mlflow_resource_class, context):
+
+    with patch.object(Mlflow_resource_class, "_setup"):
+        ## Given: a context  passed into the __init__ for MlFlow
+        mlf = Mlflow_resource_class(context)
+
+    with patch.object(
+        Mlflow_resource_class, "_get_current_run_id", return_value="run_id_mock"
+    ) as mock_get_current_run_id, patch.object(
+        Mlflow_resource_class, "_set_active_run"
+    ) as mock_set_active_run, patch.object(
+        Mlflow_resource_class, "_set_all_tags"
+    ) as mock_set_all_tags:
+        ## When _setup is called
+        mlf._setup()
+        ## Then
+        ## - _get_current_run_id is called once with the experiment object
+        mock_get_current_run_id.assert_called()
+        ## - _set_active_run is called once with the run_id returned from _get_current_run_id
+        mock_set_active_run.assert_called_once_with(run_id="run_id_mock")
+        ## - _set_all_tags is called once
+        mock_set_all_tags.assert_called_once()
+    ## - atexit.unregister is called with mlf.end_run as an argument
+    mock_atexit.assert_called_once_with(mlf.end_run)
+
+
+@pytest.mark.parametrize("run_id", [None, 0, "12"])
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_set_active_run(Mlflow_resource_class, context, run_id):
+
+    with patch.object(Mlflow_resource_class, "_setup"):
+        ## Given: a context  passed into the __init__ for MlFlow
+        mlf = Mlflow_resource_class(context)
+
+    with patch.object(Mlflow_resource_class, "_start_run") as mock_start_run:
+        ## When _set_active_run is called
+        mlf._set_active_run(run_id=run_id)
+
+    ## And: the run is nested
+    if mlf.parent_run_id is not None:
+        ## Then:
+        ## - the parent run is started if required
+        mock_start_run.assert_any_call(run_id=mlf.parent_run_id, run_name=mlf.run_name)
+        ## - mlflow.start_run is called with nested=True
+        mock_start_run.assert_any_call(run_id=run_id, run_name=mlf.run_name, nested=True)
+        ## - _start_run is called twice
+        mock_start_run.call_count == 2
+    ## And: the run is not nested
+    else:
+        ## Then:
+        mock_start_run.assert_called_once_with(run_id=run_id, run_name=mlf.run_name, nested=False)
+
+
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+def test_set_active_run_parent_zero(Mlflow_resource_class, child_context):
+    ## Given: a parent_run_id of zero
+    child_context.resource_config["parent_run_id"] = 0
+    ## : an initialization of the mlflow object
+    mlf = Mlflow_resource_class(child_context)
+
+    with patch.object(Mlflow_resource_class, "_start_run") as mock_start_run:
+        ## And _set_active_run is called with run_id
+        mlf._set_active_run(run_id="what-is-an-edge-case")
+        ## Then: _start_run_by_id is called with the parent_id
+        mock_start_run.assert_any_call(run_id=mlf.parent_run_id, run_name=mlf.run_name)
+        ## And: mlflow.start_run is called with the run_name and nested=True
+        mock_start_run.assert_any_call(
+            run_id="what-is-an-edge-case", run_name=mlf.run_name, nested=True
+        )
+        ## And _start_run is called twice
+        mock_start_run.call_count == 2
+
+
+@patch("mlflow.log_params")
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+@pytest.mark.parametrize("num_of_params", (90, 101, 223))
+def test_log_params(mock_log_params, Mlflow_resource_class, context, num_of_params, string_maker):
+    ## Given: init of MLFlowExtra
+    mlf = Mlflow_resource_class(context)
+    ## And: a set of parameters
+    param = {string_maker(5): string_maker(5) for _ in range(num_of_params)}
+    ## When: log_params is called
+    mlf.log_params(param)
+    ## Then mock_log_params is called the correct number of times
+    assert mock_log_params.call_count == num_of_params // 100 + (1 if num_of_params % 100 else 0)
+
+
+@pytest.mark.parametrize("chunk", (10, 100))
+@pytest.mark.parametrize("Mlflow_resource_class", MlFlow)
+@pytest.mark.parametrize("num_of_params", (90, 200))
+def test_chunks(context, Mlflow_resource_class, num_of_params, string_maker, chunk):
+    ## Given: init of MLFlowExtra
+    mlf = Mlflow_resource_class(context)
+    ## And: a dictionary
+    D = {string_maker(5): string_maker(5) for _ in range(num_of_params)}
+    ## When: dictionary is chunked
+    param_chunks_list = [param_chunk for param_chunk in mlf.chunks(D, chunk)]
+
+    ## Then
+    # - the number of chunks is what is expected
+    assert len(param_chunks_list) == num_of_params // chunk + (1 if num_of_params % chunk else 0)
+    # - the unwrapped dictionary is the same as was set
+    assert {k: v for d in param_chunks_list for k, v in d.items()} == D
+
+
+def test_cleanup_on_success():
+
+    # Given: - two mock solids
+    mock_solid_1 = Mock(name="solid_1")
+    mock_solid_2 = Mock(name="solid_2")
+
+    # - a mock context containing a list of these two solids and a current solid
+    mock_context = Mock()
+    mock_context.pipeline_def.solids_in_topological_order = [mock_solid_1, mock_solid_2]
+    mock_context.solid = mock_solid_2
+
+    # When: the cleanup function is called with the mock context
+    _cleanup_on_success(mock_context)
+
+    # Then:
+    # - mlflow.end_run is called if solid is the last solid
+    mock_context.resources.mlflow.end_run.assert_called_once()
+
+    # - mlflow.end_run is not called when the solid in the context is not the last solid
+    mock_context.reset_mock()
+    mock_context.solid = mock_solid_1
+    _cleanup_on_success(mock_context)
+    mock_context.resources.mlflow.end_run.assert_not_called()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -356,7 +356,10 @@ def test_cleanup_on_success():
 
     # - a mock context containing a list of these two solids and a current solid
     mock_context = Mock()
-    mock_context.pipeline_def.solids_in_topological_order = [mock_solid_1, mock_solid_2]
+    mock_context._step_execution_context.pipeline_def.solids_in_topological_order = [
+        mock_solid_1,
+        mock_solid_2,
+    ]
     mock_context.solid = mock_solid_2
 
     # When: the cleanup function is called with the mock context

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_version.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_version.py
@@ -1,0 +1,5 @@
+from dagster_mlflow.version import __version__
+
+
+def test_version():
+    assert __version__

--- a/python_modules/libraries/dagster-mlflow/setup.cfg
+++ b/python_modules/libraries/dagster-mlflow/setup.cfg
@@ -1,0 +1,9 @@
+[metadata]
+license_files = LICENSE
+
+[check-manifest]
+ignore =
+    .coveragerc
+    tox.ini
+    pytest.ini
+    dagster_mlflow_tests/**

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -1,0 +1,33 @@
+from typing import Dict
+
+from setuptools import find_packages, setup  # type: ignore
+
+
+def get_version() -> str:
+    version: Dict[str, str] = {}
+    with open("dagster_mlflow/version.py") as fp:
+        exec(fp.read(), version)  # pylint: disable=W0122
+
+    return version["__version__"]
+
+
+if __name__ == "__main__":
+    setup(
+        name="dagster-mlflow",
+        version=get_version(),
+        author="Elementl",
+        author_email="hello@elementl.com",
+        license="Apache-2.0",
+        description="Package for mlflow Dagster framework components.",
+        url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-mlflow",
+        classifiers=[
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "License :: OSI Approved :: Apache Software License",
+            "Operating System :: OS Independent",
+        ],
+        packages=find_packages(exclude=["test"]),
+        install_requires=["dagster", "mlflow"],
+        zip_safe=False,
+    )

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -28,6 +28,6 @@ if __name__ == "__main__":
             "Operating System :: OS Independent",
         ],
         packages=find_packages(exclude=["test"]),
-        install_requires=["dagster", "mlflow"],
+        install_requires=["dagster", "mlflow", "pandas"],
         zip_safe=False,
     )

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = py{38,37,36}-{unix,windows},pylint
+
+[testenv]
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
+deps =
+  -e ../../dagster[test]
+  -e .
+usedevelop = true
+whitelist_externals =
+  /bin/bash
+  echo
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  coverage erase
+  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
+  pytest -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
+  coverage report --omit='.tox/*,**/test_*.py' --skip-covered
+  coverage html --omit='.tox/*,**/test_*.py'
+  coverage xml --omit='.tox/*,**/test_*.py'
+
+[testenv:pylint]
+whitelist_externals =
+  pylint
+basepython =
+  python3.7
+commands =
+  pylint -j 0 --rcfile=../../../.pylintrc dagster_mlflow dagster_mlflow_tests

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -14,7 +14,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
-  pytest -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
+  pytest -vv --junitxml=test_results.xml --cov=dagster_mlflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

- This PR introduces a new integration library to make it easy to use mlflow tracking and model registry functionality in a dagster run. 
- Mlflow is added as a resource with the relevant configuration options available in the config_schema. 
- Configuration to log mlflow things to the same mlflow run in multiple processes is taken care of in the constructor of the mlflow class used in the resource. 
- The dagster run id is automatically logged as a tag to the relevant mlflow run.
- The new additions are in the dagster_mlflow/resources.py file. Other boilerplate files have been copied from other dagster python modules and modified accordingly.
- I have detailed the usage of the mlflow_tracking resource in the resource docstring. I'm not entirely sure if this is indeed automatically picked up in the documentation as I wasn't able to run the documentation website locally.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

- Tests have been added in dagster_mlflow_tests/test_resources.py
- Test coverage currently stands at 91%.



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.