### PR TITLE
[dagit] Show related jobs in graph sidebar

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -70,12 +70,12 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   solidHandles(parentHandleID: String): [SolidHandle!]!
   solidHandle(handleID: String!): SolidHandle
   tags: [PipelineTag!]!
+  graphName: String!
   id: ID!
   runs(cursor: String, limit: Int): [PipelineRun!]!
   schedules: [Schedule!]!
   sensors: [Sensor!]!
   parentSnapshotId: String
-  graphName: String!
   presets: [PipelinePreset!]!
 }
 
@@ -187,6 +187,7 @@ interface IPipelineSnapshot {
   solidHandles(parentHandleID: String): [SolidHandle!]!
   solidHandle(handleID: String!): SolidHandle
   tags: [PipelineTag!]!
+  graphName: String!
 }
 
 union DagsterTypeOrError = RegularDagsterType | PipelineNotFoundError | DagsterTypeNotFoundError | PythonError
@@ -1134,13 +1135,13 @@ type PipelineSnapshot implements IPipelineSnapshot & PipelineReference {
   solidHandles(parentHandleID: String): [SolidHandle!]!
   solidHandle(handleID: String!): SolidHandle
   tags: [PipelineTag!]!
+  graphName: String!
   solidSelection: [String!]
   id: ID!
   runs(cursor: String, limit: Int): [PipelineRun!]!
   schedules: [Schedule!]!
   sensors: [Sensor!]!
   parentSnapshotId: String
-  graphName: String!
 }
 
 type PipelineSnapshotNotFoundError implements Error {

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorer.tsx
@@ -39,6 +39,7 @@ interface PipelineExplorerProps {
   selectedHandle?: PipelineExplorerSolidHandleFragment;
   parentHandle?: PipelineExplorerSolidHandleFragment;
   getInvocations?: (definitionName: string) => {handleID: string}[];
+  pageContext: 'graph' | 'job';
 }
 
 export const PipelineExplorer: React.FC<PipelineExplorerProps> = (props) => {
@@ -53,6 +54,7 @@ export const PipelineExplorer: React.FC<PipelineExplorerProps> = (props) => {
     selectedHandle,
     setOptions,
     repoAddress,
+    pageContext,
   } = props;
   const [highlighted, setHighlighted] = React.useState('');
 
@@ -228,6 +230,7 @@ export const PipelineExplorer: React.FC<PipelineExplorerProps> = (props) => {
             // eslint-disable-next-line react/no-children-prop
             children={({location}: {location: any}) => (
               <SidebarTabbedContainer
+                pageContext={pageContext}
                 pipeline={pipeline}
                 explorerPath={explorerPath}
                 solidHandleID={selectedHandle && selectedHandle.handleID}

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -28,7 +28,7 @@ import {
 } from './types/PipelineExplorerRootQuery';
 
 export const PipelineExplorerRegexRoot: React.FC<
-  RouteComponentProps & {repoAddress: RepoAddress}
+  RouteComponentProps & {repoAddress: RepoAddress; pageContext: 'graph' | 'job'}
 > = (props) => {
   const explorerPath = explorerPathFromString(props.match.params['0']);
   const {flagPipelineModeTuples} = useFeatureFlags();
@@ -40,6 +40,7 @@ export const PipelineExplorerRegexRoot: React.FC<
     <PipelineExplorerContainer
       explorerPath={explorerPath}
       repoAddress={props.repoAddress}
+      pageContext={props.pageContext}
       onChangeExplorerPath={(path, mode) => {
         const tab = flagPipelineModeTuples ? 'graphs' : 'pipelines';
         const fullPath = props.repoAddress
@@ -66,6 +67,7 @@ export const PipelineExplorerSnapshotRoot: React.FC<RouteComponentProps> = (prop
   return (
     <PipelineExplorerContainer
       explorerPath={explorerPath}
+      pageContext="job"
       onChangeExplorerPath={(path, mode) => {
         history[mode](`/instance/snapshots/${explorerPathToString(path)}`);
       }}
@@ -77,7 +79,8 @@ export const PipelineExplorerContainer: React.FC<{
   explorerPath: PipelineExplorerPath;
   onChangeExplorerPath: (path: PipelineExplorerPath, mode: 'replace' | 'push') => void;
   repoAddress?: RepoAddress;
-}> = ({explorerPath, repoAddress, onChangeExplorerPath}) => {
+  pageContext: 'graph' | 'job';
+}> = ({explorerPath, repoAddress, pageContext, onChangeExplorerPath}) => {
   const [options, setOptions] = React.useState<PipelineExplorerOptions>({
     explodeComposites: false,
   });
@@ -141,6 +144,7 @@ export const PipelineExplorerContainer: React.FC<{
             handles={displayedHandles}
             parentHandle={parentHandle ? parentHandle : undefined}
             selectedHandle={selectedHandle}
+            pageContext={pageContext}
             getInvocations={(definitionName) =>
               displayedHandles
                 .filter((s) => s.solid.definition.name === definitionName)

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
@@ -38,6 +38,7 @@ export const PipelineOverviewRoot: React.FC<Props> = (props) => {
       <PipelineExplorerContainer
         repoAddress={repoAddress}
         explorerPath={explorerPath}
+        pageContext="job"
         onChangeExplorerPath={(path, action) => {
           history[action]({
             search: location.search,

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineInfo.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineInfo.tsx
@@ -46,6 +46,7 @@ export const SIDEBAR_PIPELINE_INFO_FRAGMENT = gql`
   fragment SidebarPipelineInfoFragment on IPipelineSnapshot {
     name
     description
+    graphName
     modes {
       id
       ...SidebarModeInfoFragment

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerFragment.ts
@@ -715,5 +715,6 @@ export interface PipelineExplorerFragment {
   __typename: "Pipeline" | "PipelineSnapshot";
   name: string;
   description: string | null;
+  graphName: string;
   modes: PipelineExplorerFragment_modes[];
 }

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineExplorerRootQuery.ts
@@ -1170,6 +1170,7 @@ export interface PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnaps
   id: string;
   name: string;
   description: string | null;
+  graphName: string;
   modes: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_modes[];
   solidHandle: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandle | null;
   solidHandles: PipelineExplorerRootQuery_pipelineSnapshotOrError_PipelineSnapshot_solidHandles[];

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarPipelineInfoFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarPipelineInfoFragment.ts
@@ -715,5 +715,6 @@ export interface SidebarPipelineInfoFragment {
   __typename: "Pipeline" | "PipelineSnapshot";
   name: string;
   description: string | null;
+  graphName: string;
   modes: SidebarPipelineInfoFragment_modes[];
 }

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarTabbedContainerPipelineFragment.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarTabbedContainerPipelineFragment.ts
@@ -715,5 +715,6 @@ export interface SidebarTabbedContainerPipelineFragment {
   __typename: "Pipeline" | "PipelineSnapshot";
   name: string;
   description: string | null;
+  graphName: string;
   modes: SidebarTabbedContainerPipelineFragment_modes[];
 }

--- a/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
@@ -38,7 +38,7 @@ export const GraphRoot: React.FC<Props> = (props) => {
         />
       </div>
       <div style={{position: 'relative', minHeight: 0, flex: 1, display: 'flex'}}>
-        <PipelineExplorerRegexRoot {...props} repoAddress={repoAddress} />
+        <PipelineExplorerRegexRoot {...props} repoAddress={repoAddress} pageContext="graph" />
       </div>
     </div>
   );

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -64,6 +64,7 @@ const ROOT_REPOSITORIES_QUERY = gql`
                 name
                 pipelines {
                   id
+                  graphName
                   name
                   pipelineSnapshotId
                   modes {

--- a/js_modules/dagit/packages/core/src/workspace/types/RootRepositoriesQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RootRepositoriesQuery.ts
@@ -25,6 +25,7 @@ export interface RootRepositoriesQuery_workspaceOrError_Workspace_locationEntrie
 export interface RootRepositoriesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
   __typename: "Pipeline";
   id: string;
+  graphName: string;
   name: string;
   pipelineSnapshotId: string;
   modes: RootRepositoriesQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -461,6 +461,7 @@ class GrapheneIPipelineSnapshot(graphene.Interface):
         handleID=graphene.Argument(graphene.NonNull(graphene.String)),
     )
     tags = non_null_list(GraphenePipelineTag)
+    graph_name = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "IPipelineSnapshot"


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

For Crag users, show "Related jobs" alongside "Info" and "Types" in the right pane on the Job/Graph Overview. These are jobs that use the same graph.

Note that there may be a bug here: the list of graphs shown for a given repository look wrong, as it's just a list of pipelines. So I think a bit more work needs to be done here to properly query the list of graphs from the back end.

## Test Plan

With Crag enabled, view a Job. Click "Related jobs", verify that other jobs using that graph are listed -- or if there are no related jobs, that the empty state is shown.

View a graph, verify that the "Related jobs" tab shows all of the jobs using that graph.
