### PR TITLE
refactor(permissions): introduce Permissions enum

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -1,5 +1,6 @@
 import graphene
 from dagster.core.definitions.events import AssetKey
+from dagster.core.workspace.permissions import Permissions
 
 from ...implementation.execution import (
     cancel_partition_backfill,
@@ -145,7 +146,7 @@ class GrapheneDeleteRunMutation(graphene.Mutation):
         name = "DeleteRunMutation"
 
     @capture_error
-    @check_permission("delete_pipeline_run")
+    @check_permission(Permissions.DELETE_PIPELINE_RUN)
     def mutate(self, graphene_info, **kwargs):
         run_id = kwargs["runId"]
         return delete_pipeline_run(graphene_info, run_id)
@@ -200,7 +201,7 @@ class GrapheneLaunchPipelineExecutionMutation(graphene.Mutation):
         name = "LaunchPipelineExecutionMutation"
 
     @capture_error
-    @check_permission("launch_pipeline_execution")
+    @check_permission(Permissions.LAUNCH_PIPELINE_EXECUTION)
     def mutate(self, graphene_info, **kwargs):
         return create_execution_params_and_launch_pipeline_exec(
             graphene_info, kwargs["executionParams"]
@@ -218,7 +219,7 @@ class GrapheneLaunchBackfillMutation(graphene.Mutation):
         name = "LaunchBackfillMutation"
 
     @capture_error
-    @check_permission("launch_partition_backfill")
+    @check_permission(Permissions.LAUNCH_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **kwargs):
         return create_and_launch_partition_backfill(graphene_info, kwargs["backfillParams"])
 
@@ -234,7 +235,7 @@ class GrapheneCancelBackfillMutation(graphene.Mutation):
         name = "CancelBackfillMutation"
 
     @capture_error
-    @check_permission("cancel_partition_backfill")
+    @check_permission(Permissions.CANCEL_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **kwargs):
         return cancel_partition_backfill(graphene_info, kwargs["backfillId"])
 
@@ -250,7 +251,7 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
         name = "ResumeBackfillMutation"
 
     @capture_error
-    @check_permission("launch_partition_backfill")
+    @check_permission(Permissions.LAUNCH_PARTITION_BACKFILL)
     def mutate(self, graphene_info, **kwargs):
         return resume_partition_backfill(graphene_info, kwargs["backfillId"])
 
@@ -276,7 +277,7 @@ class GrapheneLaunchPipelineReexecutionMutation(graphene.Mutation):
         name = "LaunchPipelineReexecutionMutation"
 
     @capture_error
-    @check_permission("launch_pipeline_reexecution")
+    @check_permission(Permissions.LAUNCH_PIPELINE_REEXECUTION)
     def mutate(self, graphene_info, **kwargs):
         return create_execution_params_and_launch_pipeline_reexec(
             graphene_info,
@@ -308,7 +309,7 @@ class GrapheneTerminatePipelineExecutionMutation(graphene.Mutation):
         name = "TerminatePipelineExecutionMutation"
 
     @capture_error
-    @check_permission("terminate_pipeline_execution")
+    @check_permission(Permissions.TERMINATE_PIPELINE_EXECUTION)
     def mutate(self, graphene_info, **kwargs):
         return terminate_pipeline_execution(
             graphene_info,
@@ -357,7 +358,7 @@ class GrapheneReloadRepositoryLocationMutation(graphene.Mutation):
         name = "ReloadRepositoryLocationMutation"
 
     @capture_error
-    @check_permission("reload_repository_location")
+    @check_permission(Permissions.RELOAD_REPOSITORY_LOCATION)
     def mutate(self, graphene_info, **kwargs):
         location_name = kwargs["repositoryLocationName"]
 
@@ -386,7 +387,7 @@ class GrapheneShutdownRepositoryLocationMutation(graphene.Mutation):
         name = "ShutdownRepositoryLocationMutation"
 
     @capture_error
-    @check_permission("reload_repository_location")
+    @check_permission(Permissions.RELOAD_REPOSITORY_LOCATION)
     def mutate(self, graphene_info, **kwargs):
         location_name = kwargs["repositoryLocationName"]
 
@@ -417,7 +418,7 @@ class GrapheneReloadWorkspaceMutation(graphene.Mutation):
         name = "ReloadWorkspaceMutation"
 
     @capture_error
-    @check_permission("reload_workspace")
+    @check_permission(Permissions.RELOAD_WORKSPACE)
     def mutate(self, graphene_info, **_kwargs):
         new_context = graphene_info.context.reload_workspace()
         return fetch_workspace(new_context)
@@ -451,7 +452,7 @@ class GrapheneAssetWipeMutation(graphene.Mutation):
         name = "AssetWipeMutation"
 
     @capture_error
-    @check_permission("wipe_assets")
+    @check_permission(Permissions.WIPE_ASSETS)
     def mutate(self, graphene_info, **kwargs):
         return wipe_assets(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -3,6 +3,7 @@ from dagster import check
 from dagster.core.host_representation import ExternalSchedule, ScheduleSelector
 from dagster.core.host_representation.selector import RepositorySelector
 from dagster.core.scheduler.job import JobTickStatsSnapshot
+from dagster.core.workspace.permissions import Permissions
 
 from ...implementation.fetch_schedules import (
     reconcile_scheduler_state,
@@ -96,7 +97,7 @@ class GrapheneReconcileSchedulerStateMutation(graphene.Mutation):
         name = "ReconcileSchedulerStateMutation"
 
     @capture_error
-    @check_permission("start_schedule")
+    @check_permission(Permissions.START_SCHEDULE)
     def mutate(self, graphene_info, repository_selector):
         return reconcile_scheduler_state(
             graphene_info, RepositorySelector.from_graphql_input(repository_selector)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -2,6 +2,7 @@ import graphene
 from dagster import check
 from dagster.core.host_representation import ExternalSensor, SensorSelector
 from dagster.core.scheduler.job import JobState
+from dagster.core.workspace.permissions import Permissions
 from dagster_graphql.implementation.utils import capture_error, check_permission
 
 from ..implementation.fetch_sensors import get_sensor_next_tick, start_sensor, stop_sensor
@@ -98,7 +99,7 @@ class GrapheneStartSensorMutation(graphene.Mutation):
         name = "StartSensorMutation"
 
     @capture_error
-    @check_permission("start_sensor")
+    @check_permission(Permissions.START_SENSOR)
     def mutate(self, graphene_info, sensor_selector):
         return start_sensor(graphene_info, SensorSelector.from_graphql_input(sensor_selector))
 
@@ -136,7 +137,7 @@ class GrapheneStopSensorMutation(graphene.Mutation):
         name = "StopSensorMutation"
 
     @capture_error
-    @check_permission("stop_sensor")
+    @check_permission(Permissions.STOP_SENSOR)
     def mutate(self, graphene_info, job_origin_id):
         return stop_sensor(graphene_info, job_origin_id)
 

--- a/python_modules/dagster/dagster/core/workspace/permissions.py
+++ b/python_modules/dagster/dagster/core/workspace/permissions.py
@@ -1,40 +1,63 @@
+from enum import Enum, unique
 from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from .context import WorkspaceProcessContext
 
-VIEWER_PERMISSIONS = {
-    "launch_pipeline_execution": False,
-    "launch_pipeline_reexecution": False,
-    "reconcile_scheduler_state": False,
-    "start_schedule": False,
-    "stop_running_schedule": False,
-    "start_sensor": False,
-    "stop_sensor": False,
-    "terminate_pipeline_execution": False,
-    "delete_pipeline_run": False,
-    "reload_repository_location": False,
-    "reload_workspace": False,
-    "wipe_assets": False,
-    "launch_partition_backfill": False,
-    "cancel_partition_backfill": False,
+
+@unique
+class Permissions(str, Enum):
+    LAUNCH_PIPELINE_EXECUTION = "launch_pipeline_execution"
+    LAUNCH_PIPELINE_REEXECUTION = "launch_pipeline_reexecution"
+    RECONCILE_SCHEDULER_STATE = "reconcile_scheduler_state"
+    START_SCHEDULE = "start_schedule"
+    STOP_RUNNING_SCHEDULE = "stop_running_schedule"
+    START_SENSOR = "start_sensor"
+    STOP_SENSOR = "stop_sensor"
+    TERMINATE_PIPELINE_EXECUTION = "terminate_pipeline_execution"
+    DELETE_PIPELINE_RUN = "delete_pipeline_run"
+    RELOAD_REPOSITORY_LOCATION = "reload_repository_location"
+    RELOAD_WORKSPACE = "reload_workspace"
+    WIPE_ASSETS = "wipe_assets"
+    LAUNCH_PARTITION_BACKFILL = "launch_partition_backfill"
+    CANCEL_PARTITION_BACKFILL = "cancel_partition_backfill"
+
+    def __str__(self) -> str:
+        return str.__str__(self)
+
+
+VIEWER_PERMISSIONS: Dict[str, bool] = {
+    Permissions.LAUNCH_PIPELINE_EXECUTION: False,
+    Permissions.LAUNCH_PIPELINE_REEXECUTION: False,
+    Permissions.RECONCILE_SCHEDULER_STATE: False,
+    Permissions.START_SCHEDULE: False,
+    Permissions.STOP_RUNNING_SCHEDULE: False,
+    Permissions.START_SENSOR: False,
+    Permissions.STOP_SENSOR: False,
+    Permissions.TERMINATE_PIPELINE_EXECUTION: False,
+    Permissions.DELETE_PIPELINE_RUN: False,
+    Permissions.RELOAD_REPOSITORY_LOCATION: False,
+    Permissions.RELOAD_WORKSPACE: False,
+    Permissions.WIPE_ASSETS: False,
+    Permissions.LAUNCH_PARTITION_BACKFILL: False,
+    Permissions.CANCEL_PARTITION_BACKFILL: False,
 }
 
-EDITOR_PERMISSIONS = {
-    "launch_pipeline_execution": True,
-    "launch_pipeline_reexecution": True,
-    "reconcile_scheduler_state": True,
-    "start_schedule": True,
-    "stop_running_schedule": True,
-    "start_sensor": True,
-    "stop_sensor": True,
-    "terminate_pipeline_execution": True,
-    "delete_pipeline_run": True,
-    "reload_repository_location": True,
-    "reload_workspace": True,
-    "wipe_assets": True,
-    "launch_partition_backfill": True,
-    "cancel_partition_backfill": True,
+EDITOR_PERMISSIONS: Dict[str, bool] = {
+    Permissions.LAUNCH_PIPELINE_EXECUTION: True,
+    Permissions.LAUNCH_PIPELINE_REEXECUTION: True,
+    Permissions.RECONCILE_SCHEDULER_STATE: True,
+    Permissions.START_SCHEDULE: True,
+    Permissions.STOP_RUNNING_SCHEDULE: True,
+    Permissions.START_SENSOR: True,
+    Permissions.STOP_SENSOR: True,
+    Permissions.TERMINATE_PIPELINE_EXECUTION: True,
+    Permissions.DELETE_PIPELINE_RUN: True,
+    Permissions.RELOAD_REPOSITORY_LOCATION: True,
+    Permissions.RELOAD_WORKSPACE: True,
+    Permissions.WIPE_ASSETS: True,
+    Permissions.LAUNCH_PARTITION_BACKFILL: True,
+    Permissions.CANCEL_PARTITION_BACKFILL: True,
 }
 
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
As the title. Raw strings are unwieldy, so let's use enums instead. 

The only gotcha here is to avoid calling `.value` all the time on the enum field, we subclass `str` to duck type the enum members. See https://www.cosmicpython.com/blog/2020-10-27-i-hate-enums.html. However, mypy doesn't recognize this, so we have to cast [1] accordingly.

## Test Plan
pytest