### PR TITLE
add serviceAccount.name to the user deployment subchart and schema

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -73,13 +73,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "dagsterUserDeployments.serviceAccountName" -}}
-{{- $serviceAccountName := "" }}
-
-{{- if .Values.global }}
-{{- $serviceAccountName = .Values.global.serviceAccountName }}
-{{- end }}
-
-{{- $serviceAccountName | default (printf "%s-user-deployments" (include "dagster.fullname" .)) }}
+{{- $global := .Values.global | default dict -}}
+{{- $serviceAccount := .Values.serviceAccount | default dict -}}
+{{- $global.serviceAccountName | default $serviceAccount.name | default (printf "%s-user-deployments" (include "dagster.fullname" .)) }}
 {{- end -}}
 
 {{- define "dagsterUserDeployments.postgresql.secretName" -}}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -16,11 +16,15 @@
             "items": {
                 "$ref": "#/definitions/SecretRef"
             }
+        },
+        "serviceAccount": {
+            "$ref": "#/definitions/ServiceAccount"
         }
     },
     "required": [
         "deployments",
-        "imagePullSecrets"
+        "imagePullSecrets",
+        "serviceAccount"
     ],
     "definitions": {
         "PullPolicy": {
@@ -223,6 +227,28 @@
             "type": "object",
             "properties": {},
             "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+        },
+        "ServiceAccount": {
+            "title": "ServiceAccount",
+            "type": "object",
+            "properties": {
+                "create": {
+                    "title": "Create",
+                    "type": "boolean"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations"
+                }
+            },
+            "required": [
+                "create",
+                "name",
+                "annotations"
+            ]
         }
     }
 }

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -111,6 +111,11 @@ imagePullSecrets: []
 
 serviceAccount:
   create: true
+
+  # Specifies the name for the service account to reference in the chart. Note that setting
+  # the global service account name will override this field.
+  name: ""
+
   annotations: {}
 
 ####################################################################################################

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
@@ -2,6 +2,7 @@ from typing import List
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
+from ..dagster.subschema import Global, ServiceAccount
 from ..utils import kubernetes
 from .subschema.user_deployments import UserDeployment
 
@@ -11,3 +12,4 @@ class DagsterUserDeploymentsHelmValues(BaseModel):
 
     deployments: List[UserDeployment]
     imagePullSecrets: List[kubernetes.SecretRef]
+    serviceAccount: ServiceAccount

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -5,6 +5,7 @@ from kubernetes.client import models
 from schema.charts.dagster.subschema.global_ import Global
 from schema.charts.dagster.subschema.service_account import ServiceAccount
 from schema.charts.dagster.values import DagsterHelmValues
+from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
 from schema.utils.helm_template import HelmTemplate
 
 
@@ -21,9 +22,9 @@ def umbrella_helm_template() -> HelmTemplate:
 @pytest.fixture(name="subchart_template")
 def subchart_helm_template() -> HelmTemplate:
     return HelmTemplate(
-        helm_dir_path="helm/dagster",
-        subchart_paths=["charts/dagster-user-deployments"],
-        output="charts/dagster-user-deployments/templates/serviceaccount.yaml",
+        helm_dir_path="helm/dagster/charts/dagster-user-deployments",
+        subchart_paths=[],
+        output="templates/serviceaccount.yaml",
         model=models.V1ServiceAccount,
     )
 
@@ -72,6 +73,21 @@ def test_subchart_service_account_global_name(subchart_template: HelmTemplate, c
         assert "Error: could not find template" in err
 
 
+def test_subchart_service_account_name(subchart_template: HelmTemplate):
+    service_account_name = "service-account-name"
+    service_account_values = DagsterUserDeploymentsHelmValues.construct(
+        serviceAccount=ServiceAccount.construct(name=service_account_name),
+    )
+
+    service_account_templates = subchart_template.render(service_account_values)
+
+    assert len(service_account_templates) == 1
+
+    service_account_template = service_account_templates[0]
+
+    assert service_account_template.metadata.name == service_account_name
+
+
 def test_service_account_does_not_render(template: HelmTemplate, capsys):
     with pytest.raises(subprocess.CalledProcessError):
         service_account_values = DagsterHelmValues.construct(
@@ -95,6 +111,25 @@ def test_service_account_annotations(template: HelmTemplate):
     )
 
     service_account_templates = template.render(service_account_values)
+
+    assert len(service_account_templates) == 1
+
+    service_account_template = service_account_templates[0]
+
+    assert service_account_template.metadata.name == service_account_name
+    assert service_account_template.metadata.annotations == service_account_annotations
+
+
+def test_subchart_service_account_annotations(subchart_template: HelmTemplate):
+    service_account_name = "service-account-name"
+    service_account_annotations = {"hello": "world"}
+    service_account_values = DagsterUserDeploymentsHelmValues.construct(
+        serviceAccount=ServiceAccount.construct(
+            name=service_account_name, create=True, annotations=service_account_annotations
+        ),
+    )
+
+    service_account_templates = subchart_template.render(service_account_values)
 
     assert len(service_account_templates) == 1
 

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -22,6 +22,16 @@ def umbrella_helm_template() -> HelmTemplate:
 @pytest.fixture(name="subchart_template")
 def subchart_helm_template() -> HelmTemplate:
     return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="charts/dagster-user-deployments/templates/serviceaccount.yaml",
+        model=models.V1ServiceAccount,
+    )
+
+
+@pytest.fixture(name="standalone_subchart_template")
+def standalone_subchart_helm_template() -> HelmTemplate:
+    return HelmTemplate(
         helm_dir_path="helm/dagster/charts/dagster-user-deployments",
         subchart_paths=[],
         output="templates/serviceaccount.yaml",
@@ -73,13 +83,13 @@ def test_subchart_service_account_global_name(subchart_template: HelmTemplate, c
         assert "Error: could not find template" in err
 
 
-def test_subchart_service_account_name(subchart_template: HelmTemplate):
+def test_subchart_service_account_name(standalone_subchart_template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_values = DagsterUserDeploymentsHelmValues.construct(
         serviceAccount=ServiceAccount.construct(name=service_account_name),
     )
 
-    service_account_templates = subchart_template.render(service_account_values)
+    service_account_templates = standalone_subchart_template.render(service_account_values)
 
     assert len(service_account_templates) == 1
 
@@ -120,7 +130,7 @@ def test_service_account_annotations(template: HelmTemplate):
     assert service_account_template.metadata.annotations == service_account_annotations
 
 
-def test_subchart_service_account_annotations(subchart_template: HelmTemplate):
+def test_subchart_service_account_annotations(standalone_subchart_template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_annotations = {"hello": "world"}
     service_account_values = DagsterUserDeploymentsHelmValues.construct(
@@ -129,7 +139,7 @@ def test_subchart_service_account_annotations(subchart_template: HelmTemplate):
         ),
     )
 
-    service_account_templates = subchart_template.render(service_account_values)
+    service_account_templates = standalone_subchart_template.render(service_account_values)
 
     assert len(service_account_templates) == 1
 

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -130,7 +130,9 @@ def test_service_account_annotations(template: HelmTemplate):
     assert service_account_template.metadata.annotations == service_account_annotations
 
 
-def test_standalone_subchart_service_account_annotations(standalone_subchart_template: HelmTemplate):
+def test_standalone_subchart_service_account_annotations(
+    standalone_subchart_template: HelmTemplate,
+):
     service_account_name = "service-account-name"
     service_account_annotations = {"hello": "world"}
     service_account_values = DagsterUserDeploymentsHelmValues.construct(

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -83,7 +83,7 @@ def test_subchart_service_account_global_name(subchart_template: HelmTemplate, c
         assert "Error: could not find template" in err
 
 
-def test_subchart_service_account_name(standalone_subchart_template: HelmTemplate):
+def test_standalone_subchart_service_account_name(standalone_subchart_template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_values = DagsterUserDeploymentsHelmValues.construct(
         serviceAccount=ServiceAccount.construct(name=service_account_name),
@@ -130,7 +130,7 @@ def test_service_account_annotations(template: HelmTemplate):
     assert service_account_template.metadata.annotations == service_account_annotations
 
 
-def test_subchart_service_account_annotations(standalone_subchart_template: HelmTemplate):
+def test_standalone_subchart_service_account_annotations(standalone_subchart_template: HelmTemplate):
     service_account_name = "service-account-name"
     service_account_annotations = {"hello": "world"}
     service_account_values = DagsterUserDeploymentsHelmValues.construct(


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

The user code deployment subchart consumes `serviceAccount.create` and `serviceAccount.annotations`, but not `serviceAccount.name`. Instead it _only_ uses the `global` object for this.

In the interest of standardization, I added support for `serviceAccount.name`. I also added `serviceAccount` to the subchart schema, which had previously been missing.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

I added unit tests for `serviceAccount.name` and `serviceAccount.annotations` for standalone user chart deployments.

I have also been deploying a forked version of the subchart locally and having success.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.