### PR TITLE
feat(dagster-k8s): merge env from pipeline tags into container

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -470,6 +470,12 @@ def construct_dagster_k8s_job(
         for key, value in env_vars.items():
             additional_k8s_env_vars.append(kubernetes.client.V1EnvVar(name=key, value=value))
 
+    user_defined_k8s_env_vars = user_defined_k8s_config.container_config.pop("env", [])
+    for env_var in user_defined_k8s_env_vars:
+        additional_k8s_env_vars.append(
+            kubernetes.client.V1EnvVar(name=env_var["name"], value=env_var["value"])
+        )
+
     job_container = kubernetes.client.V1Container(
         name=job_name,
         image=job_config.job_image,


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Currently, configuration from pipeline tags is not being merged properly into
the kubernetes objects. The python splat operator does not handle the case when
there are multiple keyword args of the same name.

As a first step to resolve this, merge the environment variables properly.
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
pytest - this test failed previously.
<!--- Please describe the tests you have added and your testing environment (if applicable). -->