### PR TITLE
[dagit-bb] ProgressBar component, fillColor for Spinner

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Box.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Box.tsx
@@ -21,6 +21,7 @@ const flexPropertiesToCSS = (flex: FlexProperties) => {
     ${flex.justifyContent ? `justify-content: ${flex.justifyContent};` : null}
     ${flex.grow ? `flex-grow: ${flex.grow};` : null}
     ${flex.wrap ? `flex-wrap: ${flex.wrap};` : null}
+    ${flex.gap ? `gap: ${flex.gap}px;` : null}
     ${flex.shrink !== null && flex.shrink !== undefined ? `flex-shrink: ${flex.shrink};` : null}
   `;
 };

--- a/js_modules/dagit/packages/core/src/ui/ProgressBar.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/ProgressBar.stories.tsx
@@ -1,0 +1,33 @@
+import {Colors} from '@blueprintjs/core';
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+
+import {Box} from './Box';
+import {ColorsWIP} from './Colors';
+import {Group} from './Group';
+import {ProgressBar} from './ProgressBar';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'ProgressBar',
+  component: ProgressBar,
+} as Meta;
+
+export const Sizes = () => {
+  return (
+    <Group direction="column" spacing={32}>
+      <Box padding={20} border={{side: 'all', width: 1, color: Colors.LIGHT_GRAY3}}>
+        <Group direction="column" spacing={16}>
+          <ProgressBar intent="primary" value={0.1} animate={true} />
+          <ProgressBar intent="primary" value={0.7} />
+        </Group>
+      </Box>
+      <Box padding={20} border={{side: 'all', width: 1, color: Colors.LIGHT_GRAY3}}>
+        <Group direction="column" spacing={16}>
+          <ProgressBar intent="primary" value={0.1} animate={true} fillColor={ColorsWIP.Blue500} />
+          <ProgressBar intent="primary" value={0.7} fillColor={ColorsWIP.Blue500} />
+        </Group>
+      </Box>
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/core/src/ui/ProgressBar.tsx
+++ b/js_modules/dagit/packages/core/src/ui/ProgressBar.tsx
@@ -1,0 +1,38 @@
+// eslint-disable-next-line no-restricted-imports
+import {ProgressBar as BlueprintProgressBar, ProgressBarProps} from '@blueprintjs/core';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP} from './Colors';
+
+export const ProgressBar: React.FC<ProgressBarProps & {fillColor?: string}> = ({
+  fillColor = ColorsWIP.Gray600,
+  ...rest
+}) => {
+  return (
+    <StyledProgressBar
+      {...rest}
+      intent="none"
+      $fillColor={fillColor}
+      stripes={rest.animate ? true : false}
+    />
+  );
+};
+
+const StyledProgressBar = styled(BlueprintProgressBar)<{$fillColor: string}>`
+  &.bp3-progress-bar {
+    background: transparent;
+
+    ::before {
+      content: '';
+      background: ${(p) => p.$fillColor};
+      position: absolute;
+      inset: 0;
+      opacity: 0.25;
+    }
+
+    .bp3-progress-meter {
+      background-color: ${(p) => p.$fillColor};
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/ui/Spinner.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Spinner.stories.tsx
@@ -3,6 +3,7 @@ import {Meta} from '@storybook/react/types-6-0';
 import * as React from 'react';
 
 import {Box} from './Box';
+import {ColorsWIP} from './Colors';
 import {Group} from './Group';
 import {Spinner} from './Spinner';
 import {Caption, Code} from './Text';
@@ -37,16 +38,18 @@ export const Sizes = () => {
       <Box padding={20} border={{side: 'all', width: 1, color: Colors.LIGHT_GRAY3}}>
         <Group direction="column" spacing={16}>
           <Code>{`purpose="section"`}</Code>
-          <Box flex={{direction: 'row', justifyContent: 'center'}} padding={24}>
+          <Box flex={{direction: 'row', justifyContent: 'center', gap: 10}} padding={24}>
             <Spinner purpose="section" />
+            <Spinner purpose="section" fillColor={ColorsWIP.Blue500} />
           </Box>
         </Group>
       </Box>
       <Box padding={20} border={{side: 'all', width: 1, color: Colors.LIGHT_GRAY3}}>
         <Group direction="column" spacing={16}>
           <Code>{`purpose="page"`}</Code>
-          <Box flex={{direction: 'row', justifyContent: 'center'}} padding={48}>
+          <Box flex={{direction: 'row', justifyContent: 'center', gap: 10}} padding={48}>
             <Spinner purpose="page" />
+            <Spinner purpose="page" fillColor={ColorsWIP.Blue500} />
           </Box>
         </Group>
       </Box>

--- a/js_modules/dagit/packages/core/src/ui/Spinner.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Spinner.tsx
@@ -3,12 +3,15 @@ import {Spinner as BlueprintSpinner} from '@blueprintjs/core';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {ColorsWIP} from './Colors';
+
 type SpinnerPurpose = 'page' | 'section' | 'body-text' | 'caption-text';
 
 export const Spinner: React.FC<{
   purpose: SpinnerPurpose;
   value?: number;
-}> = ({purpose, value}) => {
+  fillColor?: string;
+}> = ({purpose, value, fillColor = ColorsWIP.Gray600}) => {
   const size = () => {
     switch (purpose) {
       case 'page':
@@ -23,11 +26,20 @@ export const Spinner: React.FC<{
     }
   };
 
-  return <SlowSpinner size={size()} value={value} />;
+  return <SlowSpinner size={size()} value={value} $fillColor={fillColor} />;
 };
 
-const SlowSpinner = styled(BlueprintSpinner)`
+const SlowSpinner = styled(BlueprintSpinner)<{$fillColor: string}>`
   .bp3-spinner-animation {
     animation-duration: 0.8s;
+
+    path.bp3-spinner-track {
+      stroke: ${(p) => p.$fillColor};
+      stroke-opacity: 0.25;
+    }
+    path.bp3-spinner-head {
+      stroke: ${(p) => p.$fillColor};
+      stroke-opacity: 1;
+    }
   }
 `;

--- a/js_modules/dagit/packages/core/src/ui/types.ts
+++ b/js_modules/dagit/packages/core/src/ui/types.ts
@@ -40,6 +40,7 @@ export type FlexProperties = {
   direction?: FlexDirection;
   display?: 'flex' | 'inline-flex';
   grow?: number;
+  gap?: number;
   justifyContent?: JustifyContent;
   shrink?: number;
   wrap?: FlexWrap;


### PR DESCRIPTION
## Summary

This PR adds a basic restyled Blueprint progress bar to our component kit and updates the styling on the spinner to reflect the designs and support a fillColor as well.

I'm not sure whether we should expose the fillColor to the broader team or push for something like `<Spinner blue />` (similar to `Button.intent`), which would avoid them having to pick a color and potentially choosing the wrong one.

The BB designs didn't call for barber shop stripes on the progress bar, but I think it's important that we have an indeterminate state so I left the Blueprint option in place.

![image](https://user-images.githubusercontent.com/1037212/134552858-4cda5fd7-06b0-410f-b149-2ff268c2b3fb.png)
![image](https://user-images.githubusercontent.com/1037212/134552874-b06da385-84cc-47f0-9191-cccf1ae7ce1d.png)


## Test Plan
New storybooks 👯‍♀️



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.