### PR TITLE
Python log capture

### DIFF
--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -153,7 +153,7 @@ def raise_execution_interrupts():
 
 
 @contextmanager
-def user_code_error_boundary(error_cls, msg_fn, **kwargs):
+def user_code_error_boundary(error_cls, msg_fn, log_manager=None, **kwargs):
     """
     Wraps the execution of user-space code in an error boundary. This places a uniform
     policy around any user code invoked by the framework. This ensures that all user
@@ -179,6 +179,8 @@ def user_code_error_boundary(error_cls, msg_fn, **kwargs):
     check.subclass_param(error_cls, "error_cls", DagsterUserCodeExecutionError)
 
     with raise_execution_interrupts():
+        if log_manager:
+            log_manager.begin_python_log_capture()
         try:
             yield
         except DagsterError as de:
@@ -190,6 +192,9 @@ def user_code_error_boundary(error_cls, msg_fn, **kwargs):
             raise error_cls(
                 msg_fn(), user_exception=e, original_exc_info=sys.exc_info(), **kwargs
             ) from e
+        finally:
+            if log_manager:
+                log_manager.end_python_log_capture()
 
 
 class DagsterUserCodeExecutionError(DagsterError):

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -30,7 +30,7 @@ from dagster.utils.error import serializable_error_info_from_exc_info
 from .api import ExecuteRunWithPlanIterable, pipeline_execution_iterator
 from .context.logger import InitLoggerContext
 from .context.system import PlanData, PlanOrchestrationContext
-from .context_creation_pipeline import PlanOrchestrationContextManager, get_logging_metadata
+from .context_creation_pipeline import PlanOrchestrationContextManager
 
 
 def _get_host_mode_executor(recon_pipeline, run_config, executor_defs, instance):
@@ -100,10 +100,8 @@ def host_mode_execution_context_event_generator(
             )
         )
 
-    log_manager = DagsterLogManager(
-        logging_metadata=get_logging_metadata(pipeline_run),
-        loggers=loggers,
-        handlers=instance.get_handlers(),
+    log_manager = DagsterLogManager.create(
+        loggers=loggers, pipeline_run=pipeline_run, instance=instance
     )
 
     try:

--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -103,6 +103,7 @@ def _trigger_hook(
                 HookExecutionError,
                 lambda: "Error occurred during the execution of hook_fn triggered for solid "
                 '"{solid_name}"'.format(solid_name=step_context.solid.name),
+                log_manager=hook_context.log,
             ):
                 hook_execution_result = hook_def.hook_fn(hook_context, step_event_list)
 

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -367,6 +367,7 @@ class FromConfig(
                 f'Error occurred while loading input "{self.input_name}" of '
                 f'step "{step_context.step.key}":'
             ),
+            log_manager=step_context.log,
         ):
             dagster_type = self.get_input_def(step_context.pipeline_def).dagster_type
 

--- a/python_modules/dagster/dagster/core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/core/execution/plan/utils.py
@@ -38,6 +38,8 @@ def solid_execution_error_boundary(error_cls, msg_fn, step_context, **kwargs):
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
     with raise_execution_interrupts():
+
+        step_context.log.begin_python_log_capture()
         try:
             yield
         except DagsterError as de:
@@ -71,3 +73,5 @@ def solid_execution_error_boundary(error_cls, msg_fn, step_context, **kwargs):
                 original_exc_info=sys.exc_info(),
                 **kwargs,
             ) from e
+        finally:
+            step_context.log.end_python_log_capture()

--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -282,7 +282,9 @@ def single_resource_event_generator(context, resource_name, resource_def):
         msg_fn = lambda: "Error executing resource_fn on ResourceDefinition {name}".format(
             name=resource_name
         )
-        with user_code_error_boundary(DagsterResourceFunctionError, msg_fn):
+        with user_code_error_boundary(
+            DagsterResourceFunctionError, msg_fn, log_manager=context.log
+        ):
             try:
                 with time_execution_scope() as timer_result:
                     resource_or_gen = (
@@ -308,7 +310,7 @@ def single_resource_event_generator(context, resource_name, resource_def):
     except DagsterUserCodeExecutionError as dagster_user_error:
         raise dagster_user_error
 
-    with user_code_error_boundary(DagsterResourceFunctionError, msg_fn):
+    with user_code_error_boundary(DagsterResourceFunctionError, msg_fn, log_manager=context.log):
         try:
             next(gen)
         except StopIteration:

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -550,6 +550,18 @@ class DagsterInstance:
         else:
             return dagster_telemetry_enabled_default
 
+    # python logs
+
+    @property
+    def managed_python_loggers(self) -> List[str]:
+        python_log_settings = self.get_settings("python_logs") or {}
+        return python_log_settings.get("managed_python_loggers", [])
+
+    @property
+    def python_log_level(self) -> Optional[str]:
+        python_log_settings = self.get_settings("python_logs") or {}
+        return python_log_settings.get("python_log_level")
+
     def upgrade(self, print_fn=None):
         from dagster.core.storage.migration.utils import upgrading_instance
 

--- a/python_modules/dagster/dagster/core/instance/config.py
+++ b/python_modules/dagster/dagster/core/instance/config.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 
-from dagster import Bool, check
+from dagster import Array, Bool, check
 from dagster.config import Field, Permissive
 from dagster.config.validate import validate_config
 from dagster.core.errors import DagsterInvalidConfigError
@@ -83,13 +83,15 @@ def configurable_class_schema():
 def python_logs_config_schema():
     return Field(
         {
+            "managed_python_loggers": Field(Array(str), is_required=False),
+            "python_log_level": Field(str, is_required=False),
             "dagster_handler_config": Field(
                 {
                     "handlers": Field(dict, is_required=False),
                     "formatters": Field(dict, is_required=False),
                 },
                 is_required=False,
-            )
+            ),
         },
         is_required=False,
     )

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -1,11 +1,12 @@
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
 
 from dagster import check
 from dagster.core.utils import coerce_valid_log_level, make_new_run_id
 
 if TYPE_CHECKING:
+    from dagster import DagsterInstance, PipelineRun
     from dagster.core.events import DagsterEvent
 
 DAGSTER_META_KEY = "dagster_meta"
@@ -148,83 +149,222 @@ def construct_log_string(
     )
 
 
-class DagsterLogManager(logging.Logger):
+def get_dagster_meta_dict(
+    logging_metadata: DagsterLoggingMetadata, dagster_message_props: DagsterMessageProps
+) -> Dict[str, Any]:
+    # combine all dagster meta information into a single dictionary
+    meta_dict = {
+        **logging_metadata._asdict(),
+        **dagster_message_props._asdict(),
+    }
+    # step-level events can be logged from a pipeline context. for these cases, pull the step
+    # key from the underlying DagsterEvent
+    if meta_dict["step_key"] is None:
+        meta_dict["step_key"] = dagster_message_props.step_key
+
+    return meta_dict
+
+
+class DagsterLogHandler(logging.Handler):
+    """Internal class used to handle logs that are not generated from within Dagster. It mirrors
+    the behavior of its corresponding DagsterLogManager, adding in Dagster-specific metadata to
+    each handled log record, and sending it to the same sinks (handlers and loggers) that the
+    DagsterLogManager uses.
+
+    Note: The `loggers` argument will be populated with the set of @loggers supplied to the current
+    pipeline run. These essentially work as handlers (they do not create their own log messages,
+    they simply re-log messages that are created from context.log.x() calls), which is why they are
+    referenced from within this handler class.
+    """
+
     def __init__(
         self,
         logging_metadata: DagsterLoggingMetadata,
         loggers: List[logging.Logger],
-        handlers: Optional[List[logging.Handler]] = None,
+        handlers: List[logging.Handler],
     ):
-        self._logging_metadata = check.inst_param(
-            logging_metadata, "logging_metadata", DagsterLoggingMetadata
-        )
-        self._loggers = check.list_param(loggers, "loggers", of_type=logging.Logger)
+        self._logging_metadata = logging_metadata
+        self._loggers = loggers
+        self._handlers = handlers
+        super().__init__()
 
-        super().__init__(name="dagster", level=logging.DEBUG)
+    @property
+    def logging_metadata(self):
+        return self._logging_metadata
+
+    def with_tags(self, **new_tags):
+        return DagsterLogHandler(
+            logging_metadata=self.logging_metadata._replace(**new_tags),
+            loggers=self._loggers,
+            handlers=self._handlers,
+        )
+
+    def _extract_extra(self, record: logging.LogRecord) -> Dict[str, Any]:
+        """In the logging.Logger log() implementation, the elements of the `extra` dictionary
+        argument are smashed into the __dict__ of the underlying logging.LogRecord.
+        This function figures out what the original `extra` values of the log call were by
+        comparing the set of attributes in the received record to those of a default record.
+        """
+        ref_attrs = list(logging.makeLogRecord({}).__dict__.keys()) + ["message", "asctime"]
+        return {k: v for k, v in record.__dict__.items() if k not in ref_attrs}
+
+    def _convert_record(self, record: logging.LogRecord) -> logging.LogRecord:
+        # we store the originating DagsterEvent in the DAGSTER_META_KEY field, if applicable
+        dagster_meta = getattr(record, DAGSTER_META_KEY, None)
+
+        # generate some properties for this specific record
+        dagster_message_props = DagsterMessageProps(
+            orig_message=record.msg, dagster_event=dagster_meta
+        )
+
+        # set the dagster meta info for the record
+        setattr(
+            record,
+            DAGSTER_META_KEY,
+            get_dagster_meta_dict(self._logging_metadata, dagster_message_props),
+        )
+
+        # update the message to be formatted like other dagster logs
+        record.msg = construct_log_string(self._logging_metadata, dagster_message_props)
+
+        return record
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """If you list multiple levels of a python logging hierarchy as managed loggers, and do not
+        set the propagate attribute to False, this will result in that record getting logged
+        multiple times, as the DagsterLogHandler will be invoked at each level of the hierarchy as
+        the message is propagated. This filter prevents this from happening.
+        """
+        return not isinstance(getattr(record, DAGSTER_META_KEY, None), dict)
+
+    def emit(self, record: logging.LogRecord):
+        """For any received record, add Dagster metadata, and have handlers handle it"""
+        dagster_record = self._convert_record(record)
+        # built-in handlers
+        for handler in self._handlers:
+            handler.handle(dagster_record)
+        # user-defined @loggers
+        for logger in self._loggers:
+            logger.log(
+                level=dagster_record.levelno,
+                msg=dagster_record.msg,
+                exc_info=dagster_record.exc_info,
+                extra=self._extract_extra(record),
+            )
+
+
+class DagsterLogManager(logging.Logger):
+    def __init__(
+        self,
+        dagster_handler: DagsterLogHandler,
+        level: int = logging.NOTSET,
+        managed_loggers: List[logging.Logger] = None,
+    ):
+        super().__init__(name="dagster", level=coerce_valid_log_level(level))
+        self._managed_loggers = check.opt_list_param(
+            managed_loggers, "managed_loggers", of_type=logging.Logger
+        )
+        self._dagster_handler = dagster_handler
+        self.addHandler(dagster_handler)
+
+    @classmethod
+    def create(
+        cls,
+        loggers: List[logging.Logger],
+        handlers: List[logging.Handler] = None,
+        instance: Optional["DagsterInstance"] = None,
+        pipeline_run: Optional["PipelineRun"] = None,
+    ) -> "DagsterLogManager":
+        """Create a DagsterLogManager with a set of subservient loggers."""
 
         handlers = check.opt_list_param(handlers, "handlers", of_type=logging.Handler)
-        for handler in handlers:
-            self.addHandler(handler)
+        if instance:
+            handlers += [instance.get_event_log_handler()]
+            managed_loggers = [
+                logging.getLogger(lname) if lname != "root" else logging.getLogger()
+                for lname in instance.managed_python_loggers
+            ]
+            if instance.python_log_level is not None:
+                python_log_level = coerce_valid_log_level(instance.python_log_level)
+                # set all loggers to the declared logging level
+                for logger in managed_loggers:
+                    logger.setLevel(python_log_level)
+            else:
+                python_log_level = logging.NOTSET
+        else:
+            managed_loggers, python_log_level = [], logging.NOTSET
+
+        if pipeline_run:
+            logging_metadata = DagsterLoggingMetadata(
+                run_id=pipeline_run.run_id,
+                pipeline_name=pipeline_run.pipeline_name,
+                pipeline_tags=pipeline_run.tags,
+            )
+        else:
+            logging_metadata = DagsterLoggingMetadata()
+
+        return cls(
+            dagster_handler=DagsterLogHandler(
+                logging_metadata=logging_metadata,
+                loggers=loggers,
+                handlers=handlers,
+            ),
+            level=python_log_level,
+            managed_loggers=managed_loggers,
+        )
 
     @property
     def logging_metadata(self) -> DagsterLoggingMetadata:
-        return self._logging_metadata
+        return self._dagster_handler.logging_metadata
 
-    @property
-    def loggers(self) -> List[logging.Logger]:
-        return self._loggers
+    def begin_python_log_capture(self):
+        for logger in self._managed_loggers:
+            logger.addHandler(self._dagster_handler)
 
-    def log_dagster_event(self, level: int, msg: str, dagster_event: "DagsterEvent"):
+    def end_python_log_capture(self):
+        for logger in self._managed_loggers:
+            logger.removeHandler(self._dagster_handler)
+
+    def log_dagster_event(self, level: Union[str, int], msg: str, dagster_event: "DagsterEvent"):
+        """Log a DagsterEvent at the given level. Attributes about the context it was logged in
+        (such as the solid name or pipeline name) will be automatically attached to the created record.
+
+        Args:
+            level (str, int): either a string representing the desired log level ("INFO", "WARN"),
+                or an integer level such as logging.INFO or logging.DEBUG.
+            msg (str): message describing the event
+            dagster_event (DagsterEvent): DagsterEvent that will be logged
+        """
         self.log(level=level, msg=msg, extra={DAGSTER_META_KEY: dagster_event})
 
     def log(self, level, msg, *args, **kwargs):
-        # allow for string level names
-        super().log(coerce_valid_log_level(level), msg, *args, **kwargs)
+        """Log a message at the given level. Attributes about the context it was logged in (such as
+        the solid name or pipeline name) will be automatically attached to the created record.
 
-    def _log(
-        self, level, msg, args, exc_info=None, extra=None, stack_info=False
-    ):  # pylint: disable=arguments-differ
-
-        # we stash dagster meta information in the extra field
-        extra = extra or {}
-
-        dagster_message_props = DagsterMessageProps(
-            orig_message=msg, dagster_event=extra.get(DAGSTER_META_KEY)
-        )
-
-        # convert the message to our preferred format
-        msg = construct_log_string(self.logging_metadata, dagster_message_props)
-
-        # combine all dagster meta information into a single dictionary
-        meta_dict = {
-            **self.logging_metadata._asdict(),
-            **dagster_message_props._asdict(),
-        }
-        # step-level events can be logged from a pipeline context. for these cases, pull the step
-        # key from the underlying DagsterEvent
-        if meta_dict["step_key"] is None:
-            meta_dict["step_key"] = dagster_message_props.step_key
-
-        extra[DAGSTER_META_KEY] = meta_dict
-
-        for logger in self._loggers:
-            logger.log(level, msg, *args, extra=extra)
-
-        super()._log(level, msg, args, exc_info=exc_info, extra=extra, stack_info=stack_info)
+        Args:
+            level (str, int): either a string representing the desired log level ("INFO", "WARN"),
+                or an integer level such as logging.INFO or logging.DEBUG.
+            msg (str): the message to be logged
+            *args: the logged message will be msg % args
+        """
+        level = coerce_valid_log_level(level)
+        # log DagsterEvents regardless of level
+        if self.isEnabledFor(level) or ("extra" in kwargs and DAGSTER_META_KEY in kwargs["extra"]):
+            self._log(level, msg, args, **kwargs)
 
     def with_tags(self, **new_tags):
         """Add new tags in "new_tags" to the set of tags attached to this log manager instance, and
         return a new DagsterLogManager with the merged set of tags.
 
         Args:
-            tags (Dict[str,str]): Dictionary of tags
+            new_tags (Dict[str,str]): Dictionary of tags
 
         Returns:
             DagsterLogManager: a new DagsterLogManager namedtuple with updated tags for the same
                 run ID and loggers.
         """
         return DagsterLogManager(
-            logging_metadata=self.logging_metadata._replace(**new_tags),
-            loggers=self._loggers,
-            handlers=self.handlers,
+            dagster_handler=self._dagster_handler.with_tags(**new_tags),
+            managed_loggers=self._managed_loggers,
+            level=self.level,
         )

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -166,10 +166,8 @@ def get_dagster_meta_dict(
 
 
 class DagsterLogHandler(logging.Handler):
-    """Internal class used to handle logs that are not generated from within Dagster. It mirrors
-    the behavior of its corresponding DagsterLogManager, adding in Dagster-specific metadata to
-    each handled log record, and sending it to the same sinks (handlers and loggers) that the
-    DagsterLogManager uses.
+    """Internal class used to turn regular logs into Dagster logs by adding Dagster-specific
+    metadata (such as pipeline_name or step_key), as well as reformatting the underlying message.
 
     Note: The `loggers` argument will be populated with the set of @loggers supplied to the current
     pipeline run. These essentially work as handlers (they do not create their own log messages,
@@ -279,7 +277,7 @@ class DagsterLogManager(logging.Logger):
 
         handlers = check.opt_list_param(handlers, "handlers", of_type=logging.Handler)
         if instance:
-            handlers += [instance.get_event_log_handler()]
+            handlers += instance.get_handlers()
             managed_loggers = [
                 logging.getLogger(lname) if lname != "root" else logging.getLogger()
                 for lname in instance.managed_python_loggers

--- a/python_modules/dagster/dagster/logzample.py
+++ b/python_modules/dagster/dagster/logzample.py
@@ -1,0 +1,17 @@
+from dagster import ModeDefinition, pipeline, resource, solid
+
+
+@resource
+def dummy_resource(context):
+    context.log.info("IN RESOURCE")
+    return "dummy_resource"
+
+
+@solid
+def dummy_solid(context):
+    context.log.info("IN SOLID")
+
+
+@pipeline(mode_defs=[ModeDefinition(resource_defs={"dr": dummy_resource})])
+def pipe():
+    dummy_solid()

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_init.py
@@ -83,9 +83,7 @@ def test_clean_event_generator_exit():
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=pipeline_def, execution_plan=execution_plan
     )
-    log_manager = DagsterLogManager(
-        logging_metadata=DagsterLoggingMetadata(run_id=pipeline_run.run_id), loggers=[]
-    )
+    log_manager = DagsterLogManager.create(loggers=[], pipeline_run=pipeline_run)
     resolved_run_config = ResolvedRunConfig.build(pipeline_def)
     execution_plan = create_execution_plan(pipeline_def)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -25,6 +25,7 @@ def get_log_records(pipe, managed_loggers=None, python_logging_level=None, run_c
 @pytest.mark.parametrize(
     "managed_logs,expect_output",
     [
+        (None, False),
         (["root"], True),
         (["python_logger"], True),
         (["some_logger"], False),
@@ -59,6 +60,7 @@ def test_logging_capture_logger_defined_outside(managed_logs, expect_output):
 @pytest.mark.parametrize(
     "managed_logs,expect_output",
     [
+        (None, False),
         (["root"], True),
         (["python_logger"], True),
         (["some_logger"], False),
@@ -92,6 +94,7 @@ def test_logging_capture_logger_defined_inside(managed_logs, expect_output):
 @pytest.mark.parametrize(
     "managed_logs,expect_output",
     [
+        (None, False),
         (["root"], True),
         (["python_logger"], True),
         (["some_logger"], False),

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -1,0 +1,260 @@
+import logging
+
+import pytest
+from dagster import ModeDefinition, execute_pipeline, pipeline, reconstructable, resource, solid
+from dagster.core.test_utils import instance_for_test
+
+
+def get_log_records(pipe, managed_loggers=None, python_logging_level=None, run_config=None):
+    python_logs_overrides = {}
+    if managed_loggers is not None:
+        python_logs_overrides["managed_python_loggers"] = managed_loggers
+    if python_logging_level is not None:
+        python_logs_overrides["python_log_level"] = python_logging_level
+
+    overrides = {}
+    if python_logs_overrides:
+        overrides["python_logs"] = python_logs_overrides
+
+    with instance_for_test(overrides=overrides) as instance:
+        result = execute_pipeline(pipe, instance=instance)
+        event_records = instance.event_log_storage.get_logs_for_run(result.run_id)
+    return [er for er in event_records if er.user_message]
+
+
+@pytest.mark.parametrize(
+    "managed_logs,expect_output",
+    [
+        (["root"], True),
+        (["python_logger"], True),
+        (["some_logger"], False),
+        (["root", "python_logger"], True),
+    ],
+)
+def test_logging_capture_logger_defined_outside(managed_logs, expect_output):
+    logger = logging.getLogger("python_logger")
+    logger.setLevel(logging.INFO)
+
+    @solid
+    def my_solid():
+        logger.info("some info")
+
+    @pipeline
+    def my_pipeline():
+        my_solid()
+
+    log_event_records = [
+        lr for lr in get_log_records(my_pipeline, managed_logs) if lr.user_message == "some info"
+    ]
+
+    if expect_output:
+        assert len(log_event_records) == 1
+        log_event_record = log_event_records[0]
+        assert log_event_record.step_key == "my_solid"
+        assert log_event_record.level == logging.INFO
+    else:
+        assert len(log_event_records) == 0
+
+
+@pytest.mark.parametrize(
+    "managed_logs,expect_output",
+    [
+        (["root"], True),
+        (["python_logger"], True),
+        (["some_logger"], False),
+        (["root", "python_logger"], True),
+    ],
+)
+def test_logging_capture_logger_defined_inside(managed_logs, expect_output):
+    @solid
+    def my_solid():
+        logger = logging.getLogger("python_logger")
+        logger.setLevel(logging.INFO)
+        logger.info("some info")
+
+    @pipeline
+    def my_pipeline():
+        my_solid()
+
+    log_event_records = [
+        lr for lr in get_log_records(my_pipeline, managed_logs) if lr.user_message == "some info"
+    ]
+
+    if expect_output:
+        assert len(log_event_records) == 1
+        log_event_record = log_event_records[0]
+        assert log_event_record.step_key == "my_solid"
+        assert log_event_record.level == logging.INFO
+    else:
+        assert len(log_event_records) == 0
+
+
+@pytest.mark.parametrize(
+    "managed_logs,expect_output",
+    [
+        (["root"], True),
+        (["python_logger"], True),
+        (["some_logger"], False),
+        (["root", "python_logger"], True),
+    ],
+)
+def test_logging_capture_resource(managed_logs, expect_output):
+
+    python_log = logging.getLogger("python_logger")
+    python_log.setLevel(logging.DEBUG)
+
+    @resource
+    def foo_resource():
+        def fn():
+            python_log.info("log from resource foo")
+
+        return fn
+
+    @resource
+    def bar_resource():
+        def fn():
+            python_log.info("log from resource bar")
+
+        return fn
+
+    @solid(required_resource_keys={"foo", "bar"})
+    def process(context):
+        context.resources.foo()
+        context.resources.bar()
+
+    @pipeline(mode_defs=[ModeDefinition(resource_defs={"foo": foo_resource, "bar": bar_resource})])
+    def my_pipeline():
+        process()
+
+    log_event_records = [
+        lr
+        for lr in get_log_records(my_pipeline, managed_logs)
+        if lr.user_message.startswith("log from resource")
+    ]
+
+    if expect_output:
+        assert len(log_event_records) == 2
+        log_event_record = log_event_records[0]
+        assert log_event_record.level == logging.INFO
+    else:
+        assert len(log_event_records) == 0
+
+
+@pytest.mark.parametrize(
+    "log_level,expected_msgs",
+    [
+        (None, 3),  # default python log level is WARNING
+        ("DEBUG", 5),
+        ("INFO", 4),
+        ("WARNING", 3),
+        ("ERROR", 2),
+        ("CRITICAL", 1),
+    ],
+)
+def test_logging_capture_level_defined_outside(log_level, expected_msgs):
+    logger = logging.getLogger("python_logger_outside")
+
+    @solid
+    def my_solid():
+        for level in [
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL,
+        ]:
+            logger.log(level=level, msg="logger_foobarbaz")
+
+    @pipeline
+    def my_pipeline():
+        my_solid()
+
+    records = get_log_records(
+        my_pipeline, managed_loggers=["python_logger_outside"], python_logging_level=log_level
+    )
+    python_logger_records = [r for r in records if r.user_message == "logger_foobarbaz"]
+
+    assert len(python_logger_records) == expected_msgs
+
+
+@pytest.mark.parametrize(
+    "log_level,expected_msgs",
+    [
+        (None, 3),  # default python log level is WARNING
+        ("DEBUG", 5),
+        ("INFO", 4),
+        ("WARNING", 3),
+        ("ERROR", 2),
+        ("CRITICAL", 1),
+    ],
+)
+def test_logging_capture_level_defined_inside(log_level, expected_msgs):
+    @solid
+    def my_solid():
+        logger = logging.getLogger("python_logger_inside")
+        for level in [
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL,
+        ]:
+            logger.log(level=level, msg="foobarbaz")
+
+    @pipeline
+    def my_pipeline():
+        my_solid()
+
+    log_event_records = [
+        lr
+        for lr in get_log_records(
+            my_pipeline, managed_loggers=["root"], python_logging_level=log_level
+        )
+        if lr.user_message == "foobarbaz"
+    ]
+
+    assert len(log_event_records) == expected_msgs
+
+
+def define_logging_pipeline():
+    loggerA = logging.getLogger("loggerA")
+
+    @solid
+    def solidA():
+        loggerA.debug("loggerA")
+        loggerA.info("loggerA")
+        return 1
+
+    @solid
+    def solidB(_in):
+        loggerB = logging.getLogger("loggerB")
+        loggerB.debug("loggerB")
+        loggerB.info("loggerB")
+        loggerA.debug("loggerA")
+        loggerA.info("loggerA")
+
+    @pipeline
+    def pipe():
+        solidB(solidA())
+
+    return pipe
+
+
+@pytest.mark.parametrize("managed_loggers", [["root"], ["loggerA", "loggerB"]])
+def test_multiprocess_logging(managed_loggers):
+
+    log_records = get_log_records(
+        reconstructable(define_logging_pipeline),
+        managed_loggers=managed_loggers,
+        python_logging_level="INFO",
+        run_config={
+            "intermediate_storage": {"filesystem": {}},
+            "execution": {"multiprocess": {}},
+        },
+    )
+
+    logA_records = [lr for lr in log_records if lr.user_message == "loggerA"]
+    logB_records = [lr for lr in log_records if lr.user_message == "loggerB"]
+
+    assert len(logA_records) == 2
+    assert len(logB_records) == 1

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/log_tests/test_single_handler.py
@@ -38,7 +38,7 @@ def test_log_level_filtering():
         for logger_def in [debug_logger_def, critical_logger_def]
     ]
 
-    log_manager = DagsterLogManager(DagsterLoggingMetadata(), loggers)
+    log_manager = DagsterLogManager.create(loggers=loggers)
 
     log_manager.debug("Hello, there!")
 


### PR DESCRIPTION
This diff allows Dagster to automatically intercept normal python logs from user code and turn them into Dagster logs. This means that: 

1. they will have dagster metadata such as step_key, pipeline_name, etc. attached to them
2. they will have a message formatted like other dagster log messages ("\<pipeline name\> - \<run id\> - \<step key\> - <msg>")
3. they will be sent to all downstream loggers (dagster event log, console logger, and any user-defined loggers)

Currently, this is not configurable, and the default behavior is to ONLY capture python logs that come from the root logger at the logging.CRITICAL level (or above). However, the plan is to allow the user to specify a list of logs they'd like to capture and the level at which they would like them to be captured within their dagster.yaml file.

Right now, there are some hacky bits of code in here to make user-defined @loggers able to act a bit more like handlers. There's no particularly reliable way of replicating the behavior of a @logger without actually calling its log() function, but captured python logs will be delivered to us in the form of logging.LogRecords. In order to faithfully transmit LogRecords to the loggers, we need to deconstruct these records and then log them again through the @loggers.