### PR TITLE
[dagit] Poll for repo location status in reload workflow

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/types/ReloadRepositoryLocationMutation.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/ReloadRepositoryLocationMutation.ts
@@ -4,52 +4,13 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RepositoryLocationLoadStatus } from "./../../types/globalTypes";
-
 // ====================================================
 // GraphQL mutation operation: ReloadRepositoryLocationMutation
 // ====================================================
 
-export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation_repositories_pipelines {
-  __typename: "Pipeline";
-  id: string;
-  name: string;
-}
-
-export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation_repositories {
-  __typename: "Repository";
-  id: string;
-  name: string;
-  pipelines: ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
-}
-
-export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation {
-  __typename: "RepositoryLocation";
-  id: string;
-  repositories: ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation_repositories[];
-}
-
-export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError_cause | null;
-}
-
-export type ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError = ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_RepositoryLocation | ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError_PythonError;
-
 export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry {
   __typename: "WorkspaceLocationEntry";
   id: string;
-  name: string;
-  loadStatus: RepositoryLocationLoadStatus;
-  locationOrLoadError: ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry_locationOrLoadError | null;
 }
 
 export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_UnauthorizedError {

--- a/js_modules/dagit/packages/core/src/nav/types/ReloadRepositoryLocationMutation.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/ReloadRepositoryLocationMutation.ts
@@ -28,9 +28,17 @@ export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_Repos
   message: string;
 }
 
+export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
 export interface ReloadRepositoryLocationMutation_reloadRepositoryLocation_PythonError {
   __typename: "PythonError";
   message: string;
+  stack: string[];
+  cause: ReloadRepositoryLocationMutation_reloadRepositoryLocation_PythonError_cause | null;
 }
 
 export type ReloadRepositoryLocationMutation_reloadRepositoryLocation = ReloadRepositoryLocationMutation_reloadRepositoryLocation_WorkspaceLocationEntry | ReloadRepositoryLocationMutation_reloadRepositoryLocation_UnauthorizedError | ReloadRepositoryLocationMutation_reloadRepositoryLocation_ReloadNotSupported | ReloadRepositoryLocationMutation_reloadRepositoryLocation_RepositoryLocationNotFound | ReloadRepositoryLocationMutation_reloadRepositoryLocation_PythonError;

--- a/js_modules/dagit/packages/core/src/nav/types/RepositoryLocationStatusQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/RepositoryLocationStatusQuery.ts
@@ -10,10 +10,6 @@ import { RepositoryLocationLoadStatus } from "./../../types/globalTypes";
 // GraphQL query operation: RepositoryLocationStatusQuery
 // ====================================================
 
-export interface RepositoryLocationStatusQuery_workspaceOrError_PythonError {
-  __typename: "PythonError";
-}
-
 export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
   __typename: "Pipeline";
   id: string;
@@ -60,7 +56,20 @@ export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace {
   locationEntries: RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries[];
 }
 
-export type RepositoryLocationStatusQuery_workspaceOrError = RepositoryLocationStatusQuery_workspaceOrError_PythonError | RepositoryLocationStatusQuery_workspaceOrError_Workspace;
+export interface RepositoryLocationStatusQuery_workspaceOrError_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: RepositoryLocationStatusQuery_workspaceOrError_PythonError_cause | null;
+}
+
+export type RepositoryLocationStatusQuery_workspaceOrError = RepositoryLocationStatusQuery_workspaceOrError_Workspace | RepositoryLocationStatusQuery_workspaceOrError_PythonError;
 
 export interface RepositoryLocationStatusQuery {
   workspaceOrError: RepositoryLocationStatusQuery_workspaceOrError;

--- a/js_modules/dagit/packages/core/src/nav/types/RepositoryLocationStatusQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/RepositoryLocationStatusQuery.ts
@@ -1,0 +1,67 @@
+// @generated
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RepositoryLocationLoadStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: RepositoryLocationStatusQuery
+// ====================================================
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  pipelines: RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
+  __typename: "RepositoryLocation";
+  id: string;
+  repositories: RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories[];
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_cause | null;
+}
+
+export type RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation | RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError;
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries {
+  __typename: "WorkspaceLocationEntry";
+  id: string;
+  loadStatus: RepositoryLocationLoadStatus;
+  locationOrLoadError: RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
+}
+
+export interface RepositoryLocationStatusQuery_workspaceOrError_Workspace {
+  __typename: "Workspace";
+  locationEntries: RepositoryLocationStatusQuery_workspaceOrError_Workspace_locationEntries[];
+}
+
+export type RepositoryLocationStatusQuery_workspaceOrError = RepositoryLocationStatusQuery_workspaceOrError_PythonError | RepositoryLocationStatusQuery_workspaceOrError_Workspace;
+
+export interface RepositoryLocationStatusQuery {
+  workspaceOrError: RepositoryLocationStatusQuery_workspaceOrError;
+}

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.test.tsx
@@ -1,0 +1,234 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+
+import {useRepositoryLocationReload} from './useRepositoryLocationReload';
+
+describe('useRepositoryReloadLocation', () => {
+  jest.useFakeTimers();
+
+  const LOCATION = 'bar';
+
+  const defaultMocks = {
+    WorkspaceLocationEntry: () => ({
+      id: () => LOCATION,
+      name: () => LOCATION,
+      loadStatus: () => 'LOADED',
+    }),
+    ReloadRepositoryLocationMutationResult: () => ({
+      __typename: 'WorkspaceLocationEntry',
+    }),
+    RepositoryLocation: () => ({
+      id: () => LOCATION,
+    }),
+  };
+
+  const Test = () => {
+    const {reloading, error, tryReload} = useRepositoryLocationReload(LOCATION);
+    return (
+      <div>
+        <div>{`Reloading: ${reloading}`}</div>
+        <div>{`Has error: ${!!error}`}</div>
+        <button onClick={() => tryReload()}>Try</button>
+      </div>
+    );
+  };
+
+  it('reloads successfully if there are no errors', async () => {
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByText(/Try/));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    jest.runAllTicks();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+  });
+
+  it('surfaces mutation errors', async () => {
+    const mocks = {
+      ReloadRepositoryLocationMutationResult: () => ({
+        __typename: 'RepositoryLocationNotFound',
+        message: () => 'lol not here',
+      }),
+    };
+
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByText(/Try/));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    jest.runAllTicks();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: true/)).toBeVisible();
+    });
+  });
+
+  it('surfaces repository location errors', async () => {
+    const mocks = {
+      RepositoryLocationOrLoadError: () => ({
+        __typename: 'PythonError',
+        message: () => 'u cannot do this',
+      }),
+    };
+
+    render(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByText(/Try/));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    jest.runAllTicks();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: true/)).toBeVisible();
+    });
+  });
+
+  it('waits for polling when attempting reload', async () => {
+    const mocks = {
+      WorkspaceLocationEntry: () => ({
+        id: () => LOCATION,
+        name: () => LOCATION,
+        loadStatus: () => 'LOADING',
+      }),
+    };
+
+    const {rerender} = render(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    fireEvent.click(screen.getByText(/Try/));
+    jest.runAllTicks();
+
+    // Still considered reloading while polling occurs.
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    jest.runAllTicks();
+
+    // Still polling.
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    // Set the location entry to `LOADED`, which should terminate polling.
+    rerender(
+      <TestProvider apolloProps={{mocks: defaultMocks}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    jest.runAllTicks();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+  });
+
+  it('stops polling when attempting reload when `LOADED` and there are errors', async () => {
+    const mocks = {
+      WorkspaceLocationEntry: () => ({
+        id: () => LOCATION,
+        name: () => LOCATION,
+        loadStatus: () => 'LOADING',
+      }),
+    };
+
+    const {rerender} = render(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    fireEvent.click(screen.getByText(/Try/));
+    jest.runAllTicks();
+
+    // Still considered reloading while polling occurs.
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    jest.runAllTicks();
+
+    // Still polling.
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: true/)).toBeVisible();
+      expect(screen.queryByText(/Has error: false/)).toBeVisible();
+    });
+
+    const mocksWithError = {
+      RepositoryLocationOrLoadError: () => ({
+        __typename: 'PythonError',
+        message: () => 'u cannot do this',
+      }),
+    };
+
+    // Set an error on the repository location and use the `LOADED` state from the
+    // default mocks to end polling.
+    rerender(
+      <TestProvider apolloProps={{mocks: [defaultMocks, mocksWithError]}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    jest.runAllTicks();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Reloading: false/)).toBeVisible();
+      expect(screen.queryByText(/Has error: true/)).toBeVisible();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -1,4 +1,4 @@
-import {gql, useApolloClient, useMutation} from '@apollo/client';
+import {gql, useApolloClient, useMutation, useQuery} from '@apollo/client';
 import {Intent} from '@blueprintjs/core';
 import * as React from 'react';
 
@@ -6,42 +6,51 @@ import {SharedToaster} from '../app/DomUtils';
 import {useInvalidateConfigsForRepo} from '../app/LocalStorage';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
+import {RepositoryLocationLoadStatus} from '../types/globalTypes';
 
 import {
   ReloadRepositoryLocationMutation,
   ReloadRepositoryLocationMutationVariables,
 } from './types/ReloadRepositoryLocationMutation';
+import {RepositoryLocationStatusQuery} from './types/RepositoryLocationStatusQuery';
 
 type State = {
-  reloading: boolean;
+  mutating: boolean;
+  pollStartTime: number | null;
   error: PythonErrorFragment | {message: string} | null;
 };
 
 type Action =
-  | {type: 'start-reloading'}
-  | {type: 'finish-reloading'}
+  | {type: 'start-mutation'}
+  | {type: 'finish-mutation-and-start-polling'}
+  | {type: 'finish-polling'}
   | {type: 'error'; error: PythonErrorFragment | {message: string} | null}
   | {type: 'success'};
 
 const reducer = (state: State, action: Action) => {
   switch (action.type) {
-    case 'start-reloading':
-      return {...state, reloading: true};
-    case 'finish-reloading':
-      return {...state, reloading: false};
+    case 'start-mutation':
+      return {...state, mutating: true, pollStartTime: null};
+    case 'finish-mutation-and-start-polling':
+      return {...state, mutating: false, pollStartTime: Date.now()};
+    case 'finish-polling':
+      return {...state, pollStartTime: null};
     case 'error':
-      return {...state, error: action.error};
+      return {...state, mutating: false, error: action.error, pollStartTime: null};
     case 'success':
-      return {...state, error: null};
+      return {...state, error: null, pollStartTime: null};
     default:
       return state;
   }
 };
 
 const initialState: State = {
-  reloading: false,
+  mutating: false,
+  pollStartTime: null,
   error: null,
 };
+
+const THREE_MINUTES = 3 * 60 * 1000;
 
 export const useRepositoryLocationReload = (location: string) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
@@ -56,52 +65,103 @@ export const useRepositoryLocationReload = (location: string) => {
 
   const invalidateConfigs = useInvalidateConfigsForRepo();
 
+  const {startPolling, stopPolling} = useQuery<RepositoryLocationStatusQuery>(
+    REPOSITORY_LOCATION_STATUS_QUERY,
+    {
+      skip: state.pollStartTime === null,
+      pollInterval: 5000,
+      fetchPolicy: 'no-cache',
+      // This is irritating, but apparently necessary for now.
+      // https://github.com/apollographql/apollo-client/issues/5531
+      notifyOnNetworkStatusChange: true,
+      onCompleted: (data: RepositoryLocationStatusQuery) => {
+        const workspace = data.workspaceOrError;
+
+        // On any failure, immediately show the error dialog. This is a blocking failure that must be
+        // either retried after repairing the issue or dismissed manually.
+        if (workspace.__typename !== 'Workspace') {
+          dispatch({type: 'error', error: {message: 'Failed to load workspace.'}});
+          stopPolling();
+          return;
+        }
+
+        const match = workspace.locationEntries.find((l) => l.id === location);
+        if (!match) {
+          dispatch({
+            type: 'error',
+            error: {message: `Location ${location} not found in workspace.`},
+          });
+          stopPolling();
+          return;
+        }
+
+        // If we're still loading, there's nothing to do yet. Continue polling unless
+        // we have hit our timeout threshold.
+        if (match.loadStatus === RepositoryLocationLoadStatus.LOADING) {
+          if (Date.now() - Number(state.pollStartTime) > THREE_MINUTES) {
+            dispatch({
+              type: 'error',
+              error: {message: 'Timed out waiting for the location to reload.'},
+            });
+            stopPolling();
+          }
+          return;
+        }
+
+        // If we're done loading and an error persists, show it.
+        if (match.locationOrLoadError?.__typename === 'PythonError') {
+          dispatch({type: 'error', error: match.locationOrLoadError});
+          stopPolling();
+          return;
+        }
+
+        // Otherwise, we have no errors left.
+        dispatch({type: 'finish-polling'});
+        stopPolling();
+
+        // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
+        SharedToaster.show({
+          message: 'Repository location reloaded',
+          timeout: 3000,
+          icon: 'refresh',
+          intent: Intent.SUCCESS,
+        });
+        dispatch({type: 'success'});
+
+        // Update run config localStorage, which may now be out of date.
+        const repositories =
+          match?.__typename === 'WorkspaceLocationEntry' &&
+          match.locationOrLoadError?.__typename === 'RepositoryLocation'
+            ? match.locationOrLoadError.repositories
+            : [];
+
+        invalidateConfigs(repositories);
+
+        // Clear and refetch all the queries bound to the UI.
+        apollo.resetStore();
+      },
+    },
+  );
+
   const tryReload = React.useCallback(async () => {
-    dispatch({type: 'start-reloading'});
+    dispatch({type: 'start-mutation'});
     const {data} = await reload();
-    dispatch({type: 'finish-reloading'});
 
-    let loadFailure = null;
     if (data?.reloadRepositoryLocation.__typename === 'WorkspaceLocationEntry') {
-      if (data?.reloadRepositoryLocation.locationOrLoadError?.__typename === 'PythonError') {
-        loadFailure = data?.reloadRepositoryLocation.locationOrLoadError;
-      }
+      // If the mutation occurs successfully, begin polling.
+      dispatch({type: 'finish-mutation-and-start-polling'});
+      startPolling(5000);
     } else {
-      loadFailure = data?.reloadRepositoryLocation.message
-        ? {message: data?.reloadRepositoryLocation.message}
-        : null;
+      // Otherwise, surface the error.
+      dispatch({
+        type: 'error',
+        error: {message: data?.reloadRepositoryLocation.message || 'An unexpected error occurred.'},
+      });
     }
+  }, [reload, startPolling]);
 
-    // On failure, immediately show the error dialog. This is a blocking failure that must be
-    // either retried after repairing the issue or dismissed manually.
-    if (loadFailure) {
-      dispatch({type: 'error', error: loadFailure});
-      return;
-    }
-
-    // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
-    SharedToaster.show({
-      message: 'Repository location reloaded',
-      timeout: 3000,
-      icon: 'refresh',
-      intent: Intent.SUCCESS,
-    });
-    dispatch({type: 'success'});
-
-    // Update run config localStorage, which may now be out of date.
-    const repositories =
-      data?.reloadRepositoryLocation.__typename === 'WorkspaceLocationEntry' &&
-      data.reloadRepositoryLocation.locationOrLoadError?.__typename === 'RepositoryLocation'
-        ? data.reloadRepositoryLocation.locationOrLoadError.repositories
-        : [];
-
-    invalidateConfigs(repositories);
-
-    // Clear and refetch all the queries bound to the UI.
-    apollo.resetStore();
-  }, [apollo, invalidateConfigs, reload]);
-
-  const {reloading, error} = state;
+  const {mutating, pollStartTime, error} = state;
+  const reloading = mutating || pollStartTime !== null;
 
   return React.useMemo(() => ({reloading, error, tryReload}), [reloading, error, tryReload]);
 };
@@ -112,23 +172,6 @@ const RELOAD_REPOSITORY_LOCATION_MUTATION = gql`
       __typename
       ... on WorkspaceLocationEntry {
         id
-        name
-        loadStatus
-        locationOrLoadError {
-          __typename
-          ... on RepositoryLocation {
-            id
-            repositories {
-              id
-              name
-              pipelines {
-                id
-                name
-              }
-            }
-          }
-          ...PythonErrorFragment
-        }
       }
       ... on UnauthorizedError {
         message
@@ -141,6 +184,37 @@ const RELOAD_REPOSITORY_LOCATION_MUTATION = gql`
       }
       ... on PythonError {
         message
+      }
+    }
+  }
+`;
+
+const REPOSITORY_LOCATION_STATUS_QUERY = gql`
+  query RepositoryLocationStatusQuery {
+    workspaceOrError {
+      __typename
+      ... on Workspace {
+        locationEntries {
+          __typename
+          id
+          loadStatus
+          locationOrLoadError {
+            ... on RepositoryLocation {
+              id
+              repositories {
+                id
+                name
+                pipelines {
+                  id
+                  name
+                }
+              }
+            }
+            ... on PythonError {
+              ...PythonErrorFragment
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Repair the repo location error workflow for Cloud, for which repo locations are expected to provide their status and error state asynchronously after the reload mutation is performed. To that end:

- Add a polling query to `useRepositoryLocationReload` that asks for the `Workspace`, specifically the state of the repo location we are interested in. If the mutation completes successfully, begin polling.
- During the polling query:
  - If the query fails, surface that error.
  - If the query succeeds but the repository location is still in a `loadStatus: LOADING`, continue polling up to three minutes. After three minutes, show a timeout error.
  - If the query succeeds and is `LOADED`, show any errors.
  - If there are no errors in this circumstance, stop polling and reset the Apollo cache to get the fresh location into Dagit.

I have included a Jest test that tries to poke at some of the nuances here, but this is pretty tricky.

## Test Plan

In open source:

- Reload repository location with no errors, verify success.
- Introduce an error to `toys`, reload. Verify blocking dialog with error. Try to reload, verify that error persists.
- Repair error, try to reload from the dialog. Verify that the app reloads its cache correctly.
- Repeat behavior from Workspace page.