### PR TITLE
Run pytest finalizers on SIGTERM

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/utils.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/utils.py
@@ -1,10 +1,24 @@
 import os
+import signal
 
 import pytest
 import requests
 from urllib3.util.retry import Retry
 
 BUILDKITE = os.environ.get("BUILDKITE") is not None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def sigterm_handler():
+    # pytest finalizers don't run on SIGTERM; only SIGINT.
+    # When Buildkite terminates, it sends a SIGTERM.
+    # Intercept SIGTERM and send SIGINT instead.
+    # https://github.com/pytest-dev/pytest/issues/5243
+    original = signal.signal(signal.SIGTERM, signal.getsignal(signal.SIGINT))
+
+    yield
+
+    signal.signal(signal.SIGTERM, original)
 
 
 @pytest.fixture


### PR DESCRIPTION
pytest finalizers don't run on SIGTERM; only SIGINT. When Buildkite
terminates, it sends a SIGTERM.

This intercept SIGTERM and sends SIGINT instead.

https://github.com/pytest-dev/pytest/issues/5243