### PR TITLE
improve error for event metadata of wrong type

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/event_metadata.py
+++ b/python_modules/dagster/dagster/core/definitions/event_metadata.py
@@ -93,8 +93,9 @@ def parse_metadata_entry(label: str, value: ParseableMetadataEntryData) -> "Even
             )
 
     raise DagsterInvalidEventMetadata(
-        f'Could not resolve the metadata value for "{label}" to a known type. Consider '
-        "wrapping the value with the appropriate EventMetadata type."
+        f'Could not resolve the metadata value for "{label}" to a known type. '
+        f"Its type was {type(value)}. Consider wrapping the value with the appropriate "
+        "EventMetadata type."
     )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_event_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_event_metadata.py
@@ -80,6 +80,7 @@ def test_unknown_metadata_value():
 
     assert str(exc_info.value) == (
         'Could not resolve the metadata value for "bad" to a known type. '
+        "Its type was <class 'dagster.core.instance.DagsterInstance'>. "
         "Consider wrapping the value with the appropriate EventMetadata type."
     )
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
When debugging a bad metadata dict, I found myself wanting to know the rejected type of the value I had provided.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.