### PR TITLE
fix for DagsterInstance.logs_after limit

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -204,7 +204,7 @@ class SqlEventLogStorage(EventLogStorage):
         query = query.offset(cursor + 1)
 
         if limit:
-            query.limit(limit)
+            query = query.limit(limit)
 
         with self.run_connection(run_id) as conn:
             results = conn.execute(query).fetchall()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -541,12 +541,14 @@ class TestEventLogStorage:
         out_events = []
         cursor = -1
         fuse = 0
+        chunk_size = 2
         while fuse < 50:
             fuse += 1
             # fetch in batches w/ limit & cursor
-            chunk = storage.get_logs_for_run(result.run_id, cursor=cursor, limit=2)
+            chunk = storage.get_logs_for_run(result.run_id, cursor=cursor, limit=chunk_size)
             if not chunk:
                 break
+            assert len(chunk) <= chunk_size
             out_events += chunk
             cursor += len(chunk)
 


### PR DESCRIPTION
fix clowny mistake from #4752 of missing `query = `

### Test Plan

updated test