### PR TITLE
make some docker-compose fixtures module-scoped

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -9,7 +9,7 @@ import pytest
 from .utils import BUILDKITE
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def docker_compose_cm(test_directory):
     @contextmanager
     def docker_compose(

--- a/python_modules/dagster-test/dagster_test/fixtures/utils.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/utils.py
@@ -16,7 +16,7 @@ def retrying_requests():
     yield session
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def test_directory(request):
     yield os.path.dirname(request.fspath)
 


### PR DESCRIPTION
Summary:
These allow you to have fixtures that only run docker-compose once per module

Test Plan: BK

Reviewers: jmsanders

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.