### PR TITLE
PipelineRunsFilter can have multiple filters

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -32,8 +32,7 @@ class GraphenePipelineRunsFilter(graphene.InputObjectType):
     mode = graphene.Field(graphene.String)
 
     class Meta:
-        description = """This type represents a filter on pipeline runs.
-        Currently, you may only pass one of the filter options."""
+        description = """This type represents a filter on pipeline runs."""
         name = "PipelineRunsFilter"
 
     def to_selector(self):


### PR DESCRIPTION
I don't think this comment is accurate - or at least completely
accurate. I noticed a test elsewhere that was successfully filtering on
both tags and statuses which seems to violate the documentation. I've
added a test to prove it.

Perhaps what the original description is trying to say is that we use
the intersection of filters? That you can't represent something like
"pipeline runs that are finished or have a certain tag"? I'm not
entirely sure.