### PR TITLE
docs concept pages for graph and job

### DIFF
--- a/docs/content-crag/_navigation.json
+++ b/docs/content-crag/_navigation.json
@@ -90,15 +90,19 @@
     "path": "/concepts",
     "children": [
       {
-        "title": "Ops & Graphs",
+        "title": "Ops, Graphs, and Jobs",
         "children": [
           {
             "title": "Solids",
             "path": "/concepts/solids-pipelines/solids"
           },
           {
-            "title": "Pipelines",
+            "title": "Graphs",
             "path": "/concepts/solids-pipelines/pipelines"
+          },
+          {
+            "title": "Jobs",
+            "path": "/concepts/solids-pipelines/jobs"
           },
           {
             "title": "Pipeline Execution",

--- a/docs/content-crag/concepts/solids-pipelines/jobs.mdx
+++ b/docs/content-crag/concepts/solids-pipelines/jobs.mdx
@@ -1,0 +1,156 @@
+---
+title: Jobs | Dagster
+description: A job is a graph plus a set of resources and configuration.
+---
+
+# Jobs
+
+A job is a graph plus a set of resources and configuration.
+
+## Relevant APIs
+
+| Name                                                  | Description                                                                                                                                                                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject object="GraphDefinition" method="to_job" /> | The method used to create a job from a graph.                                                                                                                                                                  |
+| <PyObject object="JobDefinition" />                   | A job definition.  Includes a graph, [resources](/concepts/resources), default [configuration](/concepts/configuration/config-schema), tags, [hooks](/concepts/solids-pipelines/solid-hooks), and an executor. |
+
+Dagster is built around the observation that any data DAG typically contains a logical core of transformation (the graph), which is reusable across a set of environments or scenarios. The graph usually needs to be "customized" for each environment, by plugging in configuration and services that are specific to that environment.
+
+A Dagster _job_ is the combination of a graph and a set of [resources](/concepts/resources) and [configuration](/concepts/configuration/config-schema).  You can create multiple jobs from the same graph.  For example, you might build a development job that executes a graph against sample data and stores outputs in local files, as well as production job that executes the same graph against production data and stores outputs in a cloud data lake.
+
+Jobs are the unit of execution and monitoring in Dagster deployments - the [Dagit UI](/concepts/dagit/dagit) centers on jobs.  Dagit makes it easy to view all the runs of each job in one place, as well as to manually kick off runs for a job.
+
+You can define [schedules](/concepts/partitions-schedules-sensors/schedules) to execute jobs at fixed intervals or define [sensors](/concepts/partitions-schedules-sensors/sensors) to trigger them jobs when external changes occur. You can also launch jobs manually from Dagit, GraphQL APIs, or the command line.
+
+## Automatic coercion of graphs to jobs
+
+If your graph does not contain any ops that require resources, the simplest way to create a job is to do nothing at all.  I.e. you can directly include a graph in a repository, or target it from a schedule or sensor, and Dagster will automatically treat it as a job.
+
+For example, if you define a graph, as below, and run `dagit -f <file_where_graph_is_defined>`, Dagit will show you a single job, which was created from the `do_stuff` graph.
+
+```python file=/concepts/solids_pipelines/coerce_job.py
+from dagster import graph, op
+
+
+@op
+def do_something():
+    pass
+
+
+@graph
+def do_stuff():
+    do_something()
+```
+
+Dagster can only coerce a graph into a job if none of the ops in the graph have required resource keys.
+
+<!-- TODO: add screenshot -->
+
+## `to_job`
+
+If you want to supply resources, config, tags, hooks, or an executor to a job, you can invoke the <PyObject object="GraphDefinition" method="to_job" /> method of a graph to instantiate a job.
+
+```python file=/concepts/solids_pipelines/jobs.py
+from dagster import ResourceDefinition, graph, op
+
+
+@op(config_schema={"config_param": str}, required_resource_keys={"my_resource"})
+def do_something(context):
+    context.log.info("config_param: " + context.op_config["config_param"])
+    context.log.info("my_resource: " + context.resources.my_resource)
+
+
+@graph
+def do_it_all():
+    do_something()
+
+
+do_it_all_job = do_it_all.to_job(
+    config={"ops": {"do_something": {"config": {"config_param": "stuff"}}}},
+    resource_defs={"my_resource": ResourceDefinition.hardcoded_resource("hello")},
+)
+```
+
+## Including a job in a repository
+
+You make jobs available to Dagit, GraphQLs, and the command line by including them inside [repositories](/concepts/repositories-workspaces/repositories). If you include schedules or sensors in a repository, the repository will automatically include jobs that those schedules or sensors target.
+
+```python file=/concepts/solids_pipelines/repo_with_job.py
+from dagster import repository
+
+from .jobs import do_it_all_job
+
+
+@repository
+def my_repo():
+    return [do_it_all_job]
+```
+
+## Advanced job configuration
+
+Ops and resources often accept [configuration](/concepts/configuration/config-schema) that determines how they behave. By default, you supply configuration for these ops and resources at the time you launch the job.
+
+When constructing a job, you can customize how that configuration will be satisfied, by passing a value to the `config` parameter of the <PyObject object="GraphDefinition" method="to_job" /> method.  The options are discussed below:
+
+### Hardcoded configuration
+
+You can supply a config dictionary to the `config` argument of <PyObject object="GraphDefinition" method="to_job" />. The supplied dictionary will be used to configure the job whenever the job is launched. It will show up in the Dagit Playground and can be overridden.
+
+```python file=/concepts/solids_pipelines/jobs_with_default_config.py
+from dagster import graph, op
+
+
+@op(config_schema={"config_param": str})
+def do_something(context):
+    context.log.info("config_param: " + context.op_config["config_param"])
+
+
+@graph
+def do_it_all():
+    do_something()
+
+
+do_it_all_with_default_config = do_it_all.to_job(
+    config={"ops": {"do_something": {"config": {"config_param": "stuff"}}}},
+)
+
+if __name__ == "__main__":
+    # Will log "config_param: stuff"
+    do_it_all_with_default_config.execute_in_process()
+```
+
+### Partitioned jobs
+
+You can supply a <PyObject object="PartitionedConfig" /> to the `config` argument of <PyObject object="GraphDefinition" method="to_job" />. It defines a discrete set of "partitions", along with a function for generating config for a partition. You can configure a job run by selecting a partition.
+
+For more information on how this works, take a look at the [Partitions concept page](/concepts/partitions-schedules-sensors/partitions).
+
+### Config mapping
+
+You can supply a <PyObject object="ConfigMapping" /> to the `config` argument of <PyObject object="GraphDefinition" method="to_job" />. This allows you to expose a narrower config interface to your job.  Instead of needing to configure every op and resource individually when launching the job, you can supply a smaller number of values to the outer config, and the <PyObject object="ConfigMapping" /> can translate it into config for all the job's ops and resources.
+
+```python file=/concepts/solids_pipelines/jobs_with_config_mapping.py
+from dagster import config_mapping, graph, op
+
+
+@op(config_schema={"config_param": str})
+def do_something(context):
+    context.log.info("config_param: " + context.op_config["config_param"])
+
+
+@graph
+def do_it_all():
+    do_something()
+
+
+@config_mapping(config_schema={"simplified_param": str})
+def simplified_config(val):
+    return {"ops": {"do_something": {"config": {"config_param": val["simplified_param"]}}}}
+
+
+do_it_all_with_simplified_config = do_it_all.to_job(config=simplified_config)
+
+if __name__ == "__main__":
+    # Will log "config_param: stuff"
+    do_it_all_with_simplified_config.execute_in_process(run_config={"simplified_param": "stuff"})
+```

--- a/docs/content-crag/concepts/solids-pipelines/pipelines.mdx
+++ b/docs/content-crag/concepts/solids-pipelines/pipelines.mdx
@@ -1,14 +1,16 @@
 ---
-title: Pipelines | Dagster
-description: A pipeline is a set of solids with explicit data dependencies on each other, creating a directed acyclic graph, or DAG.
+title: Graphs | Dagster
+description: A graph is a set of ops or sub-graphs with explicit data dependencies on each other.
 ---
 
-# Pipeline
+# Graphs
 
-A pipeline is a set of solids with explicit data dependencies on each other, creating a directed acyclic graph, or DAG.
+A graph is a set of ops or sub-graphs with explicit data dependencies on each other.
+
+<!-- TODO: Update image to refer to graphs and ops -->
 
 <Image
-alt="Pipeline Diagram"
+alt="Graph Diagram"
 src="/images/pipelines.png"
 width={3200}
 height={1040}
@@ -16,181 +18,118 @@ height={1040}
 
 ## Relevant APIs
 
-| Name                                                                    | Description                                                                                                                                                                                                      |
-| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <PyObject module="dagster" object="pipeline" displayText="@pipeline" /> | The decorator used to define a pipeline.                                                                                                                                                                         |
-| <PyObject module="dagster" object="PipelineDefinition" />               | Class for pipelines. You almost never want to use initialize this class directly. Instead, you should use the <PyObject object="pipeline" decorator /> which returns a <PyObject object="PipelineDefinition"  /> |
-| <PyObject module="dagster" object="PresetDefinition" />                 | Presets allow you to predefine pipeline configurations.                                                                                                                                                          |
+| Name                                                   | Description                                                                                                                                                                               |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject module="dagster" object="graph" decorator /> | The decorator used to define a graph.                                                                                                                                                     |
+| <PyObject module="dagster" object="GraphDefinition" /> | Class for graphs. You almost never want to use initialize this class directly. Instead, you should use the <PyObject object="graph" decorator /> which returns an instance of this class. |
 
 ## Overview
 
-Solids are linked together into pipelines by defining the dependencies between their inputs and outputs. An important difference between Dagster and other workflow systems is that in Dagster, solids dependencies are expressed as data dependencies instead of just the order solids should execute in.
+Ops are linked together into graphs by defining the dependencies between their inputs and outputs. An important difference between Dagster and other workflow systems is that in Dagster, op dependencies are expressed as data dependencies, not just execution dependencies. Graphs can also contain other graphs.
 
 This difference enables Dagster to support richer modeling of dependencies. Instead of merely ensuring that the order of execution is correct, dependencies in Dagster provide a variety of compile and run-time checks.
 
-Dependencies are expressed in Pipelines using Dagster's function invocation DSL.
+Like ops, graphs are "logical" entities - i.e. the same graph is meant to be able to be executed in multiple environments, and you can provide [configuration](/concepts/configuration/config-schema) and [resources](/concepts/resources) to specialize them to particular environments. A [job](/concepts/solids-pipelines/jobs) is an entity that combines a graph with resources and configuration.  After packaging a graph as a job, you can define a [schedule](/concepts/partitions-schedules-sensors/schedules) to execute it at a fixed interval or define a [sensor](/concepts/partitions-schedules-sensors/sensors) to trigger it when external changes occur. You can also launch it [manually from Dagit, GraphQL APIs, or the command line](/concepts/solids-pipelines/pipeline-execution).
 
----
+## Defining a graph
 
-## Defining a pipeline
+To define a graph, use the <PyObject object="graph" decorator /> decorator.
 
-To define a pipeline, use the <PyObject object="pipeline" decorator /> decorator.
+Within the decorated function body, you can use function calls to indicate the dependency structure between the ops and sub-graphs making up the graph.
 
-Within the decorated function body, we use function calls to indicate the dependency structure between the solids making up the pipeline.
-
-In this example, the `add_one` solid depends on the `return_one` solid's output. Because this data dependency exists, the `add_one` solid executes after `return_one` runs successfully and emits the required output.
+In this example, the `add_one` op depends on the `return_one` op's output. Because this data dependency exists, the `add_one` op executes after `return_one` runs successfully and emits the required output.
 
 ```python file=/concepts/solids_pipelines/pipelines.py startafter=start_pipeline_example_marker endbefore=end_pipeline_example_marker
-@solid
+@op
 def return_one(context):
     return 1
 
 
-@solid
+@op
 def add_one(context, number: int):
     return number + 1
 
 
-@pipeline
-def one_plus_one_pipeline():
+@graph
+def one_plus_one():
     add_one(return_one())
 ```
 
-### Aliases and Tags
+## Aliases and Tags
 
-### Solid aliases
+### Op aliases
 
-You can use the same solid definition multiple times in the same pipeline.
+You can use the same op definition multiple times in the same graph.
 
 ```python file=/concepts/solids_pipelines/pipelines.py startafter=start_multiple_usage_pipeline endbefore=end_multiple_usage_pipeline
-@pipeline
-def multiple_usage_pipeline():
+@graph
+def multiple_usage():
     add_one(add_one(return_one()))
 ```
 
-To differentiate between the two invocations of `add_one`, Dagster automatically aliases the solid names to be `add_one` and `add_one_2`.
+To differentiate between the two invocations of `add_one`, Dagster automatically aliases the op names to be `add_one` and `add_one_2`.
 
-You can also manually define the alias by using the `.alias` method on the solid invocation.
+You can also manually define the alias by using the `.alias` method on the op invocation.
 
 ```python file=/concepts/solids_pipelines/pipelines.py startafter=start_alias_pipeline endbefore=end_alias_pipeline
-@pipeline
-def alias_pipeline():
+@graph
+def alias():
     add_one.alias("second_addition")(add_one(return_one()))
 ```
 
-### Solid Tags
+### Op Tags
 
-Similar to aliases, you can also define solid tags on a solid invocation.
+Similar to aliases, you can also define op tags on an op invocation.
 
 ```python file=/concepts/solids_pipelines/pipelines.py startafter=start_tag_pipeline endbefore=end_tag_pipeline
-@pipeline
-def tag_pipeline():
+@graph
+def tagged_add_one():
     add_one.tag({"my_tag": "my_value"})(add_one(return_one()))
 ```
 
-## Pipeline Configuration
+### Graph Tags
 
-### Pipeline Modes
-
-Pipeline definitions do not expose a configuration schema. Instead, they specify a set of <PyObject object="ModeDefinition" pluralize/> that can be used with the pipeline.
-
-```python file=/concepts/solids_pipelines/pipelines.py startafter=start_modes_pipeline endbefore=end_modes_pipeline
-dev_mode = ModeDefinition("dev")
-staging_mode = ModeDefinition("staging")
-prod_mode = ModeDefinition("prod")
-
-
-@pipeline(mode_defs=[dev_mode, staging_mode, prod_mode])
-def my_modes_pipeline():
-    my_solid()
-```
-
-### Pipeline Presets
-
-You can predefine configurations in which a pipeline can execute. <PyObject object="PresetDefinition" /> allows you to do so by specifying configuration values at the pipeline definition time.
-
-```python file=/concepts/solids_pipelines/pipelines.py startafter=start_preset_pipeline endbefore=end_preset_pipeline
-@pipeline(
-    preset_defs=[
-        PresetDefinition(
-            name="one",
-            run_config={"solids": {"add_one": {"inputs": {"number": 1}}}},
-        ),
-        PresetDefinition(
-            name="two",
-            run_config={"solids": {"add_one": {"inputs": {"number": 2}}}},
-        ),
-    ]
-)
-def my_presets_pipeline():
-    add_one()
-```
-
-In Dagit, You can choose and load a preset in the Playground:
-
-<Image
-alt="Pipeline Presets"
-src="/images/concepts/pipelines/presets.png"
-width={3808}
-height={2414}
-/>
-
-To run a pipeline in a script or in a test, You can specify a preset name via `preset` argument to the Python API <PyObject object="execute_pipeline" />:
-
-```python file=/concepts/solids_pipelines/pipelines.py startafter=start_run_preset endbefore=end_run_preset
-def run_pipeline():
-    execute_pipeline(my_presets_pipeline, preset="one")
-```
-
-You can also use the Dagster CLI <PyObject module="dagster-pipeline-execute" object="--preset" displayText="dagster pipeline execute --preset" /> to run a pipeline with a preset name:
-
-```bash
-dagster pipeline execute my_presets_pipeline --preset one
-```
-
-### Pipeline Tags
-
-Pipelines can specify a set of tags that are also automatically set on the resulting pipeline runs.
+Graphs can specify a set of tags that are also automatically set on the resulting runs.
 
 ```python file=/concepts/solids_pipelines/pipelines.py startafter=start_tags_pipeline endbefore=end_tags_pipeline
-@pipeline(tags={"my_tag": "my_value"})
+@graph(tags={"my_tag": "my_value"})
 def my_tags_pipeline():
-    my_solid()
+    my_op()
 ```
 
-This pipeline defines a `my_tag` tag. Any pipeline runs created using this pipeline will also have the same tag.
+This graph defines a `my_tag` tag. Any runs created using this graph will also have the same tag.
 
 ## Examples
 
-There are many DAG structures can be represented using pipelines. This section covers a few basic patterns you can use to build more complex pipelines.
+There are many DAG structures can be represented using graphs. This section covers a few basic patterns you can use to build more complex graphs.
 
 ### Linear Dependencies
 
-The simplest pipeline structure is the linear pipeline. We return one output from the root solid, and pass along data through single inputs and outputs.
+The simplest graph structure is the linear graph. We return one output from the root op, and pass along data through single inputs and outputs.
 
 <Image
-alt="Linear Pipeline"
+alt="Linear Graph"
 src="/images/concepts/pipelines/linear.png"
 width={1000}
 height={250}
 />
 
 ```python file=/concepts/solids_pipelines/linear_pipeline.py startafter=start_marker endbefore=end_marker
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def return_one(context) -> int:
     return 1
 
 
-@solid
+@op
 def add_one(context, number: int) -> int:
     return number + 1
 
 
-@pipeline
-def linear_pipeline():
+@graph
+def linear():
     add_one(add_one(add_one(return_one())))
 ```
 
@@ -203,29 +142,29 @@ width={1000}
 height={250}
 />
 
-A single output can be passed to multiple inputs on downstream solids. In this example, the output from the first solid is passed to two different solids. The outputs of those solids are combined and passed to the final solid.
+A single output can be passed to multiple inputs on downstream ops. In this example, the output from the first op is passed to two different ops. The outputs of those ops are combined and passed to the final op.
 
 ```python file=/concepts/solids_pipelines/multiple_io_pipeline.py startafter=start_marker endbefore=end_marker
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def return_one(context) -> int:
     return 1
 
 
-@solid
+@op
 def add_one(context, number: int):
     return number + 1
 
 
-@solid
+@op
 def adder(context, a: int, b: int) -> int:
     return a + b
 
 
-@pipeline
-def inputs_and_outputs_pipeline():
+@graph
+def inputs_and_outputs():
     value = return_one()
     a = add_one(value)
     b = add_one(value)
@@ -241,23 +180,18 @@ width={1000}
 height={250}
 />
 
-A solid only starts to execute once all of its inputs have been resolved. We can use this behavior to model conditional execution of solids.
+An op only starts to execute once all of its inputs have been resolved. We can use this behavior to model conditional execution of ops.
 
-In this example, the `branching_solid` outputs either the `branch_1` result or `branch_2` result. Since solid execution is skipped for solids that have unresolved inputs, only one of the downstream solids will execute.
+In this example, the `branching_op` outputs either the `branch_1` result or `branch_2` result. Since op execution is skipped for ops that have unresolved inputs, only one of the downstream ops will execute.
 
 ```python file=/concepts/solids_pipelines/branching_pipeline.py startafter=start_marker endbefore=end_marker
 import random
 
-from dagster import Output, OutputDefinition, pipeline, solid
+from dagster import Out, Output, graph, op
 
 
-@solid(
-    output_defs=[
-        OutputDefinition(name="branch_1", is_required=False),
-        OutputDefinition(name="branch_2", is_required=False),
-    ]
-)
-def branching_solid():
+@op(out={"branch_1": Out(is_required=False), "branch_2": Out(is_required=False)})
+def branching_op():
     num = random.randint(0, 1)
     if num == 0:
         yield Output(1, "branch_1")
@@ -265,24 +199,24 @@ def branching_solid():
         yield Output(2, "branch_2")
 
 
-@solid
-def branch_1_solid(_input):
+@op
+def branch_1_op(_input):
     pass
 
 
-@solid
-def branch_2_solid(_input):
+@op
+def branch_2_op(_input):
     pass
 
 
-@pipeline
-def branching_pipeline():
-    branch_1, branch_2 = branching_solid()
-    branch_1_solid(branch_1)
-    branch_2_solid(branch_2)
+@graph
+def branching():
+    branch_1, branch_2 = branching_op()
+    branch_1_op(branch_1)
+    branch_2_op(branch_2)
 ```
 
-### Fixed Fan-in Pipeline
+### Fixed Fan-in Graph
 
 <Image
 alt="Fixed Fan-in"
@@ -291,56 +225,56 @@ width={1000}
 height={250}
 />
 
-If you have a fixed set of solids that all return the same output type, you can collect all the outputs into a list and pass them into a single downstream solid.
+If you have a fixed set of op that all return the same output type, you can collect all the outputs into a list and pass them into a single downstream op.
 
-The downstream solid executes only if all of the outputs were successfully created by the upstream solids.
+The downstream op executes only if all of the outputs were successfully created by the upstream op.
 
 ```python file=/concepts/solids_pipelines/fan_in_pipeline.py startafter=start_marker endbefore=end_marker
 from typing import List
 
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def return_one() -> int:
     return 1
 
 
-@solid
+@op
 def sum_fan_in(nums: List[int]) -> int:
     return sum(nums)
 
 
-@pipeline
-def fan_in_pipeline():
+@graph
+def fan_in():
     fan_outs = []
     for i in range(0, 10):
         fan_outs.append(return_one.alias(f"return_one_{i}")())
     sum_fan_in(fan_outs)
 ```
 
-In this example, we have 10 solids that all output the number `1`. The `sum_fan_in` solid takes all of these outputs as a list and sums them.
+In this example, we have 10 op that all output the number `1`. The `sum_fan_in` op takes all of these outputs as a list and sums them.
 
 ### Dynamic Mapping & Collect
 
-In most cases, the structure of a pipeline is pre-determined before execution. Dagster also has support for creating pipelines where the final structure is not determined until run-time. This is useful for pipeline structures where you want to execute a separate instance of a solid for each entry in a certain output.
+In most cases, the structure of a graph is pre-determined before execution. Dagster also has support for creating graphs where the final structure is not determined until run-time. This is useful for graph structures where you want to execute a separate instance of an op for each entry in a certain output.
 
-In this example we have a solid `files_in_directory` that defines a <PyObject object="DynamicOutputDefinition" module="dagster.experimental"/>. We `map` over the dynamic output which will cause the downstream dependencies to be cloned for each <PyObject object="DynamicOutput"  module="dagster.experimental"/> that is yielded. The downstream copies can be identified by the `mapping_key` supplied to <PyObject object="DynamicOutput"  module="dagster.experimental"/>. Once that's all complete, we `collect` the over results of `process_file` and pass that in to `summarize_directory`.
+In this example, we have an op `files_in_directory` that defines a <PyObject object="DynamicOut" />. We `map` over the dynamic output which will cause the downstream dependencies to be cloned for each <PyObject object="DynamicOutput" /> that is yielded. The downstream copies can be identified by the `mapping_key` supplied to <PyObject object="DynamicOutput"/>. Once that's all complete, we `collect` over the results of `process_file` and pass that in to `summarize_directory`.
 
 ```python file=/concepts/solids_pipelines/dynamic_pipeline/dynamic_pipeline.py startafter=start_marker endbefore=end_marker
 import os
 from typing import List
 
-from dagster import DynamicOutput, DynamicOutputDefinition, Field, pipeline, solid
+from dagster import DynamicOut, DynamicOutput, Field, graph, op
 from dagster.utils import file_relative_path
 
 
-@solid(
+@op(
     config_schema={"path": Field(str, default_value=file_relative_path(__file__, "sample"))},
-    output_defs=[DynamicOutputDefinition(str)],
+    out=DynamicOut(str),
 )
 def files_in_directory(context):
-    path = context.solid_config["path"]
+    path = context.op_config["path"]
     dirname, _, filenames = next(os.walk(path))
     for file in filenames:
         yield DynamicOutput(
@@ -350,19 +284,19 @@ def files_in_directory(context):
         )
 
 
-@solid
+@op
 def process_file(path: str) -> int:
     # simple example of calculating size
     return os.path.getsize(path)
 
 
-@solid
+@op
 def summarize_directory(sizes: List[int]) -> int:
     # simple example of totalling sizes
     return sum(sizes)
 
 
-@pipeline
+@graph
 def process_directory():
     file_results = files_in_directory().map(process_file)
     summarize_directory(file_results.collect())
@@ -370,136 +304,133 @@ def process_directory():
 
 ### Order-based Dependencies (Nothing dependencies)
 
-Dependencies in Dagster are primarily _data dependencies_. Using data dependencies means each input of a solid depends on the output of an upstream solid.
+Dependencies in Dagster are primarily _data dependencies_. Using data dependencies means each input of an op depends on the output of an upstream op.
 
-If you have a solid, say `Solid A`, that does not depend on any outputs of another solid, say `Solid B`, there theoretically shouldn't be a reason for `Solid A` to run after `Solid B`. In most cases, these two solids should be parallelizable. However, there are some cases where an explicit ordering is required, but it doesn't make sense to pass data through inputs and outputs to model the dependency.
+If you have an op, say `Op A`, that does not depend on any outputs of another op, say `Op B`, there theoretically shouldn't be a reason for `Op A` to run after `Op B`. In most cases, these two ops should be parallelizable. However, there are some cases where an explicit ordering is required, but it doesn't make sense to pass data through inputs and outputs to model the dependency.
 
-If you need to model an explicit ordering dependency, you can use the <PyObject object="Nothing"/> Dagster type on the input definition of the downstream solid. This type specifies that you are passing "nothing" via Dagster between the solids, while still uses inputs and outputs to model the dependency between the two solids.
+If you need to model an explicit ordering dependency, you can use the <PyObject object="Nothing"/> Dagster type on the input definition of the downstream op. This type specifies that you are passing "nothing" via Dagster between the ops, while still uses inputs and outputs to model the dependency between the two ops.
 
 ```python file=/concepts/solids_pipelines/order_based_dependency_pipeline.py startafter=start_marker endbefore=end_marker
-from dagster import InputDefinition, Nothing, pipeline, solid
+from dagster import In, Nothing, graph, op
 
 
-@solid
+@op
 def create_table_1():
     get_database_connection().execute("create table_1 as select * from some_source_table")
 
 
-@solid(input_defs=[InputDefinition("start", Nothing)])
+@op(ins={"start": In(Nothing)})
 def create_table_2():
     get_database_connection().execute("create table_2 as select * from table_1")
 
 
-@pipeline
-def nothing_dependency_pipeline():
+@graph
+def nothing_dependency():
     create_table_2(start=create_table_1())
 ```
 
-In this example, `create_table_2` has an input of type `Nothing` meaning that it doesn't exepct any data to be provided by the upstream solid. This lets us connect them in the pipeline definition so that `create_table_2` executes only after `create_table_1` successfully executes.
+In this example, `create_table_2` has an input of type `Nothing` meaning that it doesn't exepct any data to be provided by the upstream op. This lets us connect them in the graph definition so that `create_table_2` executes only after `create_table_1` successfully executes.
 
 `Nothing` type inputs do not have a corresponding parameter in the function since there is no data to pass. When connecting the dependencies, it is recommended to use keyword args to prevent mix-ups with other positional inputs.
 
-Note that in most cases, it is usually possible to pass some data dependency. In the example above, even though we probably don't want to pass the table data itself between the solids, we could pass table pointers. For example, `create_table_1` could return a `table_pointer` output of type `str` with a value of `table_1`, and this table name can be used in `create_table_2` to more accurately model the data dependency.
+Note that in most cases, it is usually possible to pass some data dependency. In the example above, even though we probably don't want to pass the table data itself between the ops, we could pass table pointers. For example, `create_table_1` could return a `table_pointer` output of type `str` with a value of `table_1`, and this table name can be used in `create_table_2` to more accurately model the data dependency.
 
 Dagster also provides more advanced abstractions to handle dependencies and IO. If you find that you are finding it difficult to model data dependencies when using external storages, check out [IOManagers](/concepts/io-management/io-managers).
 
 ## Patterns
 
-### Constructing PipelineDefinitions
+### Constructing GraphDefinitions
 
-You may run into a situation where you need to programmatically construct the dependency graph for a pipeline. In that case, you can directly define the <PyObject module="dagster" object="PipelineDefinition"/> object.
+You may run into a situation where you need to programmatically construct the dependencies for a graph. In that case, you can directly define the <PyObject module="dagster" object="GraphDefinition"/> object.
 
-To construct a PipelineDefinition, you need to pass the constructor a pipeline name, a list of solid definitions, and a dictionary defining the dependency structure. The dependency structure declares the dependencies of each solid’s inputs on the outputs of other solids in the pipeline. The top-level keys of the dependency dictionary are the string names of solids. If you are using solid aliases be sure to use the aliased name. Values of the top-level keys are also dictionary, which maps input names to a <PyObject object="DependencyDefinition"/>.
+To construct a GraphDefinition, you need to pass the constructor a graph name, a list of op or graph definitions, and a dictionary defining the dependency structure. The dependency structure declares the dependencies of each op’s inputs on the outputs of other ops in the graph. The top-level keys of the dependency dictionary are the string names of ops or graphs. If you are using op aliases, be sure to use the aliased name. Values of the top-level keys are also dictionary, which maps input names to a <PyObject object="DependencyDefinition"/>.
 
 ```python file=/concepts/solids_pipelines/pipelines.py startafter=start_pipeline_definition_marker endbefore=end_pipeline_definition_marker
-one_plus_one_pipeline_def = PipelineDefinition(
-    name="one_plus_one_pipeline",
-    solid_defs=[return_one, add_one],
+one_plus_one_graph_def = GraphDefinition(
+    name="one_plus_one",
+    node_defs=[return_one, add_one],
     dependencies={"add_one": {"number": DependencyDefinition("return_one")}},
 )
 ```
 
-### Pipeline DSL
+### Graph DSL
 
-Sometimes you may want to construct the dependencies of a pipeline definition from a YAML file or similar. This is useful when migrating to Dagster from other workflow systems.
+Sometimes you may want to construct the dependencies of a graph definition from a YAML file or similar. This is useful when migrating to Dagster from other workflow systems.
 
 For example, you can have a YAML like this:
 
-```YAML
-pipeline:
-  name: some_example
-  description: blah blah blah
-  solids:
-    - def: add_one
-      alias: A
-    - def: add_one
-      alias: B
-      deps:
-        num:
-          solid: A
-    - def: add_two
-      alias: C
-      deps:
-        num:
-          solid: A
-    - def: subtract
-      deps:
-        left:
-          solid: B
-        right:
-          solid: C
+```YAML file=/concepts/solids_pipelines/my_graph.yaml
+name: some_example
+description: blah blah blah
+ops:
+  - def: add_one
+    alias: A
+  - def: add_one
+    alias: B
+    deps:
+      num:
+        op: A
+  - def: add_two
+    alias: C
+    deps:
+      num:
+        op: A
+  - def: subtract
+    deps:
+      left:
+        op: B
+      right:
+        op: C
 ```
 
 You can programatically generate a PipelineDefinition from this YAML:
 
-```python
-@solid
+```python file=/concepts/solids_pipelines/dep_dsl.py
+import os
+
+from dagster import DependencyDefinition, GraphDefinition, SolidInvocation, op
+from dagster.utils.yaml_utils import load_yaml_from_path
+
+
+@op
 def add_one(num: int) -> int:
     return num + 1
 
 
-@solid
+@op
 def add_two(num: int) -> int:
     return num + 2
 
 
-@solid
+@op
 def subtract(left: int, right: int) -> int:
     return left + right
 
 
-def construct_pipeline_with_yaml(yaml_file, solid_defs):
+def construct_graph_with_yaml(yaml_file, op_defs) -> GraphDefinition:
     yaml_data = load_yaml_from_path(yaml_file)
-    solid_def_dict = {s.name: s for s in solid_defs}
 
     deps = {}
 
-    for solid_yaml_data in yaml_data["pipeline"]["solids"]:
-        check.invariant(solid_yaml_data["def"] in solid_def_dict)
-        def_name = solid_yaml_data["def"]
-        alias = solid_yaml_data.get("alias", def_name)
-        solid_deps_entry = {}
-        for input_name, input_data in solid_yaml_data.get("deps", {}).items():
-            solid_deps_entry[input_name] = DependencyDefinition(
-                solid=input_data["solid"], output=input_data.get("output", "result")
+    for op_yaml_data in yaml_data["ops"]:
+        def_name = op_yaml_data["def"]
+        alias = op_yaml_data.get("alias", def_name)
+        op_deps_entry = {}
+        for input_name, input_data in op_yaml_data.get("deps", {}).items():
+            op_deps_entry[input_name] = DependencyDefinition(
+                solid=input_data["op"], output=input_data.get("output", "result")
             )
-        deps[SolidInvocation(name=def_name, alias=alias)] = solid_deps_entry
+        deps[SolidInvocation(name=def_name, alias=alias)] = op_deps_entry
 
-    return PipelineDefinition(
-        name=yaml_data["pipeline"]["name"],
-        description=yaml_data["pipeline"].get("description"),
-        solid_defs=solid_defs,
+    return GraphDefinition(
+        name=yaml_data["name"],
+        description=yaml_data.get("description"),
+        node_defs=op_defs,
         dependencies=deps,
     )
 
 
-def define_dep_dsl_pipeline():
-    return construct_pipeline_with_yaml(
-        file_relative_path(__file__, "example.yaml"), [add_one, add_two, subtract]
-    )
-
-
-@repository
-def define_repository():
-    return {"pipelines": {"some_example": define_dep_dsl_pipeline}}
+def define_dep_dsl_graph() -> GraphDefinition:
+    path = os.path.join(os.path.dirname(__file__), "my_graph.yaml")
+    return construct_graph_with_yaml(path, [add_one, add_two, subtract])
 ```

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/branching_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/branching_pipeline.py
@@ -3,16 +3,11 @@
 # start_marker
 import random
 
-from dagster import Output, OutputDefinition, pipeline, solid
+from dagster import Out, Output, graph, op
 
 
-@solid(
-    output_defs=[
-        OutputDefinition(name="branch_1", is_required=False),
-        OutputDefinition(name="branch_2", is_required=False),
-    ]
-)
-def branching_solid():
+@op(out={"branch_1": Out(is_required=False), "branch_2": Out(is_required=False)})
+def branching_op():
     num = random.randint(0, 1)
     if num == 0:
         yield Output(1, "branch_1")
@@ -20,21 +15,21 @@ def branching_solid():
         yield Output(2, "branch_2")
 
 
-@solid
-def branch_1_solid(_input):
+@op
+def branch_1_op(_input):
     pass
 
 
-@solid
-def branch_2_solid(_input):
+@op
+def branch_2_op(_input):
     pass
 
 
-@pipeline
-def branching_pipeline():
-    branch_1, branch_2 = branching_solid()
-    branch_1_solid(branch_1)
-    branch_2_solid(branch_2)
+@graph
+def branching():
+    branch_1, branch_2 = branching_op()
+    branch_1_op(branch_1)
+    branch_2_op(branch_2)
 
 
 # end_marker

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/coerce_job.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/coerce_job.py
@@ -1,0 +1,11 @@
+from dagster import graph, op
+
+
+@op
+def do_something():
+    pass
+
+
+@graph
+def do_stuff():
+    do_something()

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/dep_dsl.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/dep_dsl.py
@@ -1,0 +1,47 @@
+import os
+
+from dagster import DependencyDefinition, GraphDefinition, SolidInvocation, op
+from dagster.utils.yaml_utils import load_yaml_from_path
+
+
+@op
+def add_one(num: int) -> int:
+    return num + 1
+
+
+@op
+def add_two(num: int) -> int:
+    return num + 2
+
+
+@op
+def subtract(left: int, right: int) -> int:
+    return left + right
+
+
+def construct_graph_with_yaml(yaml_file, op_defs) -> GraphDefinition:
+    yaml_data = load_yaml_from_path(yaml_file)
+
+    deps = {}
+
+    for op_yaml_data in yaml_data["ops"]:
+        def_name = op_yaml_data["def"]
+        alias = op_yaml_data.get("alias", def_name)
+        op_deps_entry = {}
+        for input_name, input_data in op_yaml_data.get("deps", {}).items():
+            op_deps_entry[input_name] = DependencyDefinition(
+                solid=input_data["op"], output=input_data.get("output", "result")
+            )
+        deps[SolidInvocation(name=def_name, alias=alias)] = op_deps_entry
+
+    return GraphDefinition(
+        name=yaml_data["name"],
+        description=yaml_data.get("description"),
+        node_defs=op_defs,
+        dependencies=deps,
+    )
+
+
+def define_dep_dsl_graph() -> GraphDefinition:
+    path = os.path.join(os.path.dirname(__file__), "my_graph.yaml")
+    return construct_graph_with_yaml(path, [add_one, add_two, subtract])

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/fan_in_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/fan_in_pipeline.py
@@ -2,21 +2,21 @@
 
 from typing import List
 
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def return_one() -> int:
     return 1
 
 
-@solid
+@op
 def sum_fan_in(nums: List[int]) -> int:
     return sum(nums)
 
 
-@pipeline
-def fan_in_pipeline():
+@graph
+def fan_in():
     fan_outs = []
     for i in range(0, 10):
         fan_outs.append(return_one.alias(f"return_one_{i}")())

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/jobs.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/jobs.py
@@ -1,0 +1,18 @@
+from dagster import ResourceDefinition, graph, op
+
+
+@op(config_schema={"config_param": str}, required_resource_keys={"my_resource"})
+def do_something(context):
+    context.log.info("config_param: " + context.op_config["config_param"])
+    context.log.info("my_resource: " + context.resources.my_resource)
+
+
+@graph
+def do_it_all():
+    do_something()
+
+
+do_it_all_job = do_it_all.to_job(
+    config={"ops": {"do_something": {"config": {"config_param": "stuff"}}}},
+    resource_defs={"my_resource": ResourceDefinition.hardcoded_resource("hello")},
+)

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/jobs_with_config_mapping.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/jobs_with_config_mapping.py
@@ -1,0 +1,23 @@
+from dagster import config_mapping, graph, op
+
+
+@op(config_schema={"config_param": str})
+def do_something(context):
+    context.log.info("config_param: " + context.op_config["config_param"])
+
+
+@graph
+def do_it_all():
+    do_something()
+
+
+@config_mapping(config_schema={"simplified_param": str})
+def simplified_config(val):
+    return {"ops": {"do_something": {"config": {"config_param": val["simplified_param"]}}}}
+
+
+do_it_all_with_simplified_config = do_it_all.to_job(config=simplified_config)
+
+if __name__ == "__main__":
+    # Will log "config_param: stuff"
+    do_it_all_with_simplified_config.execute_in_process(run_config={"simplified_param": "stuff"})

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/jobs_with_default_config.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/jobs_with_default_config.py
@@ -1,0 +1,20 @@
+from dagster import graph, op
+
+
+@op(config_schema={"config_param": str})
+def do_something(context):
+    context.log.info("config_param: " + context.op_config["config_param"])
+
+
+@graph
+def do_it_all():
+    do_something()
+
+
+do_it_all_with_default_config = do_it_all.to_job(
+    config={"ops": {"do_something": {"config": {"config_param": "stuff"}}}},
+)
+
+if __name__ == "__main__":
+    # Will log "config_param: stuff"
+    do_it_all_with_default_config.execute_in_process()

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/linear_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/linear_pipeline.py
@@ -1,21 +1,21 @@
 # pylint: disable=unused-argument
 
 # start_marker
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def return_one(context) -> int:
     return 1
 
 
-@solid
+@op
 def add_one(context, number: int) -> int:
     return number + 1
 
 
-@pipeline
-def linear_pipeline():
+@graph
+def linear():
     add_one(add_one(add_one(return_one())))
 
 

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/multiple_io_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/multiple_io_pipeline.py
@@ -1,26 +1,26 @@
 # pylint: disable=unused-argument, no-value-for-parameter
 
 # start_marker
-from dagster import pipeline, solid
+from dagster import graph, op
 
 
-@solid
+@op
 def return_one(context) -> int:
     return 1
 
 
-@solid
+@op
 def add_one(context, number: int):
     return number + 1
 
 
-@solid
+@op
 def adder(context, a: int, b: int) -> int:
     return a + b
 
 
-@pipeline
-def inputs_and_outputs_pipeline():
+@graph
+def inputs_and_outputs():
     value = return_one()
     a = add_one(value)
     b = add_one(value)

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/my_graph.yaml
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/my_graph.yaml
@@ -1,0 +1,21 @@
+name: some_example
+description: blah blah blah
+ops:
+  - def: add_one
+    alias: A
+  - def: add_one
+    alias: B
+    deps:
+      num:
+        op: A
+  - def: add_two
+    alias: C
+    deps:
+      num:
+        op: A
+  - def: subtract
+    deps:
+      left:
+        op: B
+      right:
+        op: C

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/order_based_dependency_pipeline.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/order_based_dependency_pipeline.py
@@ -11,21 +11,21 @@ def get_database_connection():
 
 
 # start_marker
-from dagster import InputDefinition, Nothing, pipeline, solid
+from dagster import In, Nothing, graph, op
 
 
-@solid
+@op
 def create_table_1():
     get_database_connection().execute("create table_1 as select * from some_source_table")
 
 
-@solid(input_defs=[InputDefinition("start", Nothing)])
+@op(ins={"start": In(Nothing)})
 def create_table_2():
     get_database_connection().execute("create table_2 as select * from table_1")
 
 
-@pipeline
-def nothing_dependency_pipeline():
+@graph
+def nothing_dependency():
     create_table_2(start=create_table_1())
 
 

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/pipelines.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/pipelines.py
@@ -1,50 +1,42 @@
 # pylint: disable=unused-argument
 
-from dagster import (
-    DependencyDefinition,
-    ModeDefinition,
-    PipelineDefinition,
-    PresetDefinition,
-    execute_pipeline,
-    pipeline,
-    solid,
-)
+from dagster import DependencyDefinition, GraphDefinition, graph, op
 
 
-@solid
-def my_solid():
+@op
+def my_op():
     pass
 
 
 # start_pipeline_example_marker
-@solid
+@op
 def return_one(context):
     return 1
 
 
-@solid
+@op
 def add_one(context, number: int):
     return number + 1
 
 
-@pipeline
-def one_plus_one_pipeline():
+@graph
+def one_plus_one():
     add_one(return_one())
 
 
 # end_pipeline_example_marker
 
 # start_multiple_usage_pipeline
-@pipeline
-def multiple_usage_pipeline():
+@graph
+def multiple_usage():
     add_one(add_one(return_one()))
 
 
 # end_multiple_usage_pipeline
 
 # start_alias_pipeline
-@pipeline
-def alias_pipeline():
+@graph
+def alias():
     add_one.alias("second_addition")(add_one(return_one()))
 
 
@@ -52,8 +44,8 @@ def alias_pipeline():
 
 
 # start_tag_pipeline
-@pipeline
-def tag_pipeline():
+@graph
+def tagged_add_one():
     add_one.tag({"my_tag": "my_value"})(add_one(return_one()))
 
 
@@ -61,60 +53,18 @@ def tag_pipeline():
 
 
 # start_pipeline_definition_marker
-one_plus_one_pipeline_def = PipelineDefinition(
-    name="one_plus_one_pipeline",
-    solid_defs=[return_one, add_one],
+one_plus_one_graph_def = GraphDefinition(
+    name="one_plus_one",
+    node_defs=[return_one, add_one],
     dependencies={"add_one": {"number": DependencyDefinition("return_one")}},
 )
 # end_pipeline_definition_marker
 
 
-# start_modes_pipeline
-dev_mode = ModeDefinition("dev")
-staging_mode = ModeDefinition("staging")
-prod_mode = ModeDefinition("prod")
-
-
-@pipeline(mode_defs=[dev_mode, staging_mode, prod_mode])
-def my_modes_pipeline():
-    my_solid()
-
-
-# end_modes_pipeline
-
-# start_preset_pipeline
-@pipeline(
-    preset_defs=[
-        PresetDefinition(
-            name="one",
-            run_config={"solids": {"add_one": {"inputs": {"number": 1}}}},
-        ),
-        PresetDefinition(
-            name="two",
-            run_config={"solids": {"add_one": {"inputs": {"number": 2}}}},
-        ),
-    ]
-)
-def my_presets_pipeline():
-    add_one()
-
-
-# end_preset_pipeline
-
-# start_run_preset
-
-
-def run_pipeline():
-    execute_pipeline(my_presets_pipeline, preset="one")
-
-
-# end_run_preset
-
-
 # start_tags_pipeline
-@pipeline(tags={"my_tag": "my_value"})
+@graph(tags={"my_tag": "my_value"})
 def my_tags_pipeline():
-    my_solid()
+    my_op()
 
 
 # end_tags_pipeline

--- a/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/repo_with_job.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/concepts/solids_pipelines/repo_with_job.py
@@ -1,0 +1,8 @@
+from dagster import repository
+
+from .jobs import do_it_all_job
+
+
+@repository
+def my_repo():
+    return [do_it_all_job]

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_jobs.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_jobs.py
@@ -1,0 +1,19 @@
+from docs_snippets_crag.concepts.solids_pipelines.jobs import do_it_all_job
+from docs_snippets_crag.concepts.solids_pipelines.jobs_with_config_mapping import (
+    do_it_all_with_simplified_config,
+)
+from docs_snippets_crag.concepts.solids_pipelines.jobs_with_default_config import (
+    do_it_all_with_default_config,
+)
+
+
+def test_do_it_all_job():
+    do_it_all_job.execute_in_process()
+
+
+def test_do_it_all_with_default_config():
+    do_it_all_with_default_config.execute_in_process()
+
+
+def test_do_it_all_with_simplified_config():
+    do_it_all_with_simplified_config.execute_in_process(run_config={"simplified_param": "stuff"})

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_pipelines.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/concepts_tests/solids_pipelines_tests/test_pipelines.py
@@ -1,65 +1,61 @@
-from dagster import execute_pipeline
-from docs_snippets_crag.concepts.solids_pipelines.branching_pipeline import branching_pipeline
+from docs_snippets_crag.concepts.solids_pipelines.branching_pipeline import branching
+from docs_snippets_crag.concepts.solids_pipelines.dep_dsl import define_dep_dsl_graph
 from docs_snippets_crag.concepts.solids_pipelines.dynamic_pipeline.dynamic_pipeline import (
     process_directory,
 )
-from docs_snippets_crag.concepts.solids_pipelines.fan_in_pipeline import fan_in_pipeline
-from docs_snippets_crag.concepts.solids_pipelines.linear_pipeline import linear_pipeline
-from docs_snippets_crag.concepts.solids_pipelines.multiple_io_pipeline import (
-    inputs_and_outputs_pipeline,
-)
+from docs_snippets_crag.concepts.solids_pipelines.fan_in_pipeline import fan_in
+from docs_snippets_crag.concepts.solids_pipelines.linear_pipeline import linear
+from docs_snippets_crag.concepts.solids_pipelines.multiple_io_pipeline import inputs_and_outputs
 from docs_snippets_crag.concepts.solids_pipelines.order_based_dependency_pipeline import (
-    nothing_dependency_pipeline,
+    nothing_dependency,
 )
 from docs_snippets_crag.concepts.solids_pipelines.pipelines import (
-    alias_pipeline,
-    one_plus_one_pipeline,
-    one_plus_one_pipeline_def,
-    tag_pipeline,
+    alias,
+    one_plus_one,
+    one_plus_one_graph_def,
+    tagged_add_one,
 )
 
 
-def test_one_plus_one_pipeline():
-    result = execute_pipeline(one_plus_one_pipeline)
-    assert result.output_for_solid("add_one", output_name="result") == 2
+def test_one_plus_one():
+    result = one_plus_one.execute_in_process()
+    assert result.result_for_node("add_one").output_value() == 2
 
 
-def test_one_plus_one_pipeline_def():
-    result = execute_pipeline(one_plus_one_pipeline_def)
-    assert result.output_for_solid("add_one", output_name="result") == 2
+def test_one_plus_one_graph_def():
+    result = one_plus_one_graph_def.execute_in_process()
+    assert result.result_for_node("add_one").output_value() == 2
 
 
-def test_linear_pipeline():
-    result = execute_pipeline(linear_pipeline)
-    assert result.output_for_solid("add_one_3", output_name="result") == 4
+def test_linear():
+    result = linear.execute_in_process()
+    assert result.result_for_node("add_one_3").output_value() == 4
 
 
-def test_other_pipelines():
-    other_pipelines = [
-        branching_pipeline,
-        inputs_and_outputs_pipeline,
-        nothing_dependency_pipeline,
-        alias_pipeline,
-        tag_pipeline,
+def test_other_graphs():
+    other_graphs = [
+        branching,
+        inputs_and_outputs,
+        nothing_dependency,
+        alias,
+        tagged_add_one,
     ]
-    for pipeline in other_pipelines:
-        result = execute_pipeline(pipeline)
+    for graph in other_graphs:
+        result = graph.execute_in_process()
         assert result.success
 
 
-def test_fan_in_pipeline():
-    result = execute_pipeline(fan_in_pipeline)
+def test_fan_in():
+    result = fan_in.execute_in_process()
     assert result.success
-    assert result.result_for_solid("sum_fan_in").output_value() == 10
+    assert result.result_for_node("sum_fan_in").output_value() == 10
 
 
-def test_dynamic_pipeline():
-    result = execute_pipeline(process_directory)
+def test_dynamic():
+    result = process_directory.execute_in_process()
     assert result.success
 
-    assert result.result_for_solid("process_file").output_value() == {
-        "empty_stuff_bin": 0,
-        "program_py": 34,
-        "words_txt": 40,
-    }
-    assert result.result_for_solid("summarize_directory").output_value() == 74
+
+def test_dep_dsl():
+    result = define_dep_dsl_graph().execute_in_process(config={"A": {"inputs": {"num": 0}}})
+    assert result.success


### PR DESCRIPTION
This splits the Pipelines page into two pages: Graphs and Jobs.  We could potentially consolidate them into a single page.  There's a lot of content on the Graph page already though, FWIW.