### PR TITLE
[dagit] Show Run loading overlay for long fetches

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -58,10 +58,39 @@ const pipelineStatusFromMessages = (messages: RunPipelineRunEventFragment[]) => 
 
 const BATCH_INTERVAL = 100;
 
+type State = {
+  nodes: Nodes;
+  loading: boolean;
+};
+
+type Action =
+  | {type: 'append'; queued: RunPipelineRunEventFragment[]; hasMore: boolean}
+  | {type: 'reset'};
+
+const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'append':
+      const nodes = [...state.nodes, ...action.queued].map((m, idx) => ({
+        ...m,
+        clientsideKey: `csk${idx}`,
+      }));
+      return {...state, nodes, loading: action.hasMore};
+    case 'reset':
+      return {nodes: [], loading: true};
+    default:
+      return state;
+  }
+};
+
+const initialState = {
+  nodes: [],
+  loading: true,
+};
+
 const useLogsProviderWithSubscription = (runId: string) => {
   const client = useApolloClient();
   const queue = React.useRef<RunPipelineRunEventFragment[]>([]);
-  const [nodes, setNodes] = React.useState<Nodes>(() => []);
+  const [state, dispatch] = React.useReducer(reducer, initialState);
 
   const syncPipelineStatusToApolloCache = React.useCallback(
     (status: PipelineRunStatus) => {
@@ -95,24 +124,16 @@ const useLogsProviderWithSubscription = (runId: string) => {
 
   React.useEffect(() => {
     queue.current = [];
-    setNodes([]);
+    dispatch({type: 'reset'});
   }, [runId]);
 
   // Batch the nodes together so they don't overwhelm the animation of the Gantt,
   // which depends on a bit of a timing delay to maintain smoothness.
   const throttledSetNodes = React.useMemo(() => {
-    return throttle(() => {
-      setNodes((current) => {
-        if (queue.current.length) {
-          const update = [...current, ...queue.current].map((m, idx) => ({
-            ...m,
-            clientsideKey: `csk${idx}`,
-          }));
-          queue.current = [];
-          return update;
-        }
-        return current;
-      });
+    return throttle((hasMore: boolean) => {
+      const queued = [...queue.current];
+      queue.current = [];
+      dispatch({type: 'append', queued, hasMore});
     }, BATCH_INTERVAL);
   }, []);
 
@@ -125,7 +146,7 @@ const useLogsProviderWithSubscription = (runId: string) => {
         return;
       }
 
-      const {messages} = logs;
+      const {messages, hasMorePastEvents} = logs;
       const nextPipelineStatus = pipelineStatusFromMessages(messages);
       if (nextPipelineStatus) {
         syncPipelineStatusToApolloCache(nextPipelineStatus);
@@ -133,13 +154,15 @@ const useLogsProviderWithSubscription = (runId: string) => {
 
       // Maintain a queue of messages as they arrive, and call the throttled setter.
       queue.current = [...queue.current, ...messages];
-      throttledSetNodes();
+      throttledSetNodes(hasMorePastEvents);
     },
   });
 
+  const {nodes, loading} = state;
+
   return React.useMemo(
-    () => (nodes !== null ? {allNodes: nodes, loading: false} : {allNodes: [], loading: true}),
-    [nodes],
+    () => (nodes !== null ? {allNodes: nodes, loading} : {allNodes: [], loading}),
+    [loading, nodes],
   );
 };
 

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -148,7 +148,10 @@ const useLogsProviderWithSubscription = (runId: string) => {
 
       const {messages, hasMorePastEvents} = logs;
       const nextPipelineStatus = pipelineStatusFromMessages(messages);
-      if (nextPipelineStatus) {
+
+      // If we're still loading past events, don't sync to the cache -- event chunks could
+      // give us `status` values that don't match the actual state of the run.
+      if (nextPipelineStatus && !hasMorePastEvents) {
         syncPipelineStatusToApolloCache(nextPipelineStatus);
       }
 

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -308,11 +308,11 @@ class LogsScrollingTableSized extends React.Component<ILogsScrollingTableSizedPr
     const {filteredNodes, height, loading, width} = this.props;
     return (
       <div>
-        {loading && (
+        {loading ? (
           <ListEmptyState>
             <NonIdealState icon={<Spinner purpose="section" />} title="Fetching logs..." />
           </ListEmptyState>
-        )}
+        ) : null}
         <List
           ref={this.list}
           deferredMeasurementCache={this.cache}
@@ -385,6 +385,7 @@ class AutoSizer extends React.Component<{
 }
 
 const ListEmptyState = styled.div`
+  background-color: rgba(255, 255, 255, 0.7);
   z-index: 100;
   position: absolute;
   width: 100%;


### PR DESCRIPTION
## Summary

Use the `hasMorePastEvents` in `LogsProvider` to persist a loading state while we stream in old events, which is mostly relevant for cases where we have thousands of logs for a given run. This will do two things as we load these in:

- Persist a spinner in the Gantt view, so that we don't try rendering anything there until the logs are available.
- Persist "Fetching logs" with a medium-opacity background in the logs table, so that the user can see logs streaming in but also can see that they aren't done loading yet.

This should improve perf by not attempting to render the Gantt over and over as log chunks arrive, and should improve the UX by making it clearer that we're still fetching.

## Test Plan

Load dagit-debug with run data provided by Prezi, verify the UX described above.

Kick off a run in my own workspace, verify that things work correctly as before, and are unaffected by this change.