### PR TITLE
chunk event log subscription initial load

### DIFF
--- a/python_modules/dagit/dagit_tests/test_subscriptions.py
+++ b/python_modules/dagit/dagit_tests/test_subscriptions.py
@@ -5,7 +5,7 @@ from unittest import mock
 import objgraph
 from dagit.subscription_server import DagsterSubscriptionServer
 from dagster import execute_pipeline, pipeline, solid
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import environ, instance_for_test
 from dagster.core.workspace.context import WorkspaceProcessContext
 from dagster.core.workspace.load_target import WorkspaceFileTarget
 from dagster.utils import file_relative_path
@@ -108,6 +108,28 @@ def test_event_log_subscription():
             assert len(objgraph.by_type("PipelineRunObservableSubscribe")) == 1
             end_subscription(server, context)
             gc.collect()
+            assert len(objgraph.by_type("SubscriptionObserver")) == 0
+            assert len(objgraph.by_type("PipelineRunObservableSubscribe")) == 0
+
+
+def test_event_log_subscription_chunked():
+    schema = create_schema()
+    server = DagsterSubscriptionServer(schema=schema)
+
+    with instance_for_test() as instance, environ({"DAGIT_EVENT_LOAD_CHUNK_SIZE": "2"}):
+        run = execute_pipeline(example_pipeline, instance=instance)
+        assert run.success
+        assert run.run_id
+
+        with create_subscription_context(instance) as context:
+            start_subscription(server, context, EVENT_LOG_SUBSCRIPTION, {"runId": run.run_id})
+            gc.collect()
+            assert len(objgraph.by_type("SubscriptionObserver")) == 1
+            assert len(objgraph.by_type("PipelineRunObservableSubscribe")) == 1
+
+            end_subscription(server, context)
+            gc.collect()
+
             assert len(objgraph.by_type("SubscriptionObserver")) == 0
             assert len(objgraph.by_type("PipelineRunObservableSubscribe")) == 0
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/pipeline_run_storage.py
@@ -1,27 +1,103 @@
+import os
+from enum import Enum
+from threading import Event, Thread
+from time import sleep
+
+import gevent
+from dagster import check
+
+
+class State(Enum):
+    # initialized
+    NULL = 0
+    # streaming the existing event log entries
+    LOADING = 1
+    # watching for new writes
+    WATCHING = 2
+
+
+def get_chunk_size() -> int:
+    return int(os.getenv("DAGIT_EVENT_LOAD_CHUNK_SIZE", "10000"))
+
+
 class PipelineRunObservableSubscribe:
     def __init__(self, instance, run_id, after_cursor=None):
         self.instance = instance
         self.run_id = run_id
         self.observer = None
+        self.state = State.NULL
+        self.load_thread = None
+        self.stopping = None
         self.after_cursor = after_cursor if after_cursor is not None else -1
 
     def __call__(self, observer):
         self.observer = observer
-
-        events = self.instance.logs_after(self.run_id, self.after_cursor)
+        check.invariant(self.state is State.NULL, f"unexpected state {self.state}")
+        chunk_size = get_chunk_size()
+        events = self.instance.logs_after(self.run_id, self.after_cursor, limit=chunk_size)
         if events:
             self.observer.on_next(events)
+            self.after_cursor = len(events) + int(self.after_cursor)
 
-        cursor = len(events) + int(self.after_cursor)
-        self.instance.watch_event_logs(self.run_id, cursor, self.handle_new_event)
+        if len(events) == chunk_size:
+            self.load_events()
+        else:
+            self.watch_events()
+
         return self
+
+    def load_events(self):
+        self.state = State.LOADING
+
+        # support for gevent based dagit server
+        if gevent.get_hub().gr_frame:
+            self.stopping = gevent.event.Event()
+            self.load_thread = gevent.Greenlet(self.background_event_loading, gevent.sleep)
+        else:
+            self.stopping = Event()
+            self.load_thread = Thread(
+                target=self.background_event_loading,
+                args=(sleep,),
+                name=f"load-events-{self.run_id}",
+            )
+
+        self.load_thread.start()
+
+    def watch_events(self):
+        self.state = State.WATCHING
+        self.instance.watch_event_logs(self.run_id, self.after_cursor, self.handle_new_event)
+
+    def background_event_loading(self, sleep_fn):
+        chunk_size = get_chunk_size()
+
+        while not self.stopping.is_set():
+            events = self.instance.logs_after(self.run_id, self.after_cursor, limit=chunk_size)
+            if not events or self.observer is None:
+                break
+
+            self.observer.on_next(events)
+            self.after_cursor = len(events) + int(self.after_cursor)
+
+            if len(events) < chunk_size:
+                break
+
+            sleep_fn(0)
+
+        if not self.stopping.is_set():
+            self.watch_events()
+
+        return
 
     def dispose(self):
         # called when the connection gets closed, allowing the observer to get GC'ed
         if self.observer and callable(getattr(self.observer, "dispose", None)):
             self.observer.dispose()
         self.observer = None
-        self.instance.end_watch_event_logs(self.run_id, self.handle_new_event)
+
+        if self.state is State.WATCHING:
+            self.instance.end_watch_event_logs(self.run_id, self.handle_new_event)
+        elif self.state is State.LOADING:
+            self.stopping.set()
 
     def handle_new_event(self, new_event):
         if self.observer:


### PR DESCRIPTION
Instead of loading all the existing events on subscribe, background the work and do it in chunks.

Uses gevent primitives to function in the existing dagit webserver. This was prompted by running in to errors at socket write time about thread switches. I am not sure why we do not run in to these issues with the watching which writes events from background threads, but I specualte it has something to do with small messages flushing one event at a time.


### Test Plan
```
dagit-debug --asgi large_debug_file
dagit-debug large_debug_file
```
added test