### PR TITLE
Allow passing in a DagsterInstance directly via build_sensor_context

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor.py
@@ -58,6 +58,8 @@ class SensorEvaluationContext:
         last_run_key (str): DEPRECATED The run key of the RunRequest most recently created by this
             sensor. Use the preferred `cursor` attribute instead.
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
+        instance (Optional[DagsterInstance]): The deserialized instance can also be passed in
+            directly (primarily useful in testing contexts).
     """
 
     def __init__(
@@ -67,10 +69,9 @@ class SensorEvaluationContext:
         last_run_key: Optional[str],
         cursor: Optional[str],
         repository_name: Optional[str],
+        instance: Optional[DagsterInstance] = None,
     ):
         self._exit_stack = ExitStack()
-        self._instance = None
-
         self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
         self._last_completion_time = check.opt_float_param(
             last_completion_time, "last_completion_time"
@@ -78,8 +79,7 @@ class SensorEvaluationContext:
         self._last_run_key = check.opt_str_param(last_run_key, "last_run_key")
         self._cursor = check.opt_str_param(cursor, "cursor")
         self._repository_name = check.opt_str_param(repository_name, "repository_name")
-
-        self._instance = None
+        self._instance = check.opt_inst_param(instance, "instance", DagsterInstance)
 
     def __enter__(self):
         return self
@@ -91,11 +91,11 @@ class SensorEvaluationContext:
     def instance(self) -> DagsterInstance:
         # self._instance_ref should only ever be None when this SensorEvaluationContext was
         # constructed under test.
-        if not self._instance_ref:
-            raise DagsterInvariantViolationError(
-                "Attempted to initialize dagster instance, but no instance reference was provided."
-            )
         if not self._instance:
+            if not self._instance_ref:
+                raise DagsterInvariantViolationError(
+                    "Attempted to initialize dagster instance, but no instance reference was provided."
+                )
             self._instance = self._exit_stack.enter_context(
                 DagsterInstance.from_ref(self._instance_ref)
             )
@@ -497,11 +497,12 @@ def build_sensor_context(
     check.opt_str_param(cursor, "cursor")
     check.opt_str_param(repository_name, "repository_name")
     return SensorEvaluationContext(
-        instance_ref=instance.get_ref() if instance else None,
+        instance_ref=None,
         last_completion_time=None,
         last_run_key=None,
         cursor=cursor,
         repository_name=repository_name,
+        instance=instance,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from dagster import (
     DagsterInstance,
@@ -85,3 +87,8 @@ def test_instance_access_built_sensor():
 
     with instance_for_test() as instance:
         assert isinstance(build_sensor_context(instance).instance, DagsterInstance)
+
+
+def test_instance_access_with_mock():
+    mock_instance = mock.MagicMock(spec=DagsterInstance)
+    assert build_sensor_context(instance=mock_instance).instance == mock_instance


### PR DESCRIPTION
Summary:
Without this change, if you're using a mock DagsterInstance for your sensor test, you have to awkwardly include get_ref as part of the mock. With this change the test path can just pass the DagsterInstance straight through.

Test Plan: Existing sensor tests still pass

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.