### PR TITLE
[dagit] Observe WS disconnections to set logs cursor

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -60,11 +60,13 @@ const BATCH_INTERVAL = 100;
 
 type State = {
   nodes: Nodes;
+  cursor: number;
   loading: boolean;
 };
 
 type Action =
   | {type: 'append'; queued: RunPipelineRunEventFragment[]; hasMore: boolean}
+  | {type: 'set-cursor'}
   | {type: 'reset'};
 
 const reducer = (state: State, action: Action) => {
@@ -75,8 +77,10 @@ const reducer = (state: State, action: Action) => {
         clientsideKey: `csk${idx}`,
       }));
       return {...state, nodes, loading: action.hasMore};
+    case 'set-cursor':
+      return {...state, cursor: state.nodes.length - 1};
     case 'reset':
-      return {nodes: [], loading: true};
+      return {nodes: [], cursor: -1, loading: true};
     default:
       return state;
   }
@@ -84,11 +88,13 @@ const reducer = (state: State, action: Action) => {
 
 const initialState = {
   nodes: [],
+  cursor: -1,
   loading: true,
 };
 
 const useLogsProviderWithSubscription = (runId: string) => {
   const client = useApolloClient();
+  const {websocketClient} = React.useContext(WebSocketContext);
   const queue = React.useRef<RunPipelineRunEventFragment[]>([]);
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
@@ -122,6 +128,13 @@ const useLogsProviderWithSubscription = (runId: string) => {
     [client, runId],
   );
 
+  // If the WebSocket disconnects, move the cursor to the end to ensure that we don't
+  // incorrectly refetch logs that we already have.
+  React.useEffect(() => {
+    const unlisten = websocketClient?.onDisconnected(() => dispatch({type: 'set-cursor'}));
+    return () => unlisten && unlisten();
+  }, [websocketClient]);
+
   React.useEffect(() => {
     queue.current = [];
     dispatch({type: 'reset'});
@@ -137,9 +150,11 @@ const useLogsProviderWithSubscription = (runId: string) => {
     }, BATCH_INTERVAL);
   }, []);
 
+  const {nodes, cursor, loading} = state;
+
   useSubscription<PipelineRunLogsSubscription>(PIPELINE_RUN_LOGS_SUBSCRIPTION, {
     fetchPolicy: 'no-cache',
-    variables: {runId: runId, after: null},
+    variables: {runId, after: cursor},
     onSubscriptionData: ({subscriptionData}) => {
       const logs = subscriptionData.data?.pipelineRunLogs;
       if (!logs || logs.__typename === 'PipelineRunLogsSubscriptionFailure') {
@@ -160,8 +175,6 @@ const useLogsProviderWithSubscription = (runId: string) => {
       throttledSetNodes(hasMorePastEvents);
     },
   });
-
-  const {nodes, loading} = state;
 
   return React.useMemo(
     () => (nodes !== null ? {allNodes: nodes, loading} : {allNodes: [], loading}),


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

When the WebSocket connection is lost, update the `LogsProvider` cursor. This allows us to avoid refetching logs we've already received, when the WebSocket reconnects.

## Test Plan

Load a run, kill the backend. Verify that when the WebSocket reconnects, it uses an updated cursor and does not duplicate our previously retrieved logs.