### PR TITLE
bump js wait time for docs search

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -50,5 +50,6 @@
     }
   },
   "js_render": true,
+  "js_wait": 3,
   "nb_hits": 9458
 }

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -163,7 +163,7 @@ const LinkGridItem = ({ title, href, children, tags = [] }) => {
   return (
     <div className="rounded-tl-lg rounded-tr-lg sm:rounded-tr-none relative group bg-white dark:bg-gray-800 p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500 hover:bg-gray-50 transition-colors">
       <div className="mt-8">
-        <h3 className="text-lg font-medium">
+        <div className="text-lg font-medium">
           <Link href={href}>
             <a className="focus:outline-none">
               {/* Extend touch target to entire panel */}
@@ -171,7 +171,7 @@ const LinkGridItem = ({ title, href, children, tags = [] }) => {
               {title}
             </a>
           </Link>
-        </h3>
+        </div>
         <p className="mt-2 text-sm text-gray-500">{children}</p>
       </div>
       <span


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

Changes the algolia/doc_search config to wait longer for the client-side rendered content to load.

Also, changes the main concepts page to not index (using h3 tags) the section headers.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Rendered main concepts page locally, saw everything looked normal


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.