### PR TITLE
add pipeline_name, run_id and step_key to build_hook_context

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/hook_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/hook_invocation.py
@@ -38,6 +38,9 @@ def hook_invocation_result(
         mode_def=hook_context.mode_def,
         log_manager=hook_context.log,
         solid=hook_context._solid,  # pylint: disable=protected-access
+        pipeline_name=hook_context.pipeline_name,
+        run_id=hook_context.run_id,
+        step_key=hook_context.step_key,
     )
 
     return (

--- a/python_modules/dagster/dagster/core/definitions/hook_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/hook_invocation.py
@@ -14,7 +14,14 @@ def hook_invocation_result(
     event_list: Optional[List["DagsterEvent"]] = None,
 ):
     if not hook_context:
-        hook_context = UnboundHookContext(resources={}, mode_def=None, solid=None)
+        hook_context = UnboundHookContext(
+            resources={},
+            mode_def=None,
+            solid=None,
+            pipeline_name=None,
+            run_id=None,
+            step_key=None,
+        )
 
     # Validate that all required resources are provided in the context
     for key in hook_def.required_resource_keys:

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -187,7 +187,7 @@ class UnboundHookContext(HookContext):
         if self._resources_contain_cm and not self._cm_scope_entered:
             self._resources_cm.__exit__(None, None, None)  # pylint: disable=no-member
 
-    def _unbound_invariant(val, name):
+    def _unbound_invariant(self, val, name):
         check.invariant(
             val is not None,
             f"{name} property not specified when constructing the hook context.",

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -279,20 +279,26 @@ class BoundHookContext(HookContext):
         solid: Optional[Node],
         mode_def: Optional[ModeDefinition],
         log_manager: DagsterLogManager,
+        pipeline_name: Optional[str],
+        run_id: Optional[str],
+        step_key: Optional[str],
     ):  # pylint: disable=super-init-not-called
         self._hook_def = hook_def
         self._resources = resources
         self._solid = solid
         self._mode_def = mode_def
         self._log_manager = log_manager
+        self._pipeline_name = pipeline_name
+        self._run_id = run_id
+        self._step_key = step_key
 
     @property
     def pipeline_name(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("pipeline_name", "property"))
+        return self._pipeline_name
 
     @property
     def run_id(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("run_id", "property"))
+        return self._run_id
 
     @property
     def hook_def(self) -> HookDefinition:
@@ -312,7 +318,7 @@ class BoundHookContext(HookContext):
 
     @property
     def step_key(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("step_key", "property"))
+        return self._step_key
 
     @property
     def mode_def(self) -> Optional[ModeDefinition]:


### PR DESCRIPTION
Resolves a few parts of #4350

- Fix UnboundHookContext to not raise when the
  above properties are requested.
- Ensure these are specified in an UnboundHookContext
  instance before returning them when requested.