### PR TITLE
Initialize sub_process in execute_script_file

### DIFF
--- a/python_modules/libraries/dagster-shell/dagster_shell/utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/utils.py
@@ -68,6 +68,7 @@ def execute_script_file(shell_script_path, output_logging, log, cwd=None, env=No
     log.info(f"Running command:\n{shell_command}")
 
     # pylint: disable=subprocess-popen-preexec-fn
+    sub_process = None
     try:
         sub_process = Popen(
             ["bash", shell_script_path],


### PR DESCRIPTION
Summary:
If the POpen constructor raises an exception for some reason, the variable is not initialized.

Test Plan: I tried for a while to come up with a situation where this would happen and was not successful, but https://dagster.slack.com/archives/C01U954MEER/p1632425935208000 suggests it is happening somehow some of the time.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.