### PR TITLE
Add a function to directly derive run config from yaml files

### DIFF
--- a/docs/sphinx/sections/api/apidocs/utilities.rst
+++ b/docs/sphinx/sections/api/apidocs/utilities.rst
@@ -5,6 +5,12 @@ Utilities
 
 .. autofunction:: file_relative_path
 
+.. autofunction:: config_from_files
+
+.. autofunction:: config_from_pkg_resources
+
+.. autofunction:: config_from_yaml_strings
+
 .. autoclass:: ExperimentalWarning
 
 .. currentmodule:: dagster.utils.forked_pdb

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -99,10 +99,14 @@ from dagster.core.definitions import (
     weekly_schedule,
 )
 from dagster.core.definitions.configurable import configured
-from dagster.core.definitions.utils import config_from_files
 from dagster.core.definitions.policy import Backoff, Jitter, RetryPolicy
 from dagster.core.definitions.schedule import build_schedule_context
 from dagster.core.definitions.sensor import build_sensor_context
+from dagster.core.definitions.utils import (
+    config_from_files,
+    config_from_pkg_resources,
+    config_from_yaml_strings,
+)
 from dagster.core.definitions.version_strategy import VersionStrategy
 from dagster.core.errors import (
     DagsterConfigMappingFunctionError,
@@ -353,6 +357,8 @@ __all__ = [
     "execute_solids_within_pipeline",
     "file_relative_path",
     "config_from_files",
+    "config_from_pkg_resources",
+    "config_from_yaml_strings",
     "configured",
     # types
     "Any",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -99,6 +99,7 @@ from dagster.core.definitions import (
     weekly_schedule,
 )
 from dagster.core.definitions.configurable import configured
+from dagster.core.definitions.utils import config_from_files
 from dagster.core.definitions.policy import Backoff, Jitter, RetryPolicy
 from dagster.core.definitions.schedule import build_schedule_context
 from dagster.core.definitions.sensor import build_sensor_context
@@ -351,6 +352,7 @@ __all__ = [
     "execute_solid",
     "execute_solids_within_pipeline",
     "file_relative_path",
+    "config_from_files",
     "configured",
     # types
     "Any",


### PR DESCRIPTION
Solves https://github.com/dagster-io/dagster/issues/4447;

The `config_from_files` function underlies the `PresetDefinition.from_files` implementation. The interface is quite straightforward, so it makes sense to just make it public for the job construction case.

If we decide that this is the right approach, should probably have sufficient documentation around it as well.

## Test Plan
There already exist tests for `config_from_file`.




## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.