### PR TITLE
Merge job_image and env from executor config with K8sRunLauncher job config

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -18,7 +18,9 @@ from dagster_k8s.launcher import K8sRunLauncher
 
 from .job import (
     DagsterK8sJobConfig,
+    K8S_EXECUTOR_CONFIG_KEY,
     construct_dagster_k8s_job,
+    get_k8s_executor_config_schema,
     get_k8s_job_name,
     get_user_defined_k8s_config,
 )
@@ -26,12 +28,8 @@ from .utils import delete_job
 
 
 @executor(
-    name="k8s",
-    config_schema=merge_dicts(
-        DagsterK8sJobConfig.config_type_pipeline_run(),
-        {"job_namespace": Field(StringSource, is_required=False)},
-        {"retries": get_retries_config()},
-    ),
+    name=K8S_EXECUTOR_CONFIG_KEY,
+    config_schema=get_k8s_executor_config_schema(),
     requirements=multiple_process_executor_requirements(),
 )
 @experimental

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -47,6 +47,11 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     under the ``config`` key of this YAML block will be passed to the constructor. The full list
     of acceptable values is given below by the constructor args.
 
+    When used in conjunction with k8s executor, the ``job_image`` from the executor configuration
+    will override the one from this RunLuancher. Also, environement vaiables from the executor
+    configuration defined via ``env_config_maps``, ``env_secrets`` or ``env_vars`` will be appended
+    to the ones defined in this RunLauncher.
+
     Args:
         service_account_name (str): The name of the Kubernetes service account under which to run
             the Job.


### PR DESCRIPTION
## Summary

This allows overwriting the `job_image` from the `K8sRunLauncher` and including `env_config_maps`, `env_secrets` and `env_vars` from the execution config in the run worker.
It makes K8sRunLaucnher behavior similar to CeleryK8sRunLauncher (https://github.com/dagster-io/dagster/commit/fac4b234c243970d2b52dbb88a742b4231840779), and solves the issue of having to include user code environment variables in the run launcher to be able to access them in the run worker, which is odd when user code is deployed separately.

Relevant discussions:
https://dagster.slack.com/archives/C014N0PK37E/p1627571118231900
https://dagster.slack.com/archives/C01U954MEER/p1631022303277700

Related issue: https://github.com/dagster-io/dagster/issues/4755

## Test Plan
Added a unit_test for k8s_run_launcher




## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.