### PR TITLE
[docs-infra] yarn build-master disables versioning

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -22,7 +22,7 @@ def docs_steps() -> List[dict]:
             "pushd docs/next",
             "yarn",
             "yarn test",
-            "yarn build",
+            "yarn build-master",
         )
         .on_integration_image(SupportedPython.V3_7)
         .build(),

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -1,7 +1,8 @@
 import os
 
-from ..defines import GCP_CREDS_LOCAL_FILE
+from ..defines import GCP_CREDS_LOCAL_FILE, SupportedPython
 from ..module_build_spec import ModuleBuildSpec
+from ..step_builder import StepBuilder
 from ..utils import connect_sibling_docker_container, network_buildkite_container
 from .test_images import publish_test_images, test_image_depends_fn
 
@@ -81,4 +82,17 @@ def integration_steps():
             tox_env_suffixes=tox_env_suffixes,
             retries=2,
         ).get_tox_build_steps()
+
+        tests += (
+            StepBuilder("docs next")
+            .run(
+                "pushd docs/next",
+                "yarn",
+                "yarn test",
+                "yarn build",
+            )
+            .on_integration_image(SupportedPython.V3_7)
+            .build(),
+        )
+
     return tests

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -1,8 +1,7 @@
 import os
 
-from ..defines import GCP_CREDS_LOCAL_FILE, SupportedPython
+from ..defines import GCP_CREDS_LOCAL_FILE
 from ..module_build_spec import ModuleBuildSpec
-from ..step_builder import StepBuilder
 from ..utils import connect_sibling_docker_container, network_buildkite_container
 from .test_images import publish_test_images, test_image_depends_fn
 
@@ -82,17 +81,5 @@ def integration_steps():
             tox_env_suffixes=tox_env_suffixes,
             retries=2,
         ).get_tox_build_steps()
-
-        tests += (
-            StepBuilder("docs next")
-            .run(
-                "pushd docs/next",
-                "yarn",
-                "yarn test",
-                "yarn build",
-            )
-            .on_integration_image(SupportedPython.V3_7)
-            .build(),
-        )
 
     return tests

--- a/docs/next/next-env.d.ts
+++ b/docs/next/next-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+
+declare const __VERSIONING_DISABLED__: boolean;

--- a/docs/next/next.config.js
+++ b/docs/next/next.config.js
@@ -19,4 +19,12 @@ module.exports = {
   images: {
     domains: ["dagster-docs-versioned-content.s3.us-west-1.amazonaws.com"],
   },
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        __VERSIONING_DISABLED__: process.env.VERSIONING_DISABLED === "true",
+      })
+    );
+    return config;
+  },
 };

--- a/docs/next/package.json
+++ b/docs/next/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "PORT=3001 next-remote-watch ../content",
     "build": "next build",
+    "build-master": "VERSIONING_DISABLED=true next build",
     "start": "next start",
     "snapshot": "ts-node -O '{\"module\": \"commonjs\"}' scripts/snapshot.ts && yarn format",
     "test": "jest",

--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -56,19 +56,24 @@ export const allPaths = () => {
 
   paths = [...flattenedMasterNavigation, ...paths];
 
-  for (const [key, value] of Object.entries(versionedNavigation)) {
-    const flattenedVersionNavigation = flatten(value)
-      .filter((n: { path: any }) => n.path)
-      .map(({ path }) => [key, ...path.split("/").splice(1)])
-      .map((page: string[]) => {
-        return {
-          params: {
-            page: page,
-          },
-        };
-      });
+  // Always enable versioning when on Vercel
+  if (process.env.VERCEL || !__VERSIONING_DISABLED__) {
+    console.log("?????????", process.env.VERCEL, __VERSIONING_DISABLED__);
 
-    paths = [...paths, ...flattenedVersionNavigation];
+    for (const [key, value] of Object.entries(versionedNavigation)) {
+      const flattenedVersionNavigation = flatten(value)
+        .filter((n: { path: any }) => n.path)
+        .map(({ path }) => [key, ...path.split("/").splice(1)])
+        .map((page: string[]) => {
+          return {
+            params: {
+              page: page,
+            },
+          };
+        });
+
+      paths = [...paths, ...flattenedVersionNavigation];
+    }
   }
 
   return paths;

--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -58,8 +58,6 @@ export const allPaths = () => {
 
   // Always enable versioning when on Vercel
   if (process.env.VERCEL || !__VERSIONING_DISABLED__) {
-    console.log("?????????", process.env.VERCEL, __VERSIONING_DISABLED__);
-
     for (const [key, value] of Object.entries(versionedNavigation)) {
       const flattenedVersionNavigation = flatten(value)
         .filter((n: { path: any }) => n.path)

--- a/docs/next/yarn.lock
+++ b/docs/next/yarn.lock
@@ -3572,9 +3572,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001181:
-  version "1.0.30001183"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz#7a57ba9d6584119bb5f2bc76d3cc47ba9356b3e2"
-  integrity sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==
+  version "1.0.30001248"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
+  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
skip building versioned pages when `__VERSIONING_DISABLED__` is true.
add build all versions to integration tests


## Test Plan
- local `yarn build` and `yarn build-master`
- bk docs step should be faster: https://buildkite.com/dagster/dagster/builds/18540#2c7b9ec5-0a7a-4687-8e2f-26ca18f4c335 now takes ~1m
- vercel build is hooked to PR checks so that will handle the testing for versioing. vercel preview should build versioned pages: https://dagster-git-yuhan-docs-build-elementl.vercel.app/getting-started