### PR TITLE
Add terminate pipeline dagster gql method

### DIFF
--- a/docs/content/concepts/dagit/graphql-client.mdx
+++ b/docs/content/concepts/dagit/graphql-client.mdx
@@ -44,6 +44,11 @@ Note that all GraphQL methods on the API are not yet available in Python - the `
   object="DagsterGraphQLClient"
   method="shutdown_repository_location"
   />
+- <PyObject
+  module="dagster_graphql"
+  object="DagsterGraphQLClient"
+  method="terminate_pipeline"
+  />
 
 ## Using the GraphQL Client
 
@@ -176,6 +181,21 @@ try:
         mode="default",
     )
     do_something_on_success(new_run_id)
+except DagsterGraphQLClientError as exc:
+    do_something_with_exc(exc)
+    raise exc
+```
+
+### Terminating a Pipeline Run
+
+You can use the client to terminate a pipeline run as follows:
+
+```python file=/concepts/dagit/graphql/client_example.py startafter=start_terminate_pipeline_marker endbefore=end_terminate_pipeline_marker
+from dagster_graphql import DagsterGraphQLClientError
+
+try:
+    run_id: str = client.terminate_pipeline(RUN_ID)
+    do_something_on_success(run_id)
 except DagsterGraphQLClientError as exc:
     do_something_with_exc(exc)
     raise exc

--- a/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/dagit/graphql/client_example.py
@@ -122,3 +122,14 @@ if shutdown_info.status == ShutdownRepositoryLocationStatus.SUCCESS:
 else:
     raise Exception(f"Repository location shutdown failed: {shutdown_info.message}")
 # end_shutdown_repo_location_marker
+
+# start_terminate_pipeline_marker
+from dagster_graphql import DagsterGraphQLClientError
+
+try:
+    run_id: str = client.terminate_pipeline(RUN_ID)
+    do_something_on_success(run_id)
+except DagsterGraphQLClientError as exc:
+    do_something_with_exc(exc)
+    raise exc
+# end_terminate_pipeline_marker

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -345,7 +345,7 @@ class DagsterGraphQLClient:
             run_id (str): run id of the pipeline run to terminate.
 
         Raises:
-            DagsterGraphQLClientError("PipelineNotFoundError", message): if the requested run id is not found
+            DagsterGraphQLClientError("PipelineRunNotFoundError", message): if the requested run id is not found
             DagsterGraphQLClientError("TerminatePipelineExecutionFailure", message): if the requested run is not active
             DagsterGraphQLClientError("PythonError", message): on internal framework errors
 
@@ -359,10 +359,10 @@ class DagsterGraphQLClient:
         )
         query_result: Dict[str, Any] = res_data["terminatePipelineExecution"]
         query_result_type: str = query_result["__typename"]
+
         if query_result_type == "TerminatePipelineExecutionSuccess":
             return query_result["run"]["runId"]
-        elif query_result_type == "PipelineRunNotFoundError":
-            raise DagsterGraphQLClientError(query_result_type, query_result["run_id"])
-        else:
-            raise DagsterGraphQLClientError(query_result_type, query_result["message"])
-
+        if query_result_type == "PipelineRunNotFoundError":
+            raise DagsterGraphQLClientError(query_result_type, query_result["runId"])
+        # query_result_type is either TerminatePipelineExecutionFailure or PythonError
+        raise DagsterGraphQLClientError(query_result_type, query_result["message"])

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -16,6 +16,7 @@ from .client_queries import (
     GET_PIPELINE_RUN_STATUS_QUERY,
     RELOAD_REPOSITORY_LOCATION_MUTATION,
     SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
+    TERMINATE_PIPELINE_MUTATION,
 )
 from .utils import (
     DagsterGraphQLClientError,
@@ -336,3 +337,32 @@ class DagsterGraphQLClient:
             )
         else:
             raise Exception(f"Unexpected query result type {query_result_type}")
+
+    def terminate_pipeline(self, run_id: str) -> PipelineRunStatus:
+        """Terminate a pipeline run
+
+        Args:
+            run_id (str): run id of the pipeline run to terminate.
+
+        Raises:
+            DagsterGraphQLClientError("PipelineNotFoundError", message): if the requested run id is not found
+            DagsterGraphQLClientError("TerminatePipelineExecutionFailure", message): if the requested run is not active
+            DagsterGraphQLClientError("PythonError", message): on internal framework errors
+
+        Returns:
+            str: run id of the cancelled pipeline run
+        """
+        check.str_param(run_id, "run_id")
+
+        res_data: Dict[str, Dict[str, Any]] = self._execute(
+            TERMINATE_PIPELINE_MUTATION, {"runId": run_id}
+        )
+        query_result: Dict[str, Any] = res_data["terminatePipelineExecution"]
+        query_result_type: str = query_result["__typename"]
+        if query_result_type == "TerminatePipelineExecutionSuccess":
+            return query_result["run"]["runId"]
+        elif query_result_type == "PipelineRunNotFoundError":
+            raise DagsterGraphQLClientError(query_result_type, query_result["run_id"])
+        else:
+            raise DagsterGraphQLClientError(query_result_type, query_result["message"])
+

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -123,3 +123,26 @@ mutation ($repositoryLocationName: String!) {
    }
 }
 """
+
+TERMINATE_PIPELINE_MUTATION = """
+mutation TerminatePipeline($runId: String!) {
+  terminatePipelineExecution(runId: $runId){
+    __typename
+    ... on TerminatePipelineExecutionSuccess{
+      run {
+        runId
+      }
+    }
+    ... on TerminatePipelineExecutionFailure {
+      message
+    }
+    ... on PipelineRunNotFoundError {
+      runId
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}
+"""

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_pipeline.py
@@ -1,0 +1,58 @@
+import pytest
+from dagster_graphql import DagsterGraphQLClientError
+
+from .conftest import MockClient, python_client_test_suite
+
+EXPECTED_RUN_ID = "foo"
+
+
+@python_client_test_suite
+def test_success(mock_client: MockClient):
+    response = {
+        "terminatePipelineExecution": {
+            "__typename": "TerminatePipelineExecutionSuccess",
+            "run": {"runId": EXPECTED_RUN_ID},
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+    actual_run_id = mock_client.python_client.terminate_pipeline(
+        run_id="bar",
+    )
+    assert actual_run_id == EXPECTED_RUN_ID
+
+
+@python_client_test_suite
+def test_pipeline_not_found(mock_client: MockClient):
+    response = {
+        "terminatePipelineExecution": {
+            "__typename": "PipelineRunNotFoundError",
+            "runId": EXPECTED_RUN_ID,
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_pipeline(
+            run_id="bar",
+        )
+
+    assert exc_info.value.args[0] == "PipelineRunNotFoundError"
+
+
+@python_client_test_suite
+def test_failure(mock_client: MockClient):
+    error_type, message = "TerminatePipelineExecutionFailure", "something went wrong"
+    response = {
+        "terminatePipelineExecution": {
+            "__typename": error_type,
+            "message": message,
+        }
+    }
+    mock_client.mock_gql_client.execute.return_value = response
+
+    with pytest.raises(DagsterGraphQLClientError) as exc_info:
+        mock_client.python_client.terminate_pipeline(
+            run_id="bar",
+        )
+
+    assert exc_info.value.args == (error_type, message)


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
This PR adds a method to the `dagster-graphql` client to cancel a running pipeline, utilising [this graphql mutation](https://docs.dagster.io/concepts/dagit/graphql#terminate-a-running-pipeline).

<!-- the type of change i.e. breaking change, new feature, or bug fix -->
This is a new feature

<!-- and related GitHub issue or screenshots (if applicable). -->
Related issue: https://github.com/dagster-io/dagster/issues/4800


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Unit tests added at `python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_terminate_pipeline.py`


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.