### PR TITLE
Add lock around check_alembic_revision

### DIFF
--- a/python_modules/dagster/dagster/core/storage/sql.py
+++ b/python_modules/dagster/dagster/core/storage/sql.py
@@ -47,10 +47,11 @@ def stamp_alembic_rev(alembic_config, conn, rev="head", quiet=True):
 
 
 def check_alembic_revision(alembic_config, conn):
-    migration_context = MigrationContext.configure(conn)
-    db_revision = migration_context.get_current_revision()
-    script = ScriptDirectory.from_config(alembic_config)
-    head_revision = script.as_revision_number("head")
+    with _alembic_lock:
+        migration_context = MigrationContext.configure(conn)
+        db_revision = migration_context.get_current_revision()
+        script = ScriptDirectory.from_config(alembic_config)
+        head_revision = script.as_revision_number("head")
 
     return (db_revision, head_revision)
 


### PR DESCRIPTION
Summary:
This test failure suggests check_alembic_revision is not thread safe: https://buildkite.com/dagster/dagster-integration-tests/builds/3948#2a149e77-81d6-48d0-8ec5-2ca753f87c49

So add thes guard around it that we are using elsewhere.

Test Plan: Integration

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.