### PR TITLE
initialize value for context_manager flag to avoid __del__ error

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -62,6 +62,7 @@ class UnboundSolidExecutionContext(SolidExecutionContext):
         self._instance = self._instance_cm.__enter__()  # pylint: disable=no-member
 
         # Open resource context manager
+        self._resources_contain_cm = False
         self._resources_cm = build_resources(
             check.opt_dict_param(resources_dict, "resources_dict", key_type=str), instance
         )


### PR DESCRIPTION
## Summary
Direct invocation using `build_op_context` would error upon `__del__` because the property would not be set correctly on resource initialization failures.



