### PR TITLE
Gate mock construction behind lambda for mock_resource

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/resource.py
+++ b/python_modules/dagster/dagster/core/definitions/resource.py
@@ -150,8 +150,8 @@ class ResourceDefinition(AnonymousConfigurableDefinition):
         """
         from unittest import mock
 
-        return ResourceDefinition.hardcoded_resource(
-            value=mock.MagicMock(), description=description
+        return ResourceDefinition(
+            resource_fn=lambda _init_context: mock.MagicMock(), description=description
         )
 
     @staticmethod


### PR DESCRIPTION
Don't construct mock object until lambda runs