### PR TITLE
Fix typo in sensors docs

### DIFF
--- a/docs/content-crag/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content-crag/concepts/partitions-schedules-sensors/sensors.mdx
@@ -59,7 +59,7 @@ def log_file_pipeline():
     process_file()
 ```
 
-You can write a sensor that watches for new files in a specific directory and `yields` a `RunRequest` for each new file in the directory. By default, this sensor every 30 seconds.
+You can write a sensor that watches for new files in a specific directory and `yields` a `RunRequest` for each new file in the directory. By default, this sensor runs every 30 seconds.
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_directory_sensor_marker endbefore=end_directory_sensor_marker
 import os

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -59,7 +59,7 @@ def log_file_pipeline():
     process_file()
 ```
 
-You can write a sensor that watches for new files in a specific directory and `yields` a `RunRequest` for each new file in the directory. By default, this sensor every 30 seconds.
+You can write a sensor that watches for new files in a specific directory and `yields` a `RunRequest` for each new file in the directory. By default, this sensor runs every 30 seconds.
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_directory_sensor_marker endbefore=end_directory_sensor_marker
 import os


### PR DESCRIPTION
## Summary

Just a small typo fix. I changed the phrase "By default, this sensor every 30 seconds" to "By default, this sensor **runs** every 30 seconds"