### PR TITLE
[dagit] Blocking dialog when repository reload fails

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
@@ -1,163 +1,48 @@
-import {gql, useApolloClient, useMutation} from '@apollo/client';
-import {Button, Icon, Intent} from '@blueprintjs/core';
-import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 
-import {SharedToaster} from '../app/DomUtils';
-import {useInvalidateConfigsForRepo} from '../app/LocalStorage';
-import {ShortcutHandler} from '../app/ShortcutHandler';
-import {Spinner} from '../ui/Spinner';
+import {RepositoryLocationErrorDialog} from '../workspace/RepositoryLocationErrorDialog';
 
-import {
-  ReloadRepositoryLocationMutation,
-  ReloadRepositoryLocationMutationVariables,
-} from './types/ReloadRepositoryLocationMutation';
+import {useRepositoryLocationReload} from './useRepositoryLocationReload';
 
-type ReloadResult = {type: 'success'} | {type: 'error'; message: string} | {type: 'loading'};
-type OnReload = (location: string, result: ReloadResult) => void;
-
-export const useRepositoryLocationReload = (location: string, onReload: OnReload = () => {}) => {
-  const apollo = useApolloClient();
-  const [reload] = useMutation<
-    ReloadRepositoryLocationMutation,
-    ReloadRepositoryLocationMutationVariables
-  >(RELOAD_REPOSITORY_LOCATION_MUTATION, {
-    variables: {location},
-  });
-  const [reloading, setReloading] = React.useState(false);
-  const invalidateConfigs = useInvalidateConfigsForRepo();
-
-  const onClick = async (e: React.MouseEvent | KeyboardEvent) => {
-    e.stopPropagation();
-
-    setReloading(true);
-    const {data} = await reload();
-    setReloading(false);
-
-    let loadFailure = null;
-    let loadStatus = null;
-    switch (data?.reloadRepositoryLocation.__typename) {
-      case 'WorkspaceLocationEntry':
-        loadStatus = data?.reloadRepositoryLocation.loadStatus;
-        if (data?.reloadRepositoryLocation.locationOrLoadError?.__typename === 'PythonError') {
-          loadFailure = data?.reloadRepositoryLocation.locationOrLoadError.message;
-        }
-        break;
-      default:
-        loadFailure = data?.reloadRepositoryLocation.message;
-        break;
-    }
-
-    if (loadStatus === 'LOADING') {
-      onReload(location, {type: 'loading'});
-    } else if (loadFailure) {
-      SharedToaster.show({
-        message: 'Repository Location Reloaded with Errors',
-        timeout: 3000,
-        icon: 'refresh',
-        intent: Intent.DANGER,
-      });
-      onReload(location, {type: 'error', message: loadFailure});
-    } else {
-      SharedToaster.show({
-        message: 'Repository Location Reloaded',
-        timeout: 3000,
-        icon: 'refresh',
-        intent: Intent.SUCCESS,
-      });
-      onReload(location, {type: 'success'});
-    }
-
-    // Update run config localStorage, which may now be out of date.
-    const repositories =
-      data?.reloadRepositoryLocation.__typename === 'WorkspaceLocationEntry' &&
-      data.reloadRepositoryLocation.locationOrLoadError?.__typename === 'RepositoryLocation'
-        ? data.reloadRepositoryLocation.locationOrLoadError.repositories
-        : [];
-
-    invalidateConfigs(repositories);
-
-    // clears and re-fetches all the queries bound to the UI
-    apollo.resetStore();
-  };
-
-  return {reloading, onClick};
+type ChildProps = {
+  tryReload: () => void;
+  reloading: boolean;
 };
 
 interface Props {
-  locations: string[];
+  children: (childProps: ChildProps) => React.ReactNode;
+  location: string;
 }
 
 export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
-  const {locations} = props;
+  const {children, location} = props;
+  const [shown, setShown] = React.useState(false);
 
-  // todo dish: Allow reloading multiple!
-  const {reloading, onClick} = useRepositoryLocationReload(locations[0]);
+  const {reloading, error, tryReload} = useRepositoryLocationReload(location);
 
-  if (!locations.length) {
-    return null;
-  }
+  React.useEffect(() => {
+    if (error) {
+      setShown(true);
+    }
+  }, [error]);
 
   return (
-    <ShortcutHandler
-      onShortcut={onClick}
-      shortcutLabel={`⌥R`}
-      shortcutFilter={(e) => e.keyCode === 82 && e.altKey}
-    >
-      <Tooltip
-        className="bp3-dark"
-        hoverOpenDelay={500}
-        hoverCloseDelay={0}
-        content={'Reload metadata from this repository location.'}
-      >
-        <Button
-          icon={reloading ? <Spinner purpose="body-text" /> : <Icon icon="refresh" iconSize={12} />}
-          disabled={reloading}
-          onClick={onClick}
-        />
-      </Tooltip>
-    </ShortcutHandler>
+    <>
+      {children({tryReload, reloading})}
+      <RepositoryLocationErrorDialog
+        location={location}
+        isOpen={shown}
+        error={error}
+        reloading={reloading}
+        onTryReload={tryReload}
+        onDismiss={() => {
+          // On dismiss, redirect to the Workspace view so that the location error
+          // is presented to the user, and so that if the user was previously viewing
+          // an object in a failed repo location, they aren't staring at a blank page.
+          setShown(false);
+          window.location.href = '/workspace';
+        }}
+      />
+    </>
   );
 };
-
-const RELOAD_REPOSITORY_LOCATION_MUTATION = gql`
-  mutation ReloadRepositoryLocationMutation($location: String!) {
-    reloadRepositoryLocation(repositoryLocationName: $location) {
-      __typename
-      ... on WorkspaceLocationEntry {
-        id
-        name
-        loadStatus
-        locationOrLoadError {
-          __typename
-          ... on RepositoryLocation {
-            id
-            repositories {
-              id
-              name
-              pipelines {
-                id
-                name
-              }
-            }
-          }
-          ... on PythonError {
-            message
-          }
-        }
-      }
-      ... on UnauthorizedError {
-        message
-      }
-      ... on ReloadNotSupported {
-        message
-      }
-      ... on RepositoryLocationNotFound {
-        message
-      }
-      ... on PythonError {
-        message
-      }
-    }
-  }
-`;

--- a/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
@@ -14,7 +14,7 @@ import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {useRepositoryLocationReload} from './ReloadRepositoryLocationButton';
+import {ReloadRepositoryLocationButton} from './ReloadRepositoryLocationButton';
 import {RepoDetails, RepoSelector} from './RepoSelector';
 
 interface Props {
@@ -98,7 +98,6 @@ export const RepoNavItem: React.FC<Props> = (props) => {
 
 const SingleRepoSummary: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {
   const {canReloadRepositoryLocation} = usePermissions();
-  const {reloading, onClick} = useRepositoryLocationReload(repoAddress.location);
   return (
     <Group direction="row" spacing={8} alignItems="center">
       <SingleRepoNameLink
@@ -108,36 +107,40 @@ const SingleRepoSummary: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
         {repoAddress.name}
       </SingleRepoNameLink>
       {canReloadRepositoryLocation ? (
-        <ShortcutHandler
-          onShortcut={onClick}
-          shortcutLabel={`⌥R`}
-          shortcutFilter={(e) => e.code === 'KeyR' && e.altKey}
-        >
-          <Tooltip
-            inheritDarkTheme={false}
-            content={
-              <Reloading>
+        <ReloadRepositoryLocationButton location={repoAddress.location}>
+          {({tryReload, reloading}) => (
+            <ShortcutHandler
+              onShortcut={tryReload}
+              shortcutLabel={`⌥R`}
+              shortcutFilter={(e) => e.code === 'KeyR' && e.altKey}
+            >
+              <Tooltip
+                inheritDarkTheme={false}
+                content={
+                  <Reloading>
+                    {reloading ? (
+                      'Reloading…'
+                    ) : (
+                      <>
+                        Reload location <strong>{repoAddress.location}</strong>
+                      </>
+                    )}
+                  </Reloading>
+                }
+              >
                 {reloading ? (
-                  'Reloading…'
+                  <span style={{position: 'relative', top: '1px'}}>
+                    <Spinner purpose="body-text" />
+                  </span>
                 ) : (
-                  <>
-                    Reload location <strong>{repoAddress.location}</strong>
-                  </>
+                  <StyledButton onClick={tryReload}>
+                    <Icon icon="refresh" iconSize={11} color={Colors.GRAY4} />
+                  </StyledButton>
                 )}
-              </Reloading>
-            }
-          >
-            {reloading ? (
-              <span style={{position: 'relative', top: '1px'}}>
-                <Spinner purpose="body-text" />
-              </span>
-            ) : (
-              <StyledButton onClick={onClick}>
-                <Icon icon="refresh" iconSize={11} color={Colors.GRAY4} />
-              </StyledButton>
-            )}
-          </Tooltip>
-        </ShortcutHandler>
+              </Tooltip>
+            </ShortcutHandler>
+          )}
+        </ReloadRepositoryLocationButton>
       ) : null}
     </Group>
   );

--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -12,7 +12,7 @@ import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {useRepositoryLocationReload} from './ReloadRepositoryLocationButton';
+import {ReloadRepositoryLocationButton} from './ReloadRepositoryLocationButton';
 
 export type RepoDetails = {
   repoAddress: RepoAddress;
@@ -119,20 +119,23 @@ const BrowseLink = styled(Link)`
 `;
 
 const ReloadButton: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {
-  const {reloading, onClick} = useRepositoryLocationReload(repoAddress.location);
   return (
-    <ReloadButtonInner onClick={onClick}>
-      {reloading ? (
-        <Spinner purpose="body-text" />
-      ) : (
-        <Icon
-          icon="refresh"
-          iconSize={11}
-          color={Colors.GRAY5}
-          style={{position: 'relative', top: '-4px'}}
-        />
+    <ReloadRepositoryLocationButton location={repoAddress.location}>
+      {({tryReload, reloading}) => (
+        <ReloadButtonInner onClick={tryReload}>
+          {reloading ? (
+            <Spinner purpose="body-text" />
+          ) : (
+            <Icon
+              icon="refresh"
+              iconSize={11}
+              color={Colors.GRAY5}
+              style={{position: 'relative', top: '-4px'}}
+            />
+          )}
+        </ReloadButtonInner>
       )}
-    </ReloadButtonInner>
+    </ReloadRepositoryLocationButton>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -12,11 +12,10 @@ import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {useRepositoryLocationReload} from './ReloadRepositoryLocationButton';
+import {ReloadRepositoryLocationButton} from './ReloadRepositoryLocationButton';
 
 export const RepositoryLink: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {
   const {location} = repoAddress;
-  const {reloading, onClick} = useRepositoryLocationReload(repoAddress.location);
   const {canReloadRepositoryLocation} = usePermissions();
 
   return (
@@ -28,31 +27,35 @@ export const RepositoryLink: React.FC<{repoAddress: RepoAddress}> = ({repoAddres
         {repoAddressAsString(repoAddress)}
       </RepositoryName>
       {canReloadRepositoryLocation ? (
-        <ShortcutHandler
-          onShortcut={onClick}
-          shortcutLabel={`⌥R`}
-          shortcutFilter={(e) => e.code === 'KeyR' && e.altKey}
-        >
-          <ReloadTooltip
-            content={
-              reloading ? (
-                'Reloading…'
-              ) : (
-                <>
-                  Reload location <strong>{location}</strong>
-                </>
-              )
-            }
-          >
-            {reloading ? (
-              <Spinner purpose="body-text" />
-            ) : (
-              <StyledButton onClick={onClick}>
-                <Icon icon="refresh" iconSize={11} color={Colors.GRAY2} />
-              </StyledButton>
-            )}
-          </ReloadTooltip>
-        </ShortcutHandler>
+        <ReloadRepositoryLocationButton location={location}>
+          {({tryReload, reloading}) => (
+            <ShortcutHandler
+              onShortcut={tryReload}
+              shortcutLabel={`⌥R`}
+              shortcutFilter={(e) => e.code === 'KeyR' && e.altKey}
+            >
+              <ReloadTooltip
+                content={
+                  reloading ? (
+                    'Reloading…'
+                  ) : (
+                    <>
+                      Reload location <strong>{location}</strong>
+                    </>
+                  )
+                }
+              >
+                {reloading ? (
+                  <Spinner purpose="body-text" />
+                ) : (
+                  <StyledButton onClick={tryReload}>
+                    <Icon icon="refresh" iconSize={11} color={Colors.GRAY2} />
+                  </StyledButton>
+                )}
+              </ReloadTooltip>
+            </ShortcutHandler>
+          )}
+        </ReloadRepositoryLocationButton>
       ) : null}
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/nav/RepositoryPicker.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryPicker.tsx
@@ -1,8 +1,10 @@
-import {Colors, Icon, Menu, MenuItem, Popover} from '@blueprintjs/core';
+import {Button, Colors, Icon, Menu, MenuItem, Popover} from '@blueprintjs/core';
+import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {ShortcutHandler} from '../app/ShortcutHandler';
 import {Box} from '../ui/Box';
 import {Spinner} from '../ui/Spinner';
 import {RepositoryInformation} from '../workspace/RepositoryInformation';
@@ -92,10 +94,39 @@ export const RepositoryPicker: React.FC<RepositoryPickerProps> = (props) => {
           <RepoTitle>{titleContents()}</RepoTitle>
         </div>
         <ReloadRepositoryLocationButton
-          locations={selected
-            .filter((option) => option.repositoryLocation.isReloadSupported)
-            .map((option) => option.repositoryLocation.name)}
-        />
+          location={
+            selected
+              .filter((option) => option.repositoryLocation.isReloadSupported)
+              .map((option) => option.repositoryLocation.name)[0]
+          }
+        >
+          {({tryReload, reloading}) => (
+            <ShortcutHandler
+              onShortcut={tryReload}
+              shortcutLabel={`⌥R`}
+              shortcutFilter={(e) => e.keyCode === 82 && e.altKey}
+            >
+              <Tooltip
+                className="bp3-dark"
+                hoverOpenDelay={500}
+                hoverCloseDelay={0}
+                content="Reload metadata from this repository location."
+              >
+                <Button
+                  icon={
+                    reloading ? (
+                      <Spinner purpose="body-text" />
+                    ) : (
+                      <Icon icon="refresh" iconSize={12} />
+                    )
+                  }
+                  disabled={reloading}
+                  onClick={tryReload}
+                />
+              </Tooltip>
+            </ShortcutHandler>
+          )}
+        </ReloadRepositoryLocationButton>
       </Container>
     </Popover>
   );

--- a/js_modules/dagit/packages/core/src/nav/types/ReloadRepositoryLocationMutation.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/ReloadRepositoryLocationMutation.ts
@@ -29,9 +29,17 @@ export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_Works
   repositories: ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation_repositories[];
 }
 
+export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
 export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError {
   __typename: "PythonError";
   message: string;
+  stack: string[];
+  cause: ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError_cause | null;
 }
 
 export type ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError = ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation | ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError;

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -1,0 +1,148 @@
+import {gql, useApolloClient, useMutation} from '@apollo/client';
+import {Intent} from '@blueprintjs/core';
+import * as React from 'react';
+
+import {SharedToaster} from '../app/DomUtils';
+import {useInvalidateConfigsForRepo} from '../app/LocalStorage';
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
+
+import {
+  ReloadRepositoryLocationMutation,
+  ReloadRepositoryLocationMutationVariables,
+} from './types/ReloadRepositoryLocationMutation';
+
+type State = {
+  reloading: boolean;
+  error: PythonErrorFragment | {message: string} | null;
+};
+
+type Action =
+  | {type: 'start-reloading'}
+  | {type: 'finish-reloading'}
+  | {type: 'error'; error: PythonErrorFragment | {message: string} | null}
+  | {type: 'success'};
+
+const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'start-reloading':
+      return {...state, reloading: true};
+    case 'finish-reloading':
+      return {...state, reloading: false};
+    case 'error':
+      return {...state, error: action.error};
+    case 'success':
+      return {...state, error: null};
+    default:
+      return state;
+  }
+};
+
+const initialState: State = {
+  reloading: false,
+  error: null,
+};
+
+export const useRepositoryLocationReload = (location: string) => {
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const apollo = useApolloClient();
+  const [reload] = useMutation<
+    ReloadRepositoryLocationMutation,
+    ReloadRepositoryLocationMutationVariables
+  >(RELOAD_REPOSITORY_LOCATION_MUTATION, {
+    variables: {location},
+    fetchPolicy: 'no-cache',
+  });
+
+  const invalidateConfigs = useInvalidateConfigsForRepo();
+
+  const tryReload = React.useCallback(async () => {
+    dispatch({type: 'start-reloading'});
+    const {data} = await reload();
+    dispatch({type: 'finish-reloading'});
+
+    let loadFailure = null;
+    if (data?.reloadRepositoryLocation.__typename === 'WorkspaceLocationEntry') {
+      if (data?.reloadRepositoryLocation.locationOrLoadError?.__typename === 'PythonError') {
+        loadFailure = data?.reloadRepositoryLocation.locationOrLoadError;
+      }
+    } else {
+      loadFailure = data?.reloadRepositoryLocation.message
+        ? {message: data?.reloadRepositoryLocation.message}
+        : null;
+    }
+
+    // On failure, immediately show the error dialog. This is a blocking failure that must be
+    // either retried after repairing the issue or dismissed manually.
+    if (loadFailure) {
+      dispatch({type: 'error', error: loadFailure});
+      return;
+    }
+
+    // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
+    SharedToaster.show({
+      message: 'Repository location reloaded',
+      timeout: 3000,
+      icon: 'refresh',
+      intent: Intent.SUCCESS,
+    });
+    dispatch({type: 'success'});
+
+    // Update run config localStorage, which may now be out of date.
+    const repositories =
+      data?.reloadRepositoryLocation.__typename === 'WorkspaceLocationEntry' &&
+      data.reloadRepositoryLocation.locationOrLoadError?.__typename === 'RepositoryLocation'
+        ? data.reloadRepositoryLocation.locationOrLoadError.repositories
+        : [];
+
+    invalidateConfigs(repositories);
+
+    // Clear and refetch all the queries bound to the UI.
+    apollo.resetStore();
+  }, [apollo, invalidateConfigs, reload]);
+
+  const {reloading, error} = state;
+
+  return React.useMemo(() => ({reloading, error, tryReload}), [reloading, error, tryReload]);
+};
+
+const RELOAD_REPOSITORY_LOCATION_MUTATION = gql`
+  mutation ReloadRepositoryLocationMutation($location: String!) {
+    reloadRepositoryLocation(repositoryLocationName: $location) {
+      __typename
+      ... on WorkspaceLocationEntry {
+        id
+        name
+        loadStatus
+        locationOrLoadError {
+          __typename
+          ... on RepositoryLocation {
+            id
+            repositories {
+              id
+              name
+              pipelines {
+                id
+                name
+              }
+            }
+          }
+          ...PythonErrorFragment
+        }
+      }
+      ... on UnauthorizedError {
+        message
+      }
+      ... on ReloadNotSupported {
+        message
+      }
+      ... on RepositoryLocationNotFound {
+        message
+      }
+      ... on PythonError {
+        message
+      }
+    }
+  }
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationErrorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationErrorDialog.tsx
@@ -1,0 +1,68 @@
+import {Button, Classes, Dialog} from '@blueprintjs/core';
+import * as React from 'react';
+
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
+import {Box} from '../ui/Box';
+
+interface Props {
+  location: string;
+  isOpen: boolean;
+  error: PythonErrorFragment | {message: string} | null;
+  reloading: boolean;
+  onDismiss: () => void;
+  onTryReload: () => void;
+}
+
+export const RepositoryLocationErrorDialog: React.FC<Props> = (props) => {
+  const {isOpen, error, location, reloading, onTryReload, onDismiss} = props;
+  return (
+    <Dialog
+      isOpen={isOpen}
+      title="Repository location error"
+      canEscapeKeyClose={false}
+      canOutsideClickClose={false}
+      style={{width: '90%'}}
+    >
+      <ErrorContents location={location} error={error} />
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button onClick={onTryReload} loading={reloading} intent="primary">
+            Reload again
+          </Button>
+          <Button onClick={onDismiss}>Dismiss</Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export const RepositoryLocationNonBlockingErrorDialog: React.FC<Props> = (props) => {
+  const {isOpen, error, location, reloading, onTryReload, onDismiss} = props;
+  return (
+    <Dialog isOpen={isOpen} title="Repository location error" style={{width: '90%'}}>
+      <ErrorContents location={location} error={error} />
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button onClick={onTryReload} loading={reloading} intent="primary">
+            Reload
+          </Button>
+          <Button onClick={onDismiss}>Close</Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+const ErrorContents: React.FC<{
+  location: string;
+  error: PythonErrorFragment | {message: string} | null;
+}> = ({location, error}) => (
+  <div className={Classes.DIALOG_BODY}>
+    <Box margin={{bottom: 12}}>
+      Error loading <strong>{location}</strong>. Try reloading the repository location after
+      resolving the issue.
+    </Box>
+    {error ? <PythonErrorInfo error={error} /> : null}
+  </div>
+);


### PR DESCRIPTION
## Summary

When a failure occurs while reloading a repository location in Dagit, show a blocking dialog with the relevant error.

Right now, when a failure occurs, we dump the Apolllo cache, show a red toast, and that's it. You have to go find the error, and if you're currently viewing a page for a job/schedule/etc. in the failed location, you'll just end up on a blank 404-like page since the object you were viewing has now been unloaded from the app.

The blocking dialog is a bit aggressive, but it means that you have to either fix the issue right away or get redirected to a place that makes more sense than the 404.

On the Workspace page, you can still click "View error" and the dialog is non-blocking, but it now gives you a button to try reloading the location again.

Open to further feedback on this, since it's a pretty significant change to the location failure workflow.

## Test Plan

View Dagit with toys repo loaded. Introduce an error, click "reload" button in several different places (Workspace page, left nav, job header) and verify that the error dialog appears and must be resolved.

Fix the error, click reload. Verify that reload occurs successfully. Repeat the above, click dismiss. Verify redirect to `/workspace`.