### PR TITLE
Fix config mapping when using enums

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/config.py
+++ b/python_modules/dagster/dagster/core/definitions/config.py
@@ -18,6 +18,7 @@ class ConfigMapping(
         [
             ("config_fn", Callable[[Any], Any]),
             ("config_schema", IDefinitionConfigSchema),
+            ("enable_pre_processing", bool),
         ],
     )
 ):
@@ -41,9 +42,11 @@ class ConfigMapping(
         cls,
         config_fn: Callable[[Any], Any],
         config_schema: Any = None,
+        enable_pre_processing: bool = True,
     ):
         return super(ConfigMapping, cls).__new__(
             cls,
             config_fn=check.callable_param(config_fn, "config_fn"),
             config_schema=convert_user_facing_definition_config_schema(config_schema),
+            enable_pre_processing=check.bool_param(enable_pre_processing, "enable_pre_processing"),
         )

--- a/python_modules/dagster/dagster/core/definitions/config.py
+++ b/python_modules/dagster/dagster/core/definitions/config.py
@@ -18,7 +18,7 @@ class ConfigMapping(
         [
             ("config_fn", Callable[[Any], Any]),
             ("config_schema", IDefinitionConfigSchema),
-            ("enable_pre_processing", bool),
+            ("receive_processed_config_values", bool),
         ],
     )
 ):
@@ -36,17 +36,23 @@ class ConfigMapping(
         config_fn (Callable[[dict], dict]): The function that will be called
             to map the composite config to a config appropriate for the child solids.
         config_schema (ConfigSchema): The schema of the composite config.
+        receive_processed_config_values (bool): If true, config values provided to the config_fn
+            will be converted to their dagster types before being passed in. For example, if this
+            value is true, enum config passed to config_fn will be actual enums, while if false,
+            then enum config passed to config_fn will be strings.
     """
 
     def __new__(
         cls,
         config_fn: Callable[[Any], Any],
         config_schema: Any = None,
-        enable_pre_processing: bool = True,
+        receive_processed_config_values: bool = True,
     ):
         return super(ConfigMapping, cls).__new__(
             cls,
             config_fn=check.callable_param(config_fn, "config_fn"),
             config_schema=convert_user_facing_definition_config_schema(config_schema),
-            enable_pre_processing=check.bool_param(enable_pre_processing, "enable_pre_processing"),
+            receive_processed_config_values=check.bool_param(
+                receive_processed_config_values, "receive_processed_config_values"
+            ),
         )

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -799,8 +799,7 @@ def _config_mapping_with_default_value(
         )
 
     return ConfigMapping(
-        config_fn=config_fn,
-        config_schema=config_schema,
+        config_fn=config_fn, config_schema=config_schema, enable_pre_processing=False
     )
 
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -799,7 +799,7 @@ def _config_mapping_with_default_value(
         )
 
     return ConfigMapping(
-        config_fn=config_fn, config_schema=config_schema, enable_pre_processing=False
+        config_fn=config_fn, config_schema=config_schema, receive_processed_config_values=False
     )
 
 

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -346,6 +346,7 @@ class CompositeSolidDefinition(GraphDefinition):
             config_mapping=ConfigMapping(
                 config_mapping.config_fn,
                 config_schema=config_schema,
+                receive_processed_config_values=config_mapping.receive_processed_config_values,
             ),
             dependencies=self.dependencies,
             description=description or self.description,

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -176,8 +176,8 @@ def _get_mapped_solids_dict(
     with user_code_error_boundary(
         DagsterConfigMappingFunctionError, _get_error_lambda(current_stack)
     ):
-        mapped_solids_config = graph_def.config_mapping.resolve(
-            config_mapped_solid_config.value.get("config", {}), config_has_been_validated=True
+        mapped_solids_config = graph_def.config_mapping.resolve_from_validated_config(
+            config_mapped_solid_config.value.get("config", {})
         )
 
     # Dynamically construct the type that the output of the config mapping function will

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -176,8 +176,8 @@ def _get_mapped_solids_dict(
     with user_code_error_boundary(
         DagsterConfigMappingFunctionError, _get_error_lambda(current_stack)
     ):
-        mapped_solids_config = graph_def.config_mapping.config_fn(
-            config_mapped_solid_config.value.get("config", {})
+        mapped_solids_config = graph_def.config_mapping.resolve(
+            config_mapped_solid_config.value.get("config", {}), config_has_been_validated=True
         )
 
     # Dynamically construct the type that the output of the config mapping function will

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -167,26 +167,27 @@ class ResolvedRunConfig(
         run_config_schema = pipeline_def.get_run_config_schema(mode)
 
         if run_config_schema.config_mapping:
-            if run_config_schema.config_mapping.enable_pre_processing:
+            if run_config_schema.config_mapping.receive_processed_config_values:
                 outer_evr = process_config(
                     run_config_schema.config_mapping.config_schema.config_type,
                     run_config,
                 )
+                outer_config = outer_evr.value
             else:
                 outer_evr = validate_config(
                     run_config_schema.config_mapping.config_schema.config_type,
                     run_config,
                 )
+                outer_config = resolve_defaults(
+                    cast("ConfigType", run_config_schema.config_mapping.config_schema.config_type),
+                    outer_evr.value,
+                ).value
             if not outer_evr.success:
                 raise DagsterInvalidConfigError(
                     f"Error in config mapping for pipeline {pipeline_def.name} mode {mode}",
                     outer_evr.errors,
                     run_config,
                 )
-            outer_config = resolve_defaults(
-                cast("ConfigType", run_config_schema.config_mapping.config_schema.config_type),
-                outer_evr.value,
-            ).value
             # add user code boundary
             run_config = run_config_schema.config_mapping.config_fn(outer_config)
 

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -167,7 +167,9 @@ class ResolvedRunConfig(
 
         if run_config_schema.config_mapping:
             # add user code boundary
-            run_config = run_config_schema.config_mapping.resolve(run_config)
+            run_config = run_config_schema.config_mapping.resolve_from_unvalidated_config(
+                run_config
+            )
 
         config_evr = process_config(
             run_config_schema.run_config_schema_type,

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -518,7 +518,7 @@ def test_enum_config_mapping():
                 )
             }
         ),
-        enable_pre_processing=False,
+        receive_processed_config_values=False,
     )
     ingest_mapping = my_graph.to_job(config=default_config_mapping)
     result = ingest_mapping.execute_in_process()
@@ -528,7 +528,7 @@ def test_enum_config_mapping():
     no_default_config_mapping = ConfigMapping(
         config_fn=_ingest_config_mapping,
         config_schema=Shape({"my_field": Field(Enum.from_python_enum(TestEnum), is_required=True)}),
-        enable_pre_processing=False,
+        receive_processed_config_values=False,
     )
     ingest_mapping_no_default = my_graph.to_job(config=no_default_config_mapping)
     result = ingest_mapping_no_default.execute_in_process(run_config={"my_field": "TWO"})

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -2,7 +2,6 @@ import enum
 import json
 
 import pytest
-from dagster.check import CheckError
 from dagster import (
     ConfigMapping,
     Enum,
@@ -15,6 +14,7 @@ from dagster import (
     resource,
     success_hook,
 )
+from dagster.check import CheckError
 from dagster.core.definitions.graph import GraphDefinition
 from dagster.core.definitions.partition import (
     Partition,


### PR DESCRIPTION
## Summary
When a job is using config mapping, there are two validation steps that happen during execution. Once, for the outer config, and once for the mapped config. 

We use this pattern to implement default config on jobs. This does not fully adhere to the expected pattern though, because the config mapping might return already validated and post processed values, which the config system doesn't know how to pre-process.

This is particularly a problem for enum use cases, where pre-processing, we ingest enum config as strings, and convert them post process into enum values. The double-validation step ends up breaking the config system.

This introduces a toggle onto config mapping that will validate outer config, apply defaults, but not resolve to post-processing config types.



## Test Plan
Added a battery of tests for both config mapping, and default config on jobs.




## Checklist
- [x ] I have added tests to cover my changes.