### PR TITLE
[RFC] Add config mapping to graph decorator

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -1060,6 +1060,7 @@ def _create_run_config_schema(
     run_config_schema_type = define_run_config_schema_type(
         RunConfigSchemaCreationData(
             pipeline_name=pipeline_def.name,
+            graph_def=pipeline_def.graph,
             solids=pipeline_def.graph.solids,
             dependency_structure=pipeline_def.graph.dependency_structure,
             mode_definition=mode_definition,

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -36,6 +36,7 @@ def create_creation_data(pipeline_def):
         pipeline_def.solids,
         pipeline_def.dependency_structure,
         pipeline_def.mode_definition,
+        graph_def=pipeline_def.graph,
         logger_defs=default_loggers(),
         ignored_solids=[],
         required_resources=set(),


### PR DESCRIPTION
This is an attempt at adding config mapping to the graph decorator.
A lot of the roughness in this implementation comes from allowing the top-level graph to be config-mapped.
- needs to be special cased during composite descent
- end up in a situation where you go `ops: some_config_value` which is silly (but could be fixed with the right key)
- what to do if no config schema is provided

Mostly just want to see the levels of revulsion around it and figure a way forward. I'd imagine landing something like this is going to involve first having a coherent story around where we want the config document to go.