### PR TITLE
[dagit] Fix overflowing asset names in dialog

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -309,11 +309,12 @@ const RelatedAssets: React.FC<{runs: RunMetadataFragment[]}> = ({runs}) => {
         canEscapeKeyClose
         isOpen={open}
         onClose={() => setOpen(false)}
+        style={{maxWidth: '80%', minWidth: '500px', width: 'auto'}}
       >
         <div className={Classes.DIALOG_BODY}>
           <Group direction="column" spacing={16}>
             {keys.map((key) => (
-              <Link key={key} to={`/instance/assets/${key}`}>
+              <Link key={key} to={`/instance/assets/${key}`} style={{wordBreak: 'break-word'}}>
                 {key}
               </Link>
             ))}


### PR DESCRIPTION
## Summary

In the "Related assets" dialog on a Job page, long asset names overflow the dialog.

Allow the dialog to grow wider as needed, and use `word-break: break-word` to force strings to wrap.

## Test Plan

View a Job, open "Related assets" dialog. Make some of the asset names very long, verify that the dialog grows wider as needed and that asset names wrap when they run out of horizontal space.