### PR TITLE
Add op alias to hook

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -386,6 +386,7 @@ def build_hook_context(
             with build_hook_context(resources={"foo": context_manager_resource}) as context:
                 hook_to_invoke(context)
     """
+    check.invariant(not (solid and op))
     if op:
         experimental_arg_warning("op", "build_hook_context")
         return UnboundHookContext(

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -391,7 +391,7 @@ def build_hook_context(
         experimental_arg_warning("op", "build_hook_context")
         return UnboundHookContext(
             resources=check.opt_dict_param(resources, "resources", key_type=str),
-            mode_def=ModeDefinition,
+            mode_def=None,
             solid=check.opt_inst_param(op, "op", (OpDefinition, PendingNodeInvocation)),
         )
     return UnboundHookContext(

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -386,7 +386,7 @@ def build_hook_context(
             with build_hook_context(resources={"foo": context_manager_resource}) as context:
                 hook_to_invoke(context)
     """
-    check.invariant(not (solid and op))
+    check.invariant(not (solid and op), "cannot set both `solid` and `op`")
     if op:
         experimental_arg_warning("op", "build_hook_context")
         return UnboundHookContext(

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -445,7 +445,7 @@ def test_hook_graph_job_op():
     def hook_two(context):
         assert not context.op_config
         assert not context.op_exception
-        assert context.op_output_values['result'] == op_output
+        assert context.op_output_values["result"] == op_output
         called[context.hook_def.name] = called.get(context.hook_def.name, 0) + 1
 
     @op

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -478,5 +478,4 @@ def test_hook_context_op_solid_provided():
         pass
 
     with pytest.raises(check.CheckError):
-        ctx = build_hook_context(op=hook_op, solid=hook_op)
-        hook_one(ctx)
+        build_hook_context(op=hook_op, solid=hook_op)

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -434,6 +434,7 @@ def test_hook_with_resource_to_resource_dep():
 
 def test_hook_graph_job_op():
     called = {}
+    op_output = "hook_op_output"
 
     @success_hook(required_resource_keys={"resource_a"})
     def hook_one(context):
@@ -444,11 +445,12 @@ def test_hook_graph_job_op():
     def hook_two(context):
         assert not context.op_config
         assert not context.op_exception
+        assert context.op_output_values['result'] == op_output
         called[context.hook_def.name] = called.get(context.hook_def.name, 0) + 1
 
     @op
     def hook_op(_):
-        pass
+        return op_output
 
     ctx = build_hook_context(resources={"resource_a": resource_a}, solid=hook_op)
     hook_one(ctx)


### PR DESCRIPTION
Add aliasing to hooks, allowing users to access the following op attributes within `HookContext` (e.g. `HookContext.op`, `HookContext.op_config`, etc.)