### PR TITLE
Add JobDefinition class

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from .solid import SolidDefinition
     from .partition import PartitionedConfig
     from .executor import ExecutorDefinition
-    from .pipeline import PipelineDefinition
+    from .job import JobDefinition
     from dagster.core.execution.execute_in_process import InProcessGraphResult
 
 
@@ -373,7 +373,7 @@ class GraphDefinition(NodeDefinition):
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
-    ) -> "PipelineDefinition":
+    ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
 
@@ -418,7 +418,7 @@ class GraphDefinition(NodeDefinition):
         Returns:
             PipelineDefinition: The "Job" currently implemented as a single-mode pipeline
         """
-        from .pipeline import PipelineDefinition
+        from .job import JobDefinition
         from .partition import PartitionedConfig
         from .executor import ExecutorDefinition, multiprocess_executor
 
@@ -461,19 +461,17 @@ class GraphDefinition(NodeDefinition):
                 f"is an object of type {type(config)}"
             )
 
-        return PipelineDefinition(
+        return JobDefinition(
             name=job_name,
             description=description,
             graph_def=self,
-            mode_defs=[
-                ModeDefinition(
-                    resource_defs=resource_defs_with_defaults,
-                    logger_defs=logger_defs,
-                    executor_defs=[executor_def],
-                    _config_mapping=config_mapping,
-                    _partitioned_config=partitioned_config,
-                )
-            ],
+            mode_def=ModeDefinition(
+                resource_defs=resource_defs_with_defaults,
+                logger_defs=logger_defs,
+                executor_defs=[executor_def],
+                _config_mapping=config_mapping,
+                _partitioned_config=partitioned_config,
+            ),
             preset_defs=presets,
             tags=tags,
             hook_defs=hooks,

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -1,8 +1,8 @@
+import warnings
 from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional
 
 from dagster import check
 from dagster.core.definitions.policy import RetryPolicy
-from dagster.core.errors import DagsterInvariantViolationError
 
 from .graph import GraphDefinition
 from .hook import HookDefinition
@@ -105,10 +105,12 @@ class JobDefinition(PipelineDefinition):
 
     def get_pipeline_subset_def(self, solids_to_execute: AbstractSet[str]) -> PipelineDefinition:
 
-        # https://github.com/dagster-io/dagster/issues/4489
-        raise DagsterInvariantViolationError(
-            f"Attempted to subset job '{self.name}'. Subsetting jobs is not supported at this time."
+        warnings.warn(
+            f"Attempted to subset job {self.name}. The subsetted job will be represented by a "
+            "PipelineDefinition."
         )
+
+        return super(JobDefinition, self).get_pipeline_subset_def(solids_to_execute)
 
 
 def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -66,7 +66,7 @@ class JobDefinition(PipelineDefinition):
 
         """
         from dagster.core.definitions.executor import execute_in_process_executor
-        from dagster.core.execution.execute import core_execute_in_process
+        from dagster.core.execution.execute_in_process import core_execute_in_process
 
         run_config = check.opt_dict_param(run_config, "run_config")
         check.invariant(

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -47,6 +47,7 @@ class JobDefinition(PipelineDefinition):
         self,
         run_config: Optional[Dict[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
+        raise_on_error: bool = True,
     ) -> "InProcessGraphResult":
         """
         (Experimental) Execute the "Job" (single mode pipeline) in-process, gathering results in-memory.
@@ -101,6 +102,7 @@ class JobDefinition(PipelineDefinition):
             run_config=run_config,
             instance=instance,
             output_capturing_enabled=True,
+            raise_on_error=raise_on_error,
         )
 
     def get_pipeline_subset_def(self, solids_to_execute: AbstractSet[str]) -> PipelineDefinition:

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -2,11 +2,12 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional
 
 from dagster import check
 from dagster.core.definitions.policy import RetryPolicy
+from dagster.core.errors import DagsterInvariantViolationError
 
 from .graph import GraphDefinition
 from .hook import HookDefinition
 from .mode import ModeDefinition
-from .pipeline import PipelineDefinition, PipelineSubsetDefinition
+from .pipeline import PipelineDefinition
 from .preset import PresetDefinition
 from .resource import ResourceDefinition
 from .version_strategy import VersionStrategy
@@ -102,33 +103,11 @@ class JobDefinition(PipelineDefinition):
             output_capturing_enabled=True,
         )
 
+    def get_pipeline_subset_def(self, solids_to_execute: AbstractSet[str]) -> PipelineDefinition:
 
-class JobSubsetDefinition(PipelineSubsetDefinition):
-    def __init__(
-        self,
-        mode_def: ModeDefinition,
-        graph_def: GraphDefinition,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        preset_defs: Optional[List[PresetDefinition]] = None,
-        tags: Dict[str, Any] = None,
-        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
-        solid_retry_policy: Optional[RetryPolicy] = None,
-        _parent_pipeline_def=None,  # https://github.com/dagster-io/dagster/issues/2115
-        version_strategy: Optional[VersionStrategy] = None,
-    ):
-
-        super(JobSubsetDefinition, self).__init__(
-            name=name,
-            description=description,
-            mode_defs=[mode_def],
-            preset_defs=preset_defs,
-            tags=tags,
-            hook_defs=hook_defs,
-            solid_retry_policy=solid_retry_policy,
-            graph_def=graph_def,
-            _parent_pipeline_def=_parent_pipeline_def,
-            version_strategy=version_strategy,
+        # https://github.com/dagster-io/dagster/issues/4489
+        raise DagsterInvariantViolationError(
+            f"Attempted to subset job '{self.name}'. Subsetting jobs is not supported at this time."
         )
 
 

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -1,0 +1,152 @@
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional
+
+from dagster import check
+from dagster.core.definitions.policy import RetryPolicy
+
+from .graph import GraphDefinition
+from .hook import HookDefinition
+from .mode import ModeDefinition
+from .pipeline import PipelineDefinition, PipelineSubsetDefinition
+from .preset import PresetDefinition
+from .resource import ResourceDefinition
+from .version_strategy import VersionStrategy
+
+if TYPE_CHECKING:
+    from dagster.core.instance import DagsterInstance
+    from dagster.core.execution.execution_results import InProcessGraphResult
+
+
+class JobDefinition(PipelineDefinition):
+    def __init__(
+        self,
+        mode_def: ModeDefinition,
+        graph_def: GraphDefinition,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        preset_defs: Optional[List[PresetDefinition]] = None,
+        tags: Dict[str, Any] = None,
+        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
+        solid_retry_policy: Optional[RetryPolicy] = None,
+        version_strategy: Optional[VersionStrategy] = None,
+    ):
+
+        super(JobDefinition, self).__init__(
+            name=name,
+            description=description,
+            mode_defs=[mode_def],
+            preset_defs=preset_defs,
+            tags=tags,
+            hook_defs=hook_defs,
+            solid_retry_policy=solid_retry_policy,
+            graph_def=graph_def,
+            version_strategy=version_strategy,
+        )
+
+    def execute_in_process(
+        self,
+        run_config: Optional[Dict[str, Any]] = None,
+        instance: Optional["DagsterInstance"] = None,
+    ) -> "InProcessGraphResult":
+        """
+        (Experimental) Execute the "Job" (single mode pipeline) in-process, gathering results in-memory.
+
+        The executor_def on the Job will be ignored, and replaced with the in-process executor.
+        If using the default io_manager, it will switch from filesystem to in-memory.
+
+
+        Args:
+            run_config (Optional[Dict[str, Any]]:
+                The configuration for the run
+            instance (Optional[DagsterInstance]):
+                The instance to execute against, an ephemeral one will be used if none provided.
+
+        Returns:
+            InProcessGraphResult
+
+        """
+        from dagster.core.definitions.executor import execute_in_process_executor
+        from dagster.core.execution.execute import core_execute_in_process
+
+        run_config = check.opt_dict_param(run_config, "run_config")
+        check.invariant(
+            len(self._mode_definitions) == 1,
+            "execute_in_process only supported on job / single mode pipeline",
+        )
+
+        base_mode = self.get_mode_definition()
+        # create an ephemeral in process mode by replacing the executor_def and
+        # switching the default fs io_manager to in mem, if another was not set
+        in_proc_mode = ModeDefinition(
+            name="in_process",
+            executor_defs=[execute_in_process_executor],
+            resource_defs=_swap_default_io_man(base_mode.resource_defs, self),
+            logger_defs=base_mode.loggers,
+            _config_mapping=base_mode.config_mapping,
+            _partitioned_config=base_mode.partitioned_config,
+        )
+
+        ephemeral_pipeline = PipelineDefinition(
+            name=self._name,
+            graph_def=self._graph_def,
+            mode_defs=[in_proc_mode],
+            hook_defs=self.hook_defs,
+            tags=self.tags,
+            version_strategy=self.version_strategy,
+        )
+
+        return core_execute_in_process(
+            node=self._graph_def,
+            ephemeral_pipeline=ephemeral_pipeline,
+            run_config=run_config,
+            instance=instance,
+            output_capturing_enabled=True,
+        )
+
+
+class JobSubsetDefinition(PipelineSubsetDefinition):
+    def __init__(
+        self,
+        mode_def: ModeDefinition,
+        graph_def: GraphDefinition,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        preset_defs: Optional[List[PresetDefinition]] = None,
+        tags: Dict[str, Any] = None,
+        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
+        solid_retry_policy: Optional[RetryPolicy] = None,
+        _parent_pipeline_def=None,  # https://github.com/dagster-io/dagster/issues/2115
+        version_strategy: Optional[VersionStrategy] = None,
+    ):
+
+        super(JobSubsetDefinition, self).__init__(
+            name=name,
+            description=description,
+            mode_defs=[mode_def],
+            preset_defs=preset_defs,
+            tags=tags,
+            hook_defs=hook_defs,
+            solid_retry_policy=solid_retry_policy,
+            graph_def=graph_def,
+            _parent_pipeline_def=_parent_pipeline_def,
+            version_strategy=version_strategy,
+        )
+
+
+def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):
+    """
+    Used to create the user facing experience of the default io_manager
+    switching to in-memory when using execute_in_process.
+    """
+    from dagster.core.storage.mem_io_manager import mem_io_manager
+    from .graph import default_job_io_manager
+
+    if (
+        # pylint: disable=comparison-with-callable
+        resources.get("io_manager") == default_job_io_manager
+        and job.version_strategy is None
+    ):
+        updated_resources = dict(resources)
+        updated_resources["io_manager"] = mem_io_manager
+        return updated_resources
+
+    return resources

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -551,68 +551,6 @@ class PipelineDefinition:
             "using an execution API function (e.g. `execute_pipeline`)."
         )
 
-    def execute_in_process(
-        self,
-        run_config: Optional[Dict[str, Any]] = None,
-        instance: Optional["DagsterInstance"] = None,
-        raise_on_error: bool = True,
-    ) -> "InProcessGraphResult":
-        """
-        (Experimental) Execute the "Job" (single mode pipeline) in-process, gathering results in-memory.
-
-        The executor_def on the Job will be ignored, and replaced with the in-process executor.
-        If using the default io_manager, it will switch from filesystem to in-memory.
-
-
-        Args:
-            run_config (Optional[Dict[str, Any]]:
-                The configuration for the run
-            instance (Optional[DagsterInstance]):
-                The instance to execute against, an ephemeral one will be used if none provided.
-
-        Returns:
-            InProcessGraphResult
-
-        """
-        from dagster.core.definitions.executor import execute_in_process_executor
-        from dagster.core.execution.execute_in_process import core_execute_in_process
-
-        run_config = check.opt_dict_param(run_config, "run_config")
-        check.invariant(
-            len(self._mode_definitions) == 1,
-            "execute_in_process only supported on job / single mode pipeline",
-        )
-
-        base_mode = self.get_mode_definition()
-        # create an ephemeral in process mode by replacing the executor_def and
-        # switching the default fs io_manager to in mem, if another was not set
-        in_proc_mode = ModeDefinition(
-            name="in_process",
-            executor_defs=[execute_in_process_executor],
-            resource_defs=swap_default_io_man(base_mode.resource_defs, self),
-            logger_defs=base_mode.loggers,
-            _config_mapping=base_mode.config_mapping,
-            _partitioned_config=base_mode.partitioned_config,
-        )
-
-        ephemeral_pipeline = PipelineDefinition(
-            name=self._name,
-            graph_def=self._graph_def,
-            mode_defs=[in_proc_mode],
-            hook_defs=self.hook_defs,
-            tags=self.tags,
-            version_strategy=self.version_strategy,
-        )
-
-        return core_execute_in_process(
-            node=self._graph_def,
-            ephemeral_pipeline=ephemeral_pipeline,
-            run_config=run_config,
-            instance=instance,
-            output_capturing_enabled=True,
-            raise_on_error=raise_on_error,
-        )
-
 
 class PipelineSubsetDefinition(PipelineDefinition):
     @property
@@ -660,6 +598,7 @@ def _get_pipeline_subset_def(
     Build a pipeline which is a subset of another pipeline.
     Only includes the solids which are in solids_to_execute.
     """
+    from .job import JobDefinition, JobSubsetDefinition
 
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.set_param(solids_to_execute, "solids_to_execute", of_type=str)
@@ -708,15 +647,27 @@ def _get_pipeline_subset_def(
                 )
 
     try:
-        sub_pipeline_def = PipelineSubsetDefinition(
-            name=pipeline_def.name,  # should we change the name for subsetted pipeline?
-            solid_defs=list({solid.definition for solid in solids}),
-            mode_defs=pipeline_def.mode_definitions,
-            dependencies=deps,
-            _parent_pipeline_def=pipeline_def,
-            tags=pipeline_def.tags,
-            hook_defs=pipeline_def.hook_defs,
-        )
+        if isinstance(pipeline_def, JobDefinition):
+            sub_pipeline_def: Union[
+                PipelineSubsetDefinition, JobSubsetDefinition
+            ] = JobSubsetDefinition(
+                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
+                mode_def=pipeline_def.mode_definitions[0],
+                _parent_pipeline_def=pipeline_def,
+                tags=pipeline_def.tags,
+                hook_defs=pipeline_def.hook_defs,
+                graph_def=pipeline_def.graph,
+            )
+        else:
+            sub_pipeline_def = PipelineSubsetDefinition(
+                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
+                solid_defs=list({solid.definition for solid in solids}),
+                mode_defs=pipeline_def.mode_definitions,
+                dependencies=deps,
+                _parent_pipeline_def=pipeline_def,
+                tags=pipeline_def.tags,
+                hook_defs=pipeline_def.hook_defs,
+            )
 
         return sub_pipeline_def
     except DagsterInvalidDefinitionError as exc:
@@ -1091,26 +1042,6 @@ def _create_run_config_schema(
         config_type_dict_by_key=config_type_dict_by_key,
         config_mapping=mode_definition.config_mapping,
     )
-
-
-def swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):
-    """
-    Used to create the user facing experience of the default io_manager
-    switching to in-memory when using execute_in_process.
-    """
-    from dagster.core.storage.mem_io_manager import mem_io_manager
-    from .graph import default_job_io_manager
-
-    if (
-        # pylint: disable=comparison-with-callable
-        resources.get("io_manager") == default_job_io_manager
-        and job.version_strategy is None
-    ):
-        updated_resources = dict(resources)
-        updated_resources["io_manager"] = mem_io_manager
-        return updated_resources
-
-    return resources
 
 
 def _is_using_graph_job_op_apis(node_list: List[Node]):

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -598,7 +598,6 @@ def _get_pipeline_subset_def(
     Build a pipeline which is a subset of another pipeline.
     Only includes the solids which are in solids_to_execute.
     """
-    from .job import JobDefinition, JobSubsetDefinition
 
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.set_param(solids_to_execute, "solids_to_execute", of_type=str)
@@ -647,27 +646,15 @@ def _get_pipeline_subset_def(
                 )
 
     try:
-        if isinstance(pipeline_def, JobDefinition):
-            sub_pipeline_def: Union[
-                PipelineSubsetDefinition, JobSubsetDefinition
-            ] = JobSubsetDefinition(
-                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
-                mode_def=pipeline_def.mode_definitions[0],
-                _parent_pipeline_def=pipeline_def,
-                tags=pipeline_def.tags,
-                hook_defs=pipeline_def.hook_defs,
-                graph_def=pipeline_def.graph,
-            )
-        else:
-            sub_pipeline_def = PipelineSubsetDefinition(
-                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
-                solid_defs=list({solid.definition for solid in solids}),
-                mode_defs=pipeline_def.mode_definitions,
-                dependencies=deps,
-                _parent_pipeline_def=pipeline_def,
-                tags=pipeline_def.tags,
-                hook_defs=pipeline_def.hook_defs,
-            )
+        sub_pipeline_def = PipelineSubsetDefinition(
+            name=pipeline_def.name,  # should we change the name for subsetted pipeline?
+            solid_defs=list({solid.definition for solid in solids}),
+            mode_defs=pipeline_def.mode_definitions,
+            dependencies=deps,
+            _parent_pipeline_def=pipeline_def,
+            tags=pipeline_def.tags,
+            hook_defs=pipeline_def.hook_defs,
+        )
 
         return sub_pipeline_def
     except DagsterInvalidDefinitionError as exc:

--- a/python_modules/dagster/dagster/core/definitions/reconstructable.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstructable.py
@@ -105,11 +105,18 @@ class ReconstructablePipeline(
 
     @lru_cache(maxsize=1)
     def get_definition(self):
-        return (
-            self.repository.get_definition()
-            .get_pipeline(self.pipeline_name)
-            .get_pipeline_subset_def(self.solids_to_execute)
-        )
+        from dagster.core.definitions.job import JobDefinition
+
+        defn = self.repository.get_definition().get_pipeline(self.pipeline_name)
+
+        if isinstance(defn, JobDefinition):
+            return self.repository.get_definition().get_pipeline(self.pipeline_name)
+        else:
+            return (
+                self.repository.get_definition()
+                .get_pipeline(self.pipeline_name)
+                .get_pipeline_subset_def(self.solids_to_execute)
+            )
 
     def _resolve_solid_selection(self, solid_selection):
         # resolve a list of solid selection queries to a frozenset of qualified solid names


### PR DESCRIPTION
This diff adds a JobDefinition class to the core API. As a result, move `execute_in_process` off of pipeline, and onto the new job API.


Some trickiness ensues from Pipeline Subsetting. I don't like the fact that the implementation within PipelineDefinition is aware of the Pipeline/Job split here, and am leaning towards changing to having two separate implementations.

resolves https://github.com/dagster-io/dagster/issues/4704
