### PR TITLE
[dagit] avoid duping events on websocket reconnect

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -18,6 +18,7 @@ import {Colors} from '@blueprintjs/core';
 import * as React from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {createGlobalStyle} from 'styled-components/macro';
+import {SubscriptionClient} from 'subscriptions-transport-ws';
 
 import {FontFamily} from '../ui/styles';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
@@ -96,6 +97,15 @@ export const AppProvider: React.FC<Props> = (props) => {
   const headersAsString = JSON.stringify(headers);
   const headerObject = React.useMemo(() => JSON.parse(headersAsString), [headersAsString]);
 
+  const websocketClient = React.useMemo(
+    () =>
+      new SubscriptionClient(websocketURI, {
+        reconnect: true,
+        connectionParams: {...headerObject},
+      }),
+    [headerObject, websocketURI],
+  );
+
   const apolloClient = React.useMemo(() => {
     // Subscriptions use WebSocketLink, queries & mutations use HttpLink.
     const splitLink = split(
@@ -103,13 +113,7 @@ export const AppProvider: React.FC<Props> = (props) => {
         const definition = getMainDefinition(query);
         return definition.kind === 'OperationDefinition' && definition.operation === 'subscription';
       },
-      new WebSocketLink({
-        uri: websocketURI,
-        options: {
-          reconnect: true,
-          connectionParams: {...headerObject},
-        },
-      }),
+      new WebSocketLink(websocketClient),
       new HttpLink({uri: graphqlPath, headers: headerObject}),
     );
 
@@ -117,7 +121,7 @@ export const AppProvider: React.FC<Props> = (props) => {
       cache: appCache,
       link: ApolloLink.from([...apolloLinks, splitLink]),
     });
-  }, [apolloLinks, appCache, graphqlPath, headerObject, websocketURI]);
+  }, [apolloLinks, appCache, graphqlPath, headerObject, websocketClient]);
 
   const appContextValue = React.useMemo(
     () => ({
@@ -129,7 +133,7 @@ export const AppProvider: React.FC<Props> = (props) => {
 
   return (
     <AppContext.Provider value={appContextValue}>
-      <WebSocketProvider websocketURI={websocketURI} connectionParams={headerObject}>
+      <WebSocketProvider websocketClient={websocketClient}>
         <GlobalStyle />
         <ApolloProvider client={apolloClient}>
           <PermissionsProvider>

--- a/js_modules/dagit/packages/core/src/app/useWebsocketAvailability.tsx
+++ b/js_modules/dagit/packages/core/src/app/useWebsocketAvailability.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {WebSocketContext, WebSocketStatus} from './WebSocketProvider';
+import {WebSocketContext} from './WebSocketProvider';
 
 export const useWebsocketAvailability = () => {
   const {websocketClient} = React.useContext(WebSocketContext);


### PR DESCRIPTION
A scheme in which we move the subscription cursor on websocket reconnection to ensure we dont start loading the events from the begining again

### Test Plan

While loading the events for a large run, stop and start the webserver. Ensure no dupe events are loaded.
