### PR TITLE
Use fixed container names in k8s pods

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -519,7 +519,7 @@ def construct_dagster_k8s_job(
         additional_k8s_volume_mounts.append(kubernetes.client.V1VolumeMount(**volume_mount))
 
     job_container = kubernetes.client.V1Container(
-        name=job_name,
+        name=component.replace("_", "-") if component else job_name,
         image=job_config.job_image,
         args=args,
         image_pull_policy=job_config.image_pull_policy,


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

- Change `name` of containers spawned by K8sRunLauncher and K8sJobExecutor to fixed values: `run-coordinator` and `step-worker`, respectively.
    - So far container names are the same as job/pod names such as `dagster-run-da3dfd66-d0c5-4bbd-a78a-181daa974a98-hqbqr` and `dagster-job-a1cc211c512720c86c2874dba9bea857-fldgn`.
- Context: Random strings in identifiers complicate tools/workflow around k8s. The job pods basically only have 1 container and there's no need to make container names unique.
    - In our case container logs are managed based on pod labels and container names. Logs having the same container name are managed together and can be e.g. searched when debugging.
    - Of course this can be worked around on the tooling side, but we hope it's resolved in one place (upstream) so that we (and others) don't have to fix log collectors, logging infrastructure, debugging utilities, etc.
- Note:
    - The implementation falls back to `job_name` if `component` is not given, but this is for existing tests. Both K8sRunLauncher and K8sJobExecutor specify `component`.
    - If the current behavior should be preserved, I'd be happy to change the patch to something like "make container name overridable by USER_DEFINED_K8S_CONFIG_KEY tag". I thought fixed name is simpler but please let me know what you think.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
- Confirmed in our EKS setup (dagster 0.12.9 with this patch) that containers in pods (spawned by `k8s_job_executor`) have the same fixed name `step-worker`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.