### PR TITLE
add volumes

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -37,6 +37,10 @@ spec:
           securityContext: {{ $deployment.securityContext | toYaml | nindent 12 }}
           imagePullPolicy: {{ $deployment.image.pullPolicy }}
           image: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}
+          volumeMounts:
+            {{- range $volumeMount := $deployment.volumeMounts }}
+            - {{ $volumeMount | toYaml | nindent 16 }}
+            {{- end }}
           command: ["dagster"]
           args: ["api", "grpc", "-h", "0.0.0.0", "-p", "{{ $deployment.port }}", "{{- join "\",\"" $deployment.dagsterApiGrpcArgs }}"]
           env:
@@ -102,5 +106,9 @@ spec:
       nodeSelector: {{ $deployment.nodeSelector | toYaml | nindent 8 }}
       affinity: {{ $deployment.affinity | toYaml | nindent 8 }}
       tolerations: {{- $deployment.tolerations | toYaml | nindent 8 }}
+      volumes:
+        {{- range $volume := $.Values.volumes }}
+        - {{ $volume | toYaml | nindent 12 }}
+        {{- end }}
 ---
 {{ end }}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -37,6 +37,8 @@ deployments:
       - "/example_project/example_repo/repo.py"
     port: 3030
 
+    volumeMounts: []
+
     # Additional environment variables to set.
     # A Kubernetes ConfigMap will be created with these environment variables. See:
     # https://kubernetes.io/docs/concepts/configuration/configmap/
@@ -104,6 +106,8 @@ deployments:
 
     service:
       annotations: {}
+
+volumes: []
 
 # Specify secrets to run containers based on images in private registries. See:
 # https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod


### PR DESCRIPTION
## Summary
I needed to mount volumes for both my gRPC server and job pods. Unfortunately, this PR can only help with the gRPC server so far. By customizing the `dagster/dagster-user-deployments` a little, it's now able to mount specified volumes from user's `values.yaml` file, just as you would in a regular `deployment.yaml` file. I'm not sure if this can be related to https://github.com/dagster-io/dagster/issues/3871, but my support request is on Slack: https://dagster.slack.com/archives/C014N0PK37E/p1625321569196100

## Checklist
- [x] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.