### PR TITLE
Add make rule to build crag docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,9 @@ docs_dev_install:
 dev:
 	cd next; yarn dev;
 
+crag_dev:
+	cd next; yarn crag-dev;
+
 build:
 	cd sphinx; make clean; make json; cd ..; python pack_json.py
 


### PR DESCRIPTION
Previously would have had to alter existing makefile in order to run crag site, just slightly more ergonomic. 