### PR TITLE
Guard against empty tasks list

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -166,6 +166,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             self.ecs.stop_task(task=arn, cluster=cluster)
             return True
 
+        return False
+
     def _task_definition(self, metadata, image):
         """
         Return the launcher's default task definition if it's configured.

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -132,7 +132,11 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         )
 
     def can_terminate(self, run_id):
-        tags = self._instance.get_run_by_id(run_id).tags
+        run = self._instance.get_run_by_id(run_id)
+        if not run:
+            return False
+
+        tags = run.tags
         arn = tags.get("ecs/task_arn")
         cluster = tags.get("ecs/cluster")
 
@@ -147,7 +151,11 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         return False
 
     def terminate(self, run_id):
-        tags = self._instance.get_run_by_id(run_id).tags
+        run = self._instance.get_run_by_id(run_id)
+        if not run:
+            return False
+
+        tags = run.tags
         arn = tags.get("ecs/task_arn")
         cluster = tags.get("ecs/cluster")
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -143,30 +143,36 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
 
     def can_terminate(self, run_id):
         arn, cluster = self._get_run_tags(run_id)
-        if arn and cluster:
-            tasks = self.ecs.describe_tasks(tasks=[arn], cluster=cluster).get("tasks")
-            if not tasks:
-                return False
-            status = tasks[0].get("lastStatus")
-            if status and status != "STOPPED":
-                return True
+
+        if not (arn and cluster):
+            return False
+
+        tasks = self.ecs.describe_tasks(tasks=[arn], cluster=cluster).get("tasks")
+        if not tasks:
+            return False
+
+        status = tasks[0].get("lastStatus")
+        if status and status != "STOPPED":
+            return True
 
         return False
 
     def terminate(self, run_id):
         arn, cluster = self._get_run_tags(run_id)
-        if arn and cluster:
-            tasks = self.ecs.describe_tasks(tasks=[arn], cluster=cluster).get("tasks")
-            if not tasks:
-                return False
-            status = tasks[0].get("lastStatus")
-            if status == "STOPPED":
-                return False
 
-            self.ecs.stop_task(task=arn, cluster=cluster)
-            return True
+        if not (arn and cluster):
+            return False
 
-        return False
+        tasks = self.ecs.describe_tasks(tasks=[arn], cluster=cluster).get("tasks")
+        if not tasks:
+            return False
+
+        status = tasks[0].get("lastStatus")
+        if status == "STOPPED":
+            return False
+
+        self.ecs.stop_task(task=arn, cluster=cluster)
+        return True
 
     def _task_definition(self, metadata, image):
         """

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -1,5 +1,4 @@
 def test_termination(instance, workspace, run):
-
     assert not instance.run_launcher.can_terminate(run.run_id)
 
     instance.launch_run(run.run_id, workspace)
@@ -8,3 +7,27 @@ def test_termination(instance, workspace, run):
     assert instance.run_launcher.terminate(run.run_id)
     assert not instance.run_launcher.can_terminate(run.run_id)
     assert not instance.run_launcher.terminate(run.run_id)
+
+
+def test_eventual_consistency(instance, workspace, run, monkeypatch):
+    instance.launch_run(run.run_id, workspace)
+
+    def empty(*_args, **_kwargs):
+        return {"tasks": []}
+
+    original = instance.run_launcher.ecs.describe_tasks
+
+    # The ECS API is eventually consistent:
+    # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
+    # describe_tasks might initially return nothing even if a task exists.
+    monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", empty)
+    assert not instance.run_launcher.can_terminate(run.run_id)
+
+    monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", original)
+    assert instance.run_launcher.can_terminate(run.run_id)
+
+    monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", empty)
+    assert not instance.run_launcher.terminate(run.run_id)
+
+    monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", original)
+    assert instance.run_launcher.terminate(run.run_id)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -30,6 +30,31 @@ def test_missing_run(instance, workspace, run, monkeypatch):
     assert instance.run_launcher.terminate(run.run_id)
 
 
+def test_missing_tag(instance, workspace, run):
+    instance.launch_run(run.run_id, workspace)
+    original = instance.get_run_by_id(run.run_id).tags
+
+    instance.add_run_tags(run.run_id, {"ecs/task_arn": ""})
+    assert not instance.run_launcher.can_terminate(run.run_id)
+
+    instance.add_run_tags(run.run_id, original)
+    instance.add_run_tags(run.run_id, {"ecs/cluster": ""})
+    assert not instance.run_launcher.can_terminate(run.run_id)
+
+    instance.add_run_tags(run.run_id, original)
+    assert instance.run_launcher.can_terminate(run.run_id)
+
+    instance.add_run_tags(run.run_id, {"ecs/task_arn": ""})
+    assert not instance.run_launcher.terminate(run.run_id)
+
+    instance.add_run_tags(run.run_id, original)
+    instance.add_run_tags(run.run_id, {"ecs/cluster": ""})
+    assert not instance.run_launcher.terminate(run.run_id)
+
+    instance.add_run_tags(run.run_id, original)
+    assert instance.run_launcher.terminate(run.run_id)
+
+
 def test_eventual_consistency(instance, workspace, run, monkeypatch):
     instance.launch_run(run.run_id, workspace)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -9,6 +9,27 @@ def test_termination(instance, workspace, run):
     assert not instance.run_launcher.terminate(run.run_id)
 
 
+def test_missing_run(instance, workspace, run, monkeypatch):
+    instance.launch_run(run.run_id, workspace)
+
+    def missing_run(*_args, **_kwargs):
+        return None
+
+    original = instance.get_run_by_id
+
+    monkeypatch.setattr(instance, "get_run_by_id", missing_run)
+    assert not instance.run_launcher.can_terminate(run.run_id)
+
+    monkeypatch.setattr(instance, "get_run_by_id", original)
+    assert instance.run_launcher.can_terminate(run.run_id)
+
+    monkeypatch.setattr(instance, "get_run_by_id", missing_run)
+    assert not instance.run_launcher.terminate(run.run_id)
+
+    monkeypatch.setattr(instance, "get_run_by_id", original)
+    assert instance.run_launcher.terminate(run.run_id)
+
+
 def test_eventual_consistency(instance, workspace, run, monkeypatch):
     instance.launch_run(run.run_id, workspace)
 


### PR DESCRIPTION
https://github.com/dagster-io/dagster/commit/cdc1f5a37487f4e9cf48a61115058537a7d2eb4b
guards against the describe_tasks response not having a "tasks" key.
This guards against the key's value being an empty list.