### PR TITLE
Logging Updates [1/n] -- Created structured logging_tags format

### DIFF
--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -212,9 +212,7 @@ def log_step_event(step_context: IStepContext, event: "DagsterEvent") -> None:
     )
 
 
-def log_pipeline_event(
-    pipeline_context: IPlanContext, event: "DagsterEvent", step_key: Optional[str]
-) -> None:
+def log_pipeline_event(pipeline_context: IPlanContext, event: "DagsterEvent") -> None:
     event_type = DagsterEventType(event.event_type_value)
     log_level = logging.ERROR if event_type in FAILURE_EVENTS else logging.DEBUG
 
@@ -311,8 +309,7 @@ class DagsterEvent(
             step_handle=step_handle,
             pid=os.getpid(),
         )
-        step_key = step_handle.to_key() if step_handle else None
-        log_pipeline_event(pipeline_context, event, step_key)
+        log_pipeline_event(pipeline_context, event)
 
         return event
 

--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -201,7 +201,6 @@ def _validate_event_specific_data(
 
 
 def log_step_event(step_context: IStepContext, event: "DagsterEvent") -> None:
-
     event_type = DagsterEventType(event.event_type_value)
     log_level = logging.ERROR if event_type in FAILURE_EVENTS else logging.DEBUG
 
@@ -212,7 +211,9 @@ def log_step_event(step_context: IStepContext, event: "DagsterEvent") -> None:
     )
 
 
-def log_pipeline_event(pipeline_context: IPlanContext, event: "DagsterEvent") -> None:
+def log_pipeline_event(
+    pipeline_context: IPlanContext, event: "DagsterEvent", step_key: Optional[str]
+) -> None:
     event_type = DagsterEventType(event.event_type_value)
     log_level = logging.ERROR if event_type in FAILURE_EVENTS else logging.DEBUG
 
@@ -220,6 +221,7 @@ def log_pipeline_event(pipeline_context: IPlanContext, event: "DagsterEvent") ->
         level=log_level,
         msg=event.message or f"{event_type} for pipeline {pipeline_context.pipeline_name}",
         dagster_event=event,
+        step_key=step_key,
     )
 
 
@@ -309,7 +311,9 @@ class DagsterEvent(
             step_handle=step_handle,
             pid=os.getpid(),
         )
-        log_pipeline_event(pipeline_context, event)
+
+        step_key = step_handle.to_key() if step_handle else None
+        log_pipeline_event(pipeline_context, event, step_key)
 
         return event
 

--- a/python_modules/dagster/dagster/core/events/log.py
+++ b/python_modules/dagster/dagster/core/events/log.py
@@ -2,7 +2,7 @@ from typing import NamedTuple, Optional, Union
 
 from dagster import check
 from dagster.core.events import DagsterEvent
-from dagster.core.log_manager import coerce_valid_log_level
+from dagster.core.utils import coerce_valid_log_level
 from dagster.serdes import (
     deserialize_json_to_dagster_namedtuple,
     register_serdes_tuple_fallbacks,

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -101,11 +101,11 @@ class IPlanContext(ABC):
 
     def has_tag(self, key: str) -> bool:
         check.str_param(key, "key")
-        return self.log.logging_tags.has_tag(key)
+        return key in self.log.logging_tags.pipeline_tags
 
     def get_tag(self, key: str) -> Optional[str]:
         check.str_param(key, "key")
-        return self.log.logging_tags.get_tag(key)
+        return self.log.logging_tags.pipeline_tags.get(key)
 
 
 class PlanData(NamedTuple):

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -97,15 +97,15 @@ class IPlanContext(ABC):
 
     @property
     def logging_tags(self) -> Dict[str, str]:
-        return self.log.logging_tags
+        return self.log.logging_tags._asdict()
 
     def has_tag(self, key: str) -> bool:
         check.str_param(key, "key")
-        return key in self.logging_tags
+        return self.log.logging_tags.has_tag(key)
 
     def get_tag(self, key: str) -> Optional[str]:
         check.str_param(key, "key")
-        return self.logging_tags.get(key)
+        return self.log.logging_tags.get_tag(key)
 
 
 class PlanData(NamedTuple):

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -97,15 +97,15 @@ class IPlanContext(ABC):
 
     @property
     def logging_tags(self) -> Dict[str, str]:
-        return self.log.logging_tags._asdict()
+        return self.log.logging_metadata._asdict()
 
     def has_tag(self, key: str) -> bool:
         check.str_param(key, "key")
-        return key in self.log.logging_tags.pipeline_tags
+        return key in self.log.logging_metadata.pipeline_tags
 
     def get_tag(self, key: str) -> Optional[str]:
         check.str_param(key, "key")
-        return self.log.logging_tags.pipeline_tags.get(key)
+        return self.log.logging_metadata.pipeline_tags.get(key)
 
 
 class PlanData(NamedTuple):

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -47,7 +47,7 @@ from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.core.storage.type_storage import construct_type_storage_plugin_registry
 from dagster.core.system_config.objects import ResolvedRunConfig
 from dagster.loggers import default_loggers, default_system_loggers
-from dagster.utils import EventGenerationManager, merge_dicts
+from dagster.utils import EventGenerationManager
 from dagster.utils.error import serializable_error_info_from_exc_info
 
 from .context.logger import InitLoggerContext

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -40,7 +40,7 @@ from dagster.core.execution.resources_init import (
 from dagster.core.execution.retries import RetryMode
 from dagster.core.executor.init import InitExecutorContext
 from dagster.core.instance import DagsterInstance
-from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingMetadata
 from dagster.core.storage.init import InitIntermediateStorageContext
 from dagster.core.storage.intermediate_storage import IntermediateStorage
 from dagster.core.storage.pipeline_run import PipelineRun
@@ -76,7 +76,7 @@ def initialize_console_manager(pipeline_run: Optional[PipelineRun]) -> DagsterLo
             )
         )
     return DagsterLogManager(
-        DagsterLoggingTags(
+        DagsterLoggingMetadata(
             pipeline_tags=pipeline_run.tags if pipeline_run and pipeline_run.tags else {}
         ),
         loggers,
@@ -585,7 +585,7 @@ def create_log_manager(context_creation_data: ContextCreationData) -> DagsterLog
     loggers.append(context_creation_data.instance.get_logger())
 
     return DagsterLogManager(
-        logging_tags=get_logging_tags(pipeline_run),
+        logging_metadata=get_logging_metadata(pipeline_run),
         loggers=loggers,
     )
 
@@ -617,12 +617,12 @@ def _create_context_free_log_manager(
             )
         ]
 
-    return DagsterLogManager(get_logging_tags(pipeline_run), loggers)
+    return DagsterLogManager(get_logging_metadata(pipeline_run), loggers)
 
 
-def get_logging_tags(pipeline_run: PipelineRun) -> DagsterLoggingTags:
+def get_logging_metadata(pipeline_run: PipelineRun) -> DagsterLoggingMetadata:
     check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun)
-    return DagsterLoggingTags(
+    return DagsterLoggingMetadata(
         run_id=pipeline_run.run_id,
         pipeline_name=pipeline_run.pipeline_name,
         pipeline_tags=pipeline_run.tags,

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -29,7 +29,7 @@ from dagster.utils.error import serializable_error_info_from_exc_info
 from .api import ExecuteRunWithPlanIterable, pipeline_execution_iterator
 from .context.logger import InitLoggerContext
 from .context.system import PlanData, PlanOrchestrationContext
-from .context_creation_pipeline import PlanOrchestrationContextManager, get_logging_tags
+from .context_creation_pipeline import PlanOrchestrationContextManager, get_logging_metadata
 
 
 def _get_host_mode_executor(recon_pipeline, run_config, executor_defs, instance):
@@ -102,7 +102,7 @@ def host_mode_execution_context_event_generator(
     loggers.append(instance.get_logger())
 
     log_manager = DagsterLogManager(
-        logging_tags=get_logging_tags(pipeline_run),
+        logging_metadata=get_logging_metadata(pipeline_run),
         loggers=loggers,
     )
 

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -102,7 +102,6 @@ def host_mode_execution_context_event_generator(
     loggers.append(instance.get_logger())
 
     log_manager = DagsterLogManager(
-        run_id=pipeline_run.run_id,
         logging_tags=get_logging_tags(pipeline_run),
         loggers=loggers,
     )

--- a/python_modules/dagster/dagster/core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/step.py
@@ -105,8 +105,8 @@ class ExecutionStep(
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),
-                    "pipeline": pipeline_name,
-                    "solid": handle.solid_handle.name,
+                    "pipeline_name": pipeline_name,
+                    "solid_name": handle.solid_handle.name,
                 },
                 check.opt_dict_param(logging_tags, "logging_tags"),
             ),

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -2,10 +2,13 @@ import datetime
 import itertools
 import logging
 from collections import namedtuple
-from typing import Any, Dict, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Dict, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.utils import coerce_valid_log_level, make_new_run_id
+
+if TYPE_CHECKING:
+    from dagster.core.events import DagsterEvent
 
 DAGSTER_META_KEY = "dagster_meta"
 

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -107,7 +107,6 @@ class DagsterLoggingTags(
             ("pipeline_tags", Dict[str, str]),
             ("step_key", Optional[str]),
             ("solid_name", Optional[str]),
-            ("solid_tags", Dict[str, str]),
             ("resource_name", Optional[str]),
             ("resource_fn_name", Optional[str]),
         ],
@@ -124,7 +123,6 @@ class DagsterLoggingTags(
         pipeline_tags: Dict[str, str] = None,
         step_key: str = None,
         solid_name: str = None,
-        solid_tags: Dict[str, str] = None,
         resource_name: str = None,
         resource_fn_name: str = None,
     ):
@@ -135,7 +133,6 @@ class DagsterLoggingTags(
             pipeline_tags=pipeline_tags or {},
             step_key=step_key,
             solid_name=solid_name,
-            solid_tags=solid_tags or {},
             resource_name=resource_name,
             resource_fn_name=resource_fn_name,
         )
@@ -145,16 +142,6 @@ class DagsterLoggingTags(
         if self.resource_name is None:
             return self.pipeline_name or "system"
         return f"resource:{self.resource_name}"
-
-    def has_tag(self, key: str):
-        return key in self.solid_tags or key in self.pipeline_tags
-
-    def get_tag(self, key: str):
-        if key in self.solid_tags:
-            return self.solid_tags[key]
-        if key in self.pipeline_tags:
-            return self.pipeline_tags[key]
-        return None
 
 
 def construct_log_string(

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -2,6 +2,7 @@ import datetime
 import itertools
 import logging
 from collections import OrderedDict, namedtuple
+from typing import Any, Dict, NamedTuple, Optional
 
 from dagster import check, seven
 from dagster.core.utils import make_new_run_id
@@ -35,42 +36,147 @@ def _dump_value(value):
     return seven.json.dumps(value)
 
 
-def construct_log_string(synth_props, logging_tags, message_props):
-    # Handle this explicitly
-    dagster_event = (
-        message_props["dagster_event"]._asdict() if "dagster_event" in message_props else {}
+class DagsterMessageProps(
+    NamedTuple(
+        "_DagsterMessageProps",
+        [
+            ("orig_message", Optional[str]),
+            ("log_message_id", Optional[str]),
+            ("log_timestamp", Optional[str]),
+            ("dagster_event", Optional["DagsterEvent"]),
+        ],
     )
+):
+    """Internal class used to represent specific attributes about a logged message"""
 
-    event_specific_data = dagster_event.get("event_specific_data")
-    error = ""
-    if hasattr(event_specific_data, "error") and isinstance(
-        event_specific_data.error, SerializableErrorInfo
+    def __new__(
+        cls,
+        orig_message: str,
+        log_message_id: Optional[str] = None,
+        log_timestamp: Optional[str] = None,
+        dagster_event: Optional["DagsterEvent"] = None,
     ):
-        if hasattr(event_specific_data, "error_display_string"):
-            error = "\n\n" + event_specific_data.error_display_string
-        else:
-            error = "\n\n" + event_specific_data.error.to_string()
-
-    log_source_prefix = (
-        "resource:%s" % logging_tags["resource_name"]
-        if "resource_name" in logging_tags
-        else message_props.get("pipeline_name", "system")
-    )
-
-    prefix = " - ".join(
-        filter(
-            None,
-            (
-                log_source_prefix,
-                synth_props.get("run_id"),
-                str(dagster_event["pid"]) if dagster_event.get("pid") is not None else None,
-                logging_tags.get("step_key"),
-                dagster_event.get("event_type_value"),
-                synth_props.get("orig_message"),
+        return super().__new__(
+            cls,
+            orig_message=check.str_param(orig_message, "orig_message"),
+            log_message_id=check.opt_str_param(
+                log_message_id, "log_message_id", default=make_new_run_id()
             ),
+            log_timestamp=check.opt_str_param(
+                log_timestamp, "log_timestamp", default=datetime.datetime.utcnow().isoformat()
+            ),
+            dagster_event=dagster_event,
         )
+
+    @property
+    def error_str(self) -> Optional[str]:
+        if self.dagster_event is None:
+            return None
+
+        event_specific_data = self.dagster_event.event_specific_data
+        if not event_specific_data:
+            return None
+
+        if hasattr(event_specific_data, "error") and isinstance(
+            event_specific_data.error, SerializableErrorInfo
+        ):
+            if hasattr(event_specific_data, "error_display_string"):
+                return "\n\n" + event_specific_data.error_display_string
+            return "\n\n" + event_specific_data.error.to_string()
+        return None
+
+    @property
+    def pid(self) -> Optional[str]:
+        if self.dagster_event is None or self.dagster_event.pid is None:
+            return None
+        return str(self.dagster_event.pid)
+
+    @property
+    def event_type_value(self) -> Optional[str]:
+        if self.dagster_event is None:
+            return None
+        return self.dagster_event.event_type_value
+
+
+class DagsterLoggingTags(
+    NamedTuple(
+        "_DagsterLoggingTags",
+        [
+            ("run_id", Optional[str]),
+            ("pipeline_name", Optional[str]),
+            ("pipeline_tags", Dict[str, str]),
+            ("step_key", Optional[str]),
+            ("solid_name", Optional[str]),
+            ("solid_tags", Dict[str, str]),
+            ("resource_name", Optional[str]),
+            ("resource_fn_name", Optional[str]),
+        ],
     )
-    return prefix + error
+):
+    """Internal class used to represent the context in which a given message was logged (i.e. the
+    step, pipeline run, resource, etc.)
+    """
+
+    def __new__(
+        cls,
+        run_id: str = None,
+        pipeline_name: str = None,
+        pipeline_tags: Dict[str, str] = None,
+        step_key: str = None,
+        solid_name: str = None,
+        solid_tags: Dict[str, str] = None,
+        resource_name: str = None,
+        resource_fn_name: str = None,
+    ):
+        return super().__new__(
+            cls,
+            run_id=run_id,
+            pipeline_name=pipeline_name,
+            pipeline_tags=pipeline_tags or {},
+            step_key=step_key,
+            solid_name=solid_name,
+            solid_tags=solid_tags or {},
+            resource_name=resource_name,
+            resource_fn_name=resource_fn_name,
+        )
+
+    @property
+    def log_source(self):
+        if self.resource_name is None:
+            return self.pipeline_name or "system"
+        return f"resource:{self.resource_name}"
+
+    def has_tag(self, key: str):
+        return key in self.solid_tags or key in self.pipeline_tags
+
+    def get_tag(self, key: str):
+        if key in self.solid_tags:
+            return self.solid_tags[key]
+        if key in self.pipeline_tags:
+            return self.pipeline_tags[key]
+        return None
+
+
+def construct_log_string(
+    logging_tags: DagsterLoggingTags, message_props: DagsterMessageProps
+) -> str:
+
+    return (
+        " - ".join(
+            filter(
+                None,
+                (
+                    logging_tags.log_source,
+                    logging_tags.run_id,
+                    message_props.pid,
+                    logging_tags.step_key,
+                    message_props.event_type_value,
+                    message_props.orig_message,
+                ),
+            )
+        )
+        + (message_props.error_str or "")
+    )
 
 
 def coerce_valid_log_level(log_level):
@@ -91,7 +197,7 @@ def coerce_valid_log_level(log_level):
     return PYTHON_LOGGING_LEVELS_MAPPING[log_level]
 
 
-class DagsterLogManager(namedtuple("_DagsterLogManager", "run_id logging_tags loggers")):
+class DagsterLogManager(namedtuple("_DagsterLogManager", "logging_tags loggers")):
     """Centralized dispatch for logging from user code.
 
     Handles the construction of uniform structured log messages and passes them through to the
@@ -113,13 +219,10 @@ class DagsterLogManager(namedtuple("_DagsterLogManager", "run_id logging_tags lo
     ``context.log.trace`` or ``context.log.notice`` will result in hard exceptions **at runtime**.
     """
 
-    def __new__(cls, run_id, logging_tags, loggers):
+    def __new__(cls, logging_tags, loggers):
         return super(DagsterLogManager, cls).__new__(
             cls,
-            run_id=check.opt_str_param(run_id, "run_id"),
-            logging_tags=check.dict_param(
-                logging_tags, "logging_tags", key_type=str, value_type=str
-            ),
+            logging_tags=check.inst_param(logging_tags, "logging_tags", DagsterLoggingTags),
             loggers=check.list_param(loggers, "loggers", of_type=logging.Logger),
         )
 
@@ -134,7 +237,7 @@ class DagsterLogManager(namedtuple("_DagsterLogManager", "run_id logging_tags lo
             DagsterLogManager: a new DagsterLogManager namedtuple with updated tags for the same
                 run ID and loggers.
         """
-        return self._replace(logging_tags=merge_dicts(self.logging_tags, new_tags))
+        return self._replace(logging_tags=self.logging_tags._replace(**new_tags))
 
     def _prepare_message(self, orig_message, message_props):
         check.str_param(orig_message, "orig_message")
@@ -154,21 +257,19 @@ class DagsterLogManager(namedtuple("_DagsterLogManager", "run_id logging_tags lo
         check.invariant("log_message_id" not in message_props, "log_message_id reserved value")
         check.invariant("log_timestamp" not in message_props, "log_timestamp reserved value")
 
-        log_message_id = make_new_run_id()
-
-        log_timestamp = datetime.datetime.utcnow().isoformat()
-
-        synth_props = {
-            "orig_message": orig_message,
-            "log_message_id": log_message_id,
-            "log_timestamp": log_timestamp,
-            "run_id": self.run_id,
-        }
+        # structured information about this specific message
+        dagster_message_props = DagsterMessageProps(
+            orig_message=orig_message, dagster_event=message_props.get("dagster_event")
+        )
 
         # We first generate all props for the purpose of producing the semi-structured
         # log message via _kv_messsage
         all_props = dict(
-            itertools.chain(synth_props.items(), self.logging_tags.items(), message_props.items())
+            itertools.chain(
+                self.logging_tags._asdict().items(),
+                message_props.items(),
+                dagster_message_props._asdict().items(),
+            )
         )
 
         # So here we use the arbitrary key DAGSTER_META_KEY to store a dictionary of
@@ -180,7 +281,7 @@ class DagsterLogManager(namedtuple("_DagsterLogManager", "run_id logging_tags lo
         # See __init__.py:363 (makeLogRecord) in the python 3.6 logging module source
         # for the gory details.
         return (
-            construct_log_string(synth_props, self.logging_tags, message_props),
+            construct_log_string(self.logging_tags, dagster_message_props),
             {DAGSTER_META_KEY: all_props},
         )
 

--- a/python_modules/dagster/dagster/loggers/__init__.py
+++ b/python_modules/dagster/dagster/loggers/__init__.py
@@ -4,7 +4,7 @@ import coloredlogs
 from dagster import seven
 from dagster.config import Field
 from dagster.core.definitions.logger import logger
-from dagster.core.log_manager import coerce_valid_log_level
+from dagster.core.utils import coerce_valid_log_level
 from dagster.utils.log import default_format_string
 
 

--- a/python_modules/dagster/dagster/utils/log.py
+++ b/python_modules/dagster/dagster/utils/log.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from dagster import check, seven
 from dagster.config import Enum, EnumValue
 from dagster.core.definitions.logger import logger
-from dagster.core.log_manager import PYTHON_LOGGING_LEVELS_MAPPING, coerce_valid_log_level
+from dagster.core.utils import PYTHON_LOGGING_LEVELS_MAPPING, coerce_valid_log_level
 
 LogLevelEnum = Enum("log_level", list(map(EnumValue, PYTHON_LOGGING_LEVELS_MAPPING.keys())))
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_logger_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_logger_definition.py
@@ -11,7 +11,7 @@ from dagster import (
     logger,
     pipeline,
 )
-from dagster.core.log_manager import coerce_valid_log_level
+from dagster.core.utils import coerce_valid_log_level
 
 
 def assert_pipeline_runs_with_logger(logger_def, logger_config):

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_logger_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_logger_invocation.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from dagster import Field, build_init_logger_context, logger
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidInvocationError
-from dagster.core.log_manager import coerce_valid_log_level
+from dagster.core.utils import coerce_valid_log_level
 
 
 def test_logger_invocation_arguments():

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -110,4 +110,7 @@ def test_reentrant_execute_plan():
 
     assert called["yup"]
 
-    assert find_events(step_events, event_type="STEP_OUTPUT")[0].logging_tags["foo"] == "bar"
+    assert (
+        find_events(step_events, event_type="STEP_OUTPUT")[0].logging_tags["pipeline_tags"]["foo"]
+        == "bar"
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -27,8 +27,8 @@ from dagster.core.errors import DagsterConfigMappingFunctionError, DagsterInvali
 from dagster.core.events.log import EventLogEntry, construct_event_logger
 from dagster.core.execution.api import create_execution_plan, execute_plan, execute_run
 from dagster.core.instance import DagsterInstance
-from dagster.core.log_manager import coerce_valid_log_level
 from dagster.core.test_utils import instance_for_test
+from dagster.core.utils import coerce_valid_log_level
 
 
 def define_string_resource():

--- a/python_modules/dagster/dagster_tests/core_tests/test_log_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_log_manager.py
@@ -6,7 +6,11 @@ from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.errors import DagsterUserCodeExecutionError, user_code_error_boundary
 from dagster.core.execution.plan.objects import ErrorSource, StepFailureData
 from dagster.core.execution.plan.outputs import StepOutputData, StepOutputHandle
-from dagster.core.log_manager import DagsterLoggingTags, DagsterMessageProps, construct_log_string
+from dagster.core.log_manager import (
+    DagsterLoggingMetadata,
+    DagsterMessageProps,
+    construct_log_string,
+)
 from dagster.utils.error import serializable_error_info_from_exc_info
 
 
@@ -23,7 +27,7 @@ def test_construct_log_string_for_event():
         pid=54348,
     )
 
-    logging_tags = DagsterLoggingTags(
+    logging_metadata = DagsterLoggingMetadata(
         run_id="f79a8a93-27f1-41b5-b465-b35d0809b26d", pipeline_name="my_pipeline"
     )
     dagster_message_props = DagsterMessageProps(
@@ -32,18 +36,18 @@ def test_construct_log_string_for_event():
     )
 
     assert (
-        construct_log_string(logging_tags=logging_tags, message_props=dagster_message_props)
+        construct_log_string(logging_metadata=logging_metadata, message_props=dagster_message_props)
         == 'my_pipeline - f79a8a93-27f1-41b5-b465-b35d0809b26d - 54348 - STEP_OUTPUT - Yielded output "result" of type "Any" for step "solid2". (Type check passed).'
     )
 
 
 def test_construct_log_string_for_log():
-    logging_tags = DagsterLoggingTags(
+    logging_metadata = DagsterLoggingMetadata(
         run_id="f79a8a93-27f1-41b5-b465-b35d0809b26d", pipeline_name="my_pipeline"
     )
     dagster_message_props = DagsterMessageProps(orig_message="hear my tale")
     assert (
-        construct_log_string(logging_tags, dagster_message_props)
+        construct_log_string(logging_metadata, dagster_message_props)
         == "my_pipeline - f79a8a93-27f1-41b5-b465-b35d0809b26d - hear my tale"
     )
 
@@ -63,14 +67,14 @@ def make_log_string(error, error_source=None):
         pid=54348,
     )
 
-    logging_tags = DagsterLoggingTags(
+    logging_metadata = DagsterLoggingMetadata(
         run_id="f79a8a93-27f1-41b5-b465-b35d0809b26d", pipeline_name="my_pipeline"
     )
     dagster_message_props = DagsterMessageProps(
         orig_message=step_failure_event.message,
         dagster_event=step_failure_event,
     )
-    return construct_log_string(logging_tags, dagster_message_props)
+    return construct_log_string(logging_metadata, dagster_message_props)
 
 
 def test_construct_log_string_with_error():

--- a/python_modules/dagster/dagster_tests/core_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logging.py
@@ -18,7 +18,7 @@ from dagster.core.events import DagsterEvent
 from dagster.core.execution.context.logger import InitLoggerContext
 from dagster.core.execution.plan.objects import StepFailureData
 from dagster.core.execution.plan.outputs import StepOutputHandle
-from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingMetadata
 from dagster.loggers import colored_console_logger, json_console_logger
 from dagster.utils.error import SerializableErrorInfo
 
@@ -66,7 +66,7 @@ def _regex_match_kv_pair(regex, kv_pairs):
 
 
 def test_logging_no_loggers_registered():
-    dl = DagsterLogManager(DagsterLoggingTags(), [])
+    dl = DagsterLogManager(DagsterLoggingMetadata(), [])
     dl.debug("test")
     dl.info("test")
     dl.warning("test")
@@ -77,7 +77,7 @@ def test_logging_no_loggers_registered():
 def test_logging_basic():
     with _setup_logger("test") as (captured_results, logger):
 
-        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
+        dl = DagsterLogManager(DagsterLoggingMetadata(run_id="123"), [logger])
         dl.debug("test")
         dl.info("test")
         dl.warning("test")
@@ -90,7 +90,7 @@ def test_logging_basic():
 def test_logging_custom_log_levels():
     with _setup_logger("test", {"FOO": 3}) as (_captured_results, logger):
 
-        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
+        dl = DagsterLogManager(DagsterLoggingMetadata(run_id="123"), [logger])
         with pytest.raises(AttributeError):
             dl.foo("test")  # pylint: disable=no-member
 
@@ -98,14 +98,14 @@ def test_logging_custom_log_levels():
 def test_logging_integer_log_levels():
     with _setup_logger("test", {"FOO": 3}) as (_captured_results, logger):
 
-        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
+        dl = DagsterLogManager(DagsterLoggingMetadata(run_id="123"), [logger])
         dl.log(3, "test")  # pylint: disable=no-member
 
 
 def test_logging_bad_custom_log_levels():
     with _setup_logger("test") as (_, logger):
 
-        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
+        dl = DagsterLogManager(DagsterLoggingMetadata(run_id="123"), [logger])
         with pytest.raises(check.CheckError):
             dl._log("test", "foobar", {})  # pylint: disable=protected-access
 
@@ -142,7 +142,7 @@ def test_multiline_logging_complex():
     with _setup_logger(DAGSTER_DEFAULT_LOGGER) as (captured_results, logger):
 
         dl = DagsterLogManager(
-            DagsterLoggingTags(run_id="123", pipeline_name="error_monster"), [logger]
+            DagsterLoggingMetadata(run_id="123", pipeline_name="error_monster"), [logger]
         )
         dl.info(msg, **kwargs)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logging.py
@@ -4,13 +4,21 @@ import re
 from contextlib import contextmanager
 
 import pytest
-from dagster import ModeDefinition, check, execute_solid, pipeline, resource, solid
+from dagster import (
+    ModeDefinition,
+    check,
+    execute_pipeline,
+    execute_solid,
+    pipeline,
+    resource,
+    solid,
+)
 from dagster.core.definitions import NodeHandle
 from dagster.core.events import DagsterEvent
 from dagster.core.execution.context.logger import InitLoggerContext
 from dagster.core.execution.plan.objects import StepFailureData
 from dagster.core.execution.plan.outputs import StepOutputHandle
-from dagster.core.log_manager import DagsterLogManager
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
 from dagster.loggers import colored_console_logger, json_console_logger
 from dagster.utils.error import SerializableErrorInfo
 
@@ -58,7 +66,7 @@ def _regex_match_kv_pair(regex, kv_pairs):
 
 
 def test_logging_no_loggers_registered():
-    dl = DagsterLogManager("none", {}, [])
+    dl = DagsterLogManager(DagsterLoggingTags(), [])
     dl.debug("test")
     dl.info("test")
     dl.warning("test")
@@ -69,7 +77,7 @@ def test_logging_no_loggers_registered():
 def test_logging_basic():
     with _setup_logger("test") as (captured_results, logger):
 
-        dl = DagsterLogManager("123", {}, [logger])
+        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
         dl.debug("test")
         dl.info("test")
         dl.warning("test")
@@ -82,7 +90,7 @@ def test_logging_basic():
 def test_logging_custom_log_levels():
     with _setup_logger("test", {"FOO": 3}) as (_captured_results, logger):
 
-        dl = DagsterLogManager("123", {}, [logger])
+        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
         with pytest.raises(AttributeError):
             dl.foo("test")  # pylint: disable=no-member
 
@@ -90,14 +98,14 @@ def test_logging_custom_log_levels():
 def test_logging_integer_log_levels():
     with _setup_logger("test", {"FOO": 3}) as (_captured_results, logger):
 
-        dl = DagsterLogManager("123", {}, [logger])
+        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
         dl.log(3, "test")  # pylint: disable=no-member
 
 
 def test_logging_bad_custom_log_levels():
     with _setup_logger("test") as (_, logger):
 
-        dl = DagsterLogManager("123", {}, [logger])
+        dl = DagsterLogManager(DagsterLoggingTags(run_id="123"), [logger])
         with pytest.raises(check.CheckError):
             dl._log("test", "foobar", {})  # pylint: disable=protected-access
 
@@ -105,8 +113,6 @@ def test_logging_bad_custom_log_levels():
 def test_multiline_logging_complex():
     msg = "DagsterEventType.STEP_FAILURE for step start.materialization.output.result.0"
     kwargs = {
-        "pipeline": "example",
-        "pipeline_name": "error_monster",
         "step_key": "start.materialization.output.result.0",
         "solid": "start",
         "solid_definition": "emit_num",
@@ -135,7 +141,9 @@ def test_multiline_logging_complex():
 
     with _setup_logger(DAGSTER_DEFAULT_LOGGER) as (captured_results, logger):
 
-        dl = DagsterLogManager("123", {}, [logger])
+        dl = DagsterLogManager(
+            DagsterLoggingTags(run_id="123", pipeline_name="error_monster"), [logger]
+        )
         dl.info(msg, **kwargs)
 
     expected_results = [
@@ -200,6 +208,33 @@ def test_json_console_logger(capsys):
                 found_msg = True
 
     assert found_msg
+
+
+def test_pipeline_logging(capsys):
+    @solid
+    def foo(context):
+        context.log.info("bar")
+        return 0
+
+    @solid
+    def foo2(context, _in1):
+        context.log.info("baz")
+
+    @pipeline
+    def pipe():
+        foo2(foo())
+
+    execute_pipeline(pipe)
+
+    captured = capsys.readouterr()
+    expected_log_regexes = [
+        r"dagster - INFO - pipe - [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-"
+        r"[a-f0-9]{12} - foo - bar",
+        r"dagster - INFO - pipe - [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-"
+        r"[a-f0-9]{12} - foo2 - baz",
+    ]
+    for expected_log_regex in expected_log_regexes:
+        assert re.search(expected_log_regex, captured.err, re.MULTILINE)
 
 
 def test_resource_logging(capsys):

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -16,7 +16,7 @@ from dagster import (
     solid,
 )
 from dagster.check import CheckError
-from dagster.core.log_manager import coerce_valid_log_level
+from dagster.core.utils import coerce_valid_log_level
 from dagster.utils.test import execute_solids_within_pipeline
 from dagster_tests.general_tests.test_repository import (
     define_multi_mode_pipeline,

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
@@ -84,7 +84,7 @@ def test_clean_event_generator_exit():
         pipeline_def=pipeline_def, execution_plan=execution_plan
     )
     log_manager = DagsterLogManager(
-        logging_tags=DagsterLoggingMetadata(run_id=pipeline_run.run_id), loggers=[]
+        logging_metadata=DagsterLoggingMetadata(run_id=pipeline_run.run_id), loggers=[]
     )
     resolved_run_config = ResolvedRunConfig.build(pipeline_def)
     execution_plan = create_execution_plan(pipeline_def)

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
@@ -19,7 +19,7 @@ from dagster.core.execution.resources_init import (
     single_resource_event_generator,
 )
 from dagster.core.execution.retries import RetryMode
-from dagster.core.log_manager import DagsterLogManager
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
 from dagster.core.system_config.objects import ResolvedRunConfig
 
 
@@ -83,7 +83,9 @@ def test_clean_event_generator_exit():
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=pipeline_def, execution_plan=execution_plan
     )
-    log_manager = DagsterLogManager(run_id=pipeline_run.run_id, logging_tags={}, loggers=[])
+    log_manager = DagsterLogManager(
+        logging_tags=DagsterLoggingTags(run_id=pipeline_run.run_id), loggers=[]
+    )
     resolved_run_config = ResolvedRunConfig.build(pipeline_def)
     execution_plan = create_execution_plan(pipeline_def)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
@@ -19,7 +19,7 @@ from dagster.core.execution.resources_init import (
     single_resource_event_generator,
 )
 from dagster.core.execution.retries import RetryMode
-from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingMetadata
 from dagster.core.system_config.objects import ResolvedRunConfig
 
 
@@ -84,7 +84,7 @@ def test_clean_event_generator_exit():
         pipeline_def=pipeline_def, execution_plan=execution_plan
     )
     log_manager = DagsterLogManager(
-        logging_tags=DagsterLoggingTags(run_id=pipeline_run.run_id), loggers=[]
+        logging_tags=DagsterLoggingMetadata(run_id=pipeline_run.run_id), loggers=[]
     )
     resolved_run_config = ResolvedRunConfig.build(pipeline_def)
     execution_plan = create_execution_plan(pipeline_def)

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
@@ -2,7 +2,7 @@ import logging
 
 from dagster import PipelineDefinition
 from dagster.core.execution.context.logger import InitLoggerContext
-from dagster.core.log_manager import DagsterLogManager
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
 from dagster.utils.log import construct_single_handler_logger
 
 
@@ -38,7 +38,7 @@ def test_log_level_filtering():
         for logger_def in [debug_logger_def, critical_logger_def]
     ]
 
-    log_manager = DagsterLogManager("", {}, loggers)
+    log_manager = DagsterLogManager(DagsterLoggingTags(), loggers)
 
     log_manager.debug("Hello, there!")
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
@@ -2,7 +2,7 @@ import logging
 
 from dagster import PipelineDefinition
 from dagster.core.execution.context.logger import InitLoggerContext
-from dagster.core.log_manager import DagsterLogManager, DagsterLoggingTags
+from dagster.core.log_manager import DagsterLogManager, DagsterLoggingMetadata
 from dagster.utils.log import construct_single_handler_logger
 
 
@@ -38,7 +38,7 @@ def test_log_level_filtering():
         for logger_def in [debug_logger_def, critical_logger_def]
     ]
 
-    log_manager = DagsterLogManager(DagsterLoggingTags(), loggers)
+    log_manager = DagsterLogManager(DagsterLoggingMetadata(), loggers)
 
     log_manager.debug("Hello, there!")
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -3,7 +3,7 @@ import logging
 
 import boto3
 from dagster import Field, StringSource, check, logger, seven
-from dagster.core.log_manager import coerce_valid_log_level
+from dagster.core.utils import coerce_valid_log_level
 
 # The maximum batch size is 1,048,576 bytes, and this size is calculated as the sum of all event
 # messages in UTF-8, plus 26 bytes for each log event.

--- a/python_modules/libraries/dagster-papertrail/dagster_papertrail_tests/test_loggers.py
+++ b/python_modules/libraries/dagster-papertrail/dagster_papertrail_tests/test_loggers.py
@@ -48,6 +48,6 @@ def test_papertrail_logger():
     assert log_record.name == "hello_pipeline"
     assert log_record.levelname == "INFO"
 
-    assert log_record.msg == "system - {run_id} - hello_logs - Hello, world!".format(
+    assert log_record.msg == "hello_pipeline - {run_id} - hello_logs - Hello, world!".format(
         run_id=result.run_id
     )

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
@@ -23,7 +23,10 @@ def test_run_config():
 
 
 def test_logging_tags():
-    assert BARE_OUT_OF_PIPELINE_CONTEXT.logging_tags["pipeline"] == "ephemeral_dagstermill_pipeline"
+    assert (
+        BARE_OUT_OF_PIPELINE_CONTEXT.logging_tags["pipeline_name"]
+        == "ephemeral_dagstermill_pipeline"
+    )
 
 
 def test_environment_config():


### PR DESCRIPTION
Currently, the way we inject contextual information into log message is quite scattered, which causes some confusion around implementation. For example:

1. While the DagsterLogManager currently keeps track of the run_id of the pipeline that it's within (as a variable on the class), and other contextual information such as the step_key or solid_name (through the unstructured logging_tags dictionary), it requires that the pipeline_name be passed as a keyword argument into individual log calls.
2. In the same vein, the logging_tags dictionary sometimes contains the "pipeline" key (which is the pipeline name), but this is never used. The log message prefix is always created using "pipeline_name" from message_props (which must be added on each individual log message). This means that any context.log() call from the user will not have a pipeline_name attached in the log message.
3. There is a bit of a strange conflation between "logging tags" (information about a specific logging context) and "pipeline/solid tags" (user-specified unstructured information attached to a solid or a pipeline run). Currently, when get_tag() is called on a solid context it will look in the entire logging tags dictionary. Beyond being a little weird, the fact that these two concepts are not distinguished between means that if a user specifies a tag that happens to conflict with one of our internal tags (for example, "step_key"), this will actually get surfaced in the event log (!!).

This change fixes all of the above issues, and (hopefully) makes it easier to reason about where this information is coming from. In the future, it might make sense to convert this logging_tags field in these context objects to be DagsterLoggingTags objects instead of dictionaries, but I wanted to err on the side of minimal impact.