### PR TITLE
Allowed to pass **ssl_args into start_server function

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -200,8 +200,8 @@ def uploading_logging_thread():
         logging_thread.join()
 
 
-def start_server(instance, host, port, path_prefix, app, port_lookup, port_lookup_attempts=0):
-    server = pywsgi.WSGIServer((host, port), app, handler_class=WebSocketHandler)
+def start_server(instance, host, port, path_prefix, app, port_lookup, port_lookup_attempts=0, **ssl_args):
+    server = pywsgi.WSGIServer((host, port), app, handler_class=WebSocketHandler, **ssl_args)
 
     click.echo(
         "Serving on http://{host}:{port}{path_prefix} in process {pid}".format(


### PR DESCRIPTION
Allowed to pass **ssl_args into start_server function

## Summary
Currently, start_server does not allow passing in SSL-related arguments. However, this is needed for customization purposes.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.