### PR TITLE
add a loading field to events subscription

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1583,6 +1583,7 @@ union PipelineRunLogsSubscriptionPayload = PipelineRunLogsSubscriptionSuccess | 
 type PipelineRunLogsSubscriptionSuccess {
   run: PipelineRun!
   messages: [PipelineRunEvent!]!
+  hasMorePastEvents: Boolean!
 }
 
 type PipelineRunLogsSubscriptionFailure {

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -241,6 +241,7 @@ const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
           }
           ...RunPipelineRunEventFragment
         }
+        hasMorePastEvents
       }
       ... on PipelineRunLogsSubscriptionFailure {
         missingRunId

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineRunLogsSubscription.ts
@@ -983,6 +983,7 @@ export type PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscript
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess {
   __typename: "PipelineRunLogsSubscriptionSuccess";
   messages: PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionSuccess_messages[];
+  hasMorePastEvents: boolean;
 }
 
 export interface PipelineRunLogsSubscription_pipelineRunLogs_PipelineRunLogsSubscriptionFailure {

--- a/python_modules/dagit/dagit_tests/test_subscriptions.py
+++ b/python_modules/dagit/dagit_tests/test_subscriptions.py
@@ -1,4 +1,5 @@
 import gc
+import time
 from contextlib import contextmanager
 from unittest import mock
 
@@ -129,6 +130,13 @@ def test_event_log_subscription_chunked():
 
             end_subscription(server, context)
             gc.collect()
+
+            # give time for bg loading thread to stop
+            start = time.time()
+            while time.time() - start < 15:
+                if len(objgraph.by_type("SubscriptionObserver")) == 0:
+                    break
+                time.sleep(0.01)
 
             assert len(objgraph.by_type("SubscriptionObserver")) == 0
             assert len(objgraph.by_type("PipelineRunObservableSubscribe")) == 0

--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -207,6 +207,7 @@ subscription subscribeTest($runId: ID!) {
       messages {
         ...messageEventFragment
       }
+      hasMorePastEvents
     }
     ... on PipelineRunLogsSubscriptionFailure {
       missingRunId

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -136,15 +136,18 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
 
         return Observable.create(_get_error_observable)  # pylint: disable=E1101
 
+    def _handle_events(payload):
+        events, loading_past = payload
+        return GraphenePipelineRunLogsSubscriptionSuccess(
+            run=GraphenePipelineRun(run),
+            messages=[from_event_record(event, run.pipeline_name) for event in events],
+            hasMorePastEvents=loading_past,
+        )
+
     # pylint: disable=E1101
     return Observable.create(
         PipelineRunObservableSubscribe(instance, run_id, after_cursor=after)
-    ).map(
-        lambda events: GraphenePipelineRunLogsSubscriptionSuccess(
-            run=GraphenePipelineRun(run),
-            messages=[from_event_record(event, run.pipeline_name) for event in events],
-        )
-    )
+    ).map(_handle_events)
 
 
 def get_compute_log_observable(graphene_info, run_id, step_key, io_type, cursor=None):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/subscription.py
@@ -8,6 +8,7 @@ from .pipeline import GraphenePipelineRun
 class GraphenePipelineRunLogsSubscriptionSuccess(graphene.ObjectType):
     run = graphene.NonNull(GraphenePipelineRun)
     messages = non_null_list(GraphenePipelineRunEvent)
+    hasMorePastEvents = graphene.NonNull(graphene.Boolean)
 
     class Meta:
         name = "PipelineRunLogsSubscriptionSuccess"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/utils.py
@@ -29,6 +29,7 @@ def get_all_logs_for_finished_run_via_subscription(context, run_id):
     # remove information that changes run-to-run
     assert "pipelineRunLogs" in subscribe_result.data
     assert "messages" in subscribe_result.data["pipelineRunLogs"]
+    assert subscribe_result.data["pipelineRunLogs"]["hasMorePastEvents"] is False
     for msg in subscribe_result.data["pipelineRunLogs"]["messages"]:
         msg["runId"] = "<runId dummy value>"
         msg["timestamp"] = "<timestamp dummy value>"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_pipeline_run_observable_subscribe_with_polling.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_pipeline_run_observable_subscribe_with_polling.py
@@ -93,7 +93,7 @@ def test_using_instance(before_watch_config: NumEventsAndCursor, num_events_afte
         call_args = observable_subscribe.observer.on_next.call_args_list
 
         # wait until all events have been captured
-        most_recent_event_processed = lambda: int(call_args[-1][0][0][-1].message)
+        most_recent_event_processed = lambda: int(call_args[-1][0][0][0][-1].message)
         attempts = 10
         while (
             len(call_args) == 0 or most_recent_event_processed() < total_num_events
@@ -102,7 +102,9 @@ def test_using_instance(before_watch_config: NumEventsAndCursor, num_events_afte
             attempts -= 1
 
         # ensure all expected events captured, no duplicates, etc.
-        events_list = [[event_record.message for event_record in call[0][0]] for call in call_args]
+        events_list = [
+            [event_record.message for event_record in call[0][0][0]] for call in call_args
+        ]
         flattened_events_list = [int(message) for lst in events_list for message in lst]
         # PipelineRunObservableSubscribe requests ids > after_cursor + 1
         beginning_cursor = before_watch_config.after_cursor + 2


### PR DESCRIPTION
adds a field to the graphql subscription for events to indicate if the server is streaming events back still or has switched to watching for new ones.

### Test Plan

added to test utilty
manually load a large run in dagit-debug and inspect the payloads to validate bool changes as expected