### PR TITLE
Remove execute solid from docs

### DIFF
--- a/docs/content-crag/concepts/solids-pipelines/solids.mdx
+++ b/docs/content-crag/concepts/solids-pipelines/solids.mdx
@@ -150,7 +150,7 @@ def my_configurable_solid(context):
 
 ## Using a solid
 
-Solids are used within a <PyObject object="pipeline" displayText="@pipeline" />. You can see more information on the [Pipelines](/concepts/solids-pipelines/pipelines) page. You can also execute a single solid, usually within a test context, using the <PyObject object="execute_solid" /> function. More information can be found at [Testing single solid execution](/concepts/testing#testing-single-solid-execution)
+Solids are used within a <PyObject object="pipeline" displayText="@pipeline" />. You can see more information on the [Pipelines](/concepts/solids-pipelines/pipelines) page. You can also execute a single solid, usually within a test context, by directly invoking it. More information can be found at [Testing solids](/concepts/testing#testing-solids)
 
 ## Patterns
 

--- a/docs/content-crag/concepts/testing.mdx
+++ b/docs/content-crag/concepts/testing.mdx
@@ -12,7 +12,6 @@ Dagster enables you to build testable and maintainable data applications. It pro
 | Name                                       | Description                                                                                                           |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | <PyObject object="execute_pipeline"     /> | A method to execute a pipeline synchronously, typically for testing pipeline execution or running standalone scripts. |
-| <PyObject object="execute_solid" />        | A method to execute a single solid in an ephemeral pipeline, intended to support unit tests.                          |
 | <PyObject object="build_solid_context"  /> | A method to construct a `SolidExecutionContext`, typically to provide to the invocation of a solid for testing.       |
 
 ## Overview
@@ -120,22 +119,7 @@ For more information, you can check out the [Modes](/concepts/modes-resources) a
 
 ## Examples
 
-### Testing single solid execution
-
-You can execute a single solid without writing a pipeline using <PyObject object="execute_solid" />. Using this function you will a single solid in an ephemeral pipeline. You can then then test execution properties using the <PyObject object="SolidExecutionResult" /> object that it returns.
-
-```python file=/concepts/solids_pipelines/unit_tests.py startafter=start_test_execute_solid_marker endbefore=end_test_execute_solid_marker
-def test_solid():
-    result = execute_solid(add_one)
-
-    # return type is SolidExecutionResult
-    assert isinstance(result, SolidExecutionResult)
-    assert result.success
-    # check the solid output value
-    assert result.output_value() == 2
-```
-
-### Testing solids with invocation
+### Testing solids
 
 While using the `@solid` decorator on a function does change its signature, the invocation mirrors closely the underlying decorated function.
 

--- a/docs/content/concepts/solids-pipelines/solids.mdx
+++ b/docs/content/concepts/solids-pipelines/solids.mdx
@@ -150,7 +150,7 @@ def my_configurable_solid(context):
 
 ## Using a solid
 
-Solids are used within a <PyObject object="pipeline" displayText="@pipeline" />. You can see more information on the [Pipelines](/concepts/solids-pipelines/pipelines) page. You can also execute a single solid, usually within a test context, using the <PyObject object="execute_solid" /> function. More information can be found at [Testing single solid execution](/concepts/testing#testing-single-solid-execution)
+Solids are used within a <PyObject object="pipeline" displayText="@pipeline" />. You can see more information on the [Pipelines](/concepts/solids-pipelines/pipelines) page. You can also execute a single solid, usually within a test context, by directly invoking it. More information can be found at [Testing solids](/concepts/testing#testing-solids)
 
 ## Patterns
 

--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -12,7 +12,6 @@ Dagster enables you to build testable and maintainable data applications. It pro
 | Name                                       | Description                                                                                                           |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | <PyObject object="execute_pipeline"     /> | A method to execute a pipeline synchronously, typically for testing pipeline execution or running standalone scripts. |
-| <PyObject object="execute_solid" />        | A method to execute a single solid in an ephemeral pipeline, intended to support unit tests.                          |
 | <PyObject object="build_solid_context"  /> | A method to construct a `SolidExecutionContext`, typically to provide to the invocation of a solid for testing.       |
 
 ## Overview
@@ -120,22 +119,7 @@ For more information, you can check out the [Modes](/concepts/modes-resources) a
 
 ## Examples
 
-### Testing single solid execution
-
-You can execute a single solid without writing a pipeline using <PyObject object="execute_solid" />. Using this function you will a single solid in an ephemeral pipeline. You can then then test execution properties using the <PyObject object="SolidExecutionResult" /> object that it returns.
-
-```python file=/concepts/solids_pipelines/unit_tests.py startafter=start_test_execute_solid_marker endbefore=end_test_execute_solid_marker
-def test_solid():
-    result = execute_solid(add_one)
-
-    # return type is SolidExecutionResult
-    assert isinstance(result, SolidExecutionResult)
-    assert result.success
-    # check the solid output value
-    assert result.output_value() == 2
-```
-
-### Testing solids with invocation
+### Testing solids
 
 While using the `@solid` decorator on a function does change its signature, the invocation mirrors closely the underlying decorated function.
 

--- a/examples/docs_snippets/docs_snippets/concepts/solids_pipelines/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/solids_pipelines/unit_tests.py
@@ -9,7 +9,6 @@ from dagster import (
     PipelineExecutionResult,
     SolidExecutionResult,
     execute_pipeline,
-    execute_solid,
     pipeline,
     solid,
 )
@@ -73,20 +72,6 @@ def test_pipeline():
 
 
 # end_test_pipeline_marker
-
-
-# start_test_execute_solid_marker
-def test_solid():
-    result = execute_solid(add_one)
-
-    # return type is SolidExecutionResult
-    assert isinstance(result, SolidExecutionResult)
-    assert result.success
-    # check the solid output value
-    assert result.output_value() == 2
-
-
-# end_test_execute_solid_marker
 
 # start_invocation_solid_marker
 @solid

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_tests.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_tests.py
@@ -3,7 +3,6 @@ from docs_snippets.concepts.solids_pipelines.unit_tests import (
     test_inputs_solid_with_invocation,
     test_pipeline,
     test_pipeline_with_config,
-    test_solid,
     test_solid_resource_def,
     test_solid_with_context,
     test_solid_with_invocation,
@@ -13,7 +12,6 @@ from docs_snippets.concepts.solids_pipelines.unit_tests import (
 
 def test_unit_tests():
     test_pipeline()
-    test_solid()
     test_solid_with_invocation()
     test_solid_with_context()
     test_pipeline_with_config()

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/unit_tests.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/unit_tests.py
@@ -9,7 +9,6 @@ from dagster import (
     PipelineExecutionResult,
     SolidExecutionResult,
     execute_pipeline,
-    execute_solid,
     pipeline,
     solid,
 )
@@ -73,20 +72,6 @@ def test_pipeline():
 
 
 # end_test_pipeline_marker
-
-
-# start_test_execute_solid_marker
-def test_solid():
-    result = execute_solid(add_one)
-
-    # return type is SolidExecutionResult
-    assert isinstance(result, SolidExecutionResult)
-    assert result.success
-    # check the solid output value
-    assert result.output_value() == 2
-
-
-# end_test_execute_solid_marker
 
 # start_invocation_solid_marker
 @solid

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_tests.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_tests.py
@@ -1,4 +1,4 @@
-from docs_snippets.concepts.solids_pipelines.unit_tests import (
+from docs_snippets_crag.concepts.solids_pipelines.unit_tests import (
     test_event_stream,
     test_inputs_solid_with_invocation,
     test_pipeline,

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_tests.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_tests.py
@@ -1,9 +1,8 @@
-from docs_snippets_crag.concepts.solids_pipelines.unit_tests import (
+from docs_snippets.concepts.solids_pipelines.unit_tests import (
     test_event_stream,
     test_inputs_solid_with_invocation,
     test_pipeline,
     test_pipeline_with_config,
-    test_solid,
     test_solid_resource_def,
     test_solid_with_context,
     test_solid_with_invocation,
@@ -13,7 +12,6 @@ from docs_snippets_crag.concepts.solids_pipelines.unit_tests import (
 
 def test_unit_tests():
     test_pipeline()
-    test_solid()
     test_solid_with_invocation()
     test_solid_with_context()
     test_pipeline_with_config()


### PR DESCRIPTION
This removes execute solid from the docs site, and switches around testing links to redirect to invocation.