### PR TITLE
skip snowflake hn test

### DIFF
--- a/examples/hacker_news/hacker_news_tests/test_resources/test_snowflake_io_manager.py
+++ b/examples/hacker_news/hacker_news_tests/test_resources/test_snowflake_io_manager.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from contextlib import contextmanager
 
+import pytest
 from dagster import build_init_resource_context, build_input_context, build_output_context
 from hacker_news.resources.snowflake_io_manager import connect_snowflake, snowflake_io_manager
 from pandas import DataFrame
@@ -30,6 +31,7 @@ def temporary_snowflake_table(contents: DataFrame):
             conn.execute(f"drop table public.{table_name}")
 
 
+@pytest.mark.skip(reason="avoid dependency on snowflake for tests")
 def test_handle_output_then_load_input():
     snowflake_config = generate_snowflake_config()
     snowflake_manager = snowflake_io_manager(build_init_resource_context(config=snowflake_config))


### PR DESCRIPTION
There have been two occasions where snowflake reliability issues have caused this test to start failing, which makes builds take a long time. It's mostly just there to demonstrate how to write such a test, so it seems fine to me to skip actually running it in BK.