### PR TITLE
add mysql_lengths to the rest of our indices

### DIFF
--- a/python_modules/dagster/dagster/core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/core/storage/runs/schema.py
@@ -72,8 +72,8 @@ BulkActionsTable = db.Table(
     db.Column("body", db.Text),
 )
 
-db.Index("idx_run_tags", RunTagsTable.c.key, RunTagsTable.c.value)
-db.Index("idx_run_partitions", RunsTable.c.partition_set, RunsTable.c.partition)
-db.Index("idx_bulk_actions", BulkActionsTable.c.key)
-db.Index("idx_bulk_actions_status", BulkActionsTable.c.status)
-db.Index("idx_run_status", RunsTable.c.status)
+db.Index("idx_run_tags", RunTagsTable.c.key, RunTagsTable.c.value, mysql_length=64)
+db.Index("idx_run_partitions", RunsTable.c.partition_set, RunsTable.c.partition, mysql_length=64)
+db.Index("idx_bulk_actions", BulkActionsTable.c.key, mysql_length=32)
+db.Index("idx_bulk_actions_status", BulkActionsTable.c.status, mysql_length=32)
+db.Index("idx_run_status", RunsTable.c.status, mysql_length=32)

--- a/python_modules/dagster/dagster/core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/schema.py
@@ -30,5 +30,10 @@ JobTickTable = db.Table(
     db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
 )
 
-db.Index("idx_job_tick_status", JobTickTable.c.job_origin_id, JobTickTable.c.status)
+db.Index(
+    "idx_job_tick_status",
+    JobTickTable.c.job_origin_id,
+    JobTickTable.c.status,
+    mysql_length=32,
+)
 db.Index("idx_job_tick_timestamp", JobTickTable.c.job_origin_id, JobTickTable.c.timestamp)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -109,10 +109,17 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         )
 
     @staticmethod
+    def wipe_storage(mysql_url):
+        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool)
+        try:
+            SqlEventLogStorageMetadata.drop_all(engine)
+        finally:
+            engine.dispose()
+
+    @staticmethod
     def create_clean_storage(conn_string):
-        inst = MySQLEventLogStorage(conn_string)
-        inst.wipe()
-        return inst
+        MySQLEventLogStorage.wipe_storage(conn_string)
+        return MySQLEventLogStorage(conn_string)
 
     def store_asset(self, event):
         check.inst_param(event, "event", EventLogEntry)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -88,12 +88,16 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         return MySQLRunStorage(inst_data=inst_data, mysql_url=mysql_url_from_config(config_value))
 
     @staticmethod
-    def create_clean_storage(mysql_url):
+    def wipe_storage(mysql_url):
         engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool)
         try:
             RunStorageSqlMetadata.drop_all(engine)
         finally:
             engine.dispose()
+
+    @staticmethod
+    def create_clean_storage(mysql_url):
+        MySQLRunStorage.wipe_storage(mysql_url)
         return MySQLRunStorage(mysql_url)
 
     def connect(self, run_id=None):  # pylint: disable=arguments-differ, unused-argument

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -84,12 +84,16 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         )
 
     @staticmethod
-    def create_clean_storage(mysql_url):
+    def wipe_storage(mysql_url):
         engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool)
         try:
             ScheduleStorageSqlMetadata.drop_all(engine)
         finally:
             engine.dispose()
+
+    @staticmethod
+    def create_clean_storage(mysql_url):
+        MySQLScheduleStorage.wipe_storage(mysql_url)
         return MySQLScheduleStorage(mysql_url)
 
     def connect(self, run_id=None):  # pylint: disable=arguments-differ, unused-argument

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -4,8 +4,12 @@ import pytest
 import sqlalchemy as db
 import yaml
 from dagster.core.instance import DagsterInstance, InstanceRef
+from dagster.core.storage.sql import create_engine, get_alembic_config, stamp_alembic_rev
 from dagster.core.test_utils import instance_for_test
+from dagster.utils import file_relative_path
+from dagster_mysql import MySQLEventLogStorage, MySQLRunStorage, MySQLScheduleStorage
 from dagster_mysql.utils import get_conn
+from sqlalchemy.pool import NullPool
 
 
 def full_mysql_config(hostname):
@@ -72,6 +76,23 @@ def test_connection_leak(hostname, conn_string):
         copy.dispose()
 
     tempdir.cleanup()
+
+
+def test_load_instance(conn_string, hostname):
+    # Wipe the DB to ensure it is fresh
+    MySQLEventLogStorage.wipe_storage(conn_string)
+    MySQLRunStorage.wipe_storage(conn_string)
+    MySQLScheduleStorage.wipe_storage(conn_string)
+    engine = create_engine(conn_string, poolclass=NullPool)
+    alembic_config = get_alembic_config(
+        file_relative_path(__file__, "../dagster_mysql/__init__.py")
+    )
+    with engine.connect() as conn:
+        stamp_alembic_rev(alembic_config, conn, rev=None, quiet=False)
+
+    # Now load from scratch, verify it loads without errors
+    with instance_for_test(overrides=yaml.safe_load(full_mysql_config(hostname))):
+        pass
 
 
 @pytest.mark.skip("https://github.com/dagster-io/dagster/issues/3719")


### PR DESCRIPTION
Summary:
xu is reporting sqlalchemy issues when starting up his dagster instance. I believe that adding these indices will fix it, but I'm unable to reproduce the problem on our end.

Test Plan: BK, find a repro of the original issue, verify this solves it

Reviewers; prha, alangenfeld

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.