### PR TITLE
Retry ECS describe_tasks when launching

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/__init__.py
@@ -1,1 +1,1 @@
-from .launcher import EcsRunLauncher
+from .launcher import EcsEventualConsistencyTimeout, EcsRunLauncher

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -155,3 +155,12 @@ def test_eventual_consistency(ecs, instance, workspace, run, monkeypatch):
 
     tasks = ecs.list_tasks()["taskArns"]
     assert len(tasks) == len(initial_tasks) + 1
+
+    # backoff fails for reasons unrelated to eventual consistency
+
+    def exploding_describe_tasks(*_args, **_kwargs):
+        raise Exception("boom")
+
+    with pytest.raises(Exception, match="boom"):
+        monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", exploding_describe_tasks)
+        instance.launch_run(run.run_id, workspace)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1,6 +1,8 @@
 # pylint: disable=protected-access
+import dagster_aws
 import pytest
 from dagster.check import CheckError
+from dagster_aws.ecs import EcsEventualConsistencyTimeout
 
 
 def test_default_launcher(
@@ -123,3 +125,33 @@ def test_launching_custom_task_definition(
         assert override["name"] == container_name
         assert "execute_run" in override["command"]
         assert run.run_id in str(override["command"])
+
+
+def test_eventual_consistency(ecs, instance, workspace, run, monkeypatch):
+    initial_tasks = ecs.list_tasks()["taskArns"]
+
+    retries = 0
+    original_describe_tasks = instance.run_launcher.ecs.describe_tasks
+    original_backoff_retries = dagster_aws.ecs.launcher.BACKOFF_RETRIES
+
+    def describe_tasks(*_args, **_kwargs):
+        nonlocal retries
+        nonlocal original_describe_tasks
+
+        if retries > 1:
+            return original_describe_tasks(*_args, **_kwargs)
+        retries += 1
+        return {"tasks": []}
+
+    with pytest.raises(EcsEventualConsistencyTimeout):
+        monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", describe_tasks)
+        monkeypatch.setattr(dagster_aws.ecs.launcher, "BACKOFF_RETRIES", 0)
+        instance.launch_run(run.run_id, workspace)
+
+    # Reset the mock
+    retries = 0
+    monkeypatch.setattr(dagster_aws.ecs.launcher, "BACKOFF_RETRIES", original_backoff_retries)
+    instance.launch_run(run.run_id, workspace)
+
+    tasks = ecs.list_tasks()["taskArns"]
+    assert len(tasks) == len(initial_tasks) + 1

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -63,9 +63,6 @@ def test_eventual_consistency(instance, workspace, run, monkeypatch):
 
     original = instance.run_launcher.ecs.describe_tasks
 
-    # The ECS API is eventually consistent:
-    # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
-    # describe_tasks might initially return nothing even if a task exists.
     monkeypatch.setattr(instance.run_launcher.ecs, "describe_tasks", empty)
     assert not instance.run_launcher.can_terminate(run.run_id)
 


### PR DESCRIPTION
While implementing https://github.com/dagster-io/dagster/pull/4428 I
noticed that there's actually one more place where we describe tasks -
when gathering ECS metadata. This one is a bit more tricky than all of
the termination related requests because we don't want to fail to launch
a task immediately if ECS gives us an inconsistent response.

Instead, I'm following the ECS recommendation to exponentially backoff:

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html

> Apply an exponential backoff algorithm starting with a couple of
> seconds of wait time, and increase gradually up to about five minutes
> of wait time.

However, I'm _not_ waiting the entire 5 minutes in this initial
implementation. Instead, I'm waiting ~1 minute (51.1 seconds to be
precise since that's how long 9 retries takes) and raising an
EcsEventualConsistencyTimeout if we exhaust our retries. This might be
playing with fire but I wanted to balance the waiting against the
expectation that a new run should launch relatively close to when
Dagster requests it.