### PR TITLE
Add missing asset metadata entry

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/event_metadata.py
+++ b/python_modules/dagster/dagster/core/definitions/event_metadata.py
@@ -64,6 +64,7 @@ def parse_metadata_entry(label: str, value: ParseableMetadataEntryData) -> "Even
             FloatMetadataEntryData,
             IntMetadataEntryData,
             PythonArtifactMetadataEntryData,
+            DagsterAssetMetadataEntryData
         ),
     ):
         return EventMetadataEntry(label, None, value)

--- a/python_modules/dagster/dagster/core/definitions/event_metadata.py
+++ b/python_modules/dagster/dagster/core/definitions/event_metadata.py
@@ -64,7 +64,7 @@ def parse_metadata_entry(label: str, value: ParseableMetadataEntryData) -> "Even
             FloatMetadataEntryData,
             IntMetadataEntryData,
             PythonArtifactMetadataEntryData,
-            DagsterAssetMetadataEntryData
+            DagsterAssetMetadataEntryData,
         ),
     ):
         return EventMetadataEntry(label, None, value)


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Fixed a bug where when using the `EventMetadata.asset` key in metadata for an AssetMaterialization would raise the following error:

```
dagster.core.errors.DagsterInvalidEventMetadata: Could not resolve the metadata value for "my_metadata_name" to a known type. Consider wrapping the value with the appropriate EventMetadata type.
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/execution/plan/execute_plan.py", line 193, in _dagster_event_sequence_for_step
    for step_event in check.generator(step_events):
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/execution/plan/execute_step.py", line 321, in core_dagster_event_sequence_for_step
    for user_event in check.generator(
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/execution/plan/execute_step.py", line 65, in _step_output_error_checked_user_event_sequence
    for user_event in user_event_sequence:
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/execution/plan/compute.py", line 138, in execute_core_compute
    for step_output in _yield_compute_results(step_context, inputs, compute_fn):
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/execution/plan/compute.py", line 111, in _yield_compute_results
    for event in iterate_with_context(
  File "/workspace/venv/lib/python3.9/site-packages/dagster/utils/__init__.py", line 383, in iterate_with_context
    next_output = next(iterator)
  File "/workspace/data/dags/pipelines/my_pipeline.py", line 174, in ingest_ae_attendance_df_to_rdv
    yield AssetMaterialization(
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/definitions/events.py", line 339, in __new__
    List[EventMetadataEntry], parse_metadata(metadata, metadata_entries)
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/definitions/event_metadata.py", line 112, in parse_metadata
    return [
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/definitions/event_metadata.py", line 113, in <listcomp>
    parse_metadata_entry(k, v)
  File "/workspace/venv/lib/python3.9/site-packages/dagster/core/definitions/event_metadata.py", line 91, in parse_metadata_entry
    raise DagsterInvalidEventMetadata(
```


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.