### PR TITLE
Fix bug with nothing-input op invocation

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_invocation.py
@@ -108,6 +108,15 @@ def _resolve_inputs(
             kwargs[input_def.name] if input_def.name in kwargs else input_def.default_value
         )
 
+    input_defs_by_name = {input_def.name: input_def for input_def in input_defs}
+    # Now that we are sure that Nothing inputs have been provided, remove them before they are
+    # provided to the invocation.
+    input_dict = {
+        name: input_val
+        for name, input_val in input_dict.items()
+        if not input_defs_by_name[name].dagster_type.is_nothing
+    }
+
     # Type check inputs
     input_defs_by_name = {input_def.name: input_def for input_def in input_defs}
     for input_name, val in input_dict.items():

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -82,6 +82,17 @@ def test_solid_invocation_none_arg():
     assert result == 5
 
 
+def test_solid_invocation_out_of_order_input_defs():
+    @solid(input_defs=[InputDefinition("x"), InputDefinition("y")])
+    def check_correct_order(y, x):
+        assert y == 6
+        assert x == 5
+
+    check_correct_order(6, 5)
+    check_correct_order(x=5, y=6)
+    check_correct_order(6, x=5)
+
+
 def test_solid_invocation_with_resources():
     @solid(required_resource_keys={"foo"})
     def solid_requires_resources(context):

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -9,6 +9,7 @@ from dagster import (
     Field,
     InputDefinition,
     Noneable,
+    Nothing,
     Output,
     OutputDefinition,
     RetryRequested,
@@ -693,3 +694,18 @@ def test_coroutine_asyncio_invocation():
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(my_coroutine_test())
+
+
+def test_solid_invocation_nothing_deps():
+    @solid(input_defs=[InputDefinition("start", Nothing)])
+    def install_deps():
+        return 5
+
+    # Ensure that providing the Nothing-dependency input works
+    assert install_deps(start="blah") == 5
+
+    # Ensure that if not provided, Dagster throws that input is expected.
+    with pytest.raises(
+        DagsterInvalidInvocationError, match='No value provided for required input "start"'
+    ):
+        install_deps()

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -704,8 +704,5 @@ def test_solid_invocation_nothing_deps():
     # Ensure that providing the Nothing-dependency input works
     assert install_deps(start="blah") == 5
 
-    # Ensure that if not provided, Dagster throws that input is expected.
-    with pytest.raises(
-        DagsterInvalidInvocationError, match='No value provided for required input "start"'
-    ):
-        install_deps()
+    # Ensure that not providing nothing dependency also works.
+    install_deps()


### PR DESCRIPTION
## Summary
Previously, nothing-inputs were not under test with op/solid invocation. This PR defines the invocation behavior with nothing inputs to be: A nothing input is expected to be provided, just as it would be when invoked under composition, but it is ignored during the actual invocation.




## Test Plan
Added a test ensuring this functionality.