### PR TITLE
feat(helm): allow configuration of db statement timeout on dagit

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
@@ -1,8 +1,7 @@
-from typing import Dict, List
-
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from typing import Dict, List, Optional
 
 from ...utils import kubernetes
+from ...utils.utils import BaseModel
 
 
 class Server(BaseModel):
@@ -33,3 +32,4 @@ class Dagit(BaseModel):
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
     enableReadOnly: bool
+    dbStatementTimeout: Optional[int]

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -161,3 +161,15 @@ def test_dagit_service_read_only(service_template):
         "dagit",
         "dagit-read-only",
     ]
+
+
+def test_dagit_db_statement_timeout(deployment_template: HelmTemplate):
+    db_statement_timeout_ms = 9000
+    helm_values = DagsterHelmValues.construct(
+        dagit=Dagit.construct(dbStatementTimeout=db_statement_timeout_ms)
+    )
+
+    dagit_deployments = deployment_template.render(helm_values)
+    command = " ".join(dagit_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--db-statement-timeout {db_statement_timeout_ms}" in command

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -42,6 +42,7 @@ If release name contains chart name it will be used as a full name.
 {{- $userDeployments := index .Values "dagster-user-deployments" }}
 dagit -h 0.0.0.0 -p {{ .Values.dagit.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
+{{- with .Values.dagit.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- if .dagitReadOnly }} --read-only {{- end -}}
 {{- end -}}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -321,6 +321,17 @@
                 "enableReadOnly": {
                     "title": "Enablereadonly",
                     "type": "boolean"
+                },
+                "dbStatementTimeout": {
+                    "title": "Dbstatementtimeout",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -51,6 +51,9 @@ dagit:
   # Deploy a separate instance of Dagit in --read-only mode (can't launch runs, disable schedules, etc.)
   enableReadOnly: false
 
+  # The timeout in milliseconds to set on database statements sent to the Dagster instance.
+  dbStatementTimeout: ~
+
   # Additional environment variables to set.
   # A Kubernetes ConfigMap will be created with these environment variables. See:
   # https://kubernetes.io/docs/concepts/configuration/configmap/


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
`--db-statement-timeout` is configurable when launching dagit via CLI. Expose this option
when deploying dagit using Helm.



## Test Plan
pytest
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


