### PR TITLE
Add raise_on_error param to execute_in_process

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -514,6 +514,7 @@ class GraphDefinition(NodeDefinition):
         config: Any = None,
         instance: Optional["DagsterInstance"] = None,
         resources: Optional[Dict[str, Any]] = None,
+        raise_on_error: bool = True,
     ):
         """
         Execute this graph in-process, collecting results in-memory.
@@ -571,6 +572,7 @@ class GraphDefinition(NodeDefinition):
             run_config=run_config,
             instance=instance,
             output_capturing_enabled=True,
+            raise_on_error=raise_on_error,
         )
 
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -555,6 +555,7 @@ class PipelineDefinition:
         self,
         run_config: Optional[Dict[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
+        raise_on_error: bool = True,
     ) -> "InProcessGraphResult":
         """
         (Experimental) Execute the "Job" (single mode pipeline) in-process, gathering results in-memory.
@@ -609,6 +610,7 @@ class PipelineDefinition:
             run_config=run_config,
             instance=instance,
             output_capturing_enabled=True,
+            raise_on_error=raise_on_error,
         )
 
 

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -31,6 +31,7 @@ def core_execute_in_process(
     ephemeral_pipeline: PipelineDefinition,
     instance: Optional[DagsterInstance],
     output_capturing_enabled: bool,
+    raise_on_error: bool,
 ):
     pipeline_def = ephemeral_pipeline
     mode_def = pipeline_def.get_mode_definition()
@@ -59,6 +60,7 @@ def core_execute_in_process(
                 run_config=run_config,
                 executor_defs=None,
                 output_capture=recorder if output_capturing_enabled else None,
+                raise_on_error=raise_on_error,
             ),
         )
         event_list = list(_execute_run_iterable)

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -580,3 +580,23 @@ def test_enum_to_execution():
     result = my_graph.execute_in_process(config={"my_op": {"config": {"my_enum": "TWO"}}})
     assert result.success
     assert result.result_for_node("my_op").output_values["result"] == TestEnum.TWO
+
+
+def test_raise_on_error_execute_in_process():
+    error_str = "My error"
+
+    @op
+    def emit_error():
+        raise Exception(error_str)
+
+    @graph
+    def error_graph():
+        emit_error()
+
+    error_job = error_graph.to_job()
+
+    with pytest.raises(Exception, match=error_str):
+        error_job.execute_in_process()
+
+    result = error_job.execute_in_process(raise_on_error=False)
+    assert not result.success


### PR DESCRIPTION
- Fixes a bug where exceptions raised within `execute_in_process` error silently
- Adds `raise_on_error` param to `execute_in_process` to allow users to configure behavior