### PR TITLE
[dagit] Allow top-level error handling

### DIFF
--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -4,9 +4,11 @@ import './publicPath';
 import {Colors, Icon} from '@blueprintjs/core';
 import {App} from '@dagit/core/app/App';
 import {createAppCache} from '@dagit/core/app/AppCache';
+import {errorLink} from '@dagit/core/app/AppError';
 import {AppProvider} from '@dagit/core/app/AppProvider';
 import {AppTopNav} from '@dagit/core/app/AppTopNav';
 import {ContentRoot} from '@dagit/core/app/ContentRoot';
+import {logLink, timeStartLink} from '@dagit/core/app/apolloLinks';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {Link} from 'react-router-dom';
@@ -16,7 +18,10 @@ import {extractPathPrefix} from './extractPathPrefix';
 
 const pathPrefix = extractPathPrefix();
 
+const apolloLinks = [logLink, errorLink, timeStartLink];
+
 const config = {
+  apolloLinks,
   basePath: pathPrefix,
   origin: process.env.REACT_APP_BACKEND_ORIGIN || document.location.origin,
 };

--- a/js_modules/dagit/packages/core/src/app/AppError.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppError.tsx
@@ -25,24 +25,20 @@ const showGraphQLError = (error: DagsterGraphQLError, operationName?: string) =>
   console.error('[GraphQL error]', error);
 };
 
-export const AppErrorLink = () => {
-  return onError((response: ErrorResponse) => {
-    if (response.graphQLErrors) {
-      const {graphQLErrors, operation} = response;
-      const {operationName} = operation;
-      graphQLErrors.forEach((error) =>
-        showGraphQLError(error as DagsterGraphQLError, operationName),
-      );
-    }
-    if (response.networkError) {
-      ErrorToaster.show({
-        message: `[Network error] ${response.networkError.message}`,
-        intent: Intent.DANGER,
-      });
-      console.error('[Network error]', response.networkError);
-    }
-  });
-};
+export const errorLink = onError((response: ErrorResponse) => {
+  if (response.graphQLErrors) {
+    const {graphQLErrors, operation} = response;
+    const {operationName} = operation;
+    graphQLErrors.forEach((error) => showGraphQLError(error as DagsterGraphQLError, operationName));
+  }
+  if (response.networkError) {
+    ErrorToaster.show({
+      message: `[Network error] ${response.networkError.message}`,
+      intent: Intent.DANGER,
+    });
+    console.error('[Network error]', response.networkError);
+  }
+});
 
 interface AppStackTraceLinkProps {
   error: DagsterGraphQLError;

--- a/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
+++ b/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
@@ -1,0 +1,16 @@
+import {ApolloLink} from '@apollo/client';
+
+import {formatElapsedTime, debugLog} from './Util';
+
+export const logLink = new ApolloLink((operation, forward) =>
+  forward(operation).map((data) => {
+    const time = performance.now() - operation.getContext().start;
+    debugLog(`${operation.operationName} took ${formatElapsedTime(time)}`, {operation, data});
+    return data;
+  }),
+);
+
+export const timeStartLink = new ApolloLink((operation, forward) => {
+  operation.setContext({start: performance.now()});
+  return forward(operation);
+});


### PR DESCRIPTION
## Summary

Extract our array of ApolloLink objects (except for the WebSocket/Http split) out to be a configurable value.

This allows better customization of Apollo behavior in Cloud, e.g. handling auth failures. In OS Dagit, behavior should be completely unchanged.

In a followup, I'll make the array non-optional. It's currently optional to avoid compatibility issues with Cloud.

## Test Plan

Run Dagit, verify that Apollo behaves as normal.