### PR TITLE
[dagit] Collapsible run panel sections

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -73,7 +73,7 @@ export const GanttStatusPanel: React.FunctionComponent<GanttStatusPanelProps> = 
   return (
     <div style={{overflowY: 'auto'}}>
       <RunGroupPanel runId={runId} />
-      <SidebarSection title={isFinished ? 'Not Executed' : 'Preparing'}>
+      <SidebarSection title={`${isFinished ? 'Not Executed' : 'Preparing'} (${preparing.length})`}>
         <div>
           {preparing.length === 0 ? (
             <EmptyNotice>No steps are waiting to execute</EmptyNotice>
@@ -82,7 +82,7 @@ export const GanttStatusPanel: React.FunctionComponent<GanttStatusPanelProps> = 
           )}
         </div>
       </SidebarSection>
-      <SidebarSection title="Executing">
+      <SidebarSection title={`Executing (${executing.length})`}>
         <div>
           {executing.length === 0 ? (
             <EmptyNotice>No steps are executing</EmptyNotice>
@@ -91,7 +91,7 @@ export const GanttStatusPanel: React.FunctionComponent<GanttStatusPanelProps> = 
           )}
         </div>
       </SidebarSection>
-      <SidebarSection title="Errored">
+      <SidebarSection title={`Errored (${errored.length})`}>
         <div>
           {errored.length === 0 ? (
             <EmptyNotice>No steps have errored</EmptyNotice>

--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {formatElapsedTime} from '../app/Util';
+import {SidebarSection} from '../pipelines/SidebarComponents';
 import {IRunMetadataDict, IStepState} from '../runs/RunMetadataProvider';
 import {StepSelection} from '../runs/StepSelection';
 import {Spinner} from '../ui/Spinner';
@@ -32,15 +33,28 @@ export const GanttStatusPanel: React.FunctionComponent<GanttStatusPanelProps> = 
   onDoubleClickStep,
   onHighlightStep,
 }) => {
-  const preparing = Object.keys(metadata.steps).filter(
-    (key) => metadata.steps[key].state === IStepState.PREPARING,
-  );
-  const executing = Object.keys(metadata.steps).filter((key) =>
-    [IStepState.RUNNING, IStepState.UNKNOWN].includes(metadata.steps[key].state),
-  );
-  const errored = Object.keys(metadata.steps).filter(
-    (key) => metadata.steps[key].state === IStepState.FAILED,
-  );
+  const {preparing, executing, errored} = React.useMemo(() => {
+    const keys = Object.keys(metadata.steps);
+    const preparing = [];
+    const executing = [];
+    const errored = [];
+    for (const key of keys) {
+      const state = metadata.steps[key].state;
+      switch (state) {
+        case IStepState.PREPARING:
+          preparing.push(key);
+          break;
+        case IStepState.RUNNING:
+        case IStepState.UNKNOWN:
+          executing.push(key);
+          break;
+        case IStepState.FAILED:
+          errored.push(key);
+      }
+    }
+    return {preparing, executing, errored};
+  }, [metadata]);
+
   const renderStepItem = (stepName: string) => (
     <StepItem
       nowMs={nowMs}
@@ -53,18 +67,39 @@ export const GanttStatusPanel: React.FunctionComponent<GanttStatusPanelProps> = 
       onHover={onHighlightStep}
     />
   );
+
   const isFinished = metadata?.exitedAt && metadata.exitedAt > 0;
+
   return (
-    <div style={{display: 'flex', flexDirection: 'column', minHeight: 0, overflowY: 'auto'}}>
+    <div style={{overflowY: 'auto'}}>
       <RunGroupPanel runId={runId} />
-      <SectionHeader>{isFinished ? 'Not Executed' : 'Preparing'}</SectionHeader>
-      <Section>{preparing.map(renderStepItem)}</Section>
-      {preparing.length === 0 && <EmptyNotice>No steps are waiting to execute</EmptyNotice>}
-      <SectionHeader>Executing</SectionHeader>
-      <Section>{executing.map(renderStepItem)}</Section>
-      {executing.length === 0 && <EmptyNotice>No steps are executing</EmptyNotice>}
-      <SectionHeader>Errored</SectionHeader>
-      <Section>{errored.map(renderStepItem)}</Section>
+      <SidebarSection title={isFinished ? 'Not Executed' : 'Preparing'}>
+        <div>
+          {preparing.length === 0 ? (
+            <EmptyNotice>No steps are waiting to execute</EmptyNotice>
+          ) : (
+            preparing.map(renderStepItem)
+          )}
+        </div>
+      </SidebarSection>
+      <SidebarSection title="Executing">
+        <div>
+          {executing.length === 0 ? (
+            <EmptyNotice>No steps are executing</EmptyNotice>
+          ) : (
+            executing.map(renderStepItem)
+          )}
+        </div>
+      </SidebarSection>
+      <SidebarSection title="Errored">
+        <div>
+          {errored.length === 0 ? (
+            <EmptyNotice>No steps have errored</EmptyNotice>
+          ) : (
+            errored.map(renderStepItem)
+          )}
+        </div>
+      </SidebarSection>
     </div>
   );
 };
@@ -121,20 +156,6 @@ const StepItem: React.FunctionComponent<{
   );
 };
 
-const SectionHeader = styled.div`
-  font-size: 11px;
-  padding: 3px 6px;
-  text-transform: uppercase;
-  background: ${Colors.LIGHT_GRAY4};
-  border-bottom: 1px solid ${Colors.LIGHT_GRAY1};
-  color: ${Colors.GRAY3};
-  height: 20px;
-`;
-
-const Section = styled.div`
-  overflow-y: auto;
-`;
-
 const StepLabel = styled.div`
   margin-left: 5px;
   overflow: hidden;
@@ -170,6 +191,6 @@ const Elapsed = styled.div`
 `;
 
 const EmptyNotice = styled.div`
-  padding: 7px 24px;
-  font-size: 13px;
+  font-size: 12px;
+  padding: 12px;
 `;

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -5,6 +5,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
+import {SidebarSection} from '../pipelines/SidebarComponents';
 import {RunStatus} from '../runs/RunStatusDots';
 import {DagsterTag} from '../runs/RunTag';
 import {RunElapsed, RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
@@ -65,47 +66,52 @@ export const RunGroupPanel: React.FC<{runId: string}> = ({runId}) => {
   const runs = (group.runs || []).filter((g) => g !== null);
 
   return (
-    <RunGroupContainer>
-      {runs[0] && <RunGroupHeader>{runs[0].pipelineName}</RunGroupHeader>}
-      {runs.map((g, idx) =>
-        g ? (
-          <RunGroupRun key={g.runId} to={`/instance/runs/${g.runId}`} selected={g.runId === runId}>
-            {idx < runs.length - 1 && <ThinLine style={{height: 36}} />}
-            <Box padding={{top: 4}}>
-              <RunStatus status={g.status} />
-            </Box>
-
-            <div
-              style={{
-                flex: 1,
-                marginLeft: 5,
-                minWidth: 0,
-                color: Colors.DARK_GRAY5,
-              }}
+    <SidebarSection title={runs[0] ? runs[0].pipelineName : ''}>
+      <>
+        {runs.map((g, idx) =>
+          g ? (
+            <RunGroupRun
+              key={g.runId}
+              to={`/instance/runs/${g.runId}`}
+              selected={g.runId === runId}
             >
-              <div style={{display: 'flex', justifyContent: 'space-between'}}>
-                <RunTitle>
-                  {g.runId.split('-')[0]}
-                  {idx === 0 && RootTag}
-                </RunTitle>
-                <RunTime run={g} />
-              </div>
+              {idx < runs.length - 1 && <ThinLine style={{height: 36}} />}
+              <Box padding={{top: 4}}>
+                <RunStatus status={g.status} />
+              </Box>
 
               <div
                 style={{
-                  display: 'flex',
+                  flex: 1,
+                  marginLeft: 5,
+                  minWidth: 0,
                   color: Colors.DARK_GRAY5,
-                  justifyContent: 'space-between',
                 }}
               >
-                {subsetTitleForRun(g)}
-                <RunElapsed run={g} />
+                <div style={{display: 'flex', justifyContent: 'space-between'}}>
+                  <RunTitle>
+                    {g.runId.split('-')[0]}
+                    {idx === 0 && RootTag}
+                  </RunTitle>
+                  <RunTime run={g} />
+                </div>
+
+                <div
+                  style={{
+                    display: 'flex',
+                    color: Colors.DARK_GRAY5,
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  {subsetTitleForRun(g)}
+                  <RunElapsed run={g} />
+                </div>
               </div>
-            </div>
-          </RunGroupRun>
-        ) : null,
-      )}
-    </RunGroupContainer>
+            </RunGroupRun>
+          ) : null,
+        )}
+      </>
+    </SidebarSection>
   );
 };
 
@@ -135,11 +141,6 @@ const RUN_GROUP_PANEL_QUERY = gql`
     }
   }
   ${RUN_TIME_FRAGMENT}
-`;
-
-const RunGroupContainer = styled.div`
-  border-bottom: 2px solid ${Colors.GRAY5};
-  overflow: scroll;
 `;
 
 const RunGroupRun = styled(Link)<{selected: boolean}>`
@@ -173,17 +174,6 @@ const RunTitle = styled.span`
   text-overflow: ellipsis;
   user-select: text;
   flex: 1;
-`;
-
-const RunGroupHeader = styled.div`
-  font-size: 11px;
-  line-height: 15px;
-  padding: 3px 6px;
-  text-transform: uppercase;
-  background: ${Colors.WHITE};
-  border-bottom: 1px solid ${Colors.LIGHT_GRAY1};
-  color: ${Colors.GRAY3};
-  height: 20px;
 `;
 
 const RootTag = (

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -66,7 +66,7 @@ export const RunGroupPanel: React.FC<{runId: string}> = ({runId}) => {
   const runs = (group.runs || []).filter((g) => g !== null);
 
   return (
-    <SidebarSection title={runs[0] ? runs[0].pipelineName : ''}>
+    <SidebarSection title={runs[0] ? `${runs[0].pipelineName} (${runs.length})` : ''}>
       <>
         {runs.map((g, idx) =>
           g ? (

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
@@ -10,48 +10,37 @@ interface ISidebarSectionProps {
   collapsedByDefault?: boolean;
 }
 
-interface ISidebarSectionState {
-  isOpen: boolean;
-}
+export const SidebarSection: React.FC<ISidebarSectionProps> = (props) => {
+  const {title, collapsedByDefault, children} = props;
+  const storageKey = `sidebar-${title}`;
 
-export class SidebarSection extends React.Component<ISidebarSectionProps, ISidebarSectionState> {
-  storageKey: string;
+  const [open, setOpen] = React.useState(() => {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored === 'true' || stored === 'false') {
+      return stored === 'true';
+    }
+    return !collapsedByDefault;
+  });
 
-  constructor(props: ISidebarSectionProps) {
-    super(props);
+  const onToggle = React.useCallback(() => {
+    setOpen((current) => {
+      window.localStorage.setItem(storageKey, `${!current}`);
+      return !current;
+    });
+  }, [storageKey]);
 
-    this.storageKey = `sidebar-${props.title}`;
-    this.state = {
-      isOpen: {
-        true: true,
-        false: false,
-        null: this.props.collapsedByDefault === true ? false : true,
-      }[`${window.localStorage.getItem(this.storageKey)}`] as boolean,
-    };
-  }
-
-  onToggle = () => {
-    const isOpen = !this.state.isOpen;
-    this.setState({isOpen});
-    window.localStorage.setItem(this.storageKey, `${isOpen}`);
-  };
-
-  render() {
-    const {isOpen} = this.state;
-
-    return (
-      <div>
-        <CollapsingHeaderBar onClick={this.onToggle}>
-          {this.props.title}
-          <DisclosureIcon icon={isOpen ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_UP} />
-        </CollapsingHeaderBar>
-        <Collapse isOpen={isOpen}>
-          <SectionInner>{this.props.children}</SectionInner>
-        </Collapse>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <CollapsingHeaderBar onClick={onToggle}>
+        {title}
+        <DisclosureIcon icon={open ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_UP} />
+      </CollapsingHeaderBar>
+      <Collapse isOpen={open}>
+        <div>{children}</div>
+      </Collapse>
+    </div>
+  );
+};
 
 const DisclosureIcon = styled(Icon)`
   float: right;
@@ -107,8 +96,4 @@ const CollapsingHeaderBar = styled.div`
   color: ${Colors.GRAY1};
   text-transform: uppercase;
   font-size: 0.75rem;
-`;
-
-export const SectionInner = styled.div`
-  padding: 12px;
 `;

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineInfo.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineInfo.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 
 import {useFeatureFlags} from '../app/Flags';
 import {breakOnUnderscores} from '../app/Util';
+import {Box} from '../ui/Box';
 
 import {Description} from './Description';
-import {SectionInner, SidebarSection, SidebarSubhead, SidebarTitle} from './SidebarComponents';
+import {SidebarSection, SidebarSubhead, SidebarTitle} from './SidebarComponents';
 import {SidebarModeSection, SIDEBAR_MODE_INFO_FRAGMENT} from './SidebarModeSection';
 import {SidebarPipelineInfoFragment} from './types/SidebarPipelineInfoFragment';
 
@@ -19,18 +20,22 @@ export const SidebarPipelineInfo: React.FC<ISidebarPipelineInfoProps> = ({pipeli
   const {flagPipelineModeTuples} = useFeatureFlags();
   return (
     <div>
-      <SectionInner>
+      <Box padding={12}>
         <SidebarSubhead>{flagPipelineModeTuples ? 'Graph' : 'Pipeline'}</SidebarSubhead>
         <SidebarTitle>{breakOnUnderscores(pipeline.name)}</SidebarTitle>
-      </SectionInner>
+      </Box>
       <SidebarSection title={'Description'}>
-        <Description description={pipeline ? pipeline.description : NO_DESCRIPTION} />
+        <Box padding={12}>
+          <Description description={pipeline ? pipeline.description : NO_DESCRIPTION} />
+        </Box>
       </SidebarSection>
       {!flagPipelineModeTuples && (
         <SidebarSection title={'Modes'} collapsedByDefault={true}>
-          {pipeline.modes.map((mode) => (
-            <SidebarModeSection key={mode.name} mode={mode} />
-          ))}
+          <Box padding={12}>
+            {pipeline.modes.map((mode) => (
+              <SidebarModeSection key={mode.name} mode={mode} />
+            ))}
+          </Box>
         </SidebarSection>
       )}
     </div>

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineOrJobOverview.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineOrJobOverview.tsx
@@ -2,6 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
 
 import {useFeatureFlags} from '../app/Flags';
+import {Box} from '../ui/Box';
 import {Loading} from '../ui/Loading';
 import {usePipelineSelector} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
@@ -48,14 +49,18 @@ export const SidebarPipelineOrJobOverview: React.FC<{
         return (
           <div>
             <SidebarSection title={'Description'}>
-              <Description
-                description={pipelineSnapshotOrError.description || 'No description provided'}
-              />
+              <Box padding={12}>
+                <Description
+                  description={pipelineSnapshotOrError.description || 'No description provided'}
+                />
+              </Box>
             </SidebarSection>
             <SidebarSection title={'Resources'}>
-              {modes.map((mode) => (
-                <SidebarModeSection mode={mode} key={mode.name} />
-              ))}
+              <Box padding={12}>
+                {modes.map((mode) => (
+                  <SidebarModeSection mode={mode} key={mode.name} />
+                ))}
+              </Box>
             </SidebarSection>
           </div>
         );

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarSolidDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarSolidDefinition.tsx
@@ -9,6 +9,7 @@ import {pluginForMetadata} from '../plugins';
 import {SolidTypeSignature, SOLID_TYPE_SIGNATURE_FRAGMENT} from '../solids/SolidTypeSignature';
 import {ConfigTypeSchema, CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT, TypeWithTooltip} from '../typeexplorer/TypeWithTooltip';
+import {Box} from '../ui/Box';
 import {RepoAddress} from '../workspace/types';
 
 import {Description} from './Description';
@@ -77,75 +78,91 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
   return (
     <div>
       <SidebarSection title={'Definition'}>
-        <SidebarSubhead>{isComposite ? 'Composite Solid' : 'Solid'}</SidebarSubhead>
-        <SidebarTitle>{breakOnUnderscores(definition.name)}</SidebarTitle>
-        <SolidTypeSignature definition={definition} />
+        <Box padding={12}>
+          <SidebarSubhead>{isComposite ? 'Composite Solid' : 'Solid'}</SidebarSubhead>
+          <SidebarTitle>{breakOnUnderscores(definition.name)}</SidebarTitle>
+          <SolidTypeSignature definition={definition} />
+        </Box>
       </SidebarSection>
       {definition.description && (
         <SidebarSection title={'Description'}>
-          <Description description={definition.description} />
+          <Box padding={12}>
+            <Description description={definition.description} />
+          </Box>
         </SidebarSection>
       )}
       {definition.metadata && Plugin && Plugin.SidebarComponent && (
         <SidebarSection title={'Metadata'}>
-          <Plugin.SidebarComponent
-            definition={definition}
-            rootServerURI={rootServerURI}
-            repoAddress={repoAddress}
-          />
+          <Box padding={12}>
+            <Plugin.SidebarComponent
+              definition={definition}
+              rootServerURI={rootServerURI}
+              repoAddress={repoAddress}
+            />
+          </Box>
         </SidebarSection>
       )}
       {configField && (
         <SidebarSection title={'Config'}>
-          <ConfigTypeSchema
-            type={configField.configType}
-            typesInScope={configField.configType.recursiveConfigTypes}
-          />
+          <Box padding={12}>
+            <ConfigTypeSchema
+              type={configField.configType}
+              typesInScope={configField.configType.recursiveConfigTypes}
+            />
+          </Box>
         </SidebarSection>
       )}
       {requiredResources && (
         <SidebarSection title={'Required Resources'}>
-          {[...requiredResources].sort().map((requirement) => (
-            <ResourceContainer key={requirement.resourceKey}>
-              <Icon iconSize={14} icon={IconNames.LAYERS} color={Colors.DARK_GRAY2} />
-              <ResourceHeader>{requirement.resourceKey}</ResourceHeader>
-            </ResourceContainer>
-          ))}
+          <Box padding={12}>
+            {[...requiredResources].sort().map((requirement) => (
+              <ResourceContainer key={requirement.resourceKey}>
+                <Icon iconSize={14} icon={IconNames.LAYERS} color={Colors.DARK_GRAY2} />
+                <ResourceHeader>{requirement.resourceKey}</ResourceHeader>
+              </ResourceContainer>
+            ))}
+          </Box>
         </SidebarSection>
       )}
       <SidebarSection title={'Inputs'}>
-        {definition.inputDefinitions.map((inputDef, idx) => (
-          <SectionItemContainer key={idx}>
-            <SectionSmallHeader>{breakOnUnderscores(inputDef.name)}</SectionSmallHeader>
-            <TypeWrapper>
-              <TypeWithTooltip type={inputDef.type} />
-            </TypeWrapper>
-            <Description description={inputDef.description} />
-            <SolidLinks title="Mapped to:" items={inputMappings[inputDef.name]} />
-          </SectionItemContainer>
-        ))}
+        <Box padding={12}>
+          {definition.inputDefinitions.map((inputDef, idx) => (
+            <SectionItemContainer key={idx}>
+              <SectionSmallHeader>{breakOnUnderscores(inputDef.name)}</SectionSmallHeader>
+              <TypeWrapper>
+                <TypeWithTooltip type={inputDef.type} />
+              </TypeWrapper>
+              <Description description={inputDef.description} />
+              <SolidLinks title="Mapped to:" items={inputMappings[inputDef.name]} />
+            </SectionItemContainer>
+          ))}
+        </Box>
       </SidebarSection>
       <SidebarSection title={'Outputs'}>
-        {definition.outputDefinitions.map((outputDef, idx) => (
-          <SectionItemContainer key={idx}>
-            <SectionSmallHeader>
-              {breakOnUnderscores(outputDef.name)}
-              {outputDef.isDynamic && <span title="DynamicOutput">[*]</span>}
-            </SectionSmallHeader>
-            <TypeWrapper>
-              <TypeWithTooltip type={outputDef.type} />
-            </TypeWrapper>
-            <SolidLinks title="Mapped from:" items={outputMappings[outputDef.name]} />
-            <Description description={outputDef.description} />
-          </SectionItemContainer>
-        ))}
+        <Box padding={12}>
+          {definition.outputDefinitions.map((outputDef, idx) => (
+            <SectionItemContainer key={idx}>
+              <SectionSmallHeader>
+                {breakOnUnderscores(outputDef.name)}
+                {outputDef.isDynamic && <span title="DynamicOutput">[*]</span>}
+              </SectionSmallHeader>
+              <TypeWrapper>
+                <TypeWithTooltip type={outputDef.type} />
+              </TypeWrapper>
+              <SolidLinks title="Mapped from:" items={outputMappings[outputDef.name]} />
+              <Description description={outputDef.description} />
+            </SectionItemContainer>
+          ))}
+        </Box>
       </SidebarSection>
       {getInvocations && (
         <SidebarSection title={'All Invocations'}>
-          <InvocationList
-            invocations={getInvocations(definition.name)}
-            onClickInvocation={onClickInvocation}
-          />
+          <Box padding={12}>
+            <InvocationList
+              invocations={getInvocations(definition.name)}
+              onClickInvocation={onClickInvocation}
+            />
+          </Box>
         </SidebarSection>
       )}
     </div>

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarSolidInvocation.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarSolidInvocation.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {breakOnUnderscores} from '../app/Util';
 import {SolidNameOrPath} from '../solids/SolidNameOrPath';
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT} from '../typeexplorer/TypeWithTooltip';
+import {Box} from '../ui/Box';
 
 import {SidebarSection, SidebarTitle} from './SidebarComponents';
 import {DependencyHeaderRow, DependencyRow, DependencyTable} from './SidebarSolidHelpers';
@@ -20,43 +21,47 @@ export const SidebarSolidInvocation: React.FC<ISidebarSolidInvocationProps> = (p
   return (
     <div>
       <SidebarSection title={'Invocation'}>
-        <SidebarTitle>{breakOnUnderscores(solid.name)}</SidebarTitle>
-        <DependencyTable>
-          <tbody>
-            {solid.inputs.some((o) => o.dependsOn.length) && <DependencyHeaderRow label="Inputs" />}
-            {solid.inputs.map(({definition, dependsOn, isDynamicCollect}) =>
-              dependsOn.map((source, idx) => (
-                <DependencyRow
-                  key={idx}
-                  from={source}
-                  to={definition.name}
-                  isDynamic={isDynamicCollect}
-                />
-              )),
-            )}
-            {solid.outputs.some((o) => o.dependedBy.length) && (
-              <DependencyHeaderRow label="Outputs" style={{paddingTop: 15}} />
-            )}
-            {solid.outputs.map(({definition, dependedBy}) =>
-              dependedBy.map((target, idx) => (
-                <DependencyRow
-                  key={idx}
-                  from={definition.name}
-                  to={target}
-                  isDynamic={definition.isDynamic}
-                />
-              )),
-            )}
-          </tbody>
-        </DependencyTable>
-        {onEnterCompositeSolid && (
-          <Button
-            icon="zoom-in"
-            text="Expand Composite"
-            style={{marginTop: 15}}
-            onClick={() => onEnterCompositeSolid({name: solid.name})}
-          />
-        )}
+        <Box padding={12}>
+          <SidebarTitle>{breakOnUnderscores(solid.name)}</SidebarTitle>
+          <DependencyTable>
+            <tbody>
+              {solid.inputs.some((o) => o.dependsOn.length) && (
+                <DependencyHeaderRow label="Inputs" />
+              )}
+              {solid.inputs.map(({definition, dependsOn, isDynamicCollect}) =>
+                dependsOn.map((source, idx) => (
+                  <DependencyRow
+                    key={idx}
+                    from={source}
+                    to={definition.name}
+                    isDynamic={isDynamicCollect}
+                  />
+                )),
+              )}
+              {solid.outputs.some((o) => o.dependedBy.length) && (
+                <DependencyHeaderRow label="Outputs" style={{paddingTop: 15}} />
+              )}
+              {solid.outputs.map(({definition, dependedBy}) =>
+                dependedBy.map((target, idx) => (
+                  <DependencyRow
+                    key={idx}
+                    from={definition.name}
+                    to={target}
+                    isDynamic={definition.isDynamic}
+                  />
+                )),
+              )}
+            </tbody>
+          </DependencyTable>
+          {onEnterCompositeSolid && (
+            <Button
+              icon="zoom-in"
+              text="Expand Composite"
+              style={{marginTop: 15}}
+              onClick={() => onEnterCompositeSolid({name: solid.name})}
+            />
+          )}
+        </Box>
       </SidebarSection>
     </div>
   );

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorer.tsx
@@ -3,12 +3,8 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {Description} from '../pipelines/Description';
-import {
-  SectionInner,
-  SidebarSection,
-  SidebarSubhead,
-  SidebarTitle,
-} from '../pipelines/SidebarComponents';
+import {SidebarSection, SidebarSubhead, SidebarTitle} from '../pipelines/SidebarComponents';
+import {Box} from '../ui/Box';
 
 import {ConfigTypeSchema, CONFIG_TYPE_SCHEMA_FRAGMENT} from './ConfigTypeSchema';
 import {TypeExplorerFragment} from './types/TypeExplorerFragment';
@@ -22,28 +18,34 @@ export const TypeExplorer: React.FC<ITypeExplorerProps> = (props) => {
   return (
     <div>
       <SidebarSubhead />
-      <SectionInner>
+      <Box padding={12}>
         <SidebarTitle>
           <Link to="?tab=types">Pipeline Types</Link> {'>'} {name}
         </SidebarTitle>
-      </SectionInner>
+      </Box>
       <SidebarSection title={'Description'}>
-        <Description description={description || 'No Description Provided'} />
+        <Box padding={12}>
+          <Description description={description || 'No Description Provided'} />
+        </Box>
       </SidebarSection>
       {inputSchemaType && (
         <SidebarSection title={'Input'}>
-          <ConfigTypeSchema
-            type={inputSchemaType}
-            typesInScope={inputSchemaType.recursiveConfigTypes}
-          />
+          <Box padding={12}>
+            <ConfigTypeSchema
+              type={inputSchemaType}
+              typesInScope={inputSchemaType.recursiveConfigTypes}
+            />
+          </Box>
         </SidebarSection>
       )}
       {outputSchemaType && (
         <SidebarSection title={'Output'}>
-          <ConfigTypeSchema
-            type={outputSchemaType}
-            typesInScope={outputSchemaType.recursiveConfigTypes}
-          />
+          <Box padding={12}>
+            <ConfigTypeSchema
+              type={outputSchemaType}
+              typesInScope={outputSchemaType.recursiveConfigTypes}
+            />
+          </Box>
         </SidebarSection>
       )}
     </div>

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
@@ -3,12 +3,8 @@ import {H3, UL} from '@blueprintjs/core';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {
-  SectionInner,
-  SidebarSection,
-  SidebarSubhead,
-  SidebarTitle,
-} from '../pipelines/SidebarComponents';
+import {SidebarSection, SidebarSubhead, SidebarTitle} from '../pipelines/SidebarComponents';
+import {Box} from '../ui/Box';
 
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT, TypeWithTooltip} from './TypeWithTooltip';
 import {TypeListFragment} from './types/TypeListFragment';
@@ -37,18 +33,20 @@ export const TypeList: React.FC<ITypeListProps> = (props) => {
   return (
     <>
       <SidebarSubhead />
-      <SectionInner>
+      <Box padding={12}>
         <SidebarTitle>Pipeline Types</SidebarTitle>
-      </SectionInner>
+      </Box>
       {Object.keys(groups).map((title, idx) => (
         <SidebarSection key={idx} title={title} collapsedByDefault={idx !== 0}>
-          <UL>
-            {groups[title].map((type, i) => (
-              <TypeLI key={i}>
-                <TypeWithTooltip type={type} />
-              </TypeLI>
-            ))}
-          </UL>
+          <Box padding={12}>
+            <UL>
+              {groups[title].map((type, i) => (
+                <TypeLI key={i}>
+                  <TypeWithTooltip type={type} />
+                </TypeLI>
+              ))}
+            </UL>
+          </Box>
         </SidebarSection>
       ))}
       <H3 />


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Something of an RFC for dealing with the weird scrollability problems in the right panel of the Run page. To fix it, use collapsible sections, basically just the same component we're using for job and op explorers.

Open to thoughts on this -- I don't want to inadvertently hide things that need to be visible at all times.

## Test Plan

View several different runs, some with run groups and others without. Verify that the sections collapse/expand correctly, and that I can always scroll through everything.