### PR TITLE
migrate intro tutorial pipelines to graph and op

### DIFF
--- a/docs/content-crag/tutorial/intro-tutorial/connecting-solids.mdx
+++ b/docs/content-crag/tutorial/intro-tutorial/connecting-solids.mdx
@@ -1,28 +1,28 @@
 ---
-title: Connecting Solids in Pipelines | Dagster
-description: A Dagster pipeline is a set of solids which have data dependencies on each other to create a directed acyclic graph.
+title: Connecting Ops in Graphs | Dagster
+description: A Dagster graph is a set of ops which have data dependencies on each other to create a directed acyclic graph.
 ---
 
-# Connecting Solids in Pipelines
+# Connecting Ops in Graphs
 
 <CodeReferenceLink filePath="examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_solids/" />
 
-Our pipelines wouldn't be very interesting if they were limited to single solids. Pipelines connect solids into arbitrary [DAGs](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of computation.
+Our graphs wouldn't be very interesting if they were limited to single ops. Graphs connect ops into arbitrary [DAGs](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of computation.
 
-Why split up code into solids instead of splitting it up into regular Python functions? There are a few reasons:
+Why split up code into ops instead of splitting it up into regular Python functions? There are a few reasons:
 
-- Dagster can execute sets of solids without executing the entire pipeline. This means that, if we hit a failure in our pipeline, we can re-run just the steps that didn't complete successfully, which often allows us to avoid re-executing expensive steps.
-- When two solids don't depend on each other, Dagster can execute them simultaneously.
-- Dagster can materialize the output of a solid to persistent storage. [IOManagers](/concepts/io-management/io-managers) let us separate business logic from IO, which lets us write code that's more testable and portable across environments.
+- Dagster can execute sets of ops without executing the entire graph. This means that, if we hit a failure in our graph, we can re-run just the steps that didn't complete successfully, which often allows us to avoid re-executing expensive steps.
+- When two ops don't depend on each other, Dagster can execute them simultaneously.
+- Dagster can materialize the output of an op to persistent storage. [IOManagers](/concepts/io-management/io-managers) let us separate business logic from IO, which lets us write code that's more testable and portable across environments.
 
-Dagster pipelines model a _dataflow_ graph. In data pipelines, the reason that a later step comes after an earlier step is almost always that it uses data produced by the earlier step. Dagster models these dataflow dependencies with _inputs_ and _outputs_.
+Dagster graphs model a _dataflow_ graph. In data pipelines, the reason that a later step comes after an earlier step is almost always that it uses data produced by the earlier step. Dagster models these dataflow dependencies with _inputs_ and _outputs_.
 
 ## Let's Get Serial
 
-We'll expand the pipeline we worked with in the first section of the tutorial into two solids:
+We'll expand the graph we worked with in the first section of the tutorial into two ops:
 
-- The first solid will download the cereal data and return it as an output.
-- The second solid will consume the cereal data produced by the first solid and find the cereal with the most sugar.
+- The first op will download the cereal data and return it as an output.
+- The second op will consume the cereal data produced by the first op and find the cereal with the most sugar.
 
 This will allow us to re-run the code that finds the sugariest cereal without re-running the code that downloads the cereal data. If we spot a bug in our sugariness code, or if we decide we want to compute some other statistics about the cereal data, we won't need to re-download the data.
 
@@ -30,44 +30,44 @@ This will allow us to re-run the code that finds the sugariest cereal without re
 import csv
 
 import requests
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def download_cereals():
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
     return [row for row in csv.DictReader(lines)]
 
 
-@solid
+@op
 def find_sugariest(context, cereals):
     sorted_by_sugar = sorted(cereals, key=lambda cereal: cereal["sugars"])
     context.log.info(f'{sorted_by_sugar[-1]["name"]} is the sugariest cereal')
 
 
-@pipeline
-def serial_pipeline():
+@graph
+def serial():
     find_sugariest(download_cereals())
 ```
 
-You'll see that we've modified our existing `download_cereals` solid to return an output, in this case the data frame representing the cereals dataset. We no longer log from this solid, so we no longer need the context argument here.
+You'll see that we've modified our existing `download_cereals` op to return an output, in this case the data frame representing the cereals dataset. We no longer log from this op, so we no longer need the context argument here.
 
-We've defined our new solid, `find_sugariest`, to take a user-defined input, `cereals`, in addition to the system-provided <PyObject module="dagster" object="SolidExecutionContext"
+We've defined our new op, `find_sugariest`, to take a user-defined input, `cereals`, in addition to the system-provided <PyObject module="dagster" object="SolidExecutionContext"
 displayText="context" /> object.
 
-We can use inputs and outputs to connect solids to each other. Here we tell Dagster that:
+We can use inputs and outputs to connect ops to each other. Here we tell Dagster that:
 
-- `download_cereals` doesn't depend on the output of any other solid.
+- `download_cereals` doesn't depend on the output of any other op.
 - `find_sugariest` depends on the output of `download_cereals`.
 
-Let's visualize this pipeline in Dagit:
+Let's visualize this graph in Dagit:
 
 ```bash
 dagit -f serial_pipeline.py
 ```
 
-Navigate to <http://127.0.0.1:3000/pipeline/serial_pipeline/> or choose "serial_pipeline" from the left sidebar:
+Navigate to <http://127.0.0.1:3000/pipeline/serial_pipeline/> or choose "serial_graph" from the left sidebar:
 
 <Image
 alt="serial_pipeline_figure_one.png"
@@ -80,17 +80,23 @@ height={946}
 
 ## A More Complex DAG
 
-Solids don't need to be wired together serially. The output of one solid can be consumed by any number of other solids, and the outputs of several different solids can be consumed by a single solid.
+Ops don't need to be wired together serially. The output of one op can be consumed by any number of other ops, and the outputs of several different ops can be consumed by a single op.
 
-```python file=/intro_tutorial/basics/connecting_solids/complex_pipeline.py startafter=start_complex_pipeline_marker_0 endbefore=end_complex_pipeline_marker_0
-@solid
+```python file=/intro_tutorial/basics/connecting_solids/complex_pipeline.py
+import csv
+
+import requests
+from dagster import graph, op
+
+
+@op
 def download_cereals():
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
     return [row for row in csv.DictReader(lines)]
 
 
-@solid
+@op
 def find_highest_calorie_cereal(cereals):
     sorted_cereals = list(
         sorted(cereals, key=lambda cereal: cereal["calories"])
@@ -98,7 +104,7 @@ def find_highest_calorie_cereal(cereals):
     return sorted_cereals[-1]["name"]
 
 
-@solid
+@op
 def find_highest_protein_cereal(cereals):
     sorted_cereals = list(
         sorted(cereals, key=lambda cereal: cereal["protein"])
@@ -106,14 +112,14 @@ def find_highest_protein_cereal(cereals):
     return sorted_cereals[-1]["name"]
 
 
-@solid
+@op
 def display_results(context, most_calories, most_protein):
     context.log.info(f"Most caloric cereal: {most_calories}")
     context.log.info(f"Most protein-rich cereal: {most_protein}")
 
 
-@pipeline
-def complex_pipeline():
+@graph
+def diamond():
     cereals = download_cereals()
     display_results(
         most_calories=find_highest_calorie_cereal(cereals),
@@ -121,9 +127,9 @@ def complex_pipeline():
     )
 ```
 
-First we introduce the intermediate variable `cereals` into our pipeline definition to represent the output of the `download_cereals` solid. Then we make both `find_highest_calorie_cereal` and `find_highest_protein_cereal` consume this output. Their outputs are in turn both consumed by `display_results`.
+First we introduce the intermediate variable `cereals` into our graph definition to represent the output of the `download_cereals` op. Then we make both `find_highest_calorie_cereal` and `find_highest_protein_cereal` consume this output. Their outputs are in turn both consumed by `display_results`.
 
-Let's visualize this pipeline in Dagit:
+Let's visualize this graph in Dagit:
 
 ```bash
 dagit -f complex_pipeline.py

--- a/docs/content-crag/tutorial/intro-tutorial/single-solid-pipeline.mdx
+++ b/docs/content-crag/tutorial/intro-tutorial/single-solid-pipeline.mdx
@@ -1,39 +1,39 @@
 ---
-title: A Single-Solid Pipeline | Dagster
-description: Executing your first pipeline - with a single solid.
+title: A Single-Op Graph | Dagster
+description: Executing your first graph - with a single op.
 ---
 
-# A Single-Solid Pipeline
+# A Single-Op Graph
 
 <CodeReferenceLink filePath="examples/docs_snippets/docs_snippets/intro_tutorial/basics/single_solid_pipeline/" />
 
-## Solids and Pipelines
+## Ops and Graphs
 
-Dagster's core abstractions are **[solids](/concepts/solids-pipelines/solids)** and **[pipelines](/concepts/solids-pipelines/pipelines)**.
+Dagster's core abstractions are **[ops](/concepts/solids-pipelines/solids)** and **[graphs](/concepts/solids-pipelines/pipelines)**.
 
-**[Solids](/concepts/solids-pipelines/solids)** are individual units of computation that we wire together to form **[pipelines](/concepts/solids-pipelines/pipelines)**. By default, all solids in a pipeline execute in the same process. In production environments, Dagster is usually configured so that each solid executes in its own process.
+**[Ops](/concepts/solids-pipelines/solids)** are individual units of computation that we wire together to form **[graphs](/concepts/solids-pipelines/pipelines)**.
 
-In this section, we'll cover how to define a simple pipeline with a single solid, and then execute it.
+In this section, we'll cover how to define a simple graph with a single op, and then execute it.
 
 ## The Cereal Dataset
 
-Our pipeline will operate on a simple but scary CSV dataset, cereal.csv, which contains nutritional facts about 80 breakfast cereals.
+Our graph will operate on a simple but scary CSV dataset, cereal.csv, which contains nutritional facts about 80 breakfast cereals.
 
-## Hello, Solid!
+## Hello, Op!
 
-Let's write our first Dagster solid and save it as `hello_cereal.py`.
+Let's write our first Dagster op and save it as `hello_cereal.py`.
 
-A solid is a unit of computation in a data pipeline. Typically, you'll define solids by annotating ordinary Python functions with the <PyObject module="dagster" object="solid" displayText="@solid" /> decorator.
+A op is a unit of computation in a graph. Typically, you'll define ops by annotating ordinary Python functions with the <PyObject module="dagster" object="op" displayText="@op" /> decorator.
 
-Our first solid does three things: downloads a csv of cereal data, reads it into a list of dictionaries which each represent a row in the CSV, and logs the number of rows it finds.
+Our first op does three things: downloads a csv of cereal data, reads it into a list of dictionaries which each represent a row in the CSV, and logs the number of rows it finds.
 
 ```python file=/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py startafter=start_solid_marker endbefore=end_solid_marker
 import requests
 import csv
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def hello_cereal(context):
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
@@ -43,30 +43,30 @@ def hello_cereal(context):
     return cereals
 ```
 
-In this simple case, our solid takes no arguments except for the <PyObject module="dagster"
+In this simple case, our op takes no arguments except for the <PyObject module="dagster"
 object="SolidExecutionContext" displayText="context" /> in which it executes (provided by the Dagster framework as the first argument to solids who specify it), and also returns no outputs. Don't worry, we'll soon encounter solids that are much more dynamic.
 
-## Hello, Pipeline!
+## Hello, Graph!
 
-To execute our solid, we'll embed it in an equally simple pipeline. A pipeline is a set of solids arranged into a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of computation. You'll typically define pipelines by annotating ordinary Python functions with the <PyObject
-module="dagster" object="pipeline" displayText="@pipeline" /> decorator.
+To execute our op, we'll embed it in an equally simple graph. A graph is a set of solids arranged into a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of computation. You'll typically define graphs by annotating ordinary Python functions with the <PyObject
+module="dagster" object="graph" displayText="@graph" /> decorator.
 
 ```python file=/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py startafter=start_pipeline_marker endbefore=end_pipeline_marker
-@pipeline
-def hello_cereal_pipeline():
+@graph
+def hello_cereal_graph():
     hello_cereal()
 ```
 
-Here you'll see that we call `hello_cereal()`. This call doesn't actually execute the solid. Within the bodies of functions decorated with <PyObject module="dagster" object="pipeline"
-displayText="@pipeline" />, we use function calls to indicate the dependency structure of the solids making up the pipeline. Here, we indicate that the execution of `hello_cereal` doesn't depend on any other solids by calling it with no arguments.
+Here you'll see that we call `hello_cereal()`. This call doesn't actually execute the op. Within the bodies of functions decorated with <PyObject module="dagster" object="graph"
+displayText="@graph" />, we use function calls to indicate the dependency structure of the solids making up the graph. Here, we indicate that the execution of `hello_cereal` doesn't depend on any other solids by calling it with no arguments.
 
-## Executing Our First Pipeline
+## Executing Our First Graph
 
-Assuming you’ve saved this pipeline as `hello_cereal.py`, you can execute it via any of three different mechanisms:
+Assuming you’ve saved this graph as `hello_cereal.py`, you can execute it via any of three different mechanisms:
 
 ### Dagit
 
-To visualize your pipeline (which only has one node) in Dagit, from the directory in which you've saved the pipeline file, just run:
+To visualize your graph (which only has one node) in Dagit, from the directory in which you've saved the graph file, just run:
 
 ```bash
 dagit -f hello_cereal.py
@@ -78,7 +78,7 @@ You'll see output like
 Loading repository... Serving on http://127.0.0.1:3000
 ```
 
-You should be able to navigate to <http://127.0.0.1:3000/pipeline/hello_cereal_pipeline/> in your web browser and view your pipeline. It isn't very interesting yet, because it only has one node.
+You should be able to navigate to <http://127.0.0.1:3000/graph/hello_cereal_pipeline/> in your web browser and view your graph. It isn't very interesting yet, because it only has one node.
 
 <Image
 alt="hello_cereal_figure_one.png"
@@ -96,11 +96,11 @@ width={1680}
 height={946}
 />
 
-The large upper left pane is empty here, but, in pipelines with parameters, this is where you'll be able to edit pipeline configuration on the fly.
+The large upper left pane is empty here, but, in graphs with parameters, this is where you'll be able to edit graph configuration on the fly.
 
 Click the "Launch Execution" button on the bottom right to execute this plan directly from Dagit. A new window should open, and you'll see a much more structured view of the stream of Dagster events start to appear in the left-hand pane.
 
-If you have pop-up blocking enabled, you may need to tell your browser to allow pop-ups from 127.0.0.1—or, just navigate to the "Runs" tab to see this, and every run of your pipeline.
+If you have pop-up blocking enabled, you may need to tell your browser to allow pop-ups from 127.0.0.1—or, just navigate to the "Runs" tab to see this, and every run of your graph.
 
 <Image
 alt="hello_cereal_figure_three.png"
@@ -109,14 +109,14 @@ width={1680}
 height={946}
 />
 
-In this view, you can filter and search through the logs corresponding to your pipeline run.
+In this view, you can filter and search through the logs corresponding to your graph run.
 
 ### Dagster CLI
 
-From the directory in which you've saved the pipeline file, just run:
+From the directory in which you've saved the graph file, just run:
 
 ```bash
-dagster pipeline execute -f hello_cereal.py
+dagster graph execute -f hello_cereal.py
 ```
 
 You'll see the full stream of events emitted by Dagster appear in the console, including our call to the logging machinery, which will look like:
@@ -129,13 +129,11 @@ Success!
 
 ### Python API
 
-If you'd rather execute your pipelines as a script, you can do that without using the Dagster CLI at all. Just add a few lines to `hello_cereal.py`
+If you'd rather execute your graphs as a script, you can do that without using the Dagster CLI at all. Just add a few lines to `hello_cereal.py`
 
 ```python file=/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py startafter=start_execute_marker endbefore=end_execute_marker
-from dagster import execute_pipeline
-
 if __name__ == "__main__":
-    result = execute_pipeline(hello_cereal_pipeline)
+    result = hello_cereal_graph.execute_in_process()
 ```
 
 Now you can just run:
@@ -143,5 +141,3 @@ Now you can just run:
 ```bash
 python hello_cereal.py
 ```
-
-The <PyObject module="dagster" object="execute_pipeline" displayText="execute_pipeline()" /> function called here is the core Python API for executing Dagster pipelines from code.

--- a/docs/content-crag/tutorial/intro-tutorial/testable.mdx
+++ b/docs/content-crag/tutorial/intro-tutorial/testable.mdx
@@ -1,41 +1,35 @@
 ---
-title: Testing Solids and Pipelines | Dagster
+title: Testing Ops and Graphs | Dagster
 description: Dagster enables you to build testable data pipelines
 ---
 
-# Testing Solids and Pipelines
+# Testing Ops and Graphs
 
 <CodeReferenceLink filePath="examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/" />
 
 Data applications are notoriously difficult to test and are therefore often un- or under-tested.
 
-Creating testable and verifiable data pipelines is one of the focuses of Dagster. We believe ensuring data quality is critical for managing the complexity of data systems. Here, we'll show how to write unit tests for Dagster pipelines and solids.
+Creating testable and verifiable data pipelines is one of the focuses of Dagster. We believe ensuring data quality is critical for managing the complexity of data systems. Here, we'll show how to write unit tests for Dagster graphs and ops.
 
-## Testing the Cereal Pipeline (and its solids)
+## Testing the Cereal Graph (and its Ops)
 
-Let's go back to the `complex_pipeline` we wrote in the [prior section](/tutorial/intro-tutorial/connecting-solids#a-more-complex-dag), and ensure that it's working as expected by writing some unit tests.
+Let's go back to the `diamond` graph we wrote in the [prior section](/tutorial/intro-tutorial/connecting-solids#a-more-complex-dag), and ensure that it's working as expected by writing some unit tests.
 
-We'll start by writing a test for the `find_highest_calorie_cereal` solid, which takes a set of cereals as input and returns the name of the cereal with the most calories. To run a solid, we can invoke it directly, as if its a regular Python function:
+We'll start by writing a test for the `find_highest_calorie_cereal` op, which takes a set of cereals as input and returns the name of the cereal with the most calories. To run an op, we can invoke it directly, as if it's a regular Python function:
 
-```python file=/intro_tutorial/basics/e04_quality/test_complex_pipeline.py startafter=start_solid_test endbefore=end_solid_test
-def test_find_highest_calorie_cereal():
-    cereals = [
-        {"name": "hi-cal cereal", "calories": 400},
-        {"name": "lo-cal cereal", "calories": 50},
-    ]
-    result = find_highest_calorie_cereal(cereals)
-    assert result == "hi-cal cereal"
+```python file=/intro_tutorial/basics/e04_quality/test_complex_pipeline.py startafter=start_op_test endbefore=end_op_test
+No match for endBefore value "end_op_test"
 ```
 
 We'll also write a test for the entire pipeline. The <PyObject
-module="dagster" object="execute_pipeline" /> function synchronously executes a pipeline and returns a <PyObject module="dagster"
-object="PipelineExecutionResult" />, whose methods let us investigate, in detail, the success or failure of execution, the outputs produced by solids, and (as we'll see later) other events associated with execution.
+module="dagster" object="GraphDefinition" method="execute_in_process" /> method synchronously executes a graph and returns a <PyObject module="dagster"
+object="PipelineExecutionResult" />, whose methods let us investigate, in detail, the success or failure of execution, the outputs produced by ops, and (as we'll see later) other events associated with execution.
 
-```python file=/intro_tutorial/basics/e04_quality/test_complex_pipeline.py startafter=start_pipeline_test endbefore=end_pipeline_test
-def test_complex_pipeline():
-    res = execute_pipeline(complex_pipeline)
+```python file=/intro_tutorial/basics/e04_quality/test_complex_pipeline.py startafter=start_graph_test endbefore=end_graph_test
+def test_diamond():
+    res = diamond.execute_in_process()
     assert res.success
-    highest_protein_cereal = res.result_for_solid(
+    highest_protein_cereal = res.result_for_node(
         "find_highest_protein_cereal"
     ).output_value()
     assert highest_protein_cereal == "Special K"

--- a/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/connecting_solids/complex_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/connecting_solids/complex_pipeline.py
@@ -1,18 +1,17 @@
 import csv
 
 import requests
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-# start_complex_pipeline_marker_0
-@solid
+@op
 def download_cereals():
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
     return [row for row in csv.DictReader(lines)]
 
 
-@solid
+@op
 def find_highest_calorie_cereal(cereals):
     sorted_cereals = list(
         sorted(cereals, key=lambda cereal: cereal["calories"])
@@ -20,7 +19,7 @@ def find_highest_calorie_cereal(cereals):
     return sorted_cereals[-1]["name"]
 
 
-@solid
+@op
 def find_highest_protein_cereal(cereals):
     sorted_cereals = list(
         sorted(cereals, key=lambda cereal: cereal["protein"])
@@ -28,19 +27,16 @@ def find_highest_protein_cereal(cereals):
     return sorted_cereals[-1]["name"]
 
 
-@solid
+@op
 def display_results(context, most_calories, most_protein):
     context.log.info(f"Most caloric cereal: {most_calories}")
     context.log.info(f"Most protein-rich cereal: {most_protein}")
 
 
-@pipeline
-def complex_pipeline():
+@graph
+def diamond():
     cereals = download_cereals()
     display_results(
         most_calories=find_highest_calorie_cereal(cereals),
         most_protein=find_highest_protein_cereal(cereals),
     )
-
-
-# end_complex_pipeline_marker_0

--- a/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/connecting_solids/serial_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/connecting_solids/serial_pipeline.py
@@ -1,22 +1,22 @@
 import csv
 
 import requests
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def download_cereals():
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
     return [row for row in csv.DictReader(lines)]
 
 
-@solid
+@op
 def find_sugariest(context, cereals):
     sorted_by_sugar = sorted(cereals, key=lambda cereal: cereal["sugars"])
     context.log.info(f'{sorted_by_sugar[-1]["name"]} is the sugariest cereal')
 
 
-@pipeline
-def serial_pipeline():
+@graph
+def serial():
     find_sugariest(download_cereals())

--- a/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/e04_quality/test_complex_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/e04_quality/test_complex_pipeline.py
@@ -1,12 +1,10 @@
-from dagster import execute_pipeline
-
 from ..connecting_solids.complex_pipeline import (
-    complex_pipeline,
+    diamond,
     find_highest_calorie_cereal,
 )
 
 
-# start_solid_test
+# start_op_test
 def test_find_highest_calorie_cereal():
     cereals = [
         {"name": "hi-cal cereal", "calories": 400},
@@ -16,16 +14,16 @@ def test_find_highest_calorie_cereal():
     assert result == "hi-cal cereal"
 
 
-# end_solid_test
+# end_optest
 
-# start_pipeline_test
-def test_complex_pipeline():
-    res = execute_pipeline(complex_pipeline)
+# start_graph_test
+def test_diamond():
+    res = diamond.execute_in_process()
     assert res.success
-    highest_protein_cereal = res.result_for_solid(
+    highest_protein_cereal = res.result_for_node(
         "find_highest_protein_cereal"
     ).output_value()
     assert highest_protein_cereal == "Special K"
 
 
-# end_pipeline_test
+# end_graph_test

--- a/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py
@@ -3,10 +3,10 @@
 # start_solid_marker
 import requests
 import csv
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def hello_cereal(context):
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
@@ -20,17 +20,15 @@ def hello_cereal(context):
 
 
 # start_pipeline_marker
-@pipeline
-def hello_cereal_pipeline():
+@graph
+def hello_cereal_graph():
     hello_cereal()
 
 
 # end_pipeline_marker
 
 # start_execute_marker
-from dagster import execute_pipeline
-
 if __name__ == "__main__":
-    result = execute_pipeline(hello_cereal_pipeline)
+    result = hello_cereal_graph.execute_in_process()
 
 # end_execute_marker

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_complex_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_complex_pipeline.py
@@ -1,11 +1,8 @@
-from dagster import execute_pipeline
-from docs_snippets_crag.intro_tutorial.basics.connecting_solids.complex_pipeline import (
-    complex_pipeline,
-)
+from docs_snippets_crag.intro_tutorial.basics.connecting_solids.complex_pipeline import diamond
 from docs_snippets_crag.intro_tutorial.test_util import patch_cereal_requests
 
 
 @patch_cereal_requests
-def test_complex_pipeline():
-    result = execute_pipeline(complex_pipeline)
+def test_complex_graph():
+    result = diamond.execute_in_process()
     assert result.success

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_hello_cereal.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_hello_cereal.py
@@ -1,14 +1,13 @@
-from dagster import execute_pipeline
 from docs_snippets_crag.intro_tutorial.basics.single_solid_pipeline.hello_cereal import (
     hello_cereal,
-    hello_cereal_pipeline,
+    hello_cereal_graph,
 )
 from docs_snippets_crag.intro_tutorial.test_util import patch_cereal_requests
 
 
 @patch_cereal_requests
 def test_tutorial_intro_tutorial_hello_world():
-    result = execute_pipeline(hello_cereal_pipeline)
+    result = hello_cereal_graph.execute_in_process()
     assert result.success
 
 

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_serial_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_serial_pipeline.py
@@ -1,11 +1,8 @@
-from dagster import execute_pipeline
-from docs_snippets_crag.intro_tutorial.basics.connecting_solids.serial_pipeline import (
-    serial_pipeline,
-)
+from docs_snippets_crag.intro_tutorial.basics.connecting_solids.serial_pipeline import serial
 from docs_snippets_crag.intro_tutorial.test_util import patch_cereal_requests
 
 
 @patch_cereal_requests
-def test_serial_pipeline():
-    result = execute_pipeline(serial_pipeline)
+def test_serial_graph():
+    result = serial.execute_in_process()
     assert result.success

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_test_complex_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/basics/test_test_complex_pipeline.py
@@ -1,9 +1,9 @@
 from docs_snippets_crag.intro_tutorial.basics.e04_quality.test_complex_pipeline import (
-    test_complex_pipeline,
+    test_diamond,
     test_find_highest_calorie_cereal,
 )
 
 
 def test_example_tests():
-    test_complex_pipeline()
+    test_diamond()
     test_find_highest_calorie_cereal()

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/test_cli_invocations.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/intro_tutorial_tests/test_cli_invocations.py
@@ -34,7 +34,7 @@ cli_args = [
     (
         "basics/single_solid_pipeline/",
         "hello_cereal.py",
-        "hello_cereal_pipeline",
+        "hello_cereal_graph",
         None,
         None,
         None,
@@ -44,7 +44,7 @@ cli_args = [
     (
         "basics/connecting_solids/",
         "serial_pipeline.py",
-        "serial_pipeline",
+        "serial",
         None,
         None,
         None,
@@ -54,7 +54,7 @@ cli_args = [
     (
         "basics/connecting_solids/",
         "complex_pipeline.py",
-        "complex_pipeline",
+        "diamond",
         None,
         None,
         None,


### PR DESCRIPTION
This omits migrating the names of files and updating the screenshots.  IMO we don't need to do those in tandem.  I think updating the names of files is automate-able.