### PR TITLE
EventLogStorage watch fixes

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -126,7 +126,9 @@ def _get_instance():
         with DagsterInstance.get() as instance:
             yield instance
     else:
-        with tempfile.TemporaryDirectory() as tempdir:
+        # make the temp dir in the cwd since default temp dir roots
+        # have issues with FS notif based event log watching
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tempdir:
             click.echo(
                 f"Using temporary directory {tempdir} for storage. This will be removed when dagit exits.\n"
                 "To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.\n"

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
@@ -52,10 +53,8 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         self._conn_string = create_db_conn_string(base_dir, SQLITE_EVENT_LOG_FILENAME)
         self._secondary_index_cache = {}
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._watchdog = None
         self._watchers = defaultdict(dict)
-        self._obs = Observer()
-        self._obs.start()
+        self._obs = None
 
         if not os.path.exists(self.get_db_path()):
             self._init_db()
@@ -134,12 +133,15 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             del self._secondary_index_cache[name]
 
     def watch(self, run_id, start_cursor, callback):
-        if not self._watchdog:
-            self._watchdog = ConsolidatedSqliteEventLogStorageWatchdog(self)
+        if not self._obs:
+            self._obs = Observer()
+            self._obs.start()
+            self._obs.schedule(
+                ConsolidatedSqliteEventLogStorageWatchdog(self), self._base_dir, True
+            )
 
-        watch = self._obs.schedule(self._watchdog, self._base_dir, True)
         cursor = start_cursor if start_cursor is not None else -1
-        self._watchers[run_id][callback] = (cursor, watch)
+        self._watchers[run_id][callback] = cursor
 
     def on_modified(self):
         keys = [
@@ -148,16 +150,21 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             for callback, _ in callback_dict.items()
         ]
         for run_id, callback in keys:
-            cursor, watch = self._watchers[run_id][callback]
+            cursor = self._watchers[run_id][callback]
 
             # fetch events
             events = self.get_logs_for_run(run_id, cursor)
 
             # update cursor
-            self._watchers[run_id][callback] = (cursor + len(events), watch)
+            self._watchers[run_id][callback] = cursor + len(events)
 
             for event in events:
-                status = callback(event)
+                status = None
+                try:
+                    status = callback(event)
+                except Exception:  # pylint: disable=broad-except
+                    logging.exception("Exception in callback for event watch on run %s.", run_id)
+
                 if (
                     status == PipelineRunStatus.SUCCESS
                     or status == PipelineRunStatus.FAILURE
@@ -166,10 +173,13 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     self.end_watch(run_id, callback)
 
     def end_watch(self, run_id, handler):
-        if run_id in self._watchers:
-            _cursor, watch = self._watchers[run_id][handler]
-            self._obs.remove_handler_for_watch(self._watchdog, watch)
+        if run_id in self._watchers and handler in self._watchers[run_id]:
             del self._watchers[run_id][handler]
+
+    def dispose(self):
+        if self._obs:
+            self._obs.stop()
+            self._obs.join(timeout=15)
 
 
 class ConsolidatedSqliteEventLogStorageWatchdog(PatternMatchingEventHandler):

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
@@ -414,7 +414,11 @@ class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
         events = self._event_log_storage.get_logs_for_run(self._run_id, self._cursor)
         self._cursor += len(events)
         for event in events:
-            status = self._cb(event)
+            status = None
+            try:
+                status = self._cb(event)
+            except Exception:  # pylint: disable=broad-except
+                logging.exception("Exception in callback for event watch on run %s.", self._run_id)
 
             if (
                 status == PipelineRunStatus.SUCCESS

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_event_log.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import tempfile
-import time
 import traceback
 
 import pytest
@@ -33,8 +32,14 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
 
     @pytest.fixture(scope="function", name="storage")
     def event_log_storage(self):  # pylint: disable=arguments-differ
-        with tempfile.TemporaryDirectory() as tmpdir_path:
-            yield SqliteEventLogStorage(tmpdir_path)
+        # make the temp dir in the cwd since default temp roots
+        # have issues with FS notif based event log watching
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
+            storage = SqliteEventLogStorage(tmpdir_path)
+            try:
+                yield storage
+            finally:
+                storage.dispose()
 
     def test_filesystem_event_log_storage_run_corrupted(self, storage):
         # URL begins sqlite:///
@@ -105,5 +110,11 @@ class TestConsolidatedSqliteEventLogStorage(TestEventLogStorage):
 
     @pytest.fixture(scope="function", name="storage")
     def event_log_storage(self):  # pylint: disable=arguments-differ
-        with tempfile.TemporaryDirectory() as tmpdir_path:
-            yield ConsolidatedSqliteEventLogStorage(tmpdir_path)
+        # make the temp dir in the cwd since default temp roots
+        # have issues with FS notif based event log watching
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
+            storage = ConsolidatedSqliteEventLogStorage(tmpdir_path)
+            try:
+                yield storage
+            finally:
+                storage.dispose()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -8,6 +8,7 @@ import pytest
 from dagster import (
     AssetKey,
     AssetMaterialization,
+    DagsterInstance,
     InputDefinition,
     ModeDefinition,
     Output,
@@ -52,6 +53,9 @@ from watchdog.utils import platform
 DEFAULT_RUN_ID = "foo"
 
 TEST_TIMEOUT = 5
+
+# py36 & 37 list.append not hashable
+# pylint: disable=unnecessary-lambda
 
 
 def create_test_event_log_record(message: str, run_id: str = DEFAULT_RUN_ID):
@@ -182,7 +186,7 @@ def _synthesize_events(solids_fn, run_id=None, check_success=True, instance=None
 
     with ExitStack() as stack:
         if not instance:
-            instance = stack.enter_context(instance_for_test())
+            instance = stack.enter_context(DagsterInstance.ephemeral())
         pipeline_run = instance.create_run_for_pipeline(
             a_pipe, run_id=run_id, run_config={"loggers": {"callback": {}, "console": {}}}
         )
@@ -249,11 +253,6 @@ class TestEventLogStorage:
         # Whether the storage is allowed to wipe the event log
         return True
 
-    def can_watch(self):
-        # whether the storage is allowed to subscribe to runs
-        # for event log updates
-        return True
-
     def test_event_log_storage_store_events_and_wipe(self, storage):
         assert len(storage.get_logs_for_run(DEFAULT_RUN_ID)) == 0
         storage.store_event(
@@ -312,9 +311,6 @@ class TestEventLogStorage:
         reason="watchdog's default MacOSX FSEventsObserver sometimes fails to pick up changes",
     )
     def test_event_log_storage_watch(self, storage):
-        if self.can_watch():
-            pytest.skip("storage cannot watch runs")
-
         watched = []
         watcher = lambda x: watched.append(x)  # pylint: disable=unnecessary-lambda
 
@@ -674,9 +670,6 @@ class TestEventLogStorage:
         assert set(map(lambda e: e.run_id, out_events_two)) == {result_two.run_id}
 
     def test_event_watcher_single_run_event(self, storage):
-        if not hasattr(storage, "event_watcher"):
-            pytest.skip("This test requires an event_watcher attribute")
-
         @solid
         def return_one(_):
             return 1
@@ -688,7 +681,7 @@ class TestEventLogStorage:
 
         run_id = make_new_run_id()
 
-        storage.event_watcher.watch_run(run_id, -1, event_list.append)
+        storage.watch(run_id, -1, lambda x: event_list.append(x))
 
         events, _ = _synthesize_events(_solids, run_id=run_id)
         for event in events:
@@ -702,9 +695,6 @@ class TestEventLogStorage:
         assert all([isinstance(event, EventLogEntry) for event in event_list])
 
     def test_event_watcher_filter_run_event(self, storage):
-        if not hasattr(storage, "event_watcher"):
-            pytest.skip("This test requires an event_watcher attribute")
-
         @solid
         def return_one(_):
             return 1
@@ -717,7 +707,7 @@ class TestEventLogStorage:
 
         # only watch one of the runs
         event_list = []
-        storage.event_watcher.watch_run(run_id_two, -1, event_list.append)
+        storage.watch(run_id_two, -1, lambda x: event_list.append(x))
 
         events_one, _result_one = _synthesize_events(_solids, run_id=run_id_one)
         for event in events_one:
@@ -751,8 +741,8 @@ class TestEventLogStorage:
         run_id_one = make_new_run_id()
         run_id_two = make_new_run_id()
 
-        storage.event_watcher.watch_run(run_id_one, -1, event_list_one.append)
-        storage.event_watcher.watch_run(run_id_two, -1, event_list_two.append)
+        storage.watch(run_id_one, -1, lambda x: event_list_one.append(x))
+        storage.watch(run_id_two, -1, lambda x: event_list_two.append(x))
 
         events_one, _result_one = _synthesize_events(_solids, run_id=run_id_one)
         for event in events_one:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -234,10 +234,6 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def end_watch(self, run_id, handler):
         self._event_watcher.unwatch_run(run_id, handler)
 
-    @property
-    def event_watcher(self):
-        return self._event_watcher
-
     def __del__(self):
         # Keep the inherent limitations of __del__ in Python in mind!
         self.dispose()


### PR DESCRIPTION
Adds test cases for 
* a dead lock bug in the posgres impl when unwatching on exception
* exceptions happening in watch callbacks

and fixes the implementations accordingly