### PR TITLE
Use historical pipeline when retrying a failed run

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -312,7 +312,8 @@ class ExternalExecutionPlan:
             != represented_pipeline.identifying_pipeline_snapshot_id
         ):
             raise DagsterInvariantViolationError(
-                "Execution plan snapshot does not match passed in pipeline snapshot. "
+                "The pipeline snapshot ID from the execution plan snapshot does not match the "
+                "passed in pipeline snapshot. "
             )
 
         self._step_keys_in_plan = (

--- a/python_modules/dagster/dagster/core/host_representation/historical.py
+++ b/python_modules/dagster/dagster/core/host_representation/historical.py
@@ -8,7 +8,7 @@ from .represented import RepresentedPipeline
 class HistoricalPipeline(RepresentedPipeline):
     """
     HistoricalPipeline represents a pipeline that executed in the past
-    and has been reloaded into process by quering the instance. Notably
+    and has been reloaded into process by querying the instance. Notably
     the user must pass in the pipeline snapshot id that was originally
     assigned to the snapshot, rather than recomputing it which could
     end up different if the schema of the snapshot has changed


### PR DESCRIPTION
Reviewers: alangenfeld, yuhan, prha

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
When you retry a run from failure, we use the historical execution plan snapshot, but the current pipeline. Instead, use the historical pipeline too. This has the nice side effect of removing a bunch of pipeline fetching code in the backfill path.


## Test Plan
BK




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.