### PR TITLE
make instance available on RunStatusSensorContext

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
@@ -1,5 +1,4 @@
 from typing import Any, Callable, List, NamedTuple, Optional, Union, cast
-from dagster.core.instance import DagsterInstance
 
 import pendulum
 from dagster import check
@@ -11,6 +10,7 @@ from dagster.core.definitions.sensor import (
 )
 from dagster.core.errors import RunStatusSensorExecutionError, user_code_error_boundary
 from dagster.core.events import PIPELINE_RUN_STATUS_TO_EVENT_TYPE, DagsterEvent
+from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, PipelineRunsFilter
 from dagster.serdes import (
     deserialize_json_to_dagster_namedtuple,

--- a/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, List, NamedTuple, Optional, Union, cast
+from dagster.core.instance import DagsterInstance
 
 import pendulum
 from dagster import check
@@ -60,7 +61,12 @@ register_serdes_tuple_fallbacks({"PipelineSensorCursor": RunStatusSensorCursor})
 class RunStatusSensorContext(
     NamedTuple(
         "_RunStatusSensorContext",
-        [("sensor_name", str), ("pipeline_run", PipelineRun), ("dagster_event", DagsterEvent)],
+        [
+            ("sensor_name", str),
+            ("pipeline_run", PipelineRun),
+            ("dagster_event", DagsterEvent),
+            ("instance", DagsterInstance),
+        ],
     )
 ):
     """The ``context`` object available to a decorated function of ``run_status_sensor``.
@@ -69,15 +75,17 @@ class RunStatusSensorContext(
         sensor_name (str): the name of the sensor.
         pipeline_run (PipelineRun): the pipeline run.
         dagster_event (DagsterEvent): the event associated with the pipeline run status.
+        instance (DagsterInstance): the current instance.
     """
 
-    def __new__(cls, sensor_name, pipeline_run, dagster_event):
+    def __new__(cls, sensor_name, pipeline_run, dagster_event, instance):
 
         return super(RunStatusSensorContext, cls).__new__(
             cls,
             sensor_name=check.str_param(sensor_name, "sensor_name"),
             pipeline_run=check.inst_param(pipeline_run, "pipeline_run", PipelineRun),
             dagster_event=check.inst_param(dagster_event, "dagster_event", DagsterEvent),
+            instance=check.inst_param(instance, "instance", DagsterInstance),
         )
 
     def for_failure(self):
@@ -85,6 +93,7 @@ class RunStatusSensorContext(
             sensor_name=self.sensor_name,
             pipeline_run=self.pipeline_run,
             dagster_event=self.dagster_event,
+            instance=self.instance,
         )
 
 
@@ -276,6 +285,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                                 sensor_name=name,
                                 pipeline_run=pipeline_run,
                                 dagster_event=event_log_entry.dagster_event,
+                                instance=context.instance,
                             )
                         )
                 except RunStatusSensorExecutionError as run_status_sensor_execution_error:

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -6,6 +6,7 @@ import tempfile
 import threading
 import time
 from contextlib import contextmanager
+from dagster.core.instance import DagsterInstance
 
 import pendulum
 import pytest
@@ -198,13 +199,13 @@ def asset_job_sensor(context, _event):
 
 
 @pipeline_failure_sensor
-def my_pipeline_failure_sensor(_):
-    pass
+def my_pipeline_failure_sensor(context):
+    assert isinstance(context.instance, DagsterInstance)
 
 
 @run_status_sensor(pipeline_run_status=PipelineRunStatus.SUCCESS)
-def my_pipeline_success_sensor(_):
-    pass
+def my_pipeline_success_sensor(context):
+    assert isinstance(context.instance, DagsterInstance)
 
 
 @repository

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -6,7 +6,6 @@ import tempfile
 import threading
 import time
 from contextlib import contextmanager
-from dagster.core.instance import DagsterInstance
 
 import pendulum
 import pytest
@@ -35,6 +34,7 @@ from dagster.core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
 from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
+from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobState, JobStatus, JobTickStatus
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.test_utils import instance_for_test


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
resolves a user request for canceling runs inside run_status_sensor. we currently don't have a native way to do so. 

the recommended way will be to call `instance.run_coordinator.cancel_run()` in the body of run status sensor, so this PR makes `instance` available through the `RunStatusSensorContext` -- instance is available on `SensorEvaluationContext` so I think it's reasonable to expose it on run status sensor's too.

## Test Plan
bk

