### PR TITLE
dagster PEP 561 - expose mypy typing

### DIFF
--- a/python_modules/dagster/MANIFEST.in
+++ b/python_modules/dagster/MANIFEST.in
@@ -7,5 +7,6 @@ recursive-include dagster/core/storage/runs/sqlite/alembic *
 recursive-include dagster/core/storage/schedules/sqlite/alembic *
 recursive-include dagster/generate/new_project *
 recursive-include dagster *.proto
+recursive-include dagster py.typed
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
                 "dagster/core/storage/schedules/sqlite/alembic/*",
                 "dagster/generate/new_project/*",
                 "dagster/grpc/protos/*",
+                "dagster/py.typed",
             ]
         },
         include_package_data=True,


### PR DESCRIPTION
Make `mypy` understand the type hints in `dagster` when its imported.

https://www.python.org/dev/peps/pep-0561/

Basically the `py.typed` file acts as a signal to mypy that it should parse the package.

#### Test Plan

Use `mypy -v` when checking a library that uses dagster to verify `found module but no type hints or library stubs` no longer shows up and the types are processed
