### PR TITLE
Add volumes and volume mounts to run launcher

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -53,6 +53,8 @@ class K8sRunLauncherConfig(BaseModel):
     envConfigMaps: List[kubernetes.ConfigMapEnvSource]
     envSecrets: List[kubernetes.SecretEnvSource]
     envVars: List[str]
+    volumeMounts: List[kubernetes.VolumeMount]
+    volumes: List[kubernetes.Volume]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/utils/kubernetes.py
+++ b/helm/dagster/schema/schema/charts/utils/kubernetes.py
@@ -142,3 +142,8 @@ class ConfigMapEnvSource(BaseModel):
 class VolumeMount(BaseModel):
     class Config:
         schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.VolumeMount")}
+
+
+class Volume(BaseModel):
+    class Config:
+        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Volume")}

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -100,6 +100,24 @@ def test_k8s_run_launcher_config(template: HelmTemplate):
     env_config_maps = [{"name": "env_config_map"}]
     env_secrets = [{"name": "secret"}]
     env_vars = ["ENV_VAR"]
+    volume_mounts = [
+        {
+            "mountPath": "/opt/dagster/dagster_home/dagster.yaml",
+            "name": "dagster-instance",
+            "subPath": "dagster.yaml",
+        },
+        {
+            "name": "test-volume",
+            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+            "subPath": "volume_mounted_file.yaml",
+        },
+    ]
+
+    volumes = [
+        {"name": "test-volume", "configMap": {"name": "test-volume-configmap"}},
+        {"name": "test-pvc", "persistentVolumeClaim": {"claimName": "my_claim", "readOnly": False}},
+    ]
+
     helm_values = DagsterHelmValues.construct(
         runLauncher=RunLauncher.construct(
             type=RunLauncherType.K8S,
@@ -111,6 +129,8 @@ def test_k8s_run_launcher_config(template: HelmTemplate):
                     envConfigMaps=env_config_maps,
                     envSecrets=env_secrets,
                     envVars=env_vars,
+                    volumeMounts=volume_mounts,
+                    volumes=volumes,
                 )
             ),
         )
@@ -132,6 +152,8 @@ def test_k8s_run_launcher_config(template: HelmTemplate):
         secret["name"] for secret in env_secrets
     ]
     assert run_launcher_config["config"]["env_vars"] == env_vars
+    assert run_launcher_config["config"]["volume_mounts"] == volume_mounts
+    assert run_launcher_config["config"]["volumes"] == volumes
 
 
 @pytest.mark.parametrize("enabled", [True, False])

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -64,6 +64,15 @@ config:
   {{- if $k8sRunLauncherConfig.envVars }}
   env_vars: {{- $k8sRunLauncherConfig.envVars | toYaml | nindent 4 }}
   {{- end }}
+
+  {{- if $k8sRunLauncherConfig.volumeMounts }}
+  volume_mounts: {{- $k8sRunLauncherConfig.volumeMounts | toYaml | nindent 4 }}
+  {{- end }}
+
+  {{- if $k8sRunLauncherConfig.volumes }}
+  volumes: {{- $k8sRunLauncherConfig.volumes | toYaml | nindent 4 }}
+  {{- end }}
+
 {{- end }}
 
 {{- define "dagsterYaml.runLauncher.custom" }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1504,6 +1504,18 @@
             ],
             "additionalProperties": false
         },
+        "VolumeMount": {
+            "title": "VolumeMount",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+        },
+        "Volume": {
+            "title": "Volume",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+        },
         "K8sRunLauncherConfig": {
             "title": "K8sRunLauncherConfig",
             "type": "object",
@@ -1568,6 +1580,20 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "volumeMounts": {
+                    "title": "Volumemounts",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VolumeMount"
+                    }
+                },
+                "volumes": {
+                    "title": "Volumes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Volume"
+                    }
                 }
             },
             "required": [
@@ -1575,7 +1601,9 @@
                 "loadInclusterConfig",
                 "envConfigMaps",
                 "envSecrets",
-                "envVars"
+                "envVars",
+                "volumeMounts",
+                "volumes"
             ],
             "additionalProperties": false
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -391,6 +391,28 @@ runLauncher:
       #   - "ENV_VAR"
       envVars: []
 
+      # Additional volumes that should be included in the Job's Pod. See:
+      # https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
+      #
+      # Example:
+      #
+      # volumes:
+      #   - name: my-volume
+      #     configMap: my-config-map
+      volumes: []
+
+      # Additional volume mounts that should be included in the container in the Job's Pod. See:
+      # See: https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+      #
+      # Example:
+      #
+      # volumeMounts:
+      #   - name: test-volume
+      #     mountPath: /opt/dagster/test_folder
+      #     subPath: test_file.yaml
+      volumeMounts: []
+
+
     # This configuration will only be used if the CeleryK8sRunLauncher is selected
     celeryK8sRunLauncher:
       # The Celery workers can be deployed with a fixed image (no user code included)

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -20,6 +20,8 @@ TEST_OTHER_CONFIGMAP_NAME = "test-other-env-configmap"
 TEST_SECRET_NAME = "test-env-secret"
 TEST_OTHER_SECRET_NAME = "test-other-env-secret"
 
+TEST_VOLUME_CONFIGMAP_NAME = "test-volume-configmap"
+
 TEST_IMAGE_PULL_SECRET_NAME = "test-image-pull-secret"
 TEST_OTHER_IMAGE_PULL_SECRET_NAME = "test-other-image-pull-secret"
 
@@ -72,7 +74,9 @@ def namespace(pytestconfig, should_cleanup):
 
 @pytest.fixture(scope="session")
 def configmaps(namespace, should_cleanup):
-    print("Creating k8s test object ConfigMap %s" % (TEST_CONFIGMAP_NAME))
+    print(
+        f"Creating k8s test object ConfigMaps: {TEST_CONFIGMAP_NAME}, {TEST_OTHER_CONFIGMAP_NAME}, {TEST_VOLUME_CONFIGMAP_NAME}"
+    )
     kube_api = kubernetes.client.CoreV1Api()
 
     configmap = kubernetes.client.V1ConfigMap(
@@ -91,10 +95,20 @@ def configmaps(namespace, should_cleanup):
     )
     kube_api.create_namespaced_config_map(namespace=namespace, body=other_configmap)
 
+    volume_configmap = kubernetes.client.V1ConfigMap(
+        api_version="v1",
+        kind="ConfigMap",
+        data={"volume_mounted_file.yaml": "BAR_CONTENTS"},
+        metadata=kubernetes.client.V1ObjectMeta(name=TEST_VOLUME_CONFIGMAP_NAME),
+    )
+
+    kube_api.create_namespaced_config_map(namespace=namespace, body=volume_configmap)
+
     yield
 
     if should_cleanup:
         kube_api.delete_namespaced_config_map(name=TEST_CONFIGMAP_NAME, namespace=namespace)
+        kube_api.delete_namespaced_config_map(name=TEST_OTHER_CONFIGMAP_NAME, namespace=namespace)
         kube_api.delete_namespaced_config_map(name=TEST_OTHER_CONFIGMAP_NAME, namespace=namespace)
 
 
@@ -536,6 +550,16 @@ def helm_chart_for_k8s_run_launcher(namespace, docker_image, should_cleanup=True
                     "envSecrets": [{"name": TEST_SECRET_NAME}],
                     "envVars": ["BUILDKITE"],
                     "imagePullPolicy": image_pull_policy(),
+                    "volumeMounts": [
+                        {
+                            "name": "test-volume",
+                            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+                            "subPath": "volume_mounted_file.yaml",
+                        }
+                    ],
+                    "volumes": [
+                        {"name": "test-volume", "configMap": {"name": TEST_VOLUME_CONFIGMAP_NAME}}
+                    ],
                 }
             },
         },

--- a/integration_tests/test_suites/k8s-integration-test-suite/conftest.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/conftest.py
@@ -16,6 +16,7 @@ from dagster_k8s_test_infra.helm import (
     TEST_AWS_CONFIGMAP_NAME,
     TEST_IMAGE_PULL_SECRET_NAME,
     TEST_SECRET_NAME,
+    TEST_VOLUME_CONFIGMAP_NAME,
 )
 from dagster_k8s_test_infra.integration_utils import image_pull_policy
 from dagster_test.test_project import build_and_tag_test_image, get_test_project_docker_image
@@ -64,6 +65,14 @@ def run_launcher(
         env_config_maps=["dagster-pipeline-env", "test-env-configmap"]
         + ([TEST_AWS_CONFIGMAP_NAME] if not IS_BUILDKITE else []),
         env_secrets=["test-env-secret"],
+        volume_mounts=[
+            {
+                "name": "test-volume",
+                "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+                "subPath": "volume_mounted_file.yaml",
+            }
+        ],
+        volumes=[{"name": "test-volume", "configMap": {"name": TEST_VOLUME_CONFIGMAP_NAME}}],
     )
 
 

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_job_spec.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_job_spec.py
@@ -88,6 +88,9 @@ spec:
         - mount_path: /opt/dagster/dagster_home/dagster.yaml
           name: dagster-instance
           sub_path: dagster.yaml
+        - mount_path: /opt/dagster/test_mount_path/volume_mounted_file.yaml
+          name: test-volume
+          sub_path: volume_mounted_file.yaml
       image_pull_secrets:
       - name: test-image-pull-secret
       restart_policy: Never
@@ -96,6 +99,9 @@ spec:
       - config_map:
           name: dagster-instance
         name: dagster-instance
+      - config_map:
+          name: test-volume-configmap
+        name: test-volume
   ttl_seconds_after_finished: 86400
 """
 
@@ -146,6 +152,9 @@ spec:
         - mount_path: /opt/dagster/dagster_home/dagster.yaml
           name: dagster-instance
           sub_path: dagster.yaml
+        - mount_path: /opt/dagster/test_mount_path/volume_mounted_file.yaml
+          name: test-volume
+          sub_path: volume_mounted_file.yaml
       image_pull_secrets:
       - name: test-image-pull-secret
       restart_policy: Never
@@ -154,6 +163,9 @@ spec:
       - config_map:
           name: dagster-instance
         name: dagster-instance
+      - config_map:
+          name: test-volume-configmap
+        name: test-volume
   ttl_seconds_after_finished: {ttl_seconds_after_finished}
 """
 

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -505,6 +505,24 @@ def define_demo_k8s_executor_pipeline():
     return demo_k8s_executor_pipeline
 
 
+@solid
+def check_volume_mount(context):
+    with open("/opt/dagster/test_mount_path/volume_mounted_file.yaml", "r") as mounted_file:
+        contents = mounted_file.read()
+        context.log.info(f"Contents of mounted file: {contents}")
+        assert contents == "BAR_CONTENTS"
+
+
+def define_volume_mount_pipeline():
+    @pipeline(
+        mode_defs=k8s_mode_defs(),
+    )
+    def volume_mount_pipeline():
+        check_volume_mount()
+
+    return volume_mount_pipeline
+
+
 def define_demo_execution_repo():
     @repository
     def demo_execution_repo():
@@ -527,6 +545,7 @@ def define_demo_execution_repo():
                 "hanging_pipeline": hanging_pipeline,
                 "hard_failer": define_hard_failer,
                 "demo_k8s_executor_pipeline": define_demo_k8s_executor_pipeline,
+                "volume_mount_pipeline": define_volume_mount_pipeline,
             },
             "schedules": define_schedules(),
         }

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -125,6 +125,8 @@ def celery_k8s_job_executor(init_context):
         service_account_name=exc_cfg.get("service_account_name"),
         env_config_maps=exc_cfg.get("env_config_maps"),
         env_secrets=exc_cfg.get("env_secrets"),
+        volume_mounts=exc_cfg.get("volume_mounts"),
+        volumes=exc_cfg.get("volumes"),
     )
 
     # Set on the instance but overrideable here

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -200,6 +200,8 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             service_account_name=exc_config.get("service_account_name"),
             env_config_maps=exc_config.get("env_config_maps"),
             env_secrets=exc_config.get("env_secrets"),
+            volume_mounts=exc_config.get("volume_mounts"),
+            volumes=exc_config.get("volumes"),
         )
 
         self._instance.add_run_tags(

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -39,6 +39,8 @@ def test_get_validated_celery_k8s_executor_config():
         "job_namespace": "default",
         "repo_location_name": "<<in_process>>",
         "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
+        "volume_mounts": [],
+        "volumes": [],
     }
 
     with pytest.raises(
@@ -67,6 +69,8 @@ def test_get_validated_celery_k8s_executor_config():
             "job_namespace": "default",
             "repo_location_name": "<<in_process>>",
             "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
+            "volume_mounts": [],
+            "volumes": [],
         }
 
     # Test setting all possible config fields
@@ -110,6 +114,8 @@ def test_get_validated_celery_k8s_executor_config():
                         "env_config_maps": [{"env": "TEST_PIPELINE_RUN_ENV_CONFIGMAP"}],
                         "env_secrets": [{"env": "TEST_SECRET"}],
                         "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
+                        "volume_mounts": [],
+                        "volumes": [],
                     }
                 }
             }
@@ -133,6 +139,8 @@ def test_get_validated_celery_k8s_executor_config():
             "env_config_maps": ["config-pipeline-env"],
             "env_secrets": ["config-secret-env"],
             "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
+            "volume_mounts": [],
+            "volumes": [],
         }
 
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -91,6 +91,8 @@ def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
         ),
         env_config_maps=run_launcher.env_config_maps + (exc_cfg.get("env_config_maps") or []),
         env_secrets=run_launcher.env_secrets + (exc_cfg.get("env_secrets") or []),
+        volume_mounts=run_launcher.volume_mounts + (exc_cfg.get("volume_mounts") or []),
+        volumes=run_launcher.volumes + (exc_cfg.get("volumes") or []),
     )
 
     return StepDelegatingExecutor(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from typing import List
 
 import kubernetes
-from dagster import Array, Field, Noneable, StringSource
+from dagster import Array, BoolSource, Field, Noneable, StringSource
 from dagster import __version__ as dagster_version
 from dagster import check
 from dagster.config.field_utils import Permissive, Shape
@@ -15,6 +15,8 @@ from dagster.config.validate import validate_config
 from dagster.core.errors import DagsterInvalidConfigError
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils import frozentags, merge_dicts
+
+from .models import k8s_model_from_dict
 
 # To retry step job, users should raise RetryRequested() so that the dagster system is aware of the
 # retry. As an example, see retry_pipeline in dagster_test.test_project.test_pipelines.repo
@@ -183,7 +185,7 @@ class DagsterK8sJobConfig(
         "_K8sJobTaskConfig",
         "job_image dagster_home image_pull_policy image_pull_secrets service_account_name "
         "instance_config_map postgres_password_secret env_config_maps env_secrets env_vars "
-        "volume_mounts",
+        "volume_mounts volumes",
     )
 ):
     """Configuration parameters for launching Dagster Jobs on Kubernetes.
@@ -220,7 +222,11 @@ class DagsterK8sJobConfig(
             Default: ``[]``. See: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
         job_image (Optional[str]): The docker image to use. The Job container will be launched with this
             image. Should not be specified if using userDeployments.
-
+        volume_mounts (Optional[List[Permissive]]): A list of volume mounts to include in the job's
+            container. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+        volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
     """
 
     def __new__(
@@ -236,6 +242,7 @@ class DagsterK8sJobConfig(
         env_secrets=None,
         env_vars=None,
         volume_mounts=None,
+        volumes=None,
     ):
         return super(DagsterK8sJobConfig, cls).__new__(
             cls,
@@ -256,6 +263,7 @@ class DagsterK8sJobConfig(
             env_secrets=check.opt_list_param(env_secrets, "env_secrets", of_type=str),
             env_vars=check.opt_list_param(env_vars, "env_secrets", of_type=str),
             volume_mounts=check.opt_list_param(volume_mounts, "volume_mounts"),
+            volumes=check.opt_list_param(volumes, "volumes"),
         )
 
     @classmethod
@@ -345,6 +353,38 @@ class DagsterK8sJobConfig(
                 description="A list of environment variables to inject into the Job. "
                 "Default: ``[]``. See: "
                 "https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables",
+            ),
+            "volume_mounts": Field(
+                Array(
+                    Shape(
+                        {
+                            "name": StringSource,
+                            "mountPath": StringSource,
+                            "mountPropagation": Field(StringSource, is_required=False),
+                            "readOnly": Field(BoolSource, is_required=False),
+                            "subPath": Field(StringSource, is_required=False),
+                            "subPathExpr": Field(StringSource, is_required=False),
+                        }
+                    )
+                ),
+                is_required=False,
+                default_value=[],
+                description="A list of volume mounts to include in the job's container. Default: ``[]``. See: "
+                "https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core",
+            ),
+            "volumes": Field(
+                Array(
+                    Permissive(
+                        {
+                            "name": str,
+                        }
+                    )
+                ),
+                is_required=False,
+                default_value=[],
+                description="A list of volumes to include in the Job's Pod. Default: ``[]``. For the many "
+                "possible volume source types that can be included, see: "
+                "https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core",
             ),
         }
 
@@ -503,11 +543,7 @@ def construct_dagster_k8s_job(
             sub_path="dagster.yaml",
         )
     ] + [
-        kubernetes.client.V1VolumeMount(
-            name=mount["name"],
-            mount_path=mount["path"],
-            sub_path=mount["sub_path"],
-        )
+        k8s_model_from_dict(kubernetes.client.models.V1VolumeMount, mount)
         for mount in job_config.volume_mounts
     ]
 
@@ -516,9 +552,10 @@ def construct_dagster_k8s_job(
     user_defined_k8s_volume_mounts = user_defined_k8s_config.container_config.pop(
         "volume_mounts", []
     )
-    additional_k8s_volume_mounts = []
     for volume_mount in user_defined_k8s_volume_mounts:
-        additional_k8s_volume_mounts.append(kubernetes.client.V1VolumeMount(**volume_mount))
+        volume_mounts.append(
+            k8s_model_from_dict(kubernetes.client.models.V1VolumeMount, volume_mount)
+        )
 
     job_container = kubernetes.client.V1Container(
         name=job_name,
@@ -527,9 +564,11 @@ def construct_dagster_k8s_job(
         image_pull_policy=job_config.image_pull_policy,
         env=env + job_config.env + additional_k8s_env_vars,
         env_from=job_config.env_from_sources + additional_k8s_env_from,
-        volume_mounts=volume_mounts + additional_k8s_volume_mounts,
+        volume_mounts=volume_mounts,
         **user_defined_k8s_config.container_config,
     )
+
+    user_defined_volumes = user_defined_k8s_config.pod_spec_config.pop("volumes", [])
 
     volumes = [
         kubernetes.client.V1Volume(
@@ -538,18 +577,14 @@ def construct_dagster_k8s_job(
                 name=job_config.instance_config_map
             ),
         )
-    ] + [
-        kubernetes.client.V1Volume(
-            name=mount["name"],
-            config_map=kubernetes.client.V1ConfigMapVolumeSource(name=mount["configmap"]),
-        )
-        if mount.get("configmap")
-        else kubernetes.client.V1Volume(
-            name=mount["name"],
-            secret=kubernetes.client.V1SecretVolumeSource(secret_name=mount["secret"]),
-        )
-        for mount in job_config.volume_mounts
     ]
+
+    for volume in job_config.volumes + user_defined_volumes:
+        new_volume = k8s_model_from_dict(
+            kubernetes.client.models.V1Volume,
+            volume,
+        )
+        volumes.append(new_volume)
 
     # If the user has defined custom labels, remove them from the pod_template_spec_metadata
     # key and merge them with the dagster labels

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -88,6 +88,11 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
         env_vars (Optional[List[str]]): A list of environment variables to inject into the Job.
             Default: ``[]``. See: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+        volume_mounts (Optional[List[Permissive]]): A list of volume mounts to include in the job's
+            container. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+        volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
     """
 
     def __init__(
@@ -107,6 +112,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         env_secrets=None,
         env_vars=None,
         k8s_client_batch_api=None,
+        volume_mounts=None,
+        volumes=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.job_namespace = check.str_param(job_namespace, "job_namespace")
@@ -144,6 +151,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         )
         self._env_secrets = check.opt_list_param(env_secrets, "env_secrets", of_type=str)
         self._env_vars = check.opt_list_param(env_vars, "env_vars", of_type=str)
+        self._volume_mounts = check.opt_list_param(volume_mounts, "volume_mounts")
+        self._volumes = check.opt_list_param(volumes, "volumes")
 
         super().__init__()
 
@@ -166,6 +175,14 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     @property
     def env_secrets(self):
         return self._env_secrets
+
+    @property
+    def volume_mounts(self):
+        return self._volume_mounts
+
+    @property
+    def volumes(self):
+        return self._volumes
 
     @property
     def _batch_api(self):
@@ -218,6 +235,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                 ),
                 env_secrets=check.opt_list_param(self._env_secrets, "env_secrets", of_type=str),
                 env_vars=check.opt_list_param(self._env_vars, "env_vars", of_type=str),
+                volume_mounts=self._volume_mounts,
+                volumes=self._volumes,
             )
             return self._job_config
 
@@ -241,6 +260,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             ),
             env_secrets=check.opt_list_param(self._env_secrets, "env_secrets", of_type=str),
             env_vars=check.opt_list_param(self._env_vars, "env_vars", of_type=str),
+            volume_mounts=self._volume_mounts,
+            volumes=self._volumes,
         )
 
     def launch_run(self, context: LaunchRunContext) -> None:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
@@ -1,0 +1,53 @@
+import datetime
+from typing import Any, Dict
+
+import kubernetes
+from dagster import check
+from dagster.utils import frozendict
+from dateutil.parser import parse
+from kubernetes.client import ApiClient
+
+
+def _k8s_value(data, classname, attr_name):
+    if classname in ApiClient.NATIVE_TYPES_MAPPING:
+        klass = ApiClient.NATIVE_TYPES_MAPPING[classname]
+    else:
+        klass = getattr(kubernetes.client.models, classname)
+
+    if klass in ApiClient.PRIMITIVE_TYPES:
+        return klass(data)
+    elif klass == object:
+        return data
+    elif klass == datetime.date:
+        return parse(data).date()
+    elif klass == datetime.datetime:
+        return parse(data)
+    else:
+        if not isinstance(data, (frozendict, dict)):
+            raise Exception(
+                f"Attribute {attr_name} of type {klass.__name__} must be a dict, received {data} instead"
+            )
+
+        return k8s_model_from_dict(klass, data)
+
+
+# Heavily inspired by kubernetes.client.ApiClient.__deserialize_model, with more validation
+# that the keys and values match the expected format. Expects atribute names to be in camelCase.
+def k8s_model_from_dict(model_class, model_dict: Dict[str, Any]):
+    check.dict_param(model_dict, "model_dict")
+    kwargs = {}
+
+    expected_keys = set(model_class.attribute_map.values())
+    invalid_keys = set(model_dict).difference(expected_keys)
+
+    if len(invalid_keys):
+        raise Exception(f"Unexpected keys in model class {model_class.__name__}: {invalid_keys}")
+
+    for attr, attr_type in model_class.openapi_types.items():
+        # e.g. config_map => configMap
+        mapped_attr = model_class.attribute_map[attr]
+        if mapped_attr in model_dict:
+            value = model_dict[mapped_attr]
+            kwargs[attr] = _k8s_value(value, attr_type, mapped_attr)
+
+    return model_class(**kwargs)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import graph
 from dagster.core.test_utils import environ
 from dagster_k8s import DagsterK8sJobConfig, construct_dagster_k8s_job
@@ -97,8 +98,9 @@ def test_construct_dagster_k8s_job_with_mounts():
         postgres_password_secret=None,
         env_config_maps=None,
         env_secrets=None,
-        volume_mounts=[
-            {"name": "foo", "path": "biz/buz", "sub_path": "file.txt", "configmap": "settings-cm"}
+        volume_mounts=[{"name": "foo", "mountPath": "biz/buz", "subPath": "file.txt"}],
+        volumes=[
+            {"name": "foo", "configMap": {"name": "settings-cm"}},
         ],
     )
     job = construct_dagster_k8s_job(cfg, ["foo", "bar"], "job123").to_dict()
@@ -108,6 +110,7 @@ def test_construct_dagster_k8s_job_with_mounts():
         volume for volume in job["spec"]["template"]["spec"]["volumes"] if volume["name"] == "foo"
     ]
     assert len(foo_volumes) == 1
+    assert foo_volumes[0]["config_map"]["name"] == "settings-cm"
 
     assert len(job["spec"]["template"]["spec"]["containers"][0]["volume_mounts"]) == 2
     foo_volumes_mounts = [
@@ -127,11 +130,36 @@ def test_construct_dagster_k8s_job_with_mounts():
         postgres_password_secret=None,
         env_config_maps=None,
         env_secrets=None,
-        volume_mounts=[
-            {"name": "foo", "path": "biz/buz", "sub_path": "file.txt", "secret": "settings-secret"}
+        volume_mounts=[{"name": "foo", "mountPath": "biz/buz", "subPath": "file.txt"}],
+        volumes=[
+            {"name": "foo", "secret": {"secretName": "settings-secret"}},
         ],
     )
-    construct_dagster_k8s_job(cfg, ["foo", "bar"], "job123").to_dict()
+    job = construct_dagster_k8s_job(cfg, ["foo", "bar"], "job123").to_dict()
+    assert len(job["spec"]["template"]["spec"]["volumes"]) == 2
+    foo_volumes = [
+        volume for volume in job["spec"]["template"]["spec"]["volumes"] if volume["name"] == "foo"
+    ]
+    assert len(foo_volumes) == 1
+    assert foo_volumes[0]["secret"]["secret_name"] == "settings-secret"
+
+    cfg_with_invalid_volume_key = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        image_pull_policy="Always",
+        image_pull_secrets=[{"name": "my_secret"}],
+        service_account_name=None,
+        instance_config_map="some-instance-configmap",
+        postgres_password_secret=None,
+        env_config_maps=None,
+        env_secrets=None,
+        volume_mounts=[{"name": "foo", "mountPath": "biz/buz", "subPath": "file.txt"}],
+        volumes=[
+            {"name": "foo", "invalidKey": "settings-secret"},
+        ],
+    )
+    with pytest.raises(Exception, match="Unexpected keys in model class V1Volume: {'invalidKey'}"):
+        construct_dagster_k8s_job(cfg_with_invalid_volume_key, ["foo", "bar"], "job123").to_dict()
 
 
 def test_construct_dagster_k8s_job_with_env():
@@ -263,18 +291,18 @@ def test_construct_dagster_k8s_job_with_user_defined_volume_mounts():
                     "container_config": {
                         "volume_mounts": [
                             {
-                                "mount_path": "mount_path",
-                                "mount_propagation": "mount_propagation",
+                                "mountPath": "mount_path",
+                                "mountPropagation": "mount_propagation",
                                 "name": "a_volume_mount_one",
-                                "read_only": "False",
-                                "sub_path": "path/",
+                                "readOnly": "False",
+                                "subPath": "path/",
                             },
                             {
-                                "mount_path": "mount_path",
-                                "mount_propagation": "mount_propagation",
+                                "mountPath": "mount_path",
+                                "mountPropagation": "mount_propagation",
                                 "name": "a_volume_mount_two",
-                                "read_only": "False",
-                                "sub_path_expr": "path/",
+                                "readOnly": "False",
+                                "subPathExpr": "path/",
                             },
                         ]
                     }

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_models.py
@@ -1,0 +1,38 @@
+import kubernetes
+import pytest
+from dagster_k8s.models import k8s_model_from_dict
+
+
+def test_deserialize_volume():
+    volume_dict = {
+        "name": "my_volume",
+        "configMap": {
+            "name": "my_config_map",
+        },
+    }
+
+    model = k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)
+    assert model.name == "my_volume"
+    assert model.config_map.name == "my_config_map"
+
+
+def test_bad_source_structure():
+    volume_dict = {"name": "my_volume", "configMap": "my_config_map"}
+
+    with pytest.raises(
+        Exception,
+        match="Attribute configMap of type V1ConfigMapVolumeSource must be a dict, received my_config_map instead",
+    ):
+        k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)
+
+
+def test_extra_key():
+    volume_dict = {
+        "name": "my_volume",
+        "configMap": {
+            "name": "my_config_map",
+        },
+        "extraKey": "extra_val",
+    }
+    with pytest.raises(Exception, match="Unexpected keys in model class V1Volume: {'extraKey'}"):
+        k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)


### PR DESCRIPTION
Still adding tests that cover the new fields on run launcher. It seems untenable to add config for every type of volume source here: https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Volume.md though..

Test Plan: Integration

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.