### PR TITLE
Logging Updates [2/n] -- Make DagsterLogManager a Python log

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from abc import ABC, abstractproperty
 from contextlib import contextmanager
@@ -392,10 +393,8 @@ def orchestration_context_event_generator(
             ),
             error_info=error_info,
         )
-        log_manager.error(
-            event.message,
-            dagster_event=event,
-            pipeline_name=pipeline_run.pipeline_name,
+        log_manager.log_dagster_event(
+            level=logging.ERROR, msg=event.message or "", dagster_event=event
         )
         yield event
 

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from typing import List, Optional
 
@@ -143,10 +144,8 @@ def host_mode_execution_context_event_generator(
                 ),
                 error_info=error_info,
             )
-            log_manager.error(
-                event.message,
-                dagster_event=event,
-                pipeline_name=pipeline_run.pipeline_name,
+            log_manager.log_dagster_event(
+                level=logging.ERROR, msg=event.message, dagster_event=event
             )
             yield event
         else:

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_json_logging.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_json_logging.py
@@ -77,7 +77,7 @@ def test_write_dagster_meta():
         execution_context = create_test_pipeline_execution_context(
             logger_defs={"json": define_json_file_logger("foo", tf_name, logging.DEBUG)}
         )
-        execution_context.log.debug("some_debug_message", context_key="context_value")
+        execution_context.log.debug("some_debug_message", extra={"context_key": "context_value"})
         data = list(parse_json_lines(tf_name))
         assert len(data) == 1
         assert data[0]["name"] == "foo"

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_structured_logging.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_structured_logging.py
@@ -20,12 +20,12 @@ def construct_structured_logger(constructor=lambda x: x):
 def test_structured_logger_in_context():
     with construct_structured_logger() as (logger, messages):
         context = create_test_pipeline_execution_context(logger_defs={"structured_log": logger})
-        context.log.debug("from_context", foo=2)
+        context.log.debug("from_context", extra={"foo": 2})
         assert len(messages) == 1
         message = messages[0]
         assert message.name == "some_name"
         assert message.level == logging.DEBUG
-        assert message.meta["foo"] == 2
+        assert message.record.__dict__["foo"] == 2
         assert message.meta["orig_message"] == "from_context"
 
 
@@ -38,4 +38,4 @@ def test_structured_logger_in_context_with_bad_log_level():
     logger = define_structured_logger("some_name", _append_message, level=logging.DEBUG)
     context = create_test_pipeline_execution_context(logger_defs={"structured_logger": logger})
     with pytest.raises(AttributeError):
-        context.log.gargle("from_context", foo=2)
+        context.log.gargle("from_context")


### PR DESCRIPTION
Depends on: https://github.com/dagster-io/dagster/pull/4526

Currently, the DagsterLogManager is a simple namedtuple class, which attempts to replicate the interface of the logging.Logger class. However, the function signatures / implementation differ in some meaningful ways.

-  Our implementation only accepts bare strings as a msg argument, which can be jarring for people who are used to a more permissive interface (for example context.log.error("%s happened", "something bad") will not work, even though this sort of pattern works fine for normal python loggers)
- Certain fields end up being "reserved". Critically, things like the "extra" field cannot be used, as we reserve it during our record manipulations so that we can store meta information. This is not a necessary constraint, and can cause frictions when trying to integrate with external systems that make use of the extras field.

This PR turns the DagsterLogManager into a subclass of logging.Logger, and adds an explicit log_dagster_event method to the class, so that we no longer need to rely on an implicit keyword argument being correctly passed into the log call in order for the event to properly show up.