### PR TITLE
Support serviceaccount annotations in user deployments.

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "dagsterUserDeployments.serviceAccountName" . }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
@@ -10,8 +10,5 @@ kind: ServiceAccount
 metadata:
   name: {{ include "dagsterUserDeployments.serviceAccountName" . }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
 {{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -107,3 +107,4 @@ deployments:
 
 serviceAccount:
   create: true
+  annotations: {}

--- a/helm/dagster/schema/schema/charts/dagster/subschema/service_account.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/service_account.py
@@ -1,6 +1,9 @@
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
+from ...utils import kubernetes
+
 
 class ServiceAccount(BaseModel):
     create: bool
     name: str
+    annotations: kubernetes.Annotations

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -5,7 +5,6 @@ from kubernetes.client import models
 from schema.charts.dagster.subschema.global_ import Global
 from schema.charts.dagster.subschema.service_account import ServiceAccount
 from schema.charts.dagster.values import DagsterHelmValues
-from schema.charts.utils.kubernetes import Annotations
 
 from .helm_template import HelmTemplate
 

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -6,6 +6,8 @@ from schema.charts.dagster.subschema.global_ import Global
 from schema.charts.dagster.subschema.service_account import ServiceAccount
 from schema.charts.dagster.values import DagsterHelmValues
 
+from schema.charts.utils.kubernetes import Annotations
+
 from .helm_template import HelmTemplate
 
 
@@ -28,7 +30,7 @@ def subchart_helm_template() -> HelmTemplate:
 def test_service_account_name(template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_values = DagsterHelmValues.construct(
-        serviceAccount=ServiceAccount(name=service_account_name, create=True)
+        serviceAccount=ServiceAccount.construct(name=service_account_name, create=True)
     )
 
     service_account_templates = template.render(service_account_values)
@@ -72,7 +74,7 @@ def test_subchart_service_account_global_name(subchart_template: HelmTemplate, c
 def test_service_account_does_not_render(template: HelmTemplate, capsys):
     with pytest.raises(subprocess.CalledProcessError):
         service_account_values = DagsterHelmValues.construct(
-            serviceAccount=ServiceAccount(name="service-account-name", create=False),
+            serviceAccount=ServiceAccount.construct(name="service-account-name", create=False),
         )
 
         template.render(service_account_values)
@@ -80,3 +82,24 @@ def test_service_account_does_not_render(template: HelmTemplate, capsys):
         _, err = capsys.readouterr()
 
         assert "Error: could not find template" in err
+
+
+def test_service_account_annotations(template: HelmTemplate):
+    service_account_name = "service-account-name"
+    service_account_annotations = {"hello": "world"}
+    service_account_values = DagsterHelmValues.construct(
+        serviceAccount=ServiceAccount.construct(
+            name=service_account_name,
+            create=True,
+            annotations=service_account_annotations
+        )
+    )
+
+    service_account_templates = template.render(service_account_values)
+
+    assert len(service_account_templates) == 1
+
+    service_account_template = service_account_templates[0]
+
+    assert service_account_template.metadata.name == service_account_name
+    assert service_account_template.metadata.annotations == service_account_annotations

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -5,7 +5,6 @@ from kubernetes.client import models
 from schema.charts.dagster.subschema.global_ import Global
 from schema.charts.dagster.subschema.service_account import ServiceAccount
 from schema.charts.dagster.values import DagsterHelmValues
-
 from schema.charts.utils.kubernetes import Annotations
 
 from .helm_template import HelmTemplate

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -88,9 +88,7 @@ def test_service_account_annotations(template: HelmTemplate):
     service_account_annotations = {"hello": "world"}
     service_account_values = DagsterHelmValues.construct(
         serviceAccount=ServiceAccount.construct(
-            name=service_account_name,
-            create=True,
-            annotations=service_account_annotations
+            name=service_account_name, create=True, annotations=service_account_annotations
         )
     )
 

--- a/helm/dagster/templates/serviceaccount.yaml
+++ b/helm/dagster/templates/serviceaccount.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dagster.serviceAccountName" . }}
-  labels:
-{{ include "dagster.labels" . | nindent 4 }}
-  annotations:
-{{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
+  labels: {{ include "dagster.labels" . | nindent 4 }}
+  annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
 {{- end -}}

--- a/helm/dagster/templates/serviceaccount.yaml
+++ b/helm/dagster/templates/serviceaccount.yaml
@@ -3,9 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dagster.serviceAccountName" . }}
-  labels: {{ include "dagster.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  labels:
+{{ include "dagster.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
 {{- end -}}

--- a/helm/dagster/templates/serviceaccount.yaml
+++ b/helm/dagster/templates/serviceaccount.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dagster.serviceAccountName" . }}
-  labels:
-{{ include "dagster.labels" . | nindent 4 }}
+  labels: {{ include "dagster.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1849,11 +1849,15 @@
                 "name": {
                     "title": "Name",
                     "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations"
                 }
             },
             "required": [
                 "create",
-                "name"
+                "name",
+                "annotations"
             ]
         },
         "Global": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -907,3 +907,5 @@ serviceAccount:
   # Specifies the name for the service account to reference in the chart. Note that setting
   # the global service account name will override this field.
   name: ""
+
+  annotations: {}


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
The `dagster/dagster` helm chart doesn't currently support annotations on the `serviceAccount`, for example to associate an IAM role for [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html).

On other charts I've seen patterns like the following:
```yaml
serviceAccount:
  create: true
  name: ACCOUNT_NAME
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT:ROLE_NAME
```

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

I'm something of a Helm noob unfortunately, so the only way I was able to test this was by packaging this forked chart and installing it on my cluster (which worked great!). If you would rather see tests baked into helm, I may need some support from the Dagster team.

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.