### PR TITLE
[RFC] Split out JobSnapshot from PipelineSnapshot

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from .solid import SolidDefinition
     from .partition import PartitionedConfig
     from .executor import ExecutorDefinition
-    from .pipeline import PipelineDefinition
+    from .job import JobDefinition
     from dagster.core.execution.execute import InProcessGraphResult
 
 
@@ -369,7 +369,7 @@ class GraphDefinition(NodeDefinition):
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
-    ) -> "PipelineDefinition":
+    ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
 
@@ -414,7 +414,7 @@ class GraphDefinition(NodeDefinition):
         Returns:
             PipelineDefinition: The "Job" currently implemented as a single-mode pipeline
         """
-        from .pipeline import PipelineDefinition
+        from .job import JobDefinition
         from .partition import PartitionedConfig
         from .executor import ExecutorDefinition, multiprocess_executor
 
@@ -457,19 +457,17 @@ class GraphDefinition(NodeDefinition):
                 f"is an object of type {type(config)}"
             )
 
-        return PipelineDefinition(
+        return JobDefinition(
             name=job_name,
             description=description,
             graph_def=self,
-            mode_defs=[
-                ModeDefinition(
-                    resource_defs=resource_defs_with_defaults,
-                    logger_defs=logger_defs,
-                    executor_defs=[executor_def],
-                    _config_mapping=config_mapping,
-                    _partitioned_config=partitioned_config,
-                )
-            ],
+            mode_def=ModeDefinition(
+                resource_defs=resource_defs_with_defaults,
+                logger_defs=logger_defs,
+                executor_defs=[executor_def],
+                _config_mapping=config_mapping,
+                _partitioned_config=partitioned_config,
+            ),
             preset_defs=presets,
             tags=tags,
             hook_defs=hooks,

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -14,6 +14,7 @@ from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
     from dagster.core.instance import DagsterInstance
+    from dagster.core.host_representation import PipelineIndex
     from dagster.core.execution.execution_results import InProcessGraphResult
 
 
@@ -109,6 +110,12 @@ class JobDefinition(PipelineDefinition):
         raise DagsterInvariantViolationError(
             f"Attempted to subset job '{self.name}'. Subsetting jobs is not supported at this time."
         )
+
+    def get_pipeline_index(self) -> "PipelineIndex":
+        from dagster.core.snap import JobSnapshot
+        from dagster.core.host_representation import PipelineIndex
+
+        return PipelineIndex(JobSnapshot.from_job_def(self), None)
 
 
 def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -2,11 +2,12 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional
 
 from dagster import check
 from dagster.core.definitions.policy import RetryPolicy
+from dagster.core.errors import DagsterInvariantViolationError
 
 from .graph import GraphDefinition
 from .hook import HookDefinition
 from .mode import ModeDefinition
-from .pipeline import PipelineDefinition, PipelineSubsetDefinition
+from .pipeline import PipelineDefinition
 from .preset import PresetDefinition
 from .resource import ResourceDefinition
 from .version_strategy import VersionStrategy
@@ -102,33 +103,11 @@ class JobDefinition(PipelineDefinition):
             output_capturing_enabled=True,
         )
 
+    def get_pipeline_subset_def(self, solids_to_execute: AbstractSet[str]) -> PipelineDefinition:
 
-class JobSubsetDefinition(PipelineSubsetDefinition):
-    def __init__(
-        self,
-        mode_def: ModeDefinition,
-        graph_def: GraphDefinition,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        preset_defs: Optional[List[PresetDefinition]] = None,
-        tags: Dict[str, Any] = None,
-        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
-        solid_retry_policy: Optional[RetryPolicy] = None,
-        _parent_pipeline_def=None,  # https://github.com/dagster-io/dagster/issues/2115
-        version_strategy: Optional[VersionStrategy] = None,
-    ):
-
-        super(JobSubsetDefinition, self).__init__(
-            name=name,
-            description=description,
-            mode_defs=[mode_def],
-            preset_defs=preset_defs,
-            tags=tags,
-            hook_defs=hook_defs,
-            solid_retry_policy=solid_retry_policy,
-            graph_def=graph_def,
-            _parent_pipeline_def=_parent_pipeline_def,
-            version_strategy=version_strategy,
+        # https://github.com/dagster-io/dagster/issues/4489
+        raise DagsterInvariantViolationError(
+            f"Attempted to subset job '{self.name}'. Subsetting jobs is not supported at this time."
         )
 
 

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -1,0 +1,152 @@
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional
+
+from dagster import check
+from dagster.core.definitions.policy import RetryPolicy
+
+from .graph import GraphDefinition
+from .hook import HookDefinition
+from .mode import ModeDefinition
+from .pipeline import PipelineDefinition, PipelineSubsetDefinition
+from .preset import PresetDefinition
+from .resource import ResourceDefinition
+from .version_strategy import VersionStrategy
+
+if TYPE_CHECKING:
+    from dagster.core.instance import DagsterInstance
+    from dagster.core.execution.execution_results import InProcessGraphResult
+
+
+class JobDefinition(PipelineDefinition):
+    def __init__(
+        self,
+        mode_def: ModeDefinition,
+        graph_def: GraphDefinition,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        preset_defs: Optional[List[PresetDefinition]] = None,
+        tags: Dict[str, Any] = None,
+        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
+        solid_retry_policy: Optional[RetryPolicy] = None,
+        version_strategy: Optional[VersionStrategy] = None,
+    ):
+
+        super(JobDefinition, self).__init__(
+            name=name,
+            description=description,
+            mode_defs=[mode_def],
+            preset_defs=preset_defs,
+            tags=tags,
+            hook_defs=hook_defs,
+            solid_retry_policy=solid_retry_policy,
+            graph_def=graph_def,
+            version_strategy=version_strategy,
+        )
+
+    def execute_in_process(
+        self,
+        run_config: Optional[Dict[str, Any]] = None,
+        instance: Optional["DagsterInstance"] = None,
+    ) -> "InProcessGraphResult":
+        """
+        (Experimental) Execute the "Job" (single mode pipeline) in-process, gathering results in-memory.
+
+        The executor_def on the Job will be ignored, and replaced with the in-process executor.
+        If using the default io_manager, it will switch from filesystem to in-memory.
+
+
+        Args:
+            run_config (Optional[Dict[str, Any]]:
+                The configuration for the run
+            instance (Optional[DagsterInstance]):
+                The instance to execute against, an ephemeral one will be used if none provided.
+
+        Returns:
+            InProcessGraphResult
+
+        """
+        from dagster.core.definitions.executor import execute_in_process_executor
+        from dagster.core.execution.execute import core_execute_in_process
+
+        run_config = check.opt_dict_param(run_config, "run_config")
+        check.invariant(
+            len(self._mode_definitions) == 1,
+            "execute_in_process only supported on job / single mode pipeline",
+        )
+
+        base_mode = self.get_mode_definition()
+        # create an ephemeral in process mode by replacing the executor_def and
+        # switching the default fs io_manager to in mem, if another was not set
+        in_proc_mode = ModeDefinition(
+            name="in_process",
+            executor_defs=[execute_in_process_executor],
+            resource_defs=_swap_default_io_man(base_mode.resource_defs, self),
+            logger_defs=base_mode.loggers,
+            _config_mapping=base_mode.config_mapping,
+            _partitioned_config=base_mode.partitioned_config,
+        )
+
+        ephemeral_pipeline = PipelineDefinition(
+            name=self._name,
+            graph_def=self._graph_def,
+            mode_defs=[in_proc_mode],
+            hook_defs=self.hook_defs,
+            tags=self.tags,
+            version_strategy=self.version_strategy,
+        )
+
+        return core_execute_in_process(
+            node=self._graph_def,
+            ephemeral_pipeline=ephemeral_pipeline,
+            run_config=run_config,
+            instance=instance,
+            output_capturing_enabled=True,
+        )
+
+
+class JobSubsetDefinition(PipelineSubsetDefinition):
+    def __init__(
+        self,
+        mode_def: ModeDefinition,
+        graph_def: GraphDefinition,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        preset_defs: Optional[List[PresetDefinition]] = None,
+        tags: Dict[str, Any] = None,
+        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
+        solid_retry_policy: Optional[RetryPolicy] = None,
+        _parent_pipeline_def=None,  # https://github.com/dagster-io/dagster/issues/2115
+        version_strategy: Optional[VersionStrategy] = None,
+    ):
+
+        super(JobSubsetDefinition, self).__init__(
+            name=name,
+            description=description,
+            mode_defs=[mode_def],
+            preset_defs=preset_defs,
+            tags=tags,
+            hook_defs=hook_defs,
+            solid_retry_policy=solid_retry_policy,
+            graph_def=graph_def,
+            _parent_pipeline_def=_parent_pipeline_def,
+            version_strategy=version_strategy,
+        )
+
+
+def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):
+    """
+    Used to create the user facing experience of the default io_manager
+    switching to in-memory when using execute_in_process.
+    """
+    from dagster.core.storage.mem_io_manager import mem_io_manager
+    from .graph import default_job_io_manager
+
+    if (
+        # pylint: disable=comparison-with-callable
+        resources.get("io_manager") == default_job_io_manager
+        and job.version_strategy is None
+    ):
+        updated_resources = dict(resources)
+        updated_resources["io_manager"] = mem_io_manager
+        return updated_resources
+
+    return resources

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -551,66 +551,6 @@ class PipelineDefinition:
             "using an execution API function (e.g. `execute_pipeline`)."
         )
 
-    def execute_in_process(
-        self,
-        run_config: Optional[Dict[str, Any]] = None,
-        instance: Optional["DagsterInstance"] = None,
-    ) -> "InProcessGraphResult":
-        """
-        (Experimental) Execute the "Job" (single mode pipeline) in-process, gathering results in-memory.
-
-        The executor_def on the Job will be ignored, and replaced with the in-process executor.
-        If using the default io_manager, it will switch from filesystem to in-memory.
-
-
-        Args:
-            run_config (Optional[Dict[str, Any]]:
-                The configuration for the run
-            instance (Optional[DagsterInstance]):
-                The instance to execute against, an ephemeral one will be used if none provided.
-
-        Returns:
-            InProcessGraphResult
-
-        """
-        from dagster.core.definitions.executor import execute_in_process_executor
-        from dagster.core.execution.execute import core_execute_in_process
-
-        run_config = check.opt_dict_param(run_config, "run_config")
-        check.invariant(
-            len(self._mode_definitions) == 1,
-            "execute_in_process only supported on job / single mode pipeline",
-        )
-
-        base_mode = self.get_mode_definition()
-        # create an ephemeral in process mode by replacing the executor_def and
-        # switching the default fs io_manager to in mem, if another was not set
-        in_proc_mode = ModeDefinition(
-            name="in_process",
-            executor_defs=[execute_in_process_executor],
-            resource_defs=_swap_default_io_man(base_mode.resource_defs, self),
-            logger_defs=base_mode.loggers,
-            _config_mapping=base_mode.config_mapping,
-            _partitioned_config=base_mode.partitioned_config,
-        )
-
-        ephemeral_pipeline = PipelineDefinition(
-            name=self._name,
-            graph_def=self._graph_def,
-            mode_defs=[in_proc_mode],
-            hook_defs=self.hook_defs,
-            tags=self.tags,
-            version_strategy=self.version_strategy,
-        )
-
-        return core_execute_in_process(
-            node=self._graph_def,
-            ephemeral_pipeline=ephemeral_pipeline,
-            run_config=run_config,
-            instance=instance,
-            output_capturing_enabled=True,
-        )
-
 
 class PipelineSubsetDefinition(PipelineDefinition):
     @property
@@ -658,6 +598,7 @@ def _get_pipeline_subset_def(
     Build a pipeline which is a subset of another pipeline.
     Only includes the solids which are in solids_to_execute.
     """
+    from .job import JobDefinition, JobSubsetDefinition
 
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.set_param(solids_to_execute, "solids_to_execute", of_type=str)
@@ -706,15 +647,27 @@ def _get_pipeline_subset_def(
                 )
 
     try:
-        sub_pipeline_def = PipelineSubsetDefinition(
-            name=pipeline_def.name,  # should we change the name for subsetted pipeline?
-            solid_defs=list({solid.definition for solid in solids}),
-            mode_defs=pipeline_def.mode_definitions,
-            dependencies=deps,
-            _parent_pipeline_def=pipeline_def,
-            tags=pipeline_def.tags,
-            hook_defs=pipeline_def.hook_defs,
-        )
+        if isinstance(pipeline_def, JobDefinition):
+            sub_pipeline_def: Union[
+                PipelineSubsetDefinition, JobSubsetDefinition
+            ] = JobSubsetDefinition(
+                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
+                mode_def=pipeline_def.mode_definitions[0],
+                _parent_pipeline_def=pipeline_def,
+                tags=pipeline_def.tags,
+                hook_defs=pipeline_def.hook_defs,
+                graph_def=pipeline_def.graph,
+            )
+        else:
+            sub_pipeline_def = PipelineSubsetDefinition(
+                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
+                solid_defs=list({solid.definition for solid in solids}),
+                mode_defs=pipeline_def.mode_definitions,
+                dependencies=deps,
+                _parent_pipeline_def=pipeline_def,
+                tags=pipeline_def.tags,
+                hook_defs=pipeline_def.hook_defs,
+            )
 
         return sub_pipeline_def
     except DagsterInvalidDefinitionError as exc:
@@ -1089,26 +1042,6 @@ def _create_run_config_schema(
         config_type_dict_by_key=config_type_dict_by_key,
         config_mapping=mode_definition.config_mapping,
     )
-
-
-def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):
-    """
-    Used to create the user facing experience of the default io_manager
-    switching to in-memory when using execute_in_process.
-    """
-    from dagster.core.storage.mem_io_manager import mem_io_manager
-    from .graph import default_job_io_manager
-
-    if (
-        # pylint: disable=comparison-with-callable
-        resources.get("io_manager") == default_job_io_manager
-        and job.version_strategy is None
-    ):
-        updated_resources = dict(resources)
-        updated_resources["io_manager"] = mem_io_manager
-        return updated_resources
-
-    return resources
 
 
 def _is_using_graph_job_op_apis(node_list: List[Node]):

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -598,7 +598,6 @@ def _get_pipeline_subset_def(
     Build a pipeline which is a subset of another pipeline.
     Only includes the solids which are in solids_to_execute.
     """
-    from .job import JobDefinition, JobSubsetDefinition
 
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.set_param(solids_to_execute, "solids_to_execute", of_type=str)
@@ -647,27 +646,15 @@ def _get_pipeline_subset_def(
                 )
 
     try:
-        if isinstance(pipeline_def, JobDefinition):
-            sub_pipeline_def: Union[
-                PipelineSubsetDefinition, JobSubsetDefinition
-            ] = JobSubsetDefinition(
-                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
-                mode_def=pipeline_def.mode_definitions[0],
-                _parent_pipeline_def=pipeline_def,
-                tags=pipeline_def.tags,
-                hook_defs=pipeline_def.hook_defs,
-                graph_def=pipeline_def.graph,
-            )
-        else:
-            sub_pipeline_def = PipelineSubsetDefinition(
-                name=pipeline_def.name,  # should we change the name for subsetted pipeline?
-                solid_defs=list({solid.definition for solid in solids}),
-                mode_defs=pipeline_def.mode_definitions,
-                dependencies=deps,
-                _parent_pipeline_def=pipeline_def,
-                tags=pipeline_def.tags,
-                hook_defs=pipeline_def.hook_defs,
-            )
+        sub_pipeline_def = PipelineSubsetDefinition(
+            name=pipeline_def.name,  # should we change the name for subsetted pipeline?
+            solid_defs=list({solid.definition for solid in solids}),
+            mode_defs=pipeline_def.mode_definitions,
+            dependencies=deps,
+            _parent_pipeline_def=pipeline_def,
+            tags=pipeline_def.tags,
+            hook_defs=pipeline_def.hook_defs,
+        )
 
         return sub_pipeline_def
     except DagsterInvalidDefinitionError as exc:

--- a/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
@@ -2,6 +2,7 @@ from dagster import check
 from dagster.core.snap import (
     DependencyStructureIndex,
     PipelineSnapshot,
+    JobSnapshot,
     create_pipeline_snapshot_id,
 )
 
@@ -9,7 +10,7 @@ from dagster.core.snap import (
 class PipelineIndex:
     def __init__(self, pipeline_snapshot, parent_pipeline_snapshot):
         self.pipeline_snapshot = check.inst_param(
-            pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot
+            pipeline_snapshot, "pipeline_snapshot", (PipelineSnapshot, JobSnapshot)
         )
         self.parent_pipeline_snapshot = check.opt_inst_param(
             parent_pipeline_snapshot, "parent_pipeline_snapshot", PipelineSnapshot

--- a/python_modules/dagster/dagster/core/snap/__init__.py
+++ b/python_modules/dagster/dagster/core/snap/__init__.py
@@ -50,5 +50,5 @@ from .execution_plan_snapshot import (
     snapshot_from_execution_plan,
 )
 from .mode import LoggerDefSnap, ModeDefSnap, ResourceDefSnap
-from .pipeline_snapshot import PipelineSnapshot, create_pipeline_snapshot_id
+from .pipeline_snapshot import PipelineSnapshot, create_pipeline_snapshot_id, JobSnapshot
 from .solid import CompositeSolidDefSnap, SolidDefSnap, build_composite_solid_def_snap

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['test_basic_dep_fan_out 1'] = '''{
@@ -1133,6 +1134,7 @@ snapshots['test_basic_dep_fan_out 1'] = '''{
   },
   "description": null,
   "graph_def_name": "single_dep_pipeline",
+  "is_job": false,
   "lineage_snapshot": null,
   "mode_def_snaps": [
     {
@@ -1245,7 +1247,7 @@ snapshots['test_basic_dep_fan_out 1'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_basic_dep_fan_out 2'] = 'd050dcaed582d0e5c560a9d91633dfb08a96480c'
+snapshots['test_basic_dep_fan_out 2'] = '5e8d956cbc90b11c270d443d220ea3c9b2c8186c'
 
 snapshots['test_basic_fan_in 1'] = '''{
   "__class__": "PipelineSnapshot",
@@ -2392,6 +2394,7 @@ snapshots['test_basic_fan_in 1'] = '''{
   },
   "description": null,
   "graph_def_name": "fan_in_test",
+  "is_job": false,
   "lineage_snapshot": null,
   "mode_def_snaps": [
     {
@@ -2504,7 +2507,7 @@ snapshots['test_basic_fan_in 1'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_basic_fan_in 2'] = 'eaa4fb019beea45963314e2e28f2544caa28e466'
+snapshots['test_basic_fan_in 2'] = '3d5c3b8dfd38e8b742ef8050cb877c590cb0b9c1'
 
 snapshots['test_deserialize_solid_def_snaps_multi_type_config 1'] = '''{
   "__class__": "ConfigTypeSnap",
@@ -3606,6 +3609,7 @@ snapshots['test_empty_pipeline_snap_props 1'] = '''{
   },
   "description": null,
   "graph_def_name": "noop_pipeline",
+  "is_job": false,
   "lineage_snapshot": null,
   "mode_def_snaps": [
     {
@@ -3684,7 +3688,7 @@ snapshots['test_empty_pipeline_snap_props 1'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_empty_pipeline_snap_props 2'] = '0965b76124e758660317760c7e9bbc66282f33b0'
+snapshots['test_empty_pipeline_snap_props 2'] = '6b2fd63f7d2c05e8c7d112c85cfd77e36741201c'
 
 snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
   "__class__": "PipelineSnapshot",
@@ -4753,6 +4757,7 @@ snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
   },
   "description": null,
   "graph_def_name": "noop_pipeline",
+  "is_job": false,
   "lineage_snapshot": null,
   "mode_def_snaps": [
     {
@@ -4830,6 +4835,1091 @@ snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
   },
   "tags": {}
 }'''
+
+snapshots['test_job_snap_all_props 1'] = '''{
+  "__class__": "JobSnapshot",
+  "config_schema_snapshot": {
+    "__class__": "ConfigSchemaSnapshot",
+    "all_config_snaps_by_key": {
+      "Any": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": null,
+        "given_name": "Any",
+        "key": "Any",
+        "kind": {
+          "__enum__": "ConfigTypeKind.ANY"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b": {
+        "__class__": "ConfigTypeSnap",
+        "description": "List of Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b",
+        "enum_values": null,
+        "fields": null,
+        "given_name": null,
+        "key": "Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b",
+        "kind": {
+          "__enum__": "ConfigTypeKind.ARRAY"
+        },
+        "scalar_kind": null,
+        "type_param_keys": [
+          "Shape.41de0e2d7b75524510155d0bdab8723c6feced3b"
+        ]
+      },
+      "Bool": {
+        "__class__": "ConfigTypeSnap",
+        "description": "",
+        "enum_values": null,
+        "fields": null,
+        "given_name": "Bool",
+        "key": "Bool",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR"
+        },
+        "scalar_kind": {
+          "__enum__": "ConfigScalarKind.BOOL"
+        },
+        "type_param_keys": null
+      },
+      "Float": {
+        "__class__": "ConfigTypeSnap",
+        "description": "",
+        "enum_values": null,
+        "fields": null,
+        "given_name": "Float",
+        "key": "Float",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR"
+        },
+        "scalar_kind": {
+          "__enum__": "ConfigScalarKind.FLOAT"
+        },
+        "type_param_keys": null
+      },
+      "Int": {
+        "__class__": "ConfigTypeSnap",
+        "description": "",
+        "enum_values": null,
+        "fields": null,
+        "given_name": "Int",
+        "key": "Int",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR"
+        },
+        "scalar_kind": {
+          "__enum__": "ConfigScalarKind.INT"
+        },
+        "type_param_keys": null
+      },
+      "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": null,
+        "given_name": null,
+        "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR_UNION"
+        },
+        "scalar_kind": null,
+        "type_param_keys": [
+          "Bool",
+          "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+        ]
+      },
+      "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": null,
+        "given_name": null,
+        "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR_UNION"
+        },
+        "scalar_kind": null,
+        "type_param_keys": [
+          "Float",
+          "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+        ]
+      },
+      "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": null,
+        "given_name": null,
+        "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR_UNION"
+        },
+        "scalar_kind": null,
+        "type_param_keys": [
+          "Int",
+          "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+        ]
+      },
+      "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": null,
+        "given_name": null,
+        "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR_UNION"
+        },
+        "scalar_kind": null,
+        "type_param_keys": [
+          "String",
+          "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+        ]
+      },
+      "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "disabled",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "enabled",
+            "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.986e19e764b826d3c111d7bf840b1003f6b8ee15": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "multiprocess",
+            "type_key": "Shape.fff3afcfe0467fefa4b97fb8f72911aeb0e8fe4e"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.986e19e764b826d3c111d7bf840b1003f6b8ee15",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.a2588a6acfaabe9de47899395c58b06786b9e2eb": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "filesystem",
+            "type_key": "Shape.889b7348071b49700db678dab98bb0a15fd57ecd"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "in_memory",
+            "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.a2588a6acfaabe9de47899395c58b06786b9e2eb",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "json",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "pickle",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "value",
+            "type_key": "Int"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "json",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "pickle",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "value",
+            "type_key": "Bool"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "json",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "pickle",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "value",
+            "type_key": "Float"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "json",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "pickle",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "value",
+            "type_key": "String"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "json",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "pickle",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "json",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "pickle",
+            "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "value",
+            "type_key": "Any"
+          }
+        ],
+        "given_name": null,
+        "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SELECTOR"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.0bb49540f1708dcf5378009c9571eba999502e19": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "io_manager",
+            "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.0bb49540f1708dcf5378009c9571eba999502e19",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.1abcd866a24f906f1b2d79ddf76439380a03c4e0": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "noop",
+            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.1abcd866a24f906f1b2d79ddf76439380a03c4e0",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.241ac489ffa5f718db6444bae7849fb86a62e441": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "\\"INFO\\"",
+            "description": null,
+            "is_required": false,
+            "name": "log_level",
+            "type_key": "String"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "\\"dagster\\"",
+            "description": null,
+            "is_required": false,
+            "name": "name",
+            "type_key": "String"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.241ac489ffa5f718db6444bae7849fb86a62e441",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.3baab16166bacfaf4705811e64d356112fd733cb": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"log_level\\": \\"INFO\\", \\"name\\": \\"dagster\\"}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.241ac489ffa5f718db6444bae7849fb86a62e441"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.3baab16166bacfaf4705811e64d356112fd733cb",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.41de0e2d7b75524510155d0bdab8723c6feced3b": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "result",
+            "type_key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.41de0e2d7b75524510155d0bdab8723c6feced3b",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "path",
+            "type_key": "String"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.5e1408bbca4a94620fa0891dd5adc4448574af3b": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"multiprocess\\": {\\"config\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "execution",
+            "type_key": "Selector.986e19e764b826d3c111d7bf840b1003f6b8ee15"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "intermediate_storage",
+            "type_key": "Selector.a2588a6acfaabe9de47899395c58b06786b9e2eb"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "loggers",
+            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"noop\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "ops",
+            "type_key": "Shape.1abcd866a24f906f1b2d79ddf76439380a03c4e0"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"io_manager\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "resources",
+            "type_key": "Shape.0bb49540f1708dcf5378009c9571eba999502e19"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "storage",
+            "type_key": "Selector.a2588a6acfaabe9de47899395c58b06786b9e2eb"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.5e1408bbca4a94620fa0891dd5adc4448574af3b",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.889b7348071b49700db678dab98bb0a15fd57ecd": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.e26e0c525e2d2c66b5a06f4cfdd053de6d44e3ed"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.889b7348071b49700db678dab98bb0a15fd57ecd",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.a476f98f7c4e324d4b665af722d1f2cd7f99b023": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "0",
+            "description": null,
+            "is_required": false,
+            "name": "max_concurrent",
+            "type_key": "Int"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"enabled\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "retries",
+            "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.a476f98f7c4e324d4b665af722d1f2cd7f99b023",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [],
+        "given_name": null,
+        "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "outputs",
+            "type_key": "Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.e26e0c525e2d2c66b5a06f4cfdd053de6d44e3ed": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "base_dir",
+            "type_key": "String"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.e26e0c525e2d2c66b5a06f4cfdd053de6d44e3ed",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "console",
+            "type_key": "Shape.3baab16166bacfaf4705811e64d356112fd733cb"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.fff3afcfe0467fefa4b97fb8f72911aeb0e8fe4e": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.a476f98f7c4e324d4b665af722d1f2cd7f99b023"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.fff3afcfe0467fefa4b97fb8f72911aeb0e8fe4e",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "String": {
+        "__class__": "ConfigTypeSnap",
+        "description": "",
+        "enum_values": null,
+        "fields": null,
+        "given_name": "String",
+        "key": "String",
+        "kind": {
+          "__enum__": "ConfigTypeKind.SCALAR"
+        },
+        "scalar_kind": {
+          "__enum__": "ConfigScalarKind.STRING"
+        },
+        "type_param_keys": null
+      }
+    }
+  },
+  "dagster_type_namespace_snapshot": {
+    "__class__": "DagsterTypeNamespaceSnapshot",
+    "all_dagster_type_snaps_by_key": {
+      "Any": {
+        "__class__": "DagsterTypeSnap",
+        "description": null,
+        "display_name": "Any",
+        "is_builtin": true,
+        "key": "Any",
+        "kind": {
+          "__enum__": "DagsterTypeKind.ANY"
+        },
+        "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+        "materializer_schema_key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742",
+        "name": "Any",
+        "type_param_keys": []
+      },
+      "Bool": {
+        "__class__": "DagsterTypeSnap",
+        "description": null,
+        "display_name": "Bool",
+        "is_builtin": true,
+        "key": "Bool",
+        "kind": {
+          "__enum__": "DagsterTypeKind.SCALAR"
+        },
+        "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+        "materializer_schema_key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742",
+        "name": "Bool",
+        "type_param_keys": []
+      },
+      "Float": {
+        "__class__": "DagsterTypeSnap",
+        "description": null,
+        "display_name": "Float",
+        "is_builtin": true,
+        "key": "Float",
+        "kind": {
+          "__enum__": "DagsterTypeKind.SCALAR"
+        },
+        "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+        "materializer_schema_key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742",
+        "name": "Float",
+        "type_param_keys": []
+      },
+      "Int": {
+        "__class__": "DagsterTypeSnap",
+        "description": null,
+        "display_name": "Int",
+        "is_builtin": true,
+        "key": "Int",
+        "kind": {
+          "__enum__": "DagsterTypeKind.SCALAR"
+        },
+        "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+        "materializer_schema_key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742",
+        "name": "Int",
+        "type_param_keys": []
+      },
+      "Nothing": {
+        "__class__": "DagsterTypeSnap",
+        "description": null,
+        "display_name": "Nothing",
+        "is_builtin": true,
+        "key": "Nothing",
+        "kind": {
+          "__enum__": "DagsterTypeKind.NOTHING"
+        },
+        "loader_schema_key": null,
+        "materializer_schema_key": null,
+        "name": "Nothing",
+        "type_param_keys": []
+      },
+      "String": {
+        "__class__": "DagsterTypeSnap",
+        "description": null,
+        "display_name": "String",
+        "is_builtin": true,
+        "key": "String",
+        "kind": {
+          "__enum__": "DagsterTypeKind.SCALAR"
+        },
+        "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+        "materializer_schema_key": "Selector.e52fa3afbe531d9522fae1206f3ae9d248775742",
+        "name": "String",
+        "type_param_keys": []
+      }
+    }
+  },
+  "dep_structure_snapshot": {
+    "__class__": "DependencyStructureSnapshot",
+    "solid_invocation_snaps": [
+      {
+        "__class__": "SolidInvocationSnap",
+        "input_dep_snaps": [],
+        "is_dynamic_mapped": false,
+        "solid_def_name": "noop",
+        "solid_name": "noop",
+        "tags": {}
+      }
+    ]
+  },
+  "description": "desc",
+  "graph_def_name": "noop_graph",
+  "is_job": true,
+  "mode_def_snaps": [
+    {
+      "__class__": "ModeDefSnap",
+      "description": null,
+      "logger_def_snaps": [
+        {
+          "__class__": "LoggerDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"log_level\\": \\"INFO\\", \\"name\\": \\"dagster\\"}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.241ac489ffa5f718db6444bae7849fb86a62e441"
+          },
+          "description": "The default colored console logger.",
+          "name": "console"
+        }
+      ],
+      "name": "default",
+      "resource_def_snaps": [
+        {
+          "__class__": "ResourceDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": "The default io manager for Jobs. Uses filesystem but switches to in-memory when invoked through execute_in_process.",
+          "name": "io_manager"
+        }
+      ],
+      "root_config_key": "Shape.5e1408bbca4a94620fa0891dd5adc4448574af3b"
+    }
+  ],
+  "name": "noop_job",
+  "solid_definitions_snapshot": {
+    "__class__": "SolidDefinitionsSnapshot",
+    "composite_solid_def_snaps": [],
+    "solid_def_snaps": [
+      {
+        "__class__": "SolidDefSnap",
+        "config_field_snap": {
+          "__class__": "ConfigFieldSnap",
+          "default_provided": false,
+          "default_value_as_json_str": null,
+          "description": null,
+          "is_required": false,
+          "name": "config",
+          "type_key": "Any"
+        },
+        "description": null,
+        "input_def_snaps": [],
+        "name": "noop",
+        "output_def_snaps": [
+          {
+            "__class__": "OutputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "is_dynamic": false,
+            "is_required": true,
+            "name": "result"
+          }
+        ],
+        "required_resource_keys": [],
+        "tags": {}
+      }
+    ]
+  },
+  "tags": {
+    "key": "value"
+  }
+}'''
+
+snapshots['test_job_snap_all_props 2'] = '53b24a5934a90017e052c86d70d53db89f62c5f5'
 
 snapshots['test_multi_type_config_array_dict_fields[Permissive] 1'] = '''{
   "__class__": "ConfigTypeSnap",
@@ -6090,6 +7180,7 @@ snapshots['test_pipeline_snap_all_props 1'] = '''{
   },
   "description": "desc",
   "graph_def_name": "noop_pipeline",
+  "is_job": false,
   "lineage_snapshot": null,
   "mode_def_snaps": [
     {
@@ -6170,7 +7261,7 @@ snapshots['test_pipeline_snap_all_props 1'] = '''{
   }
 }'''
 
-snapshots['test_pipeline_snap_all_props 2'] = '5ebae3c42c9b43fcdda72d972e140601bbd8821b'
+snapshots['test_pipeline_snap_all_props 2'] = '96c74c69d8db86e29cbff4c9e9e89f7da24a9e45'
 
 snapshots['test_two_invocations_deps_snap 1'] = '''{
   "__class__": "PipelineSnapshot",
@@ -7256,6 +8347,7 @@ snapshots['test_two_invocations_deps_snap 1'] = '''{
   },
   "description": null,
   "graph_def_name": "two_solid_pipeline",
+  "is_job": false,
   "lineage_snapshot": null,
   "mode_def_snaps": [
     {
@@ -7334,4 +8426,4 @@ snapshots['test_two_invocations_deps_snap 1'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_two_invocations_deps_snap 2'] = 'e2bf3c5257f8c979501f9cec33d0c96219496fad'
+snapshots['test_two_invocations_deps_snap 2'] = '7d0ff47c110009a6e28fcce7797fb5f78af5f1c5'


### PR DESCRIPTION
Split out JobSnapshot from PipelineSnapshot.
I opted for a pretty conservative approach in terms of attributes on JobSnapshot. My main concern was that we want a recent (> 0.13.x) Dagster version to be able to construct a JobSnapshot in one process, and then in another process running 0.12.x, that can still be interpreted as a PipelineSnapshot s.t. we don't have a hard cut between versions.

As a result, it's difficult to be able to tell which came from which across serdes. So I added a very janky `is_job` argument. There are likely better approaches here.

Landing something like this would be contingent on having integration tests set up to test the 0.12.x / 0.13.x backcompat that I mentioned earlier.