### PR TITLE
add missing pre-exit hooks for docs_snippets

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -16,6 +16,16 @@ docker-compose stop
 docker-compose rm -f
 popd
 
+pushd examples/docs_snippets
+docker-compose stop
+docker-compose rm -f
+popd
+
+pushd examples/docs_snippets_crag
+docker-compose stop
+docker-compose rm -f
+popd
+
 pushd python_modules/libraries/dagster-celery
 docker-compose stop
 docker-compose rm -f


### PR DESCRIPTION


### Test Plan

ensure pre-exit runs cleanly on buildkite 