### PR TITLE
Revert "chore(buildkite): make trigger step fail during development if triggered build fails"

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -21,25 +21,23 @@ def dagster():
     if not dagit_only:
         all_steps += dagster_steps()
 
-        # Trigger builds of the internal pipeline.
-        dagster_branch = os.getenv("BUILDKITE_BRANCH", "master")
-        dagster_commit_hash = os.getenv("BUILDKITE_COMMIT", "HEAD")
-        all_steps += [
-            trigger_step(
-                pipeline="internal",
-                async_step=dagster_branch == "master",
-                if_condition="build.creator.email =~ /elementl.com$$/",
-                env={
-                    "DAGSTER_BRANCH": dagster_branch,
-                    "DAGSTER_COMMIT_HASH": dagster_commit_hash,
-                },
-            ),
-        ]
-
         all_steps += [wait_step()]
 
         if DO_COVERAGE:
             all_steps += [coverage_step()]
+
+        # Trigger builds of the internal pipeline for builds on master
+        all_steps += [
+            trigger_step(
+                pipeline="internal",
+                async_step=True,
+                if_condition="build.branch=='master' && build.creator.email =~ /elementl.com$$/",
+                env={
+                    "DAGSTER_BRANCH": os.getenv("BUILDKITE_BRANCH"),
+                    "DAGSTER_COMMIT_HASH": os.getenv("BUILDKITE_COMMIT"),
+                },
+            ),
+        ]
 
     buildkite_yaml = buildkite_yaml_for_steps(all_steps)
     print(buildkite_yaml)  # pylint: disable=print-call


### PR DESCRIPTION
Reverts dagster-io/dagster#4544

While I think the eventual goal is still worth pursuing, this is creating a lot of noise in our internal builds and making it difficult to tell if internal is actually broken or not.

I'm going to revert this and explore other solutions to the problem.