### PR TITLE
Add config mapping decorator

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -68,6 +68,7 @@ from dagster.core.definitions import (
     asset_sensor,
     build_init_logger_context,
     composite_solid,
+    config_mapping,
     daily_partitioned_config,
     daily_schedule,
     default_executors,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -275,6 +275,7 @@ __all__ = [
     # Decorators
     "asset_sensor",
     "composite_solid",
+    "config_mapping",
     "executor",
     "graph",
     "intermediate_storage",

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -1,6 +1,7 @@
 from .config import ConfigMapping
 from .decorators import (
     asset_sensor,
+    config_mapping,
     composite_solid,
     daily_schedule,
     failure_hook,

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -1,8 +1,8 @@
 from .config import ConfigMapping
 from .decorators import (
     asset_sensor,
-    config_mapping,
     composite_solid,
+    config_mapping,
     daily_schedule,
     failure_hook,
     graph,

--- a/python_modules/dagster/dagster/core/definitions/decorators/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/__init__.py
@@ -1,5 +1,5 @@
-from .config_mapping import config_mapping
 from .composite_solid import composite_solid
+from .config_mapping import config_mapping
 from .graph import graph
 from .hook import failure_hook, success_hook
 from .op import op

--- a/python_modules/dagster/dagster/core/definitions/decorators/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/__init__.py
@@ -1,3 +1,4 @@
+from .config_mapping import config_mapping
 from .composite_solid import composite_solid
 from .graph import graph
 from .hook import failure_hook, success_hook

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
@@ -63,6 +63,8 @@ def config_mapping(
             def my_config_mapping(val):
                 return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
 
+            result = my_graph.to_job(config=my_config_mapping).execute_in_process()
+
     """
     # This case is for when decorator is used bare, without arguments. e.g. @config_mapping versus @config_mapping()
     if callable(config_fn):

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
@@ -12,7 +12,9 @@ class _ConfigMapping:
         receive_processed_config_values: Optional[bool] = None,
     ):
         self.config_schema = config_schema
-        self.receive_processed_config_values = check.opt_bool_param(receive_processed_config_values, "receive_processed_config_values")
+        self.receive_processed_config_values = check.opt_bool_param(
+            receive_processed_config_values, "receive_processed_config_values"
+        )
 
     def __call__(self, fn: Callable[..., Any]) -> ConfigMapping:
         check.callable_param(fn, "fn")
@@ -22,6 +24,7 @@ class _ConfigMapping:
             config_schema=self.config_schema,
             receive_processed_config_values=self.receive_processed_config_values,
         )
+
 
 def config_mapping(
     config_fn: Callable[..., Any] = None,
@@ -55,7 +58,7 @@ def config_mapping(
             @config_mapping
             def my_config_mapping(val):
                 return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
-            
+
             @config_mapping(config_schema={"foo": str})
             def my_config_mapping(val):
                 return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
@@ -1,7 +1,9 @@
 from typing import Any, Callable, Optional, Union
 
 from dagster import check
+
 from ..config import ConfigMapping
+
 
 class _ConfigMapping:
     def __init__(

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
@@ -15,23 +15,20 @@ class _ConfigMapping:
     def __call__(self, fn: Callable[..., Any]) -> ConfigMapping:
         check.callable_param(fn, "fn")
 
-        config_mapping_def = ConfigMapping(
+        return ConfigMapping(
             config_fn=fn,
             config_schema=self.config_schema,
             receive_processed_config_values=self.receive_processed_config_values,
         )
-        return config_mapping_def
 
 def config_mapping(
     config_fn: Callable[..., Any] = None,
-    config_schema: Optional[Any] = None,
+    config_schema: Any = None,
     receive_processed_config_values: Optional[bool] = None,
 ) -> Union[_ConfigMapping, ConfigMapping]:
     """Create a config mapping with the specified parameters from the decorated function.
 
-    This shortcut simplifies the core :class:`ConfigMapping` API by omitting additional
-    parameters when they are not needed. The config schema will be inferred from the type
-    signature of the decorated function if not explicitly provided.
+    The config schema will be inferred from the type signature of the decorated function if not explicitly provided.
 
     Args:
         config_schema (ConfigSchema): The schema of the composite config.

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
@@ -1,0 +1,76 @@
+from typing import Any, Callable, Optional, Union
+
+from dagster import check
+from ..config import ConfigMapping
+
+def config_mapping(
+    config_fn: Callable[..., Any] = None,
+    config_schema: Optional[Any] = None,
+    receive_processed_config_values: Optional[bool] = None,
+) -> Union[_ConfigMapping, ConfigMapping]:
+    """Create a config mapping with the specified parameters from the decorated function.
+
+    This shortcut simplifies the core :class:`ConfigMapping` API by omitting additional
+    parameters when they are not needed. The config schema will be inferred from the type
+    signature of the decorated function if not explicitly provided.
+
+    Args:
+        config_schema (ConfigSchema): The schema of the composite config.
+        receive_processed_config_values (Optional[bool]): If true, config values provided to the config_fn
+            will be converted to their dagster types before being passed in. For example, if this
+            value is true, enum config passed to config_fn will be actual enums, while if false,
+            then enum config passed to config_fn will be strings.
+
+
+    Examples:
+
+        .. code-block:: python
+
+            @op
+            def my_op(context):
+                return context.op_config["foo"]
+
+            @graph
+            def my_graph():
+                my_op()
+
+            @config_mapping
+            def my_config_mapping(val):
+                return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
+            
+            @config_mapping(config_schema={"foo": str})
+            def my_config_mapping(val):
+                return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
+
+    """
+    # This case is for when decorator is used bare, without arguments. e.g. @config_mapping versus @config_mapping()
+    if callable(config_fn):
+        check.invariant(config_schema is None)
+        check.invariant(receive_processed_config_values is None)
+
+        return _ConfigMapping()(config_fn)
+
+    check.invariant(config_fn is None)
+    return _ConfigMapping(
+        config_schema=config_schema,
+        receive_processed_config_values=receive_processed_config_values,
+    )
+
+class _ConfigMapping:
+    def __init__(
+        self,
+        config_schema: Optional[Any] = None,
+        receive_processed_config_values: Optional[bool] = None,
+    ):
+        self.config_schema = config_schema
+        self.receive_processed_config_values = check.opt_bool_param(receive_processed_config_values, "receive_processed_config_values")
+
+    def __call__(self, fn: Callable[..., Any]) -> ConfigMapping:
+        check.callable_param(fn, "fn")
+
+        config_mapping_def = ConfigMapping(
+            config_fn=fn,
+            config_schema=self.config_schema,
+            receive_processed_config_values=self.receive_processed_config_values,
+        )
+        return config_mapping_def

--- a/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/config_mapping.py
@@ -3,6 +3,25 @@ from typing import Any, Callable, Optional, Union
 from dagster import check
 from ..config import ConfigMapping
 
+class _ConfigMapping:
+    def __init__(
+        self,
+        config_schema: Optional[Any] = None,
+        receive_processed_config_values: Optional[bool] = None,
+    ):
+        self.config_schema = config_schema
+        self.receive_processed_config_values = check.opt_bool_param(receive_processed_config_values, "receive_processed_config_values")
+
+    def __call__(self, fn: Callable[..., Any]) -> ConfigMapping:
+        check.callable_param(fn, "fn")
+
+        config_mapping_def = ConfigMapping(
+            config_fn=fn,
+            config_schema=self.config_schema,
+            receive_processed_config_values=self.receive_processed_config_values,
+        )
+        return config_mapping_def
+
 def config_mapping(
     config_fn: Callable[..., Any] = None,
     config_schema: Optional[Any] = None,
@@ -55,22 +74,3 @@ def config_mapping(
         config_schema=config_schema,
         receive_processed_config_values=receive_processed_config_values,
     )
-
-class _ConfigMapping:
-    def __init__(
-        self,
-        config_schema: Optional[Any] = None,
-        receive_processed_config_values: Optional[bool] = None,
-    ):
-        self.config_schema = config_schema
-        self.receive_processed_config_values = check.opt_bool_param(receive_processed_config_values, "receive_processed_config_values")
-
-    def __call__(self, fn: Callable[..., Any]) -> ConfigMapping:
-        check.callable_param(fn, "fn")
-
-        config_mapping_def = ConfigMapping(
-            config_fn=fn,
-            config_schema=self.config_schema,
-            receive_processed_config_values=self.receive_processed_config_values,
-        )
-        return config_mapping_def

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
@@ -59,10 +59,10 @@ def test_conf_schema_typing_config_mapping():
         return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
 
     with pytest.raises(DagsterInvalidConfigError):
-        assert not my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": 1}).success
+        my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": 1})
         
     with pytest.raises(DagsterInvalidConfigError):
-        assert not my_graph.to_job(config=my_config_mapping).execute_in_process().success
+        my_graph.to_job(config=my_config_mapping).execute_in_process()
 
     result = my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": "bar"})
     assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
@@ -2,15 +2,7 @@ import enum
 import re
 
 import pytest
-from dagster import (
-    DagsterInvalidConfigError,
-    Enum,
-    Field,
-    check,
-    op,
-    graph,
-    config_mapping,
-)
+from dagster import DagsterInvalidConfigError, Enum, Field, check, config_mapping, graph, op
 
 def test_empty_config_mapping():
     @op

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
@@ -1,0 +1,96 @@
+import enum
+import re
+
+import pytest
+from dagster import (
+    DagsterInvalidConfigError,
+    Enum,
+    Field,
+    check,
+    op,
+    graph,
+    config_mapping,
+)
+
+def test_empty_config_mapping():
+    @op
+    def empty_op():
+        pass
+
+    @graph
+    def empty_graph():
+        empty_op()
+
+    @config_mapping
+    def empty_config_mapping(_):
+        return {}
+
+    assert empty_graph.to_job(config=empty_config_mapping).execute_in_process().success
+
+@op
+def my_op(context):
+    return context.op_config["foo"]
+
+@graph
+def my_graph():
+    my_op()
+
+def test_bare_config_mapping():
+    @config_mapping
+    def my_config_mapping(val):
+        return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
+
+    result = my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": "bar"})
+    assert result.success
+    assert result.result_for_node("my_op").output_values["result"] == "bar"
+
+def test_no_params_config_mapping():
+    @config_mapping()
+    def my_config_mapping(val):
+        return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
+
+    result = my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": "bar"})
+    assert result.success
+    assert result.result_for_node("my_op").output_values["result"] == "bar"
+
+def test_conf_schema_typing_config_mapping():
+    @config_mapping(config_schema={"foo": str})
+    def my_config_mapping(val):
+        return {"ops": {"my_op": {"config": {"foo": val["foo"]}}}}
+
+    with pytest.raises(DagsterInvalidConfigError):
+        assert not my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": 1}).success
+        
+    with pytest.raises(DagsterInvalidConfigError):
+        assert not my_graph.to_job(config=my_config_mapping).execute_in_process().success
+
+    result = my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": "bar"})
+    assert result.success
+    assert result.result_for_node("my_op").output_values["result"] == "bar"
+
+def test_receive_processed_config_values():
+    class TestEnum(enum.Enum):
+        FOO = 1
+        BAR = 2
+    
+    enum_conf_schema = {
+                "foo": Field(
+                    Enum.from_python_enum(TestEnum), is_required=False, default_value="BAR"
+                )
+            }
+    
+    @config_mapping(config_schema=enum_conf_schema)
+    def processed_config_mapping(outer_config):
+        return {"ops": {"my_op": {"config": {"foo": outer_config["foo"]}}}}
+
+    processed_result = my_graph.to_job(config=processed_config_mapping).execute_in_process()
+    assert processed_result.success
+    assert processed_result.result_for_node("my_op").output_values["result"] == TestEnum.BAR
+
+    @config_mapping(config_schema=enum_conf_schema, receive_processed_config_values=False)
+    def unprocessed_config_mapping(outer_config):
+        return {"ops": {"my_op": {"config": {"foo": outer_config["foo"]}}}}
+
+    unprocessed_result = my_graph.to_job(config=unprocessed_config_mapping).execute_in_process()
+    assert unprocessed_result.success
+    assert unprocessed_result.result_for_node("my_op").output_values["result"] == "BAR"

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_config_mapping.py
@@ -4,6 +4,7 @@ import re
 import pytest
 from dagster import DagsterInvalidConfigError, Enum, Field, check, config_mapping, graph, op
 
+
 def test_empty_config_mapping():
     @op
     def empty_op():
@@ -19,13 +20,16 @@ def test_empty_config_mapping():
 
     assert empty_graph.to_job(config=empty_config_mapping).execute_in_process().success
 
+
 @op
 def my_op(context):
     return context.op_config["foo"]
 
+
 @graph
 def my_graph():
     my_op()
+
 
 def test_bare_config_mapping():
     @config_mapping
@@ -36,6 +40,7 @@ def test_bare_config_mapping():
     assert result.success
     assert result.result_for_node("my_op").output_values["result"] == "bar"
 
+
 def test_no_params_config_mapping():
     @config_mapping()
     def my_config_mapping(val):
@@ -45,6 +50,7 @@ def test_no_params_config_mapping():
     assert result.success
     assert result.result_for_node("my_op").output_values["result"] == "bar"
 
+
 def test_conf_schema_typing_config_mapping():
     @config_mapping(config_schema={"foo": str})
     def my_config_mapping(val):
@@ -52,7 +58,7 @@ def test_conf_schema_typing_config_mapping():
 
     with pytest.raises(DagsterInvalidConfigError):
         my_graph.to_job(config=my_config_mapping).execute_in_process(run_config={"foo": 1})
-        
+
     with pytest.raises(DagsterInvalidConfigError):
         my_graph.to_job(config=my_config_mapping).execute_in_process()
 
@@ -60,17 +66,16 @@ def test_conf_schema_typing_config_mapping():
     assert result.success
     assert result.result_for_node("my_op").output_values["result"] == "bar"
 
+
 def test_receive_processed_config_values():
     class TestEnum(enum.Enum):
         FOO = 1
         BAR = 2
-    
+
     enum_conf_schema = {
-                "foo": Field(
-                    Enum.from_python_enum(TestEnum), is_required=False, default_value="BAR"
-                )
-            }
-    
+        "foo": Field(Enum.from_python_enum(TestEnum), is_required=False, default_value="BAR")
+    }
+
     @config_mapping(config_schema=enum_conf_schema)
     def processed_config_mapping(outer_config):
         return {"ops": {"my_op": {"config": {"foo": outer_config["foo"]}}}}


### PR DESCRIPTION
Adds a config mapping decorator to shortcut the core `ConfigMapping` API. Operates under the assumption that the decorated config function should always accept a parameter.