### PR TITLE
Add a missign basePath to reload repo location button

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import {AppContext} from '../app/AppContext';
 import {RepositoryLocationErrorDialog} from '../workspace/RepositoryLocationErrorDialog';
 
 import {useRepositoryLocationReload} from './useRepositoryLocationReload';
@@ -17,6 +18,8 @@ interface Props {
 export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
   const {children, location} = props;
   const [shown, setShown] = React.useState(false);
+
+  const {basePath} = React.useContext(AppContext);
 
   const {reloading, error, tryReload} = useRepositoryLocationReload(location);
 
@@ -36,7 +39,7 @@ export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
           // is presented to the user, and so that if the user was previously viewing
           // an object in a failed repo location, they aren't staring at a blank page.
           setShown(false);
-          window.location.href = '/workspace';
+          window.location.href = `${basePath}/workspace`;
         }}
       />
     </>


### PR DESCRIPTION
Test Plan: reload repo location with base path set when repo has an error

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.