### PR TITLE
Pin to avoid graphql-ws 0.4.0 breaking changes

### DIFF
--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             "flask>=0.12.4,<2.0.0",
             "gevent-websocket>=0.10.1",
             "gevent",
-            "graphql-ws>=0.3.0",
+            "graphql-ws>=0.3.0,<0.4.0",
             "requests",
             # watchdog
             "watchdog>=0.8.3",


### PR DESCRIPTION
https://github.com/graphql-python/graphql-ws

We're seeing: https://buildkite.com/dagster/dagster/builds/19049#f6af6072-1374-42d4-a1c4-6c2037dd5c6c

```
ImportError while importing test module '/workdir/python_modules/dagit/dagit_tests/test_app.py'.
--
  | Hint: make sure your test modules/packages have valid Python names.
  | Traceback:
  | /usr/local/lib/python3.6/importlib/__init__.py:126: in import_module
  | return _bootstrap._gcd_import(name[level:], package, level)
  | dagit_tests/test_app.py:7: in <module>
  | from dagit.app import create_app_from_workspace_process_context
  | dagit/app.py:23: in <module>
  | from .subscription_server import DagsterSubscriptionServer
  | dagit/subscription_server.py:4: in <module>
  | from graphql_ws.gevent import GeventSubscriptionServer, SubscriptionObserver
  | E   ImportError: cannot import name 'SubscriptionObserver'
```

Pinning for now - we should go through their upgrade instructions to remove this pin.