### PR TITLE
feat(helm): allow labels to be configured for user code deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "dagster.selectorLabels" $ | nindent 8 }}
         component: user-deployments
         deployment: {{ $deployment.name }}
+        {{- with $deployment.labels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/dagster-user-deployment: {{ $deployment | toJson | sha256sum }}
         {{- with $deployment.annotations }}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -227,6 +227,13 @@
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"
+                },
+                "labels": {
+                    "title": "Labels",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -79,6 +79,7 @@ deployments:
     securityContext: {}
     resources: {}
     replicaCount: 1
+    labels: {}
     # Liveness Probe and Startup Probe are optional. For more configuration docs, see:
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
     # Note that Startup Probe is only available as a kubernetes v1.16+ feature.

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -23,6 +23,7 @@ class UserDeployment(BaseModel):
     resources: Optional[kubernetes.Resources]
     livenessProbe: Optional[kubernetes.LivenessProbe]
     startupProbe: Optional[kubernetes.StartupProbe]
+    labels: Optional[Dict[str, str]]
 
 
 class UserDeployments(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -49,13 +49,18 @@ def assert_user_deployment_template(
 
     for template, deployment_values in zip(templates, values.dagsterUserDeployments.deployments):
         # Assert simple stuff
-        assert template.metadata.labels["deployment"] == deployment_values.name
         assert len(template.spec.template.spec.containers) == 1
         assert template.spec.template.spec.containers[0].image == deployment_values.image.name
         assert (
             template.spec.template.spec.containers[0].image_pull_policy
             == deployment_values.image.pullPolicy
         )
+
+        # Assert labels
+        assert template.spec.template.metadata.labels["deployment"] == deployment_values.name
+        if deployment_values.labels:
+            pod_spec_labels = template.spec.template.metadata.labels
+            assert set(deployment_values.labels.items()).issubset(pod_spec_labels.items())
 
         # Assert annotations
         if deployment_values.annotations:

--- a/helm/dagster/schema/schema_tests/utils.py
+++ b/helm/dagster/schema/schema_tests/utils.py
@@ -57,4 +57,8 @@ def create_complex_user_deployment(name: str) -> UserDeployment:
                 "limits": {"memory": "128Mi", "cpu": "500m"},
             }
         ),
+        labels={
+            "label_one": "one",
+            "label_two": "two",
+        },
     )

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -417,6 +417,13 @@
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"
+                },
+                "labels": {
+                    "title": "Labels",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Allow labels to be configured on the pod spec template of the user code deployment.


## Test Plan
pytest
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


