### PR TITLE
Bring back doing an internal build on all OSS PRs

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -16,6 +16,34 @@ def dagster():
     all_steps = dagit_steps()
     dagit_only = is_pr_and_dagit_only()
 
+    branch_name = os.getenv("BUILDKITE_BRANCH")
+    build_creator_email = os.getenv("BUILDKITE_BUILD_CREATOR_EMAIL")
+
+    if build_creator_email and build_creator_email.endswith("@elementl.com"):
+
+        if branch_name == "master" or is_release_branch(branch_name):
+            pipeline_name = "internal"
+            trigger_branch = branch_name
+            async_step = True
+        else:
+            pipeline_name = "oss-internal-compatibility"
+            trigger_branch = "master"
+            async_step = False
+
+        # Trigger builds of the internal pipeline for builds on master
+        all_steps += [
+            trigger_step(
+                pipeline=pipeline_name,
+                trigger_branch=trigger_branch,
+                async_step=async_step,
+                env={
+                    "DAGSTER_BRANCH": branch_name,
+                    "DAGSTER_COMMIT_HASH": os.getenv("BUILDKITE_COMMIT"),
+                    "DAGIT_ONLY_OSS_CHANGE": "1" if dagit_only else "",
+                },
+            ),
+        ]
+
     # If we're in a Phabricator diff and are only making dagit changes, skip the
     # remaining steps since they're not relevant to the diff.
     if not dagit_only:
@@ -25,26 +53,6 @@ def dagster():
 
         if DO_COVERAGE:
             all_steps += [coverage_step()]
-
-        branch_name = os.getenv("BUILDKITE_BRANCH")
-        build_creator_email = os.getenv("BUILDKITE_BUILD_CREATOR_EMAIL")
-        if (
-            (branch_name == "master" or is_release_branch(branch_name))
-            and build_creator_email
-            and build_creator_email.endswith("@elementl.com")
-        ):
-            # Trigger builds of the internal pipeline for builds on master
-            all_steps += [
-                trigger_step(
-                    pipeline="internal",
-                    trigger_branch=branch_name,
-                    async_step=True,
-                    env={
-                        "DAGSTER_BRANCH": branch_name,
-                        "DAGSTER_COMMIT_HASH": os.getenv("BUILDKITE_COMMIT"),
-                    },
-                ),
-            ]
 
     buildkite_yaml = buildkite_yaml_for_steps(all_steps)
     print(buildkite_yaml)  # pylint: disable=print-call


### PR DESCRIPTION
    Attempt to bring back doing an internal build on all OSS PRs
    
    Summary:
    I think the missing piece before was that all of these pipeline runs were writing to the 'master' buildkite branch before - instead, write them to a branch that's the same name as the OSS branch. Was there anything else I missed?
    
    I left it as async still for now for all builds, which is another change - I figure we start conservative for now. But I could be convinced otherwise.

