### PR TITLE
chore(buildkite): make trigger step fail during development if triggered build fails

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -22,14 +22,16 @@ def dagster():
         all_steps += dagster_steps()
 
         # Trigger builds of the internal pipeline.
+        dagster_branch = os.getenv("BUILDKITE_BRANCH", "master")
+        dagster_commit_hash = os.getenv("BUILDKITE_COMMIT", "HEAD")
         all_steps += [
             trigger_step(
                 pipeline="internal",
-                async_step=os.getenv("BUILDKITE_BRANCH", "master") == "master",
+                async_step=dagster_branch == "master",
                 if_condition="build.creator.email =~ /elementl.com$$/",
                 env={
-                    "DAGSTER_BRANCH": os.getenv("BUILDKITE_BRANCH"),
-                    "DAGSTER_COMMIT_HASH": os.getenv("BUILDKITE_COMMIT"),
+                    "DAGSTER_BRANCH": dagster_branch,
+                    "DAGSTER_COMMIT_HASH": dagster_commit_hash,
                 },
             ),
         ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -26,7 +26,7 @@ def dagster():
             trigger_step(
                 pipeline="internal",
                 async_step=os.getenv("BUILDKITE_BRANCH", "master") == "master",
-                if_condition="build.branch=='master' && build.creator.email =~ /elementl.com$$/",
+                if_condition="build.creator.email =~ /elementl.com$$/",
                 env={
                     "DAGSTER_BRANCH": os.getenv("BUILDKITE_BRANCH"),
                     "DAGSTER_COMMIT_HASH": os.getenv("BUILDKITE_COMMIT"),


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Depends on https://github.com/dagster-io/dagster/pull/4542.

In the previous state of the world, internal builds were triggered only when commits were landed onto `master`. If things broke in internal, we would not know until merge time. 

We want to know if things break ahead of time, ideally when the PR is being merged. In this change, we trigger builds to internal for all future PRs. In addition, the buildkite step will now fail if the triggered build also failed. 




## Test Plan
bk
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


