### PR TITLE
[dagit] Move repo locations list into Workspace overview

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -5,8 +5,6 @@ import * as React from 'react';
 import {POLL_INTERVAL} from '../runs/useCursorPaginatedQuery';
 import {Group} from '../ui/Group';
 import {Subheading} from '../ui/Text';
-import {ReloadAllButton} from '../workspace/ReloadAllButton';
-import {RepositoryLocationsList} from '../workspace/RepositoryLocationsList';
 import {REPOSITORY_LOCATIONS_FRAGMENT} from '../workspace/WorkspaceContext';
 
 import {DaemonList} from './DaemonList';
@@ -33,18 +31,9 @@ export const InstanceHealthPage = () => {
   return (
     <Group direction="column" spacing={20}>
       <InstanceTabs tab="health" queryData={queryData} />
-      <Group direction="column" spacing={32}>
-        <Group direction="column" spacing={16}>
-          <Group direction="row" spacing={12} alignItems="center">
-            <Subheading id="repository-locations">Workspace</Subheading>
-            <ReloadAllButton />
-          </Group>
-          <RepositoryLocationsList />
-        </Group>
-        <Group direction="column" spacing={16}>
-          <Subheading>Daemon statuses</Subheading>
-          {daemonContent()}
-        </Group>
+      <Group direction="column" spacing={16}>
+        <Subheading>Daemon statuses</Subheading>
+        {daemonContent()}
       </Group>
     </Group>
   );

--- a/js_modules/dagit/packages/core/src/instance/InstanceStatusRoot.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceStatusRoot.tsx
@@ -15,7 +15,7 @@ import {InstanceSensors} from './InstanceSensors';
 export const InstanceStatusRoot = () => {
   return (
     <Page>
-      <Group direction="column" spacing={24}>
+      <Group direction="column" spacing={12}>
         <PageHeader title={<Heading>Instance status</Heading>} />
         <Switch>
           <Route path="/instance/health" render={() => <InstanceHealthPage />} />

--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.test.tsx
@@ -22,19 +22,6 @@ describe('InstanceWarningIcon', () => {
     );
   };
 
-  it('displays if any repo errors', async () => {
-    const mocks = {
-      RepositoryLocationOrLoadError: () => ({
-        __typename: 'PythonError',
-        message: () => 'Failure',
-      }),
-    };
-    render(<Test mocks={[defaultMocks, mocks]} />);
-    await waitFor(() => {
-      expect(screen.getByText(/warnings found/i)).toBeVisible();
-    });
-  });
-
   it('displays if daemon errors', async () => {
     const mocks = {
       DaemonStatus: () => ({

--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
@@ -1,49 +1,33 @@
 import {gql, useQuery} from '@apollo/client';
-import {Colors, Icon, Tooltip} from '@blueprintjs/core';
+import {Colors, Icon} from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components/macro';
 
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
-import {Group} from '../ui/Group';
-import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
+import {WarningTooltip} from './WarningTooltip';
 import {InstanceWarningQuery} from './types/InstanceWarningQuery';
 
 export const InstanceWarningIcon = React.memo(() => {
-  const {locationEntries} = React.useContext(WorkspaceContext);
-
   const {data: healthData} = useQuery<InstanceWarningQuery>(INSTANCE_WARNING_QUERY, {
     fetchPolicy: 'cache-and-network',
     pollInterval: 15 * 1000,
   });
 
-  const repoErrors = locationEntries.filter(
-    (locationEntry) => locationEntry.locationOrLoadError?.__typename === 'PythonError',
-  );
   const daemonErrors =
     healthData?.instance.daemonHealth.allDaemonStatuses.filter(
       (daemon) => !daemon.healthy && daemon.required,
     ) || [];
 
-  if (repoErrors.length || daemonErrors.length) {
-    const content = (
-      <Group direction="column" spacing={4}>
-        {repoErrors.length ? (
-          <div>{`${repoErrors.length} ${
-            repoErrors.length === 1
-              ? 'repository location failed to load'
-              : 'repository locations failed to load'
-          }`}</div>
-        ) : null}
-        {daemonErrors.length ? (
+  if (daemonErrors.length) {
+    return (
+      <WarningTooltip
+        content={
           <div>{`${daemonErrors.length} ${
             daemonErrors.length === 1 ? 'daemon not running' : 'daemons not running'
           }`}</div>
-        ) : null}
-      </Group>
-    );
-    return (
-      <WarningTooltip content={content} position="right">
+        }
+        position="right"
+      >
         <Icon icon="warning-sign" iconSize={14} color={Colors.GOLD4} title="Warnings found" />
       </WarningTooltip>
     );
@@ -59,19 +43,4 @@ const INSTANCE_WARNING_QUERY = gql`
     }
   }
   ${INSTANCE_HEALTH_FRAGMENT}
-`;
-
-const WarningTooltip = styled(Tooltip)`
-  display: block;
-  outline: none;
-
-  .bp3-popover-target,
-  .bp3-icon {
-    display: block;
-  }
-
-  .bp3-icon:focus,
-  .bp3-icon:active {
-    outline: none;
-  }
 `;

--- a/js_modules/dagit/packages/core/src/nav/LeftNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNav.test.tsx
@@ -98,7 +98,7 @@ describe('LeftNav', () => {
 
       render(<Test mocks={[defaultMocks, mocks]} />);
       await waitFor(() => {
-        expect(screen.getByRole('link', {name: /status warnings found/i})).toBeVisible();
+        expect(screen.getByRole('link', {name: /workspace warnings found/i})).toBeVisible();
       });
     });
   });

--- a/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
@@ -9,6 +9,7 @@ import {Box} from '../ui/Box';
 
 import {InstanceWarningIcon} from './InstanceWarningIcon';
 import {LeftNavRepositorySection} from './LeftNavRepositorySection';
+import {WorkspaceWarningIcon} from './WorkspaceWarningIcon';
 
 export const LeftNav = () => {
   const history = useHistory();
@@ -67,9 +68,7 @@ export const LeftNav = () => {
           <Tab to="/instance" className={!!statusMatch ? 'selected' : ''}>
             <Icon icon="dashboard" iconSize={16} />
             <TabLabel>Status</TabLabel>
-            <Box margin={{left: 8}}>
-              <InstanceWarningIcon />
-            </Box>
+            <InstanceWarningIcon />
           </Tab>
         </ShortcutHandler>
         <ShortcutHandler
@@ -80,6 +79,7 @@ export const LeftNav = () => {
           <Tab to="/workspace" className={!!workspaceMatch ? 'selected' : ''}>
             <Icon icon="cube" iconSize={16} />
             <TabLabel>Workspace</TabLabel>
+            <WorkspaceWarningIcon />
           </Tab>
         </ShortcutHandler>
       </Box>

--- a/js_modules/dagit/packages/core/src/nav/WarningTooltip.tsx
+++ b/js_modules/dagit/packages/core/src/nav/WarningTooltip.tsx
@@ -1,0 +1,18 @@
+import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
+import styled from 'styled-components/macro';
+
+export const WarningTooltip = styled(Tooltip)`
+  display: block;
+  margin-left: 8px;
+  outline: none;
+
+  .bp3-popover-target,
+  .bp3-icon {
+    display: block;
+  }
+
+  .bp3-icon:focus,
+  .bp3-icon:active {
+    outline: none;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/nav/WorkspaceWarningIcon.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/WorkspaceWarningIcon.test.tsx
@@ -1,0 +1,38 @@
+import {MockList} from '@graphql-tools/mock';
+import {waitFor} from '@testing-library/dom';
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+
+import {WorkspaceWarningIcon} from './WorkspaceWarningIcon';
+
+describe('WorkspaceWarningIcon', () => {
+  const Test: React.FC<{mocks?: any}> = ({mocks}) => {
+    return (
+      <TestProvider apolloProps={{mocks}}>
+        <WorkspaceWarningIcon />
+      </TestProvider>
+    );
+  };
+
+  it('does not display if no errors', async () => {
+    render(<Test />);
+    await waitFor(() => {
+      expect(screen.queryByText(/warnings found/i)).toBeNull();
+    });
+  });
+
+  it('displays if any repo errors', async () => {
+    const mocks = {
+      RepositoryLocationOrLoadError: () => ({
+        __typename: 'PythonError',
+        message: () => 'Failure',
+      }),
+    };
+    render(<Test mocks={mocks} />);
+    await waitFor(() => {
+      expect(screen.getByText(/warnings found/i)).toBeVisible();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/nav/WorkspaceWarningIcon.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/WorkspaceWarningIcon.test.tsx
@@ -1,4 +1,3 @@
-import {MockList} from '@graphql-tools/mock';
 import {waitFor} from '@testing-library/dom';
 import {render, screen} from '@testing-library/react';
 import * as React from 'react';

--- a/js_modules/dagit/packages/core/src/nav/WorkspaceWarningIcon.tsx
+++ b/js_modules/dagit/packages/core/src/nav/WorkspaceWarningIcon.tsx
@@ -1,0 +1,33 @@
+import {Colors, Icon} from '@blueprintjs/core';
+import * as React from 'react';
+
+import {WorkspaceContext} from '../workspace/WorkspaceContext';
+
+import {WarningTooltip} from './WarningTooltip';
+
+export const WorkspaceWarningIcon = React.memo(() => {
+  const {locationEntries} = React.useContext(WorkspaceContext);
+
+  const repoErrors = locationEntries.filter(
+    (locationEntry) => locationEntry.locationOrLoadError?.__typename === 'PythonError',
+  );
+
+  if (repoErrors.length) {
+    return (
+      <WarningTooltip
+        content={
+          <div>{`${repoErrors.length} ${
+            repoErrors.length === 1
+              ? 'repository location failed to load'
+              : 'repository locations failed to load'
+          }`}</div>
+        }
+        position="right"
+      >
+        <Icon icon="warning-sign" iconSize={14} color={Colors.GOLD4} title="Warnings found" />
+      </WarningTooltip>
+    );
+  }
+
+  return null;
+});

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
@@ -8,8 +8,10 @@ import {LoadingSpinner} from '../ui/Loading';
 import {Page} from '../ui/Page';
 import {PageHeader} from '../ui/PageHeader';
 import {Table} from '../ui/Table';
-import {Heading} from '../ui/Text';
+import {Heading, Subheading} from '../ui/Text';
 
+import {ReloadAllButton} from './ReloadAllButton';
+import {RepositoryLocationsList} from './RepositoryLocationsList';
 import {useRepositoryOptions} from './WorkspaceContext';
 import {buildRepoPath} from './buildRepoAddress';
 import {workspacePath} from './workspacePath';
@@ -110,6 +112,14 @@ export const WorkspaceOverviewRoot = () => {
     <Page>
       <Group direction="column" spacing={16}>
         <PageHeader title={<Heading>Workspace</Heading>} />
+        <Group direction="column" spacing={16}>
+          <Group direction="row" spacing={12} alignItems="center">
+            <Subheading id="repository-locations">Locations</Subheading>
+            <ReloadAllButton />
+          </Group>
+          <RepositoryLocationsList />
+        </Group>
+        <Subheading id="repository-locations">Repositories</Subheading>
         {content()}
       </Group>
     </Page>


### PR DESCRIPTION
## Summary

Resolves #4493.

As discussed with @sryza.

Since we now have a "Workspace" left nav item, move a few things around:

- Move the Locations list (and "Reload all" button) to the Workspace page.
- Give the Workspace item its own warning icon, displayed when any repository errors show up. This means the "Status" icon now only applies to daemon health.

Screenshots attached below.

## Test Plan

View the Workspace root in Dagit, verify that the locations list is present there. Force a python error in the toys repository, reload. Verify that the error surfaces as a warning icon in the left nav. Fix the error, reload, verify that it goes away.