### PR TITLE
fix(helm): infer tag from chart version for instance migration job

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -33,3 +33,14 @@ def test_job_instance_migrate_renders(template: HelmTemplate):
     jobs = template.render(helm_values_migrate_enabled)
 
     assert len(jobs) == 1
+
+
+@pytest.mark.parametrize("chart_version", ["0.12.0", "0.12.1"])
+def test_job_instance_migrate_image(template: HelmTemplate, chart_version: str):
+    helm_values_migrate_enabled = DagsterHelmValues.construct(migrate=Migrate(enabled=True))
+
+    [job] = template.render(helm_values_migrate_enabled, chart_version=chart_version)
+    image = job.spec.template.spec.containers[0].image
+    _, tag = image.split(":")
+
+    assert tag == chart_version

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -16,7 +16,7 @@ spec:
         - name: dagster-instance-migrate
           securityContext: {{ .Values.dagit.securityContext | toYaml | nindent 12 }}
           imagePullPolicy: {{ .Values.dagit.image.pullPolicy }}
-          image: {{ include "dagster.externalImage.name" .Values.dagit.image | quote }}
+          image: {{ include "dagster.dagsterImage.name" (list $ .Values.dagit.image) | quote }}
           command: ["dagster"]
           args: ["instance", "migrate"]
           env:


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Solves an issue where the migration job didn't run properly when the tag wasn't specified. In this case,
the image used is the default dagster image, so default to using the chart version as the tag. 
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
pytest
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

