### PR TITLE
[docs][easy] prevent header from going off the screen on mobile

### DIFF
--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -79,7 +79,7 @@ export function Search() {
           width="24"
           height="24"
           fill="none"
-          className="text-gray-400 group-hover:text-gray-500 transition-colors duration-200"
+          className="text-gray-400 group-hover:text-gray-500 transition-colors duration-200 flex-shrink-0"
         >
           <path
             d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"

--- a/docs/next/layouts/MainLayout.tsx
+++ b/docs/next/layouts/MainLayout.tsx
@@ -329,7 +329,7 @@ export const FeedbackModal = ({
 
 const Header = ({ openFeedback, isDarkMode, setDarkMode }) => {
   return (
-    <div className="sticky top-0 z-30 flex items-center bg-white dark:bg-gray-900 border-b">
+    <div className="sticky top-0 z-30 flex items-center bg-white dark:bg-gray-900 border-b overflow-x-auto">
       <div
         className="flex-1 relative z-0 cursor-pointer focus:outline-none"
         tabIndex={0}


### PR DESCRIPTION
## Summary
header layout is a bit broken on mobile

https://user-images.githubusercontent.com/2268452/130319982-01a41a30-458a-4a28-a1d3-bce1e04b76c1.mov

## Test Plan
1. Nothing changes on desktop
2. On mobile header becomes an h-scroll. Also the search icon no longer gets clipped

https://user-images.githubusercontent.com/2268452/130320015-1ed553c3-8b83-4d33-9e2d-f6f6c47ba45d.mov