### PR TITLE
[dagit] Repair left nav when repositories are added async

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
@@ -64,7 +64,25 @@ describe('Repository options', () => {
     const locationTwo = 'bar';
     const repoTwo = 'foo';
 
-    const mocks = {
+    const mocksWithOne = {
+      Workspace: () => ({
+        locationEntries: () => [
+          {
+            name: locationOne,
+            locationOrLoadError: {
+              name: locationOne,
+              repositories: () =>
+                new MockList(1, () => ({
+                  name: repoOne,
+                  pipelines: () => new MockList(2),
+                })),
+            },
+          },
+        ],
+      }),
+    };
+
+    const mocksWithTwo = {
       Workspace: () => ({
         locationEntries: () => [
           {
@@ -93,10 +111,10 @@ describe('Repository options', () => {
       }),
     };
 
-    it('initializes with first repo option, if no localStorage', async () => {
+    it('initializes with first repo option, if one option and no localStorage', async () => {
       render(
         <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocks]}}
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
           routerProps={{initialEntries: ['/instance/runs']}}
         >
           <LeftNavRepositorySection />
@@ -109,11 +127,27 @@ describe('Repository options', () => {
       });
     });
 
+    it('initializes empty, if multiple options and no localStorage', async () => {
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
+          routerProps={{initialEntries: ['/instance/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        // We have multiple options and select none by default. Empty.
+        expect(screen.queryAllByRole('link')).toHaveLength(0);
+      });
+    });
+
     it('initializes with correct repo option, if `LAST_REPO_KEY` localStorage', async () => {
       window.localStorage.setItem(LAST_REPO_KEY, 'lorem:ipsum');
       render(
         <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocks]}}
+          apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
           routerProps={{initialEntries: ['/instance/runs']}}
         >
           <LeftNavRepositorySection />
@@ -130,7 +164,7 @@ describe('Repository options', () => {
       window.localStorage.setItem(REPO_KEYS, '["foo:bar"]');
       render(
         <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocks]}}
+          apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
           routerProps={{initialEntries: ['/instance/runs']}}
         >
           <LeftNavRepositorySection />
@@ -143,11 +177,11 @@ describe('Repository options', () => {
       });
     });
 
-    it('initializes with first repo option, if no matching `REPO_KEYS` localStorage', async () => {
+    it('initializes with first repo option, if one option and no matching `REPO_KEYS` localStorage', async () => {
       window.localStorage.setItem(REPO_KEYS, '["hello:world"]');
       render(
         <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocks]}}
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
           routerProps={{initialEntries: ['/instance/runs']}}
         >
           <LeftNavRepositorySection />
@@ -164,7 +198,7 @@ describe('Repository options', () => {
       window.localStorage.setItem(REPO_KEYS, '["lorem:ipsum", "foo:bar"]');
       render(
         <TestProvider
-          apolloProps={{mocks: [defaultMocks, mocks]}}
+          apolloProps={{mocks: [defaultMocks, mocksWithTwo]}}
           routerProps={{initialEntries: ['/instance/runs']}}
         >
           <LeftNavRepositorySection />
@@ -174,6 +208,78 @@ describe('Repository options', () => {
       // Six total pipelines, and no link for single repo name.
       await waitFor(() => {
         expect(screen.getAllByRole('link')).toHaveLength(6);
+      });
+    });
+
+    it('initializes empty, then shows first option when options are added', async () => {
+      const initialMocks = {
+        Workspace: () => ({
+          locationEntries: () => [],
+        }),
+      };
+
+      const {rerender} = render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, initialMocks]}}
+          routerProps={{initialEntries: ['/instance/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      // Zero repositories, so zero pipelines.
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(0);
+      });
+
+      rerender(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
+          routerProps={{initialEntries: ['/instance/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      // After repositories are added, the first one becomes visible.
+      await waitFor(() => {
+        expect(screen.getAllByRole('link')).toHaveLength(3);
+      });
+    });
+
+    it('initializes with options, then shows empty if they are removed', async () => {
+      const mocksAfterRemoval = {
+        Workspace: () => ({
+          locationEntries: () => [],
+        }),
+      };
+
+      const {rerender} = render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
+          routerProps={{initialEntries: ['/instance/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      // One repo by default, so three pipelines.
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(3);
+      });
+
+      rerender(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksAfterRemoval]}}
+          routerProps={{initialEntries: ['/instance/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      // After repositories are removed, there are none displayed.
+      await waitFor(() => {
+        expect(screen.queryAllByRole('link')).toHaveLength(0);
       });
     });
   });

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -51,23 +51,28 @@ const keysFromLocalStorage = () => {
 const useNavVisibleRepos = (
   options: DagsterRepoOption[],
 ): [typeof repoDetailsForKeys, typeof toggleRepo] => {
-  // Collect keys from localStorage. Any keys that are present in our option list will be our
-  // initial state. If there are none, just grab the first option.
-  const [repoKeys, setRepoKeys] = React.useState<Set<string>>(() => {
-    const keys = keysFromLocalStorage();
-    const hashes = options.map((option) => getRepositoryOptionHash(option));
-    const matches = hashes.filter((hash) => keys.has(hash));
+  // Initialize local state with an empty Set.
+  const [repoKeys, setRepoKeys] = React.useState<Set<string>>(() => new Set());
 
-    if (matches.length) {
-      return new Set(matches);
-    }
+  // Collect keys from localStorage. Any keys that are present in our option list will be pushed into
+  // local state. If there are none specified in localStorage, just grab the first option.
+  React.useEffect(() => {
+    setRepoKeys(() => {
+      const keys = keysFromLocalStorage();
+      const hashes = options.map((option) => getRepositoryOptionHash(option));
+      const matches = hashes.filter((hash) => keys.has(hash));
 
-    if (hashes.length) {
-      return new Set([hashes[0]]);
-    }
+      if (matches.length) {
+        return new Set(matches);
+      }
 
-    return new Set();
-  });
+      if (hashes.length) {
+        return new Set([hashes[0]]);
+      }
+
+      return new Set();
+    });
+  }, [options]);
 
   const toggleRepo = React.useCallback((option: RepoDetails) => {
     const {repoAddress} = option;


### PR DESCRIPTION
## Summary

In Cloud, when adding a repository after Dagit is already open (and there are no repositories in the workspace), the jobs for the newly added repository are not populated.

This is because of the way we manage the state of "selected" repos in the nav. State is set up front, and newly added options are never marked as selected.

Repair this by setting state in an effect. This way, when the options list changes (e.g. by asynchronously introducing a new repo to the workspace) the effect will find the first repository in the list and make it the "selected" state.

## Test Plan

`yarn jest`

Run Cloud host and user host, open Dagit. Add a repo to the workspace, navigate to trigger a query that updates the workspace in Dagit. Verify that the newly added repo appears in the nav, along with its jobs.

Run OS Dagit with several repositories loaded. Verify that I can select/unselect them in the nav as before.