### PR TITLE
[dagit] Add dagit-only build check to PRs

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -4,7 +4,7 @@ from .steps.dagster import coverage_step, dagster_steps
 from .steps.integration import integration_steps
 from .steps.trigger import trigger_step
 from .steps.wait import wait_step
-from .utils import buildkite_yaml_for_steps, is_phab_and_dagit_only
+from .utils import buildkite_yaml_for_steps, is_pr_and_dagit_only
 
 CLI_HELP = """This CLI is used for generating Buildkite YAML.
 """
@@ -12,7 +12,7 @@ CLI_HELP = """This CLI is used for generating Buildkite YAML.
 
 def dagster():
     all_steps = dagit_steps()
-    dagit_only = is_phab_and_dagit_only()
+    dagit_only = is_pr_and_dagit_only()
 
     # If we're in a Phabricator diff and are only making dagit changes, skip the
     # remaining steps since they're not relevant to the diff.

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 
+import sys
 import yaml
 
 DAGIT_PATH = "js_modules/dagit"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -47,21 +47,13 @@ def is_pr_and_dagit_only():
     branch_name = os.getenv("BUILDKITE_BRANCH")
     base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
 
-    # if branch_name is None:
-    #     branch_name = (
-    #         subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    #         .decode("utf-8")
-    #         .strip()
-    #     )
     if branch_name is None or branch_name == "master" or branch_name.startswith("release"):
         return False
 
     try:
-        # sys.stderr.write("Base branch: " + base_branch + "\n")
-        # sys.stderr.write("Branch name: " + branch_name)
-        # subprocess.check_call(["git", "fetch", "--tags"])
+        pr_commit = os.getenv("BUILDKITE_COMMIT")
         diff_files = (
-            subprocess.check_output(["git", "diff", base_branch, branch_name, "--name-only"])
+            subprocess.check_output(["git", "diff", base_branch, pr_commit, "--name-only"])
             .decode("utf-8")
             .strip()
             .split("\n")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 
-import sys
 import yaml
 
 DAGIT_PATH = "js_modules/dagit"

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -42,7 +42,7 @@ def check_for_release():
     return False
 
 
-def is_phab_and_dagit_only():
+def is_pr_and_dagit_only():
     branch_name = os.getenv("BUILDKITE_BRANCH")
     if branch_name is None:
         branch_name = (
@@ -50,11 +50,11 @@ def is_phab_and_dagit_only():
             .decode("utf-8")
             .strip()
         )
-    if not branch_name.startswith("phabricator"):
+    if branch_name == "master" or branch_name.startswith("release"):
         return False
 
     try:
-        base_branch = branch_name.replace("/diff/", "/base/")
+        base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
         subprocess.check_call(["git", "fetch", "--tags"])
         diff_files = (
             subprocess.check_output(["git", "diff", base_branch, branch_name, "--name-only"])

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -55,8 +55,8 @@ def is_pr_and_dagit_only():
 
     try:
         base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
-        print("Base branch: " + base_branch)
-        print("Branch name: " + branch_name)
+        sys.stderr.write("Base branch: " + base_branch + "\n")
+        sys.stderr.write("Branch name: " + branch_name)
         subprocess.check_call(["git", "fetch", "--tags"])
         diff_files = (
             subprocess.check_output(["git", "diff", base_branch, branch_name, "--name-only"])

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -55,6 +55,8 @@ def is_pr_and_dagit_only():
 
     try:
         base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+        print("Base branch: " + base_branch)
+        print("Branch name: " + branch_name)
         subprocess.check_call(["git", "fetch", "--tags"])
         diff_files = (
             subprocess.check_output(["git", "diff", base_branch, branch_name, "--name-only"])

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -45,20 +45,21 @@ def check_for_release():
 
 def is_pr_and_dagit_only():
     branch_name = os.getenv("BUILDKITE_BRANCH")
-    if branch_name is None:
-        branch_name = (
-            subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-            .decode("utf-8")
-            .strip()
-        )
-    if branch_name == "master" or branch_name.startswith("release"):
+    base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+
+    # if branch_name is None:
+    #     branch_name = (
+    #         subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    #         .decode("utf-8")
+    #         .strip()
+    #     )
+    if branch_name is None or branch_name == "master" or branch_name.startswith("release"):
         return False
 
     try:
-        base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
-        sys.stderr.write("Base branch: " + base_branch + "\n")
-        sys.stderr.write("Branch name: " + branch_name)
-        subprocess.check_call(["git", "fetch", "--tags"])
+        # sys.stderr.write("Base branch: " + base_branch + "\n")
+        # sys.stderr.write("Branch name: " + branch_name)
+        # subprocess.check_call(["git", "fetch", "--tags"])
         diff_files = (
             subprocess.check_output(["git", "diff", base_branch, branch_name, "--name-only"])
             .decode("utf-8")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -52,8 +52,9 @@ def is_pr_and_dagit_only():
 
     try:
         pr_commit = os.getenv("BUILDKITE_COMMIT")
+        origin_base = "origin/" + base_branch
         diff_files = (
-            subprocess.check_output(["git", "diff", base_branch, pr_commit, "--name-only"])
+            subprocess.check_output(["git", "diff", origin_base, pr_commit, "--name-only"])
             .decode("utf-8")
             .strip()
             .split("\n")


### PR DESCRIPTION
## Summary

Try to replicate the behavior we've got in place for Phabricator on Dagit-only changes. Specifically, just run the Dagit webapp build step for PRs, but still run the full build on master and release branches.

## Test Plan

Verify that this PR runs a full build.

Create a JS-only PR that uses this branch as a base, verify that it only runs the Dagit build step. (#4482)