### PR TITLE
Enable s3 intermediate storage on large files

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -1,5 +1,5 @@
-import pickle
 import io
+import pickle
 
 from dagster import Field, IOManager, StringSource, check, io_manager
 from dagster.utils import PICKLE_PROTOCOL

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -1,4 +1,5 @@
 import pickle
+import io
 
 from dagster import Field, IOManager, StringSource, check, io_manager
 from dagster.utils import PICKLE_PROTOCOL
@@ -69,7 +70,8 @@ class PickledObjectS3IOManager(IOManager):
             self._rm_object(key)
 
         pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
-        self.s3.put_object(Bucket=self.bucket, Key=key, Body=pickled_obj)
+        pickled_obj_bytes = io.BytesIO(pickled_obj)
+        self.s3.upload_fileobj(pickled_obj_bytes, self.bucket, key)
 
 
 @io_manager(


### PR DESCRIPTION
 Addresses [this issue](https://github.com/dagster-io/dagster/issues/4249). Replaces low-level `put_object` method with `upload_fileobj` to enable large file upload to s3.