### PR TITLE
add linter transformation for op decorator

### DIFF
--- a/python_modules/dagster/dagster/utils/linter.py
+++ b/python_modules/dagster/dagster/utils/linter.py
@@ -113,6 +113,8 @@ def register_solid_transform():
             in node.decoratornames()
             or "dagster.core.definitions.decorators.op.op" in node.decoratornames()
             or "dagster.core.definitions.decorators.op._Op" in node.decoratornames()
+            or "dagster.core.definitions.decorators.graph.graph" in node.decoratornames()
+            or "dagster.core.definitions.decorators.graph._Graph" in node.decoratornames()
         )
 
     @astroid.inference_tip

--- a/python_modules/dagster/dagster/utils/linter.py
+++ b/python_modules/dagster/dagster/utils/linter.py
@@ -101,7 +101,7 @@ def define_dagster_checker():
 def register_solid_transform():
     import astroid
 
-    def _is_solid(node):
+    def _is_solid_or_op(node):
         if not node.decorators:
             return False
         return (
@@ -111,6 +111,8 @@ def register_solid_transform():
             in node.decoratornames()
             or "dagster.core.definitions.decorators.composite_solid.composite_solid"
             in node.decoratornames()
+            or "dagster.core.definitions.decorators.op.op" in node.decoratornames()
+            or "dagster.core.definitions.decorators.op._Op" in node.decoratornames()
         )
 
     @astroid.inference_tip
@@ -127,7 +129,7 @@ def register_solid_transform():
 
     # Register a new inference result for solid decorated functions which effectively
     # blanks out the inference by changing the return type to the output of an unknown function
-    astroid.MANAGER.register_transform(astroid.FunctionDef, _modify_return, _is_solid)
+    astroid.MANAGER.register_transform(astroid.FunctionDef, _modify_return, _is_solid_or_op)
 
 
 def register(linter):


### PR DESCRIPTION
## Summary
Have better lint support for ops with dynamic output, by transforming the decorator inference using the AST.


## Test Plan
BK

