### PR TITLE
fix bug with log message templating

### DIFF
--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -212,7 +212,7 @@ class DagsterLogHandler(logging.Handler):
 
         # generate some properties for this specific record
         dagster_message_props = DagsterMessageProps(
-            orig_message=record.msg, dagster_event=dagster_meta
+            orig_message=record.getMessage(), dagster_event=dagster_meta
         )
 
         # set the dagster meta info for the record


### PR DESCRIPTION
Fixes: https://github.com/dagster-io/dagster/issues/4787

the .msg property is the original template, so you're meant to use getMessage() instead.


