### PR TITLE
Update dbt_example to use dbt_cli_resource

### DIFF
--- a/examples/dbt_example/dbt_example/pipelines.py
+++ b/examples/dbt_example/dbt_example/pipelines.py
@@ -1,5 +1,6 @@
-from dagster import ModeDefinition, PresetDefinition, fs_io_manager, pipeline
+from dagster import ModeDefinition, PresetDefinition, fs_io_manager, pipeline, file_relative_path
 from dagster_slack import slack_resource
+from dagster_dbt import dbt_cli_resource
 
 from .resources import mock_slack_resource, postgres
 from .solids import (
@@ -13,6 +14,8 @@ from .solids import (
 
 CEREALS_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9f01855cfa6870b1fce/raw/2de62a57fb08da7c58d6480c987077cf91c783a1/cereal.csv"
 
+DBT_PROJECT_DIR = file_relative_path(__file__, "../dbt_example_project")
+
 # start_pipeline_marker_0
 @pipeline(
     mode_defs=[
@@ -22,6 +25,9 @@ CEREALS_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9
                 "db": postgres,
                 "slack": slack_resource,
                 "io_manager": fs_io_manager,
+                "dbt": dbt_cli_resource.configured(
+                    {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROJECT_DIR}
+                ),
             },
         ),
         ModeDefinition(
@@ -30,6 +36,9 @@ CEREALS_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9
                 "db": postgres,
                 "slack": mock_slack_resource,
                 "io_manager": fs_io_manager,
+                "dbt": dbt_cli_resource.configured(
+                    {"project_dir": DBT_PROJECT_DIR, "profiles_dir": DBT_PROJECT_DIR}
+                ),
             },
         ),
     ],
@@ -78,8 +87,8 @@ CEREALS_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9
 )
 def dbt_example_pipeline():
     loaded = load_cereals_from_csv(download_file())
-    run_results = run_cereals_models(start_after=loaded)
-    test_cereals_models(start_after=run_results)
+    run_results = run_cereals_models(after=loaded)
+    test_cereals_models(after=run_results)
     post_plot_to_slack(analyze_cereals(run_results))
 
 

--- a/examples/dbt_example/dbt_example/pipelines.py
+++ b/examples/dbt_example/dbt_example/pipelines.py
@@ -1,6 +1,6 @@
-from dagster import ModeDefinition, PresetDefinition, fs_io_manager, pipeline, file_relative_path
-from dagster_slack import slack_resource
+from dagster import ModeDefinition, PresetDefinition, file_relative_path, fs_io_manager, pipeline
 from dagster_dbt import dbt_cli_resource
+from dagster_slack import slack_resource
 
 from .resources import mock_slack_resource, postgres
 from .solids import (

--- a/examples/dbt_example/dbt_example/solids.py
+++ b/examples/dbt_example/dbt_example/solids.py
@@ -1,14 +1,11 @@
 import pandas
 import requests
-from dagster import Array, InputDefinition, OutputDefinition, solid
+from dagster import Array, InputDefinition, OutputDefinition, solid, Nothing
 from dagster.utils import file_relative_path
-from dagster_dbt import dbt_cli_run, dbt_cli_test
 from dagster_dbt.cli.types import DbtCliOutput
 from dagstermill import define_dagstermill_solid
 
 CEREAL_DATASET_URL = "https://gist.githubusercontent.com/mgasner/bd2c0f66dff4a9f01855cfa6870b1fce/raw/2de62a57fb08da7c58d6480c987077cf91c783a1/cereal.csv"
-
-PROJECT_DIR = file_relative_path(__file__, "../dbt_example_project")
 
 
 @solid(config_schema={"url": str, "target_path": str})
@@ -38,17 +35,14 @@ def post_plot_to_slack(context, plot_path):
     )
 
 
-# start_solid_marker_0
-run_cereals_models = dbt_cli_run.configured(
-    config_or_config_fn={"project-dir": PROJECT_DIR},
-    name="run_cereals_models",
-)
-# end_solid_marker_0
+@solid(required_resource_keys={"dbt"}, input_defs=[InputDefinition("after", Nothing)])
+def run_cereals_models(context) -> DbtCliOutput:
+    return context.resources.dbt.run()
 
-test_cereals_models = dbt_cli_test.configured(
-    config_or_config_fn={"project-dir": PROJECT_DIR},
-    name="test_cereals_models",
-)
+
+@solid(required_resource_keys={"dbt"}, input_defs=[InputDefinition("after", Nothing)])
+def test_cereals_models(context) -> DbtCliOutput:
+    return context.resources.dbt.test()
 
 
 analyze_cereals = define_dagstermill_solid(

--- a/examples/dbt_example/dbt_example/solids.py
+++ b/examples/dbt_example/dbt_example/solids.py
@@ -1,6 +1,6 @@
 import pandas
 import requests
-from dagster import Array, InputDefinition, OutputDefinition, solid, Nothing
+from dagster import Array, InputDefinition, Nothing, OutputDefinition, solid
 from dagster.utils import file_relative_path
 from dagster_dbt.cli.types import DbtCliOutput
 from dagstermill import define_dagstermill_solid


### PR DESCRIPTION
## Summary

Updated this example to use current best practices. While the hackernews example repo does contain an example pipeline using dbt, this example shows how to use dbt in a pipeline with other types of solids, so it seems worth keeping around (plus the blog post shows the structure of this pipeline, so it would be confusing to link to the hackernews example from there).

## Test Plan
bk