### PR TITLE
[crag] pyspark guide

### DIFF
--- a/docs/content-crag/_navigation.json
+++ b/docs/content-crag/_navigation.json
@@ -350,7 +350,7 @@
           },
           {
             "title": "Dagster with PySpark",
-            "path": "/integrations/pyspark"
+            "path": "/integrations/spark"
           },
           {
             "title": "Dagster with Pandas",

--- a/docs/content-crag/integrations.mdx
+++ b/docs/content-crag/integrations.mdx
@@ -15,7 +15,7 @@ This section includes guides on how to use Dagster with other tools.
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [Dagster with dbt](/integrations/dbt)                               | Orchestrate dbt from Dagster.                                                        |
 | [Dagster with Great Expectations](/integrations/great-expectations) | Run data quality tests using Great Expectations in a Dagster pipeline.               |
-| [Dagster with PySpark](/integrations/pyspark)                       | Define and execute spark jobs in Dagster.                                            |
+| [Dagster with PySpark](/integrations/spark)                       | Define and execute spark jobs in Dagster.                                            |
 | [Dagster with Pandas](/integrations/pandas)                         | How Dagster works with Pandas.                                                       |
 | [Dagster with Jupyter/Papermill](/integrations/dagstermill)         | How to orchestrate Jupyter notebooks from Dagster.                                   |
 | [Dagster with Airflow](/integrations/airflow)                       | Use Dagster in an Airflow cluster, or transform Airflow DAGs into Dagster pipelines. |

--- a/docs/content-crag/integrations.mdx
+++ b/docs/content-crag/integrations.mdx
@@ -15,7 +15,7 @@ This section includes guides on how to use Dagster with other tools.
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [Dagster with dbt](/integrations/dbt)                               | Orchestrate dbt from Dagster.                                                        |
 | [Dagster with Great Expectations](/integrations/great-expectations) | Run data quality tests using Great Expectations in a Dagster pipeline.               |
-| [Dagster with PySpark](/integrations/spark)                       | Define and execute spark jobs in Dagster.                                            |
+| [Dagster with PySpark](/integrations/spark)                         | Define and execute spark jobs in Dagster.                                            |
 | [Dagster with Pandas](/integrations/pandas)                         | How Dagster works with Pandas.                                                       |
 | [Dagster with Jupyter/Papermill](/integrations/dagstermill)         | How to orchestrate Jupyter notebooks from Dagster.                                   |
 | [Dagster with Airflow](/integrations/airflow)                       | Use Dagster in an Airflow cluster, or transform Airflow DAGs into Dagster pipelines. |

--- a/docs/content-crag/integrations/pyspark.mdx
+++ b/docs/content-crag/integrations/pyspark.mdx
@@ -27,8 +27,8 @@ This example writes out DataFrames to the local file system, but can be tweaked 
 ```python file=../../basic_pyspark/repo.py startafter=start_repo_marker_0 endbefore=end_repo_marker_0
 import os
 
-from dagster import IOManager, ModeDefinition, io_manager, pipeline, repository, solid
-from pyspark.sql import Row, SparkSession
+from dagster import IOManager, graph, io_manager, op, repository
+from pyspark.sql import DataFrame, Row, SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 
@@ -45,26 +45,31 @@ class LocalParquetStore(IOManager):
 
 
 @io_manager
-def local_parquet_store(_):
+def local_parquet_store():
     return LocalParquetStore()
 
 
-@solid
-def make_people():
+@op
+def make_people() -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     spark = SparkSession.builder.getOrCreate()
     return spark.createDataFrame(rows, schema)
 
 
-@solid
-def filter_over_50(people):
+@op
+def filter_over_50(people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": local_parquet_store})])
-def my_pipeline():
+@graph
+def make_and_filter_data():
     filter_over_50(make_people())
+
+
+make_and_filter_data_job = make_and_filter_data.to_job(
+    resource_defs={"io_manager": local_parquet_store}
+)
 ```
 
 ## Submitting PySpark solids on EMR
@@ -76,13 +81,7 @@ This example demonstrates how to have a solid run as a Spark step on an EMR clus
 ```python file=../../emr_pyspark/repo.py startafter=start-snippet endbefore=end-snippet
 from pathlib import Path
 
-from dagster import (
-    ModeDefinition,
-    make_python_type_usable_as_dagster_type,
-    pipeline,
-    repository,
-    solid,
-)
+from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster_aws.emr import emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
@@ -95,56 +94,57 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 make_python_type_usable_as_dagster_type(python_type=DataFrame, dagster_type=DagsterPySparkDataFrame)
 
 
-@solid(required_resource_keys={"pyspark", "pyspark_step_launcher"})
+@op(required_resource_keys={"pyspark", "pyspark_step_launcher"})
 def make_people(context) -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
-@solid(required_resource_keys={"pyspark_step_launcher"})
-def filter_over_50(_, people: DataFrame) -> DataFrame:
+@op(required_resource_keys={"pyspark_step_launcher"})
+def filter_over_50(people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@solid(required_resource_keys={"pyspark_step_launcher"})
-def count_people(_, people: DataFrame) -> int:
+@op(required_resource_keys={"pyspark_step_launcher"})
+def count_people(people: DataFrame) -> int:
     return people.count()
 
 
-emr_mode = ModeDefinition(
-    name="emr",
-    resource_defs={
-        "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
-            {
-                "cluster_id": {"env": "EMR_CLUSTER_ID"},
-                "local_pipeline_package_path": str(Path(__file__).parent),
-                "deploy_local_pipeline_package": True,
-                "region_name": "us-west-1",
-                "staging_bucket": "my_staging_bucket",
-                "wait_for_logs": True,
-            }
-        ),
-        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
-        "s3": s3_resource,
-        "io_manager": s3_pickle_io_manager.configured(
-            {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
-        ),
-    },
-)
+emr_resource_defs = {
+    "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
+        {
+            "cluster_id": {"env": "EMR_CLUSTER_ID"},
+            "local_pipeline_package_path": str(Path(__file__).parent),
+            "deploy_local_pipeline_package": True,
+            "region_name": "us-west-1",
+            "staging_bucket": "my_staging_bucket",
+            "wait_for_logs": True,
+        }
+    ),
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
+    "s3": s3_resource,
+    "io_manager": s3_pickle_io_manager.configured(
+        {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
+    ),
+}
 
-local_mode = ModeDefinition(
-    name="local",
-    resource_defs={
-        "pyspark_step_launcher": no_step_launcher,
-        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
-    },
-)
+local_resource_defs = {
+    "pyspark_step_launcher": no_step_launcher,
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
+}
 
 
-@pipeline(mode_defs=[emr_mode, local_mode])
-def my_pipeline():
+@graph
+def count_people_over_50():
     count_people(filter_over_50(make_people()))
+
+
+count_people_over_50_local = count_people_over_50.to_job(
+    name="local", resource_defs=local_resource_defs
+)
+
+count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
 ```
 
 It accomplishes this by using the `emr_pyspark_step_launcher`, which knows how to launch an EMR step that runs the contents of a solid. The example defines a mode that links the resource key "pyspark_step_launcher" to the `emr_pyspark_step_launcher` resource definition, and then requires that "pyspark_step_launcher" resource key for the solid which it wants to launch remotely.

--- a/docs/content-crag/integrations/spark.mdx
+++ b/docs/content-crag/integrations/spark.mdx
@@ -1,30 +1,52 @@
 ---
-title: Dagster with PySpark | Dagster
+title: Dagster with Spark
+description: Dagster ops can perform computations using Spark.
 ---
 
-# Using Dagster with PySpark
+# Using Dagster with Spark
 
-This guide includes two examples:
+Dagster ops can perform computations using Spark.
 
-- [Running PySpark code in solids](#running-pyspark-code-in-solids) demonstrates the basic usage of the [`dagster-pyspark`](/\_apidocs/libraries/dagster_pyspark) package.
-- [Submitting PySpark solids on EMR](#submitting-pyspark-solids-on-emr) shows have a solid run as a Spark step on an EMR cluster.
+Running computations on Spark presents unique challenges, because, unlike other computations, Spark jobs typically execute on infrastructure that's specialized for Spark - i.e. that can network sets of workers into clusters that Spark can run computations against. Spark applications are typically not containerized or executed on Kubernetes. Running Spark code often requires submitting code to a Databricks or EMR cluster.
 
-## Running PySpark code in solids
+There are two approaches to writing Dagster ops that invoke Spark computations:
+
+## Op body submits job
+
+With this approach, the code inside the op submits a job to an external system like Databricks or EMR, usually pointing to a jar or zip of Python files that contain the actual Spark data transformations and actions.
+
+If you want to use this approach to run a Spark job on Databricks, <PyObject module='dagster_databricks' object='create_databricks_job_solid' /> helps create an op that submits a job using the Databricks REST API.
+
+If you want to run a Spark job against YARN or a Spark Standalone cluster, you can use <PyObject module='dagster_shell' object='create_shell_command_solid' /> to create an op that invokes `spark-submit`.
+
+This is the easiest approach for migrating existing Spark jobs, and it's the only approach that works for Spark jobs written in Java or Scala. The downside is that it loses out on some of the benefits of Dagster - the implementation of each op is bound to the execution environment, so you can't run your Spark transformations without relying on external infrastructure. Writing unit tests is cumbersome.
+
+## Op accepts and produces DataFrames or RDDs
+
+With this approach, the code inside the op consists of pure logical data transformations on Spark DataFrames or RDDs. The op-decorated function accepts DataFrames as parameters and returns DataFrames when it completes. An [IOManager](/concepts/io-management/io-managers) handles writing and reading the DataFrames to and from persistent storage. The [Running PySpark code in op](#running-pyspark-code-in-ops) example below shows what this looks like.
+
+If you want your Spark driver to run inside a Spark cluster, you use a "step launcher" resource that informs Dagster how to launch the op. The step launcher resource is responsible for invoking `spark-submit` or submitting the job to Databricks or EMR. [Submitting PySpark ops on EMR](#submitting-pyspark-ops-on-emr) shows what this looks like for EMR.
+
+The advantage of this approach is a very clean local testing story. You can run an entire pipeline of Spark ops in a single process. You can use [IOManagers](/concepts/io-management/io-managers) to abstract away IO - storing outputs on the local filesystem during local development and in the cloud in production.
+
+The downside is that this approach only works with PySpark, and setting up a step launcher can be difficult. We currently provide an <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> and a <PyObject module='dagster_databricks' object='databricks_pyspark_step_launcher' />, but if you need to submit your Spark job to a different kind of cluster, writing your own can be time consuming ([here are some tips](https://github.com/dagster-io/dagster/discussions/3201)). You also need to install the Dagster library itself on the cluster.
+
+### Running PySpark code in ops
 
 <CodeReferenceLink filePath="examples/basic_pyspark" />
 
-Passing PySpark DataFrames between solids requires a little bit of extra care, for a couple reasons:
+Passing PySpark DataFrames between ops requires a little bit of extra care, compared to other data types, for a couple reasons:
 
 - Spark has a lazy execution model, which means that PySpark won't process any data until an action like `write` or `collect` is called on a DataFrame.
 - PySpark DataFrames cannot be pickled, which means that [IO Managers](/concepts/io-management/io-managers) like the `fs_io_manager` won't work for them.
 
-In this example, we've defined an Asset Store that knows how to store and retrieve PySpark DataFrames that are produced and consumed by solids.
+In this example, we've defined an <PyObject module='dagster' object='IOManager' /> that knows how to store and retrieve PySpark DataFrames that are produced and consumed by ops.
 
 This example assumes that all the outputs within the pipeline will be PySpark DataFrames and stored in the same way. To learn how to use different IO managers for different outputs within the same pipeline, take a look at the [IO Manager](/concepts/io-management/io-managers) concept page.
 
 This example writes out DataFrames to the local file system, but can be tweaked to write to cloud object stores like S3 by changing to the `write` and `read` invocations.
 
-```python file=../../basic_pyspark/repo.py startafter=start_repo_marker_0 endbefore=end_repo_marker_0
+```python file=../../basic_pyspark_crag/repo.py startafter=start_repo_marker_0 endbefore=end_repo_marker_0
 import os
 
 from dagster import IOManager, graph, io_manager, op, repository
@@ -72,13 +94,13 @@ make_and_filter_data_job = make_and_filter_data.to_job(
 )
 ```
 
-## Submitting PySpark solids on EMR
+### Submitting PySpark ops on EMR
 
 <CodeReferenceLink filePath="examples/emr_pyspark" />
 
-This example demonstrates how to have a solid run as a Spark step on an EMR cluster. In it, each of the three solids will be executed as a separate EMR step on the same EMR cluster.
+This example demonstrates how to use the <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> to have an op run as a Spark step on an EMR cluster. In it, each of the three ops will be executed as a separate EMR step on the same EMR cluster.
 
-```python file=../../emr_pyspark/repo.py startafter=start-snippet endbefore=end-snippet
+```python file=../../emr_pyspark_crag/repo.py startafter=start-snippet endbefore=end-snippet
 from pathlib import Path
 
 from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
@@ -147,8 +169,4 @@ count_people_over_50_local = count_people_over_50.to_job(
 count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
 ```
 
-It accomplishes this by using the `emr_pyspark_step_launcher`, which knows how to launch an EMR step that runs the contents of a solid. The example defines a mode that links the resource key "pyspark_step_launcher" to the `emr_pyspark_step_launcher` resource definition, and then requires that "pyspark_step_launcher" resource key for the solid which it wants to launch remotely.
-
 The EMR PySpark step launcher relies on S3 to shuttle config and events to and from EMR.
-
-More generally, a step launcher is any resource that extends the StepLauncher abstract class, whose methods can be invoked where a solid would otherwise be executed in-process to instead launch a remote process with the solid running inside it. To use a step launcher for a particular solid, set a required resource key for the solid that points to that resource.

--- a/docs/content/integrations/spark.mdx
+++ b/docs/content/integrations/spark.mdx
@@ -1,46 +1,46 @@
 ---
 title: Dagster with Spark
-description: Dagster solids can perform computations using Spark.
+description: Dagster ops can perform computations using Spark.
 ---
 
 # Using Dagster with Spark
 
-Dagster solids can perform computations using Spark.
+Dagster ops can perform computations using Spark.
 
 Running computations on Spark presents unique challenges, because, unlike other computations, Spark jobs typically execute on infrastructure that's specialized for Spark - i.e. that can network sets of workers into clusters that Spark can run computations against. Spark applications are typically not containerized or executed on Kubernetes. Running Spark code often requires submitting code to a Databricks or EMR cluster.
 
-There are two approaches to writing Dagster solids that invoke Spark computations:
+There are two approaches to writing Dagster ops that invoke Spark computations:
 
-## Solid body submits job
+## Op body submits job
 
-With this approach, the code inside the solid submits a job to an external system like Databricks or EMR, usually pointing to a jar or zip of Python files that contain the actual Spark data transformations and actions.
+With this approach, the code inside the op submits a job to an external system like Databricks or EMR, usually pointing to a jar or zip of Python files that contain the actual Spark data transformations and actions.
 
-If you want to use this approach to run a Spark job on Databricks, <PyObject module='dagster_databricks' object='create_databricks_job_solid' /> helps create a solid that submits a job using the Databricks REST API.
+If you want to use this approach to run a Spark job on Databricks, <PyObject module='dagster_databricks' object='create_databricks_job_solid' /> helps create an op that submits a job using the Databricks REST API.
 
-If you want to run a Spark job against YARN or a Spark Standalone cluster, you can use <PyObject module='dagster_shell' object='create_shell_command_solid' /> to create a solid that invokes `spark-submit`.
+If you want to run a Spark job against YARN or a Spark Standalone cluster, you can use <PyObject module='dagster_shell' object='create_shell_command_solid' /> to create an op that invokes `spark-submit`.
 
-This is the easiest approach for migrating existing Spark jobs, and it's the only approach that works for Spark jobs written in Java or Scala. The downside is that it loses out on some of the benefits of Dagster - the implementation of each solid is bound to the execution environment, so you can't run your Spark transformations without relying on external infrastructure. Writing unit tests is cumbersome.
+This is the easiest approach for migrating existing Spark jobs, and it's the only approach that works for Spark jobs written in Java or Scala. The downside is that it loses out on some of the benefits of Dagster - the implementation of each op is bound to the execution environment, so you can't run your Spark transformations without relying on external infrastructure. Writing unit tests is cumbersome.
 
-## Solid accepts and produces DataFrames or RDDs
+## Op accepts and produces DataFrames or RDDs
 
-With this approach, the code inside the solid consists of pure logical data transformations on Spark DataFrames or RDDs. The solid-decorated function accepts DataFrames as parameters and returns DataFrames when it completes. An [IOManager](/concepts/io-management/io-managers) handles writing and reading the DataFrames to and from persistent storage. The [Running PySpark code in solids](#running-pyspark-code-in-solids) example below shows what this looks like.
+With this approach, the code inside the op consists of pure logical data transformations on Spark DataFrames or RDDs. The op-decorated function accepts DataFrames as parameters and returns DataFrames when it completes. An [IOManager](/concepts/io-management/io-managers) handles writing and reading the DataFrames to and from persistent storage. The [Running PySpark code in op](#running-pyspark-code-in-ops) example below shows what this looks like.
 
-If you want your Spark driver to run inside a Spark cluster, you use a "step launcher" resource that informs Dagster how to launch the solid. The step launcher resource is responsible for invoking `spark-submit` or submitting the job to Databricks or EMR. [Submitting PySpark solids on EMR](#submitting-pyspark-solids-on-emr) shows what this looks like for EMR.
+If you want your Spark driver to run inside a Spark cluster, you use a "step launcher" resource that informs Dagster how to launch the op. The step launcher resource is responsible for invoking `spark-submit` or submitting the job to Databricks or EMR. [Submitting PySpark ops on EMR](#submitting-pyspark-ops-on-emr) shows what this looks like for EMR.
 
-The advantage of this approach is a very clean local testing story. You can run an entire pipeline of Spark solids in a single process. You can use [IOManagers](/concepts/io-management/io-managers) to abstract away IO - storing outputs on the local filesystem during local development and in the cloud in production.
+The advantage of this approach is a very clean local testing story. You can run an entire pipeline of Spark ops in a single process. You can use [IOManagers](/concepts/io-management/io-managers) to abstract away IO - storing outputs on the local filesystem during local development and in the cloud in production.
 
 The downside is that this approach only works with PySpark, and setting up a step launcher can be difficult. We currently provide an <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> and a <PyObject module='dagster_databricks' object='databricks_pyspark_step_launcher' />, but if you need to submit your Spark job to a different kind of cluster, writing your own can be time consuming ([here are some tips](https://github.com/dagster-io/dagster/discussions/3201)). You also need to install the Dagster library itself on the cluster.
 
-### Running PySpark code in solids
+### Running PySpark code in ops
 
 <CodeReferenceLink filePath="examples/basic_pyspark" />
 
-Passing PySpark DataFrames between solids requires a little bit of extra care, compared to other data types, for a couple reasons:
+Passing PySpark DataFrames between ops requires a little bit of extra care, compared to other data types, for a couple reasons:
 
 - Spark has a lazy execution model, which means that PySpark won't process any data until an action like `write` or `collect` is called on a DataFrame.
 - PySpark DataFrames cannot be pickled, which means that [IO Managers](/concepts/io-management/io-managers) like the `fs_io_manager` won't work for them.
 
-In this example, we've defined an <PyObject module='dagster' object='IOManager' /> that knows how to store and retrieve PySpark DataFrames that are produced and consumed by solids.
+In this example, we've defined an <PyObject module='dagster' object='IOManager' /> that knows how to store and retrieve PySpark DataFrames that are produced and consumed by ops.
 
 This example assumes that all the outputs within the pipeline will be PySpark DataFrames and stored in the same way. To learn how to use different IO managers for different outputs within the same pipeline, take a look at the [IO Manager](/concepts/io-management/io-managers) concept page.
 
@@ -49,8 +49,8 @@ This example writes out DataFrames to the local file system, but can be tweaked 
 ```python file=../../basic_pyspark/repo.py startafter=start_repo_marker_0 endbefore=end_repo_marker_0
 import os
 
-from dagster import IOManager, ModeDefinition, io_manager, pipeline, repository, solid
-from pyspark.sql import Row, SparkSession
+from dagster import IOManager, graph, io_manager, op, repository
+from pyspark.sql import DataFrame, Row, SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 
@@ -67,44 +67,43 @@ class LocalParquetStore(IOManager):
 
 
 @io_manager
-def local_parquet_store(_):
+def local_parquet_store():
     return LocalParquetStore()
 
 
-@solid
-def make_people():
+@op
+def make_people() -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     spark = SparkSession.builder.getOrCreate()
     return spark.createDataFrame(rows, schema)
 
 
-@solid
-def filter_over_50(people):
+@op
+def filter_over_50(people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": local_parquet_store})])
-def my_pipeline():
+@graph
+def make_and_filter_data():
     filter_over_50(make_people())
+
+
+make_and_filter_data_job = make_and_filter_data.to_job(
+    resource_defs={"io_manager": local_parquet_store}
+)
 ```
 
-### Submitting PySpark solids on EMR
+### Submitting PySpark ops on EMR
 
 <CodeReferenceLink filePath="examples/emr_pyspark" />
 
-This example demonstrates how to use the <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> to have a solid run as a Spark step on an EMR cluster. In it, each of the three solids will be executed as a separate EMR step on the same EMR cluster.
+This example demonstrates how to use the <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> to have an op run as a Spark step on an EMR cluster. In it, each of the three ops will be executed as a separate EMR step on the same EMR cluster.
 
 ```python file=../../emr_pyspark/repo.py startafter=start-snippet endbefore=end-snippet
 from pathlib import Path
 
-from dagster import (
-    ModeDefinition,
-    make_python_type_usable_as_dagster_type,
-    pipeline,
-    repository,
-    solid,
-)
+from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster_aws.emr import emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
@@ -117,56 +116,57 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 make_python_type_usable_as_dagster_type(python_type=DataFrame, dagster_type=DagsterPySparkDataFrame)
 
 
-@solid(required_resource_keys={"pyspark", "pyspark_step_launcher"})
+@op(required_resource_keys={"pyspark", "pyspark_step_launcher"})
 def make_people(context) -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
-@solid(required_resource_keys={"pyspark_step_launcher"})
-def filter_over_50(_, people: DataFrame) -> DataFrame:
+@op(required_resource_keys={"pyspark_step_launcher"})
+def filter_over_50(people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@solid(required_resource_keys={"pyspark_step_launcher"})
-def count_people(_, people: DataFrame) -> int:
+@op(required_resource_keys={"pyspark_step_launcher"})
+def count_people(people: DataFrame) -> int:
     return people.count()
 
 
-emr_mode = ModeDefinition(
-    name="emr",
-    resource_defs={
-        "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
-            {
-                "cluster_id": {"env": "EMR_CLUSTER_ID"},
-                "local_pipeline_package_path": str(Path(__file__).parent),
-                "deploy_local_pipeline_package": True,
-                "region_name": "us-west-1",
-                "staging_bucket": "my_staging_bucket",
-                "wait_for_logs": True,
-            }
-        ),
-        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
-        "s3": s3_resource,
-        "io_manager": s3_pickle_io_manager.configured(
-            {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
-        ),
-    },
-)
+emr_resource_defs = {
+    "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
+        {
+            "cluster_id": {"env": "EMR_CLUSTER_ID"},
+            "local_pipeline_package_path": str(Path(__file__).parent),
+            "deploy_local_pipeline_package": True,
+            "region_name": "us-west-1",
+            "staging_bucket": "my_staging_bucket",
+            "wait_for_logs": True,
+        }
+    ),
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
+    "s3": s3_resource,
+    "io_manager": s3_pickle_io_manager.configured(
+        {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
+    ),
+}
 
-local_mode = ModeDefinition(
-    name="local",
-    resource_defs={
-        "pyspark_step_launcher": no_step_launcher,
-        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
-    },
-)
+local_resource_defs = {
+    "pyspark_step_launcher": no_step_launcher,
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
+}
 
 
-@pipeline(mode_defs=[emr_mode, local_mode])
-def my_pipeline():
+@graph
+def count_people_over_50():
     count_people(filter_over_50(make_people()))
+
+
+count_people_over_50_local = count_people_over_50.to_job(
+    name="local", resource_defs=local_resource_defs
+)
+
+count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
 ```
 
 The EMR PySpark step launcher relies on S3 to shuttle config and events to and from EMR.

--- a/docs/content/integrations/spark.mdx
+++ b/docs/content/integrations/spark.mdx
@@ -1,46 +1,46 @@
 ---
 title: Dagster with Spark
-description: Dagster ops can perform computations using Spark.
+description: Dagster solids can perform computations using Spark.
 ---
 
 # Using Dagster with Spark
 
-Dagster ops can perform computations using Spark.
+Dagster solids can perform computations using Spark.
 
 Running computations on Spark presents unique challenges, because, unlike other computations, Spark jobs typically execute on infrastructure that's specialized for Spark - i.e. that can network sets of workers into clusters that Spark can run computations against. Spark applications are typically not containerized or executed on Kubernetes. Running Spark code often requires submitting code to a Databricks or EMR cluster.
 
-There are two approaches to writing Dagster ops that invoke Spark computations:
+There are two approaches to writing Dagster solids that invoke Spark computations:
 
-## Op body submits job
+## Solid body submits job
 
-With this approach, the code inside the op submits a job to an external system like Databricks or EMR, usually pointing to a jar or zip of Python files that contain the actual Spark data transformations and actions.
+With this approach, the code inside the solid submits a job to an external system like Databricks or EMR, usually pointing to a jar or zip of Python files that contain the actual Spark data transformations and actions.
 
-If you want to use this approach to run a Spark job on Databricks, <PyObject module='dagster_databricks' object='create_databricks_job_solid' /> helps create an op that submits a job using the Databricks REST API.
+If you want to use this approach to run a Spark job on Databricks, <PyObject module='dagster_databricks' object='create_databricks_job_solid' /> helps create a solid that submits a job using the Databricks REST API.
 
-If you want to run a Spark job against YARN or a Spark Standalone cluster, you can use <PyObject module='dagster_shell' object='create_shell_command_solid' /> to create an op that invokes `spark-submit`.
+If you want to run a Spark job against YARN or a Spark Standalone cluster, you can use <PyObject module='dagster_shell' object='create_shell_command_solid' /> to create a solid that invokes `spark-submit`.
 
-This is the easiest approach for migrating existing Spark jobs, and it's the only approach that works for Spark jobs written in Java or Scala. The downside is that it loses out on some of the benefits of Dagster - the implementation of each op is bound to the execution environment, so you can't run your Spark transformations without relying on external infrastructure. Writing unit tests is cumbersome.
+This is the easiest approach for migrating existing Spark jobs, and it's the only approach that works for Spark jobs written in Java or Scala. The downside is that it loses out on some of the benefits of Dagster - the implementation of each solid is bound to the execution environment, so you can't run your Spark transformations without relying on external infrastructure. Writing unit tests is cumbersome.
 
-## Op accepts and produces DataFrames or RDDs
+## Solid accepts and produces DataFrames or RDDs
 
-With this approach, the code inside the op consists of pure logical data transformations on Spark DataFrames or RDDs. The op-decorated function accepts DataFrames as parameters and returns DataFrames when it completes. An [IOManager](/concepts/io-management/io-managers) handles writing and reading the DataFrames to and from persistent storage. The [Running PySpark code in op](#running-pyspark-code-in-ops) example below shows what this looks like.
+With this approach, the code inside the solid consists of pure logical data transformations on Spark DataFrames or RDDs. The solid-decorated function accepts DataFrames as parameters and returns DataFrames when it completes. An [IOManager](/concepts/io-management/io-managers) handles writing and reading the DataFrames to and from persistent storage. The [Running PySpark code in solids](#running-pyspark-code-in-solids) example below shows what this looks like.
 
-If you want your Spark driver to run inside a Spark cluster, you use a "step launcher" resource that informs Dagster how to launch the op. The step launcher resource is responsible for invoking `spark-submit` or submitting the job to Databricks or EMR. [Submitting PySpark ops on EMR](#submitting-pyspark-ops-on-emr) shows what this looks like for EMR.
+If you want your Spark driver to run inside a Spark cluster, you use a "step launcher" resource that informs Dagster how to launch the solid. The step launcher resource is responsible for invoking `spark-submit` or submitting the job to Databricks or EMR. [Submitting PySpark solids on EMR](#submitting-pyspark-solids-on-emr) shows what this looks like for EMR.
 
-The advantage of this approach is a very clean local testing story. You can run an entire pipeline of Spark ops in a single process. You can use [IOManagers](/concepts/io-management/io-managers) to abstract away IO - storing outputs on the local filesystem during local development and in the cloud in production.
+The advantage of this approach is a very clean local testing story. You can run an entire pipeline of Spark solids in a single process. You can use [IOManagers](/concepts/io-management/io-managers) to abstract away IO - storing outputs on the local filesystem during local development and in the cloud in production.
 
 The downside is that this approach only works with PySpark, and setting up a step launcher can be difficult. We currently provide an <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> and a <PyObject module='dagster_databricks' object='databricks_pyspark_step_launcher' />, but if you need to submit your Spark job to a different kind of cluster, writing your own can be time consuming ([here are some tips](https://github.com/dagster-io/dagster/discussions/3201)). You also need to install the Dagster library itself on the cluster.
 
-### Running PySpark code in ops
+### Running PySpark code in solids
 
 <CodeReferenceLink filePath="examples/basic_pyspark" />
 
-Passing PySpark DataFrames between ops requires a little bit of extra care, compared to other data types, for a couple reasons:
+Passing PySpark DataFrames between solids requires a little bit of extra care, compared to other data types, for a couple reasons:
 
 - Spark has a lazy execution model, which means that PySpark won't process any data until an action like `write` or `collect` is called on a DataFrame.
 - PySpark DataFrames cannot be pickled, which means that [IO Managers](/concepts/io-management/io-managers) like the `fs_io_manager` won't work for them.
 
-In this example, we've defined an <PyObject module='dagster' object='IOManager' /> that knows how to store and retrieve PySpark DataFrames that are produced and consumed by ops.
+In this example, we've defined an <PyObject module='dagster' object='IOManager' /> that knows how to store and retrieve PySpark DataFrames that are produced and consumed by solids.
 
 This example assumes that all the outputs within the pipeline will be PySpark DataFrames and stored in the same way. To learn how to use different IO managers for different outputs within the same pipeline, take a look at the [IO Manager](/concepts/io-management/io-managers) concept page.
 
@@ -49,8 +49,8 @@ This example writes out DataFrames to the local file system, but can be tweaked 
 ```python file=../../basic_pyspark/repo.py startafter=start_repo_marker_0 endbefore=end_repo_marker_0
 import os
 
-from dagster import IOManager, graph, io_manager, op, repository
-from pyspark.sql import DataFrame, Row, SparkSession
+from dagster import IOManager, ModeDefinition, io_manager, pipeline, repository, solid
+from pyspark.sql import Row, SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 
@@ -67,43 +67,44 @@ class LocalParquetStore(IOManager):
 
 
 @io_manager
-def local_parquet_store():
+def local_parquet_store(_):
     return LocalParquetStore()
 
 
-@op
-def make_people() -> DataFrame:
+@solid
+def make_people():
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     spark = SparkSession.builder.getOrCreate()
     return spark.createDataFrame(rows, schema)
 
 
-@op
-def filter_over_50(people: DataFrame) -> DataFrame:
+@solid
+def filter_over_50(people):
     return people.filter(people["age"] > 50)
 
 
-@graph
-def make_and_filter_data():
+@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": local_parquet_store})])
+def my_pipeline():
     filter_over_50(make_people())
-
-
-make_and_filter_data_job = make_and_filter_data.to_job(
-    resource_defs={"io_manager": local_parquet_store}
-)
 ```
 
-### Submitting PySpark ops on EMR
+### Submitting PySpark solids on EMR
 
 <CodeReferenceLink filePath="examples/emr_pyspark" />
 
-This example demonstrates how to use the <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> to have an op run as a Spark step on an EMR cluster. In it, each of the three ops will be executed as a separate EMR step on the same EMR cluster.
+This example demonstrates how to use the <PyObject module='dagster_aws.emr' object='emr_pyspark_step_launcher' /> to have a solid run as a Spark step on an EMR cluster. In it, each of the three solids will be executed as a separate EMR step on the same EMR cluster.
 
 ```python file=../../emr_pyspark/repo.py startafter=start-snippet endbefore=end-snippet
 from pathlib import Path
 
-from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
+from dagster import (
+    ModeDefinition,
+    make_python_type_usable_as_dagster_type,
+    pipeline,
+    repository,
+    solid,
+)
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster_aws.emr import emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
@@ -116,57 +117,56 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 make_python_type_usable_as_dagster_type(python_type=DataFrame, dagster_type=DagsterPySparkDataFrame)
 
 
-@op(required_resource_keys={"pyspark", "pyspark_step_launcher"})
+@solid(required_resource_keys={"pyspark", "pyspark_step_launcher"})
 def make_people(context) -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
-@op(required_resource_keys={"pyspark_step_launcher"})
-def filter_over_50(people: DataFrame) -> DataFrame:
+@solid(required_resource_keys={"pyspark_step_launcher"})
+def filter_over_50(_, people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@op(required_resource_keys={"pyspark_step_launcher"})
-def count_people(people: DataFrame) -> int:
+@solid(required_resource_keys={"pyspark_step_launcher"})
+def count_people(_, people: DataFrame) -> int:
     return people.count()
 
 
-emr_resource_defs = {
-    "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
-        {
-            "cluster_id": {"env": "EMR_CLUSTER_ID"},
-            "local_pipeline_package_path": str(Path(__file__).parent),
-            "deploy_local_pipeline_package": True,
-            "region_name": "us-west-1",
-            "staging_bucket": "my_staging_bucket",
-            "wait_for_logs": True,
-        }
-    ),
-    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
-    "s3": s3_resource,
-    "io_manager": s3_pickle_io_manager.configured(
-        {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
-    ),
-}
-
-local_resource_defs = {
-    "pyspark_step_launcher": no_step_launcher,
-    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
-}
-
-
-@graph
-def count_people_over_50():
-    count_people(filter_over_50(make_people()))
-
-
-count_people_over_50_local = count_people_over_50.to_job(
-    name="local", resource_defs=local_resource_defs
+emr_mode = ModeDefinition(
+    name="emr",
+    resource_defs={
+        "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
+            {
+                "cluster_id": {"env": "EMR_CLUSTER_ID"},
+                "local_pipeline_package_path": str(Path(__file__).parent),
+                "deploy_local_pipeline_package": True,
+                "region_name": "us-west-1",
+                "staging_bucket": "my_staging_bucket",
+                "wait_for_logs": True,
+            }
+        ),
+        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
+        "s3": s3_resource,
+        "io_manager": s3_pickle_io_manager.configured(
+            {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
+        ),
+    },
 )
 
-count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
+local_mode = ModeDefinition(
+    name="local",
+    resource_defs={
+        "pyspark_step_launcher": no_step_launcher,
+        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
+    },
+)
+
+
+@pipeline(mode_defs=[emr_mode, local_mode])
+def my_pipeline():
+    count_people(filter_over_50(make_people()))
 ```
 
 The EMR PySpark step launcher relies on S3 to shuttle config and events to and from EMR.

--- a/examples/basic_pyspark/tests/test_basic_pyspark.py
+++ b/examples/basic_pyspark/tests/test_basic_pyspark.py
@@ -1,6 +1,8 @@
-from ..repo import make_and_filter_data_job
+from dagster import execute_pipeline
+
+from ..repo import my_pipeline
 
 
 def test_basic_pyspark():
-    res = make_and_filter_data_job.execute_in_process()
+    res = execute_pipeline(my_pipeline)
     assert res.success

--- a/examples/basic_pyspark/tests/test_basic_pyspark.py
+++ b/examples/basic_pyspark/tests/test_basic_pyspark.py
@@ -1,8 +1,6 @@
-from dagster import execute_pipeline
-
-from ..repo import my_pipeline
+from ..repo import make_and_filter_data_job
 
 
 def test_basic_pyspark():
-    res = execute_pipeline(my_pipeline)
+    res = make_and_filter_data_job.execute_in_process()
     assert res.success

--- a/examples/basic_pyspark_crag/README.md
+++ b/examples/basic_pyspark_crag/README.md
@@ -1,0 +1,1 @@
+View this example in the Dagster docs at https://docs.dagster.io/examples/basic_pyspark.

--- a/examples/basic_pyspark_crag/requirements.txt
+++ b/examples/basic_pyspark_crag/requirements.txt
@@ -1,0 +1,2 @@
+dagster
+dagit

--- a/examples/basic_pyspark_crag/tests/test_basic_pyspark.py
+++ b/examples/basic_pyspark_crag/tests/test_basic_pyspark.py
@@ -1,0 +1,6 @@
+from ..repo import make_and_filter_data_job
+
+
+def test_basic_pyspark():
+    res = make_and_filter_data_job.execute_in_process()
+    assert res.success

--- a/examples/basic_pyspark_crag/tox.ini
+++ b/examples/basic_pyspark_crag/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py{38,37,36}-{unix,windows},pylint
+skipsdist = True
+
+[testenv]
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
+deps =
+  -e ../../python_modules/dagster[test]
+  -e ../../python_modules/libraries/dagster-spark
+  -e ../../python_modules/libraries/dagster-pyspark
+whitelist_externals =
+  /bin/bash
+  echo
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
+  pytest -vv {posargs}
+
+[testenv:pylint]
+basepython = python
+commands =
+  /bin/bash -c 'cd .. && pylint -j 0 --rcfile=../.pylintrc basic_pyspark/'

--- a/examples/basic_pyspark_crag/tox.ini
+++ b/examples/basic_pyspark_crag/tox.ini
@@ -19,4 +19,4 @@ commands =
 [testenv:pylint]
 basepython = python
 commands =
-  /bin/bash -c 'cd .. && pylint -j 0 --rcfile=../.pylintrc basic_pyspark/'
+  /bin/bash -c 'cd .. && pylint -j 0 --rcfile=../.pylintrc basic_pyspark_crag/'

--- a/examples/basic_pyspark_crag/workspace.yaml
+++ b/examples/basic_pyspark_crag/workspace.yaml
@@ -1,0 +1,2 @@
+load_from:
+  - python_file: repo.py

--- a/examples/emr_pyspark/repo.py
+++ b/examples/emr_pyspark/repo.py
@@ -1,13 +1,7 @@
 # start-snippet
 from pathlib import Path
 
-from dagster import (
-    ModeDefinition,
-    make_python_type_usable_as_dagster_type,
-    pipeline,
-    repository,
-    solid,
-)
+from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster_aws.emr import emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
@@ -20,61 +14,61 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 make_python_type_usable_as_dagster_type(python_type=DataFrame, dagster_type=DagsterPySparkDataFrame)
 
 
-@solid(required_resource_keys={"pyspark", "pyspark_step_launcher"})
+@op(required_resource_keys={"pyspark", "pyspark_step_launcher"})
 def make_people(context) -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
-@solid(required_resource_keys={"pyspark_step_launcher"})
-def filter_over_50(_, people: DataFrame) -> DataFrame:
+@op(required_resource_keys={"pyspark_step_launcher"})
+def filter_over_50(people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@solid(required_resource_keys={"pyspark_step_launcher"})
-def count_people(_, people: DataFrame) -> int:
+@op(required_resource_keys={"pyspark_step_launcher"})
+def count_people(people: DataFrame) -> int:
     return people.count()
 
 
-emr_mode = ModeDefinition(
-    name="emr",
-    resource_defs={
-        "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
-            {
-                "cluster_id": {"env": "EMR_CLUSTER_ID"},
-                "local_pipeline_package_path": str(Path(__file__).parent),
-                "deploy_local_pipeline_package": True,
-                "region_name": "us-west-1",
-                "staging_bucket": "my_staging_bucket",
-                "wait_for_logs": True,
-            }
-        ),
-        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
-        "s3": s3_resource,
-        "io_manager": s3_pickle_io_manager.configured(
-            {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
-        ),
-    },
-)
+emr_resource_defs = {
+    "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
+        {
+            "cluster_id": {"env": "EMR_CLUSTER_ID"},
+            "local_pipeline_package_path": str(Path(__file__).parent),
+            "deploy_local_pipeline_package": True,
+            "region_name": "us-west-1",
+            "staging_bucket": "my_staging_bucket",
+            "wait_for_logs": True,
+        }
+    ),
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
+    "s3": s3_resource,
+    "io_manager": s3_pickle_io_manager.configured(
+        {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
+    ),
+}
 
-local_mode = ModeDefinition(
-    name="local",
-    resource_defs={
-        "pyspark_step_launcher": no_step_launcher,
-        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
-    },
-)
+local_resource_defs = {
+    "pyspark_step_launcher": no_step_launcher,
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
+}
 
 
-@pipeline(mode_defs=[emr_mode, local_mode])
-def my_pipeline():
+@graph
+def count_people_over_50():
     count_people(filter_over_50(make_people()))
 
+
+count_people_over_50_local = count_people_over_50.to_job(
+    name="local", resource_defs=local_resource_defs
+)
+
+count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
 
 # end-snippet
 
 
 @repository
 def emr_pyspark_example():
-    return [my_pipeline]
+    return [count_people_over_50_emr, count_people_over_50_local]

--- a/examples/emr_pyspark/repo.py
+++ b/examples/emr_pyspark/repo.py
@@ -1,7 +1,13 @@
 # start-snippet
 from pathlib import Path
 
-from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
+from dagster import (
+    ModeDefinition,
+    make_python_type_usable_as_dagster_type,
+    pipeline,
+    repository,
+    solid,
+)
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster_aws.emr import emr_pyspark_step_launcher
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
@@ -14,61 +20,61 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 make_python_type_usable_as_dagster_type(python_type=DataFrame, dagster_type=DagsterPySparkDataFrame)
 
 
-@op(required_resource_keys={"pyspark", "pyspark_step_launcher"})
+@solid(required_resource_keys={"pyspark", "pyspark_step_launcher"})
 def make_people(context) -> DataFrame:
     schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
     rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
     return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
 
 
-@op(required_resource_keys={"pyspark_step_launcher"})
-def filter_over_50(people: DataFrame) -> DataFrame:
+@solid(required_resource_keys={"pyspark_step_launcher"})
+def filter_over_50(_, people: DataFrame) -> DataFrame:
     return people.filter(people["age"] > 50)
 
 
-@op(required_resource_keys={"pyspark_step_launcher"})
-def count_people(people: DataFrame) -> int:
+@solid(required_resource_keys={"pyspark_step_launcher"})
+def count_people(_, people: DataFrame) -> int:
     return people.count()
 
 
-emr_resource_defs = {
-    "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
-        {
-            "cluster_id": {"env": "EMR_CLUSTER_ID"},
-            "local_pipeline_package_path": str(Path(__file__).parent),
-            "deploy_local_pipeline_package": True,
-            "region_name": "us-west-1",
-            "staging_bucket": "my_staging_bucket",
-            "wait_for_logs": True,
-        }
-    ),
-    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
-    "s3": s3_resource,
-    "io_manager": s3_pickle_io_manager.configured(
-        {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
-    ),
-}
-
-local_resource_defs = {
-    "pyspark_step_launcher": no_step_launcher,
-    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
-}
-
-
-@graph
-def count_people_over_50():
-    count_people(filter_over_50(make_people()))
-
-
-count_people_over_50_local = count_people_over_50.to_job(
-    name="local", resource_defs=local_resource_defs
+emr_mode = ModeDefinition(
+    name="emr",
+    resource_defs={
+        "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
+            {
+                "cluster_id": {"env": "EMR_CLUSTER_ID"},
+                "local_pipeline_package_path": str(Path(__file__).parent),
+                "deploy_local_pipeline_package": True,
+                "region_name": "us-west-1",
+                "staging_bucket": "my_staging_bucket",
+                "wait_for_logs": True,
+            }
+        ),
+        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
+        "s3": s3_resource,
+        "io_manager": s3_pickle_io_manager.configured(
+            {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
+        ),
+    },
 )
 
-count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
+local_mode = ModeDefinition(
+    name="local",
+    resource_defs={
+        "pyspark_step_launcher": no_step_launcher,
+        "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
+    },
+)
+
+
+@pipeline(mode_defs=[emr_mode, local_mode])
+def my_pipeline():
+    count_people(filter_over_50(make_people()))
+
 
 # end-snippet
 
 
 @repository
 def emr_pyspark_example():
-    return [count_people_over_50_emr, count_people_over_50_local]
+    return [my_pipeline]

--- a/examples/emr_pyspark/tests/test_emr_pyspark.py
+++ b/examples/emr_pyspark/tests/test_emr_pyspark.py
@@ -1,18 +1,17 @@
 """Launching in EMR is prohibitively time consuming, so we just verify that the plan compiles"""
 import os
 
-from dagster import execute_pipeline
 from dagster.core.execution.api import create_execution_plan
 
-from ..repo import my_pipeline
+from ..repo import count_people_over_50_emr, count_people_over_50_local
 
 
 def test_emr_pyspark_execution_plan():
     os.environ["EMR_CLUSTER_ID"] = "some_cluster_id"
-    create_execution_plan(my_pipeline, mode="emr")
+    create_execution_plan(count_people_over_50_emr)
 
 
-def test_emr_pyspark_local_mode():
-    res = execute_pipeline(my_pipeline, mode="local")
+def test_emr_pyspark_local():
+    res = count_people_over_50_local.execute_in_process()
     assert res.success
-    assert res.result_for_solid("count_people").output_value() == 1
+    assert res.result_for_node("count_people").output_value() == 1

--- a/examples/emr_pyspark_crag/README.md
+++ b/examples/emr_pyspark_crag/README.md
@@ -1,0 +1,1 @@
+View this example in the Dagster docs at https://docs.dagster.io/examples/emr_pyspark.

--- a/examples/emr_pyspark_crag/repo.py
+++ b/examples/emr_pyspark_crag/repo.py
@@ -1,0 +1,74 @@
+# start-snippet
+from pathlib import Path
+
+from dagster import graph, make_python_type_usable_as_dagster_type, op, repository
+from dagster.core.definitions.no_step_launcher import no_step_launcher
+from dagster_aws.emr import emr_pyspark_step_launcher
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_pyspark import DataFrame as DagsterPySparkDataFrame
+from dagster_pyspark import pyspark_resource
+from pyspark.sql import DataFrame, Row
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+# Make pyspark.sql.DataFrame map to dagster_pyspark.DataFrame
+make_python_type_usable_as_dagster_type(python_type=DataFrame, dagster_type=DagsterPySparkDataFrame)
+
+
+@op(required_resource_keys={"pyspark", "pyspark_step_launcher"})
+def make_people(context) -> DataFrame:
+    schema = StructType([StructField("name", StringType()), StructField("age", IntegerType())])
+    rows = [Row(name="Thom", age=51), Row(name="Jonny", age=48), Row(name="Nigel", age=49)]
+    return context.resources.pyspark.spark_session.createDataFrame(rows, schema)
+
+
+@op(required_resource_keys={"pyspark_step_launcher"})
+def filter_over_50(people: DataFrame) -> DataFrame:
+    return people.filter(people["age"] > 50)
+
+
+@op(required_resource_keys={"pyspark_step_launcher"})
+def count_people(people: DataFrame) -> int:
+    return people.count()
+
+
+emr_resource_defs = {
+    "pyspark_step_launcher": emr_pyspark_step_launcher.configured(
+        {
+            "cluster_id": {"env": "EMR_CLUSTER_ID"},
+            "local_pipeline_package_path": str(Path(__file__).parent),
+            "deploy_local_pipeline_package": True,
+            "region_name": "us-west-1",
+            "staging_bucket": "my_staging_bucket",
+            "wait_for_logs": True,
+        }
+    ),
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "2g"}}),
+    "s3": s3_resource,
+    "io_manager": s3_pickle_io_manager.configured(
+        {"s3_bucket": "my_staging_bucket", "s3_prefix": "simple-pyspark"}
+    ),
+}
+
+local_resource_defs = {
+    "pyspark_step_launcher": no_step_launcher,
+    "pyspark": pyspark_resource.configured({"spark_conf": {"spark.default.parallelism": 1}}),
+}
+
+
+@graph
+def count_people_over_50():
+    count_people(filter_over_50(make_people()))
+
+
+count_people_over_50_local = count_people_over_50.to_job(
+    name="local", resource_defs=local_resource_defs
+)
+
+count_people_over_50_emr = count_people_over_50.to_job(name="prod", resource_defs=emr_resource_defs)
+
+# end-snippet
+
+
+@repository
+def emr_pyspark_example():
+    return [count_people_over_50_emr, count_people_over_50_local]

--- a/examples/emr_pyspark_crag/requirements.txt
+++ b/examples/emr_pyspark_crag/requirements.txt
@@ -1,0 +1,4 @@
+dagster
+dagit
+dagster-aws
+dagster-pyspark

--- a/examples/emr_pyspark_crag/tests/test_emr_pyspark.py
+++ b/examples/emr_pyspark_crag/tests/test_emr_pyspark.py
@@ -1,18 +1,17 @@
 """Launching in EMR is prohibitively time consuming, so we just verify that the plan compiles"""
 import os
 
-from dagster import execute_pipeline
 from dagster.core.execution.api import create_execution_plan
 
-from ..repo import my_pipeline
+from ..repo import count_people_over_50_emr, count_people_over_50_local
 
 
 def test_emr_pyspark_execution_plan():
     os.environ["EMR_CLUSTER_ID"] = "some_cluster_id"
-    create_execution_plan(my_pipeline, mode="emr")
+    create_execution_plan(count_people_over_50_emr)
 
 
-def test_emr_pyspark_local_mode():
-    res = execute_pipeline(my_pipeline, mode="local")
+def test_emr_pyspark_local():
+    res = count_people_over_50_local.execute_in_process()
     assert res.success
-    assert res.result_for_solid("count_people").output_value() == 1
+    assert res.result_for_node("count_people").output_value() == 1

--- a/examples/emr_pyspark_crag/tox.ini
+++ b/examples/emr_pyspark_crag/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = py{38,37,36}-{unix,windows},pylint
+skipsdist = True
+
+[testenv]
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
+deps =
+  -e ../../python_modules/dagster[test]
+  -e ../../python_modules/libraries/dagster-aws[test]
+  -e ../../python_modules/libraries/dagster-spark
+  -e ../../python_modules/libraries/dagster-pyspark
+whitelist_externals =
+  /bin/bash
+  echo
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
+  pytest -vv {posargs}
+
+[testenv:pylint]
+basepython = python
+commands =
+  /bin/bash -c 'cd .. && pylint -j 0 --rcfile=../.pylintrc emr_pyspark/'

--- a/examples/emr_pyspark_crag/tox.ini
+++ b/examples/emr_pyspark_crag/tox.ini
@@ -20,4 +20,4 @@ commands =
 [testenv:pylint]
 basepython = python
 commands =
-  /bin/bash -c 'cd .. && pylint -j 0 --rcfile=../.pylintrc emr_pyspark/'
+  /bin/bash -c 'cd .. && pylint -j 0 --rcfile=../.pylintrc emr_pyspark_crag/'

--- a/examples/emr_pyspark_crag/workspace.yaml
+++ b/examples/emr_pyspark_crag/workspace.yaml
@@ -1,0 +1,2 @@
+load_from:
+  - python_file: repo.py


### PR DESCRIPTION
I think we might want to do the crag examples split a layer higher, because I'm worried about the link changes this entails. Maybe we can just do a big find and replace when we migrate over?
Updates pyspark guide to use crag APIs.
The fact that databricks and pyspark have top-level job concepts is unfortunate. Wondering what a good way to handle that mismatch could be.