### PR TITLE
Cragify dagster-shell

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-shell.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-shell.rst
@@ -3,10 +3,10 @@ Shell (dagster-shell)
 
 .. currentmodule:: dagster_shell
 
-The Dagster shell library provides solid factories for executing inline shell scripts or script files.
+The Dagster shell library provides op factories for executing inline shell scripts or script files.
 
-.. autofunction:: create_shell_command_solid
+.. autofunction:: create_shell_command_op
 
-.. autofunction:: create_shell_script_solid
+.. autofunction:: create_shell_script_op
 
-.. autofunction:: shell_solid
+.. autofunction:: shell_op

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-shell.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-shell.rst
@@ -1,12 +1,26 @@
 Shell (dagster-shell)
 ---------------------
 
-.. currentmodule:: dagster_shell
+
 
 The Dagster shell library provides op factories for executing inline shell scripts or script files.
+
+APIs
+----
+.. currentmodule:: dagster_shell
 
 .. autofunction:: create_shell_command_op
 
 .. autofunction:: create_shell_script_op
 
 .. autofunction:: shell_op
+
+Legacy APIs
+-----------
+.. currentmodule:: dagster_shell
+
+.. autofunction:: create_shell_command_solid
+
+.. autofunction:: create_shell_script_solid
+
+.. autofunction:: shell_solid

--- a/python_modules/libraries/dagster-shell/dagster_shell/__init__.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/__init__.py
@@ -1,8 +1,22 @@
 from dagster.core.utils import check_dagster_package_version
 
-from .solids import create_shell_command_solid, create_shell_script_solid, shell_solid
+from .solids import (
+    create_shell_command_op,
+    create_shell_command_solid,
+    create_shell_script_op,
+    create_shell_script_solid,
+    shell_op,
+    shell_solid,
+)
 from .version import __version__
 
 check_dagster_package_version("dagster-shell", __version__)
 
-__all__ = ["create_shell_command_solid", "create_shell_script_solid", "shell_solid"]
+__all__ = [
+    "create_shell_command_solid",
+    "create_shell_script_solid",
+    "shell_solid",
+    "create_shell_command_op",
+    "create_shell_script_op",
+    "shell_op",
+]

--- a/python_modules/libraries/dagster-shell/dagster_shell/solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/solids.py
@@ -18,7 +18,7 @@ from dagster import (
 from .utils import execute, execute_script_file
 
 
-def shell_solid_config():
+def shell_op_config():
     return {
         "env": Field(
             Noneable(Permissive()),
@@ -62,12 +62,12 @@ def core_shell(dagster_decorator, decorator_name):
         ),
         input_defs=[InputDefinition("shell_command", str)],
         output_defs=[OutputDefinition(str, "result")],
-        config_schema=shell_solid_config(),
+        config_schema=shell_op_config(),
     )
     def shell_fn(context, shell_command):
 
         output, return_code = execute(
-            shell_command=shell_command, log=context.log, **context.solid_config
+            shell_command=shell_command, log=context.log, **context.op_config
         )
 
         if return_code:
@@ -196,13 +196,13 @@ def core_create_shell_command(
         description=description,
         input_defs=[InputDefinition("start", Nothing)],
         output_defs=[OutputDefinition(str, "result")],
-        config_schema=shell_solid_config(),
+        config_schema=shell_op_config(),
         required_resource_keys=required_resource_keys,
         tags=tags,
     )
     def _shell_fn(context):
         output, return_code = execute(
-            shell_command=shell_command, log=context.log, **context.solid_config
+            shell_command=shell_command, log=context.log, **context.op_config
         )
 
         if return_code:
@@ -218,7 +218,7 @@ def core_create_shell_command(
 
 
 def create_shell_script_op(
-    shell_script_path, name="create_shell_script_solid", input_defs=None, **kwargs
+    shell_script_path, name="create_shell_script_op", input_defs=None, **kwargs
 ):
     """This function is a factory which constructs an op that will execute a shell command read
     from a script file.
@@ -324,12 +324,12 @@ def core_create_shell_script(
         description=kwargs.pop("description", f"A {decorator_name} to invoke a shell command."),
         input_defs=input_defs or [InputDefinition("start", Nothing)],
         output_defs=[OutputDefinition(str, "result")],
-        config_schema=shell_solid_config(),
+        config_schema=shell_op_config(),
         **kwargs,
     )
     def _shell_script_fn(context):
         output, return_code = execute_script_file(
-            shell_script_path=shell_script_path, log=context.log, **context.solid_config
+            shell_script_path=shell_script_path, log=context.log, **context.op_config
         )
 
         if return_code:

--- a/python_modules/libraries/dagster-shell/dagster_shell/solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/solids.py
@@ -11,6 +11,7 @@ from dagster import (
     OutputDefinition,
     Permissive,
     check,
+    op,
     solid,
 )
 
@@ -50,35 +51,86 @@ def shell_solid_config():
     }
 
 
-@solid(
-    name="shell_solid",
-    description=(
-        "This solid executes a shell command it receives as input.\n\n"
-        "This solid is suitable for uses where the command to execute is generated dynamically by "
-        "upstream solids. If you know the command to execute at pipeline construction time, "
-        "consider `shell_command_solid` instead."
-    ),
-    input_defs=[InputDefinition("shell_command", str)],
-    output_defs=[OutputDefinition(str, "result")],
-    config_schema=shell_solid_config(),
-)
-def shell_solid(context, shell_command):
-    """This solid executes a shell command it receives as input.
-
-    This solid is suitable for uses where the command to execute is generated dynamically by
-    upstream solids. If you know the command to execute at pipeline construction time, consider
-    `shell_command_solid` instead.
-    """
-    output, return_code = execute(
-        shell_command=shell_command, log=context.log, **context.solid_config
+def core_shell(dagster_decorator, decorator_name):
+    @dagster_decorator(
+        name=f"shell_{decorator_name}",
+        description=(
+            f"This {decorator_name} executes a shell command it receives as input.\n\n"
+            f"This {decorator_name} is suitable for uses where the command to execute is generated dynamically by "
+            f"upstream {decorator_name}. If you know the command to execute at pipeline construction time, "
+            f"consider `shell_command_{decorator_name}` instead."
+        ),
+        input_defs=[InputDefinition("shell_command", str)],
+        output_defs=[OutputDefinition(str, "result")],
+        config_schema=shell_solid_config(),
     )
+    def shell_fn(context, shell_command):
 
-    if return_code:
-        raise Failure(
-            description="Shell command execution failed with output: {output}".format(output=output)
+        output, return_code = execute(
+            shell_command=shell_command, log=context.log, **context.solid_config
         )
 
-    return output
+        if return_code:
+            raise Failure(
+                description="Shell command execution failed with output: {output}".format(
+                    output=output
+                )
+            )
+
+        return output
+
+    return shell_fn
+
+
+shell_solid = core_shell(solid, "solid")
+shell_op = core_shell(op, "op")
+
+
+def create_shell_command_op(
+    shell_command,
+    name,
+    description=None,
+    required_resource_keys=None,
+    tags=None,
+):
+    """This function is a factory that constructs ops to execute a shell command.
+
+    Note that you can only use `shell_command_op` if you know the command you'd like to execute
+    at pipeline construction time. If you'd like to construct shell commands dynamically during
+    pipeline execution and pass them between ops, you should use `shell_op` instead.
+
+    Examples:
+
+    .. literalinclude:: ../../../../../../python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_op.py
+       :language: python
+
+
+    Args:
+        shell_command (str): The shell command that the constructed op will execute.
+        name (str): The name of the constructed op.
+        description (Optional[str]): Human-readable description of this op.
+        required_resource_keys (Optional[Set[str]]): Set of resource handles required by this op.
+            Setting this ensures that resource spin up for the required resources will occur before
+            the shell command is executed.
+        tags (Optional[Dict[str, Any]]): Arbitrary metadata for the op. Frameworks may
+            expect and require certain metadata to be attached to a op. Users should generally
+            not set metadata directly. Values that are not strings will be json encoded and must meet
+            the criteria that `json.loads(json.dumps(value)) == value`.
+
+    Raises:
+        Failure: Raised when the shell command returns a non-zero exit code.
+
+    Returns:
+        OpDefinition: Returns the constructed op definition.
+    """
+    return core_create_shell_command(
+        op,
+        shell_command=shell_command,
+        name=name,
+        description=description,
+        required_resource_keys=required_resource_keys,
+        tags=tags,
+    )
 
 
 def create_shell_command_solid(
@@ -118,10 +170,28 @@ def create_shell_command_solid(
     Returns:
         SolidDefinition: Returns the constructed solid definition.
     """
+    return core_create_shell_command(
+        solid,
+        shell_command=shell_command,
+        name=name,
+        description=description,
+        required_resource_keys=required_resource_keys,
+        tags=tags,
+    )
+
+
+def core_create_shell_command(
+    dagster_decorator,
+    shell_command,
+    name,
+    description=None,
+    required_resource_keys=None,
+    tags=None,
+):
     check.str_param(shell_command, "shell_command")
     name = check.str_param(name, "name")
 
-    @solid(
+    @dagster_decorator(
         name=name,
         description=description,
         input_defs=[InputDefinition("start", Nothing)],
@@ -130,7 +200,7 @@ def create_shell_command_solid(
         required_resource_keys=required_resource_keys,
         tags=tags,
     )
-    def _shell_solid(context):
+    def _shell_fn(context):
         output, return_code = execute(
             shell_command=shell_command, log=context.log, **context.solid_config
         )
@@ -144,7 +214,49 @@ def create_shell_command_solid(
 
         return output
 
-    return _shell_solid
+    return _shell_fn
+
+
+def create_shell_script_op(
+    shell_script_path, name="create_shell_script_solid", input_defs=None, **kwargs
+):
+    """This function is a factory which constructs an op that will execute a shell command read
+    from a script file.
+
+    Any kwargs passed to this function will be passed along to the underlying :func:`@op
+    <dagster.op>` decorator. However, note that overriding ``config`` or ``output_defs`` is not
+    supported.
+
+    You might consider using :func:`@graph <dagster.graph>` to wrap this op
+    in the cases where you'd like to configure the shell op with different config fields.
+
+
+    Examples:
+
+    .. literalinclude:: ../../../../../../python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_op.py
+       :language: python
+
+
+    Args:
+        shell_script_path (str): The script file to execute.
+        name (str, optional): The name of this op. Defaults to "create_shell_script_op".
+        input_defs (List[InputDefinition], optional): input definitions for the op. Defaults to
+            a single Nothing input.
+
+    Raises:
+        Failure: Raised when the shell command returns a non-zero exit code.
+
+    Returns:
+        OpDefinition: Returns the constructed op definition.
+    """
+    return core_create_shell_script(
+        dagster_decorator=solid,
+        decorator_name="solid",
+        shell_script_path=shell_script_path,
+        name=name,
+        input_defs=input_defs,
+        **kwargs,
+    )
 
 
 def create_shell_script_solid(
@@ -179,25 +291,43 @@ def create_shell_script_solid(
     Returns:
         SolidDefinition: Returns the constructed solid definition.
     """
+    return core_create_shell_script(
+        dagster_decorator=solid,
+        decorator_name="solid",
+        shell_script_path=shell_script_path,
+        name=name,
+        input_defs=input_defs,
+        **kwargs,
+    )
+
+
+def core_create_shell_script(
+    dagster_decorator,
+    decorator_name,
+    shell_script_path,
+    name="create_shell_script_solid",
+    input_defs=None,
+    **kwargs,
+):
     check.str_param(shell_script_path, "shell_script_path")
     name = check.str_param(name, "name")
     check.opt_list_param(input_defs, "input_defs", of_type=InputDefinition)
 
     if "output_defs" in kwargs:
-        raise TypeError("Overriding output_defs for shell solid is not supported.")
+        raise TypeError(f"Overriding output_defs for shell {decorator_name} is not supported.")
 
     if "config" in kwargs:
-        raise TypeError("Overriding config for shell solid is not supported.")
+        raise TypeError(f"Overriding config for shell {decorator_name} is not supported.")
 
-    @solid(
+    @dagster_decorator(
         name=name,
-        description=kwargs.pop("description", "A solid to invoke a shell command."),
+        description=kwargs.pop("description", f"A {decorator_name} to invoke a shell command."),
         input_defs=input_defs or [InputDefinition("start", Nothing)],
         output_defs=[OutputDefinition(str, "result")],
         config_schema=shell_solid_config(),
         **kwargs,
     )
-    def _shell_script_solid(context):
+    def _shell_script_fn(context):
         output, return_code = execute_script_file(
             shell_script_path=shell_script_path, log=context.log, **context.solid_config
         )
@@ -211,4 +341,4 @@ def create_shell_script_solid(
 
         return output
 
-    return _shell_script_solid
+    return _shell_script_fn

--- a/python_modules/libraries/dagster-shell/dagster_shell/utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/utils.py
@@ -43,7 +43,7 @@ def execute_script_file(shell_script_path, output_logging, log, cwd=None, env=No
             Unused by default.
 
     Raises:
-        Exception: When an invalid output_logging is selected. Unreachable from solid-based
+        Exception: When an invalid output_logging is selected. Unreachable from op-based
             invocation since the config system will check output_logging against the config
             enum.
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_op.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_op.py
@@ -1,0 +1,8 @@
+from dagster import graph
+from dagster_shell import create_shell_command_op
+
+
+@graph
+def my_graph():
+    a = create_shell_command_op('echo "hello, world!"', name="a")
+    a()

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_op.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_op.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-value-for-parameter
 from dagster import graph
 from dagster_shell import create_shell_command_op
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_solid.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_command_solid.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-value-for-parameter
 from dagster import pipeline
 from dagster_shell import create_shell_command_solid
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_op.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_op.py
@@ -1,0 +1,8 @@
+from dagster import file_relative_path, graph
+from dagster_shell import create_shell_script_op
+
+
+@graph
+def my_graph():
+    a = create_shell_script_op(file_relative_path(__file__, "hello_world.sh"), name="a")
+    a()

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_op.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_op.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-value-for-parameter
 from dagster import file_relative_path, graph
 from dagster_shell import create_shell_script_op
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_solid.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/example_shell_script_solid.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-value-for-parameter
 from dagster import file_relative_path, pipeline
 from dagster_shell import create_shell_script_solid
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_examples.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_examples.py
@@ -15,3 +15,17 @@ def test_example_shell_script_solid():
     res = execute_pipeline(pipe)
     assert res.success
     assert res.result_for_solid("a").output_value() == "hello, world!\n"
+
+
+def test_example_shell_command_op():
+    from .example_shell_command_op import my_graph
+
+    res = my_graph.execute_in_process()
+    assert res.success
+
+
+def test_example_shell_script_op():
+    from .example_shell_script_op import my_graph
+
+    res = my_graph.execute_in_process()
+    assert res.success

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_solids.py
@@ -2,11 +2,19 @@ import os
 
 import pytest
 from dagster import Failure, OutputDefinition, composite_solid, execute_solid
-from dagster_shell import create_shell_command_solid, create_shell_script_solid, shell_solid
+from dagster_shell import (
+    create_shell_command_op,
+    create_shell_command_solid,
+    create_shell_script_op,
+    create_shell_script_solid,
+    shell_op,
+    shell_solid,
+)
 
 
-def test_shell_command_solid():
-    solid = create_shell_command_solid('echo "this is a test message: $MY_ENV_VAR"', name="foobar")
+@pytest.mark.parametrize("factory", [create_shell_command_solid, create_shell_command_op])
+def test_shell_command(factory):
+    solid = factory('echo "this is a test message: $MY_ENV_VAR"', name="foobar")
 
     result = execute_solid(
         solid,
@@ -15,30 +23,32 @@ def test_shell_command_solid():
     assert result.output_values == {"result": "this is a test message: foobar\n"}
 
 
-def test_shell_solid():
+@pytest.mark.parametrize("shell_defn,name", [(shell_op, "shell_op"), (shell_solid, "shell_solid")])
+def test_shell(shell_defn, name):
 
     result = execute_solid(
-        shell_solid,
+        shell_defn,
         input_values={"shell_command": 'echo "this is a test message: $MY_ENV_VAR"'},
-        run_config={"solids": {"shell_solid": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
+        run_config={"solids": {name: {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
     )
     assert result.output_values == {"result": "this is a test message: foobar\n"}
 
 
-def test_shell_command_retcode():
+@pytest.mark.parametrize("factory", [create_shell_command_op, create_shell_command_solid])
+def test_shell_command_retcode(factory):
     with pytest.raises(Failure, match="Shell command execution failed"):
-        execute_solid(create_shell_command_solid("exit 1", name="exit_solid"))
+        execute_solid(factory("exit 1", name="exit_solid"))
 
 
-def test_shell_solid_retcode():
+@pytest.mark.parametrize("shell_defn", [shell_op, shell_solid])
+def test_shell_solid_retcode(shell_defn):
     with pytest.raises(Failure, match="Shell command execution failed"):
-        execute_solid(shell_solid, input_values={"shell_command": "exit 1"})
+        execute_solid(shell_defn, input_values={"shell_command": "exit 1"})
 
 
-def test_shell_command_stream_logs():
-    solid = create_shell_command_solid(
-        'for i in 1 2 3 4 5; do echo "hello ${i}"; done', name="foobar"
-    )
+@pytest.mark.parametrize("factory", [create_shell_command_op, create_shell_command_solid])
+def test_shell_command_stream_logs(factory):
+    solid = factory('for i in 1 2 3 4 5; do echo "hello ${i}"; done', name="foobar")
 
     result = execute_solid(
         solid,
@@ -51,9 +61,10 @@ def test_shell_command_stream_logs():
     assert result.output_values == {"result": "hello 1\nhello 2\nhello 3\nhello 4\nhello 5\n"}
 
 
-def test_shell_script_solid():
+@pytest.mark.parametrize("factory", [create_shell_script_op, create_shell_script_solid])
+def test_shell_script_solid(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = create_shell_script_solid(os.path.join(script_dir, "test.sh"), name="foobar")
+    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
     result = execute_solid(
         solid,
         run_config={"solids": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
@@ -61,16 +72,18 @@ def test_shell_script_solid():
     assert result.output_values == {"result": "this is a test message: foobar\n"}
 
 
-def test_shell_script_solid_no_config():
+@pytest.mark.parametrize("factory", [create_shell_script_op, create_shell_script_solid])
+def test_shell_script_solid_no_config(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = create_shell_script_solid(os.path.join(script_dir, "test.sh"), name="foobar")
+    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
     result = execute_solid(solid)
     assert result.output_values == {"result": "this is a test message: \n"}
 
 
-def test_shell_script_solid_no_config_composite():
+@pytest.mark.parametrize("factory", [create_shell_script_op, create_shell_script_solid])
+def test_shell_script_solid_no_config_composite(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = create_shell_script_solid(os.path.join(script_dir, "test.sh"), name="foobar")
+    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
 
     @composite_solid(
         config_schema={}, config_fn=lambda cfg: {}, output_defs=[OutputDefinition(str, "result")]
@@ -82,8 +95,9 @@ def test_shell_script_solid_no_config_composite():
     assert result.output_values == {"result": "this is a test message: \n"}
 
 
-def test_shell_command_solid_overrides():
-    solid = create_shell_command_solid(
+@pytest.mark.parametrize("factory", [create_shell_command_op, create_shell_command_solid])
+def test_shell_command_solid_overrides(factory):
+    solid = factory(
         'echo "this is a test message: $MY_ENV_VAR"',
         name="foobar",
         description="a description override",

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         author="Elementl",
         author_email="hello@elementl.com",
         license="Apache-2.0",
-        description="Package for Dagster shell solids.",
+        description="Package for Dagster shell ops.",
         url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-shell",
         classifiers=[
             "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Title. This is a good prototype of what cragifying various dagster libraries will probably look like.

Should we keep old apis in documentation under a `legacy APIs` section?