### PR TITLE
Synchronous RPC dbt resource

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -25,6 +25,7 @@ from .errors import (
 )
 from .rpc import (
     DbtRpcClient,
+    DbtRpcSyncClient,
     DbtRpcOutput,
     create_dbt_rpc_run_sql_solid,
     dbt_rpc_compile_sql,
@@ -43,6 +44,7 @@ from .rpc import (
     dbt_rpc_snapshot_freshness_and_wait,
     dbt_rpc_test,
     dbt_rpc_test_and_wait,
+    dbt_rpc_sync_resource,
     local_dbt_rpc_resource,
 )
 from .types import DbtOutput

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -25,8 +25,8 @@ from .errors import (
 )
 from .rpc import (
     DbtRpcClient,
-    DbtRpcSyncClient,
     DbtRpcOutput,
+    DbtRpcSyncClient,
     create_dbt_rpc_run_sql_solid,
     dbt_rpc_compile_sql,
     dbt_rpc_docs_generate,
@@ -42,9 +42,9 @@ from .rpc import (
     dbt_rpc_snapshot_and_wait,
     dbt_rpc_snapshot_freshness,
     dbt_rpc_snapshot_freshness_and_wait,
+    dbt_rpc_sync_resource,
     dbt_rpc_test,
     dbt_rpc_test_and_wait,
-    dbt_rpc_sync_resource,
     local_dbt_rpc_resource,
 )
 from .types import DbtOutput

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -172,18 +172,18 @@ class DbtCliResource(DbtResource):
         """
         return self.cli("seed", show=show, **kwargs)
 
-    def generate_docs(self, compile: bool = False, **kwargs) -> DbtCliOutput:
+    def generate_docs(self, compile_project: bool = False, **kwargs) -> DbtCliOutput:
         """
         Run the ``docs generate`` command on a dbt project. kwargs are passed in as additional parameters.
 
         Args:
-            compile (bool, optional): If true, compile the project before generating a catalog.
+            compile_project (bool, optional): If true, compile the project before generating a catalog.
 
         Returns:
             DbtCliOutput: An instance of :class:`DbtCliOutput<dagster_dbt.DbtCliOutput>` containing
                 parsed log output as well as the contents of run_results.json (if applicable).
         """
-        return self.cli("docs generate", compile=compile, **kwargs)
+        return self.cli("docs generate", compile=compile_project, **kwargs)
 
     def run_operation(
         self, macro: str, args: Optional[Dict[str, Any]] = None, **kwargs

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -172,21 +172,18 @@ class DbtCliResource(DbtResource):
         """
         return self.cli("seed", show=show, **kwargs)
 
-    def generate_docs(
-        self, models: List[str] = None, exclude: List[str] = None, **kwargs
-    ) -> DbtCliOutput:
+    def generate_docs(self, compile: bool = False, **kwargs) -> DbtCliOutput:
         """
         Run the ``docs generate`` command on a dbt project. kwargs are passed in as additional parameters.
 
         Args:
-            models (List[str], optional): the models to include in docs generation.
-            exclude (List[str], optional): the models to exclude from docs generation.
+            compile (bool, optional): If true, compile the project before generating a catalog.
 
         Returns:
             DbtCliOutput: An instance of :class:`DbtCliOutput<dagster_dbt.DbtCliOutput>` containing
                 parsed log output as well as the contents of run_results.json (if applicable).
         """
-        return self.cli("docs generate", models=models, exclude=exclude, **kwargs)
+        return self.cli("docs generate", compile=compile, **kwargs)
 
     def run_operation(
         self, macro: str, args: Optional[Dict[str, Any]] = None, **kwargs

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
@@ -126,15 +126,12 @@ class DbtResource:
         """
 
     @abstractmethod
-    def generate_docs(
-        self, models: List[str] = None, exclude: List[str] = None, **kwargs
-    ) -> DbtOutput:
+    def generate_docs(self, compile: bool = False, **kwargs) -> DbtOutput:
         """
         Run the ``docs generate`` command on a dbt project. kwargs are passed in as additional parameters.
 
         Args:
-            models (List[str], optional): the models to include in docs generation.
-            exclude (List[str], optional): the models to exclude from docs generation.
+            compile (bool, optional): If true, compile the project before generating a catalog.
 
         Returns:
             DbtOutput: object containing parsed output from dbt

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_resource.py
@@ -126,12 +126,12 @@ class DbtResource:
         """
 
     @abstractmethod
-    def generate_docs(self, compile: bool = False, **kwargs) -> DbtOutput:
+    def generate_docs(self, compile_project: bool = False, **kwargs) -> DbtOutput:
         """
         Run the ``docs generate`` command on a dbt project. kwargs are passed in as additional parameters.
 
         Args:
-            compile (bool, optional): If true, compile the project before generating a catalog.
+            compile_project (bool, optional): If true, compile the project before generating a catalog.
 
         Returns:
             DbtOutput: object containing parsed output from dbt

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/__init__.py
@@ -1,9 +1,9 @@
 from .resources import (
     DbtRpcClient,
-    dbt_rpc_resource,
-    local_dbt_rpc_resource,
-    dbt_rpc_sync_resource,
     DbtRpcSyncClient,
+    dbt_rpc_resource,
+    dbt_rpc_sync_resource,
+    local_dbt_rpc_resource,
 )
 from .solids import (
     create_dbt_rpc_run_sql_solid,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/__init__.py
@@ -1,4 +1,10 @@
-from .resources import DbtRpcClient, dbt_rpc_resource, local_dbt_rpc_resource
+from .resources import (
+    DbtRpcClient,
+    dbt_rpc_resource,
+    local_dbt_rpc_resource,
+    dbt_rpc_sync_resource,
+    DbtRpcSyncClient,
+)
 from .solids import (
     create_dbt_rpc_run_sql_solid,
     dbt_rpc_compile_sql,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -329,7 +329,7 @@ class DbtRpcClient(DbtResource):
 
     def generate_docs(
         self,
-        compile: bool = False,
+        compile_project: bool = False,
         **kwargs,
     ) -> DbtRpcOutput:
         """Sends a request with the method ``docs.generate`` to the dbt RPC server, and returns the
@@ -337,10 +337,10 @@ class DbtRpcClient(DbtResource):
         <https://docs.getdbt.com/reference/commands/rpc/#generate-docs>`_.
 
         Args:
-            compile (bool, optional): If true, compile the project before generating a catalog.
+            compile_project (bool, optional): If true, compile the project before generating a catalog.
 
         """
-        explicit_params = dict(compile=compile)
+        explicit_params = dict(compile=compile_project)
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="docs.generate", params=params)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -76,7 +76,7 @@ class DbtRpcClient(DbtResource):
         headers["Accept"] = "application/json"
         return headers
 
-    def _post(self, data: str = None) -> DbtRpcOutput:
+    def _get_result(self, data: str = None) -> DbtRpcOutput:
         """Constructs and sends a POST request to the dbt RPC server.
 
         Returns:
@@ -144,7 +144,7 @@ class DbtRpcClient(DbtResource):
             Response: the HTTP response from the dbt RPC server.
         """
         data = self._default_request(method="status")
-        return self._post(data=json.dumps(data))
+        return DbtRpcClient._get_result(self, data=json.dumps(data))
 
     def poll(self, request_token: str, logs: bool = False, logs_start: int = 0) -> DbtRpcOutput:
         """Sends a request with the method ``poll`` to the dbt RPC server, and returns the response.
@@ -161,7 +161,7 @@ class DbtRpcClient(DbtResource):
         """
         data = self._default_request(method="poll")
         data["params"] = {"request_token": request_token, "logs": logs, "logs_start": logs_start}
-        return self._post(data=json.dumps(data))
+        return DbtRpcClient._get_result(self, data=json.dumps(data))
 
     def ps(self, completed: bool = False) -> DbtRpcOutput:
         """Sends a request with the method ``ps`` to the dbt RPC server, and returns the response.
@@ -176,7 +176,7 @@ class DbtRpcClient(DbtResource):
         """
         data = self._default_request(method="ps")
         data["params"] = {"completed": completed}
-        return self._post(data=json.dumps(data))
+        return DbtRpcClient._get_result(self, data=json.dumps(data))
 
     def kill(self, task_id: str) -> DbtRpcOutput:
         """Sends a request with the method ``kill`` to the dbt RPC server, and returns the response.
@@ -191,7 +191,7 @@ class DbtRpcClient(DbtResource):
         """
         data = self._default_request(method="kill")
         data["params"] = {"task_id": task_id}
-        return self._post(data=json.dumps(data))
+        return DbtRpcClient._get_result(self, data=json.dumps(data))
 
     def cli(self, command: str, **kwargs) -> DbtRpcOutput:
         """Sends a request with CLI syntax to the dbt RPC server, and returns the response.
@@ -207,7 +207,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({"cli": command, **kwargs})
         data = self._default_request(method="cli_args", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def compile(
         self, models: List[str] = None, exclude: List[str] = None, **kwargs
@@ -228,7 +228,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="compile", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def run(self, models: List[str] = None, exclude: List[str] = None, **kwargs) -> DbtRpcOutput:
         """Sends a request with the method ``run`` to the dbt RPC server, and returns the response.
@@ -246,7 +246,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="run", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def snapshot(
         self, select: List[str] = None, exclude: List[str] = None, **kwargs
@@ -266,7 +266,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="snapshot", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def test(
         self,
@@ -293,7 +293,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="test", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def seed(
         self, show: bool = False, select: List[str] = None, exclude: List[str] = None, **kwargs
@@ -317,7 +317,7 @@ class DbtRpcClient(DbtResource):
         if kwargs is not None:
             data["params"]["task_tags"] = kwargs
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def generate_docs(
         self,
@@ -338,7 +338,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="docs.generate", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def run_operation(
         self, macro: str, args: Optional[Dict[str, Any]] = None, **kwargs
@@ -358,7 +358,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="run-operation", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def snapshot_freshness(self, select: Optional[List[str]] = None, **kwargs) -> DbtRpcOutput:
         """Sends a request with the method ``snapshot-freshness`` to the dbt RPC server, and returns
@@ -375,7 +375,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params({**explicit_params, **kwargs})
         data = self._default_request(method="snapshot-freshness", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def compile_sql(self, sql: str, name: str) -> DbtRpcOutput:
         """Sends a request with the method ``compile_sql`` to the dbt RPC server, and returns the
@@ -393,7 +393,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params(explicit_params)
         data = self._default_request(method="compile_sql", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
     def run_sql(self, sql: str, name: str) -> DbtRpcOutput:
         """Sends a request with the method ``run_sql`` to the dbt RPC server, and returns the
@@ -411,7 +411,7 @@ class DbtRpcClient(DbtResource):
         params = self._format_params(explicit_params)
         data = self._default_request(method="run_sql", params=params)
 
-        return self._post(data=json.dumps(data))
+        return self._get_result(data=json.dumps(data))
 
 
 @resource(
@@ -441,8 +441,13 @@ def dbt_rpc_resource(context) -> DbtRpcClient:
     return DbtRpcClient(host=context.resource_config["host"], port=context.resource_config["port"])
 
 
+## define shared base class among sync and async clients. replace implementation of `get result`
+# with posting or polling
 class DbtRpcSyncClient(DbtRpcClient):
-    def _poll_rpc_until_complete(self, request_token: str):
+    def _get_result(self, data: str = None) -> DbtRpcOutput:
+        out = super()._get_result(data)
+        request_token = out.result.get("request_token")
+
         """Polls the dbt RPC server for the status of a request until the state is ``success``."""
 
         logs_start = 0
@@ -479,217 +484,6 @@ class DbtRpcSyncClient(DbtRpcClient):
             )
 
         return out
-
-    def cli(self, command: str, **kwargs) -> DbtRpcOutput:
-        """Sends a request with CLI syntax to the dbt RPC server, and returns the response.
-        For more details, see the dbt docs for `running CLI commands via RPC
-        <https://docs.getdbt.com/reference/commands/rpc/#running-a-task-with-cli-syntax>`_.
-
-        Args:
-            cli (str): a dbt command in CLI syntax.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-        out = super().cli(command, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def compile(
-        self, models: List[str] = None, exclude: List[str] = None, **kwargs
-    ) -> DbtRpcOutput:
-        """Sends a request with the method ``compile`` to the dbt RPC server, and returns the
-        response. For more details, see the dbt docs for `compiling projects via RPC
-        <https://docs.getdbt.com/reference/commands/rpc/#compile-a-project>`_.
-
-        Args:
-            models (List[str], optional): the models to include in compilation.
-            exclude (List[str]), optional): the models to exclude from compilation.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-
-        out = super().compile(models, exclude, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def run(self, models: List[str] = None, exclude: List[str] = None, **kwargs) -> DbtRpcOutput:
-        """Sends a request with the method ``run`` to the dbt RPC server, and returns the response.
-        For more details, see the dbt docs for the RPC method `run
-        <https://docs.getdbt.com/reference/commands/rpc/#run-models>`_.
-
-        Args:
-            models (List[str], optional): the models to include in the run.
-            exclude (List[str]), optional): the models to exclude from the run.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-
-        out = super().run(models, exclude, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def snapshot(
-        self, select: List[str] = None, exclude: List[str] = None, **kwargs
-    ) -> DbtRpcOutput:
-        """Sends a request with the method ``snapshot`` to the dbt RPC server, and returns the
-        response. For more details, see the dbt docs for the command `snapshot
-        <https://docs.getdbt.com/reference/commands/snapshot>`_.
-
-        Args:
-            select (List[str], optional): the snapshots to include in the run.
-            exclude (List[str], optional): the snapshots to exclude from the run.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-
-        out = super().snapshot(select, exclude, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def test(
-        self,
-        models: List[str] = None,
-        exclude: List[str] = None,
-        data: bool = True,
-        schema: bool = True,
-        **kwargs,
-    ) -> DbtRpcOutput:
-        """Sends a request with the method ``test`` to the dbt RPC server, and returns the response.
-        For more details, see the dbt docs for the RPC method `test
-        <https://docs.getdbt.com/reference/commands/rpc/#run-test>`_.
-
-        Args:
-            models (List[str], optional): the models to include in testing.
-            exclude (List[str], optional): the models to exclude from testing.
-            data (bool, optional): If ``True`` (default), then run data tests.
-            schema (bool, optional): If ``True`` (default), then run schema tests.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-
-        out = super().test(models, exclude, data, schema, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def seed(
-        self, show: bool = False, select: List[str] = None, exclude: List[str] = None, **kwargs
-    ) -> DbtRpcOutput:
-        """Sends a request with the method ``seed`` to the dbt RPC server, and returns the response.
-        For more details, see the dbt docs for the RPC method `seed
-        <https://docs.getdbt.com/reference/commands/rpc/#run-seed>`_.
-
-        Args:
-            show (bool, optional): If ``True``, then show a sample of the seeded data in the
-                response. Defaults to ``False``.
-            select (List[str], optional): the snapshots to include in the run.
-            exclude (List[str], optional): the snapshots to exclude from the run.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-
-        out = super().seed(show, select, exclude, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def generate_docs(
-        self,
-        models: List[str] = None,
-        exclude: List[str] = None,
-        **kwargs,
-    ) -> DbtRpcOutput:
-        """Sends a request with the method ``docs.generate`` to the dbt RPC server, and returns the
-        response. For more details, see the dbt docs for the RPC method `docs.generate
-        <https://docs.getdbt.com/reference/commands/rpc/#generate-docs>`_.
-
-        Args:
-            models (List[str], optional): the models to include in docs generation.
-            exclude (List[str], optional): the models to exclude from docs generation.
-
-        """
-        # Currently erroring:
-        # 2021-08-06 15:36:06 - dagster - ERROR - ephemeral_compile_solid_solid_pipeline - 1873c7f3-ea95-40dd-b7ec-31f1939a7028 - 37004 - PIPELINE_FAILURE - Execution of pipeline "ephemeral_compile_solid_solid_pipeline" failed. An exception was thrown during execution.
-
-        out = super().generate_docs(models, exclude, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def run_operation(
-        self, macro: str, args: Optional[Dict[str, Any]] = None, **kwargs
-    ) -> DbtRpcOutput:
-        """Sends a request with the method ``run-operation`` to the dbt RPC server, and returns the
-        response. For more details, see the dbt docs for the command `run-operation
-        <https://docs.getdbt.com/reference/commands/run-operation>`_.
-
-        Args:
-            macro (str): the dbt macro to invoke.
-            args (Dict[str, Any], optional): the keyword arguments to be supplied to the macro.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-
-        out = super().run_operation(macro, args, **kwargs)
-        request_token = out.result.get("request_token")
-        return self._poll_rpc_until_complete(request_token)
-
-    def snapshot_freshness(self, select: Optional[List[str]] = None, **kwargs) -> DbtRpcOutput:
-        """Sends a request with the method ``snapshot-freshness`` to the dbt RPC server, and returns
-        the response. For more details, see the dbt docs for the command `source snapshot-freshness
-        <https://docs.getdbt.com/reference/commands/source#dbt-source-snapshot-freshness>`_.
-
-        Args:
-            select (List[str], optional): the models to include in calculating snapshot freshness.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-        explicit_params = dict(select=select)
-        params = self._format_params({**explicit_params, **kwargs})
-        data = self._default_request(method="snapshot-freshness", params=params)
-
-        return self._post(data=json.dumps(data))
-
-    def compile_sql(self, sql: str, name: str) -> DbtRpcOutput:
-        """Sends a request with the method ``compile_sql`` to the dbt RPC server, and returns the
-        response. For more details, see the dbt docs for `compiling SQL via RPC
-        <https://docs.getdbt.com/reference/commands/rpc#compiling-a-query>`_.
-
-        Args:
-            sql (str): the SQL to compile in base-64 encoding.
-            name (str): a name for the compiled SQL.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-        explicit_params = dict(sql=b64(sql.encode("utf-8")).decode("utf-8"), name=name)
-        params = self._format_params(explicit_params)
-        data = self._default_request(method="compile_sql", params=params)
-
-        return self._post(data=json.dumps(data))
-
-    def run_sql(self, sql: str, name: str) -> DbtRpcOutput:
-        """Sends a request with the method ``run_sql`` to the dbt RPC server, and returns the
-        response. For more details, see the dbt docs for `running SQL via RPC
-        <https://docs.getdbt.com/reference/commands/rpc#executing-a-query>`_.
-
-        Args:
-            sql (str): the SQL to run in base-64 encoding.
-            name (str): a name for the compiled SQL.
-
-        Returns:
-            Response: the HTTP response from the dbt RPC server.
-        """
-        explicit_params = dict(sql=b64(sql.encode("utf-8")).decode("utf-8"), name=name)
-        params = self._format_params(explicit_params)
-        data = self._default_request(method="run_sql", params=params)
-
-        return self._post(data=json.dumps(data))
 
 
 @resource(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -11,7 +11,7 @@ from dagster import Field, IntSource, RetryRequested, StringSource, check, resou
 
 from ..dbt_resource import DbtResource
 from .types import DbtRpcOutput
-from .utils import is_fatal_code, raise_for_rpc_error, log_rpc
+from .utils import is_fatal_code
 
 
 class DbtRpcClient(DbtResource):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -7,7 +7,7 @@ from base64 import standard_b64encode as b64
 from typing import Any, Dict, List, Optional
 
 import requests
-from dagster import Field, IntSource, RetryRequested, StringSource, check, resource, Failure
+from dagster import Failure, Field, IntSource, RetryRequested, StringSource, check, resource
 
 from ..dbt_resource import DbtResource
 from .types import DbtRpcOutput
@@ -519,7 +519,6 @@ class DbtRpcSyncClient(DbtRpcClient):
 )
 def dbt_rpc_sync_resource(
     context,
-    poll_interval: int = 1,
 ) -> DbtRpcClient:
     """This resource defines a synchronous dbt RPC client.
 
@@ -540,7 +539,7 @@ def dbt_rpc_sync_resource(
     return DbtRpcSyncClient(
         host=context.resource_config["host"],
         port=context.resource_config["port"],
-        poll_interval=poll_interval,
+        poll_interval=context.resource_config["poll_interval"],
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/resources.py
@@ -446,10 +446,8 @@ class DbtRpcSyncClient(DbtRpcClient):
         out = super()._get_result(data)
         request_token = out.result.get("request_token")
 
-        logs_start = 0  # Set as 0 for default, confirm this is the expected value
-        interval = 1  # Do we need to allow users to pass in interval?
-
-        # Any additional logging that needs to happen in this method?
+        logs_start = 0
+        interval = 1
 
         elapsed_time = -1
         current_state = None

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -140,124 +140,101 @@ def test_dbt_rpc_sync_resource():
     assert it["ran"]
 
 
-# def test_dbt_rpc_sync_resource_cli(dbt_rpc_server):
+@pytest.mark.parametrize(
+    "client_class,resource",
+    [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+)
+def test_dbt_rpc_resource_status(dbt_rpc_server, client_class, resource):
+    @solid(required_resource_keys={"dbt_rpc"})
+    def compile_solid(context):
+        assert isinstance(context.resources.dbt_rpc, client_class)
+        out = context.resources.dbt_rpc.status()
+        return out
+
+    result = execute_solid(
+        compile_solid,
+        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+    )
+
+    assert result.success
+    assert isinstance(result.output_value("result"), DbtRpcOutput)
+
+
+# @pytest.mark.parametrize(
+#     "client_class,resource",
+#     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+# )
+# def test_dbt_rpc_resource_cli(dbt_rpc_server, client_class, resource):
 #     @solid(required_resource_keys={"dbt_rpc"})
 #     def cli_solid(context):
-#         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
+#         assert isinstance(context.resources.dbt_rpc, client_class)
 #         out = context.resources.dbt_rpc.cli("run")
 #         return out
 
 #     result = execute_solid(
 #         cli_solid,
-#         ModeDefinition(
-#             resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
-#         ),
+#         ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
 #     )
 
 #     assert result.success
 #     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
-# def test_dbt_rpc_sync_resource_compile(dbt_rpc_server):
+# @pytest.mark.parametrize(
+#     "client_class,resource",
+#     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+# )
+# def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
 #     @solid(required_resource_keys={"dbt_rpc"})
-#     def compile_solid(context):
-#         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
-#         out = context.resources.dbt_rpc.generate_docs(['sort_by_calories.sql'])
+#     def cli_solid(context):
+#         assert isinstance(context.resources.dbt_rpc, client_class)
+#         out = context.resources.dbt_rpc.run(['sort_by_calories'])
 #         return out
 
 #     result = execute_solid(
-#         compile_solid,
-#         ModeDefinition(
-#             resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
-#         ),
+#         cli_solid,
+#         ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
 #     )
 
 #     assert result.success
 #     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
-# parametrize to run with sync and async resources
-def test_dbt_rpc_sync_resource_generate_docs(dbt_rpc_server):
+
+@pytest.mark.parametrize(
+    "client_class,resource",
+    [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+)
+def test_dbt_rpc_resource_generate_docs(dbt_rpc_server, client_class, resource):
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
-        assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
-        out = context.resources.dbt_rpc.generate_docs()
-
+        assert isinstance(context.resources.dbt_rpc, client_class)
+        out = context.resources.dbt_rpc.generate_docs(True)
         return out
 
     result = execute_solid(
         compile_solid,
-        ModeDefinition(
-            resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
-        ),
+        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
     )
 
     assert result.success
     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
-# parametrize to run with sync and async resources
-def test_dbt_rpc_sync_resource_run_operation(dbt_rpc_server):
+@pytest.mark.parametrize(
+    "client_class,resource",
+    [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+)
+def test_dbt_rpc_resource_run_operation(dbt_rpc_server, client_class, resource):
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
-        assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
+        assert isinstance(context.resources.dbt_rpc, client_class)
         out = context.resources.dbt_rpc.run_operation('log_macro', {"msg": "hello world"})
         return out
 
     result = execute_solid(
         compile_solid,
-        ModeDefinition(
-            resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
-        ),
+        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
     )
 
     assert result.success
     assert isinstance(result.output_value("result"), DbtRpcOutput)
-
-
-### passing test reference function is successfully obtaining request token
-# def test_dbt_rpc_resource_2(dbt_rpc_server):
-#     response = {}
-
-#     @solid(required_resource_keys={"dbt_rpc"})
-#     def a_solid(context):
-#         assert isinstance(context.resources.dbt_rpc, DbtRpcClient)
-#         # assert context.resources.dbt_rpc.host == "<default host>"
-#         # assert context.resources.dbt_rpc.port == 8580
-
-#         response["response"] = context.resources.dbt_rpc.cli("run")
-#         # print("wya response")
-#         # print(str(response.__dict__))
-#         # response.result.get("request_token")
-
-#     # use this fn instead:
-#     # dpt_rpc_resource.configured(dictionary)
-#     execute_solid(
-#         a_solid,
-#         ModeDefinition(resource_defs={"dbt_rpc": dbt_rpc_resource}),
-#         None,
-#         None,
-#         {"resources": {"dbt_rpc": {"config": {"host": "localhost"}}}},
-#     )
-#     # assert it["ran"]
-#     assert response["response"] != None
-
-# parametrize to run with sync and async resources
-# test currently fails because generate_docs shoudl not accept params.
-# def test_dbt_rpc_resource_generate_docs(dbt_rpc_server):
-#     @solid(required_resource_keys={"dbt_rpc"})
-#     def compile_solid(context):
-#         assert isinstance(context.resources.dbt_rpc, DbtRpcClient)
-#         out = context.resources.dbt_rpc.generate_docs(['sort_by_calories'])
-#         # request_token = out.result.get("request_token")
-#         print(out.__dict__)
-#         return out
-
-#     result = execute_solid(
-#         compile_solid,
-#         ModeDefinition(
-#             resource_defs={"dbt_rpc": dbt_rpc_resource.configured({"host": "localhost"})}
-#         ),
-#     )
-
-#     assert result.success
-#     assert isinstance(result.output_value("result"), DbtRpcOutput)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -144,7 +144,9 @@ def test_dbt_rpc_sync_resource():
     "client_class,resource",
     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
 )
-def test_dbt_rpc_resource_status(dbt_rpc_server, client_class, resource):
+def test_dbt_rpc_resource_status(
+    dbt_rpc_server, client_class, resource
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)
@@ -160,7 +162,7 @@ def test_dbt_rpc_resource_status(dbt_rpc_server, client_class, resource):
     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
-def test_dbt_rpc_resource_is_not_waiting(dbt_rpc_server):
+def test_dbt_rpc_resource_is_not_waiting(dbt_rpc_server):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcClient)
@@ -183,7 +185,7 @@ def test_dbt_rpc_resource_is_not_waiting(dbt_rpc_server):
     assert "request_token" in response
 
 
-def test_dbt_rpc_sync_resource_is_waiting(dbt_rpc_server):
+def test_dbt_rpc_sync_resource_is_waiting(dbt_rpc_server):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
@@ -210,7 +212,9 @@ def test_dbt_rpc_sync_resource_is_waiting(dbt_rpc_server):
     "client_class,resource",
     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
 )
-def test_dbt_rpc_resource_cli(dbt_rpc_server, client_class, resource):
+def test_dbt_rpc_resource_cli(
+    dbt_rpc_server, client_class, resource
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)
@@ -230,7 +234,9 @@ def test_dbt_rpc_resource_cli(dbt_rpc_server, client_class, resource):
     "client_class,resource",
     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
 )
-def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
+def test_dbt_rpc_resource_run(
+    dbt_rpc_server, client_class, resource
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)
@@ -250,7 +256,9 @@ def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
     "client_class,resource",
     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
 )
-def test_dbt_rpc_resource_generate_docs(dbt_rpc_server, client_class, resource):
+def test_dbt_rpc_resource_generate_docs(
+    dbt_rpc_server, client_class, resource
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)
@@ -270,7 +278,9 @@ def test_dbt_rpc_resource_generate_docs(dbt_rpc_server, client_class, resource):
     "client_class,resource",
     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
 )
-def test_dbt_rpc_resource_run_operation(dbt_rpc_server, client_class, resource):
+def test_dbt_rpc_resource_run_operation(
+    dbt_rpc_server, client_class, resource
+):  # pylint: disable=unused-argument
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -175,12 +175,32 @@ def test_dbt_rpc_sync_resource():
 #     assert result.success
 #     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
+# parametrize to run with sync and async resources
+def test_dbt_rpc_sync_resource_generate_docs(dbt_rpc_server):
+    @solid(required_resource_keys={"dbt_rpc"})
+    def compile_solid(context):
+        assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
+        out = context.resources.dbt_rpc.generate_docs()
 
+        return out
+
+    result = execute_solid(
+        compile_solid,
+        ModeDefinition(
+            resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
+        ),
+    )
+
+    assert result.success
+    assert isinstance(result.output_value("result"), DbtRpcOutput)
+
+
+# parametrize to run with sync and async resources
 def test_dbt_rpc_sync_resource_run_operation(dbt_rpc_server):
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
-        out = context.resources.dbt_rpc.run_operation('log_macro.sql', {"msg": "hello world"})
+        out = context.resources.dbt_rpc.run_operation('log_macro', {"msg": "hello world"})
         return out
 
     result = execute_solid(
@@ -220,3 +240,24 @@ def test_dbt_rpc_sync_resource_run_operation(dbt_rpc_server):
 #     )
 #     # assert it["ran"]
 #     assert response["response"] != None
+
+# parametrize to run with sync and async resources
+# test currently fails because generate_docs shoudl not accept params.
+# def test_dbt_rpc_resource_generate_docs(dbt_rpc_server):
+#     @solid(required_resource_keys={"dbt_rpc"})
+#     def compile_solid(context):
+#         assert isinstance(context.resources.dbt_rpc, DbtRpcClient)
+#         out = context.resources.dbt_rpc.generate_docs(['sort_by_calories'])
+#         # request_token = out.result.get("request_token")
+#         print(out.__dict__)
+#         return out
+
+#     result = execute_solid(
+#         compile_solid,
+#         ModeDefinition(
+#             resource_defs={"dbt_rpc": dbt_rpc_resource.configured({"host": "localhost"})}
+#         ),
+#     )
+
+#     assert result.success
+#     assert isinstance(result.output_value("result"), DbtRpcOutput)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -160,44 +160,44 @@ def test_dbt_rpc_resource_status(dbt_rpc_server, client_class, resource):
     assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
-# @pytest.mark.parametrize(
-#     "client_class,resource",
-#     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
-# )
-# def test_dbt_rpc_resource_cli(dbt_rpc_server, client_class, resource):
-#     @solid(required_resource_keys={"dbt_rpc"})
-#     def cli_solid(context):
-#         assert isinstance(context.resources.dbt_rpc, client_class)
-#         out = context.resources.dbt_rpc.cli("run")
-#         return out
+@pytest.mark.parametrize(
+    "client_class,resource",
+    [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+)
+def test_dbt_rpc_resource_cli(dbt_rpc_server, client_class, resource):
+    @solid(required_resource_keys={"dbt_rpc"})
+    def cli_solid(context):
+        assert isinstance(context.resources.dbt_rpc, client_class)
+        out = context.resources.dbt_rpc.cli("run")
+        return out
 
-#     result = execute_solid(
-#         cli_solid,
-#         ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
-#     )
+    result = execute_solid(
+        cli_solid,
+        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+    )
 
-#     assert result.success
-#     assert isinstance(result.output_value("result"), DbtRpcOutput)
+    assert result.success
+    assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
-# @pytest.mark.parametrize(
-#     "client_class,resource",
-#     [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
-# )
-# def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
-#     @solid(required_resource_keys={"dbt_rpc"})
-#     def cli_solid(context):
-#         assert isinstance(context.resources.dbt_rpc, client_class)
-#         out = context.resources.dbt_rpc.run(['sort_by_calories'])
-#         return out
+@pytest.mark.parametrize(
+    "client_class,resource",
+    [(DbtRpcClient, dbt_rpc_resource), (DbtRpcSyncClient, dbt_rpc_sync_resource)],
+)
+def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
+    @solid(required_resource_keys={"dbt_rpc"})
+    def cli_solid(context):
+        assert isinstance(context.resources.dbt_rpc, client_class)
+        out = context.resources.dbt_rpc.run(['sort_by_calories'])
+        return out
 
-#     result = execute_solid(
-#         cli_solid,
-#         ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
-#     )
+    result = execute_solid(
+        cli_solid,
+        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+    )
 
-#     assert result.success
-#     assert isinstance(result.output_value("result"), DbtRpcOutput)
+    assert result.success
+    assert isinstance(result.output_value("result"), DbtRpcOutput)
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -140,21 +140,54 @@ def test_dbt_rpc_sync_resource():
     assert it["ran"]
 
 
-def test_dbt_rpc_sync_resource_2(dbt_rpc_server):
+# def test_dbt_rpc_sync_resource_cli(dbt_rpc_server):
+#     @solid(required_resource_keys={"dbt_rpc"})
+#     def cli_solid(context):
+#         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
+#         out = context.resources.dbt_rpc.cli("run")
+#         return out
+
+#     result = execute_solid(
+#         cli_solid,
+#         ModeDefinition(
+#             resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
+#         ),
+#     )
+
+#     assert result.success
+#     assert isinstance(result.output_value("result"), DbtRpcOutput)
+
+
+# def test_dbt_rpc_sync_resource_compile(dbt_rpc_server):
+#     @solid(required_resource_keys={"dbt_rpc"})
+#     def compile_solid(context):
+#         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
+#         out = context.resources.dbt_rpc.generate_docs(['sort_by_calories.sql'])
+#         return out
+
+#     result = execute_solid(
+#         compile_solid,
+#         ModeDefinition(
+#             resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
+#         ),
+#     )
+
+#     assert result.success
+#     assert isinstance(result.output_value("result"), DbtRpcOutput)
+
+
+def test_dbt_rpc_sync_resource_run_operation(dbt_rpc_server):
     @solid(required_resource_keys={"dbt_rpc"})
-    def a_solid(context):
+    def compile_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
-
-        out = context.resources.dbt_rpc.cli("run")
-
+        out = context.resources.dbt_rpc.run_operation('log_macro.sql', {"msg": "hello world"})
         return out
 
     result = execute_solid(
-        a_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": dbt_rpc_sync_resource}),
-        None,
-        None,
-        {"resources": {"dbt_rpc": {"config": {"host": "localhost"}}}},
+        compile_solid,
+        ModeDefinition(
+            resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
+        ),
     )
 
     assert result.success

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -2,12 +2,12 @@ import pytest
 import responses
 from dagster import ModeDefinition, execute_solid, solid
 from dagster_dbt import (
-    DbtRpcOutput,
     DbtRpcClient,
+    DbtRpcOutput,
     DbtRpcSyncClient,
     dbt_rpc_resource,
-    local_dbt_rpc_resource,
     dbt_rpc_sync_resource,
+    local_dbt_rpc_resource,
 )
 
 
@@ -234,7 +234,7 @@ def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
     @solid(required_resource_keys={"dbt_rpc"})
     def cli_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)
-        out = context.resources.dbt_rpc.run(['sort_by_calories'])
+        out = context.resources.dbt_rpc.run(["sort_by_calories"])
         return out
 
     result = execute_solid(
@@ -274,7 +274,7 @@ def test_dbt_rpc_resource_run_operation(dbt_rpc_server, client_class, resource):
     @solid(required_resource_keys={"dbt_rpc"})
     def compile_solid(context):
         assert isinstance(context.resources.dbt_rpc, client_class)
-        out = context.resources.dbt_rpc.run_operation('log_macro', {"msg": "hello world"})
+        out = context.resources.dbt_rpc.run_operation("log_macro", {"msg": "hello world"})
         return out
 
     result = execute_solid(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -141,20 +141,13 @@ def test_dbt_rpc_sync_resource():
 
 
 def test_dbt_rpc_sync_resource_2(dbt_rpc_server):
-    # it = {}
-
     @solid(required_resource_keys={"dbt_rpc"})
     def a_solid(context):
         assert isinstance(context.resources.dbt_rpc, DbtRpcSyncClient)
-        # assert context.resources.dbt_rpc.host == "<default host>"
-        # assert context.resources.dbt_rpc.port == 8580
 
         out = context.resources.dbt_rpc.cli("run")
 
-        print("lmaoooo")
-        print(out)
         return out
-        # it["ran"] = True
 
     result = execute_solid(
         a_solid,

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -16,7 +16,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
-  pytest -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
+  pytest ./dagster_dbt_tests/rpc/test_resources.py -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs} -s
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -16,7 +16,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
-  pytest ./dagster_dbt_tests/rpc/test_resources.py -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs} -s
+  pytest ./dagster_dbt_tests/rpc/test_resources.py -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -16,7 +16,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
-  pytest ./dagster_dbt_tests/rpc/test_resources.py -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
+  pytest -vv --junitxml=test_results.xml --cov=dagster_dbt --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
Addresses [this issue](https://github.com/dagster-io/dagster/issues/4461).

Adds a synchronous RPC dbt resource that posts a request, continuously polls until completion, and returns the response back to the user.