### PR TITLE
Remove dagster.yaml and DAGSTER_HOME from pipeline container in docker example

### DIFF
--- a/examples/deploy_docker/Dockerfile_pipelines
+++ b/examples/deploy_docker/Dockerfile_pipelines
@@ -8,14 +8,6 @@ RUN pip install \
     dagster-postgres \
     dagster-docker
 
-# Set $DAGSTER_HOME and copy dagster instance there
-
-ENV DAGSTER_HOME=/opt/dagster/dagster_home
-
-RUN mkdir -p $DAGSTER_HOME
-
-COPY dagster.yaml $DAGSTER_HOME
-
 # Add repository code
 
 WORKDIR /opt/dagster/app

--- a/examples/deploy_docker/from_source/Dockerfile_pipelines
+++ b/examples/deploy_docker/from_source/Dockerfile_pipelines
@@ -12,14 +12,6 @@ RUN pip install \
     -e python_modules/libraries/dagster-postgres \
     -e python_modules/libraries/dagster-docker
 
-# Set $DAGSTER_HOME and copy dagster instance there
-
-ENV DAGSTER_HOME=/opt/dagster/dagster_home
-
-RUN mkdir -p $DAGSTER_HOME
-
-COPY dagster.yaml $DAGSTER_HOME
-
 # Add repository code
 
 WORKDIR /opt/dagster/app


### PR DESCRIPTION
Summary:
This shouldn't be needed, we don't load the DagsterInstance directly ever in the pipeline container.

Test Plan: BK, run deploy_docker and launch a run

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.