### PR TITLE
[serdes] filter unknown keys before unpacking

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -370,10 +370,10 @@ class AssetMaterialization(
 
 class MaterializationSerializer(DefaultNamedTupleSerializer):
     @classmethod
-    def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
+    def value_from_unpacked(cls, unpacked_dict, klass):
         # override the default `from_storage_dict` implementation in order to skip the deprecation
         # warning for historical Materialization events, loaded from event_log storage
-        return Materialization(skip_deprecation_warning=True, **storage_dict)
+        return Materialization(skip_deprecation_warning=True, **unpacked_dict)
 
 
 @whitelist_for_serdes(serializer=MaterializationSerializer)

--- a/python_modules/dagster/dagster/daemon/types.py
+++ b/python_modules/dagster/dagster/daemon/types.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from enum import Enum
 
 from dagster import check
-from dagster.serdes import DefaultNamedTupleSerializer, unpack_value, whitelist_for_serdes
+from dagster.serdes import DefaultNamedTupleSerializer, unpack_inner_value, whitelist_for_serdes
 from dagster.utils.error import SerializableErrorInfo
 
 
@@ -16,19 +16,37 @@ class DaemonType(Enum):
 
 class DaemonBackcompat(DefaultNamedTupleSerializer):
     @classmethod
-    def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
+    def value_from_storage_dict(
+        cls,
+        storage_dict,
+        klass,
+        args_for_class,
+        whitelist_map,
+        descent_path,
+    ):
         # Handle case where daemon_type used to be an enum (e.g. DaemonType.SCHEDULER)
+        daemon_type = unpack_inner_value(
+            storage_dict.get("daemon_type"),
+            whitelist_map,
+            descent_path=f"{descent_path}.daemon_type",
+        )
         return DaemonHeartbeat(
             timestamp=storage_dict.get("timestamp"),
-            daemon_type=(
-                storage_dict.get("daemon_type").value
-                if isinstance(storage_dict.get("daemon_type"), DaemonType)
-                else storage_dict.get("daemon_type")
-            ),
+            daemon_type=(daemon_type.value if isinstance(daemon_type, DaemonType) else daemon_type),
             daemon_id=storage_dict.get("daemon_id"),
-            errors=[unpack_value(storage_dict.get("error"))]  # error was replaced with errors
+            errors=[
+                unpack_inner_value(
+                    storage_dict.get("error"),
+                    whitelist_map,
+                    descent_path=f"{descent_path}.error",
+                )
+            ]  # error was replaced with errors
             if storage_dict.get("error")
-            else unpack_value(storage_dict.get("errors")),
+            else unpack_inner_value(
+                storage_dict.get("errors"),
+                whitelist_map,
+                descent_path=f"{descent_path}.errors",
+            ),
         )
 
 

--- a/python_modules/dagster/dagster/serdes/__init__.py
+++ b/python_modules/dagster/dagster/serdes/__init__.py
@@ -4,10 +4,12 @@ from .serdes import (
     deserialize_as,
     deserialize_json_to_dagster_namedtuple,
     deserialize_value,
+    pack_inner_value,
     pack_value,
     register_serdes_tuple_fallbacks,
     serialize_dagster_namedtuple,
     serialize_value,
+    unpack_inner_value,
     unpack_value,
     whitelist_for_serdes,
 )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_types.py
@@ -1,11 +1,12 @@
 from dagster.core.definitions.pipeline_sensor import RunStatusSensorCursor
-from dagster.serdes import deserialize_json_to_dagster_namedtuple
+from dagster.daemon.types import DaemonHeartbeat
+from dagster.serdes import deserialize_as, deserialize_json_to_dagster_namedtuple
 from dagster.utils.error import SerializableErrorInfo
 
 
 def test_error_backcompat():
     old_heartbeat = '{"__class__": "DaemonHeartbeat", "daemon_id": "foobar", "daemon_type": {"__enum__": "DaemonType.SENSOR"}, "error": {"__class__": "SerializableErrorInfo", "cause": null, "cls_name": null, "message": "fizbuz", "stack": []}, "timestamp": 0.0}'
-    heartbeat = deserialize_json_to_dagster_namedtuple(old_heartbeat)
+    heartbeat = deserialize_as(old_heartbeat, DaemonHeartbeat)
     assert heartbeat.daemon_id == "foobar"
     assert heartbeat.daemon_type == "SENSOR"
     assert heartbeat.timestamp == 0.0
@@ -14,7 +15,7 @@ def test_error_backcompat():
 
 def test_heartbeat_backcompat():
     old_heartbeat = '{"__class__": "DaemonHeartbeat", "daemon_id": "05f24887-fb6a-4821-807b-fbd772a921e3", "daemon_type": {"__enum__": "DaemonType.SCHEDULER"}, "errors": [], "timestamp": 1612453213.775866}'
-    heartbeat = deserialize_json_to_dagster_namedtuple(old_heartbeat)
+    heartbeat = deserialize_as(old_heartbeat, DaemonHeartbeat)
     assert heartbeat.daemon_id == "05f24887-fb6a-4821-807b-fbd772a921e3"
     assert heartbeat.daemon_type == "SCHEDULER"
     assert heartbeat.errors == []

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -12,13 +12,13 @@ from dagster.serdes.serdes import (
     DefaultNamedTupleSerializer,
     WhitelistMap,
     _deserialize_json,
-    _pack_value,
     _serialize_dagster_namedtuple,
-    _unpack_value,
     _whitelist_for_serdes,
     deserialize_json_to_dagster_namedtuple,
     deserialize_value,
+    pack_inner_value,
     serialize_value,
+    unpack_inner_value,
 )
 from dagster.serdes.utils import hash_str
 
@@ -114,7 +114,7 @@ def test_forward_compat_serdes_new_enum_field():
 
     corge = Corge.FOO
 
-    packed = _pack_value(corge, whitelist_map=test_map, descent_path="")
+    packed = pack_inner_value(corge, whitelist_map=test_map, descent_path="")
 
     # pylint: disable=function-redefined
     @_whitelist_for_serdes(whitelist_map=test_map)
@@ -123,7 +123,7 @@ def test_forward_compat_serdes_new_enum_field():
         BAR = 2
         BAZ = 3
 
-    unpacked = _unpack_value(packed, whitelist_map=test_map, descent_path="")
+    unpacked = unpack_inner_value(packed, whitelist_map=test_map, descent_path="")
 
     assert unpacked != corge
     assert unpacked.name == corge.name
@@ -142,7 +142,7 @@ def test_serdes_enum_backcompat():
 
     corge = Corge.FOO
 
-    packed = _pack_value(corge, whitelist_map=test_map, descent_path="")
+    packed = pack_inner_value(corge, whitelist_map=test_map, descent_path="")
 
     class CorgeBackCompatSerializer(DefaultEnumSerializer):
         @classmethod
@@ -161,7 +161,7 @@ def test_serdes_enum_backcompat():
         BAZ = 3
         FOO_FOO = 4
 
-    unpacked = _unpack_value(packed, whitelist_map=test_map, descent_path="")
+    unpacked = unpack_inner_value(packed, whitelist_map=test_map, descent_path="")
 
     assert unpacked != corge
     assert unpacked == Corge.FOO_FOO
@@ -191,6 +191,39 @@ def test_backward_compat_serdes():
     assert deserialized.foo == quux.foo
     assert deserialized.bar == quux.bar
     assert not hasattr(deserialized, "baz")
+
+
+def test_forward_compat():
+    old_map = WhitelistMap.create()
+
+    @_whitelist_for_serdes(whitelist_map=old_map)
+    class Quux(namedtuple("_Quux", "bar baz")):
+        def __new__(cls, bar, baz):
+            return super().__new__(cls, bar, baz)
+
+    # new version has a new field with a new type
+    new_map = WhitelistMap.create()
+
+    # pylint: disable=function-redefined
+    @_whitelist_for_serdes(whitelist_map=new_map)
+    class Quux(namedtuple("_Quux", "foo bar baz")):
+        def __new__(cls, foo, bar, baz):
+            return super().__new__(cls, foo, bar, baz)
+
+    @_whitelist_for_serdes(whitelist_map=new_map)
+    class Foo(namedtuple("_Foo", "wow")):
+        def __new__(cls, wow):
+            return super().__new__(cls, wow)
+
+    new_quux = Quux(foo=Foo("wow"), bar="bar", baz="baz")
+
+    # write from new
+    serialized = _serialize_dagster_namedtuple(new_quux, whitelist_map=new_map)
+
+    # read from old, foo ignored
+    deserialized = _deserialize_json(serialized, whitelist_map=old_map)
+    assert deserialized.bar == "bar"
+    assert deserialized.baz == "baz"
 
 
 def serdes_test_class(klass):
@@ -361,12 +394,44 @@ def test_persistent_tuple():
 
 
 def test_from_storage_dict():
+    old_map = WhitelistMap.create()
+
+    @_whitelist_for_serdes(whitelist_map=old_map)
+    class MyThing(NamedTuple):
+        orig_name: str
+
+    serialized_old = _serialize_dagster_namedtuple(MyThing("old"), whitelist_map=old_map)
+
+    class CompatSerializer(DefaultNamedTupleSerializer):
+        @classmethod
+        def value_from_storage_dict(
+            cls, storage_dict, klass, args_for_class, whitelist_map, descent_path
+        ):
+            # simplified demo of field renaming
+            return klass(storage_dict.get("orig_name") or storage_dict.get("new_name"))
+
+    new_map = WhitelistMap.create()
+
+    @_whitelist_for_serdes(whitelist_map=new_map, serializer=CompatSerializer)
+    class MyThing(NamedTuple):  # pylint: disable=function-redefined
+        new_name: str
+
+    deser_old_val = _deserialize_json(serialized_old, whitelist_map=new_map)
+
+    assert deser_old_val.new_name == "old"
+
+    serialized_new = _serialize_dagster_namedtuple(MyThing("new"), whitelist_map=new_map)
+    deser_new_val = _deserialize_json(serialized_new, whitelist_map=new_map)
+    assert deser_new_val.new_name == "new"
+
+
+def test_from_unpacked():
     test_map = WhitelistMap.create()
 
     class CompatSerializer(DefaultNamedTupleSerializer):
         @classmethod
-        def value_from_storage_dict(cls, storage_dict, klass, args_for_class):
-            return DeprecatedAlphabet.legacy_load(storage_dict)
+        def value_from_unpacked(cls, unpacked_dict, klass):
+            return DeprecatedAlphabet.legacy_load(unpacked_dict)
 
     @_whitelist_for_serdes(whitelist_map=test_map, serializer=CompatSerializer)
     class DeprecatedAlphabet(namedtuple("_DeprecatedAlphabet", "a b c")):


### PR DESCRIPTION
* changes `value_from_storage_dict` to receive the actual storage dict instead of the unpacked
* make the `DefaultNamedTupleSerializer.value_from_storage_dict` only unpack values in `args_for_class` 
* add `value_from_unpacked` to `DefaultNamedTupleSerializer` to emulate existing behavior 
* rename `_pack_value` to `pack_inner_value`, and `_unpack_value` to `unpack_inner_value`


resolves https://github.com/dagster-io/dagster/issues/4857

### Test Plan

added representative test case that fails without changes