### PR TITLE
add index for event_type in event log table

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/schema.py
@@ -59,3 +59,9 @@ db.Index(
     SqlEventLogStorageTable.c.partition,
     mysql_length=64,
 )
+db.Index(
+    "idx_event_type",
+    SqlEventLogStorageTable.c.dagster_event_type,
+    SqlEventLogStorageTable.c.id,
+    mysql_length={"dagster_event_type": 64},
+)

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -629,10 +629,7 @@ class SqlEventLogStorage(EventLogStorage):
                     if isinstance(event_records_filter.after_cursor, RunShardedEventsCursor)
                     else event_records_filter.after_cursor
                 )
-                after_query = db.select([SqlEventLogStorageTable.c.id]).where(
-                    SqlEventLogStorageTable.c.id == after_cursor_id
-                )
-                query = query.where(SqlEventLogStorageTable.c.id > after_query)
+                query = query.where(SqlEventLogStorageTable.c.id > after_cursor_id)
 
         if event_records_filter.before_timestamp:
             query = query.where(

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/alembic/versions/05844c702676_add_event_log_event_type_idx.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/alembic/versions/05844c702676_add_event_log_event_type_idx.py
@@ -1,0 +1,22 @@
+"""add event log event type idx
+
+Revision ID: 05844c702676
+Revises: e784752027a6
+Create Date: 2021-09-08 10:42:42.063814
+
+"""
+from dagster.core.storage.migration.utils import create_event_log_event_idx
+
+# revision identifiers, used by Alembic.
+revision = "05844c702676"
+down_revision = "e784752027a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_event_log_event_idx()
+
+
+def downgrade():
+    pass

--- a/python_modules/dagster/dagster/core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/core/storage/migration/utils.py
@@ -192,3 +192,15 @@ def extract_asset_keys_idx_columns():
     op.add_column("asset_keys", db.Column("wipe_timestamp", db.types.TIMESTAMP))
     op.add_column("asset_keys", db.Column("last_materialization_timestamp", db.types.TIMESTAMP))
     op.add_column("asset_keys", db.Column("tags", db.TEXT))
+
+
+def create_event_log_event_idx():
+    if not has_table("event_logs"):
+        return
+
+    op.create_index(
+        "idx_event_type",
+        "event_logs",
+        ["dagster_event_type", "id"],
+        mysql_length={"dagster_event_type": 64},
+    )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/alembic/versions/29a8e9d74220_add_event_log_event_type_idx.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/alembic/versions/29a8e9d74220_add_event_log_event_type_idx.py
@@ -1,0 +1,22 @@
+"""add event log event type idx
+
+Revision ID: 29a8e9d74220
+Revises: 1a2d72f6b24e
+Create Date: 2021-09-08 10:29:08.823969
+
+"""
+from dagster.core.storage.migration.utils import create_event_log_event_idx
+
+# revision identifiers, used by Alembic.
+revision = "29a8e9d74220"
+down_revision = "1a2d72f6b24e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_event_log_event_idx()
+
+
+def downgrade():
+    pass

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/alembic/versions/f4b6a4885876_add_event_log_event_type_idx.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/alembic/versions/f4b6a4885876_add_event_log_event_type_idx.py
@@ -1,0 +1,22 @@
+"""add event log event type idx
+
+Revision ID: f4b6a4885876
+Revises: 7b8304b4429d
+Create Date: 2021-09-08 10:28:28.730620
+
+"""
+from dagster.core.storage.migration.utils import create_event_log_event_idx
+
+# revision identifiers, used by Alembic.
+revision = "f4b6a4885876"
+down_revision = "7b8304b4429d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_event_log_event_idx()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
We're doing a range query on id, but with an event type filter in place.  This can be a pretty expensive query.

## Test Plan
printed out the explain query from the pipeline failure sensor, saw that it was using the newly created (from migration) index.
