### PR TITLE
[dagit] Use Google Fonts API v2

### DIFF
--- a/js_modules/dagit/packages/app/public/index.html
+++ b/js_modules/dagit/packages/app/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter|Inconsolata" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inconsolata&family=Material+Icons&display=swap" rel="stylesheet">
 
     <!-- A target element to insert a custom path prefix, replaced server-side. -->
     <script type="application/json" id="path-prefix">


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Use v2 of the Google Fonts API to be more specific about which font weights to pull in, especially to improve Inter rendering of bold text.

## Test Plan

Run dagit, verify that fonts look fine. Make some text `<strong>`, verify that it doesn't look horrible.