### PR TITLE
[serdes] memoize inspect.signature

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -370,7 +370,7 @@ class AssetMaterialization(
 
 class MaterializationSerializer(DefaultNamedTupleSerializer):
     @classmethod
-    def value_from_storage_dict(cls, storage_dict, klass):
+    def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
         # override the default `from_storage_dict` implementation in order to skip the deprecation
         # warning for historical Materialization events, loaded from event_log storage
         return Materialization(skip_deprecation_warning=True, **storage_dict)

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -49,7 +49,7 @@ def create_pipeline_snapshot_id(snapshot: "PipelineSnapshot") -> str:
 
 class PipelineSnapshotSerializer(DefaultNamedTupleSerializer):
     @classmethod
-    def value_from_storage_dict(cls, storage_dict, _klass):
+    def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
         # called by the serdes layer, delegates to helper method with expanded kwargs
         return _pipeline_snapshot_from_storage(**storage_dict)
 

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -92,7 +92,7 @@ class PipelineRunStatsSnapshot(
 
 class PipelineRunSerializer(DefaultNamedTupleSerializer):
     @classmethod
-    def value_from_storage_dict(cls, storage_dict, _klass):
+    def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
         # called by the serdes layer, delegates to helper method with expanded kwargs
         return pipeline_run_from_storage(**storage_dict)
 

--- a/python_modules/dagster/dagster/daemon/types.py
+++ b/python_modules/dagster/dagster/daemon/types.py
@@ -16,7 +16,7 @@ class DaemonType(Enum):
 
 class DaemonBackcompat(DefaultNamedTupleSerializer):
     @classmethod
-    def value_from_storage_dict(cls, storage_dict, klass):
+    def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
         # Handle case where daemon_type used to be an enum (e.g. DaemonType.SCHEDULER)
         return DaemonHeartbeat(
             timestamp=storage_dict.get("timestamp"),

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import NamedTuple, Set
 
 import pytest
-from dagster.check import CheckError, ParameterCheckError, inst_param, set_param
+from dagster.check import ParameterCheckError, inst_param, set_param
 from dagster.serdes.errors import DeserializationError, SerdesUsageError, SerializationError
 from dagster.serdes.serdes import (
     DefaultEnumSerializer,
@@ -18,7 +18,6 @@ from dagster.serdes.serdes import (
     _whitelist_for_serdes,
     deserialize_json_to_dagster_namedtuple,
     deserialize_value,
-    serialize_dagster_namedtuple,
     serialize_value,
 )
 from dagster.serdes.utils import hash_str
@@ -77,7 +76,7 @@ def test_forward_compat_serdes_new_field_with_default():
             return super(Quux, cls).__new__(cls, foo, bar)  # pylint: disable=bad-super-call
 
     assert test_map.has_tuple_entry("Quux")
-    klass, _ = test_map.get_tuple_entry("Quux")
+    klass, _, _ = test_map.get_tuple_entry("Quux")
     assert klass is Quux
 
     quux = Quux("zip", "zow")
@@ -92,7 +91,7 @@ def test_forward_compat_serdes_new_field_with_default():
 
     assert test_map.has_tuple_entry("Quux")
 
-    klass, _ = test_map.get_tuple_entry("Quux")
+    klass, _, _ = test_map.get_tuple_entry("Quux")
     assert klass is Quux
 
     deserialized = _deserialize_json(serialized, whitelist_map=test_map)
@@ -366,7 +365,7 @@ def test_from_storage_dict():
 
     class CompatSerializer(DefaultNamedTupleSerializer):
         @classmethod
-        def value_from_storage_dict(cls, storage_dict, klass):
+        def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
             return DeprecatedAlphabet.legacy_load(storage_dict)
 
     @_whitelist_for_serdes(whitelist_map=test_map, serializer=CompatSerializer)


### PR DESCRIPTION
Looking at profiling samples of loading a large `DebugRunPayload`, the thing that was commented as expensive is in fact expensive.

We were calling it on whitelist registration to perform some validation so just hold on to that value and re-use it.

### Test Plan

```
buf = gzip.open(path).read().decode()
t1 = time.perf_counter()
val = json.loads(buf)
t2 = time.perf_counter()
print("json.loads time ", t2 - t1)

tup = unpack_value(val)
t3 = time.perf_counter()
print("unpack val time ", t3 - t2)
```

before:
```
json.loads time  1.296848542
unpack val time  7.621963458
```
after:
```
json.loads time  1.3586094169999998
unpack val time  2.1245450830000006
```