### PR TITLE
loosen invariant check in run status sensor evaluation

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -86,12 +86,11 @@ def get_toys_sensors():
                 },
             )
 
-    @pipeline_failure_sensor(pipeline_selection=["error_monster"])
+    @pipeline_failure_sensor(pipeline_selection=["error_monster", "unreliable_pipeline"])
     def custom_slack_on_pipeline_failure(context: PipelineFailureSensorContext):
 
         base_url = "http://localhost:3000"
 
-        # TBD: support resources?
         slack_client = WebClient(token=os.environ["SLACK_DAGSTER_ETL_BOT_TOKEN"])
 
         run_page_url = f"{base_url}/instance/runs/{context.pipeline_run.run_id}"

--- a/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
@@ -1,5 +1,4 @@
 from typing import Any, Callable, List, NamedTuple, Optional, Union, cast
-from dagster.utils import utc_datetime_from_timestamp
 
 import pendulum
 from dagster import check
@@ -22,6 +21,7 @@ from dagster.serdes import (
 from dagster.serdes.errors import DeserializationError
 from dagster.serdes.serdes import register_serdes_tuple_fallbacks
 from dagster.seven import JSONDecodeError
+from dagster.utils import utc_datetime_from_timestamp
 from dagster.utils.error import serializable_error_info_from_exc_info
 
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, List, NamedTuple, Optional, Union, cast
+from dagster.utils import utc_datetime_from_timestamp
 
 import pendulum
 from dagster import check
@@ -335,7 +336,22 @@ class RunStatusSensorDefinition(SensorDefinition):
                 run_records = context.instance.get_run_records(
                     filters=PipelineRunsFilter(run_ids=[event_log_entry.run_id])
                 )
-                check.invariant(len(run_records) == 1)
+
+                # skip if we couldn't find the right run
+                if len(run_records) != 1:
+                    # bc we couldn't find the run, we use the event timestamp as the approximate
+                    # run update timestamp
+                    approximate_update_timestamp = utc_datetime_from_timestamp(
+                        event_log_entry.timestamp
+                    )
+                    context.update_cursor(
+                        RunStatusSensorCursor(
+                            record_id=storage_id,
+                            update_timestamp=approximate_update_timestamp.isoformat(),
+                        ).to_json()
+                    )
+                    continue
+
                 pipeline_run = run_records[0].pipeline_run
                 update_timestamp = run_records[0].update_timestamp
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -6,9 +6,6 @@ import tempfile
 import threading
 import time
 from contextlib import contextmanager
-from dagster.core.events import DagsterEvent, DagsterEventType
-from dagster.core.events.log import EventLogEntry
-from dagster.core.storage.event_log.base import EventRecordsFilter
 
 import pendulum
 import pytest
@@ -30,6 +27,8 @@ from dagster.core.definitions.pipeline_sensor import run_status_sensor
 from dagster.core.definitions.reconstructable import ReconstructableRepository
 from dagster.core.definitions.run_request import JobType
 from dagster.core.definitions.sensor import DEFAULT_SENSOR_DAEMON_INTERVAL, RunRequest, SkipReason
+from dagster.core.events import DagsterEvent, DagsterEventType
+from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.api import execute_pipeline
 from dagster.core.host_representation import (
     ExternalJobOrigin,
@@ -40,6 +39,7 @@ from dagster.core.host_representation import (
 from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobState, JobStatus, JobTickStatus
+from dagster.core.storage.event_log.base import EventRecordsFilter
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.test_utils import instance_for_test
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
**repro:**
- the sensor monitors multiple pipelines, e.g. `pipeline_selection=["error_monster", "unreliable_pipeline"]`
- runs of both pipelines failed.
- one of them hit a system error, e.g. the "unreliable_pipeline" failed run errored at `check.invariant(len(run_records) == 1)`

this resulted in endless slack messages for the same run of "error_monster".

**cause:** 
when a sensor monitors multiple pipelines and one of the "pipeline reaction" in the [loop](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py#L330) errors, the other successful reactions (which have sent alerts) would not update the cursor successfully. 

this means, in the repro, the "error_monstor" run reaction successfully executed the user code but failed to update the cursor, which later resulted in flooding slack with the same messages:
![image](https://user-images.githubusercontent.com/4531914/134200647-aded221e-35da-4b1d-bd5d-64f9a6983f7b.png)


**fix:**
loosen the invariant check: instead of hard failing, we update the cursor and continue the sensor evaluation.

caveat: see [1]. ideally we would want to log the reason why we choose to skip while we found a qualified event. the log msg would be something like `f"Cannot find run info corresponding to event {storage_id} where pipeline_name={event_log_entry.pipeline_name} and run_id={event_log_entry.run_id}"`. but i found it hard to pass that info from the evaluation func to the sensor daemon, i.e. i dont think we have a good way to log that kind of info when pipeline run isn't present (correct me if im wrong).

*i think* it's pretty tricky to ensure the idempotency of the full "pipeline reaction" cycle (i.e. user code execution + cursor update), bc we chose to keep the user code execution in evaluation and updating the cursor in the sensor daemon. open to suggestions if we could make it work!


## Test Plan
reproed the issue in toy sensor and it works after the fix.
added a unit test which creates the event/run storage mismatch, which failed without the fix the same as the user report: 
![image](https://user-images.githubusercontent.com/4531914/134200542-940d7332-b590-4b55-b95b-2aacbca99d4c.png)
 



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [-] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.