### PR TITLE
Scroll logs table to bottom if you're anywhere within the bottom padding

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -19,6 +19,8 @@ import {ColumnWidthsProvider, Headers} from './LogsScrollingTableHeader';
 import {IRunMetadataDict} from './RunMetadataProvider';
 import {RunPipelineRunEventFragment} from './types/RunPipelineRunEventFragment';
 
+const LOGS_PADDING_BOTTOM = 50;
+
 interface ILogsScrollingTableProps {
   logs: LogsProviderLogs;
   filter: LogFilter;
@@ -226,7 +228,12 @@ class LogsScrollingTableSized extends React.Component<ILogsScrollingTableSizedPr
 
   onScroll = ({scrollTop, scrollHeight, clientHeight}: ScrollParams) => {
     const atTopAndStarting = scrollTop === 0 && scrollHeight <= clientHeight;
-    const atBottom = Math.abs(scrollTop - (scrollHeight - clientHeight)) < 5;
+
+    // Note: The distance to the bottom can go negative if you scroll into the padding at the bottom of the list.
+    // react-virtualized seems to be faking these numbers (they're different than what you get if you inspect the el)
+    const distanceToBottom = scrollHeight - clientHeight - scrollTop;
+    const atBottom = distanceToBottom < 5;
+
     this.isAtBottomOrZero = atTopAndStarting || atBottom;
   };
 
@@ -328,7 +335,7 @@ class LogsScrollingTableSized extends React.Component<ILogsScrollingTableSizedPr
           width={width}
           height={height}
           overscanRowCount={10}
-          style={{paddingBottom: 50}}
+          style={{paddingBottom: LOGS_PADDING_BOTTOM}}
           onScroll={this.onScroll}
         />
       </div>


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
When you scroll down into the 50px of padding at the bottom of the list, scrollTop > scrollHeight - clientHeight, which shouldn't really be possible but is thanks to react-virtualized screwing around with the data somehow? Adjusting the bottom padding on the table adjusts the severity of this problem, but the values we get aren't off by exactly 50px which is strange.

## Test Plan
Observe that the logs panel scrolls as new logs come in and that if you break away from the bottom it stops scrolling.



## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.