### PR TITLE
Cragify DagsterConfigMappingError

### DIFF
--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -225,23 +225,19 @@ def _get_error_lambda(current_stack):
         current_stack.current_solid.definition, CompositeSolidDefinition
     ) or not isinstance(current_stack.pipeline_def, JobDefinition):
         definition_type = "composite solid"
-        container_type = "solid"
         execution_target = "pipeline"
     else:
         definition_type = "graph"
-        container_type = "graph/op"
         execution_target = "job"
 
     return lambda: (
-        "The config mapping function on the {definition_type} definition "
-        '"{definition_name}" at {container_type} "{solid_name}" in {execution_target} "{pipeline_name}" '
+        "The config mapping function on the {definition_type} named "
+        '"{solid_name}" in {execution_target} "{pipeline_name}" '
         "has thrown an unexpected error during its execution. The definition is "
         'instantiated at stack "{stack_str}".'
     ).format(
         definition_type=definition_type,
-        container_type=container_type,
         execution_target=execution_target,
-        definition_name=current_stack.current_solid.definition.name,
         solid_name=current_stack.current_solid.name,
         pipeline_name=current_stack.pipeline_def.name,
         stack_str=":".join(current_stack.handle.path),

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -4,13 +4,12 @@ from dagster import check
 from dagster.config.evaluate_value_result import EvaluateValueResult
 from dagster.config.validate import process_config
 from dagster.core.definitions.dependency import NodeHandle
-from dagster.core.definitions.solid import CompositeSolidDefinition
-from dagster.core.definitions.job import JobDefinition
 from dagster.core.definitions.graph import GraphDefinition
+from dagster.core.definitions.job import JobDefinition
 from dagster.core.definitions.pipeline import PipelineDefinition
 from dagster.core.definitions.resource import ResourceDefinition
 from dagster.core.definitions.run_config import define_solid_dictionary_cls
-from dagster.core.definitions.solid import SolidDefinition
+from dagster.core.definitions.solid import CompositeSolidDefinition, SolidDefinition
 from dagster.core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterInvalidConfigError,
@@ -230,7 +229,7 @@ def _get_error_lambda(current_stack):
         execution_target = "pipeline"
     else:
         definition_type = "graph"
-        container_type = "node"
+        container_type = "graph/op"
         execution_target = "job"
 
     return lambda: (


### PR DESCRIPTION
This one is referencing too much stuff to do the `/` error message backcompat trick. Instead, we get a good indicator of whether we are using the new / old APIs, and just hard push error message in either direction.