### PR TITLE
Remove weakref to RepositoryLocation from RepositoryHandle

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -166,7 +166,7 @@ def fetch_workspace(workspace_request_context):
 
     nodes = [
         GrapheneWorkspaceLocationEntry(entry)
-        for entry in workspace_request_context.workspace_snapshot.values()
+        for entry in workspace_request_context.get_workspace_snapshot().values()
     ]
 
     return GrapheneWorkspace(locationEntries=nodes)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -374,7 +374,7 @@ class GrapheneReloadRepositoryLocationMutation(graphene.Mutation):
         # our current WorkspaceRequestContext outdated. Therefore, `reload_repository_location` returns
         # an updated WorkspaceRequestContext for us to use.
         new_context = graphene_info.context.reload_repository_location(location_name)
-        return GrapheneWorkspaceLocationEntry(new_context.workspace_snapshot[location_name])
+        return GrapheneWorkspaceLocationEntry(new_context.get_location_entry(location_name))
 
 
 class GrapheneShutdownRepositoryLocationMutation(graphene.Mutation):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
@@ -15,7 +15,7 @@ class TestShutdownRepositoryLocation(
     )
 ):
     def test_shutdown_repository_location(self, graphql_client, graphql_context):
-        origin = next(iter(graphql_context.workspace_snapshot.values())).origin
+        origin = next(iter(graphql_context.get_workspace_snapshot().values())).origin
         origin.create_client().heartbeat()
 
         result = graphql_client.shutdown_repository_location("test")

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -137,9 +137,7 @@ class ExternalRepository:
         return self.handle.get_external_origin()
 
     def get_python_origin(self):
-        return self.handle.repository_location.get_repository_python_origin(
-            self.name,
-        )
+        return self.handle.get_python_origin()
 
     def get_external_origin_id(self):
         """
@@ -160,7 +158,7 @@ class ExternalRepository:
         return matching[0] if matching else None
 
     def get_display_metadata(self):
-        return self.handle.repository_location.get_display_metadata()
+        return self.handle.display_metadata
 
 
 class ExternalPipeline(RepresentedPipeline):
@@ -287,11 +285,7 @@ class ExternalPipeline(RepresentedPipeline):
         return self.get_python_origin()
 
     def get_python_origin(self):
-        repository_python_origin = (
-            self.repository_handle.repository_location.get_repository_python_origin(
-                self.repository_handle.repository_name,
-            )
-        )
+        repository_python_origin = self.repository_handle.get_python_origin()
         return PipelinePythonOrigin(self.name, repository_python_origin)
 
     def get_external_origin(self):

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -224,7 +224,7 @@ class RepositoryLocation(AbstractContextManager):
     def get_repository_python_origin(self, repository_name: str) -> "RepositoryPythonOrigin":
         if repository_name not in self.repository_code_pointer_dict:
             raise DagsterInvariantViolationError(
-                "Unable to find repository name {} on GRPC server.".format(repository_name)
+                "Unable to find repository {}.".format(repository_name)
             )
 
         code_pointer = self.repository_code_pointer_dict[repository_name]

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -1,9 +1,10 @@
+from dagster.core.host_representation.handle import PipelineHandle
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.test_utils import instance_for_test, poll_for_event, poll_for_finished_run
 from dagster.grpc.server import ExecuteExternalPipelineArgs
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 
-from .utils import get_foo_pipeline_handle
+from .utils import get_bar_repo_repository_location
 
 
 def _check_event_log_contains(event_log, expected_type_and_message):
@@ -19,8 +20,11 @@ def _check_event_log_contains(event_log, expected_type_and_message):
 
 def test_launch_run_with_unloadable_pipeline_grpc():
     with instance_for_test() as instance:
-        with get_foo_pipeline_handle() as pipeline_handle:
-            api_client = pipeline_handle.repository_handle.repository_location.client
+        with get_bar_repo_repository_location() as repository_location:
+            pipeline_handle = PipelineHandle(
+                "foo", repository_location.get_repository("bar_repo").handle
+            )
+            api_client = repository_location.client
 
             pipeline_run = instance.create_run(
                 pipeline_name="foo",
@@ -81,8 +85,11 @@ def test_launch_run_with_unloadable_pipeline_grpc():
 
 def test_launch_run_grpc():
     with instance_for_test() as instance:
-        with get_foo_pipeline_handle() as pipeline_handle:
-            api_client = pipeline_handle.repository_handle.repository_location.client
+        with get_bar_repo_repository_location() as repository_location:
+            pipeline_handle = PipelineHandle(
+                "foo", repository_location.get_repository("bar_repo").handle
+            )
+            api_client = repository_location.client
 
             pipeline_run = instance.create_run(
                 pipeline_name="foo",
@@ -138,8 +145,11 @@ def test_launch_run_grpc():
 
 def test_launch_unloadable_run_grpc():
     with instance_for_test() as instance:
-        with get_foo_pipeline_handle() as pipeline_handle:
-            api_client = pipeline_handle.repository_handle.repository_location.client
+        with get_bar_repo_repository_location() as repository_location:
+            pipeline_handle = PipelineHandle(
+                "foo", repository_location.get_repository("bar_repo").handle
+            )
+            api_client = repository_location.client
 
             pipeline_run = instance.create_run(
                 pipeline_name="foo",

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_notebook_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_notebook_data.py
@@ -1,13 +1,13 @@
 from dagster.api.notebook_data import sync_get_streaming_external_notebook_data_grpc
 from dagster.utils import file_relative_path
 
-from .utils import get_bar_repo_handle
+from .utils import get_bar_repo_repository_location
 
 
 def test_external_notebook_grpc():
     notebook_path = file_relative_path(__file__, "foo.ipynb")
-    with get_bar_repo_handle() as repository_handle:
-        api_client = repository_handle.repository_location.client
+    with get_bar_repo_repository_location() as repository_location:
+        api_client = repository_location.client
 
         content = sync_get_streaming_external_notebook_data_grpc(
             api_client, notebook_path=notebook_path

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
@@ -3,14 +3,18 @@ import re
 import pytest
 from dagster.api.snapshot_execution_plan import sync_get_external_execution_plan_grpc
 from dagster.core.errors import DagsterUserCodeProcessError
+from dagster.core.host_representation.handle import PipelineHandle
 from dagster.core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
 
-from .utils import get_foo_pipeline_handle
+from .utils import get_bar_repo_repository_location
 
 
 def test_execution_plan_error_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        api_client = pipeline_handle.repository_handle.repository_location.client
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
 
         with pytest.raises(
             DagsterUserCodeProcessError,
@@ -26,8 +30,11 @@ def test_execution_plan_error_grpc():
 
 
 def test_execution_plan_snapshot_api_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        api_client = pipeline_handle.repository_handle.repository_location.client
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
 
         execution_plan_snapshot = sync_get_external_execution_plan_grpc(
             api_client,
@@ -46,8 +53,11 @@ def test_execution_plan_snapshot_api_grpc():
 
 
 def test_execution_plan_with_step_keys_to_execute_snapshot_api_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        api_client = pipeline_handle.repository_handle.repository_location.client
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
 
         execution_plan_snapshot = sync_get_external_execution_plan_grpc(
             api_client,
@@ -66,8 +76,11 @@ def test_execution_plan_with_step_keys_to_execute_snapshot_api_grpc():
 
 
 def test_execution_plan_with_subset_snapshot_api_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        api_client = pipeline_handle.repository_handle.repository_location.client
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
 
         execution_plan_snapshot = sync_get_external_execution_plan_grpc(
             api_client,

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -15,32 +15,37 @@ from dagster.core.host_representation import (
     ExternalPartitionTagsData,
 )
 
-from .utils import get_bar_repo_handle
+from .utils import get_bar_repo_repository_location
 
 
 def test_external_partition_names_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
         data = sync_get_external_partition_names_grpc(
-            repository_handle.repository_location.client, repository_handle, "baz_partitions"
+            repository_location.client, repository_handle, "baz_partitions"
         )
         assert isinstance(data, ExternalPartitionNamesData)
         assert data.partition_names == list(string.ascii_lowercase)
 
 
 def test_external_partition_names_error_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
+
         with pytest.raises(DagsterUserCodeProcessError, match="womp womp"):
             sync_get_external_partition_names_grpc(
-                repository_handle.repository_location.client,
+                repository_location.client,
                 repository_handle,
                 "error_partitions",
             )
 
 
 def test_external_partitions_config_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
+
         data = sync_get_external_partition_config_grpc(
-            repository_handle.repository_location.client,
+            repository_location.client,
             repository_handle,
             "baz_partitions",
             "c",
@@ -51,10 +56,12 @@ def test_external_partitions_config_grpc():
 
 
 def test_external_partitions_config_error_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
+
         with pytest.raises(DagsterUserCodeProcessError):
             sync_get_external_partition_config_grpc(
-                repository_handle.repository_location.client,
+                repository_location.client,
                 repository_handle,
                 "error_partition_config",
                 "c",
@@ -62,9 +69,11 @@ def test_external_partitions_config_error_grpc():
 
 
 def test_external_partitions_tags_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
+
         data = sync_get_external_partition_tags_grpc(
-            repository_handle.repository_location.client,
+            repository_location.client,
             repository_handle,
             "baz_partitions",
             "c",
@@ -75,10 +84,12 @@ def test_external_partitions_tags_grpc():
 
 
 def test_external_partitions_tags_error_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
+
         with pytest.raises(DagsterUserCodeProcessError):
             sync_get_external_partition_tags_grpc(
-                repository_handle.repository_location.client,
+                repository_location.client,
                 repository_handle,
                 "error_partition_tags",
                 "c",
@@ -86,9 +97,11 @@ def test_external_partitions_tags_error_grpc():
 
 
 def test_external_partition_set_execution_params_grpc():
-    with get_bar_repo_handle() as repository_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        repository_handle = repository_location.get_repository("bar_repo").handle
+
         data = sync_get_external_partition_set_execution_param_data_grpc(
-            repository_handle.repository_location.client,
+            repository_location.client,
             repository_handle,
             "baz_partitions",
             ["a", "b", "c"],

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
@@ -8,29 +8,37 @@ from dagster.core.host_representation.external_data import ExternalPipelineSubse
 from dagster.core.host_representation.handle import PipelineHandle
 from dagster.utils.error import serializable_error_info_from_exc_info
 
-from .utils import get_bar_repo_handle, get_foo_pipeline_handle
+from .utils import get_bar_repo_repository_location
 
 
-def _test_pipeline_subset_grpc(pipeline_handle, solid_selection=None):
-    api_client = pipeline_handle.repository_handle.repository_location.client
+def _test_pipeline_subset_grpc(pipeline_handle, api_client, solid_selection=None):
     return sync_get_external_pipeline_subset_grpc(
         api_client, pipeline_handle.get_external_origin(), solid_selection=solid_selection
     )
 
 
 def test_pipeline_snapshot_api_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
-        external_pipeline_subset_result = _test_pipeline_subset_grpc(pipeline_handle)
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
+
+        external_pipeline_subset_result = _test_pipeline_subset_grpc(pipeline_handle, api_client)
         assert isinstance(external_pipeline_subset_result, ExternalPipelineSubsetResult)
         assert external_pipeline_subset_result.success == True
         assert external_pipeline_subset_result.external_pipeline_data.name == "foo"
 
 
 def test_pipeline_with_valid_subset_snapshot_api_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
 
         external_pipeline_subset_result = _test_pipeline_subset_grpc(
-            pipeline_handle, ["do_something"]
+            pipeline_handle, api_client, ["do_something"]
         )
         assert isinstance(external_pipeline_subset_result, ExternalPipelineSubsetResult)
         assert external_pipeline_subset_result.success == True
@@ -38,20 +46,28 @@ def test_pipeline_with_valid_subset_snapshot_api_grpc():
 
 
 def test_pipeline_with_invalid_subset_snapshot_api_grpc():
-    with get_foo_pipeline_handle() as pipeline_handle:
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "foo", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
+
         with pytest.raises(
             DagsterUserCodeProcessError,
             match="No qualified solids to execute found for solid_selection",
         ):
-            _test_pipeline_subset_grpc(pipeline_handle, ["invalid_solid"])
+            _test_pipeline_subset_grpc(pipeline_handle, api_client, ["invalid_solid"])
 
 
 def test_pipeline_with_invalid_definition_snapshot_api_grpc():
-    with get_bar_repo_handle() as repo_handle:
-        pipeline_handle = PipelineHandle("bar", repo_handle)
+    with get_bar_repo_repository_location() as repository_location:
+        pipeline_handle = PipelineHandle(
+            "bar", repository_location.get_repository("bar_repo").handle
+        )
+        api_client = repository_location.client
 
         try:
-            _test_pipeline_subset_grpc(pipeline_handle, ["fail_subset"])
+            _test_pipeline_subset_grpc(pipeline_handle, api_client, ["fail_subset"])
         except DagsterUserCodeProcessError:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
             assert re.match(

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
@@ -100,7 +100,7 @@ MULTI_LOCATION_WORKSPACE = file_relative_path(__file__, "multi_location/multi_lo
 def test_valid_multi_location_from_file():
     def the_assert(external_repository):
         assert external_repository.name == "hello_world_repository"
-        assert external_repository.handle.repository_location.name == "loaded_from_file"
+        assert external_repository.handle.location_name == "loaded_from_file"
 
     successfully_load_repository_via_cli(
         ["-w", MULTI_LOCATION_WORKSPACE, "-l", "loaded_from_file"], the_assert
@@ -110,7 +110,7 @@ def test_valid_multi_location_from_file():
 def test_valid_multi_location_from_module():
     def the_assert(external_repository):
         assert external_repository.name == "hello_world_repository"
-        assert external_repository.handle.repository_location.name == "loaded_from_module"
+        assert external_repository.handle.location_name == "loaded_from_module"
 
     successfully_load_repository_via_cli(
         ["-w", MULTI_LOCATION_WORKSPACE, "-l", "loaded_from_module"], the_assert


### PR DESCRIPTION
Summary:
This change paves the way to a world where dagit doesn't have a map of RepositoryLocations in memory at all times - without this change, removing that map causes this weakref to null out since the RepositoryLocation no longer has a fixed home in the workspace.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.