### PR TITLE
[dagit-bb] Checkbox, star, switch components

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Checkbox.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.stories.tsx
@@ -1,4 +1,3 @@
-import {Colors, H4} from '@blueprintjs/core';
 import {Meta} from '@storybook/react/types-6-0';
 import * as React from 'react';
 import {useState} from 'react';

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.stories.tsx
@@ -1,0 +1,79 @@
+import {Colors, H4} from '@blueprintjs/core';
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+import {useState} from 'react';
+
+import {Checkbox} from './Checkbox';
+import {ColorsWIP} from './Colors';
+import {Group} from './Group';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Checkbox',
+  component: Checkbox,
+} as Meta;
+
+export const Default = () => {
+  const [state, setState] = useState<'true' | 'false' | 'indeterminate'>('false');
+  const onChange = () =>
+    setState(({true: 'indeterminate', indeterminate: 'false', false: 'true'} as const)[state]);
+
+  return (
+    <Group spacing={8} direction="column">
+      {[ColorsWIP.Blue500, ColorsWIP.ForestGreen, ColorsWIP.Gray800].map((fillColor) => (
+        <Group spacing={24} direction="row" key={fillColor}>
+          <Checkbox
+            label="Hello world"
+            checked={state === 'false' ? false : true}
+            indeterminate={state === 'indeterminate'}
+            fillColor={fillColor}
+            onChange={onChange}
+            format="check"
+          />
+          <Checkbox
+            label="Hello world"
+            checked={state === 'false' ? false : true}
+            indeterminate={state === 'indeterminate'}
+            fillColor={fillColor}
+            onChange={onChange}
+            format="star"
+          />
+          <Checkbox
+            label="Hello world"
+            checked={state === 'false' ? false : true}
+            indeterminate={state === 'indeterminate'}
+            fillColor={fillColor}
+            onChange={onChange}
+            format="switch"
+          />
+        </Group>
+      ))}
+      <Group spacing={24} direction="row">
+        <Checkbox
+          disabled
+          label="Hello world"
+          checked={state === 'false' ? false : true}
+          indeterminate={state === 'indeterminate'}
+          onChange={onChange}
+          format="check"
+        />
+        <Checkbox
+          disabled
+          label="Hello world"
+          checked={state === 'false' ? false : true}
+          indeterminate={state === 'indeterminate'}
+          onChange={onChange}
+          format="star"
+        />
+        <Checkbox
+          disabled
+          label="Hello world"
+          checked={state === 'false' ? false : true}
+          indeterminate={state === 'indeterminate'}
+          onChange={onChange}
+          format="switch"
+        />
+      </Group>
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -47,7 +47,7 @@ const StarIcon: React.FC<IconProps> = ({checked, fillColor}) => (
 );
 
 const SwitchIcon: React.FC<IconProps> = ({checked, indeterminate, disabled, fillColor}) => (
-  <svg width="42px" height="28px" viewBox="-3 -3 42 28" version="1.1">
+  <svg width="42px" height="28px" viewBox="-3 -3 42 28">
     <defs>
       <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="innerShadow">
         <stop stopColor="#000" stopOpacity="0.2" offset="0%" />
@@ -84,7 +84,7 @@ const CheckIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => 
   <svg width="24px" height="24px" viewBox="-3 -3 24 24">
     <path
       d="M16,0 C17.1,0 18,0.9 18,2 L18,2 L18,16 C18,17.1 17.1,18 16,18 L16,18 L2,18 C0.9,18 0,17.1 0,16 L0,16 L0,2 C0,0.9 0.9,0 2,0 L2,0 Z"
-      id="Fill"
+      id="Background"
       className=" interaction-focus-outline"
       style={{transition: 'fill 100ms linear'}}
       fill={ColorsWIP.White}
@@ -118,6 +118,7 @@ const CheckIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => 
       points="3.5 9 7 12.5 14.5 5.0"
     />
     <line
+      id="Indeterminate"
       x1="5"
       y1="9"
       x2="13"
@@ -131,7 +132,6 @@ const CheckIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => 
       strokeDasharray="8"
       strokeLinecap="round"
       strokeDashoffset={indeterminate ? '0' : '8'}
-      id="Indeterminate"
     />
   </svg>
 );

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -7,12 +7,16 @@ import {ColorsWIP} from './Colors';
 
 const DISABLED_COLOR = ColorsWIP.Gray300;
 
-interface Props {
+type Props = React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> & {
   checked: boolean;
+  label: string;
   indeterminate?: boolean;
   format?: 'check' | 'star' | 'switch';
   fillColor?: string;
-}
+};
 
 interface IconProps {
   checked: boolean;
@@ -21,7 +25,7 @@ interface IconProps {
   fillColor: string;
 }
 
-const StarIcon: React.FC<IconProps> = ({checked, fillColor}) => (
+const StarIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => (
   <svg width="24px" height="24px" viewBox="-3 -3 24 24">
     <path
       className="interaction-focus-outline"
@@ -33,13 +37,20 @@ const StarIcon: React.FC<IconProps> = ({checked, fillColor}) => (
       className="interaction-darken"
       fill={ColorsWIP.Gray300}
     />
+    {indeterminate && (
+      <path
+        d="M11.6490126,5.26286597 L11.8098,5.64001 L16.6398,6.05001 C17.5198,6.12001 17.8798,7.22001 17.2098,7.80001 L17.2098,7.80001 L13.5398,10.98 L14.6398,15.7 C14.8398,16.56 13.9098,17.24 13.1498,16.78 L13.1498,16.78 L8.99983,14.27 L4.84983,16.77 C4.49121528,16.9870563 4.09474951,16.9502879 3.79701262,16.7605538 L11.6490126,5.26286597 Z"
+        className="interaction-darken"
+        fill={fillColor}
+      />
+    )}
     <path
       d="M8.99983 14.27L13.1498 16.78C13.9098 17.24 14.8398 16.56 14.6398 15.7L13.5398 10.98L17.2098 7.80001C17.8798 7.22001 17.5198 6.12001 16.6398 6.05001L11.8098 5.64001L9.91983 1.18001C9.57983 0.37001 8.41983 0.37001 8.07983 1.18001L6.18983 5.63001L1.35983 6.04001C0.479829 6.11001 0.119828 7.21001 0.789828 7.79001L4.45983 10.97L3.35983 15.69C3.15983 16.55 4.08983 17.23 4.84983 16.77L8.99983 14.27Z"
       className="interaction-darken"
       fill={fillColor}
       style={{
         transformOrigin: '9px 9px',
-        transform: checked ? 'scale(1,1)' : 'scale(0,0)',
+        transform: !indeterminate && checked ? 'scale(1,1)' : 'scale(0,0)',
         transition: 'transform 80ms linear',
       }}
     />
@@ -63,7 +74,8 @@ const SwitchIcon: React.FC<IconProps> = ({checked, indeterminate, disabled, fill
       width="36"
       height="22"
       rx="11"
-      fill={fillColor}
+      fill={disabled || (checked && !indeterminate) ? fillColor : ColorsWIP.Gray500}
+      style={{transition: 'fill 100ms linear'}}
       className="interaction-darken interaction-focus-outline"
     />
     {!disabled && <rect x="0" y="0" width="36" height="22" rx="11" fill="url(#innerShadow)" />}
@@ -136,45 +148,44 @@ const CheckIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => 
   </svg>
 );
 
-export const Checkbox = styled(
-  ({
-    id,
-    checked,
-    label,
-    className,
-    format = 'check',
-    disabled = false,
-    indeterminate = false,
-    fillColor = ColorsWIP.Gray800,
-    ...rest
-  }) => {
-    const uid = useRef(id || uniqueId('checkbox-'));
-    const Component: React.FC<IconProps> = {star: StarIcon, check: CheckIcon, switch: SwitchIcon}[
-      format
-    ];
+const Base: React.FC<Props> = ({
+  id,
+  checked,
+  label,
+  className,
+  format = 'check',
+  disabled = false,
+  indeterminate = false,
+  fillColor = ColorsWIP.Gray800,
+  ...rest
+}) => {
+  const uid = useRef(id || uniqueId('checkbox-'));
+  const Component: React.FC<IconProps> = {star: StarIcon, check: CheckIcon, switch: SwitchIcon}[
+    format
+  ];
 
-    return (
-      <label htmlFor={uid.current} className={className}>
-        <input
-          type="checkbox"
-          id={uid.current}
-          tabIndex={0}
-          checked={checked}
-          disabled={disabled}
-          indeterminate={indeterminate}
-          {...rest}
-        />
-        <Component
-          disabled={disabled}
-          checked={checked}
-          indeterminate={indeterminate}
-          fillColor={disabled ? DISABLED_COLOR : fillColor}
-        />
-        {label}
-      </label>
-    );
-  },
-)<Props>`
+  return (
+    <label htmlFor={uid.current} className={className}>
+      <input
+        type="checkbox"
+        id={uid.current}
+        tabIndex={0}
+        checked={checked}
+        disabled={disabled}
+        {...rest}
+      />
+      <Component
+        disabled={disabled}
+        checked={checked}
+        indeterminate={indeterminate}
+        fillColor={disabled ? DISABLED_COLOR : fillColor}
+      />
+      {label}
+    </label>
+  );
+};
+
+export const Checkbox = styled(Base)`
   display: inline-flex;
   position: relative;
   user-select: none;

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -1,0 +1,213 @@
+import {uniqueId} from 'lodash';
+import * as React from 'react';
+import {useRef} from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP} from './Colors';
+
+const DISABLED_COLOR = ColorsWIP.Gray300;
+
+interface Props {
+  checked: boolean;
+  indeterminate?: boolean;
+  format?: 'check' | 'star' | 'switch';
+  fillColor?: string;
+}
+
+interface IconProps {
+  checked: boolean;
+  disabled: boolean;
+  indeterminate: boolean;
+  fillColor: string;
+}
+
+const StarIcon: React.FC<IconProps> = ({checked, fillColor}) => (
+  <svg width="24px" height="24px" viewBox="-3 -3 24 24">
+    <path
+      className="interaction-focus-outline"
+      d="M8.99983 14.27L13.1498 16.78C13.9098 17.24 14.8398 16.56 14.6398 15.7L13.5398 10.98L17.2098 7.80001C17.8798 7.22001 17.5198 6.12001 16.6398 6.05001L11.8098 5.64001L9.91983 1.18001C9.57983 0.37001 8.41983 0.37001 8.07983 1.18001L6.18983 5.63001L1.35983 6.04001C0.479829 6.11001 0.119828 7.21001 0.789828 7.79001L4.45983 10.97L3.35983 15.69C3.15983 16.55 4.08983 17.23 4.84983 16.77L8.99983 14.27Z"
+      fill={ColorsWIP.White}
+    />
+    <path
+      d="M16.65 6.04L11.81 5.62L9.92 1.17C9.58 0.36 8.42 0.36 8.08 1.17L6.19 5.63L1.36 6.04C0.48 6.11 0.12 7.21 0.79 7.79L4.46 10.97L3.36 15.69C3.16 16.55 4.09 17.23 4.85 16.77L9 14.27L13.15 16.78C13.91 17.24 14.84 16.56 14.64 15.7L13.54 10.97L17.21 7.79C17.88 7.21 17.53 6.11 16.65 6.04ZM9 12.4L5.24 14.67L6.24 10.39L2.92 7.51L7.3 7.13L9 3.1L10.71 7.14L15.09 7.52L11.77 10.4L12.77 14.68L9 12.4Z"
+      className="interaction-darken"
+      fill={ColorsWIP.Gray300}
+    />
+    <path
+      d="M8.99983 14.27L13.1498 16.78C13.9098 17.24 14.8398 16.56 14.6398 15.7L13.5398 10.98L17.2098 7.80001C17.8798 7.22001 17.5198 6.12001 16.6398 6.05001L11.8098 5.64001L9.91983 1.18001C9.57983 0.37001 8.41983 0.37001 8.07983 1.18001L6.18983 5.63001L1.35983 6.04001C0.479829 6.11001 0.119828 7.21001 0.789828 7.79001L4.45983 10.97L3.35983 15.69C3.15983 16.55 4.08983 17.23 4.84983 16.77L8.99983 14.27Z"
+      className="interaction-darken"
+      fill={fillColor}
+      style={{
+        transformOrigin: '9px 9px',
+        transform: checked ? 'scale(1,1)' : 'scale(0,0)',
+        transition: 'transform 80ms linear',
+      }}
+    />
+  </svg>
+);
+
+const SwitchIcon: React.FC<IconProps> = ({checked, indeterminate, disabled, fillColor}) => (
+  <svg width="42px" height="28px" viewBox="-3 -3 42 28" version="1.1">
+    <defs>
+      <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="innerShadow">
+        <stop stopColor="#000" stopOpacity="0.2" offset="0%" />
+        <stop stopColor="#000" stopOpacity="0.12" offset="15%" />
+        <stop stopColor="#000" stopOpacity="0.06" offset="40%" />
+        <stop stopColor="#000" stopOpacity="0" offset="100%" />
+      </linearGradient>
+    </defs>
+    <rect
+      id="bg"
+      x="0"
+      y="0"
+      width="36"
+      height="22"
+      rx="11"
+      fill={fillColor}
+      className="interaction-darken interaction-focus-outline"
+    />
+    {!disabled && <rect x="0" y="0" width="36" height="22" rx="11" fill="url(#innerShadow)" />}
+    <rect
+      id="handle"
+      style={{transition: 'x 100ms linear'}}
+      x={indeterminate ? '8' : checked ? '15' : '1'}
+      y="1"
+      width="20"
+      height="20"
+      rx="10"
+      fill={ColorsWIP.White}
+    />
+  </svg>
+);
+
+const CheckIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => (
+  <svg width="24px" height="24px" viewBox="-3 -3 24 24">
+    <path
+      d="M16,0 C17.1,0 18,0.9 18,2 L18,2 L18,16 C18,17.1 17.1,18 16,18 L16,18 L2,18 C0.9,18 0,17.1 0,16 L0,16 L0,2 C0,0.9 0.9,0 2,0 L2,0 Z"
+      id="Fill"
+      className=" interaction-focus-outline"
+      style={{transition: 'fill 100ms linear'}}
+      fill={ColorsWIP.White}
+    />
+    <path
+      id="Border"
+      className="interaction-darken"
+      d="M15 16H3C2.45 16 2 15.55 2 15V3C2 2.45 2.45 2 3 2H15C15.55 2 16 2.45 16 3V15C16 15.55 15.55 16 15 16ZM16 0H2C0.9 0 0 0.9 0 2V16C0 17.1 0.9 18 2 18H16C17.1 18 18 17.1 18 16V2C18 0.9 17.1 0 16 0Z"
+      fill={ColorsWIP.Gray300}
+    />
+    <path
+      d="M16,0 C17.1,0 18,0.9 18,2 L18,2 L18,16 C18,17.1 17.1,18 16,18 L16,18 L2,18 C0.9,18 0,17.1 0,16 L0,16 L0,2 C0,0.9 0.9,0 2,0 L2,0 Z"
+      id="Fill"
+      className="interaction-darken"
+      style={{transition: 'fill 100ms linear'}}
+      fill={checked || indeterminate ? fillColor : 'transparent'}
+    />
+    <polyline
+      id="Check"
+      fill="none"
+      stroke={ColorsWIP.White}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeDasharray="16"
+      style={{
+        transition: 'stroke-dashoffset 100ms linear',
+        transitionDelay: !(checked && !indeterminate) ? '80ms' : '0',
+      }}
+      strokeDashoffset={checked && !indeterminate ? '0' : '16'}
+      points="3.5 9 7 12.5 14.5 5.0"
+    />
+    <line
+      x1="5"
+      y1="9"
+      x2="13"
+      y2="9"
+      style={{
+        transition: 'stroke-dashoffset 100ms linear',
+        transitionDelay: !indeterminate ? '80ms' : '0',
+      }}
+      stroke={ColorsWIP.White}
+      strokeWidth="2"
+      strokeDasharray="8"
+      strokeLinecap="round"
+      strokeDashoffset={indeterminate ? '0' : '8'}
+      id="Indeterminate"
+    />
+  </svg>
+);
+
+export const Checkbox = styled(
+  ({
+    id,
+    checked,
+    label,
+    className,
+    format = 'check',
+    disabled = false,
+    indeterminate = false,
+    fillColor = ColorsWIP.Gray800,
+    ...rest
+  }) => {
+    const uid = useRef(id || uniqueId('checkbox-'));
+    const Component: React.FC<IconProps> = {star: StarIcon, check: CheckIcon, switch: SwitchIcon}[
+      format
+    ];
+
+    return (
+      <label htmlFor={uid.current} className={className}>
+        <input
+          type="checkbox"
+          id={uid.current}
+          tabIndex={0}
+          checked={checked}
+          disabled={disabled}
+          indeterminate={indeterminate}
+          {...rest}
+        />
+        <Component
+          disabled={disabled}
+          checked={checked}
+          indeterminate={indeterminate}
+          fillColor={disabled ? DISABLED_COLOR : fillColor}
+        />
+        {label}
+      </label>
+    );
+  },
+)<Props>`
+  display: inline-flex;
+  position: relative;
+  user-select: none;
+  align-items: center;
+  color: ${({disabled}) => (disabled ? DISABLED_COLOR : ColorsWIP.Gray900)};
+  cursor: pointer;
+  gap: 13px;
+
+  input[type='checkbox'] {
+    position: absolute;
+    cursor: pointer;
+    opacity: 0;
+    height: 0;
+    width: 0;
+  }
+  input:focus + svg {
+    .interaction-focus-outline {
+      stroke: rgba(58, 151, 212, 0.6);
+      stroke-width: 6px;
+      paint-order: stroke fill;
+    }
+  }
+
+  ${({disabled}) =>
+    !disabled &&
+    `
+    svg:hover {
+      filter: drop-shadow(0 0 5px rgba(0, 0, 0, 0.12));
+
+      &.interaction-darken,
+      .interaction-darken {
+        filter: brightness(0.8);
+      }
+    }
+  `}
+`;

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -190,11 +190,19 @@ export const Checkbox = styled(
     height: 0;
     width: 0;
   }
+
   input:focus + svg {
     .interaction-focus-outline {
       stroke: rgba(58, 151, 212, 0.6);
       stroke-width: 6px;
       paint-order: stroke fill;
+    }
+  }
+  /* Focus outline only when using keyboard, not when focusing via mouse,
+     if focus-visible is supported and this rule is understood. */
+  input:focus:not(input:focus-visible) + svg {
+    .interaction-focus-outline {
+      stroke-width: 0;
     }
   }
 


### PR DESCRIPTION
## Summary
This PR adds a `<Checkbox format="..." />` component that mirrors the BlueprintJS checkbox component already in use in Dagit. It includes keyboard focus, disabled / hover / active states and three 'format' options that specify the type of icon used for the checkbox.

I /think/ we may need to make `label` optional or allow custom components to be the label so you can provide text with a link, etc., but I figure we can wait and see what all the callsites look like.

I got a little carried away with the checkbox state transitions and exported the figma assets as SVGs to animate individual components of the svg files. I think this approach worked out pretty well but if we want to just use the icon font that'd be ok too. 🙏 

![Sep-19-2021 22-17-59](https://user-images.githubusercontent.com/1037212/133953998-3022b60c-7855-410d-8706-989b694695f1.gif)

One small note about this, it looks like you can only tab between the checkboxes in safari if you enable this option in Advanced settings. Seems to be a design choice...

![image](https://user-images.githubusercontent.com/1037212/133958382-73f228cb-5ff4-45cb-b826-4c5a6d2daddd.png)


## Test Plan
New storybook page!




## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.