### PR TITLE
[dagit] Improve Inconsolata weights

### DIFF
--- a/js_modules/dagit/packages/app/public/index.html
+++ b/js_modules/dagit/packages/app/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inconsolata&family=Material+Icons&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inconsolata:wght@400;500;600&family=Material+Icons&display=swap" rel="stylesheet">
 
     <!-- A target element to insert a custom path prefix, replaced server-side. -->
     <script type="application/json" id="path-prefix">


### PR DESCRIPTION
## Summary

Improve rendering of heavier Inconsolata by specifying weights in the Google Fonts API. Like Inter bold, it looks pretty bad without retrieving the specific weight.

## Test Plan

View right panel of a job view and bolded step names in Run logs. Verify that they look better than before.