### PR TITLE
Fix context manager-decorated resources

### DIFF
--- a/python_modules/dagster/dagster/core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/core/execution/resources_init.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import deque
+from contextlib import ContextDecorator
 from typing import AbstractSet, Any, Callable, Deque, Dict, Optional, cast
 
 from dagster import check
@@ -294,7 +295,9 @@ def single_resource_event_generator(context, resource_name, resource_def):
                     )
                     # Flag for whether resource is generator. This is used to ensure that teardown
                     # occurs when resources are initialized out of execution.
-                    is_gen = inspect.isgenerator(resource_or_gen)
+                    is_gen = inspect.isgenerator(resource_or_gen) or isinstance(
+                        resource_or_gen, ContextDecorator
+                    )
                     gen = ensure_gen(resource_or_gen)
                     resource = next(gen)
                 resource = InitializedResource(

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -306,6 +306,17 @@ def safe_tempfile_path() -> Iterator[str]:
 
 
 def ensure_gen(thing_or_gen):
+
+    # Context managers created using contextlib.contextdecorator are not usable as iterators.
+    # This special casing makes them usable as iterators.
+    if isinstance(thing_or_gen, contextlib.ContextDecorator):
+
+        def _gen_thing():
+            with thing_or_gen as thing:
+                yield thing
+
+        return _gen_thing()
+
     if not inspect.isgenerator(thing_or_gen):
 
         def _gen_thing():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest
@@ -13,9 +14,12 @@ from dagster import (
     PipelineDefinition,
     ResourceDefinition,
     String,
+    build_op_context,
     configured,
     execute_pipeline,
     execute_pipeline_iterator,
+    graph,
+    op,
     reconstructable,
     resource,
     solid,
@@ -1185,3 +1189,30 @@ def test_configured_resource_unused():
     execute_pipeline(basic_pipeline)
 
     assert not entered
+
+
+def test_context_manager_resource():
+    @resource
+    @contextmanager
+    def cm_resource():
+        yield "foo"
+
+    @op(required_resource_keys={"cm"})
+    def basic(context):
+        assert context.resources.cm == "foo"
+
+    with build_op_context(resources={"cm": cm_resource}) as context:
+        basic(context)
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="At least one provided resource is a generator, but attempting to access resources "
+        "outside of context manager scope.",
+    ):
+        basic(build_op_context(resources={"cm": cm_resource}))
+
+    @graph
+    def call_basic():
+        basic()
+
+    assert call_basic.execute_in_process(resources={"cm": cm_resource}).success


### PR DESCRIPTION
Previously, we didn't recognize context managers created using the context manager decorator as context managers. This PR changes that and puts it under test.