### PR TITLE
add id as secondary order by parameter

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -674,9 +674,13 @@ class SqlEventLogStorage(EventLogStorage):
             query = query.limit(limit)
 
         if ascending:
-            query = query.order_by(SqlEventLogStorageTable.c.timestamp.asc())
+            query = query.order_by(
+                SqlEventLogStorageTable.c.timestamp.asc(), SqlEventLogStorageTable.c.id.asc()
+            )
         else:
-            query = query.order_by(SqlEventLogStorageTable.c.timestamp.desc())
+            query = query.order_by(
+                SqlEventLogStorageTable.c.timestamp.desc(), SqlEventLogStorageTable.c.id.desc()
+            )
 
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()


### PR DESCRIPTION
## Summary
I think this is because we're returning the same timestamp for the same set of events

## Test Plan
push branch?

