### PR TITLE
Fix docker run launcher with no network or networks set

### DIFF
--- a/python_modules/dagster/dagster/utils/test/postgres_instance.py
+++ b/python_modules/dagster/dagster/utils/test/postgres_instance.py
@@ -13,11 +13,12 @@ BUILDKITE = bool(os.getenv("BUILDKITE"))
 
 
 @contextmanager
-def postgres_instance_for_test(dunder_file, container_name, overrides=None):
+def postgres_instance_for_test(dunder_file, container_name, overrides=None, conn_args=None):
     with tempfile.TemporaryDirectory() as temp_dir:
         with TestPostgresInstance.docker_service_up_or_skip(
             file_relative_path(dunder_file, "docker-compose.yml"),
             container_name,
+            conn_args=conn_args,
         ) as pg_conn_string:
             TestPostgresInstance.clean_run_storage(pg_conn_string)
             TestPostgresInstance.clean_event_log_storage(pg_conn_string)

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -49,6 +49,8 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             self._networks = [network]
         elif networks:
             self._networks = networks
+        else:
+            self._networks = []
 
         self._container_kwargs = check.opt_dict_param(
             container_kwargs, "container_kwargs", key_type=str


### PR DESCRIPTION
Summary:
This was erroring out in launch_run. Testing is a little funky since we kind of need it to be set for the run to actually complete (a mocked out docker client would help here), but we can still validate that the launch_run call completes successfully and a container is started.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.