### PR TITLE
Migrate from slackclient to slack_sdk

### DIFF
--- a/docs/content-crag/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content-crag/concepts/partitions-schedules-sensors/sensors.mdx
@@ -403,7 +403,7 @@ For example, you can write a sensor that sends a slack message when it runs usin
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensor_alert.py startafter=start_alert_sensor_marker endbefore=end_alert_sensor_marker
 import os
 from dagster import job_failure_sensor, JobFailureSensorContext
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 @job_failure_sensor

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -403,7 +403,7 @@ For example, you can write a sensor that sends a slack message when it runs usin
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensor_alert.py startafter=start_alert_sensor_marker endbefore=end_alert_sensor_marker
 import os
 from dagster import pipeline_failure_sensor, PipelineFailureSensorContext
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 @pipeline_failure_sensor

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -4,7 +4,7 @@
 # start_alert_sensor_marker
 import os
 from dagster import pipeline_failure_sensor, PipelineFailureSensorContext
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 @pipeline_failure_sensor

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -4,7 +4,7 @@
 # start_alert_sensor_marker
 import os
 from dagster import job_failure_sensor, JobFailureSensorContext
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 @job_failure_sensor

--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -22,7 +22,6 @@ setup(
         "pandas",
         "pytablereader",
         "requests",
-        "slack_sdk",
         "twine==1.15.0",
         "virtualenv==16.5.0",
         "wheel==0.33.6",

--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -22,14 +22,11 @@ setup(
         "pandas",
         "pytablereader",
         "requests",
-        "slackclient>=2,<3",
+        "slack_sdk",
         "twine==1.15.0",
         "virtualenv==16.5.0",
         "wheel==0.33.6",
         "urllib3",
-        # resolve issue with aiohttp pin of chardet for aiohttp<=3.7.3, req'd by slackclient
-        # https://github.com/dagster-io/dagster/issues/3539
-        "chardet<4.0",
     ],
     entry_points={
         "console_scripts": [

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/sensors.py
@@ -6,7 +6,7 @@ from dagster.core.definitions.pipeline_sensor import (
     PipelineFailureSensorContext,
     pipeline_failure_sensor,
 )
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 def get_directory_files(directory_name, since=None):

--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -6,7 +6,7 @@ from dagster.core.definitions.pipeline_sensor import (
     PipelineFailureSensorContext,
     pipeline_failure_sensor,
 )
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 def get_directory_files(directory_name, since=None):

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -21,7 +21,7 @@ from slack_sdk import WebClient
 def slack_resource(context):
     """This resource is for connecting to Slack.
 
-    The resource object is a `slack.WebClient`.
+    The resource object is a `slack_sdk.WebClient`.
 
     By configuring this Slack resource, you can post messages to Slack from any Dagster solid:
 

--- a/python_modules/libraries/dagster-slack/dagster_slack/resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/resources.py
@@ -1,5 +1,5 @@
 from dagster import Field, StringSource, resource
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 @resource(

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -7,7 +7,7 @@ from dagster.core.definitions.pipeline_sensor import (
     job_failure_sensor,
     pipeline_failure_sensor,
 )
-from slack import WebClient
+from slack_sdk import WebClient
 
 
 def _default_failure_message(context: PipelineFailureSensorContext) -> str:

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -8,7 +8,7 @@ class SomeUserException(Exception):
     pass
 
 
-@patch("slack.web.base_client.BaseClient._perform_urllib_http_request")
+@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
 def test_failure_hook_on_solid_instance(mock_urllib_http_request):
     @solid
     def pass_solid(_):
@@ -38,7 +38,7 @@ def test_failure_hook_on_solid_instance(mock_urllib_http_request):
     assert mock_urllib_http_request.call_count == 1
 
 
-@patch("slack.web.base_client.BaseClient._perform_urllib_http_request")
+@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
 def test_failure_hook_decorator(mock_urllib_http_request):
     @solid
     def pass_solid(_):
@@ -66,7 +66,7 @@ def test_failure_hook_decorator(mock_urllib_http_request):
     assert mock_urllib_http_request.call_count == 2
 
 
-@patch("slack.web.base_client.BaseClient._perform_urllib_http_request")
+@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
 def test_success_hook_on_solid_instance(mock_urllib_http_request):
     def my_message_fn(_):
         return "Some custom text"
@@ -97,7 +97,7 @@ def test_success_hook_on_solid_instance(mock_urllib_http_request):
     assert mock_urllib_http_request.call_count == 2
 
 
-@patch("slack.web.base_client.BaseClient._perform_urllib_http_request")
+@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
 def test_success_hook_decorator(mock_urllib_http_request):
     @solid
     def pass_solid(_):

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -8,8 +8,8 @@ class SomeUserException(Exception):
     pass
 
 
-@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
-def test_failure_hook_on_solid_instance(mock_urllib_http_request):
+@patch("slack_sdk.web.base_client.BaseClient.api_call")
+def test_failure_hook_on_solid_instance(mock_api_call):
     @solid
     def pass_solid(_):
         pass
@@ -35,11 +35,11 @@ def test_failure_hook_on_solid_instance(mock_urllib_http_request):
         raise_on_error=False,
     )
     assert not result.success
-    assert mock_urllib_http_request.call_count == 1
+    assert mock_api_call.call_count == 1
 
 
-@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
-def test_failure_hook_decorator(mock_urllib_http_request):
+@patch("slack_sdk.web.base_client.BaseClient.api_call")
+def test_failure_hook_decorator(mock_api_call):
     @solid
     def pass_solid(_):
         pass
@@ -63,11 +63,11 @@ def test_failure_hook_decorator(mock_urllib_http_request):
         raise_on_error=False,
     )
     assert not result.success
-    assert mock_urllib_http_request.call_count == 2
+    assert mock_api_call.call_count == 2
 
 
-@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
-def test_success_hook_on_solid_instance(mock_urllib_http_request):
+@patch("slack_sdk.web.base_client.BaseClient.api_call")
+def test_success_hook_on_solid_instance(mock_api_call):
     def my_message_fn(_):
         return "Some custom text"
 
@@ -94,11 +94,11 @@ def test_success_hook_on_solid_instance(mock_urllib_http_request):
         raise_on_error=False,
     )
     assert not result.success
-    assert mock_urllib_http_request.call_count == 2
+    assert mock_api_call.call_count == 2
 
 
-@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
-def test_success_hook_decorator(mock_urllib_http_request):
+@patch("slack_sdk.web.base_client.BaseClient.api_call")
+def test_success_hook_decorator(mock_api_call):
     @solid
     def pass_solid(_):
         pass
@@ -122,4 +122,4 @@ def test_success_hook_decorator(mock_urllib_http_request):
         raise_on_error=False,
     )
     assert not result.success
-    assert mock_urllib_http_request.call_count == 2
+    assert mock_api_call.call_count == 2

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -8,7 +8,7 @@ class SomeUserException(Exception):
     pass
 
 
-@patch("slack_sdk.web.base_client.BaseClient.api_call")
+@patch("slack_sdk.WebClient.api_call")
 def test_failure_hook_on_solid_instance(mock_api_call):
     @solid
     def pass_solid(_):
@@ -38,7 +38,7 @@ def test_failure_hook_on_solid_instance(mock_api_call):
     assert mock_api_call.call_count == 1
 
 
-@patch("slack_sdk.web.base_client.BaseClient.api_call")
+@patch("slack_sdk.WebClient.api_call")
 def test_failure_hook_decorator(mock_api_call):
     @solid
     def pass_solid(_):
@@ -66,7 +66,7 @@ def test_failure_hook_decorator(mock_api_call):
     assert mock_api_call.call_count == 2
 
 
-@patch("slack_sdk.web.base_client.BaseClient.api_call")
+@patch("slack_sdk.WebClient.api_call")
 def test_success_hook_on_solid_instance(mock_api_call):
     def my_message_fn(_):
         return "Some custom text"
@@ -97,7 +97,7 @@ def test_success_hook_on_solid_instance(mock_api_call):
     assert mock_api_call.call_count == 2
 
 
-@patch("slack_sdk.web.base_client.BaseClient.api_call")
+@patch("slack_sdk.WebClient.api_call")
 def test_success_hook_decorator(mock_api_call):
     @solid
     def pass_solid(_):

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
@@ -5,13 +5,13 @@ from dagster_slack import slack_resource
 from mock import patch
 
 
-@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
-def test_slack_resource(mock_urllib_http_request):
+@patch("slack_sdk.web.base_client.BaseClient.api_call")
+def test_slack_resource(mock_api_call):
     @solid(required_resource_keys={"slack"})
     def slack_solid(context):
         assert context.resources.slack
         body = {"ok": True}
-        mock_urllib_http_request.return_value = {
+        mock_api_call.return_value = {
             "status": 200,
             "body": json.dumps(body),
             "headers": "",
@@ -19,7 +19,7 @@ def test_slack_resource(mock_urllib_http_request):
 
         context.resources.slack.chat_postMessage(channel="#random", text=":wave: hey there!")
 
-        assert mock_urllib_http_request.called
+        assert mock_api_call.called
 
     result = execute_solid(
         slack_solid,

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
@@ -5,7 +5,7 @@ from dagster_slack import slack_resource
 from mock import patch
 
 
-@patch("slack.web.base_client.BaseClient._perform_urllib_http_request")
+@patch("slack_sdk.web.base_client.BaseClient._perform_urllib_http_request")
 def test_slack_resource(mock_urllib_http_request):
     @solid(required_resource_keys={"slack"})
     def slack_solid(context):

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
@@ -5,7 +5,7 @@ from dagster_slack import slack_resource
 from mock import patch
 
 
-@patch("slack_sdk.web.base_client.BaseClient.api_call")
+@patch("slack_sdk.WebClient.api_call")
 def test_slack_resource(mock_api_call):
     @solid(required_resource_keys={"slack"})
     def slack_solid(context):

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -32,7 +32,6 @@ if __name__ == "__main__":
         install_requires=[
             f"dagster{pin}",
             "slack_sdk",
-            "aiohttp",
         ],
         zip_safe=False,
     )

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
         install_requires=[
             f"dagster{pin}",
             "slack_sdk",
+            "aiohttp",
         ],
         zip_safe=False,
     )

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -31,10 +31,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["test"]),
         install_requires=[
             f"dagster{pin}",
-            "slackclient>=2,<3",
-            # resolve issue with aiohttp pin of chardet for aiohttp<=3.7.3, req'd by slackclient
-            # https://github.com/dagster-io/dagster/issues/3539
-            "chardet<4.0",
+            "slack_sdk",
         ],
         zip_safe=False,
     )


### PR DESCRIPTION
`slackclient` is deprecated:

https://github.com/slackapi/python-slack-sdk#slackclient-is-in-maintenance-mode

Instead, Slack now recommends using `slack_sdk`.

Migration guide:

https://slack.dev/python-slack-sdk/v3-migration/