### PR TITLE
[jog] Make error messages respect whether using job or pipeline

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -13,7 +13,7 @@ def my_slack_on_pipeline_failure(context: PipelineFailureSensorContext):
 
     slack_client.chat_postMessage(
         channel="#alert-channel",
-        message=f'Pipeline "{context.pipeline_run.pipeline_name}" failed. Error: {context.failure_event.message}',
+        message=f'{context.pipeline_run.origin_class.uppercase()} "{context.pipeline_run.pipeline_name}" failed. Error: {context.failure_event.message}',
     )
 
 
@@ -53,7 +53,7 @@ def my_slack_on_pipeline_success(context: RunStatusSensorContext):
 
     slack_client.chat_postMessage(
         channel="#alert-channel",
-        message=f'Pipeline "{context.pipeline_run.pipeline_name}" succeeded.',
+        message=f'{context.pipeline_run.origin_class.uppercase()} "{context.pipeline_run.pipeline_name}" succeeded.',
     )
 
 

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -13,7 +13,7 @@ def my_slack_on_pipeline_failure(context: PipelineFailureSensorContext):
 
     slack_client.chat_postMessage(
         channel="#alert-channel",
-        message=f'Pipeline "{context.pipeline_run.pipeline_name}" failed. Error: {context.failure_event.message}',
+        message=f'{context.pipeline_run.origin_class.uppercase()} "{context.pipeline_run.pipeline_name}" failed. Error: {context.failure_event.message}',
     )
 
 
@@ -53,7 +53,7 @@ def my_slack_on_pipeline_success(context: RunStatusSensorContext):
 
     slack_client.chat_postMessage(
         channel="#alert-channel",
-        message=f'Pipeline "{context.pipeline_run.pipeline_name}" succeeded.',
+        message=f'{context.pipeline_run.origin_class.uppercase()} "{context.pipeline_run.pipeline_name}" succeeded.',
     )
 
 

--- a/examples/hacker_news/hacker_news/sensors/slack_on_pipeline_failure_sensor.py
+++ b/examples/hacker_news/hacker_news/sensors/slack_on_pipeline_failure_sensor.py
@@ -10,7 +10,7 @@ from hacker_news.utils.slack_message import build_slack_message_blocks
 def slack_message_blocks_fn(context: PipelineFailureSensorContext, base_url: str) -> List[Dict]:
     return build_slack_message_blocks(
         title="👎 Pipeline Failure",
-        markdown_message=f'Pipeline "{context.pipeline_run.pipeline_name}" failed.',
+        markdown_message=f'{context.pipeline_run.origin_class.uppercase()} "{context.pipeline_run.pipeline_name}" failed.',
         pipeline_name=context.pipeline_run.pipeline_name,
         run_id=context.pipeline_run.run_id,
         mode=context.pipeline_run.mode,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -75,6 +75,7 @@ def create_valid_pipeline_run(graphene_info, external_pipeline, execution_params
         status=PipelineRunStatus.NOT_STARTED,
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
+        origin_class=external_pipeline.origin_class,
     )
 
     return pipeline_run

--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -98,7 +98,7 @@ def get_toys_sensors():
         channel = "#yuhan-test"
         message = "\n".join(
             [
-                f'Pipeline "{context.pipeline_run.pipeline_name}" failed.',
+                f'{context.pipeline_run.origin_class.uppercase()} "{context.pipeline_run.pipeline_name}" failed.',
                 f"error: {context.failure_event.message}",
                 f"mode: {context.pipeline_run.mode}",
                 f"run_page_url: {run_page_url}",

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -519,6 +519,7 @@ def _create_external_pipeline_run(
         parent_pipeline_snapshot=external_pipeline_subset.parent_pipeline_snapshot,
         external_pipeline_origin=external_pipeline_subset.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
+        origin_class=external_pipeline.origin_class,
     )
 
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from .solid import SolidDefinition
     from .partition import PartitionedConfig
     from .executor import ExecutorDefinition
-    from .pipeline import PipelineDefinition
+    from .job import JobDefinition
     from dagster.core.execution.execute import InProcessGraphResult
 
 
@@ -369,7 +369,7 @@ class GraphDefinition(NodeDefinition):
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
-    ) -> "PipelineDefinition":
+    ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
 
@@ -412,9 +412,9 @@ class GraphDefinition(NodeDefinition):
                 provided, memoizaton will be enabled for this job.
 
         Returns:
-            PipelineDefinition: The "Job" currently implemented as a single-mode pipeline
+            JobDefinition: The "Job" currently implemented as a single-mode pipeline
         """
-        from .pipeline import PipelineDefinition
+        from .job import JobDefinition
         from .partition import PartitionedConfig
         from .executor import ExecutorDefinition, multiprocess_executor
 
@@ -457,7 +457,7 @@ class GraphDefinition(NodeDefinition):
                 f"is an object of type {type(config)}"
             )
 
-        return PipelineDefinition(
+        return JobDefinition(
             name=job_name,
             description=description,
             graph_def=self,

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -1,0 +1,60 @@
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional, Union
+
+from dagster import check
+from dagster.core.definitions.policy import RetryPolicy
+from dagster.core.definitions.solid import NodeDefinition
+
+from .dependency import IDependencyDefinition, SolidInvocation
+from .hook import HookDefinition
+from .mode import ModeDefinition
+from .pipeline import PipelineDefinition
+from .preset import PresetDefinition
+from .solid import NodeDefinition
+from .version_strategy import VersionStrategy
+
+if TYPE_CHECKING:
+    from .run_config_schema import RunConfigSchema
+    from dagster.core.snap import PipelineSnapshot, ConfigSchemaSnapshot
+    from dagster.core.host_representation import PipelineIndex
+    from dagster.core.instance import DagsterInstance
+    from dagster.core.execution.execution_results import InProcessGraphResult
+
+
+class JobDefinition(PipelineDefinition):
+    def __init__(
+        self,
+        node_defs: Optional[List[NodeDefinition]] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        dependencies: Optional[
+            Dict[Union[str, SolidInvocation], Dict[str, IDependencyDefinition]]
+        ] = None,
+        mode_defs: Optional[List[ModeDefinition]] = None,
+        preset_defs: Optional[List[PresetDefinition]] = None,
+        tags: Dict[str, Any] = None,
+        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
+        solid_retry_policy: Optional[RetryPolicy] = None,
+        graph_def=None,
+        version_strategy: Optional[VersionStrategy] = None,
+    ):
+
+        mode_defs = check.opt_list_param(mode_defs, "mode_defs", of_type=ModeDefinition)
+
+        check.invariant(
+            len(mode_defs) <= 1,
+            "Instantiating a pipeline that represents a job, but pipeline has multiple modes.",
+        )
+
+        super(JobDefinition, self).__init__(
+            solid_defs=node_defs,
+            name=name,
+            description=description,
+            dependencies=dependencies,
+            mode_defs=mode_defs,
+            preset_defs=preset_defs,
+            tags=tags,
+            hook_defs=hook_defs,
+            solid_retry_policy=solid_retry_policy,
+            graph_def=graph_def,
+            version_strategy=version_strategy,
+        )

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -58,3 +58,7 @@ class JobDefinition(PipelineDefinition):
             graph_def=graph_def,
             version_strategy=version_strategy,
         )
+
+    @property
+    def origin_class(self) -> str:
+        return "job"

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -259,6 +259,10 @@ class PipelineDefinition:
             experimental_class_warning("VersionStrategy")
 
     @property
+    def origin_class(self) -> str:
+        return "pipeline"
+
+    @property
     def name(self):
         return self._name
 

--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -217,7 +217,8 @@ def log_pipeline_event(pipeline_context: IPlanContext, event: "DagsterEvent") ->
 
     pipeline_context.log.log_dagster_event(
         level=log_level,
-        msg=event.message or f"{event_type} for pipeline {pipeline_context.pipeline_name}",
+        msg=event.message
+        or f"{event_type} for {pipeline_context.pipeline_run.origin_class} {pipeline_context.pipeline_name}",
         dagster_event=event,
     )
 
@@ -726,8 +727,9 @@ class DagsterEvent(
         return DagsterEvent.from_pipeline(
             DagsterEventType.PIPELINE_START,
             pipeline_context,
-            message='Started execution of pipeline "{pipeline_name}".'.format(
-                pipeline_name=pipeline_context.pipeline_name
+            message='Started execution of {origin_class} "{pipeline_name}".'.format(
+                pipeline_name=pipeline_context.pipeline_name,
+                origin_class=pipeline_context.pipeline_run.origin_class,
             ),
         )
 
@@ -736,8 +738,9 @@ class DagsterEvent(
         return DagsterEvent.from_pipeline(
             DagsterEventType.PIPELINE_SUCCESS,
             pipeline_context,
-            message='Finished execution of pipeline "{pipeline_name}".'.format(
-                pipeline_name=pipeline_context.pipeline_name
+            message='Finished execution of {origin_class} "{pipeline_name}".'.format(
+                pipeline_name=pipeline_context.pipeline_name,
+                origin_class=pipeline_context.pipeline_run.origin_class,
             ),
         )
 
@@ -752,8 +755,9 @@ class DagsterEvent(
             return DagsterEvent.from_pipeline(
                 DagsterEventType.PIPELINE_FAILURE,
                 pipeline_context_or_name,
-                message='Execution of pipeline "{pipeline_name}" failed. {context_msg}'.format(
+                message='Execution of {origin_class} "{pipeline_name}" failed. {context_msg}'.format(
                     pipeline_name=pipeline_context_or_name.pipeline_name,
+                    origin_class=pipeline_context_or_name.pipeline_run.origin_class,
                     context_msg=context_msg,
                 ),
                 event_specific_data=PipelineFailureData(error_info),
@@ -781,8 +785,9 @@ class DagsterEvent(
         return DagsterEvent.from_pipeline(
             DagsterEventType.PIPELINE_CANCELED,
             pipeline_context,
-            message='Execution of pipeline "{pipeline_name}" canceled.'.format(
-                pipeline_name=pipeline_context.pipeline_name
+            message='Execution of {origin_class} "{pipeline_name}" canceled.'.format(
+                pipeline_name=pipeline_context.pipeline_name,
+                origin_class=pipeline_context.pipeline_run.origin_class,
             ),
             event_specific_data=PipelineCanceledData(
                 check.opt_inst_param(error_info, "error_info", SerializableErrorInfo)

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -73,8 +73,11 @@ def execute_run_iterator(
     check.invariant(
         pipeline_run.status == PipelineRunStatus.NOT_STARTED
         or pipeline_run.status == PipelineRunStatus.STARTING,
-        desc="Pipeline run {} ({}) in state {}, expected NOT_STARTED or STARTING".format(
-            pipeline_run.pipeline_name, pipeline_run.run_id, pipeline_run.status
+        desc="{} run {} ({}) in state {}, expected NOT_STARTED or STARTING".format(
+            pipeline_run.origin_class.uppercase(),
+            pipeline_run.pipeline_name,
+            pipeline_run.run_id,
+            pipeline_run.status,
         ),
     )
 
@@ -161,8 +164,11 @@ def execute_run(
     check.invariant(
         pipeline_run.status == PipelineRunStatus.NOT_STARTED
         or pipeline_run.status == PipelineRunStatus.STARTING,
-        desc="Pipeline run {} ({}) in state {}, expected NOT_STARTED or STARTING".format(
-            pipeline_run.pipeline_name, pipeline_run.run_id, pipeline_run.status
+        desc="{} run {} ({}) in state {}, expected NOT_STARTED or STARTING".format(
+            pipeline_run.origin_class.uppercase(),
+            pipeline_run.pipeline_name,
+            pipeline_run.run_id,
+            pipeline_run.status,
         ),
     )
     pipeline_def = pipeline.get_definition()

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -264,6 +264,7 @@ def create_backfill_run(
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
         solid_selection=solid_selection,
+        origin_class=external_pipeline.origin_class,
     )
 
 

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -385,10 +385,11 @@ def orchestration_context_event_generator(
         )
         error_info = serializable_error_info_from_exc_info(user_facing_exc_info)
 
+        origin_class = pipeline_run.origin_class
         event = DagsterEvent.pipeline_failure(
             pipeline_context_or_name=pipeline_run.pipeline_name,
             context_msg=(
-                f'Pipeline failure during initialization for pipeline "{pipeline_run.pipeline_name}". '
+                f'{origin_class.capitalize()} failure during initialization for {origin_class} "{pipeline_run.pipeline_name}". '
                 "This may be due to a failure in initializing the executor or one of the loggers."
             ),
             error_info=error_info,

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -136,10 +136,11 @@ def host_mode_execution_context_event_generator(
             )
             error_info = serializable_error_info_from_exc_info(user_facing_exc_info)
 
+            origin_class = pipeline_run.origin_class
             event = DagsterEvent.pipeline_failure(
                 pipeline_context_or_name=pipeline_run.pipeline_name,
                 context_msg=(
-                    f'Pipeline failure during initialization for pipeline "{pipeline_run.pipeline_name}". '
+                    f'{origin_class.capitalize()} failure during initialization for {origin_class} "{pipeline_run.pipeline_name}". '
                     "This may be due to a failure in initializing the executor or one of the loggers."
                 ),
                 error_info=error_info,

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -782,7 +782,7 @@ class ExecutionPlan(
                 io_manager = getattr(resources, io_manager_key)
                 if not isinstance(io_manager, MemoizableIOManager):
                     raise DagsterInvariantViolationError(
-                        f"Pipeline {pipeline_def.name} uses memoization, but IO manager "
+                        f"{pipeline_def.origin_class} {pipeline_def.name} uses memoization, but IO manager "
                         f"'{io_manager_key}' is not a MemoizableIOManager. In order to use "
                         "memoization, all io managers need to subclass MemoizableIOManager. "
                         "Learn more about MemoizableIOManagers here: "

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -515,11 +515,14 @@ def get_step_input_source(
     # Otherwise we throw an error.
     raise DagsterInvariantViolationError(
         (
-            "In pipeline {pipeline_name} solid {solid_name}, input {input_name} "
+            "In {origin_class} {pipeline_name} solid {solid_name}, input {input_name} "
             "must get a value either (a) from a dependency or (b) from the "
             "inputs section of its configuration."
         ).format(
-            pipeline_name=plan_builder.pipeline_name, solid_name=solid.name, input_name=input_name
+            origin_class=plan_builder.pipeline.get_definition().origin_class,
+            pipeline_name=plan_builder.pipeline_name,
+            solid_name=solid.name,
+            input_name=input_name,
         )
     )
 

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -156,7 +156,12 @@ class ExternalPipeline(RepresentedPipeline):
     objects such as these to interact with user-defined artifacts.
     """
 
-    def __init__(self, external_pipeline_data, repository_handle, pipeline_index=None):
+    def __init__(
+        self,
+        external_pipeline_data,
+        repository_handle,
+        pipeline_index=None,
+    ):
         check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
         check.inst_param(external_pipeline_data, "external_pipeline_data", ExternalPipelineData)
         check.opt_inst_param(pipeline_index, "pipeline_index", PipelineIndex)
@@ -188,6 +193,10 @@ class ExternalPipeline(RepresentedPipeline):
     @property
     def external_pipeline_data(self):
         return self._external_pipeline_data
+
+    @property
+    def origin_class(self):
+        return self.external_pipeline_data.origin_class
 
     @property
     def repository_handle(self):

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -121,10 +121,13 @@ class ExternalPipelineSubsetResult(
 @whitelist_for_serdes
 class ExternalPipelineData(
     namedtuple(
-        "_ExternalPipelineData", "name pipeline_snapshot active_presets parent_pipeline_snapshot"
+        "_ExternalPipelineData",
+        "name pipeline_snapshot active_presets parent_pipeline_snapshot origin_class",
     )
 ):
-    def __new__(cls, name, pipeline_snapshot, active_presets, parent_pipeline_snapshot):
+    def __new__(
+        cls, name, pipeline_snapshot, active_presets, parent_pipeline_snapshot, origin_class
+    ):
         return super(ExternalPipelineData, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
@@ -137,6 +140,7 @@ class ExternalPipelineData(
             active_presets=check.list_param(
                 active_presets, "active_presets", of_type=ExternalPresetData
             ),
+            origin_class=check.str_param(origin_class, "origin_class"),
         )
 
 
@@ -370,6 +374,7 @@ def external_pipeline_data_from_def(pipeline_def):
             list(map(external_preset_data_from_def, pipeline_def.preset_defs)),
             key=lambda pd: pd.name,
         ),
+        origin_class=pipeline_def.origin_class,
     )
 
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -709,6 +709,7 @@ class DagsterInstance:
             parent_pipeline_snapshot=pipeline_def.get_parent_pipeline_snapshot(),
             external_pipeline_origin=external_pipeline_origin,
             pipeline_code_origin=pipeline_code_origin,
+            origin_class=pipeline_def.origin_class,
         )
 
     def _construct_run_with_snapshots(
@@ -729,6 +730,7 @@ class DagsterInstance:
         solid_selection=None,
         external_pipeline_origin=None,
         pipeline_code_origin=None,
+        origin_class="pipeline",
     ):
 
         # https://github.com/dagster-io/dagster/issues/2403
@@ -773,6 +775,7 @@ class DagsterInstance:
             execution_plan_snapshot_id=execution_plan_snapshot_id,
             external_pipeline_origin=external_pipeline_origin,
             pipeline_code_origin=pipeline_code_origin,
+            origin_class=origin_class,
         )
 
     def _ensure_persisted_pipeline_snapshot(self, pipeline_snapshot, parent_pipeline_snapshot):
@@ -861,6 +864,7 @@ class DagsterInstance:
         solid_selection=None,
         external_pipeline_origin=None,
         pipeline_code_origin=None,
+        origin_class="pipeline",
     ):
 
         pipeline_run = self._construct_run_with_snapshots(
@@ -880,6 +884,7 @@ class DagsterInstance:
             parent_pipeline_snapshot=parent_pipeline_snapshot,
             external_pipeline_origin=external_pipeline_origin,
             pipeline_code_origin=pipeline_code_origin,
+            origin_class=origin_class,
         )
         return self._run_storage.add_run(pipeline_run)
 

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -211,7 +211,7 @@ class PipelineRun(
             "pipeline_name run_id run_config mode solid_selection solids_to_execute "
             "step_keys_to_execute status tags root_run_id parent_run_id "
             "pipeline_snapshot_id execution_plan_snapshot_id external_pipeline_origin "
-            "pipeline_code_origin"
+            "pipeline_code_origin origin_class"
         ),
     )
 ):
@@ -240,6 +240,7 @@ class PipelineRun(
         # A PipelinePythonOrigin with information about where to find the pipeline definition in
         # code. Most run launchers will pass this origin as an argument to the run worker process.
         pipeline_code_origin=None,
+        origin_class="pipeline",
     ):
         check.invariant(
             (root_run_id is not None and parent_run_id is not None)
@@ -293,6 +294,7 @@ class PipelineRun(
             pipeline_code_origin=check.opt_inst_param(
                 pipeline_code_origin, "pipeline_code_origin", PipelinePythonOrigin
             ),
+            origin_class=origin_class,
         )
 
     def with_status(self, status):

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -219,13 +219,14 @@ def _get_mapped_solids_dict(
 
 def _get_error_lambda(current_stack):
     return lambda: (
-        "The config mapping function on the composite solid definition "
-        '"{definition_name}" at solid "{solid_name}" in pipeline "{pipeline_name}" '
+        "The config mapping function on the graph definition "
+        '"{definition_name}" at solid "{solid_name}" in {origin_class} "{pipeline_name}" '
         "has thrown an unexpected error during its execution. The definition is "
         'instantiated at stack "{stack_str}".'
     ).format(
         definition_name=current_stack.current_solid.definition.name,
         solid_name=current_stack.current_solid.name,
+        origin_class=current_stack.pipeline_def.origin_class,
         pipeline_name=current_stack.pipeline_def.name,
         stack_str=":".join(current_stack.handle.path),
     )
@@ -236,7 +237,8 @@ def raise_composite_descent_config_error(descent_stack, failed_config_value, evr
     check.inst_param(evr, "evr", EvaluateValueResult)
 
     solid = descent_stack.current_solid
-    message = "In pipeline {pipeline_name} at stack {stack}: \n".format(
+    message = "In {origin_class} {pipeline_name} at stack {stack}: \n".format(
+        origin_class=descent_stack.pipeline_def.origin_class,
         pipeline_name=descent_stack.pipeline_def.name,
         stack=":".join(descent_stack.handle.path),
     )

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -177,7 +177,9 @@ class ResolvedRunConfig(
         )
         if not config_evr.success:
             raise DagsterInvalidConfigError(
-                "Error in config for pipeline {}".format(pipeline_def.name),
+                "Error in config for {origin_class} {pipeline_name}".format(
+                    origin_class=pipeline_def.origin_class, pipeline_name=pipeline_def.name
+                ),
                 config_evr.errors,
                 run_config,
             )

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -473,4 +473,5 @@ def _create_sensor_run(instance, repo_location, external_sensor, external_pipeli
         parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
+        origin_class=external_pipeline.origin_class,
     )

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -397,6 +397,7 @@ def _create_scheduler_run(
         parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
+        origin_class=external_pipeline.origin_class,
     )
 
     if len(execution_plan_errors) > 0:

--- a/python_modules/dagster/dagster/utils/alert.py
+++ b/python_modules/dagster/dagster/utils/alert.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 def _default_failure_email_body(context: "PipelineFailureSensorContext") -> str:
     return "<br>".join(
         [
-            f"Pipeline {context.pipeline_run.pipeline_name} failed!",
+            f"{context.pipeline_run.origin_class.uppercase()} {context.pipeline_run.pipeline_name} failed!",
             f"Run ID: {context.pipeline_run.run_id}",
             f"Mode: {context.pipeline_run.mode}",
             f"Error: {context.failure_event.message}",
@@ -21,7 +21,7 @@ def _default_failure_email_body(context: "PipelineFailureSensorContext") -> str:
 
 
 def _default_failure_email_subject(context: "PipelineFailureSensorContext") -> str:
-    return f"Dagster Pipeline Failed: {context.pipeline_run.pipeline_name}"
+    return f"Dagster {context.pipeline_run.origin_class.uppercase()} Failed: {context.pipeline_run.pipeline_name}"
 
 
 EMAIL_MESSAGE = """From: {email_from}


### PR DESCRIPTION
## Summary
An attempt to triage error message switch-arounds that need to occur in order to gracefully error based upon whether using a pipeline or a job. Unsure whether I want to land yet.

As part of this exploration, I have added a `JobDefinition` class (more or less just a PipelineDefinition). One annoying thing that needs to be properly supported is the current way we do pipeline subselection. To preserve existing behavior, probably gonna be a lot of code reuse.

Things get ugly when looking at error messages derived from just the pipeline run. My initial approach was to just use a flag on the PipelineRun, but this is kinda unseemly. I'm wondering, do we expect to have both a `PipelineRun` and a `JobRun`, or do we expect backcompat pipeline runs to be implemented basically just as `JobRun`? If we expect both to exist in some capacity, it might be better to hard cut away in this diff to also have a `JobRun` class.


## Test Plan
Fixing tests as they break.
