### PR TITLE
[dagster graphql] fix long int handling

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -18,6 +18,9 @@ from dagster.core.events import DagsterEventType
 from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.plan.objects import StepFailureData
 
+MAX_INT = 2147483647
+MIN_INT = -2147483648
+
 
 def iterate_metadata_entries(metadata_entries):
     from ..schema.logs.events import (
@@ -87,7 +90,7 @@ def iterate_metadata_entries(metadata_entries):
         elif isinstance(metadata_entry.entry_data, IntMetadataEntryData):
             # coerce > 32 bit ints to null
             int_val = None
-            if metadata_entry.entry_data.value.bit_length() <= 32:
+            if MIN_INT <= metadata_entry.entry_data.value <= MAX_INT:
                 int_val = metadata_entry.entry_data.value
 
             yield GrapheneEventIntMetadataEntry(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
@@ -74,7 +74,7 @@ from dagster_graphql.test.utils import (
     main_repo_name,
 )
 
-LONG_INT = 29119888133298982934829348
+LONG_INT = 2875972244  # 32b unsigned, > 32b signed
 
 
 @dagster_type_loader(String)


### PR DESCRIPTION
In which we care about signed vs unisgned bit length in python

https://dagster.phacility.com/D7124 added graceful fallback for long ints for GraphQL so they don't get coerced in to float and lose precision in JS

How ever it did a 32 bit length check which did not work for numbers that were 32b unsigned but > 32b signed


### Test Plan

updated the test LONG_INT to be 32b unisgned but > 32b signed 