### PR TITLE
Fix EventMetadata parsing

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/event_metadata.py
+++ b/python_modules/dagster/dagster/core/definitions/event_metadata.py
@@ -18,6 +18,8 @@ ParseableMetadataEntryData = Union[
     "FloatMetadataEntryData",
     "IntMetadataEntryData",
     "PythonArtifactMetadataEntryData",
+    "DagsterAssetMetadataEntryData",
+    "DagsterPipelineRunMetadataEntryData",
     str,
     float,
     int,
@@ -64,6 +66,8 @@ def parse_metadata_entry(label: str, value: ParseableMetadataEntryData) -> "Even
             FloatMetadataEntryData,
             IntMetadataEntryData,
             PythonArtifactMetadataEntryData,
+            DagsterAssetMetadataEntryData,
+            DagsterPipelineRunMetadataEntryData,
         ),
     ):
         return EventMetadataEntry(label, None, value)


### PR DESCRIPTION
Parse `EventMetadata.asset` and `EventMetadata.piepline_run` correctly when they are passed in the `metadata` dict.
Fixes #4613

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.