### PR TITLE
Add definition time error for invalid Mode Definition resource keys

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/mode.py
+++ b/python_modules/dagster/dagster/core/definitions/mode.py
@@ -73,9 +73,14 @@ class ModeDefinition(
         from .intermediate_storage import IntermediateStorageDefinition
         from .partition import PartitionedConfig
 
-        check.opt_dict_param(
+        resource_defs = check.opt_dict_param(
             resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition
         )
+
+        for key in resource_defs:
+            if not key.isidentifier():
+                check.failed(f"Resource key '{key}' must be a valid Python identifier.")
+
         if resource_defs and "io_manager" in resource_defs:
             resource_defs_with_defaults = resource_defs
         else:

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -15,6 +15,7 @@ from dagster import (
     resource,
     solid,
 )
+from dagster.check import CheckError
 from dagster.core.log_manager import coerce_valid_log_level
 from dagster.utils.test import execute_solids_within_pipeline
 from dagster_tests.general_tests.test_repository import (
@@ -34,6 +35,19 @@ def test_mode_takes_a_name():
         name="takesamode", solid_defs=[], mode_defs=[ModeDefinition(name="a_mode")]
     )
     assert pipeline_def
+
+
+def test_error_on_invalid_resource_key():
+    @resource
+    def test_resource():
+        return ""
+
+    with pytest.raises(CheckError, match="test-foo"):
+        test_mode_def = ModeDefinition(
+            resource_defs={
+                "test-foo": test_resource,
+            },
+        )
 
 
 def test_mode_from_resources():


### PR DESCRIPTION
Fixes [this issue](https://github.com/dagster-io/dagster/issues/4276). Adds definition time error when invalid resource keys are provided in `ModeDefinition`. 