### PR TITLE
configclass

### DIFF
--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -425,10 +425,6 @@ class DagsterBackfillFailedError(DagsterError):
         super(DagsterBackfillFailedError, self).__init__(*args, **kwargs)
 
 
-class DagsterScheduleWipeRequired(DagsterError):
-    """Indicates that the user must wipe their stored schedule state."""
-
-
 class DagsterInstanceMigrationRequired(DagsterError):
     """Indicates that the dagster instance must be migrated."""
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -583,7 +583,6 @@ class DagsterInstance:
 
     def optimize_for_dagit(self, statement_timeout):
         if self._schedule_storage:
-            self._schedule_storage.validate_stored_schedules(self.scheduler_class)
             self._schedule_storage.optimize_for_dagit(statement_timeout=statement_timeout)
         self._run_storage.optimize_for_dagit(statement_timeout=statement_timeout)
         self._event_storage.optimize_for_dagit(statement_timeout=statement_timeout)

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -1,10 +1,9 @@
 import abc
-from typing import Iterable, Type
+from typing import Iterable
 
 from dagster.core.definitions.run_request import JobType
-from dagster.core.errors import DagsterScheduleWipeRequired
 from dagster.core.instance import MayHaveInstanceWeakref
-from dagster.core.scheduler.job import JobState, JobStatus, JobTick, JobTickData, JobTickStatus
+from dagster.core.scheduler.job import JobState, JobTick, JobTickData, JobTickStatus
 
 
 class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
@@ -115,27 +114,3 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
 
     def optimize_for_dagit(self, statement_timeout: int):
         """Allows for optimizing database connection / use in the context of a long lived dagit process"""
-
-    def validate_stored_schedules(self, scheduler_class: Type):
-        # Check for any running job states that reference a different scheduler,
-        # prompt the user to wipe if they don't match
-        stored_schedules = self.all_stored_job_state(job_type=JobType.SCHEDULE)
-
-        for schedule in stored_schedules:
-            if schedule.status != JobStatus.RUNNING:
-                continue
-
-            stored_scheduler_class = schedule.job_specific_data.scheduler
-
-            if stored_scheduler_class and stored_scheduler_class != scheduler_class:
-                instance_scheduler_class = scheduler_class if scheduler_class else "None"
-
-                raise DagsterScheduleWipeRequired(
-                    f"Found a running schedule using a scheduler ({stored_scheduler_class}) "
-                    + f"that differs from the scheduler on the instance ({instance_scheduler_class}). "
-                    + "The most likely reason for this error is that you changed the scheduler on "
-                    + "your instance while it was still running schedules. "
-                    + "To fix this, change the scheduler on your instance back to the previous "
-                    + "scheduler configuration and run the command 'dagster schedule wipe'. It "
-                    + f"will then be safe to change back to {instance_scheduler_class}."
-                )

--- a/python_modules/dagster/dagster/serdes/config_class.py
+++ b/python_modules/dagster/dagster/serdes/config_class.py
@@ -128,6 +128,7 @@ class ConfigurableClass(ABC):
         """dagster.ConfigType: The config type against which to validate a config yaml fragment
         serialized in an instance of ``ConfigurableClassData``.
         """
+        raise NotImplementedError(f"{cls.__name__} must implement the config_type classmethod")
 
     @staticmethod
     @abstractmethod
@@ -152,6 +153,9 @@ class ConfigurableClass(ABC):
                 return MyConfigurableClass(inst_data=inst_data, **config_value)
 
         """
+        raise NotImplementedError(
+            "ConfigurableClass subclasses must implement the from_config_value staticmethod"
+        )
 
 
 def class_from_code_pointer(module_name, class_name):

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -1,10 +1,8 @@
-import re
 import sys
 import time
 
 import pendulum
 import pytest
-from dagster.core.errors import DagsterScheduleWipeRequired
 from dagster.core.host_representation import (
     ExternalRepositoryOrigin,
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
@@ -594,38 +592,3 @@ class TestScheduleStorage:
 
         ticks = storage.get_job_ticks("my_sensor")
         assert len(ticks) == 2
-
-    def test_migrate_schedulers(self, storage):
-
-        if not self.can_delete():
-            pytest.skip("Storage cannot delete")
-
-        schedule = self.build_schedule("my_schedule", "* * * * *")
-        storage.add_job_state(schedule)
-
-        # changing if its not running is fine
-        storage.validate_stored_schedules(OTHER_FAKE_SCHEDULER_NAME)
-
-        running_schedule = self.build_schedule(
-            "my_other_schedule", "* * * * *", status=JobStatus.RUNNING
-        )
-        storage.add_job_state(running_schedule)
-
-        with pytest.raises(
-            DagsterScheduleWipeRequired,
-            match=re.escape(
-                "Found a running schedule using a scheduler (FakeSchedulerClassName) "
-                "that differs from the scheduler on the instance (OtherFakeSchedulerClassName). "
-                "The most likely reason for this error is that you changed the scheduler on your "
-                "instance while it was still running schedules. To fix this, change the scheduler "
-                "on your instance back to the previous scheduler configuration and run the command "
-                "'dagster schedule wipe'. It will then be safe to change back "
-                "to OtherFakeSchedulerClassName."
-            ),
-        ):
-            storage.validate_stored_schedules(OTHER_FAKE_SCHEDULER_NAME)
-
-        storage.wipe()
-
-        # Now passes
-        storage.validate_stored_schedules(OTHER_FAKE_SCHEDULER_NAME)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -393,10 +393,6 @@ def test_0_10_0_schedule_wipe():
         assert "jobs" not in get_sqlite3_tables(db_path)
         assert "job_ticks" not in get_sqlite3_tables(db_path)
 
-        with pytest.raises(DagsterInstanceMigrationRequired):
-            with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
-                instance.optimize_for_dagit(statement_timeout=500)
-
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
             instance.upgrade()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -162,10 +162,6 @@ def test_0_10_0_schedule_wipe(hostname, conn_string):
                 template = template_fd.read().format(hostname=hostname)
                 target_fd.write(template)
 
-        with pytest.raises(DagsterInstanceMigrationRequired):
-            with DagsterInstance.from_config(tempdir) as instance:
-                instance.optimize_for_dagit(statement_timeout=500)
-
         with DagsterInstance.from_config(tempdir) as instance:
             instance.upgrade()
 


### PR DESCRIPTION
- remove validate_stored_scehdules
- Raise a more useful error when you don't implement the static/class methods on configurable class

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.