### PR TITLE
Orient error message around either crag APIs or original APIs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -733,7 +733,6 @@ def composite_mapping_from_output(
                     "Output name mismatch returning output tuple in {decorator_name} '{name}'. "
                     "No matching OutputDefinition named {output_name} for {solid_name}.{output_name}."
                     "Return a dict to map to the desired OutputDefinition".format(
-                        node_type=handle.node_type,
                         decorator_name=decorator_name,
                         name=solid_name,
                         output_name=handle.output_name,
@@ -877,7 +876,9 @@ def do_composition(
                 )
             output = None
 
-        returned_mapping = composite_mapping_from_output(output, actual_output_defs, graph_name)
+        returned_mapping = composite_mapping_from_output(
+            output, actual_output_defs, graph_name, decorator_name
+        )
     finally:
         context = exit_composition(returned_mapping)
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository.py
@@ -61,8 +61,9 @@ class _Repository:
                 )
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
-                    "must be of type PipelineDefinition, PartitionSetDefinition, "
-                    f"ScheduleDefinition, or SensorDefinition. Got {bad_definitions_str}."
+                    "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
+                    "PartitionSetDefinition, ScheduleDefinition, or SensorDefinition. "
+                    f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid.py
@@ -332,9 +332,9 @@ def resolve_checked_solid_fn_inputs(
         elif param.kind == funcsigs.Parameter.VAR_POSITIONAL:
             raise DagsterInvalidDefinitionError(
                 f"{decorator_name} '{fn_name}' decorated function has positional vararg parameter "
-                f"'{param}'. Solid functions should only have keyword arguments that match "
-                "input names and, if system information is required, a first positional "
-                "parameter named 'context'."
+                f"'{param}'. {decorator_name} decorated functions should only have keyword "
+                "arguments that match input names and, if system information is required, a first "
+                "positional parameter named 'context'."
             )
 
         else:
@@ -342,7 +342,7 @@ def resolve_checked_solid_fn_inputs(
                 if param.name in nothing_names:
                     raise DagsterInvalidDefinitionError(
                         f"{decorator_name} '{fn_name}' decorated function has parameter '{param.name}' that is "
-                        "one of the solid input_defs of type 'Nothing' which should not be included since "
+                        "one of the input_defs of type 'Nothing' which should not be included since "
                         "no data will be passed for it. "
                     )
                 else:
@@ -356,9 +356,9 @@ def resolve_checked_solid_fn_inputs(
         undeclared_inputs_printed = ", '".join(undeclared_inputs)
         raise DagsterInvalidDefinitionError(
             f"{decorator_name} '{fn_name}' decorated function does not have parameter(s) "
-            f"'{undeclared_inputs_printed}', which are in solid's input_defs. Solid functions "
-            "should only have keyword arguments that match input names and, if system information "
-            "is required, a first positional parameter named 'context'."
+            f"'{undeclared_inputs_printed}', which are in provided input_defs. {decorator_name} "
+            "decorated functions should only have keyword arguments that match input names and, if "
+            "system information is required, a first positional parameter named 'context'."
         )
 
     inferred_props = {

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -643,7 +643,7 @@ class MultiDependencyDefinition(
                 key = dep.solid + ":" + dep.output
                 if key in seen:
                     raise DagsterInvalidDefinitionError(
-                        'Duplicate dependencies on solid "{dep.solid}" output "{dep.output}" '
+                        'Duplicate dependencies on node "{dep.solid}" output "{dep.output}" '
                         "used in the same MultiDependencyDefinition.".format(dep=dep)
                     )
                 seen[key] = True
@@ -820,15 +820,15 @@ class DependencyStructure:
             input_handle.input_name
         ):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be downstream of dynamic output '
-                f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a solid '
-                "that is already downstream of another dynamic output. Solids cannot be downstream of more "
+                f'{input_handle.solid.describe_node} cannot be downstream of dynamic output '
+                f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a node '
+                "that is already downstream of another dynamic output. Nodes cannot be downstream of more "
                 "than one dynamic output"
             )
 
         if self._collect_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be both downstream of dynamic output '
+                f'{input_handle.solid.describe_node} cannot be both downstream of dynamic output '
                 f"{output_handle.describe()} and collect over dynamic output "
                 f"{list(self._collect_index[input_handle.solid_name])[0].describe()}."
             )
@@ -839,7 +839,7 @@ class DependencyStructure:
 
         if self._dynamic_fan_out_index[input_handle.solid_name] != output_handle:
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be downstream of more than one dynamic output. '
+                f'{input_handle.solid_describe_node} cannot be downstream of more than one dynamic output. '
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}"'
             )
@@ -851,7 +851,7 @@ class DependencyStructure:
     ) -> None:
         if self._dynamic_fan_out_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot both collect over dynamic output '
+                f"{input_handle.solid.describe_node} cannot both collect over dynamic output "
                 f"{output_handle.describe()} and be downstream of the dynamic output "
                 f"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}."
             )
@@ -861,7 +861,7 @@ class DependencyStructure:
         # if the output is already fanned out
         if self._dynamic_fan_out_index.get(output_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be downstream of more than one dynamic output. '
+                f'{input_handle.solid.describe_node} cannot be downstream of more than one dynamic output. '
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[output_handle.solid_name].describe()}"'
             )

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -182,6 +182,20 @@ class Node:
         return isinstance(self.definition, GraphDefinition)
 
     @property
+    def describe_node(self) -> str:
+        from .solid import CompositeSolidDefinition, SolidDefinition
+        from .op import OpDefinition
+
+        if isinstance(self.definition, CompositeSolidDefinition):
+            return f"composite solid '{self.name}'"
+        elif isinstance(self.definition, OpDefinition):
+            return f"op '{self.name}'"
+        elif isinstance(self.definition, SolidDefinition):
+            return f"solid '{self.name}'"
+        else:
+            return f"graph '{self.name}'"
+
+    @property
     def input_dict(self):
         return self.definition.input_dict
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -181,6 +181,10 @@ class GraphDefinition(NodeDefinition):
         return [self.solid_named(solid_name) for solid_name in order]
 
     @property
+    def node_as_str(self) -> str:
+        return "graph"
+
+    @property
     def solids(self) -> List[Node]:
         return list(set(self._node_dict.values()))
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
 def _check_node_defs_arg(graph_name: str, node_defs: List[NodeDefinition]):
     if not isinstance(node_defs, list):
         raise DagsterInvalidDefinitionError(
-            '"solids" arg to "{name}" is not a list. Got {val}.'.format(
+            '"nodes" arg to "{name}" is not a list. Got {val}.'.format(
                 name=graph_name, val=repr(node_defs)
             )
         )
@@ -75,15 +75,15 @@ def _check_node_defs_arg(graph_name: str, node_defs: List[NodeDefinition]):
         elif callable(node_def):
             raise DagsterInvalidDefinitionError(
                 """You have passed a lambda or function {func} into {name} that is
-                not a solid. You have likely forgetten to annotate this function with
-                an @solid or @lambda_solid decorator.'
+                not a node. You have likely forgetten to annotate this function with
+                the @op or @graph decorators.'
                 """.format(
                     name=graph_name, func=node_def.__name__
                 )
             )
         else:
             raise DagsterInvalidDefinitionError(
-                "Invalid item in solid list: {item}".format(item=repr(node_def))
+                "Invalid item in node list: {item}".format(item=repr(node_def))
             )
 
     return node_defs
@@ -614,7 +614,7 @@ def _validate_in_mappings(
         if input_def_dict.get(mapping.definition.name):
             if input_def_dict[mapping.definition.name] != mapping.definition:
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} {name} multiple input mappings with same "
+                    "In {class_name} '{name}' multiple input mappings with same "
                     "definition name but different definitions".format(
                         name=name, class_name=class_name
                     ),
@@ -644,7 +644,7 @@ def _validate_in_mappings(
         if mapping.maps_to_fan_in:
             if not dependency_structure.has_fan_in_deps(solid_input_handle):
                 raise DagsterInvalidDefinitionError(
-                    'In {class_name} "{name}" input mapping target '
+                    "In {class_name} '{name}' input mapping target "
                     '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" (index {mapping.maps_to.fan_in_index} of fan-in) '
                     "is not a MultiDependencyDefinition.".format(
                         name=name, mapping=mapping, class_name=class_name
@@ -655,7 +655,7 @@ def _validate_in_mappings(
                 inner_deps[mapping.maps_to.fan_in_index] is not MappedInputPlaceholder
             ):
                 raise DagsterInvalidDefinitionError(
-                    'In {class_name} "{name}" input mapping target '
+                    "In {class_name} '{name}' input mapping target "
                     '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" index {mapping.maps_to.fan_in_index} in '
                     "the MultiDependencyDefinition is not a MappedInputPlaceholder".format(
                         name=name, mapping=mapping, class_name=class_name
@@ -671,9 +671,9 @@ def _validate_in_mappings(
         else:
             if dependency_structure.has_deps(solid_input_handle):
                 raise DagsterInvalidDefinitionError(
-                    'In {class_name} "{name}" input mapping target '
+                    "In {class_name} '{name}' input mapping target "
                     '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" '
-                    "is already satisfied by solid output".format(
+                    "is already satisfied by output".format(
                         name=name, mapping=mapping, class_name=class_name
                     )
                 )
@@ -732,16 +732,19 @@ def _validate_out_mappings(
             target_solid = solid_dict.get(mapping.maps_from.solid_name)
             if target_solid is None:
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} '{name}' output mapping references solid "
+                    "In {class_name} '{name}' output mapping references node "
                     "'{solid_name}' which it does not contain.".format(
                         name=name, solid_name=mapping.maps_from.solid_name, class_name=class_name
                     )
                 )
             if not target_solid.has_output(mapping.maps_from.output_name):
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} {name} output mapping from solid '{mapping.maps_from.solid_name}' "
+                    "In {class_name} {name} output mapping from {described_node} "
                     "which contains no output named '{mapping.maps_from.output_name}'".format(
-                        name=name, mapping=mapping, class_name=class_name
+                        described_node=target_solid.describe_node,
+                        name=name,
+                        mapping=mapping,
+                        class_name=class_name,
                     )
                 )
 
@@ -776,7 +779,7 @@ def _validate_out_mappings(
             if dynamic_handle and not mapping.definition.is_dynamic:
                 raise DagsterInvalidDefinitionError(
                     f'In {class_name} "{name}" output "{mapping.definition.name}" mapping from '
-                    f'solid "{mapping.maps_from.solid_name}" must be a DynamicOutputDefinition since it is '
+                    f"{target_solid.describe_node} must be a DynamicOutputDefinition since it is "
                     f'downstream of dynamic output "{dynamic_handle.describe()}".'
                 )
 

--- a/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
 from typing import TYPE_CHECKING
 
 from dagster import check
@@ -42,6 +42,10 @@ class NodeDefinition(NamedConfigurableDefinition):
             if positional_inputs is not None
             else list(map(lambda inp: inp.name, input_defs))
         )
+
+    @abstractproperty
+    def node_as_str(self):
+        raise NotImplementedError()
 
     @property
     def name(self):

--- a/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
@@ -52,6 +52,10 @@ class NodeDefinition(NamedConfigurableDefinition):
         return self._name
 
     @property
+    def describe_node(self):
+        return f"{self.node_as_str} '{self.name}'"
+
+    @property
     def description(self):
         return self._description
 

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -43,6 +43,10 @@ class JobDefinition(PipelineDefinition):
             version_strategy=version_strategy,
         )
 
+    @property
+    def describe_target(self):
+        return f"job '{self.name}'"
+
     def execute_in_process(
         self,
         run_config: Optional[Dict[str, Any]] = None,

--- a/python_modules/dagster/dagster/core/definitions/op.py
+++ b/python_modules/dagster/dagster/core/definitions/op.py
@@ -2,4 +2,6 @@ from .solid import SolidDefinition
 
 
 class OpDefinition(SolidDefinition):
-    pass
+    @property
+    def node_as_str(self) -> str:
+        return "op"

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -263,8 +263,12 @@ class PipelineDefinition:
         return self._name
 
     @property
+    def target_type(self):
+        return "pipeline"
+
+    @property
     def describe_target(self):
-        return f"pipeline '{self.name}'"
+        return f"{self.target_type} '{self.name}'"
 
     @property
     def tags(self):

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -698,27 +698,26 @@ def _checked_resource_reqs_for_mode(
             for required_resource in solid_def.required_resource_keys:
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by solid def '
-                            f'{solid_def.name}, but is not provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=solid_def.describe_node,
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
             for output_def in solid_def.output_defs:
                 resource_reqs.add(output_def.io_manager_key)
                 if output_def.io_manager_key not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'IO manager key "{output_def.io_manager_key}" is required by output '
-                            f'"{output_def.name}" of solid def {solid_def.name}, but is not '
-                            f'provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide an IO manager for key "{output_def.io_manager_key}", '
-                            f'or change "{output_def.io_manager_key}" to one of the provided IO manager keys: {sorted(mode_output_managers)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="IO manager",
+                        resource_key=output_def.io_manager_key,
+                        descriptor=f"output '{output_def.name}' of {solid_def.describe_node}",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_output_managers,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
     resource_reqs.update(
         _checked_type_resource_reqs_for_mode(
@@ -736,51 +735,54 @@ def _checked_resource_reqs_for_mode(
         for required_resource in intermediate_storage.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    (
-                        f'Resource key "{required_resource}" is required by intermediate storage '
-                        f'"{intermediate_storage.name}", but is not provided by mode "{mode_def.name}". '
-                        f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                        f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                    )
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"intermediate storage {intermediate_storage.name}",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
+
     for solid in solid_dict.values():
         for hook_def in solid.hook_defs:
             for required_resource in hook_def.required_resource_keys:
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by hook "{hook_def.name}", but is not '
-                            f'provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=f"hook '{hook_def.name}'",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
     for hook_def in pipeline_hook_defs:
         for required_resource in hook_def.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    (
-                        f'Resource key "{required_resource}" is required by hook "{hook_def.name}", but is not '
-                        f'provided by mode "{mode_def.name}". '
-                        f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                        f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                    )
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"hook '{hook_def.name}'",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
 
     for resource_key, resource in mode_def.resource_defs.items():
         for required_resource in resource.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    f'Resource key "{required_resource}" is required by resource at key "{resource_key}", '
-                    f'but is not provided by mode "{mode_def.name}" '
-                    f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                    f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"resource at key '{resource_key}'",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
 
     return resource_reqs
 
@@ -800,38 +802,38 @@ def _checked_type_resource_reqs_for_mode(
         for required_resource in dagster_type.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    (
-                        f'Resource key "{required_resource}" is required by type "{dagster_type.display_name}", '
-                        f'but is not provided by mode "{mode_def.name}". '
-                        f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                        f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                    )
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"type '{dagster_type.display_name}'",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
         if dagster_type.loader:
             for required_resource in dagster_type.loader.required_resource_keys():
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by the loader on type '
-                            f'"{dagster_type.display_name}", but is not provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=f"the loader on type '{dagster_type.display_name}'",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
         if dagster_type.materializer:
             for required_resource in dagster_type.materializer.required_resource_keys():
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by the materializer on type '
-                            f'"{dagster_type.display_name}", but is not provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=f"the materializer on type '{dagster_type.display_name}'",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
         for plugin in dagster_type.auto_plugins:
             used_by_storage = set(
@@ -846,15 +848,14 @@ def _checked_type_resource_reqs_for_mode(
                 for required_resource in plugin.required_resource_keys():
                     resource_reqs.add(required_resource)
                     if required_resource not in mode_resources:
-                        raise DagsterInvalidDefinitionError(
-                            (
-                                f'Resource key "{required_resource}" is required by the plugin "{plugin.__name__}" '
-                                f'on type "{dagster_type.display_name}" (used with storages {used_by_storage}), '
-                                f'but is not provided by mode "{mode_def.name}". '
-                                f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                                f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                            )
+                        error_msg = _get_missing_resource_error_msg(
+                            resource_type="resource",
+                            resource_key=required_resource,
+                            descriptor=f"the plugin on type '{dagster_type.display_name}'",
+                            mode_def=mode_def,
+                            resource_defs_of_type=mode_resources,
                         )
+                        raise DagsterInvalidDefinitionError(error_msg)
     return resource_reqs
 
 
@@ -911,10 +912,10 @@ def _checked_input_resource_reqs_for_mode(
                     output_manager_def = mode_def.resource_defs[output_manager_key]
                     if not isinstance(output_manager_def, IInputManagerDefinition):
                         raise DagsterInvalidDefinitionError(
-                            f'Input "{handle.input_def.name}" of solid "{node.name}" is '
+                            f'Input "{handle.input_def.name}" of {node.describe_node} is '
                             f'connected to output "{source_output_handle.output_def.name}" '
-                            f'of solid "{source_output_handle.solid.name}". In mode '
-                            f'"{mode_def.name}", that output does not have an output '
+                            f'of {source_output_handle.solid.describe_node}. That output does not '
+                            'have an output '
                             f"manager that knows how to load inputs, so we don't know how "
                             f"to load the input. To address this, assign an IOManager to "
                             f"the upstream output."
@@ -928,13 +929,13 @@ def _checked_input_resource_reqs_for_mode(
                     and not input_def.root_manager_key
                 ):
                     raise DagsterInvalidDefinitionError(
-                        'Input "{input_name}" in solid "{solid_name}" is not connected to '
-                        "the output of a previous solid and can not be loaded from configuration, "
-                        "creating an impossible to execute pipeline. "
+                        'Input "{input_name}" in {described_node} is not connected to '
+                        "the output of a previous node and can not be loaded from configuration, "
+                        "creating an impossible to execute job. "
                         "Possible solutions are:\n"
                         '  * add a dagster_type_loader for the type "{dagster_type}"\n'
-                        '  * connect "{input_name}" to the output of another solid\n'.format(
-                            solid_name=node.name,
+                        '  * connect "{input_name}" to the output of another node\n'.format(
+                            described_node=node.describe_node,
                             input_name=input_def.name,
                             dagster_type=input_def.dagster_type.display_name,
                         )
@@ -946,15 +947,35 @@ def _checked_input_resource_reqs_for_mode(
                 if input_def.root_manager_key:
                     resource_reqs.add(input_def.root_manager_key)
                     if input_def.root_manager_key not in mode_def.resource_defs:
-                        raise DagsterInvalidDefinitionError(
-                            f'Root input manager key "{input_def.root_manager_key}" is required by '
-                            f'unsatisfied input "{input_def.name}" of solid {node.name}, but is not '
-                            f'provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a root input manager for key "{input_def.root_manager_key}", '
-                            f'or change "{input_def.root_manager_key}" to one of the provided root input managers keys: {sorted(mode_root_input_managers)}.'
+                        error_msg = _get_missing_resource_error_msg(
+                            resource_type="root input manager",
+                            resource_key=input_def.root_manager_key,
+                            descriptor=f"unsatisfied input '{input_def.name}' of {node.describe_node}",
+                            mode_def=mode_def,
+                            resource_defs_of_type=mode_root_input_managers,
                         )
+                        raise DagsterInvalidDefinitionError(error_msg)
 
     return resource_reqs
+
+
+def _get_missing_resource_error_msg(
+    resource_type, resource_key, descriptor, mode_def, resource_defs_of_type
+):
+    if mode_def.name == "default":
+        return (
+            f"{resource_type} key '{resource_key}' is required by "
+            f"{descriptor}, but is not provided. Provide a {resource_type} for key '{resource_key}',  "
+            f"or change '{resource_key}' to one of the provided {resource_type} keys: "
+            f"{sorted(resource_defs_of_type)}."
+        )
+    else:
+        return (
+            f"{resource_type} key '{resource_key}' is required by "
+            f"{descriptor}, but is not provided by mode '{mode_def.name}'. "
+            f"In mode '{mode_def.name}', provide a {resource_type} for key '{resource_key}', "
+            f"or change '{resource_key}' to one of the provided root input managers keys: {sorted(resource_defs_of_type)}."
+        )
 
 
 def _build_all_node_defs(node_defs: List[NodeDefinition]) -> Dict[str, NodeDefinition]:
@@ -964,7 +985,7 @@ def _build_all_node_defs(node_defs: List[NodeDefinition]) -> Dict[str, NodeDefin
             if node_def.name in all_defs:
                 if all_defs[node_def.name] != node_def:
                     raise DagsterInvalidDefinitionError(
-                        'Detected conflicting solid definitions with the same name "{name}"'.format(
+                        'Detected conflicting node definitions with the same name "{name}"'.format(
                             name=node_def.name
                         )
                     )

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -263,6 +263,10 @@ class PipelineDefinition:
         return self._name
 
     @property
+    def describe_target(self):
+        return f"pipeline '{self.name}'"
+
+    @property
     def tags(self):
         # could merge with graph level tags here
         return self._tags

--- a/python_modules/dagster/dagster/core/definitions/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/repository.py
@@ -491,8 +491,8 @@ class CachingRepositoryData(RepositoryData):
             if isinstance(definition, PipelineDefinition):
                 if definition.name in pipelines and pipelines[definition.name] != definition:
                     raise DagsterInvalidDefinitionError(
-                        "Duplicate pipeline definition found for pipeline {pipeline_name}".format(
-                            pipeline_name=definition.name
+                        "Duplicate {target_type} definition found for {target}".format(
+                            target_type=definition.target_type, target=definition.describe_target
                         )
                     )
                 pipelines[definition.name] = definition
@@ -729,7 +729,7 @@ class CachingRepositoryData(RepositoryData):
 
         if schedule.pipeline_name not in pipelines:
             raise DagsterInvalidDefinitionError(
-                f'ScheduleDefinition "{schedule.name}" targets pipeline "{schedule.pipeline_name}" '
+                f'ScheduleDefinition "{schedule.name}" targets job/pipeline "{schedule.pipeline_name}" '
                 "which was not found in this repository."
             )
 
@@ -743,7 +743,7 @@ class CachingRepositoryData(RepositoryData):
 
         if sensor.pipeline_name not in pipelines:
             raise DagsterInvalidDefinitionError(
-                f'SensorDefinition "{sensor.name}" targets pipeline "{sensor.pipeline_name}" '
+                f'SensorDefinition "{sensor.name}" targets job/pipeline "{sensor.pipeline_name}" '
                 "which was not found in this repository."
             )
 

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -226,15 +226,15 @@ def get_input_manager_input_field(
 ) -> Optional[Field]:
     if input_def.root_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for solid "{solid.name}" requires root_manager_key '
+            f'Input "{input_def.name}" for {solid.describe_node} requires root_manager_key '
             f'"{input_def.root_manager_key}", but no resource has been provided. Please include a '
-            f"resource definition for that key in the resource_defs of your ModeDefinition."
+            f"resource definition for that key in the provided resource_defs."
         )
 
     root_manager = resource_defs[input_def.root_manager_key]
     if not isinstance(root_manager, IInputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for solid "{solid.name}" requires root_manager_key '
+            f'Input "{input_def.name}" for {solid.describe_node} requires root_manager_key '
             f'"{input_def.root_manager_key}", but the resource definition provided is not an '
             "IInputManagerDefinition"
         )
@@ -291,13 +291,13 @@ def get_output_manager_output_field(
 ) -> Optional[ConfigType]:
     if output_def.io_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Output "{output_def.name}" for solid "{solid.name}" requires io_manager_key '
+            f'Output "{output_def.name}" for {solid.describe_node} requires io_manager_key '
             f'"{output_def.io_manager_key}", but no resource has been provided. Please include a '
-            f"resource definition for that key in the resource_defs of your ModeDefinition."
+            f"resource definition for that key in the provided resource_defs."
         )
     if not isinstance(resource_defs[output_def.io_manager_key], IOutputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Output "{output_def.name}" for solid "{solid.name}" requires io_manager_key '
+            f'Output "{output_def.name}" for {solid.describe_node} requires io_manager_key '
             f'"{output_def.io_manager_key}", but the resource definition provided is not an '
             "IOutputManagerDefinition"
         )

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -171,6 +171,10 @@ class SolidDefinition(NodeDefinition):
                 return solid_invocation_result(self, None, *args, **kwargs)
 
     @property
+    def node_as_str(self) -> str:
+        return "solid"
+
+    @property
     def compute_fn(self) -> Union[Callable[..., Any], "DecoratedSolidFunction"]:
         return self._compute_fn
 
@@ -353,6 +357,10 @@ class CompositeSolidDefinition(GraphDefinition):
             tags=self.tags,
             positional_inputs=self.positional_inputs,
         )
+
+    @property
+    def node_as_str(self):
+        return "composite solid"
 
 
 def _check_io_managers_on_composite_solid(

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -337,9 +337,9 @@ class CompositeSolidDefinition(GraphDefinition):
         config_mapping = self._config_mapping
         if config_mapping is None:
             raise DagsterInvalidDefinitionError(
-                "Only composite solids utilizing config mapping can be pre-configured. The solid "
-                '"{graph_name}" does not have a config mapping, and thus has nothing to be '
-                "configured.".format(graph_name=self.name)
+                "Only composite solids utilizing config mapping can be pre-configured. The "
+                'composite solid "{graph_name}" does not have a config mapping, and thus has '
+                "nothing to be configured.".format(graph_name=self.name)
             )
 
         return CompositeSolidDefinition(

--- a/python_modules/dagster/dagster/core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_container.py
@@ -34,7 +34,7 @@ def validate_dependency_dict(
     for key, dep_dict in dependencies.items():
         if not (isinstance(key, str) or isinstance(key, SolidInvocation)):
             raise DagsterInvalidDefinitionError(
-                prelude + "Expected str or SolidInvocation key in the top level dict. "
+                prelude + "Expected str or NodeInvocation key in the top level dict. "
                 "Received value {val} of type {type}".format(val=key, type=type(key))
             )
         if not isinstance(dep_dict, dict):
@@ -202,7 +202,7 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
                 if from_solid == dep.solid:
                     raise DagsterInvalidDefinitionError(
                         (
-                            "Invalid dependencies: circular reference detected in solid "
+                            "Invalid dependencies: circular reference detected in node "
                             '"{from_solid}" input "{from_input}"'
                         ).format(from_solid=from_solid, from_input=from_input)
                     )
@@ -211,14 +211,14 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
                     aliased_solid = alias_to_name.get(from_solid)
                     if aliased_solid == from_solid:
                         raise DagsterInvalidDefinitionError(
-                            'Invalid dependencies: solid "{solid}" in dependency dictionary not '
-                            "found in solid list".format(solid=from_solid)
+                            'Invalid dependencies: node "{solid}" in dependency dictionary not '
+                            "found in node list".format(solid=from_solid)
                         )
                     else:
                         raise DagsterInvalidDefinitionError(
                             (
-                                'Invalid dependencies: solid "{aliased_solid}" (aliased by '
-                                '"{from_solid}" in dependency dictionary) not found in solid list'
+                                'Invalid dependencies: node "{aliased_solid}" (aliased by '
+                                '"{from_solid}" in dependency dictionary) not found in node list'
                             ).format(aliased_solid=aliased_solid, from_solid=from_solid)
                         )
                 if not solid_dict[from_solid].definition.has_input(from_input):
@@ -240,16 +240,16 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
 
                 if not dep.solid in solid_dict:
                     raise DagsterInvalidDefinitionError(
-                        'Invalid dependencies: solid "{dep.solid}" not found in solid list. '
-                        'Listed as dependency for solid "{from_solid}" input "{from_input}" '.format(
+                        'Invalid dependencies: node "{dep.solid}" not found in node list. '
+                        'Listed as dependency for node "{from_solid}" input "{from_input}" '.format(
                             dep=dep, from_solid=from_solid, from_input=from_input
                         )
                     )
 
                 if not solid_dict[dep.solid].definition.has_output(dep.output):
                     raise DagsterInvalidDefinitionError(
-                        'Invalid dependencies: solid "{dep.solid}" does not have output '
-                        '"{dep.output}". Listed as dependency for solid "{from_solid} input '
+                        'Invalid dependencies: node "{dep.solid}" does not have output '
+                        '"{dep.output}". Listed as dependency for node "{from_solid} input '
                         '"{from_input}"'.format(
                             dep=dep, from_solid=from_solid, from_input=from_input
                         )
@@ -260,7 +260,7 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
 
                 if dep_def.is_fan_in() and not input_def.dagster_type.supports_fan_in:
                     raise DagsterInvalidDefinitionError(
-                        f'Invalid dependencies: for solid "{dep.solid}" input "{input_def.name}", the '
+                        f'Invalid dependencies: for node "{dep.solid}" input "{input_def.name}", the '
                         f'DagsterType "{input_def.dagster_type.display_name}" does not support fanning in '
                         "(MultiDependencyDefinition). Use the List type, since fanning in will result in a list."
                     )
@@ -278,8 +278,8 @@ def _validate_input_output_pair(input_def, output_def, from_solid, dep):
     ):
         raise DagsterInvalidDefinitionError(
             (
-                'Input "{input_def.name}" to solid "{from_solid}" can not depend on the output '
-                '"{output_def.name}" from solid "{dep.solid}". '
+                'Input "{input_def.name}" to node "{from_solid}" can not depend on the output '
+                '"{output_def.name}" from node "{dep.solid}". '
                 'Input "{input_def.name}" expects a value of type '
                 '{input_def.dagster_type.display_name} and output "{output_def.name}" returns '
                 "type {output_def.dagster_type.display_name}{extra}."

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -219,14 +219,12 @@ def _get_mapped_solids_dict(
 
 def _get_error_lambda(current_stack):
     return lambda: (
-        "The config mapping function on the composite solid definition "
-        '"{definition_name}" at solid "{solid_name}" in pipeline "{pipeline_name}" '
+        "The config mapping function on {described_node} in {described_target} "
         "has thrown an unexpected error during its execution. The definition is "
         'instantiated at stack "{stack_str}".'
     ).format(
-        definition_name=current_stack.current_solid.definition.name,
-        solid_name=current_stack.current_solid.name,
-        pipeline_name=current_stack.pipeline_def.name,
+        described_node=current_stack.current_solid.describe_node,
+        described_target=current_stack.pipeline_def.describe_target,
         stack_str=":".join(current_stack.handle.path),
     )
 

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -180,7 +180,7 @@ def dagster_type_loader(
         if missing_positional:
             raise DagsterInvalidDefinitionError(
                 "@dagster_type_loader '{solid_name}' decorated function does not have required positional "
-                "parameter '{missing_param}'. Solid functions should only have keyword arguments "
+                "parameter '{missing_param}'. @dagster_type_loader decorated functions should only have keyword arguments "
                 "that match input names and a first positional parameter named 'context'.".format(
                     solid_name=func.__name__, missing_param=missing_positional
                 )

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
@@ -184,8 +184,8 @@ def test_config_mapper_throws():
         )
 
     assert (
-        'The config mapping function on the composite solid definition "bad_wrap" at solid '
-        '"do_stuff" in pipeline "wrap_pipeline" has thrown an unexpected error during its '
+        "The config mapping function on composite solid 'do_stuff' "
+        "in pipeline 'wrap_pipeline' has thrown an unexpected error during its "
         'execution. The definition is instantiated at stack "do_stuff"'
     ) in str(exc_info.value)
 
@@ -216,8 +216,8 @@ def test_config_mapper_throws_nested():
         )
 
     assert (
-        'The config mapping function on the composite solid definition "bad_wrap" '
-        'at solid "layer1" in pipeline "wrap_pipeline" has thrown an unexpected '
+        "The config mapping function on composite solid 'layer1' "
+        "in pipeline 'wrap_pipeline' has thrown an unexpected "
         'error during its execution. The definition is instantiated at stack "layer0:layer1".'
     ) in str(exc_info.value)
 


### PR DESCRIPTION
Some of these are quite rough in my opinion. I really think that we should rethink the strategy of just blindly saying op/solid. I think we either need to respect the definition, or we need to hard cut to the new APIs, and explain in the migration guide that error messages are in terms of new APIs.