### PR TITLE
give VersionStrategy.get_X_version access to X config

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/version_strategy.py
+++ b/python_modules/dagster/dagster/core/definitions/version_strategy.py
@@ -1,10 +1,61 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
+from collections import namedtuple
+from dagster import check
 
 if TYPE_CHECKING:
     from .solid import SolidDefinition
     from .resource import ResourceDefinition
 
+class SolidVersionContext(
+    namedtuple(
+        "SolidVersionContext",
+        "solid_def solid_config",
+    )
+    ):
+    """Version-specific solid context.
+    Attributes:
+        solid_def (SolidDefinition): The definition of the versioned solid
+        solid_config (Any): The parsed config received by the versioned solid
+    """
+
+    def __new__(
+            cls,
+            solid_def,
+            solid_config,
+    ):
+        if TYPE_CHECKING:
+            solid_def = check.inst_param(solid_def, "solid_def", SolidDefinition)
+        return super(SolidVersionContext, cls).__new__(
+            cls,
+            solid_def=solid_def,
+            solid_config=solid_config
+        )
+
+class ResourceVersionContext(
+    namedtuple(
+        "SolidVersionContext",
+        "solid_def solid_config",
+    )
+    ):
+    """Version-specific solid context.
+    Attributes:
+        resource_def (ResourceDefinition): The definition of the versioned resource
+        resource_config (Any): The parsed config received by the versioned resource
+    """
+
+    def __new__(
+            cls,
+            resource_def,
+            resource_config,
+    ):
+        if TYPE_CHECKING:
+            resource_def = check.inst_param(resource_def, "resource_def", ResourceDefinition)
+        return super(ResourceVersionContext, cls).__new__(
+            cls,
+            solid_def=resource_def,
+            solid_config=resource_config
+        )
 
 class VersionStrategy(ABC):
     """Abstract class for defining a strategy to version solids and resources.
@@ -12,18 +63,18 @@ class VersionStrategy(ABC):
     When subclassing, `get_solid_version` must be implemented, and `get_resource_version` can be
     optionally implemented.
 
-    `get_solid_version` should ingest a SolidDefinition, and `get_resource_version` should ingest a
-    ResourceDefinition. From that,  each synthesize a unique string called a `version`, which will
+    `get_solid_version` should ingest a SolidVersionContext, and `get_resource_version` should ingest a
+    ResourceVersionContext. From that,  each synthesize a unique string called a `version`, which will
     be tagged to outputs of that solid in the pipeline. Providing a `VersionStrategy` instance to a
     job will enable memoization on that job, such that only steps whose outputs do not have an
     up-to-date version will run.
     """
 
     @abstractmethod
-    def get_solid_version(self, solid_def: "SolidDefinition") -> str:
+    def get_solid_version(self, context: SolidVersionContext) -> str:
         pass
 
     def get_resource_version(
-        self, resource_def: "ResourceDefinition"  # pylint: disable=unused-argument
+        self, context: ResourceVersionContext # pylint: disable=unused-argument
     ) -> Optional[str]:
         return None

--- a/python_modules/dagster/dagster/core/execution/resolve_versions.py
+++ b/python_modules/dagster/dagster/core/execution/resolve_versions.py
@@ -4,6 +4,7 @@ from dagster import check
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.plan.outputs import StepOutputHandle
 from dagster.core.execution.plan.step import is_executable_step
+from dagster.core.definitions.version_strategy import SolidVersionContext, ResourceVersionContext
 
 from .plan.inputs import join_and_hash
 
@@ -96,11 +97,14 @@ def resolve_step_versions(pipeline_def, execution_plan, resolved_run_config):
 
         solid_name = str(step.solid_handle)
 
+        solid_config = resolved_run_config.solids[solid_name].config
+
         solid_def_version = None
         if solid_def.version is not None:
             solid_def_version = solid_def.version
         elif pipeline_def.version_strategy is not None:
-            solid_def_version = pipeline_def.version_strategy.get_solid_version(solid_def)
+            version_context = SolidVersionContext(solid_def=solid_def, solid_config=solid_config)
+            solid_def_version = pipeline_def.version_strategy.get_solid_version(version_context)
 
         if solid_def_version is None:
             raise DagsterInvariantViolationError(
@@ -111,7 +115,7 @@ def resolve_step_versions(pipeline_def, execution_plan, resolved_run_config):
 
         check_valid_version(solid_def_version)
 
-        solid_config_version = resolve_config_version(resolved_run_config.solids[solid_name].config)
+        solid_config_version = resolve_config_version(solid_config)
 
         resource_versions_for_solid = []
         for resource_key in solid_def.required_resource_keys:
@@ -125,9 +129,8 @@ def resolve_step_versions(pipeline_def, execution_plan, resolved_run_config):
                 if resource_def.version is not None:
                     resource_def_version = resource_def.version
                 else:
-                    resource_def_version = pipeline_def.version_strategy.get_resource_version(
-                        resource_def
-                    )
+                    version_context = ResourceVersionContext(resource_def=resource_def, resource_config=resource_config)
+                    resource_def_version = pipeline_def.version_strategy.get_resource_version(version_context)
 
                 if resource_def_version is not None:
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
@@ -101,10 +101,10 @@ def test_memoization_with_default_strategy():
         my_op()
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, solid_def):
+        def get_solid_version(self, _):
             return "foo"
 
-        def get_resource_version(self, resource_def):
+        def get_resource_version(self, _):
             return "foo"
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -137,7 +137,7 @@ def test_memoization_with_default_strategy_overriden():
     version = ["foo"]
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, solid_def):
+        def get_solid_version(self, _):
             return version[0]
 
     recorder = []
@@ -179,6 +179,83 @@ def test_memoization_with_default_strategy_overriden():
             assert result.success
 
             assert len(recorder) == 1
+
+            # Ensure that after switching memoization tag off, that the plan recognizes every step
+            # should be run.
+            unmemoized_plan = create_execution_plan(
+                my_job, instance=instance, tags={MEMOIZED_RUN_TAG: "false"}
+            )
+            assert len(unmemoized_plan.step_keys_to_execute) == 1
+
+
+def test_version_strategy_depends_from_context():
+    # this dict is to emulate execution which depends on some argument in context
+    version = {"foo": "bar"}
+    version_strategy_called = []
+    graph_executed = []
+
+    class ContextDependantVersionStrategy(VersionStrategy):
+        def get_solid_version(self, context):
+            version_strategy_called.append("versioned")
+            solid_arg = context.solid_config["arg"]
+            return version[solid_arg]
+
+        def get_resource_version(self, context):
+            resource_arg = context.resource_config["arg"]
+            return version[resource_arg]
+
+    run_config = {
+        "solids": {
+            "my_op": {"config": {"arg": "foo"}}
+        }
+    }
+
+    @op
+    def my_op(context):
+        graph_executed.append('executed')
+
+    @graph
+    def my_graph():
+        my_op()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_for_test(temp_dir=temp_dir) as instance:
+            my_job = my_graph.to_job(
+                version_strategy=ContextDependantVersionStrategy(),
+                resource_defs={
+                    "io_manager": versioned_filesystem_io_manager.configured(
+                        {"base_dir": temp_dir}
+                    ),
+                },
+            )
+
+            result = my_job.execute_in_process(run_config=run_config, instance=instance)
+            assert result.success
+
+            assert len(graph_executed) > 0
+            assert len(version_strategy_called) > 0
+
+            # check that memoization works
+            graph_executed = []
+            version_strategy_called = []
+
+            result = my_job.execute_in_process(run_config=run_config, instance=instance)
+            assert result.success
+
+            assert len(graph_executed) == 0
+            assert len(version_strategy_called) > 0
+
+            # check that changing the version leads to reexecution
+            graph_executed = []
+            version_strategy_called = []
+
+            version["foo"] = "not_bar"
+
+            result = my_job.execute_in_process(run_config=run_config, instance=instance)
+            assert result.success
+
+            assert len(graph_executed) > 0
+            assert len(version_strategy_called) > 0
 
             # Ensure that after switching memoization tag off, that the plan recognizes every step
             # should be run.


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
In the context of memoization, if no version tag is given to a solid but a VersionStrategy is provided to the pipeline, `VersionStrategy.get_solid_version` (respectively `VersionStrategy.get_resource_version`) is called to provide a version of the solid definition. 
Originally, these methods have access to the solid definition only (respectively the resource definition). In this PR, they also have access to the context.solid_config (respectively resource_config) via a new SolidVersionContext (respectively ResourceVersionContext).

This answers to a specific use case where some code needs to be _executed_ based on the user config to provide a relevant version (in particular, if the config alone is not enough). An example is when the solid receives a dataset name corresponding to a dataset stored on a repo, and the version should be the sha1 of the repo/master (a more detailed example is provided in #4744 )

Changes:
- added to context definitions `SolidVersionContext` and `ResourceVersionContext` which contains only the definition and the config of the corresponding solid/resource
- Changed the signature of `VersionStrategy.get_solid_version` and `get_resource_version` to use the two new contexts.
- Instead of just the solid definition, new context objects are provided as arguments in `resolve_versions.py`
- minor fix: changed in some previous tests changed `get_solid_version(solid_def)` to  `get_solid_version(_)` as solid_def in not a relevant name anymore
<!-- and related GitHub issue or screenshots (if applicable). -->
Related issue: #4744

Points of concern:
- It might make sense to also give access to the (instantiated) resources in get_solid_version. However, this probably requires bigger changes.
- With this feature, it might make sense to allow per-solid version strategy (like for iomanagers, via the io_manager_key). This would require bigger changes.
- I am not entirely confident regarding the way I am implementing the VersionContext object, in particular regarding the use of the check lib. For now, this is basically a copy of InitContextExecutor.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
A new test was added where the config dependant behaviour is emulated with a dict ( EG  `return version[context.solid_config["arg"]`). We check that: 1)The memoization works normally and 2) If we change the `version` dict, and nothing else, the pipeline is rerun.
All other tests passed.
Environment:
- Ubuntu 18.04
- python 3.8
- pip 21.2.4



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
There is few documentation on that part for now, so I only changed the docstring of VersionStrategy.
- [x] I have added tests to cover my changes.