### PR TITLE
Add logging handlers to Dagster Log Manager

### DIFF
--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -210,7 +210,7 @@ class DagsterLogManager(logging.Logger):
         for logger in self._loggers:
             logger.log(level, msg, *args, extra=extra)
 
-        super()._log(level, msg, args)
+        super()._log(level, msg, args, exc_info=exc_info, extra=extra, stack_info=stack_info)
 
     def with_tags(self, **new_tags):
         """Add new tags in "new_tags" to the set of tags attached to this log manager instance, and

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -162,10 +162,9 @@ class DagsterLogManager(logging.Logger):
 
         super().__init__(name="dagster", level=logging.DEBUG)
 
-        check.opt_nullable_list_param(handlers, "handlers", of_type=logging.Handler)
-        if handlers:
-            for handler in handlers:
-                self.addHandler(handler)
+        handlers = check.opt_list_param(handlers, "handlers", of_type=logging.Handler)
+        for handler in handlers:
+            self.addHandler(handler)
 
     @property
     def logging_metadata(self) -> DagsterLoggingMetadata:

--- a/python_modules/dagster/dagster_tests/core_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logging.py
@@ -153,7 +153,7 @@ def test_multiline_logging_complex():
 
 
 def _setup_test_two_handler_log_mgr():
-    test_formatter = logging.Formatter(fmt='%(levelname)s :: %(message)s')
+    test_formatter = logging.Formatter(fmt="%(levelname)s :: %(message)s")
 
     test_info_handler = logging.StreamHandler(sys.stdout)
     test_info_handler.setLevel("INFO")

--- a/python_modules/dagster/dagster_tests/core_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logging.py
@@ -216,7 +216,7 @@ def test_capture_handler_log_records():
     )
 
     dl.info("info")
-    dl.critical("critical error")
+    dl.critical("critical error", extra={"foo": "bar"})
 
     assert len(capture_handler.captured) == 2
 
@@ -229,6 +229,7 @@ def test_capture_handler_log_records():
     assert captured_critical_record.name == "dagster"
     assert captured_critical_record.msg == "pipeline - 123456 - some_step - critical error"
     assert captured_critical_record.levelno == logging.CRITICAL
+    assert captured_critical_record.foo == "bar"
 
 
 def test_default_context_logging():


### PR DESCRIPTION
- Adds a param to `DagsterLogManager` accepting a list of handlers
- Upon every log, each log is also handled by the list of handlers
- Adds tests to validate behavior