### PR TITLE
dagstermill io 0/ test for file managers with the output_notebook param

### DIFF
--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -134,6 +134,30 @@ def hello_world_with_output_notebook_pipeline():
     load_notebook(notebook)
 
 
+hello_world_no_output_notebook_no_file_manager = dagstermill.define_dagstermill_solid(
+    name="hello_world_no_output_notebook_no_file_manager",
+    notebook_path=nb_test_path("hello_world"),
+)
+
+
+@pipeline
+def hello_world_no_output_notebook_no_file_manager_pipeline():
+    hello_world_no_output_notebook_no_file_manager()
+
+
+hello_world_no_output_notebook = dagstermill.define_dagstermill_solid(
+    name="hello_world_no_output_notebook",
+    notebook_path=nb_test_path("hello_world"),
+    # FIXME the current behavior is implicitly peristing output notebooks based on whether resources.file_manager.write works.
+    required_resource_keys={"file_manager"},
+)
+
+
+@pipeline(mode_defs=default_mode_defs)
+def hello_world_no_output_notebook_pipeline():
+    hello_world_no_output_notebook()
+
+
 hello_world_output = test_nb_solid("hello_world_output", output_defs=[OutputDefinition(str)])
 
 

--- a/python_modules/libraries/dagstermill/dagstermill/solids.py
+++ b/python_modules/libraries/dagstermill/dagstermill/solids.py
@@ -170,7 +170,7 @@ def _dm_solid_compute(name, notebook_path, output_notebook=None, asset_key_prefi
         step_execution_context = step_context.get_step_execution_context()
 
         with tempfile.TemporaryDirectory() as output_notebook_dir:
-            with safe_tempfile_path() as output_log_path:  # [2]??????????? what is this
+            with safe_tempfile_path() as output_log_path:
 
                 prefix = str(uuid.uuid4())
                 parameterized_notebook_path = os.path.join(
@@ -192,14 +192,13 @@ def _dm_solid_compute(name, notebook_path, output_notebook=None, asset_key_prefi
                     papermill_engines.register("dagstermill", DagstermillEngine)
                     papermill.execute_notebook(
                         input_path=parameterized_notebook_path,
-                        output_path=executed_notebook_path,  # if the user wants to upload to s3, they have to output to local and upload the file up to s3
+                        output_path=executed_notebook_path,
                         engine_name="dagstermill",
                         log_output=True,
                     )
 
                 except Exception as ex:  # pylint: disable=broad-except
                     try:
-                        # [1] WHY OPEN AND WRITE AGAIN?????????
                         with open(executed_notebook_path, "rb") as fd:
                             executed_notebook_file_handle = (
                                 step_context.resources.file_manager.write(
@@ -217,7 +216,6 @@ def _dm_solid_compute(name, notebook_path, output_notebook=None, asset_key_prefi
                         )
                         executed_notebook_materialization_path = executed_notebook_path
 
-                    # WTF????? why twice
                     yield AssetMaterialization(
                         asset_key=(asset_key_prefix + [f"{name}_output_notebook"]),
                         description="Location of output notebook in file manager",
@@ -253,8 +251,6 @@ def _dm_solid_compute(name, notebook_path, output_notebook=None, asset_key_prefi
                 # use binary mode when when moving the file since certain file_managers such as S3
                 # may try to hash the contents
                 with open(executed_notebook_path, "rb") as fd:
-                    # hi! here's how the output notebook is stored
-                    # TODO: this should be changed to io manager
                     executed_notebook_file_handle = step_context.resources.file_manager.write(
                         fd, mode="wb", ext="ipynb"
                     )
@@ -287,7 +283,6 @@ def _dm_solid_compute(name, notebook_path, output_notebook=None, asset_key_prefi
                 data_dict = output_nb.scraps.data_dict
                 if output_name in data_dict:
                     # read result that was written by the "yield_result" call
-                    # TODO: read value via io manager
                     value = read_value(output_def.dagster_type, data_dict[output_name])
 
                     yield Output(value, output_name)
@@ -311,8 +306,7 @@ def define_dagstermill_solid(
     output_defs=None,
     config_schema=None,
     required_resource_keys=None,
-    output_notebook=None,  # TODO: how do i specify the path rather than the file name?
-    # => so i dont think we have a way to specify the path or file name. instead, `output_notebook` is just the output name.
+    output_notebook=None,
     asset_key_prefix=None,
     description=None,
     tags=None,

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -53,7 +53,7 @@ def test_yes_output_notebook_no_file_manager():
 
 @pytest.mark.notebook_test
 def test_no_output_notebook_yes_file_manager():
-    # when output_notebook is not set and file_manager is not provided:
+    # when output_notebook is not set and file_manager is provided:
     # * persist output notebook (but no solid output)
     # * yield AssetMaterialization
     with exec_for_test("hello_world_no_output_notebook_pipeline") as result:

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -1,0 +1,95 @@
+import os
+
+import pytest
+from dagster import FileHandle, pipeline
+from dagster.core.errors import DagsterInvalidDefinitionError
+from dagstermill.examples.repository import hello_world
+
+from .test_solids import exec_for_test
+
+
+@pytest.mark.notebook_test
+def test_yes_output_notebook_yes_file_manager():
+    # when output_notebook is set and file_manager is provided:
+    # * persist the output notebook in a temp file
+    # * yield AssetMaterialization
+    # * yield Output(value=FileHandle(...), name=output_notebook)
+    with exec_for_test("hello_world_with_output_notebook_pipeline") as result:
+        assert result.success
+        materializations = [
+            x for x in result.event_list if x.event_type_value == "ASSET_MATERIALIZATION"
+        ]
+        assert len(materializations) == 1
+
+        assert result.result_for_solid("hello_world").success
+        assert "notebook" in result.result_for_solid("hello_world").output_values
+        assert isinstance(
+            result.result_for_solid("hello_world").output_values["notebook"], FileHandle
+        )
+
+        assert os.path.exists(
+            result.result_for_solid("hello_world").output_values["notebook"].path_desc
+        )
+        assert (
+            materializations[0]
+            .event_specific_data.materialization.metadata_entries[0]
+            .entry_data.path
+            == result.result_for_solid("hello_world").output_values["notebook"].path_desc
+        )
+
+        assert result.result_for_solid("load_notebook").success
+        assert result.result_for_solid("load_notebook").output_value() is True
+
+
+def test_yes_output_notebook_no_file_manager():
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match='Resource key "file_manager" is required'
+    ):
+
+        @pipeline
+        def _pipe():
+            hello_world()
+
+
+@pytest.mark.notebook_test
+def test_no_output_notebook_yes_file_manager():
+    # when output_notebook is not set and file_manager is not provided:
+    # * persist output notebook (but no solid output)
+    # * yield AssetMaterialization
+    with exec_for_test("hello_world_no_output_notebook_pipeline") as result:
+        assert result.success
+        materializations = [
+            x for x in result.event_list if x.event_type_value == "ASSET_MATERIALIZATION"
+        ]
+        assert len(materializations) == 1
+        assert os.path.exists(
+            materializations[0]
+            .event_specific_data.materialization.metadata_entries[0]
+            .entry_data.path
+        )
+
+        assert result.result_for_solid("hello_world_no_output_notebook").success
+        assert not result.result_for_solid("hello_world_no_output_notebook").output_values
+
+
+@pytest.mark.notebook_test
+def test_no_output_notebook_no_file_manager():
+    # when output_notebook is not set and file_manager is not provided:
+    # * throw warning and persisting fails
+    # * yield AssetMaterialization - FIXME: shouldn't yield AssetMaterialization when persisting fails
+    with exec_for_test("hello_world_no_output_notebook_no_file_manager_pipeline") as result:
+        assert result.success
+        materializations = [
+            x for x in result.event_list if x.event_type_value == "ASSET_MATERIALIZATION"
+        ]
+        assert len(materializations) == 1
+        assert not os.path.exists(
+            materializations[0]
+            .event_specific_data.materialization.metadata_entries[0]
+            .entry_data.path
+        )
+
+        assert result.result_for_solid("hello_world_no_output_notebook_no_file_manager").success
+        assert not result.result_for_solid(
+            "hello_world_no_output_notebook_no_file_manager"
+        ).output_values

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_solids.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_solids.py
@@ -92,31 +92,6 @@ def test_hello_world_with_config():
 
 
 @pytest.mark.notebook_test
-def test_hello_world_with_output_notebook():
-    with exec_for_test("hello_world_with_output_notebook_pipeline") as result:
-        assert result.success
-        materializations = [
-            x for x in result.event_list if x.event_type_value == "ASSET_MATERIALIZATION"
-        ]
-        assert len(materializations) == 1
-
-        assert result.result_for_solid("hello_world").success
-        assert "notebook" in result.result_for_solid("hello_world").output_values
-        assert os.path.exists(
-            result.result_for_solid("hello_world").output_values["notebook"].path_desc
-        )
-        assert (
-            materializations[0]
-            .event_specific_data.materialization.metadata_entries[0]
-            .entry_data.path
-            == result.result_for_solid("hello_world").output_values["notebook"].path_desc
-        )
-
-        assert result.result_for_solid("load_notebook").success
-        assert result.result_for_solid("load_notebook").output_value() is True
-
-
-@pytest.mark.notebook_test
 def test_hello_world_with_config_escape():
     with exec_for_test(
         "hello_world_config_pipeline",


### PR DESCRIPTION
## Summary
resolves https://github.com/dagster-io/dagster/issues/3374
add tests for file managers resource and output_notebook param

Status quo:

File Manager provided? | output_notebook? | Behavior
-- | -- | --
N | N | warning: `Error when attempting to materialize executed notebook using file manager (falling back to local)`
Y | N | if `{"file_manager"}` is specified on `required_resource_keys` param, it will successfully generate output notebook: 1) persist the output notebook in a temp file. 2) yield `AssetMaterialization`. 
Y | N | if nothing is specified when defining the dagstermill solid, same as the first case, i.e. warning: `Error when attempting to materialize executed notebook using file manager (falling back to local)`
N | Y | `error: dagster.core.errors.DagsterInvalidDefinitionError: Resource key "file_manager" is required by solid def plot_solid, but is not provided by mode "dev". In mode "dev", provide a resource for key "file_manager", or change "file_manager" to one of the provided resources keys: ['io_manager', 'warehouse_io_manager', 'warehouse_loader'].`
Y | Y | successfully generate output notebook and an extra solid output: 1) persist the output notebook in a temp file 2) yield `AssetMaterialization` 3) `yield Output(value=FileHandle(...), name=output_notebook)`

This PR is just adding tests for the status quo behaviors, while some of them do not make sense and here are the follow up fixes:
- when writing output notebook fails, it shouldn't log the path in AssetMaterialization, i.e. the second case of (Y, N) shouldn't yield AssetMaterialization. 

- In case (Y, N) (file_manager is provided but no output_notebook), the behavior is odd:
  * in order to persist an output notebook, user needs to specify `define_dagstermill_solid(..., required_resource_keys={"file_manager"})`, otherwise the file_manager key won't be passed in even when it's included in the mode def - this is an implicit behavior, we should either disable it or make it explicit. 


## Test Plan
unit tests

