### PR TITLE
dagster-user-deployments bugfixes

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -12,14 +12,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "dagster.fullname" -}}
-{{- $fullnameOverride := .Values.fullnameOverride }}
-{{- $nameOverride :=  .Values.nameOverride }}
-
-{{- if .Values.global }}
-{{- $fullnameOverride = .Values.global.fullnameOverride }}
-{{- $nameOverride = .Values.global.nameOverride }}
-{{- end }}
-
+{{- $global := .Values.global | default dict }}
+{{- $fullnameOverride := $global.fullnameOverride | default .Values.fullnameOverride }}
+{{- $nameOverride := $global.nameOverride | default .Values.nameOverride }}
 {{- if $fullnameOverride -}}
 {{- $fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -90,11 +85,8 @@ Create the name of the service account to use
 This environment shared across all User Code containers
 */}}
 {{- define "dagsterUserDeployments.sharedEnv" -}}
-{{- $dagsterHome := .Values.dagsterHome }}
-
-{{- if .Values.global }}
-{{- $dagsterHome = .Values.global.dagsterHome }}
-{{- end }}
+{{- $global := .Values.global | default dict }}
+{{- $dagsterHome := $global.dagsterHome | default .Values.dagsterHome }}
 
 DAGSTER_HOME: {{ $dagsterHome | quote }}
 DAGSTER_K8S_PG_PASSWORD_SECRET: {{ include "dagsterUserDeployments.postgresql.secretName" . | quote }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -73,13 +73,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "dagsterUserDeployments.serviceAccountName" -}}
-{{- $serviceAccountName := "" }}
-
-{{- if .Values.global }}
-{{- $serviceAccountName = .Values.global.serviceAccountName }}
-{{- end }}
-
-{{- $serviceAccountName | default (printf "%s-user-deployments" (include "dagster.fullname" .)) }}
+{{- $global := .Values.global | default dict -}}
+{{- $serviceAccount := .Values.serviceAccount | default dict -}}
+{{- $global.serviceAccountName | default $serviceAccount.name | default (printf "%s-user-deployments" (include "dagster.fullname" .)) }}
 {{- end -}}
 
 {{- define "dagsterUserDeployments.postgresql.secretName" -}}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -3,16 +3,42 @@
     "description": "@generated",
     "type": "object",
     "properties": {
+        "dagsterHome": {
+            "title": "Dagsterhome",
+            "type": "string"
+        },
+        "postgresqlSecretName": {
+            "title": "Postgresqlsecretname",
+            "type": "string"
+        },
         "deployments": {
             "title": "Deployments",
             "type": "array",
             "items": {
                 "$ref": "#/definitions/UserDeployment"
             }
+        },
+        "imagePullSecrets": {
+            "title": "Imagepullsecrets",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/SecretRef"
+            }
+        },
+        "serviceAccount": {
+            "$ref": "#/definitions/ServiceAccount"
+        },
+        "global": {
+            "$ref": "#/definitions/Global"
         }
     },
     "required": [
-        "deployments"
+        "dagsterHome",
+        "postgresqlSecretName",
+        "deployments",
+        "imagePullSecrets",
+        "serviceAccount",
+        "global"
     ],
     "definitions": {
         "PullPolicy": {
@@ -208,6 +234,57 @@
                 "image",
                 "dagsterApiGrpcArgs",
                 "port"
+            ]
+        },
+        "SecretRef": {
+            "title": "SecretRef",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+        },
+        "ServiceAccount": {
+            "title": "ServiceAccount",
+            "type": "object",
+            "properties": {
+                "create": {
+                    "title": "Create",
+                    "type": "boolean"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations"
+                }
+            },
+            "required": [
+                "create",
+                "name",
+                "annotations"
+            ]
+        },
+        "Global": {
+            "title": "Global",
+            "type": "object",
+            "properties": {
+                "postgresqlSecretName": {
+                    "title": "Postgresqlsecretname",
+                    "type": "string"
+                },
+                "dagsterHome": {
+                    "title": "Dagsterhome",
+                    "type": "string"
+                },
+                "serviceAccountName": {
+                    "title": "Serviceaccountname",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "postgresqlSecretName",
+                "dagsterHome",
+                "serviceAccountName"
             ]
         }
     }

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -111,6 +111,11 @@ imagePullSecrets: []
 
 serviceAccount:
   create: true
+
+  # Specifies the name for the service account to reference in the chart. Note that setting
+  # the global service account name will override this field.
+  name: ""
+
   annotations: {}
 
 ####################################################################################################

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -1,4 +1,13 @@
 ---
+global:
+  postgresqlSecretName: "dagster-postgresql-secret"
+  # The DAGSTER_HOME env var is set by default on all nodes from this value
+  dagsterHome: "/opt/dagster/dagster_home"
+
+  # A service account name to use for this chart and all subcharts. If this is set, then
+  # dagster subcharts will not create their own service accounts.
+  serviceAccountName: ""
+
 dagsterHome: "/opt/dagster/dagster_home"
 postgresqlSecretName: "dagster-postgresql-secret"
 

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -105,6 +105,10 @@ deployments:
     service:
       annotations: {}
 
+# Specify secrets to run containers based on images in private registries. See:
+# https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
+imagePullSecrets: []
+
 serviceAccount:
   create: true
   annotations: {}

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
@@ -2,9 +2,9 @@ from typing import List
 
 from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
-from .subschema.user_deployments import UserDeployment
 from ..dagster.subschema import Global, ServiceAccount
 from ..utils import kubernetes
+from .subschema.user_deployments import UserDeployment
 
 
 class DagsterUserDeploymentsHelmValues(BaseModel):

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
@@ -1,11 +1,18 @@
 from typing import List
 
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
 from .subschema.user_deployments import UserDeployment
+from ..dagster.subschema import Global, ServiceAccount
+from ..utils import kubernetes
 
 
 class DagsterUserDeploymentsHelmValues(BaseModel):
     __doc__ = "@" + "generated"
 
+    dagsterHome: str
+    postgresqlSecretName: str
     deployments: List[UserDeployment]
+    imagePullSecrets: List[kubernetes.SecretRef]
+    serviceAccount: ServiceAccount
+    global_: Global = Field(..., alias="global")

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -59,19 +59,18 @@ def test_service_account_global_name(template: HelmTemplate):
     assert service_account_template.metadata.name == global_service_account_name
 
 
-def test_subchart_service_account_global_name(subchart_template: HelmTemplate):
-    global_service_account_name = "global-service-account-name"
-    service_account_values = DagsterHelmValues.construct(
-        global_=Global.construct(serviceAccountName=global_service_account_name),
-    )
+def test_subchart_service_account_global_name(subchart_template: HelmTemplate, capsys):
+    with pytest.raises(subprocess.CalledProcessError):
+        global_service_account_name = "global-service-account-name"
+        service_account_values = DagsterHelmValues.construct(
+            global_=Global.construct(serviceAccountName=global_service_account_name),
+        )
 
-    service_account_templates = subchart_template.render(service_account_values)
+        subchart_template.render(service_account_values)
 
-    assert len(service_account_templates) == 1
+        _, err = capsys.readouterr()
 
-    service_account_template = service_account_templates[0]
-
-    assert service_account_template.metadata.name == global_service_account_name
+        assert "Error: could not find template" in err
 
 
 def test_subchart_service_account_name(subchart_template: HelmTemplate):

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -77,9 +77,7 @@ def test_subchart_service_account_global_name(subchart_template: HelmTemplate):
 def test_subchart_service_account_name(subchart_template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_values = DagsterUserDeploymentsHelmValues.construct(
-        serviceAccount=ServiceAccount.construct(
-            name=service_account_name
-        ),
+        serviceAccount=ServiceAccount.construct(name=service_account_name),
     )
 
     service_account_templates = subchart_template.render(service_account_values)

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -5,6 +5,7 @@ from typing import List
 import pytest
 from kubernetes.client import models
 from schema.charts.dagster.values import DagsterHelmValues
+from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
 from schema.charts.dagster_user_deployments.subschema.user_deployments import UserDeployments
 from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate
@@ -27,6 +28,16 @@ def full_helm_template() -> HelmTemplate:
     return HelmTemplate(
         helm_dir_path="helm/dagster",
         subchart_paths=["charts/dagster-user-deployments"],
+    )
+
+
+@pytest.fixture(name="subchart_template")
+def subchart_helm_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster/charts/dagster-user-deployments",
+        subchart_paths=[],
+        output="templates/deployment-user.yaml",
+        model=models.V1Deployment,
     )
 
 
@@ -448,3 +459,19 @@ def test_user_deployment_image(template: HelmTemplate):
 
     assert image_name == deployment.image.repository
     assert image_tag == deployment.image.tag
+
+
+def test_subchart_image_pull_secrets(subchart_template: HelmTemplate):
+    image_pull_secrets = [{"name": "super-duper-secret"}]
+    deployment_values = DagsterUserDeploymentsHelmValues.construct(
+        imagePullSecrets=image_pull_secrets,
+    )
+
+    deployment_templates = subchart_template.render(deployment_values)
+
+    assert len(deployment_templates) == 1
+
+    deployment_template = deployment_templates[0]
+    pod_spec = deployment_template.spec.template.spec
+
+    assert pod_spec.image_pull_secrets[0].name == image_pull_secrets[0]['name']

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -5,8 +5,8 @@ from typing import List
 import pytest
 from kubernetes.client import models
 from schema.charts.dagster.values import DagsterHelmValues
-from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
 from schema.charts.dagster_user_deployments.subschema.user_deployments import UserDeployments
+from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
 from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate
 
@@ -474,4 +474,4 @@ def test_subchart_image_pull_secrets(subchart_template: HelmTemplate):
     deployment_template = deployment_templates[0]
     pod_spec = deployment_template.spec.template.spec
 
-    assert pod_spec.image_pull_secrets[0].name == image_pull_secrets[0]['name']
+    assert pod_spec.image_pull_secrets[0].name == image_pull_secrets[0]["name"]


### PR DESCRIPTION
## Summary

Hello again. I'm back with some patches for the `dagster-user-deployments` subchart. They fall into a few categories...

#### `values.yaml` documentation

The values file was missing `imagePullSecrets`, despite it actually being supported and consumed by the `deployment-user.yaml` template. I added this to `values.yaml` to make it explicit where `imagePullSecrets` should be.

#### `serviceAccount.name`

The `serviceAccount` key exists in `values.yaml`, but `serviceAccount.name` wasn't being read -- only `global.serviceAccountName` and then some defaulting logic. I added support for `serviceAccount.name` to match the `dagster/dagster` Helm chart (and what seems to be a standard).

But, testing this out turned me on to a general class of bug...

#### `global` object access

So first of all, it seems that Helm [doesn't support traversing `nil` pointers with `default`](https://github.com/helm/helm/issues/8026). e.g., `foo.bar.foo.bar | default x` will fail if `foo`, `foo.bar`, or `foo.bar.foo` are undefined. I'm assuming this is why the `.Values.global` access in `helpers.tpl` is a little awkward.

Unfortunately that awkwardness leads to the situation where, if a user defines `global: {}` without _every single_ required subkey (undocumented), the chart installation fails in weird ways because all of those subkeys are set to `""` or `nil`. e.g. I got a secret access error because the Postgres secret wasn't specified, and I also got a weird yaml error because the `ConfigMap` wasn't specified.

So, I've changed the access around to be more like this:
```
{{- $global := .Values.global | default dict }}
{{- $foobar := $global.foobar | default .Values.foobar }}
```

The same (or similar) problem exists in the primary Helm chart too, but because the keys are defaulted in `values.yaml` it doesn't crop up.

However...

#### schema update

...after making these changes, I updated the schema for `DagsterUserDeploymentsHelmValues`, which previously only had `deployments`. This immediately indicated that I needed to add `global`, `imagePullSecrets` (already added), and some others as required top level fields. I think this is probably how the outer chart got to where it is with the `global` field being present - so my `global` object access changes probably aren't _necessary_ anymore, but I do think they make reasoning about the template logic a little simpler?


## Test Plan

When I started writing tests, I discovered some more issues. Generally, in `test_service_account` and `test_user_deployments`, it looks like the subchart was never really being tested on its own. I made some updates here and added tests for `serviceAccount.name` and `imagePullSecrets` (the two keys I added) which I think make sense, but I'd appreciate careful eyes on this too.

I've deployed the standalone chart with success in the following scenarios:
* `secretAccount.name` and `imagePullSecrets` specified, no `global` object. Works.
* `secretAccount.name` and `imagePullSecrets` specified, empty `global` object. Works.
* `secretAccount.name` and `global.serviceAccountName` specified. Uses the global account name and does NOT create the account (this is current behavior). Works. Other `global` subkeys work as expected.

Deploying the standalone subchart seems to check out for me now.

FYI @rexledesma :)

#### 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.