### PR TITLE
remove intermediate storage from docs 1/

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -731,9 +731,9 @@ compute_logs:
 
 ### Local Artifact Storage
 
-The local artifact storage is used to configure storage for any artifacts that require a local disk, such as schedules, or when using the filesystem system storage to manage files and intermediates.
+The local artifact storage is used to configure storage for any artifacts that require a local disk, such as schedules, or when using the filesystem IO manager to manage files and intermediates.
 
-Note that pipeline intermediates storage is itself not configured this way, but instead is configured on the pipeline level (i.e. via <Link href="/concepts/io-management/io-managers">IO Managers</Link>)
+Note how a pipeline persists its artifact through IO managers is not configured this way, but instead is configured on the pipeline level (i.e. via <Link href="/concepts/io-management/io-managers">IO Managers</Link>)
 
 To configure Local Artifact Storage, set `local_artifact_storage` as follows in your `dagster.yaml`:
 
@@ -741,8 +741,8 @@ To configure Local Artifact Storage, set `local_artifact_storage` as follows in 
 
 <PyObject module="dagster.core.storage.root" object="LocalArtifactStorage" /> is
 currently the only option for Local Artifact Storage. This configures the directory
-used by the default filesystem intermediates storage, as well as any schedule-related
-artifacts that require a local disk.
+used by the default filesystem IO Manager, as well as any schedule-related artifacts
+that require a local disk.
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_local_artifact_storage endbefore=end_marker_local_artifact_storage
 # there are two possible ways to configure LocalArtifactStorage

--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -731,9 +731,9 @@ compute_logs:
 
 ### Local Artifact Storage
 
-The local artifact storage is used to configure storage for any artifacts that require a local disk, such as schedules, or when using the filesystem IO manager to manage files and intermediates.
+The local artifact storage is used to configure storage for any artifacts that require a local disk, such as schedules, or when using the filesystem IO manager to manage intermediates.
 
-Note how a pipeline persists its artifact through IO managers is not configured this way, but instead is configured on the pipeline level (i.e. via <Link href="/concepts/io-management/io-managers">IO Managers</Link>)
+Note that how a pipeline persists its artifact through IO managers is not configured this way, but instead is configured on the pipeline level (i.e. via <Link href="/concepts/io-management/io-managers">IO Managers</Link>)
 
 To configure Local Artifact Storage, set `local_artifact_storage` as follows in your `dagster.yaml`:
 

--- a/docs/content/deployment/guides/celery.mdx
+++ b/docs/content/deployment/guides/celery.mdx
@@ -73,7 +73,7 @@ execution:
 
 In the quick start, we cheated in a couple of ways:
 
-- By running a single Celery worker on the same node as Dagit, so that local ephemeral run storage and event log storage could be shared between them, and so that filesystem intermediates storage would be sufficient to exchange values between the worker's task executions.
+- By running a single Celery worker on the same node as Dagit, so that local ephemeral run storage and event log storage could be shared between them, and so that filesystem io manager would be sufficient to exchange values between the worker's task executions.
 - By running the Celery worker in the same directory to which we saved `celery_pipeline.py`, so that our Dagster code would be available both to Dagit and to the worker: i.e., the worker and Dagit can both find the pipeline definition in the same file (`-f celery_pipeline.py`).
 
 In production, more configuration is required.

--- a/docs/content/deployment/guides/dask.mdx
+++ b/docs/content/deployment/guides/dask.mdx
@@ -9,7 +9,7 @@ The [dagster-dask](https://github.com/dagster-io/dagster/tree/master/python_modu
 
 This executor takes the compiled execution plan, and converts each execution step into a [Dask Future](https://docs.dask.org/en/latest/futures.html) configured with the appropriate task dependencies to ensure tasks are properly sequenced. When the pipeline is executed, these futures are generated and then awaited by the parent Dagster process.
 
-Data is passed between step executions via intermediate storage. As a consequence, a persistent shared storage (such as a network filesystem shared by all of the Dask nodes, S3, or GCS) must be used.
+Data is passed between step executions via [IO Managers](/concepts/io-management/io-managers). As a consequence, a persistent shared storage (such as a network filesystem shared by all of the Dask nodes, S3, or GCS) must be used.
 
 Note that, when using this executor, the compute function of a single solid is still executed in a single process on a single machine. If your goal is to distribute execution of workloads _within_ the logic of a single solid, you may find that invoking Dask or PySpark directly from within the body of a solid's compute function is a better fit than the engine layer covered in this documentation.
 
@@ -25,24 +25,16 @@ First, run `pip install dagster-dask`.
 
 Then, you'll need to add the dask executor to a **`ModeDefinition`** on your pipeline:
 
-```python file=/deploying/dask_hello_world.py
-from dagster import ModeDefinition, default_executors, fs_io_manager, pipeline, solid
-from dagster_dask import dask_executor
-
-
-@solid
-def hello_world():
-    return "Hello, World!"
-
-
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-            executor_defs=default_executors + [dask_executor],
-        )
-    ]
+```python file=/deploying/dask_hello_world.py startafter=start_local_mode endbefore=end_local_mode
+local_mode = ModeDefinition(
+    name="local",
+    resource_defs={"io_manager": fs_io_manager},
+    executor_defs=default_executors + [dask_executor],
 )
+```
+
+```python file=/deploying/dask_hello_world.py startafter=start_pipeline_marker endbefore=end_pipeline_marker
+@pipeline(mode_defs=[local_mode, distributed_mode])
 def dask_pipeline():
     return hello_world()
 ```
@@ -63,7 +55,15 @@ Executing this pipeline will spin up local Dask execution, run the Dagster pipel
 
 If you want to use a Dask cluster for distributed execution, you will first need to [set up a Dask cluster](https://distributed.readthedocs.io/en/latest/quickstart.html#setup-dask-distributed-the-hard-way). Note that the machine running the Dagster parent process must be able to connect to the host/port on which the Dask scheduler is running.
 
-You'll also need a persistent shared storage, which should be attached to a pipeline **`ModeDefinition`** along with any resources on which it depends. (Here, we use the **`s3_system_storage`**)
+You'll also need an IO manager that uses persistent shared storage, which should be attached to a pipeline **`ModeDefinition`** along with any resources on which it depends. Here, we use the <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/>:
+
+```python file=/deploying/dask_hello_world.py startafter=start_distributed_mode endbefore=end_distributed_mode
+distributed_mode = ModeDefinition(
+    name="distributed",
+    resource_defs={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    executor_defs=default_executors + [dask_executor],
+)
+```
 
 For distributing task execution on a Dask cluster, you must provide a config block that includes the address/port of the Dask scheduler:
 
@@ -113,7 +113,7 @@ The dict passed to `dagster-dask/resource_requirements` will be passed through a
 
 ## Caveats
 
-- For distributed execution, you must use a persistent intermediates storage such as S3 or GCS.
+- For distributed execution, you must use a persistent io manager for handling intermediates between solids, such as <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/>, <PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager"/>, or <PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager"/>.
 - Dagster logs are not yet retrieved from Dask workers; this will be addressed in follow-up work.
 
 While this library is still nascent, we're working to improve it, and we are happy to accept contributions.

--- a/docs/content/deployment/guides/dask.mdx
+++ b/docs/content/deployment/guides/dask.mdx
@@ -26,6 +26,10 @@ First, run `pip install dagster-dask`.
 Then, you'll need to add the dask executor to a **`ModeDefinition`** on your pipeline:
 
 ```python file=/deploying/dask_hello_world.py startafter=start_local_mode endbefore=end_local_mode
+from dagster_dask import dask_executor
+from dagster import ModeDefinition, default_executors, fs_io_manager
+
+
 local_mode = ModeDefinition(
     name="local",
     resource_defs={"io_manager": fs_io_manager},
@@ -34,6 +38,14 @@ local_mode = ModeDefinition(
 ```
 
 ```python file=/deploying/dask_hello_world.py startafter=start_pipeline_marker endbefore=end_pipeline_marker
+from dagster import pipeline, solid
+
+
+@solid
+def hello_world():
+    return "Hello, World!"
+
+
 @pipeline(mode_defs=[local_mode, distributed_mode])
 def dask_pipeline():
     return hello_world()
@@ -58,6 +70,9 @@ If you want to use a Dask cluster for distributed execution, you will first need
 You'll also need an IO manager that uses persistent shared storage, which should be attached to a pipeline **`ModeDefinition`** along with any resources on which it depends. Here, we use the <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/>:
 
 ```python file=/deploying/dask_hello_world.py startafter=start_distributed_mode endbefore=end_distributed_mode
+from dagster_aws.s3.io_manager import s3_pickle_io_manager
+from dagster_aws.s3.resources import s3_resource
+
 distributed_mode = ModeDefinition(
     name="distributed",
     resource_defs={"io_manager": s3_pickle_io_manager, "s3": s3_resource},

--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
@@ -229,7 +229,7 @@ After Helm has successfully installed all the required kubernetes resources, sta
       -o jsonpath="{.items[0].metadata.name}")
     kubectl --namespace default port-forward $DAGIT_POD_NAME 8080:80
 
-Visit <http://127.0.0.1:8080>, navigate to the [playground](http://127.0.0.1:8080/workspace/example_repo@k8s-example-user-code-1/pipelines/example_pipe/playground), select the `celery_k8s` preset. Notice how `intermediate_storage.s3.config.s3_bucket` is set to `dagster-test`. You can replace this string with any other accessible S3 bucket. Then, click _Launch Execution_.
+Visit <http://127.0.0.1:8080>, navigate to the [playground](http://127.0.0.1:8080/workspace/example_repo@k8s-example-user-code-1/pipelines/example_pipe/playground), select the `celery_k8s` preset. Notice how `resources.io_manager.config.s3_bucket` is set to `dagster-test`. You can replace this string with any other accessible S3 bucket. Then, click _Launch Execution_.
 
 You can introspect the jobs that were launched with `kubectl`:
 

--- a/examples/docs_snippets/docs_snippets/deploying/dask_hello_world.py
+++ b/examples/docs_snippets/docs_snippets/deploying/dask_hello_world.py
@@ -1,15 +1,10 @@
-from dagster import ModeDefinition, default_executors, fs_io_manager, pipeline, solid
-from dagster_aws.s3.io_manager import s3_pickle_io_manager
-from dagster_aws.s3.resources import s3_resource
-from dagster_dask import dask_executor
-
-
-@solid
-def hello_world():
-    return "Hello, World!"
+"""isort:skip_file"""
 
 
 # start_local_mode
+from dagster_dask import dask_executor
+from dagster import ModeDefinition, default_executors, fs_io_manager
+
 
 local_mode = ModeDefinition(
     name="local",
@@ -19,6 +14,9 @@ local_mode = ModeDefinition(
 # end_local_mode
 # start_distributed_mode
 
+from dagster_aws.s3.io_manager import s3_pickle_io_manager
+from dagster_aws.s3.resources import s3_resource
+
 distributed_mode = ModeDefinition(
     name="distributed",
     resource_defs={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
@@ -27,6 +25,15 @@ distributed_mode = ModeDefinition(
 # end_distributed_mode
 
 # start_pipeline_marker
+
+from dagster import pipeline, solid
+
+
+@solid
+def hello_world():
+    return "Hello, World!"
+
+
 @pipeline(mode_defs=[local_mode, distributed_mode])
 def dask_pipeline():
     return hello_world()

--- a/examples/docs_snippets/docs_snippets/deploying/dask_hello_world.py
+++ b/examples/docs_snippets/docs_snippets/deploying/dask_hello_world.py
@@ -1,4 +1,6 @@
 from dagster import ModeDefinition, default_executors, fs_io_manager, pipeline, solid
+from dagster_aws.s3.io_manager import s3_pickle_io_manager
+from dagster_aws.s3.resources import s3_resource
 from dagster_dask import dask_executor
 
 
@@ -7,13 +9,27 @@ def hello_world():
     return "Hello, World!"
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-            executor_defs=default_executors + [dask_executor],
-        )
-    ]
+# start_local_mode
+
+local_mode = ModeDefinition(
+    name="local",
+    resource_defs={"io_manager": fs_io_manager},
+    executor_defs=default_executors + [dask_executor],
 )
+# end_local_mode
+# start_distributed_mode
+
+distributed_mode = ModeDefinition(
+    name="distributed",
+    resource_defs={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    executor_defs=default_executors + [dask_executor],
+)
+# end_distributed_mode
+
+# start_pipeline_marker
+@pipeline(mode_defs=[local_mode, distributed_mode])
 def dask_pipeline():
     return hello_world()
+
+
+# end_pipeline_marker

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_dask.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_dask.py
@@ -4,13 +4,14 @@ from dagster.utils.yaml_utils import load_yaml_from_globs
 from docs_snippets.deploying.dask_hello_world import dask_pipeline  # pylint: disable=import-error
 
 
-def test_dask_pipeline():
+def test_local_dask_pipeline():
     with instance_for_test() as instance:
         run_config = load_yaml_from_globs(
             file_relative_path(__file__, "../../docs_snippets/deploying/dask_hello_world.yaml")
         )
         result = execute_pipeline(
             reconstructable(dask_pipeline),
+            mode="local",
             run_config=run_config,
             instance=instance,
         )


### PR DESCRIPTION
## Summary
https://github.com/dagster-io/dagster/issues/4232

audited the docs and found the following places still mentioning intermediate storage:
- [x]  instance config
- [x]  dask guide
- [x]  deploying-with-helm-advanced
- [ ]  airflow guide - looks a bit hairy, will fix it in a separate PR
- [ ]  Dagstermill still depends on intermediate storage until the io revamping is done



## Test Plan
- unit test in docs snippets
- see changes in vercel preview



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.