### PR TITLE
Migrate DagsterInvalidDefinitionError to crag

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
@@ -73,7 +73,7 @@ class TestSolidSelections(NonLaunchableGraphQLContextTestMatrix):
         assert re.match(
             (
                 r".*DagsterInvalidSubsetError[\s\S]*"
-                r'add a dagster_type_loader for the type "InputTypeWithoutHydration"'
+                r"add a dagster_type_loader for the type 'InputTypeWithoutHydration'"
             ),
             result.data["runConfigSchemaOrError"]["message"],
         )

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -500,7 +500,7 @@ class PendingNodeInvocation:
                     arg_desc=arg_desc,
                     input_name=input_name,
                     node_name=node_name,
-                    node_type=output_node.describe_node(),
+                    node_type=self.node_def.node_as_str,
                 )
             )
 

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -395,11 +395,11 @@ class PendingNodeInvocation:
             output_name = output_def.name
             if output_def.is_dynamic:
                 return InvokedSolidDynamicOutputWrapper(
-                    resolved_node_name, output_name, self.node_def.node_as_str
+                    resolved_node_name, output_name, self.node_def.node_type_str
                 )
             else:
                 return InvokedSolidOutputHandle(
-                    resolved_node_name, output_name, self.node_def.node_as_str
+                    resolved_node_name, output_name, self.node_def.node_type_str
                 )
 
         outputs = [output_def for output_def in self.node_def.output_defs]
@@ -407,11 +407,11 @@ class PendingNodeInvocation:
         for output_def in outputs:
             if output_def.is_dynamic:
                 invoked_output_handles[output_def.name] = InvokedSolidDynamicOutputWrapper(
-                    resolved_node_name, output_def.name, self.node_def.node_as_str
+                    resolved_node_name, output_def.name, self.node_def.node_type_str
                 )
             else:
                 invoked_output_handles[output_def.name] = InvokedSolidOutputHandle(
-                    resolved_node_name, output_def.name, self.node_def.node_as_str
+                    resolved_node_name, output_def.name, self.node_def.node_type_str
                 )
 
         return namedtuple(
@@ -421,7 +421,7 @@ class PendingNodeInvocation:
 
     def describe_node(self):
         node_name = self.given_alias if self.given_alias else self.node_def.name
-        return f"{self.node_def.node_as_str} '{node_name}'"
+        return f"{self.node_def.node_type_str} '{node_name}'"
 
     def _process_argument_node(self, node_name, output_node, input_name, input_bindings, arg_desc):
 
@@ -444,7 +444,7 @@ class PendingNodeInvocation:
                             name=current_context().name,
                             arg_desc=arg_desc,
                             input_name=input_name,
-                            node_type=self.node_def.node_as_str,
+                            node_type=self.node_def.node_type_str,
                             node_name=node_name,
                             idx=idx,
                             type=type(output_node),
@@ -463,7 +463,7 @@ class PendingNodeInvocation:
                     arg_desc=arg_desc,
                     input_name=input_name,
                     node_name=node_name,
-                    node_type=self.node_def.node_as_str,
+                    node_type=self.node_def.node_type_str,
                     options=output_node._fields,
                 )
             )
@@ -503,7 +503,7 @@ class PendingNodeInvocation:
                     arg_desc=arg_desc,
                     input_name=input_name,
                     node_name=node_name,
-                    node_type=self.node_def.node_as_str,
+                    node_type=self.node_def.node_type_str,
                 )
             )
 

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -207,7 +207,7 @@ class CompleteCompositionContext(NamedTuple):
             def_name = invocation.node_def.name
             if def_name in node_def_dict and node_def_dict[def_name] is not invocation.node_def:
                 raise DagsterInvalidDefinitionError(
-                    'Detected conflicting solid definitions with the same name "{name}"'.format(
+                    'Detected conflicting node definitions with the same name "{name}"'.format(
                         name=def_name
                     )
                 )
@@ -394,20 +394,24 @@ class PendingNodeInvocation:
             output_def = self.node_def.output_defs[0]
             output_name = output_def.name
             if output_def.is_dynamic:
-                return InvokedSolidDynamicOutputWrapper(resolved_node_name, output_name)
+                return InvokedSolidDynamicOutputWrapper(
+                    resolved_node_name, output_name, self.node_def.node_as_str
+                )
             else:
-                return InvokedSolidOutputHandle(resolved_node_name, output_name)
+                return InvokedSolidOutputHandle(
+                    resolved_node_name, output_name, self.node_def.node_as_str
+                )
 
         outputs = [output_def for output_def in self.node_def.output_defs]
         invoked_output_handles = {}
         for output_def in outputs:
             if output_def.is_dynamic:
                 invoked_output_handles[output_def.name] = InvokedSolidDynamicOutputWrapper(
-                    resolved_node_name, output_def.name
+                    resolved_node_name, output_def.name, self.node_def.node_as_str
                 )
             else:
                 invoked_output_handles[output_def.name] = InvokedSolidOutputHandle(
-                    resolved_node_name, output_def.name
+                    resolved_node_name, output_def.name, self.node_def.node_as_str
                 )
 
         return namedtuple(
@@ -415,7 +419,7 @@ class PendingNodeInvocation:
             " ".join([output_def.name for output_def in outputs]),
         )(**invoked_output_handles)
 
-    def _process_argument_node(self, solid_name, output_node, input_name, input_bindings, arg_desc):
+    def _process_argument_node(self, node_name, output_node, input_name, input_bindings, arg_desc):
 
         if isinstance(output_node, (InvokedSolidOutputHandle, InputMappingNode, DynamicFanIn)):
             input_bindings[input_name] = output_node
@@ -429,14 +433,15 @@ class PendingNodeInvocation:
                     raise DagsterInvalidDefinitionError(
                         "In {source} {name}, received a list containing an invalid type "
                         'at index {idx} for input "{input_name}" {arg_desc} in '
-                        "solid invocation {solid_name}. Lists can only contain the "
+                        "{node_type} invocation {node_name}. Lists can only contain the "
                         "output from previous solid invocations or input mappings, "
                         "received {type}".format(
                             source=current_context().source,
                             name=current_context().name,
                             arg_desc=arg_desc,
                             input_name=input_name,
-                            solid_name=solid_name,
+                            node_type=self.node_def.node_as_str,
+                            node_name=node_name,
                             idx=idx,
                             type=type(output_node),
                         )
@@ -447,20 +452,21 @@ class PendingNodeInvocation:
         ):
             raise DagsterInvalidDefinitionError(
                 "In {source} {name}, received a tuple of multiple outputs for "
-                'input "{input_name}" {arg_desc} in solid invocation {solid_name}. '
+                'input "{input_name}" {arg_desc} in {node_type} invocation {node_name}. '
                 "Must pass individual output, available from tuple: {options}".format(
                     source=current_context().source,
                     name=current_context().name,
                     arg_desc=arg_desc,
                     input_name=input_name,
-                    solid_name=solid_name,
+                    node_name=node_name,
+                    node_type=self.node_def.node_as_str,
                     options=output_node._fields,
                 )
             )
         elif isinstance(output_node, InvokedSolidDynamicOutputWrapper):
             raise DagsterInvalidDefinitionError(
                 f"In {current_context().source} {current_context().name}, received the dynamic output "
-                f"{output_node.output_name} from solid {output_node.solid_name} directly. Dynamic "
+                f"{output_node.output_name} from {output_node.describe_node()} directly. Dynamic "
                 "output must be unpacked by invoking map or collect."
             )
 
@@ -468,28 +474,33 @@ class PendingNodeInvocation:
             output_node, NodeDefinition
         ):
             raise DagsterInvalidDefinitionError(
-                "In {source} {name}, received an un-invoked solid for input "
-                '"{input_name}" {arg_desc} in solid invocation "{solid_name}". '
+                "In {source} {name}, received an un-invoked {uninvoked_node_type} "
+                "'{uninvoked_node_name}' for input "
+                '"{input_name}" {arg_desc} in {node_type} invocation "{node_name}". '
                 "Did you forget parentheses?".format(
                     source=current_context().source,
+                    uninvoked_node_type=output_node.node_as_str,
+                    uninvoked_node_name=output_node.name,
                     name=current_context().name,
                     arg_desc=arg_desc,
                     input_name=input_name,
-                    solid_name=solid_name,
+                    node_name=node_name,
+                    node_type=output_node.describe_node(),
                 )
             )
         else:
             raise DagsterInvalidDefinitionError(
                 "In {source} {name}, received invalid type {type} for input "
-                '"{input_name}" {arg_desc} in solid invocation "{solid_name}". '
-                "Must pass the output from previous solid invocations or inputs to the "
-                "composition function as inputs when invoking solids during composition.".format(
+                '"{input_name}" {arg_desc} in {node_type} invocation "{node_name}". '
+                "Must pass the output from previous node invocations or inputs to the "
+                "composition function as inputs when invoking nodes during composition.".format(
                     source=current_context().source,
                     name=current_context().name,
                     type=type(output_node),
                     arg_desc=arg_desc,
                     input_name=input_name,
-                    solid_name=solid_name,
+                    node_name=node_name,
+                    node_type=output_node.describe_node(),
                 )
             )
 
@@ -627,11 +638,12 @@ class InvokedNode(NamedTuple):
 
 
 class InvokedSolidOutputHandle:
-    """The return value for an output when invoking a solid in a composition function."""
+    """The return value for an output when invoking a node in a composition function."""
 
-    def __init__(self, solid_name, output_name):
+    def __init__(self, solid_name, output_name, node_type):
         self.solid_name = check.str_param(solid_name, "solid_name")
         self.output_name = check.str_param(output_name, "output_name")
+        self.node_type = check.str_param(node_type, "node_type")
 
     def __iter__(self):
         raise DagsterInvariantViolationError(
@@ -694,23 +706,29 @@ class InvokedSolidDynamicOutputWrapper:
     Must be unwrapped by invoking map or collect.
     """
 
-    def __init__(self, solid_name: str, output_name: str):
+    def __init__(self, solid_name: str, output_name: str, node_type: str):
         self.solid_name = check.str_param(solid_name, "solid_name")
         self.output_name = check.str_param(output_name, "output_name")
+        self.node_type = check.str_param(node_type, "node_type")
+
+    def describe_node(self):
+        return f"{self.node_type} '{self.solid_name}'"
 
     def map(self, fn):
         check.is_callable(fn)
-        result = fn(InvokedSolidOutputHandle(self.solid_name, self.output_name))
+        result = fn(InvokedSolidOutputHandle(self.solid_name, self.output_name, self.node_type))
 
         if isinstance(result, InvokedSolidOutputHandle):
-            return InvokedSolidDynamicOutputWrapper(result.solid_name, result.output_name)
+            return InvokedSolidDynamicOutputWrapper(
+                result.solid_name, result.output_name, result.node_type
+            )
         elif isinstance(result, tuple) and all(
             map(lambda item: isinstance(item, InvokedSolidOutputHandle), result)
         ):
             return tuple(
                 map(
                     lambda item: InvokedSolidDynamicOutputWrapper(
-                        item.solid_name, item.output_name
+                        item.solid_name, item.output_name, item.node_type
                     ),
                     result,
                 )
@@ -729,7 +747,7 @@ class InvokedSolidDynamicOutputWrapper:
         return DynamicFanIn(self.solid_name, self.output_name)
 
     def unwrap_for_composite_mapping(self) -> InvokedSolidOutputHandle:
-        return InvokedSolidOutputHandle(self.solid_name, self.output_name)
+        return InvokedSolidOutputHandle(self.solid_name, self.output_name, self.node_type)
 
     def __iter__(self):
         raise DagsterInvariantViolationError(
@@ -786,6 +804,7 @@ def composite_mapping_from_output(
     output: Any,
     output_defs: List[OutputDefinition],
     solid_name: str,
+    decorator_name: str,
 ) -> Optional[Dict[str, OutputMapping]]:
     # output can be different types
     check.list_param(output_defs, "output_defs", OutputDefinition)
@@ -799,10 +818,11 @@ def composite_mapping_from_output(
         else:
             raise DagsterInvalidDefinitionError(
                 "Returned a single output ({solid_name}.{output_name}) in "
-                "@composite_solid {name} but {num} outputs are defined. "
+                "{decorator_name} '{name}' but {num} outputs are defined. "
                 "Return a dict to map defined outputs.".format(
                     solid_name=output.solid_name,
                     output_name=output.output_name,
+                    decorator_name=decorator_name,
                     name=solid_name,
                     num=len(output_defs),
                 )
@@ -818,9 +838,11 @@ def composite_mapping_from_output(
         for handle in output:
             if handle.output_name not in output_def_dict:
                 raise DagsterInvalidDefinitionError(
-                    "Output name mismatch returning output tuple in @composite_solid {name}. "
+                    "Output name mismatch returning output tuple in {decorator_name} '{name}'. "
                     "No matching OutputDefinition named {output_name} for {solid_name}.{output_name}."
                     "Return a dict to map to the desired OutputDefinition".format(
+                        node_type=handle.node_type,
+                        decorator_name=decorator_name,
                         name=solid_name,
                         output_name=handle.output_name,
                         solid_name=handle.solid_name,
@@ -837,9 +859,12 @@ def composite_mapping_from_output(
         for name, handle in output.items():
             if name not in output_def_dict:
                 raise DagsterInvalidDefinitionError(
-                    "@composite_solid {name} referenced key {key} which does not match any "
+                    "{decorator_name} '{name}' referenced key {key} which does not match any "
                     "OutputDefinitions. Valid options are: {options}".format(
-                        name=solid_name, key=name, options=list(output_def_dict.keys())
+                        decorator_name=decorator_name,
+                        name=solid_name,
+                        key=name,
+                        options=list(output_def_dict.keys()),
                     )
                 )
 
@@ -854,25 +879,27 @@ def composite_mapping_from_output(
                 )
             else:
                 raise DagsterInvalidDefinitionError(
-                    "@composite_solid {name} returned problematic dict entry under "
+                    "{decorator_name} '{name}' returned problematic dict entry under "
                     "key {key} of type {type}. Dict values must be outputs of "
-                    "invoked solids".format(name=solid_name, key=name, type=type(handle))
+                    "invoked solids".format(
+                        decorator_name=decorator_name, name=solid_name, key=name, type=type(handle)
+                    )
                 )
 
         return output_mapping_dict
 
     elif isinstance(output, InvokedSolidDynamicOutputWrapper):
         return composite_mapping_from_output(
-            output.unwrap_for_composite_mapping(), output_defs, solid_name
+            output.unwrap_for_composite_mapping(), output_defs, solid_name, decorator_name
         )
 
     # error
     if output is not None:
         raise DagsterInvalidDefinitionError(
-            "@composite_solid {name} returned problematic value "
+            "{decorator_name} '{name}' returned problematic value "
             "of type {type}. Expected return value from invoked solid or dict mapping "
             "output name to return values from invoked solids".format(
-                name=solid_name, type=type(output)
+                decorator_name=decorator_name, name=solid_name, type=type(output)
             )
         )
 
@@ -1005,7 +1032,9 @@ def do_composition(
             )
         output_mappings.append(mapping)
 
-    config_mapping = _get_validated_config_mapping(graph_name, config_schema, config_fn)
+    config_mapping = _get_validated_config_mapping(
+        graph_name, config_schema, config_fn, decorator_name
+    )
 
     return (
         input_mappings,
@@ -1018,9 +1047,7 @@ def do_composition(
 
 
 def _get_validated_config_mapping(
-    name: str,
-    config_schema: Any,
-    config_fn: Optional[Callable[[Any], Any]],
+    name: str, config_schema: Any, config_fn: Optional[Callable[[Any], Any]], decorator_name: str
 ) -> Optional[ConfigMapping]:
     if config_fn is None and config_schema is None:
         return None
@@ -1028,6 +1055,6 @@ def _get_validated_config_mapping(
         return ConfigMapping(config_fn=config_fn, config_schema=config_schema)
     else:
         raise DagsterInvalidDefinitionError(
-            f"@composite_solid '{name}' defines a configuration schema but does not "
+            f"{decorator_name} '{name}' defines a configuration schema but does not "
             "define a configuration function."
         )

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -419,6 +419,10 @@ class PendingNodeInvocation:
             " ".join([output_def.name for output_def in outputs]),
         )(**invoked_output_handles)
 
+    def describe_node(self):
+        node_name = self.given_alias if self.given_alias else self.node_def.name
+        return f"{self.node_def.node_as_str} '{node_name}'"
+
     def _process_argument_node(self, node_name, output_node, input_name, input_bindings, arg_desc):
 
         if isinstance(output_node, (InvokedSolidOutputHandle, InputMappingNode, DynamicFanIn)):
@@ -474,13 +478,12 @@ class PendingNodeInvocation:
             output_node, NodeDefinition
         ):
             raise DagsterInvalidDefinitionError(
-                "In {source} {name}, received an un-invoked {uninvoked_node_type} "
-                "'{uninvoked_node_name}' for input "
+                "In {source} {name}, received an un-invoked {described_node} "
+                " for input "
                 '"{input_name}" {arg_desc} in {node_type} invocation "{node_name}". '
                 "Did you forget parentheses?".format(
                     source=current_context().source,
-                    uninvoked_node_type=output_node.node_as_str,
-                    uninvoked_node_name=output_node.name,
+                    described_node=output_node.describe_node(),
                     name=current_context().name,
                     arg_desc=arg_desc,
                     input_name=input_name,

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -841,7 +841,6 @@ def composite_mapping_from_output(
                     "Output name mismatch returning output tuple in {decorator_name} '{name}'. "
                     "No matching OutputDefinition named {output_name} for {solid_name}.{output_name}."
                     "Return a dict to map to the desired OutputDefinition".format(
-                        node_type=handle.node_type,
                         decorator_name=decorator_name,
                         name=solid_name,
                         output_name=handle.output_name,
@@ -985,7 +984,9 @@ def do_composition(
                 )
             output = None
 
-        returned_mapping = composite_mapping_from_output(output, actual_output_defs, graph_name)
+        returned_mapping = composite_mapping_from_output(
+            output, actual_output_defs, graph_name, decorator_name
+        )
     finally:
         context = exit_composition(returned_mapping)
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository.py
@@ -61,8 +61,9 @@ class _Repository:
                 )
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
-                    "must be of type PipelineDefinition, PartitionSetDefinition, "
-                    f"ScheduleDefinition, or SensorDefinition. Got {bad_definitions_str}."
+                    "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
+                    "PartitionSetDefinition, ScheduleDefinition, or SensorDefinition. "
+                    f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid.py
@@ -332,9 +332,9 @@ def resolve_checked_solid_fn_inputs(
         elif param.kind == funcsigs.Parameter.VAR_POSITIONAL:
             raise DagsterInvalidDefinitionError(
                 f"{decorator_name} '{fn_name}' decorated function has positional vararg parameter "
-                f"'{param}'. Solid functions should only have keyword arguments that match "
-                "input names and, if system information is required, a first positional "
-                "parameter named 'context'."
+                f"'{param}'. {decorator_name} decorated functions should only have keyword "
+                "arguments that match input names and, if system information is required, a first "
+                "positional parameter named 'context'."
             )
 
         else:
@@ -342,7 +342,7 @@ def resolve_checked_solid_fn_inputs(
                 if param.name in nothing_names:
                     raise DagsterInvalidDefinitionError(
                         f"{decorator_name} '{fn_name}' decorated function has parameter '{param.name}' that is "
-                        "one of the solid input_defs of type 'Nothing' which should not be included since "
+                        "one of the input_defs of type 'Nothing' which should not be included since "
                         "no data will be passed for it. "
                     )
                 else:
@@ -356,9 +356,9 @@ def resolve_checked_solid_fn_inputs(
         undeclared_inputs_printed = ", '".join(undeclared_inputs)
         raise DagsterInvalidDefinitionError(
             f"{decorator_name} '{fn_name}' decorated function does not have parameter(s) "
-            f"'{undeclared_inputs_printed}', which are in solid's input_defs. Solid functions "
-            "should only have keyword arguments that match input names and, if system information "
-            "is required, a first positional parameter named 'context'."
+            f"'{undeclared_inputs_printed}', which are in provided input_defs. {decorator_name} "
+            "decorated functions should only have keyword arguments that match input names and, if "
+            "system information is required, a first positional parameter named 'context'."
         )
 
     inferred_props = {

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -642,7 +642,7 @@ class MultiDependencyDefinition(
                 key = dep.solid + ":" + dep.output
                 if key in seen:
                     raise DagsterInvalidDefinitionError(
-                        'Duplicate dependencies on solid "{dep.solid}" output "{dep.output}" '
+                        'Duplicate dependencies on node "{dep.solid}" output "{dep.output}" '
                         "used in the same MultiDependencyDefinition.".format(dep=dep)
                     )
                 seen[key] = True
@@ -821,15 +821,15 @@ class DependencyStructure:
             input_handle.input_name
         ):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be downstream of dynamic output '
-                f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a solid '
-                "that is already downstream of another dynamic output. Solids cannot be downstream of more "
+                f'{input_handle.solid.describe_node} cannot be downstream of dynamic output '
+                f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a node '
+                "that is already downstream of another dynamic output. Nodes cannot be downstream of more "
                 "than one dynamic output"
             )
 
         if self._collect_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be both downstream of dynamic output '
+                f'{input_handle.solid.describe_node} cannot be both downstream of dynamic output '
                 f"{output_handle.describe()} and collect over dynamic output "
                 f"{list(self._collect_index[input_handle.solid_name])[0].describe()}."
             )
@@ -840,7 +840,7 @@ class DependencyStructure:
 
         if self._dynamic_fan_out_index[input_handle.solid_name] != output_handle:
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be downstream of more than one dynamic output. '
+                f'{input_handle.solid_describe_node} cannot be downstream of more than one dynamic output. '
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}"'
             )
@@ -852,7 +852,7 @@ class DependencyStructure:
     ) -> None:
         if self._dynamic_fan_out_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot both collect over dynamic output '
+                f"{input_handle.solid.describe_node} cannot both collect over dynamic output "
                 f"{output_handle.describe()} and be downstream of the dynamic output "
                 f"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}."
             )
@@ -862,7 +862,7 @@ class DependencyStructure:
         # if the output is already fanned out
         if self._dynamic_fan_out_index.get(output_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'Solid "{input_handle.solid_name}" cannot be downstream of more than one dynamic output. '
+                f'{input_handle.solid.describe_node} cannot be downstream of more than one dynamic output. '
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[output_handle.solid_name].describe()}"'
             )

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -821,7 +821,7 @@ class DependencyStructure:
             input_handle.input_name
         ):
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node} cannot be downstream of dynamic output '
+                f'{input_handle.solid.describe_node()} cannot be downstream of dynamic output '
                 f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a node '
                 "that is already downstream of another dynamic output. Nodes cannot be downstream of more "
                 "than one dynamic output"
@@ -829,7 +829,7 @@ class DependencyStructure:
 
         if self._collect_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node} cannot be both downstream of dynamic output '
+                f'{input_handle.solid.describe_node()} cannot be both downstream of dynamic output '
                 f"{output_handle.describe()} and collect over dynamic output "
                 f"{list(self._collect_index[input_handle.solid_name])[0].describe()}."
             )
@@ -852,7 +852,7 @@ class DependencyStructure:
     ) -> None:
         if self._dynamic_fan_out_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f"{input_handle.solid.describe_node} cannot both collect over dynamic output "
+                f"{input_handle.solid.describe_node()} cannot both collect over dynamic output "
                 f"{output_handle.describe()} and be downstream of the dynamic output "
                 f"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}."
             )
@@ -862,7 +862,7 @@ class DependencyStructure:
         # if the output is already fanned out
         if self._dynamic_fan_out_index.get(output_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node} cannot be downstream of more than one dynamic output. '
+                f'{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. '
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[output_handle.solid_name].describe()}"'
             )

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -840,7 +840,7 @@ class DependencyStructure:
 
         if self._dynamic_fan_out_index[input_handle.solid_name] != output_handle:
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid_describe_node} cannot be downstream of more than one dynamic output. '
+                f'{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. '
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}"'
             )

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -821,7 +821,7 @@ class DependencyStructure:
             input_handle.input_name
         ):
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node()} cannot be downstream of dynamic output '
+                f"{input_handle.solid.describe_node()} cannot be downstream of dynamic output "
                 f'"{output_handle.describe()}" since input "{input_handle.input_name}" maps to a node '
                 "that is already downstream of another dynamic output. Nodes cannot be downstream of more "
                 "than one dynamic output"
@@ -829,7 +829,7 @@ class DependencyStructure:
 
         if self._collect_index.get(input_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node()} cannot be both downstream of dynamic output '
+                f"{input_handle.solid.describe_node()} cannot be both downstream of dynamic output "
                 f"{output_handle.describe()} and collect over dynamic output "
                 f"{list(self._collect_index[input_handle.solid_name])[0].describe()}."
             )
@@ -840,7 +840,7 @@ class DependencyStructure:
 
         if self._dynamic_fan_out_index[input_handle.solid_name] != output_handle:
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. '
+                f"{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. "
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[input_handle.solid_name].describe()}"'
             )
@@ -862,7 +862,7 @@ class DependencyStructure:
         # if the output is already fanned out
         if self._dynamic_fan_out_index.get(output_handle.solid_name):
             raise DagsterInvalidDefinitionError(
-                f'{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. '
+                f"{input_handle.solid.describe_node()} cannot be downstream of more than one dynamic output. "
                 f'It is downstream of both "{output_handle.describe()}" and '
                 f'"{self._dynamic_fan_out_index[output_handle.solid_name].describe()}"'
             )

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -67,7 +67,7 @@ def _check_node_defs_arg(graph_name: str, node_defs: Optional[List[NodeDefinitio
 
     if not isinstance(node_defs, list):
         raise DagsterInvalidDefinitionError(
-            '"solids" arg to "{name}" is not a list. Got {val}.'.format(
+            '"nodes" arg to "{name}" is not a list. Got {val}.'.format(
                 name=graph_name, val=repr(node_defs)
             )
         )
@@ -77,15 +77,15 @@ def _check_node_defs_arg(graph_name: str, node_defs: Optional[List[NodeDefinitio
         elif callable(node_def):
             raise DagsterInvalidDefinitionError(
                 """You have passed a lambda or function {func} into {name} that is
-                not a solid. You have likely forgetten to annotate this function with
-                an @solid or @lambda_solid decorator.'
+                not a node. You have likely forgetten to annotate this function with
+                the @op or @graph decorators.'
                 """.format(
                     name=graph_name, func=node_def.__name__
                 )
             )
         else:
             raise DagsterInvalidDefinitionError(
-                "Invalid item in solid list: {item}".format(item=repr(node_def))
+                "Invalid item in node list: {item}".format(item=repr(node_def))
             )
 
     return node_defs
@@ -607,7 +607,7 @@ def _validate_in_mappings(
         if input_def_dict.get(mapping.definition.name):
             if input_def_dict[mapping.definition.name] != mapping.definition:
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} {name} multiple input mappings with same "
+                    "In {class_name} '{name}' multiple input mappings with same "
                     "definition name but different definitions".format(
                         name=name, class_name=class_name
                     ),
@@ -637,7 +637,7 @@ def _validate_in_mappings(
         if mapping.maps_to_fan_in:
             if not dependency_structure.has_fan_in_deps(solid_input_handle):
                 raise DagsterInvalidDefinitionError(
-                    'In {class_name} "{name}" input mapping target '
+                    "In {class_name} '{name}' input mapping target "
                     '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" (index {mapping.maps_to.fan_in_index} of fan-in) '
                     "is not a MultiDependencyDefinition.".format(
                         name=name, mapping=mapping, class_name=class_name
@@ -648,7 +648,7 @@ def _validate_in_mappings(
                 inner_deps[mapping.maps_to.fan_in_index] is not MappedInputPlaceholder
             ):
                 raise DagsterInvalidDefinitionError(
-                    'In {class_name} "{name}" input mapping target '
+                    "In {class_name} '{name}' input mapping target "
                     '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" index {mapping.maps_to.fan_in_index} in '
                     "the MultiDependencyDefinition is not a MappedInputPlaceholder".format(
                         name=name, mapping=mapping, class_name=class_name
@@ -664,9 +664,9 @@ def _validate_in_mappings(
         else:
             if dependency_structure.has_deps(solid_input_handle):
                 raise DagsterInvalidDefinitionError(
-                    'In {class_name} "{name}" input mapping target '
+                    "In {class_name} '{name}' input mapping target "
                     '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" '
-                    "is already satisfied by solid output".format(
+                    "is already satisfied by output".format(
                         name=name, mapping=mapping, class_name=class_name
                     )
                 )
@@ -725,16 +725,19 @@ def _validate_out_mappings(
             target_solid = solid_dict.get(mapping.maps_from.solid_name)
             if target_solid is None:
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} '{name}' output mapping references solid "
+                    "In {class_name} '{name}' output mapping references node "
                     "'{solid_name}' which it does not contain.".format(
                         name=name, solid_name=mapping.maps_from.solid_name, class_name=class_name
                     )
                 )
             if not target_solid.has_output(mapping.maps_from.output_name):
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} {name} output mapping from solid '{mapping.maps_from.solid_name}' "
+                    "In {class_name} {name} output mapping from {described_node} "
                     "which contains no output named '{mapping.maps_from.output_name}'".format(
-                        name=name, mapping=mapping, class_name=class_name
+                        described_node=target_solid.describe_node,
+                        name=name,
+                        mapping=mapping,
+                        class_name=class_name,
                     )
                 )
 
@@ -771,7 +774,7 @@ def _validate_out_mappings(
             if dynamic_handle and not mapping.definition.is_dynamic:
                 raise DagsterInvalidDefinitionError(
                     f'In {class_name} "{name}" output "{mapping.definition.name}" mapping from '
-                    f'solid "{mapping.maps_from.solid_name}" must be a DynamicOutputDefinition since it is '
+                    f"{target_solid.describe_node} must be a DynamicOutputDefinition since it is "
                     f'downstream of dynamic output "{dynamic_handle.describe()}".'
                 )
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -734,7 +734,7 @@ def _validate_out_mappings(
                 raise DagsterInvalidDefinitionError(
                     "In {class_name} {name} output mapping from {described_node} "
                     "which contains no output named '{mapping.maps_from.output_name}'".format(
-                        described_node=target_solid.describe_node,
+                        described_node=target_solid.describe_node(),
                         name=name,
                         mapping=mapping,
                         class_name=class_name,
@@ -774,7 +774,7 @@ def _validate_out_mappings(
             if dynamic_handle and not mapping.definition.is_dynamic:
                 raise DagsterInvalidDefinitionError(
                     f'In {class_name} "{name}" output "{mapping.definition.name}" mapping from '
-                    f"{target_solid.describe_node} must be a DynamicOutputDefinition since it is "
+                    f"{target_solid.describe_node()} must be a DynamicOutputDefinition since it is "
                     f'downstream of dynamic output "{dynamic_handle.describe()}".'
                 )
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -187,6 +187,10 @@ class GraphDefinition(NodeDefinition):
         return [self.solid_named(solid_name) for solid_name in order]
 
     @property
+    def node_as_str(self) -> str:
+        return "graph"
+
+    @property
     def solids(self) -> List[Node]:
         return list(set(self._node_dict.values()))
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -187,7 +187,7 @@ class GraphDefinition(NodeDefinition):
         return [self.solid_named(solid_name) for solid_name in order]
 
     @property
-    def node_as_str(self) -> str:
+    def node_type_str(self) -> str:
         return "graph"
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
 from typing import TYPE_CHECKING
 
 from dagster import check
@@ -42,6 +42,10 @@ class NodeDefinition(NamedConfigurableDefinition):
             if positional_inputs is not None
             else list(map(lambda inp: inp.name, input_defs))
         )
+
+    @abstractproperty
+    def node_as_str(self):
+        raise NotImplementedError()
 
     @property
     def name(self):

--- a/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
@@ -52,6 +52,10 @@ class NodeDefinition(NamedConfigurableDefinition):
         return self._name
 
     @property
+    def describe_node(self):
+        return f"{self.node_as_str} '{self.name}'"
+
+    @property
     def description(self):
         return self._description
 

--- a/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
@@ -44,7 +44,7 @@ class NodeDefinition(NamedConfigurableDefinition):
         )
 
     @abstractproperty
-    def node_as_str(self):
+    def node_type_str(self):
         raise NotImplementedError()
 
     @property
@@ -52,7 +52,7 @@ class NodeDefinition(NamedConfigurableDefinition):
         return self._name
 
     def describe_node(self):
-        return f"{self.node_as_str} '{self.name}'"
+        return f"{self.node_type_str} '{self.name}'"
 
     @property
     def description(self):

--- a/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/i_solid_definition.py
@@ -51,7 +51,6 @@ class NodeDefinition(NamedConfigurableDefinition):
     def name(self):
         return self._name
 
-    @property
     def describe_node(self):
         return f"{self.node_as_str} '{self.name}'"
 

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -46,8 +46,12 @@ class JobDefinition(PipelineDefinition):
             version_strategy=version_strategy,
         )
 
+    @property
+    def target_type(self):
+        return "job"
+
     def describe_target(self):
-        return f"job '{self.name}'"
+        return f"{self.target_type} '{self.name}'"
 
     def execute_in_process(
         self,

--- a/python_modules/dagster/dagster/core/definitions/op.py
+++ b/python_modules/dagster/dagster/core/definitions/op.py
@@ -3,5 +3,5 @@ from .solid import SolidDefinition
 
 class OpDefinition(SolidDefinition):
     @property
-    def node_as_str(self) -> str:
+    def node_type_str(self) -> str:
         return "op"

--- a/python_modules/dagster/dagster/core/definitions/op.py
+++ b/python_modules/dagster/dagster/core/definitions/op.py
@@ -2,4 +2,6 @@ from .solid import SolidDefinition
 
 
 class OpDefinition(SolidDefinition):
-    pass
+    @property
+    def node_as_str(self) -> str:
+        return "op"

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -941,8 +941,8 @@ def _checked_input_resource_reqs_for_mode(
                         raise DagsterInvalidDefinitionError(
                             f'Input "{handle.input_def.name}" of {node.describe_node()} is '
                             f'connected to output "{source_output_handle.output_def.name}" '
-                            f'of {source_output_handle.solid.describe_node()}. That output does not '
-                            'have an output '
+                            f"of {source_output_handle.solid.describe_node()}. That output does not "
+                            "have an output "
                             f"manager that knows how to load inputs, so we don't know how "
                             f"to load the input. To address this, assign an IOManager to "
                             f"the upstream output."
@@ -956,12 +956,12 @@ def _checked_input_resource_reqs_for_mode(
                     and not input_def.root_manager_key
                 ):
                     raise DagsterInvalidDefinitionError(
-                        'Input "{input_name}" in {described_node} is not connected to '
+                        "Input '{input_name}' in {described_node} is not connected to "
                         "the output of a previous node and can not be loaded from configuration, "
-                        "creating an impossible to execute job. "
+                        "making it impossible to execute. "
                         "Possible solutions are:\n"
-                        '  * add a dagster_type_loader for the type "{dagster_type}"\n'
-                        '  * connect "{input_name}" to the output of another node\n'.format(
+                        "  * add a dagster_type_loader for the type '{dagster_type}'\n"
+                        "  * connect '{input_name}' to the output of another node\n".format(
                             described_node=node.describe_node(),
                             input_name=input_def.name,
                             dagster_type=input_def.dagster_type.display_name,

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -860,7 +860,8 @@ def _checked_type_resource_reqs_for_mode(
                         error_msg = _get_missing_resource_error_msg(
                             resource_type="resource",
                             resource_key=required_resource,
-                            descriptor=f"the plugin on type '{dagster_type.display_name}'",
+                            descriptor=f"the plugin '{plugin.__name__}' on type "
+                            f"'{dagster_type.display_name}' (used with storages {used_by_storage})",
                             mode_def=mode_def,
                             resource_defs_of_type=mode_resources,
                         )

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -267,6 +267,13 @@ class PipelineDefinition:
         return f"pipeline '{self.name}'"
 
     @property
+    def target_type(self):
+        return "pipeline"
+
+    def describe_target(self):
+        return f"{self.target_type} '{self.name}'"
+
+    @property
     def tags(self):
         return frozentags(**merge_dicts(self._graph_def.tags, self._tags))
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -703,27 +703,26 @@ def _checked_resource_reqs_for_mode(
             for required_resource in solid_def.required_resource_keys:
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by solid def '
-                            f'{solid_def.name}, but is not provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=solid_def.describe_node,
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
             for output_def in solid_def.output_defs:
                 resource_reqs.add(output_def.io_manager_key)
                 if output_def.io_manager_key not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'IO manager key "{output_def.io_manager_key}" is required by output '
-                            f'"{output_def.name}" of solid def {solid_def.name}, but is not '
-                            f'provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide an IO manager for key "{output_def.io_manager_key}", '
-                            f'or change "{output_def.io_manager_key}" to one of the provided IO manager keys: {sorted(mode_output_managers)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="IO manager",
+                        resource_key=output_def.io_manager_key,
+                        descriptor=f"output '{output_def.name}' of {solid_def.describe_node}",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_output_managers,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
     resource_reqs.update(
         _checked_type_resource_reqs_for_mode(
@@ -741,51 +740,54 @@ def _checked_resource_reqs_for_mode(
         for required_resource in intermediate_storage.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    (
-                        f'Resource key "{required_resource}" is required by intermediate storage '
-                        f'"{intermediate_storage.name}", but is not provided by mode "{mode_def.name}". '
-                        f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                        f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                    )
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"intermediate storage {intermediate_storage.name}",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
+
     for solid in solid_dict.values():
         for hook_def in solid.hook_defs:
             for required_resource in hook_def.required_resource_keys:
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by hook "{hook_def.name}", but is not '
-                            f'provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=f"hook '{hook_def.name}'",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
     for hook_def in pipeline_hook_defs:
         for required_resource in hook_def.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    (
-                        f'Resource key "{required_resource}" is required by hook "{hook_def.name}", but is not '
-                        f'provided by mode "{mode_def.name}". '
-                        f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                        f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                    )
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"hook '{hook_def.name}'",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
 
     for resource_key, resource in mode_def.resource_defs.items():
         for required_resource in resource.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    f'Resource key "{required_resource}" is required by resource at key "{resource_key}", '
-                    f'but is not provided by mode "{mode_def.name}" '
-                    f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                    f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"resource at key '{resource_key}'",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
 
     return resource_reqs
 
@@ -805,38 +807,38 @@ def _checked_type_resource_reqs_for_mode(
         for required_resource in dagster_type.required_resource_keys:
             resource_reqs.add(required_resource)
             if required_resource not in mode_resources:
-                raise DagsterInvalidDefinitionError(
-                    (
-                        f'Resource key "{required_resource}" is required by type "{dagster_type.display_name}", '
-                        f'but is not provided by mode "{mode_def.name}". '
-                        f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                        f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                    )
+                error_msg = _get_missing_resource_error_msg(
+                    resource_type="resource",
+                    resource_key=required_resource,
+                    descriptor=f"type '{dagster_type.display_name}'",
+                    mode_def=mode_def,
+                    resource_defs_of_type=mode_resources,
                 )
+                raise DagsterInvalidDefinitionError(error_msg)
         if dagster_type.loader:
             for required_resource in dagster_type.loader.required_resource_keys():
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by the loader on type '
-                            f'"{dagster_type.display_name}", but is not provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=f"the loader on type '{dagster_type.display_name}'",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
         if dagster_type.materializer:
             for required_resource in dagster_type.materializer.required_resource_keys():
                 resource_reqs.add(required_resource)
                 if required_resource not in mode_resources:
-                    raise DagsterInvalidDefinitionError(
-                        (
-                            f'Resource key "{required_resource}" is required by the materializer on type '
-                            f'"{dagster_type.display_name}", but is not provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                            f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                        )
+                    error_msg = _get_missing_resource_error_msg(
+                        resource_type="resource",
+                        resource_key=required_resource,
+                        descriptor=f"the materializer on type '{dagster_type.display_name}'",
+                        mode_def=mode_def,
+                        resource_defs_of_type=mode_resources,
                     )
+                    raise DagsterInvalidDefinitionError(error_msg)
 
         for plugin in dagster_type.auto_plugins:
             used_by_storage = set(
@@ -851,15 +853,14 @@ def _checked_type_resource_reqs_for_mode(
                 for required_resource in plugin.required_resource_keys():
                     resource_reqs.add(required_resource)
                     if required_resource not in mode_resources:
-                        raise DagsterInvalidDefinitionError(
-                            (
-                                f'Resource key "{required_resource}" is required by the plugin "{plugin.__name__}" '
-                                f'on type "{dagster_type.display_name}" (used with storages {used_by_storage}), '
-                                f'but is not provided by mode "{mode_def.name}". '
-                                f'In mode "{mode_def.name}", provide a resource for key "{required_resource}", '
-                                f'or change "{required_resource}" to one of the provided resources keys: {sorted(mode_resources)}.'
-                            )
+                        error_msg = _get_missing_resource_error_msg(
+                            resource_type="resource",
+                            resource_key=required_resource,
+                            descriptor=f"the plugin on type '{dagster_type.display_name}'",
+                            mode_def=mode_def,
+                            resource_defs_of_type=mode_resources,
                         )
+                        raise DagsterInvalidDefinitionError(error_msg)
     return resource_reqs
 
 
@@ -933,10 +934,10 @@ def _checked_input_resource_reqs_for_mode(
                     output_manager_def = mode_def.resource_defs[output_manager_key]
                     if not isinstance(output_manager_def, IInputManagerDefinition):
                         raise DagsterInvalidDefinitionError(
-                            f'Input "{handle.input_def.name}" of solid "{node.name}" is '
+                            f'Input "{handle.input_def.name}" of {node.describe_node} is '
                             f'connected to output "{source_output_handle.output_def.name}" '
-                            f'of solid "{source_output_handle.solid.name}". In mode '
-                            f'"{mode_def.name}", that output does not have an output '
+                            f'of {source_output_handle.solid.describe_node}. That output does not '
+                            'have an output '
                             f"manager that knows how to load inputs, so we don't know how "
                             f"to load the input. To address this, assign an IOManager to "
                             f"the upstream output."
@@ -950,13 +951,13 @@ def _checked_input_resource_reqs_for_mode(
                     and not input_def.root_manager_key
                 ):
                     raise DagsterInvalidDefinitionError(
-                        'Input "{input_name}" in solid "{solid_name}" is not connected to '
-                        "the output of a previous solid and can not be loaded from configuration, "
-                        "creating an impossible to execute pipeline. "
+                        'Input "{input_name}" in {described_node} is not connected to '
+                        "the output of a previous node and can not be loaded from configuration, "
+                        "creating an impossible to execute job. "
                         "Possible solutions are:\n"
                         '  * add a dagster_type_loader for the type "{dagster_type}"\n'
-                        '  * connect "{input_name}" to the output of another solid\n'.format(
-                            solid_name=node.name,
+                        '  * connect "{input_name}" to the output of another node\n'.format(
+                            described_node=node.describe_node,
                             input_name=input_def.name,
                             dagster_type=input_def.dagster_type.display_name,
                         )
@@ -968,15 +969,35 @@ def _checked_input_resource_reqs_for_mode(
                 if input_def.root_manager_key:
                     resource_reqs.add(input_def.root_manager_key)
                     if input_def.root_manager_key not in mode_def.resource_defs:
-                        raise DagsterInvalidDefinitionError(
-                            f'Root input manager key "{input_def.root_manager_key}" is required by '
-                            f'unsatisfied input "{input_def.name}" of solid {node.name}, but is not '
-                            f'provided by mode "{mode_def.name}". '
-                            f'In mode "{mode_def.name}", provide a root input manager for key "{input_def.root_manager_key}", '
-                            f'or change "{input_def.root_manager_key}" to one of the provided root input managers keys: {sorted(mode_root_input_managers)}.'
+                        error_msg = _get_missing_resource_error_msg(
+                            resource_type="root input manager",
+                            resource_key=input_def.root_manager_key,
+                            descriptor=f"unsatisfied input '{input_def.name}' of {node.describe_node}",
+                            mode_def=mode_def,
+                            resource_defs_of_type=mode_root_input_managers,
                         )
+                        raise DagsterInvalidDefinitionError(error_msg)
 
     return resource_reqs
+
+
+def _get_missing_resource_error_msg(
+    resource_type, resource_key, descriptor, mode_def, resource_defs_of_type
+):
+    if mode_def.name == "default":
+        return (
+            f"{resource_type} key '{resource_key}' is required by "
+            f"{descriptor}, but is not provided. Provide a {resource_type} for key '{resource_key}',  "
+            f"or change '{resource_key}' to one of the provided {resource_type} keys: "
+            f"{sorted(resource_defs_of_type)}."
+        )
+    else:
+        return (
+            f"{resource_type} key '{resource_key}' is required by "
+            f"{descriptor}, but is not provided by mode '{mode_def.name}'. "
+            f"In mode '{mode_def.name}', provide a {resource_type} for key '{resource_key}', "
+            f"or change '{resource_key}' to one of the provided root input managers keys: {sorted(resource_defs_of_type)}."
+        )
 
 
 def _build_all_node_defs(node_defs: List[NodeDefinition]) -> Dict[str, NodeDefinition]:
@@ -986,7 +1007,7 @@ def _build_all_node_defs(node_defs: List[NodeDefinition]) -> Dict[str, NodeDefin
             if node_def.name in all_defs:
                 if all_defs[node_def.name] != node_def:
                     raise DagsterInvalidDefinitionError(
-                        'Detected conflicting solid definitions with the same name "{name}"'.format(
+                        'Detected conflicting node definitions with the same name "{name}"'.format(
                             name=node_def.name
                         )
                     )

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -710,7 +710,7 @@ def _checked_resource_reqs_for_mode(
                     error_msg = _get_missing_resource_error_msg(
                         resource_type="resource",
                         resource_key=required_resource,
-                        descriptor=solid_def.describe_node,
+                        descriptor=solid_def.describe_node(),
                         mode_def=mode_def,
                         resource_defs_of_type=mode_resources,
                     )
@@ -722,7 +722,7 @@ def _checked_resource_reqs_for_mode(
                     error_msg = _get_missing_resource_error_msg(
                         resource_type="IO manager",
                         resource_key=output_def.io_manager_key,
-                        descriptor=f"output '{output_def.name}' of {solid_def.describe_node}",
+                        descriptor=f"output '{output_def.name}' of {solid_def.describe_node()}",
                         mode_def=mode_def,
                         resource_defs_of_type=mode_output_managers,
                     )
@@ -938,9 +938,9 @@ def _checked_input_resource_reqs_for_mode(
                     output_manager_def = mode_def.resource_defs[output_manager_key]
                     if not isinstance(output_manager_def, IInputManagerDefinition):
                         raise DagsterInvalidDefinitionError(
-                            f'Input "{handle.input_def.name}" of {node.describe_node} is '
+                            f'Input "{handle.input_def.name}" of {node.describe_node()} is '
                             f'connected to output "{source_output_handle.output_def.name}" '
-                            f'of {source_output_handle.solid.describe_node}. That output does not '
+                            f'of {source_output_handle.solid.describe_node()}. That output does not '
                             'have an output '
                             f"manager that knows how to load inputs, so we don't know how "
                             f"to load the input. To address this, assign an IOManager to "
@@ -961,7 +961,7 @@ def _checked_input_resource_reqs_for_mode(
                         "Possible solutions are:\n"
                         '  * add a dagster_type_loader for the type "{dagster_type}"\n'
                         '  * connect "{input_name}" to the output of another node\n'.format(
-                            described_node=node.describe_node,
+                            described_node=node.describe_node(),
                             input_name=input_def.name,
                             dagster_type=input_def.dagster_type.display_name,
                         )
@@ -976,7 +976,7 @@ def _checked_input_resource_reqs_for_mode(
                         error_msg = _get_missing_resource_error_msg(
                             resource_type="root input manager",
                             resource_key=input_def.root_manager_key,
-                            descriptor=f"unsatisfied input '{input_def.name}' of {node.describe_node}",
+                            descriptor=f"unsatisfied input '{input_def.name}' of {node.describe_node()}",
                             mode_def=mode_def,
                             resource_defs_of_type=mode_root_input_managers,
                         )

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -263,9 +263,6 @@ class PipelineDefinition:
     def name(self):
         return self._name
 
-    def describe_target(self):
-        return f"pipeline '{self.name}'"
-
     @property
     def target_type(self):
         return "pipeline"

--- a/python_modules/dagster/dagster/core/definitions/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/repository.py
@@ -509,7 +509,7 @@ class CachingRepositoryData(RepositoryData):
                 if definition.name in pipelines and pipelines[definition.name] != definition:
                     raise DagsterInvalidDefinitionError(
                         "Duplicate {target_type} definition found for {target}".format(
-                            target_type=definition.target_type, target=definition.describe_target
+                            target_type=definition.target_type, target=definition.describe_target()
                         )
                     )
                 pipelines[definition.name] = definition

--- a/python_modules/dagster/dagster/core/definitions/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/repository.py
@@ -508,8 +508,8 @@ class CachingRepositoryData(RepositoryData):
             if isinstance(definition, PipelineDefinition):
                 if definition.name in pipelines and pipelines[definition.name] != definition:
                     raise DagsterInvalidDefinitionError(
-                        "Duplicate pipeline definition found for pipeline {pipeline_name}".format(
-                            pipeline_name=definition.name
+                        "Duplicate {target_type} definition found for {target}".format(
+                            target_type=definition.target_type, target=definition.describe_target
                         )
                     )
                 pipelines[definition.name] = definition
@@ -747,7 +747,7 @@ class CachingRepositoryData(RepositoryData):
 
         if schedule.pipeline_name not in pipelines:
             raise DagsterInvalidDefinitionError(
-                f'ScheduleDefinition "{schedule.name}" targets pipeline "{schedule.pipeline_name}" '
+                f'ScheduleDefinition "{schedule.name}" targets job/pipeline "{schedule.pipeline_name}" '
                 "which was not found in this repository."
             )
 
@@ -762,7 +762,7 @@ class CachingRepositoryData(RepositoryData):
         for target in sensor.targets:
             if target.pipeline_name not in pipelines:
                 raise DagsterInvalidDefinitionError(
-                    f'SensorDefinition "{sensor.name}" targets pipeline "{target.pipeline_name}" '
+                    f'SensorDefinition "{sensor.name}" targets job/pipeline "{sensor.pipeline_name}" '
                     "which was not found in this repository."
                 )
 

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -226,15 +226,15 @@ def get_input_manager_input_field(
 ) -> Optional[Field]:
     if input_def.root_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for solid "{solid.name}" requires root_manager_key '
+            f'Input "{input_def.name}" for {solid.describe_node} requires root_manager_key '
             f'"{input_def.root_manager_key}", but no resource has been provided. Please include a '
-            f"resource definition for that key in the resource_defs of your ModeDefinition."
+            f"resource definition for that key in the provided resource_defs."
         )
 
     root_manager = resource_defs[input_def.root_manager_key]
     if not isinstance(root_manager, IInputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for solid "{solid.name}" requires root_manager_key '
+            f'Input "{input_def.name}" for {solid.describe_node} requires root_manager_key '
             f'"{input_def.root_manager_key}", but the resource definition provided is not an '
             "IInputManagerDefinition"
         )
@@ -291,13 +291,13 @@ def get_output_manager_output_field(
 ) -> Optional[ConfigType]:
     if output_def.io_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Output "{output_def.name}" for solid "{solid.name}" requires io_manager_key '
+            f'Output "{output_def.name}" for {solid.describe_node} requires io_manager_key '
             f'"{output_def.io_manager_key}", but no resource has been provided. Please include a '
-            f"resource definition for that key in the resource_defs of your ModeDefinition."
+            f"resource definition for that key in the provided resource_defs."
         )
     if not isinstance(resource_defs[output_def.io_manager_key], IOutputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Output "{output_def.name}" for solid "{solid.name}" requires io_manager_key '
+            f'Output "{output_def.name}" for {solid.describe_node} requires io_manager_key '
             f'"{output_def.io_manager_key}", but the resource definition provided is not an '
             "IOutputManagerDefinition"
         )

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -226,7 +226,7 @@ def get_input_manager_input_field(
 ) -> Optional[Field]:
     if input_def.root_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for {solid.describe_node} requires root_manager_key '
+            f'Input "{input_def.name}" for {solid.describe_node()} requires root_manager_key '
             f'"{input_def.root_manager_key}", but no resource has been provided. Please include a '
             f"resource definition for that key in the provided resource_defs."
         )
@@ -234,7 +234,7 @@ def get_input_manager_input_field(
     root_manager = resource_defs[input_def.root_manager_key]
     if not isinstance(root_manager, IInputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for {solid.describe_node} requires root_manager_key '
+            f'Input "{input_def.name}" for {solid.describe_node()} requires root_manager_key '
             f'"{input_def.root_manager_key}", but the resource definition provided is not an '
             "IInputManagerDefinition"
         )
@@ -291,13 +291,13 @@ def get_output_manager_output_field(
 ) -> Optional[ConfigType]:
     if output_def.io_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Output "{output_def.name}" for {solid.describe_node} requires io_manager_key '
+            f'Output "{output_def.name}" for {solid.describe_node()} requires io_manager_key '
             f'"{output_def.io_manager_key}", but no resource has been provided. Please include a '
             f"resource definition for that key in the provided resource_defs."
         )
     if not isinstance(resource_defs[output_def.io_manager_key], IOutputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Output "{output_def.name}" for {solid.describe_node} requires io_manager_key '
+            f'Output "{output_def.name}" for {solid.describe_node()} requires io_manager_key '
             f'"{output_def.io_manager_key}", but the resource definition provided is not an '
             "IOutputManagerDefinition"
         )

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -226,16 +226,16 @@ def get_input_manager_input_field(
 ) -> Optional[Field]:
     if input_def.root_manager_key not in resource_defs:
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for {solid.describe_node()} requires root_manager_key '
-            f'"{input_def.root_manager_key}", but no resource has been provided. Please include a '
+            f"Input '{input_def.name}' for {solid.describe_node()} requires root_manager_key "
+            f"'{input_def.root_manager_key}', but no resource has been provided. Please include a "
             f"resource definition for that key in the provided resource_defs."
         )
 
     root_manager = resource_defs[input_def.root_manager_key]
     if not isinstance(root_manager, IInputManagerDefinition):
         raise DagsterInvalidDefinitionError(
-            f'Input "{input_def.name}" for {solid.describe_node()} requires root_manager_key '
-            f'"{input_def.root_manager_key}", but the resource definition provided is not an '
+            f"Input '{input_def.name}' for {solid.describe_node()} requires root_manager_key "
+            f"'{input_def.root_manager_key}', but the resource definition provided is not an "
             "IInputManagerDefinition"
         )
 

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -171,7 +171,7 @@ class SolidDefinition(NodeDefinition):
                 return solid_invocation_result(self, None, *args, **kwargs)
 
     @property
-    def node_as_str(self) -> str:
+    def node_type_str(self) -> str:
         return "solid"
 
     @property
@@ -359,7 +359,7 @@ class CompositeSolidDefinition(GraphDefinition):
         )
 
     @property
-    def node_as_str(self):
+    def node_type_str(self):
         return "composite solid"
 
 

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -171,6 +171,10 @@ class SolidDefinition(NodeDefinition):
                 return solid_invocation_result(self, None, *args, **kwargs)
 
     @property
+    def node_as_str(self) -> str:
+        return "solid"
+
+    @property
     def compute_fn(self) -> Union[Callable[..., Any], "DecoratedSolidFunction"]:
         return self._compute_fn
 
@@ -353,6 +357,10 @@ class CompositeSolidDefinition(GraphDefinition):
             tags=self.tags,
             positional_inputs=self.positional_inputs,
         )
+
+    @property
+    def node_as_str(self):
+        return "composite solid"
 
 
 def _check_io_managers_on_composite_solid(

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -337,9 +337,9 @@ class CompositeSolidDefinition(GraphDefinition):
         config_mapping = self._config_mapping
         if config_mapping is None:
             raise DagsterInvalidDefinitionError(
-                "Only composite solids utilizing config mapping can be pre-configured. The solid "
-                '"{graph_name}" does not have a config mapping, and thus has nothing to be '
-                "configured.".format(graph_name=self.name)
+                "Only composite solids utilizing config mapping can be pre-configured. The "
+                'composite solid "{graph_name}" does not have a config mapping, and thus has '
+                "nothing to be configured.".format(graph_name=self.name)
             )
 
         return CompositeSolidDefinition(

--- a/python_modules/dagster/dagster/core/definitions/solid_container.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_container.py
@@ -34,7 +34,7 @@ def validate_dependency_dict(
     for key, dep_dict in dependencies.items():
         if not (isinstance(key, str) or isinstance(key, SolidInvocation)):
             raise DagsterInvalidDefinitionError(
-                prelude + "Expected str or SolidInvocation key in the top level dict. "
+                prelude + "Expected str or NodeInvocation key in the top level dict. "
                 "Received value {val} of type {type}".format(val=key, type=type(key))
             )
         if not isinstance(dep_dict, dict):
@@ -202,7 +202,7 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
                 if from_solid == dep.solid:
                     raise DagsterInvalidDefinitionError(
                         (
-                            "Invalid dependencies: circular reference detected in solid "
+                            "Invalid dependencies: circular reference detected in node "
                             '"{from_solid}" input "{from_input}"'
                         ).format(from_solid=from_solid, from_input=from_input)
                     )
@@ -211,14 +211,14 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
                     aliased_solid = alias_to_name.get(from_solid)
                     if aliased_solid == from_solid:
                         raise DagsterInvalidDefinitionError(
-                            'Invalid dependencies: solid "{solid}" in dependency dictionary not '
-                            "found in solid list".format(solid=from_solid)
+                            'Invalid dependencies: node "{solid}" in dependency dictionary not '
+                            "found in node list".format(solid=from_solid)
                         )
                     else:
                         raise DagsterInvalidDefinitionError(
                             (
-                                'Invalid dependencies: solid "{aliased_solid}" (aliased by '
-                                '"{from_solid}" in dependency dictionary) not found in solid list'
+                                'Invalid dependencies: node "{aliased_solid}" (aliased by '
+                                '"{from_solid}" in dependency dictionary) not found in node list'
                             ).format(aliased_solid=aliased_solid, from_solid=from_solid)
                         )
                 if not solid_dict[from_solid].definition.has_input(from_input):
@@ -240,16 +240,16 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
 
                 if not dep.solid in solid_dict:
                     raise DagsterInvalidDefinitionError(
-                        'Invalid dependencies: solid "{dep.solid}" not found in solid list. '
-                        'Listed as dependency for solid "{from_solid}" input "{from_input}" '.format(
+                        'Invalid dependencies: node "{dep.solid}" not found in node list. '
+                        'Listed as dependency for node "{from_solid}" input "{from_input}" '.format(
                             dep=dep, from_solid=from_solid, from_input=from_input
                         )
                     )
 
                 if not solid_dict[dep.solid].definition.has_output(dep.output):
                     raise DagsterInvalidDefinitionError(
-                        'Invalid dependencies: solid "{dep.solid}" does not have output '
-                        '"{dep.output}". Listed as dependency for solid "{from_solid} input '
+                        'Invalid dependencies: node "{dep.solid}" does not have output '
+                        '"{dep.output}". Listed as dependency for node "{from_solid} input '
                         '"{from_input}"'.format(
                             dep=dep, from_solid=from_solid, from_input=from_input
                         )
@@ -260,7 +260,7 @@ def _validate_dependencies(dependencies, solid_dict, alias_to_name):
 
                 if dep_def.is_fan_in() and not input_def.dagster_type.supports_fan_in:
                     raise DagsterInvalidDefinitionError(
-                        f'Invalid dependencies: for solid "{dep.solid}" input "{input_def.name}", the '
+                        f'Invalid dependencies: for node "{dep.solid}" input "{input_def.name}", the '
                         f'DagsterType "{input_def.dagster_type.display_name}" does not support fanning in '
                         "(MultiDependencyDefinition). Use the List type, since fanning in will result in a list."
                     )
@@ -278,8 +278,8 @@ def _validate_input_output_pair(input_def, output_def, from_solid, dep):
     ):
         raise DagsterInvalidDefinitionError(
             (
-                'Input "{input_def.name}" to solid "{from_solid}" can not depend on the output '
-                '"{output_def.name}" from solid "{dep.solid}". '
+                'Input "{input_def.name}" to node "{from_solid}" can not depend on the output '
+                '"{output_def.name}" from node "{dep.solid}". '
                 'Input "{input_def.name}" expects a value of type '
                 '{input_def.dagster_type.display_name} and output "{output_def.name}" returns '
                 "type {output_def.dagster_type.display_name}{extra}."

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -180,7 +180,7 @@ def dagster_type_loader(
         if missing_positional:
             raise DagsterInvalidDefinitionError(
                 "@dagster_type_loader '{solid_name}' decorated function does not have required positional "
-                "parameter '{missing_param}'. Solid functions should only have keyword arguments "
+                "parameter '{missing_param}'. @dagster_type_loader decorated functions should only have keyword arguments "
                 "that match input names and a first positional parameter named 'context'.".format(
                     solid_name=func.__name__, missing_param=missing_positional
                 )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
@@ -80,7 +80,7 @@ def test_pipeline_with_invalid_definition_snapshot_api_grpc():
             assert re.match(
                 (
                     r".*DagsterInvalidDefinitionError[\s\S]*"
-                    r'add a dagster_type_loader for the type "InputTypeWithoutHydration"'
+                    r"add a dagster_type_loader for the type 'InputTypeWithoutHydration'"
                 ),
                 error_info.cause.message,
             )

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
@@ -796,6 +796,7 @@ def test_configuring_composite_solid_with_no_config_mapping():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Only composite solids utilizing config mapping can be pre-configured. The solid "composite_without_config_fn"',
+        match='Only composite solids utilizing config mapping can be pre-configured. The composite '
+        'solid "composite_without_config_fn"',
     ):
         configured(composite_without_config_fn, name="configured_composite")({})

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
@@ -796,7 +796,7 @@ def test_configuring_composite_solid_with_no_config_mapping():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Only composite solids utilizing config mapping can be pre-configured. The composite '
+        match="Only composite solids utilizing config mapping can be pre-configured. The composite "
         'solid "composite_without_config_fn"',
     ):
         configured(composite_without_config_fn, name="configured_composite")({})

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -165,7 +165,7 @@ def test_composite_with_duplicate_solids():
     solid_1, solid_2 = get_duplicate_solids()
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Detected conflicting solid definitions with the same name",
+        match="Detected conflicting node definitions with the same name",
     ):
 
         @composite_solid

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -178,7 +178,7 @@ def test_pipeline_with_duplicate_solids():
     solid_1, solid_2 = get_duplicate_solids()
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Detected conflicting solid definitions with the same name",
+        match="Detected conflicting node definitions with the same name",
     ):
 
         @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definition_errors.py
@@ -36,7 +36,7 @@ def solid_a_b_list():
 def test_create_pipeline_with_bad_solids_list():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='"solids" arg to "a_pipeline" is not a list. Got',
+        match='"nodes" arg to "a_pipeline" is not a list. Got',
     ):
         PipelineDefinition(
             name="a_pipeline", solid_defs=define_stub_solid("stub", [{"a key": "a value"}])
@@ -54,7 +54,7 @@ def test_circular_dep():
 
 def test_from_solid_not_there():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='solid "NOTTHERE" in dependency dictionary not found'
+        DagsterInvalidDefinitionError, match='node "NOTTHERE" in dependency dictionary not found'
     ):
         PipelineDefinition(
             solid_defs=solid_a_b_list(),
@@ -80,7 +80,7 @@ def test_from_non_existant_input():
 
 def test_to_solid_not_there():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='solid "NOTTHERE" not found in solid list'
+        DagsterInvalidDefinitionError, match='node "NOTTHERE" not found in node list'
     ):
         PipelineDefinition(
             solid_defs=solid_a_b_list(),
@@ -91,7 +91,7 @@ def test_to_solid_not_there():
 
 def test_to_solid_output_not_there():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='solid "A" does not have output "NOTTHERE"'
+        DagsterInvalidDefinitionError, match='node "A" does not have output "NOTTHERE"'
     ):
         PipelineDefinition(
             solid_defs=solid_a_b_list(),
@@ -102,7 +102,7 @@ def test_to_solid_output_not_there():
 
 def test_invalid_item_in_solid_list():
     with pytest.raises(
-        DagsterInvalidDefinitionError, match="Invalid item in solid list: 'not_a_solid'"
+        DagsterInvalidDefinitionError, match="Invalid item in node list: 'not_a_solid'"
     ):
         PipelineDefinition(
             solid_defs=["not_a_solid"],

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions.py
@@ -157,7 +157,7 @@ def test_mapper_errors():
         )
     assert (
         str(excinfo_1.value)
-        == 'Invalid dependencies: solid "solid_b" in dependency dictionary not found in solid list'
+        == 'Invalid dependencies: node "solid_b" in dependency dictionary not found in node list'
     )
 
     with pytest.raises(DagsterInvalidDefinitionError) as excinfo_2:
@@ -172,7 +172,7 @@ def test_mapper_errors():
         )
     assert (
         str(excinfo_2.value)
-        == 'Invalid dependencies: solid "solid_b" (aliased by "solid_c" in dependency dictionary) not found in solid list'
+        == 'Invalid dependencies: node "solid_b" (aliased by "solid_c" in dependency dictionary) not found in node list'
     )
 
 
@@ -274,7 +274,7 @@ def test_composite_mapping_collision():
     def add(a, b):
         return a + b
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="already satisfied by solid output"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="already satisfied by output"):
         CompositeSolidDefinition(
             name="add_one",
             solid_defs=[return_one, add],

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -10,9 +10,7 @@ from dagster import (
     daily_partitioned_config,
     daily_schedule,
     graph,
-    hourly_schedule,
     lambda_solid,
-    monthly_schedule,
     op,
     pipeline,
     repository,
@@ -20,7 +18,6 @@ from dagster import (
     schedule_from_partitions,
     sensor,
     solid,
-    weekly_schedule,
 )
 from dagster.core.definitions.partition import (
     Partition,
@@ -126,7 +123,7 @@ def test_non_lazy_pipeline_dict():
 
 def test_conflict():
     called = defaultdict(int)
-    with pytest.raises(Exception, match="Duplicate pipeline definition found for pipeline foo"):
+    with pytest.raises(Exception, match="Duplicate pipeline definition found for pipeline 'foo'"):
 
         @repository
         def _some_repo():
@@ -185,7 +182,7 @@ def test_bad_schedule():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='targets pipeline "foo" which was not found in this repository',
+        match='targets job/pipeline "foo" which was not found in this repository',
     ):
 
         @repository
@@ -202,7 +199,7 @@ def test_bad_sensor():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='targets pipeline "foo" which was not found in this repository',
+        match='targets job/pipeline "foo" which was not found in this repository',
     ):
 
         @repository
@@ -358,7 +355,7 @@ def test_dupe_graph_defs():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         # expect to change as migrate to graph/job
-        match="Duplicate pipeline definition found for pipeline foo",
+        match="Duplicate pipeline definition found for pipeline 'foo'",
     ):
 
         @repository

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -149,7 +149,7 @@ def test_hook_resource_error():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Resource key "resource_b" is required by hook "a_hook"',
+        match="resource key 'resource_b' is required by hook 'a_hook'",
     ):
         PipelineDefinition(
             solid_defs=[a_solid],
@@ -469,10 +469,6 @@ def test_hook_graph_job_op():
 
 
 def test_hook_context_op_solid_provided():
-    @success_hook()
-    def hook_one(context):
-        pass
-
     @op
     def hook_op(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_run.py
@@ -574,7 +574,7 @@ def test_hook_resource_mismatch():
         pass
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='Resource key "b" is required by hook "a_hook"'
+        DagsterInvalidDefinitionError, match="resource key 'b' is required by hook 'a_hook'"
     ):
 
         @a_hook
@@ -583,7 +583,7 @@ def test_hook_resource_mismatch():
             a_solid()
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='Resource key "b" is required by hook "a_hook"'
+        DagsterInvalidDefinitionError, match="resource key 'b' is required by hook 'a_hook'"
     ):
 
         @pipeline(mode_defs=[ModeDefinition(resource_defs={"a": resource_a})])

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -718,7 +718,7 @@ def test_type_missing_resource_fails():
     def custom_type_solid(_):
         return "A"
 
-    with pytest.raises(DagsterInvalidDefinitionError, match='required by type "NeedsA"'):
+    with pytest.raises(DagsterInvalidDefinitionError, match="required by type 'NeedsA'"):
 
         @pipeline
         def _type_check_pipeline():
@@ -740,7 +740,7 @@ def test_loader_missing_resource_fails():
         return "A"
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='required by the loader on type "CustomType"'
+        DagsterInvalidDefinitionError, match="required by the loader on type 'CustomType'"
     ):
 
         @pipeline
@@ -761,7 +761,7 @@ def test_materialize_missing_resource_fails():
         return "A"
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match='required by the materializer on type "CustomType"'
+        DagsterInvalidDefinitionError, match="required by the materializer on type 'CustomType'"
     ):
 
         @pipeline
@@ -772,7 +772,7 @@ def test_materialize_missing_resource_fails():
 def test_plugin_missing_resource_fails():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r'required by the plugin "CustomStoragePlugin" on type "CustomType" \(used with storages',
+        match=r"required by the plugin 'CustomStoragePlugin' on type 'CustomType' \(used with storages",
     ):
         define_plugin_pipeline(mode_defines_resource=False)
 
@@ -871,7 +871,7 @@ def test_root_input_manager_missing_fails():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r'"missing_root_input_manager" is required by unsatisfied input "root_input" of solid requires_missing_root_input_manager',
+        match=r"'missing_root_input_manager' is required by unsatisfied input 'root_input' of solid 'requires_missing_root_input_manager'",
     ):
 
         @pipeline
@@ -886,7 +886,7 @@ def test_io_manager_missing_fails():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r'"missing_io_manager" is required by output "result" of solid def requires_missing_io_manager',
+        match=r"'missing_io_manager' is required by output 'result' of solid 'requires_missing_io_manager'",
     ):
 
         @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -1,4 +1,3 @@
-import re
 import typing
 
 import pytest
@@ -200,11 +199,9 @@ def test_dict_type_loader_typing_fail():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=re.compile(
-            'Input "dict_input" in solid '
-            '"emit_dict" is not connected to the output of a previous solid and can not be loaded '
-            "from configuration, creating an impossible to execute pipeline. Possible solutions are:"
-        ),
+        match="Input 'dict_input' in solid "
+        "'emit_dict' is not connected to the output of a previous node and can not be loaded "
+        "from configuration, making it impossible to execute. Possible solutions are:",
     ):
         execute_solid(
             emit_dict,

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
@@ -330,8 +330,8 @@ def test_resource_not_input_manager():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='Input "_input" for solid "solid_requires_manager" requires root_manager_key '
-        '"not_manager", but the resource definition provided is not an '
+        match="Input '_input' for solid 'solid_requires_manager' requires root_manager_key "
+        "'not_manager', but the resource definition provided is not an "
         "IInputManagerDefinition",
     ):
         execute_pipeline(basic)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_intermediate_storage_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_intermediate_storage_resources.py
@@ -88,7 +88,7 @@ def test_resource_requirements_fail():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r'"yup" is required by intermediate storage "storage_with_req"',
+        match=r"'yup' is required by intermediate storage storage_with_req",
     ):
 
         @pipeline(

--- a/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mode_definitions.py
@@ -43,7 +43,7 @@ def test_error_on_invalid_resource_key():
         return ""
 
     with pytest.raises(CheckError, match="test-foo"):
-        test_mode_def = ModeDefinition(
+        ModeDefinition(
             resource_defs={
                 "test-foo": test_resource,
             },
@@ -186,7 +186,7 @@ def test_mode_with_resource_deps():
     assert called["count"] == 1
 
     with pytest.raises(
-        DagsterInvalidDefinitionError, match=r'"a" is required by solid def requires_a'
+        DagsterInvalidDefinitionError, match=r"'a' is required by solid 'requires_a'"
     ):
         PipelineDefinition(
             name="mode_with_bad_deps",

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -356,8 +356,8 @@ def test_attempted_invocation_in_composition():
         pass
 
     msg = (
-        "Must pass the output from previous solid invocations or inputs to the composition "
-        "function as inputs when invoking solids during composition."
+        "Must pass the output from previous node invocations or inputs to the composition "
+        "function as inputs when invoking nodes during composition."
     )
     with pytest.raises(
         DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
@@ -113,7 +113,7 @@ def test_multi_composite_out():
 def test_multi_composite_in():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a solid that is already downstream of another dynamic output',
+        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a node that is already downstream of another dynamic output',
     ):
 
         @composite_solid
@@ -128,7 +128,7 @@ def test_multi_composite_in():
 def test_multi_composite_in_2():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a solid that is already downstream of another dynamic output',
+        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a node that is already downstream of another dynamic output',
     ):
 
         @composite_solid
@@ -147,7 +147,7 @@ def test_multi_composite_in_2():
 def test_multi_composite_in_3():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a solid that is already downstream of another dynamic output',
+        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a node that is already downstream of another dynamic output',
     ):
 
         @composite_solid
@@ -162,7 +162,7 @@ def test_multi_composite_in_3():
 def test_multi_composite_in_4():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a solid that is already downstream of another dynamic output',
+        match='cannot be downstream of dynamic output "dynamic_solid:result" since input "a" maps to a node that is already downstream of another dynamic output',
     ):
 
         @composite_solid


### PR DESCRIPTION
This error is used all over the place, so involves a bunch of different changes.

Regarding migrating error messages, I think if we needed to do op/solid it would generally be OK, but we actually need to do graph/op/solid in a lot of places, which is a pretty rough experience IMO. In general, for crag versions of error messages, it's already important to distinguish between graphs and ops in a way that we didn't have to distinguish between composite solids and solids before. Because of this, I'm bullish on the idea of error messages being aware of which type of node they are interacting with (it's broadly useful going forward, not machinery we'll rip out later).

A pattern I found useful for errors during composition was to have just the name of the definition type a node represented when switching over errors, as the alias wasn't bound to the node yet.

There are certain error messages where the entity referred to can be either a graph or op and we don't really know which. I opted to use node in these scenarios.