### PR TITLE
[easy] set image pull policy in k8s test suite

### DIFF
--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -535,6 +535,7 @@ def helm_chart_for_k8s_run_launcher(namespace, docker_image, should_cleanup=True
                     + ([{"name": TEST_AWS_CONFIGMAP_NAME}] if not IS_BUILDKITE else []),
                     "envSecrets": [{"name": TEST_SECRET_NAME}],
                     "envVars": ["BUILDKITE"],
+                    "imagePullPolicy": image_pull_policy(),
                 }
             },
         },


### PR DESCRIPTION
Summary:
I inadvertently broke running the k8s suite locally by not setting this - it defaults to Always which is not what we want in local runs

Test Plan: Integration

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.