### PR TITLE
[RFC] Add k8s raw config escape hatch

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job_with_spec.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job_with_spec.py
@@ -1,0 +1,64 @@
+from dagster_k8s.job import DagsterK8sJobConfig, construct_dagster_k8s_job
+
+import yaml
+
+
+def test_construct_job_with_spec():
+    job_spec = """
+    metadata: {}
+    spec:
+        template:
+            spec:
+                containers:
+                - name: first
+                  imagePullPolicy: Always
+                - name: second
+                  image: my-image
+    """
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/dagster/home",
+        instance_config_map="test",
+        k8s_job_object=yaml.load(job_spec),
+    )
+    job = construct_dagster_k8s_job(cfg, ["echo", "dagsterz"], "job123")
+    job_dict = job.to_dict()
+
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["name"] == "first"
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["image"] == "test/foo:latest"
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["image_pull_policy"] == "Always"
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["args"] == ["echo", "dagsterz"]
+
+    assert job_dict["spec"]["template"]["spec"]["containers"][1]["name"] == "second"
+    assert job_dict["spec"]["template"]["spec"]["containers"][1]["image"] == "my-image"
+
+
+def test_construct_job_with_spec_with_image():
+    job_spec = """
+    metadata: {}
+    spec:
+        template:
+            spec:
+                containers:
+                - name: first
+                  imagePullPolicy: Always
+                  image: my-image
+                - name: second
+                  image: my-image
+    """
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/dagster/home",
+        instance_config_map="test",
+        k8s_job_object=yaml.load(job_spec),
+    )
+    job = construct_dagster_k8s_job(cfg, ["echo", "dagsterz"], "job123")
+    job_dict = job.to_dict()
+
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["name"] == "first"
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["image"] == "my-image"
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["image_pull_policy"] == "Always"
+    assert job_dict["spec"]["template"]["spec"]["containers"][0]["args"] == ["echo", "dagsterz"]
+
+    assert job_dict["spec"]["template"]["spec"]["containers"][1]["name"] == "second"
+    assert job_dict["spec"]["template"]["spec"]["containers"][1]["image"] == "my-image"


### PR DESCRIPTION
- what should this config be called? 'spec' is bad since it already has k8s meaning. Technically this would be a 'k8s object', but eh
- some todo cases with the new support for per solid job image, etc.
- I think either with permissive or just manually we can spec out the container and metadata fields if not present
- TODO: fill in instance mounting