### PR TITLE
[dagit-bb] Tabs component

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Tabs.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Tabs.stories.tsx
@@ -1,0 +1,43 @@
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+import {ColorsWIP} from './Colors';
+import {Group} from './Group';
+import {IconWIP} from './Icon';
+
+import {Tabs, Tab} from './Tabs';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Tabs',
+  component: Tabs,
+} as Meta;
+
+export const Default = () => {
+  const [tab, setTab] = React.useState('health');
+  return (
+    <Group spacing={0} direction="column">
+      <Tabs selectedTabId={tab} onChange={setTab}>
+        <Tab id="health" title="Health" />
+        <Tab id="schedules" title="Schedules" count={2} />
+        <Tab
+          id="sensors"
+          title="Sensors"
+          icon={<IconWIP name={'warning'} color={ColorsWIP.Yellow500} />}
+        />
+        <Tab id="backfills" title="Backfills" disabled />
+        <Tab id="config" title={<a href="/?path=/story/box">Box Component</a>} />
+      </Tabs>
+      <Tabs small selectedTabId={tab} onChange={setTab}>
+        <Tab id="health" title="Health" />
+        <Tab id="schedules" title="Schedules" count={2} />
+        <Tab
+          id="sensors"
+          title="Sensors"
+          icon={<IconWIP name={'warning'} color={ColorsWIP.Yellow500} />}
+        />
+        <Tab id="backfills" title="Backfills" disabled />
+        <Tab id="config" title={<a href="/?path=/story/box">Box Component</a>} />
+      </Tabs>
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/core/src/ui/Tabs.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Tabs.stories.tsx
@@ -1,9 +1,9 @@
 import {Meta} from '@storybook/react/types-6-0';
 import * as React from 'react';
+
 import {ColorsWIP} from './Colors';
 import {Group} from './Group';
 import {IconWIP} from './Icon';
-
 import {Tabs, Tab} from './Tabs';
 
 // eslint-disable-next-line import/no-default-export

--- a/js_modules/dagit/packages/core/src/ui/Tabs.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Tabs.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP} from './Colors';
+import {IconWrapper} from './Icon';
+import {FontFamily} from './styles';
+
+interface TabsProps {
+  children: Array<React.ReactElement<TabProps>>;
+  selectedTabId?: string;
+  onChange?: (selectedTabId: string) => void;
+  small?: boolean;
+}
+
+export const Tabs = styled(({selectedTabId, children, small, onChange, ...rest}) => {
+  if (!(children instanceof Array) || children.some((c) => c.type !== Tab)) {
+    throw new Error('Tabs must render Tab instances');
+  }
+
+  return (
+    <div {...rest} role="tablist">
+      {children.map((child) =>
+        React.cloneElement(child, {
+          key: child.props.key || child.props.id,
+          selected: child.props.selected || child.props.id === selectedTabId,
+          $small: small,
+          ...(onChange && !child.props.disabled
+            ? {
+                onClick: () => onChange(child.props.id),
+                onKeyDown: (e: React.KeyboardEvent) =>
+                  [' ', 'Return', 'Enter'].includes(e.key) && onChange(child.props.id),
+              }
+            : {}),
+        }),
+      )}
+    </div>
+  );
+})<TabsProps>`
+  display: flex;
+  gap: 16px;
+  border-bottom: 1px solid ${ColorsWIP.Gray100};
+  font-size: ${({small}) => (small ? '12px' : '14px')};
+  line-height: ${({small}) => (small ? '16px' : '20px')};
+  font-weight: 600;
+`;
+
+interface TabProps {
+  id: string;
+  title: React.ReactNode;
+  disabled?: boolean;
+  selected?: boolean;
+  count?: number;
+  icon: React.ReactNode;
+  $small?: boolean;
+}
+
+export const Tab = styled(({title, count, icon, selected, disabled, ...rest}) => (
+  <div
+    role="tab"
+    tabIndex={disabled ? -1 : 0}
+    aria-disabled={disabled}
+    aria-expanded={selected}
+    aria-selected={selected}
+    {...rest}
+  >
+    {title}
+    {icon}
+    {count && <Count>{count}</Count>}
+  </div>
+))<TabProps>`
+  padding: ${({$small}) => ($small ? '12px 0 10px' : '18px 0 16px')};
+  border-bottom: ${({selected}) => (selected ? ColorsWIP.Blue500 : 'transparent')} solid 2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  &,
+  & a {
+    cursor: default;
+    user-select: none;
+    color: ${({selected, disabled}) =>
+      selected ? ColorsWIP.Blue500 : disabled ? ColorsWIP.Gray300 : ColorsWIP.Gray700};
+  }
+
+  & ${IconWrapper} {
+    color: ${({selected, disabled}) =>
+      selected ? ColorsWIP.Blue500 : disabled ? ColorsWIP.Gray300 : ''};
+  }
+
+  /* Focus outline only when using keyboard, not when focusing via mouse. */
+  &:focus {
+    outline: none !important;
+    border-bottom: ${({selected}) => (selected ? ColorsWIP.Blue500 : ColorsWIP.Blue200)} solid 2px;
+  }
+
+  &:hover {
+    &,
+    a {
+      text-decoration: none;
+      color: ${({selected, disabled}) =>
+        selected ? ColorsWIP.Blue700 : disabled ? ColorsWIP.Gray300 : ColorsWIP.Blue700};
+    }
+    ${IconWrapper} {
+      color: ${({selected, disabled}) =>
+        selected ? ColorsWIP.Blue700 : disabled ? ColorsWIP.Gray300 : ''};
+    }
+  }
+`;
+
+export const Count = styled.div`
+  display: inline;
+  font-family: ${FontFamily.monospace};
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.02%;
+  padding: 0 4px;
+  color: ${ColorsWIP.Gray900};
+  background: ${ColorsWIP.Gray100};
+`;

--- a/js_modules/dagit/packages/core/src/ui/Tabs.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Tabs.tsx
@@ -9,21 +9,21 @@ interface TabsProps {
   children: Array<React.ReactElement<TabProps>>;
   selectedTabId?: string;
   onChange?: (selectedTabId: string) => void;
-  small?: boolean;
+  size?: 'small' | 'large';
 }
 
-export const Tabs = styled(({selectedTabId, children, small, onChange, ...rest}) => {
+export const Tabs = styled(({selectedTabId, children, onChange, size = 'large', ...rest}) => {
   if (!(children instanceof Array) || children.some((c) => c.type !== Tab)) {
     throw new Error('Tabs must render Tab instances');
   }
 
   return (
     <div {...rest} role="tablist">
-      {children.map((child) =>
+      {React.Children.map(children, (child) =>
         React.cloneElement(child, {
           key: child.props.key || child.props.id,
           selected: child.props.selected || child.props.id === selectedTabId,
-          $small: small,
+          $size: size,
           ...(onChange && !child.props.disabled
             ? {
                 onClick: () => onChange(child.props.id),
@@ -51,7 +51,7 @@ interface TabProps {
   selected?: boolean;
   count?: number;
   icon: React.ReactNode;
-  $small?: boolean;
+  $size?: 'small' | 'large';
 }
 
 export const Tab = styled(({title, count, icon, selected, disabled, ...rest}) => (
@@ -68,7 +68,7 @@ export const Tab = styled(({title, count, icon, selected, disabled, ...rest}) =>
     {count && <Count>{count}</Count>}
   </div>
 ))<TabProps>`
-  padding: ${({$small}) => ($small ? '12px 0 10px' : '18px 0 16px')};
+  padding: ${({$size}) => ($size === 'small' ? '12px 0 10px' : '18px 0 16px')};
   border-bottom: ${({selected}) => (selected ? ColorsWIP.Blue500 : 'transparent')} solid 2px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
I originally planned to reskin the Blueprint components for this one, but we aren't using much of the Blueprint component surface area and a fresh implementation for the callsites in Dagit was only ~100loc. Don't have a strong preference but this seemed like it'd be a bit easier to maintain.

It might be interesting to try to align how the icon is passed in here with the Tags PR, I put the color on the icon but we could put iconColor on the Tab to match instead.

![Sep-20-2021 14-11-43](https://user-images.githubusercontent.com/1037212/134061488-845a98e9-941a-4d3c-8243-de1ce7b3bd11.gif)

## Test Plan
Try out new Tabs storybook


## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.