### PR TITLE
[dagit] Use cursor on LogsProvider subscription

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -137,9 +137,11 @@ const useLogsProviderWithSubscription = (runId: string) => {
     }, BATCH_INTERVAL);
   }, []);
 
+  const {nodes, loading} = state;
+
   useSubscription<PipelineRunLogsSubscription>(PIPELINE_RUN_LOGS_SUBSCRIPTION, {
     fetchPolicy: 'no-cache',
-    variables: {runId: runId, after: null},
+    variables: {runId: runId, after: nodes.length - 1},
     onSubscriptionData: ({subscriptionData}) => {
       const logs = subscriptionData.data?.pipelineRunLogs;
       if (!logs || logs.__typename === 'PipelineRunLogsSubscriptionFailure') {
@@ -160,8 +162,6 @@ const useLogsProviderWithSubscription = (runId: string) => {
       throttledSetNodes(hasMorePastEvents);
     },
   });
-
-  const {nodes, loading} = state;
 
   return React.useMemo(
     () => (nodes !== null ? {allNodes: nodes, loading} : {allNodes: [], loading}),


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Bugfix: when viewing an unfinished Run, if the backend resets the WebSocket connection, the logs are fetched again when the `PipelineRunLogsSubscription` reconnects. This results in duplicate logs.

To avoid this, use the current `nodes` length to determine the cursor to request from the backend. In this way, if the WebSocket reconnects, we can just look at how many nodes we have in memory within the React hook, and request new nodes from there.

## Test Plan

Run dagit-debug with a known problem Run. View the Run, verify WS response. Kill the backend, then restart it. Verify that the new subscription is set up, but uses the updated cursor value and does not receive any new nodes from the backend, nor does it receive duplicates.