### PR TITLE
Convert event logger to handler

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -580,12 +580,12 @@ def create_log_manager(context_creation_data: ContextCreationData) -> DagsterLog
                 )
             )
 
-    # should this be first in loggers list?
-    loggers.append(context_creation_data.instance.get_logger())
+    handlers = [context_creation_data.instance.get_event_log_handler()]
 
     return DagsterLogManager(
         logging_metadata=get_logging_metadata(pipeline_run),
         loggers=loggers,
+        handlers=handlers,
     )
 
 
@@ -602,7 +602,7 @@ def _create_context_free_log_manager(
     check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
 
-    loggers = [instance.get_logger()]
+    loggers = []
     # Use the default logger
     for (logger_def, logger_config) in default_system_loggers():
         loggers += [
@@ -616,7 +616,9 @@ def _create_context_free_log_manager(
             )
         ]
 
-    return DagsterLogManager(get_logging_metadata(pipeline_run), loggers)
+    handlers = [instance.get_event_log_handler()]
+
+    return DagsterLogManager(get_logging_metadata(pipeline_run), loggers, handlers)
 
 
 def get_logging_metadata(pipeline_run: PipelineRun) -> DagsterLoggingMetadata:

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -100,11 +100,12 @@ def host_mode_execution_context_event_generator(
             )
         )
 
-    loggers.append(instance.get_logger())
+    handlers = [instance.get_event_log_handler()]
 
     log_manager = DagsterLogManager(
         logging_metadata=get_logging_metadata(pipeline_run),
         loggers=loggers,
+        handlers=handlers,
     )
 
     try:

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1107,11 +1107,10 @@ records = instance.get_event_records(
 
     # event subscriptions
 
-    def get_logger(self):
-        logger = logging.Logger("__event_listener")
-        logger.addHandler(_EventListenerLogHandler(self))
-        logger.setLevel(10)
-        return logger
+    def get_event_log_handler(self):
+        event_log_handler = _EventListenerLogHandler(self)
+        event_log_handler.setLevel(10)
+        return event_log_handler
 
     def handle_new_event(self, event):
         run_id = event.run_id


### PR DESCRIPTION
- Converts `__event_listener` logger into a handler attached to `DagsterLogManager`
- Existing tests in `test_event_logging.py` validate that log events are handled with the same behavior as before this change