### PR TITLE
have logging_tags respect declared Dict[str, str] type

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -97,7 +97,7 @@ class IPlanContext(ABC):
 
     @property
     def logging_tags(self) -> Dict[str, str]:
-        return self.log.logging_metadata._asdict()
+        return self.log.logging_metadata.to_tags()
 
     def has_tag(self, key: str) -> bool:
         check.str_param(key, "key")

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -121,6 +121,10 @@ class DagsterLoggingMetadata(
             return self.pipeline_name or "system"
         return f"resource:{self.resource_name}"
 
+    def to_tags(self) -> Dict[str, str]:
+        # converts all values into strings
+        return {k: str(v) for k, v in self._asdict().items()}
+
 
 def construct_log_string(
     logging_metadata: DagsterLoggingMetadata, message_props: DagsterMessageProps

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -111,6 +111,6 @@ def test_reentrant_execute_plan():
     assert called["yup"]
 
     assert (
-        find_events(step_events, event_type="STEP_OUTPUT")[0].logging_tags["pipeline_tags"]["foo"]
-        == "bar"
+        find_events(step_events, event_type="STEP_OUTPUT")[0].logging_tags["pipeline_tags"]
+        == "{'foo': 'bar'}"
     )


### PR DESCRIPTION
logging_tags is supposed to be a Dict[str, str], but one of the values could be a dictionary. this PR fixes this issue