### PR TITLE
Add assert_permission utility function

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from dagster import check
 from dagster.core.host_representation import PipelineSelector
 from dagster.utils.error import serializable_error_info_from_exc_info
+from graphql.execution.base import ResolveInfo
 
 
 def check_permission(permission):
@@ -18,13 +19,11 @@ def check_permission(permission):
     return decorator
 
 
-def assert_permission(graphene_info, permission):
+def assert_permission(graphene_info: ResolveInfo, permission: str) -> None:
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
     if not graphene_info.context.has_permission(permission):
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
-
-    return True
 
 
 def capture_error(fn):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -9,16 +9,22 @@ from dagster.utils.error import serializable_error_info_from_exc_info
 def check_permission(permission):
     def decorator(fn):
         def _fn(self, graphene_info, *args, **kwargs):  # pylint: disable=unused-argument
-            from dagster_graphql.schema.errors import GrapheneUnauthorizedError
-
-            if not graphene_info.context.has_permission(permission):
-                raise UserFacingGraphQLError(GrapheneUnauthorizedError())
+            assert_permission(graphene_info, permission)
 
             return fn(self, graphene_info, *args, **kwargs)
 
         return _fn
 
     return decorator
+
+
+def assert_permission(graphene_info, permission):
+    from dagster_graphql.schema.errors import GrapheneUnauthorizedError
+
+    if not graphene_info.context.has_permission(permission):
+        raise UserFacingGraphQLError(GrapheneUnauthorizedError())
+
+    return True
 
 
 def capture_error(fn):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
@@ -3,7 +3,11 @@ from unittest.mock import Mock
 import pytest
 from dagster import check
 from dagster.core.workspace.permissions import EDITOR_PERMISSIONS, VIEWER_PERMISSIONS
-from dagster_graphql.implementation.utils import UserFacingGraphQLError, check_permission
+from dagster_graphql.implementation.utils import (
+    UserFacingGraphQLError,
+    assert_permission,
+    check_permission,
+)
 from dagster_graphql.test.utils import execute_dagster_graphql
 
 from .graphql_context_test_suite import NonLaunchableGraphQLContextTestMatrix
@@ -71,6 +75,20 @@ def test_check_permission_permission_does_not_exist(fake_graphene_info):
     mutation = FakeMissingPermissionMutation()
     with pytest.raises(check.CheckError):
         mutation.mutate(fake_graphene_info)
+
+
+def test_assert_permission_has_permission(fake_graphene_info):
+    assert assert_permission(fake_graphene_info, "fake_permission")
+
+
+def test_assert_permission_does_not_have_permission(fake_graphene_info):
+    with pytest.raises(UserFacingGraphQLError, match="GrapheneUnauthorizedError"):
+        assert_permission(fake_graphene_info, "fake_other_permission")
+
+
+def test_assert_permission_permission_does_not_exist(fake_graphene_info):
+    with pytest.raises(check.CheckError):
+        assert_permission(fake_graphene_info, "fake_missing_permission")
 
 
 class TestPermissionsQuery(NonLaunchableGraphQLContextTestMatrix):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
@@ -78,7 +78,7 @@ def test_check_permission_permission_does_not_exist(fake_graphene_info):
 
 
 def test_assert_permission_has_permission(fake_graphene_info):
-    assert assert_permission(fake_graphene_info, "fake_permission")
+    assert_permission(fake_graphene_info, "fake_permission")
 
 
 def test_assert_permission_does_not_have_permission(fake_graphene_info):


### PR DESCRIPTION
## Summary
Adds the `assert_permission` utility function to the `dagster-graphql` package, which can be used to check for a permission inline rather than as a decorator. This is useful in cases where a permission is only needed conditionally.

It can be used as a standalone statement or part of an if guard:
```python
if need_for_perm:
  assert_permission(graphene_info, "permission_for_this_condition")
  perform_action()
```

```python
if need_for_perm and assert_permission(graphene_info, "permission_for_this_condition"):
  perform_action()
```

```python
if no_need_for_perm or assert_permission(graphene_info, "permission_for_this_condition"):
  perform_action()
```

## Test Plan
Added relevant unit tests.