### PR TITLE
[dagit-bb] Replace Dialog

### DIFF
--- a/js_modules/dagit/packages/core/.eslintrc.js
+++ b/js_modules/dagit/packages/core/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
         paths: [
           {
             name: '@blueprintjs/core',
-            importNames: ['Alert', 'Callout', 'Icon', 'Spinner', 'Tooltip'],
+            importNames: ['Alert', 'Callout', 'Dialog', 'Icon', 'Spinner', 'Tooltip'],
             message: 'Please use components in src/ui instead.',
           },
           {

--- a/js_modules/dagit/packages/core/.storybook/preview.js
+++ b/js_modules/dagit/packages/core/.storybook/preview.js
@@ -5,6 +5,7 @@ import '@blueprintjs/table/lib/css/table.css';
 import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
 
 import {FontFamily} from '../src/ui/styles';
+import {GlobalDialogStyle} from '../src/ui/Dialog';
 
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
@@ -35,6 +36,7 @@ export const decorators = [
   (Story) => (
     <MemoryRouter>
       <GlobalStyle />
+      <GlobalDialogStyle />
       <Story />
     </MemoryRouter>
   ),

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -21,6 +21,7 @@ import {createGlobalStyle} from 'styled-components/macro';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 
 import {ColorsWIP} from '../ui/Colors';
+import {GlobalDialogStyle} from '../ui/Dialog';
 import {GlobalPopoverStyle} from '../ui/Popover';
 import {GlobalTooltipStyle} from '../ui/Tooltip';
 import {FontFamily} from '../ui/styles';
@@ -155,6 +156,7 @@ export const AppProvider: React.FC<Props> = (props) => {
         <GlobalStyle />
         <GlobalTooltipStyle />
         <GlobalPopoverStyle />
+        <GlobalDialogStyle />
         <ApolloProvider client={apolloClient}>
           <PermissionsProvider>
             <BrowserRouter basename={basePath || ''}>

--- a/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
@@ -1,5 +1,7 @@
-import {Button, Classes, Dialog, Intent} from '@blueprintjs/core';
 import * as React from 'react';
+
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 
 interface ConfirmationOptions {
   catchOnCancel?: boolean;
@@ -21,19 +23,15 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   onClose,
 }) => {
   return (
-    <Dialog icon={title ? 'info-sign' : undefined} onClose={onClose} title={title} isOpen={open}>
-      <div className={Classes.DIALOG_BODY}>
-        <p>{description}</p>
-      </div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button onClick={onClose}>Cancel</Button>
-          <Button onClick={onSubmit} intent={Intent.WARNING}>
-            Confirm
-          </Button>
-        </div>
-      </div>
-    </Dialog>
+    <DialogWIP icon={title ? 'info' : undefined} onClose={onClose} title={title} isOpen={open}>
+      <DialogBody>{description}</DialogBody>
+      <DialogFooter>
+        <ButtonWIP onClick={onClose}>Cancel</ButtonWIP>
+        <ButtonWIP onClick={onSubmit} intent="warning">
+          Confirm
+        </ButtonWIP>
+      </DialogFooter>
+    </DialogWIP>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationTable.tsx
@@ -1,4 +1,4 @@
-import {Button, Classes, Colors, Dialog} from '@blueprintjs/core';
+import {Colors} from '@blueprintjs/core';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -8,7 +8,9 @@ import {PipelineReference} from '../pipelines/PipelineReference';
 import {MetadataEntries} from '../runs/MetadataEntry';
 import {RunStatusTagWithStats} from '../runs/RunStatusTag';
 import {titleForRun} from '../runs/RunUtils';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {Table} from '../ui/Table';
 import {Mono} from '../ui/Text';
@@ -144,7 +146,7 @@ export const AssetPredecessorLink: React.FC<PredecessorDialogProps> = ({
   return (
     <>
       <ButtonLink onClick={() => setOpen(true)}>{`View ${count} previous`}</ButtonLink>
-      <Dialog
+      <DialogWIP
         isOpen={open}
         canEscapeKeyClose
         canOutsideClickClose
@@ -152,22 +154,20 @@ export const AssetPredecessorLink: React.FC<PredecessorDialogProps> = ({
         style={{width: '80%', minWidth: '800px'}}
         title={title()}
       >
-        <div className={Classes.DIALOG_BODY}>
+        <DialogBody>
           <AssetMaterializationTable
             hasLineage={hasLineage}
             isPartitioned={isPartitioned}
             materializations={predecessors.map((p) => ({latest: p}))}
             shouldBucketPartitions={false}
           />
-        </div>
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button intent="primary" onClick={() => setOpen(false)}>
-              OK
-            </Button>
-          </div>
-        </div>
-      </Dialog>
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP intent="primary" onClick={() => setOpen(false)}>
+            OK
+          </ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
     </>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
@@ -1,6 +1,9 @@
 import {gql, RefetchQueriesFunction, useMutation} from '@apollo/client';
-import {Button, Classes, Dialog} from '@blueprintjs/core';
 import * as React from 'react';
+
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
+import {Group} from '../ui/Group';
 
 interface AssetKey {
   path: string[];
@@ -26,28 +29,31 @@ export const AssetWipeDialog: React.FC<{
     onComplete(assetKeys);
   };
 
-  const title =
-    assetKeys.length === 1 ? (
-      <>
-        Wipe asset <code>{assetKeys[0].path.join(' > ')}</code>
-      </>
-    ) : (
-      <>Wipe {assetKeys.length} assets</>
-    );
   return (
-    <Dialog isOpen={isOpen} title={title} onClose={onClose} style={{width: 800}}>
-      <div className={Classes.DIALOG_BODY}>Wiping assets cannot be undone.</div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button intent="danger" onClick={wipe}>
-            Wipe
-          </Button>
-          <Button intent="none" onClick={onClose}>
-            Cancel
-          </Button>
-        </div>
-      </div>
-    </Dialog>
+    <DialogWIP isOpen={isOpen} title="Wipe assets?" onClose={onClose} style={{width: 400}}>
+      <DialogBody>
+        <Group direction="column" spacing={8}>
+          <div>
+            {assetKeys.length === 1 ? (
+              <>
+                The asset <code>{assetKeys[0].path.join(' > ')}</code> will be wiped.
+              </>
+            ) : (
+              <>{assetKeys.length} assets will be wiped.</>
+            )}
+          </div>
+          <strong>Wiping assets cannot be undone.</strong>
+        </Group>
+      </DialogBody>
+      <DialogFooter>
+        <ButtonWIP intent="none" onClick={onClose}>
+          Cancel
+        </ButtonWIP>
+        <ButtonWIP intent="danger" onClick={wipe}>
+          Wipe
+        </ButtonWIP>
+      </DialogFooter>
+    </DialogWIP>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/execute/TagEditor.tsx
+++ b/js_modules/dagit/packages/core/src/execute/TagEditor.tsx
@@ -1,4 +1,3 @@
-import {Button, Classes, Dialog} from '@blueprintjs/core';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 import styled from 'styled-components/macro';
@@ -7,8 +6,10 @@ import {PipelineRunTag} from '../app/LocalStorage';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {RunTag} from '../runs/RunTag';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
 
@@ -74,24 +75,15 @@ export const TagEditor: React.FC<ITagEditorProps> = ({
   };
 
   return (
-    <Dialog
-      icon="info-sign"
+    <DialogWIP
+      icon="info"
       onClose={onRequestClose}
       style={{minWidth: 500}}
       title="Add tags to run"
-      usePortal={true}
       isOpen={open}
     >
-      <div
-        className={Classes.DIALOG_BODY}
-        style={{
-          margin: 0,
-          marginBottom: 17,
-          height: `calc(100% - 85px)`,
-          position: 'relative',
-        }}
-      >
-        <Group padding={16} spacing={16} direction="column">
+      <DialogBody>
+        <Group spacing={16} direction="column">
           {tagsFromDefinition.length ? (
             <Group direction="column" spacing={8}>
               <Box margin={{left: 2}} style={{fontSize: '13px', fontWeight: 500}}>
@@ -155,22 +147,20 @@ export const TagEditor: React.FC<ITagEditorProps> = ({
             </div>
           </Group>
         </Group>
-      </div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button onClick={onRequestClose}>Cancel</Button>
-          <ShortcutHandler
-            shortcutLabel="⌥Enter"
-            shortcutFilter={(e) => e.keyCode === 13 && e.altKey}
-            onShortcut={onSave}
-          >
-            <Button intent="primary" onClick={onSave} disabled={disabled}>
-              Apply
-            </Button>
-          </ShortcutHandler>
-        </div>
-      </div>
-    </Dialog>
+      </DialogBody>
+      <DialogFooter>
+        <ButtonWIP onClick={onRequestClose}>Cancel</ButtonWIP>
+        <ShortcutHandler
+          shortcutLabel="⌥Enter"
+          shortcutFilter={(e) => e.keyCode === 13 && e.altKey}
+          onShortcut={onSave}
+        >
+          <ButtonWIP intent="primary" onClick={onSave} disabled={disabled}>
+            Apply
+          </ButtonWIP>
+        </ShortcutHandler>
+      </DialogFooter>
+    </DialogWIP>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -1,10 +1,11 @@
 import {gql, useMutation} from '@apollo/client';
-import {Button, Classes, Dialog} from '@blueprintjs/core';
 import * as React from 'react';
 
 import {doneStatuses} from '../runs/RunStatuses';
 import {TerminationDialog} from '../runs/TerminationDialog';
 import {BulkActionStatus} from '../types/globalTypes';
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 
 import {InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results} from './types/InstanceBackfillsQuery';
 
@@ -39,34 +40,30 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
 
   return (
     <>
-      <Dialog
+      <DialogWIP
         isOpen={!!backfill && backfill.status !== BulkActionStatus.CANCELED && !!numUnscheduled}
         title="Cancel backfill"
         onClose={onClose}
       >
-        <div className={Classes.DIALOG_BODY}>
-          <div>
-            There {numUnscheduled === 1 ? 'is 1 partition ' : `are ${numUnscheduled} partitions `}
-            yet to be queued or launched.
-          </div>
-        </div>
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button intent="none" onClick={onClose}>
-              Close
-            </Button>
-            {isSubmitting ? (
-              <Button intent="danger" disabled>
-                Canceling...
-              </Button>
-            ) : (
-              <Button intent="danger" onClick={cancel}>
-                Cancel backfill
-              </Button>
-            )}
-          </div>
-        </div>
-      </Dialog>
+        <DialogBody>
+          There {numUnscheduled === 1 ? 'is 1 partition ' : `are ${numUnscheduled} partitions `}
+          yet to be queued or launched.
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP intent="none" onClick={onClose}>
+            Close
+          </ButtonWIP>
+          {isSubmitting ? (
+            <ButtonWIP intent="danger" disabled>
+              Canceling...
+            </ButtonWIP>
+          ) : (
+            <ButtonWIP intent="danger" onClick={cancel}>
+              Cancel backfill
+            </ButtonWIP>
+          )}
+        </DialogFooter>
+      </DialogWIP>
       <TerminationDialog
         isOpen={
           !!backfill &&

--- a/js_modules/dagit/packages/core/src/instance/DaemonHealth.tsx
+++ b/js_modules/dagit/packages/core/src/instance/DaemonHealth.tsx
@@ -1,9 +1,10 @@
-import {Button, Classes, Colors, Dialog, Tag} from '@blueprintjs/core';
+import {Colors, Tag} from '@blueprintjs/core';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {Trace} from '../ui/Trace';
 
@@ -81,13 +82,13 @@ export const DaemonHealth = (props: Props) => {
           <ButtonLink color={Colors.BLUE2} underline="hover" onClick={show}>
             {errorCount > 1 ? `View errors (${errorCount})` : 'View error'}
           </ButtonLink>
-          <Dialog
+          <DialogWIP
             isOpen={shown}
             title="Daemon error"
             onClose={hide}
             style={{maxWidth: '80%', minWidth: '70%'}}
           >
-            <div className={Classes.DIALOG_BODY}>
+            <DialogBody>
               <Group direction="column" spacing={12}>
                 {errorCount === 1 ? (
                   <div>
@@ -105,10 +106,10 @@ export const DaemonHealth = (props: Props) => {
                   </Group>
                 </Trace>
               </Group>
-            </div>
-            <div className={Classes.DIALOG_FOOTER}>
-              <Box flex={{alignItems: 'center', justifyContent: 'space-between'}}>
-                {errorCount > 1 ? (
+            </DialogBody>
+            <DialogFooter
+              left={
+                errorCount > 1 ? (
                   <Group direction="row" spacing={12} alignItems="center">
                     <ButtonLink onClick={prev}>&larr; Previous</ButtonLink>
                     <span>{`${page + 1} of ${errorCount}`}</span>
@@ -116,11 +117,14 @@ export const DaemonHealth = (props: Props) => {
                   </Group>
                 ) : (
                   <div />
-                )}
-                <Button onClick={hide}>OK</Button>
-              </Box>
-            </div>
-          </Dialog>
+                )
+              }
+            >
+              <ButtonWIP intent="primary" onClick={hide}>
+                OK
+              </ButtonWIP>
+            </DialogFooter>
+          </DialogWIP>
         </>
       );
     }

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Tag, Dialog, Button, Intent, NonIdealState, Classes, Colors} from '@blueprintjs/core';
+import {Tag, Intent, NonIdealState, Colors} from '@blueprintjs/core';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 import styled from 'styled-components/macro';
@@ -10,8 +10,10 @@ import {assertUnreachable} from '../app/Util';
 import {RunTable, RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTable';
 import {InstigationTickStatus, InstigationType} from '../types/globalTypes';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
 import {Spinner} from '../ui/Spinner';
@@ -47,23 +49,19 @@ export const TickTag: React.FunctionComponent<{
               {tick.runIds.length} Requested
             </ButtonLink>
           </Tag>
-          <Dialog
+          <DialogWIP
             isOpen={open}
             onClose={() => setOpen(false)}
             style={{width: '90vw'}}
-            title={`Launched runs`}
+            title="Launched runs"
           >
-            <Box background={Colors.WHITE} padding={16} margin={{bottom: 16}}>
-              {open && <RunList runIds={tick.runIds} />}
-            </Box>
-            <div className={Classes.DIALOG_FOOTER}>
-              <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                <Button intent="primary" onClick={() => setOpen(false)}>
-                  OK
-                </Button>
-              </div>
-            </div>
-          </Dialog>
+            <DialogBody>{open && <RunList runIds={tick.runIds} />}</DialogBody>
+            <DialogFooter>
+              <ButtonWIP intent="primary" onClick={() => setOpen(false)}>
+                OK
+              </ButtonWIP>
+            </DialogFooter>
+          </DialogWIP>
         </>
       );
     case InstigationTickStatus.SKIPPED:

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -1,14 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {
-  Button,
-  Checkbox,
-  Classes,
-  Colors,
-  Dialog,
-  NonIdealState,
-  Tabs,
-  Tab,
-} from '@blueprintjs/core';
+import {Checkbox, Colors, NonIdealState, Tabs, Tab} from '@blueprintjs/core';
 import {ActiveElement, Chart, TimeUnit} from 'chart.js';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import moment from 'moment-timezone';
@@ -20,7 +11,9 @@ import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {InstigationTickStatus, InstigationType} from '../types/globalTypes';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {Spinner} from '../ui/Spinner';
 import {Subheading} from '../ui/Text';
@@ -247,11 +240,13 @@ export const TickHistory = ({
           <NonIdealState description="No ticks to display" />
         </Box>
       )}
-      <Dialog
+      <DialogWIP
         isOpen={
-          selectedTick &&
-          (selectedTick.status === InstigationTickStatus.SUCCESS ||
-            selectedTick.status === InstigationTickStatus.SKIPPED)
+          !!(
+            selectedTick &&
+            (selectedTick.status === InstigationTickStatus.SUCCESS ||
+              selectedTick.status === InstigationTickStatus.SKIPPED)
+          )
         }
         onClose={() => setSelectedTick(undefined)}
         style={{
@@ -261,7 +256,7 @@ export const TickHistory = ({
         title={selectedTick ? <TimestampDisplay timestamp={selectedTick.timestamp} /> : null}
       >
         {selectedTick ? (
-          <Box background={Colors.WHITE} padding={16} margin={{bottom: 16}}>
+          <DialogBody>
             {selectedTick.status === InstigationTickStatus.SUCCESS ? (
               selectedTick.runIds.length ? (
                 <RunList runIds={selectedTick.runIds} />
@@ -275,16 +270,14 @@ export const TickHistory = ({
                 <span>{selectedTick.skipReason || 'No skip reason provided'}</span>
               </Group>
             ) : null}
-          </Box>
+          </DialogBody>
         ) : null}
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button intent="primary" onClick={() => setSelectedTick(undefined)}>
-              OK
-            </Button>
-          </div>
-        </div>
-      </Dialog>
+        <DialogFooter>
+          <ButtonWIP intent="primary" onClick={() => setSelectedTick(undefined)}>
+            OK
+          </ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
     </Group>
   );
 };

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Button, Classes, Colors, Dialog} from '@blueprintjs/core';
+import {Colors} from '@blueprintjs/core';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -13,8 +13,10 @@ import {ScheduleSwitch, SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwi
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {SensorSwitch, SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
 import {MetadataTable, StyledTable} from '../ui/MetadataTable';
@@ -154,14 +156,14 @@ const ScheduleOrSensor: React.FC<{job: Job; mode: string; repoAddress: RepoAddre
     return (
       <>
         <ButtonLink onClick={() => setOpen(true)}>{buttonText}</ButtonLink>
-        <Dialog
+        <DialogWIP
           title={dialogTitle}
           canOutsideClickClose
           canEscapeKeyClose
           isOpen={open}
           onClose={() => setOpen(false)}
         >
-          <div className={Classes.DIALOG_BODY}>
+          <DialogBody>
             <Group direction="column" spacing={16}>
               {matchingSchedules.map((schedule) => (
                 <MatchingSchedule
@@ -174,13 +176,13 @@ const ScheduleOrSensor: React.FC<{job: Job; mode: string; repoAddress: RepoAddre
                 <MatchingSensor key={sensor.name} sensor={sensor} repoAddress={repoAddress} />
               ))}
             </Group>
-          </div>
-          <div className={Classes.DIALOG_FOOTER}>
-            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-              <Button text="OK" onClick={() => setOpen(false)} />
-            </div>
-          </div>
-        </Dialog>
+          </DialogBody>
+          <DialogFooter>
+            <ButtonWIP intent="primary" onClick={() => setOpen(false)}>
+              OK
+            </ButtonWIP>
+          </DialogFooter>
+        </DialogWIP>
       </>
     );
   }
@@ -299,7 +301,7 @@ const RelatedAssets: React.FC<{runs: RunMetadataFragment[]}> = ({runs}) => {
   return (
     <>
       <ButtonLink onClick={() => setOpen(true)}>{`View ${keys.length} assets`}</ButtonLink>
-      <Dialog
+      <DialogWIP
         title="Related assets"
         canOutsideClickClose
         canEscapeKeyClose
@@ -307,7 +309,7 @@ const RelatedAssets: React.FC<{runs: RunMetadataFragment[]}> = ({runs}) => {
         onClose={() => setOpen(false)}
         style={{maxWidth: '80%', minWidth: '500px', width: 'auto'}}
       >
-        <div className={Classes.DIALOG_BODY}>
+        <DialogBody>
           <Group direction="column" spacing={16}>
             {keys.map((key) => (
               <Link key={key} to={`/instance/assets/${key}`} style={{wordBreak: 'break-word'}}>
@@ -315,13 +317,13 @@ const RelatedAssets: React.FC<{runs: RunMetadataFragment[]}> = ({runs}) => {
               </Link>
             ))}
           </Group>
-        </div>
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button text="OK" onClick={() => setOpen(false)} />
-          </div>
-        </div>
-      </Dialog>
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP intent="primary" onClick={() => setOpen(false)}>
+            OK
+          </ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
     </>
   );
 };

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Colors, Dialog, Button, Classes, MenuItem, Menu, Popover} from '@blueprintjs/core';
+import {Colors, Button, MenuItem, Menu, Popover} from '@blueprintjs/core';
 import {Popover2} from '@blueprintjs/popover2';
 import qs from 'query-string';
 import * as React from 'react';
@@ -10,7 +10,9 @@ import {useViewport} from '../gantt/useViewport';
 import {QueryPersistedStateConfig, useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {PIPELINE_EXPLORER_SOLID_HANDLE_FRAGMENT} from '../pipelines/PipelineExplorer';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
@@ -169,13 +171,13 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
 
   return (
     <PartitionRunMatrixContainer>
-      <Dialog
+      <DialogWIP
         isOpen={!!focused}
         onClose={() => setFocused(null)}
         style={{width: '90vw'}}
         title={focused ? `${focused.partitionName} runs (${focused.stepName})` : ''}
       >
-        <div style={{background: Colors.WHITE, padding: 15, marginBottom: 15}}>
+        <DialogBody>
           {focused && (
             <PartitionRunListForStep
               pipelineName={props.pipelineName}
@@ -193,15 +195,13 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
               )}
             />
           )}
-        </div>
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button intent="primary" autoFocus={true} onClick={() => setFocused(null)}>
-              OK
-            </Button>
-          </div>
-        </div>
-      </Dialog>
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP intent="primary" autoFocus={true} onClick={() => setFocused(null)}>
+            OK
+          </ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
       <Box
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
         padding={{vertical: 4}}

--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -1,4 +1,4 @@
-import {Button, Dialog, Colors} from '@blueprintjs/core';
+import {Button} from '@blueprintjs/core';
 import {IconNames} from '@blueprintjs/icons';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
@@ -12,6 +12,7 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useQueryPersistedRunFilters} from '../runs/RunsFilter';
 import {Box} from '../ui/Box';
 import {CursorHistoryControls} from '../ui/CursorControls';
+import {DialogWIP} from '../ui/Dialog';
 import {Spinner} from '../ui/Spinner';
 import {RepoAddress} from '../workspace/types';
 
@@ -103,11 +104,11 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
 
   return (
     <div>
-      <Dialog
+      <DialogWIP
         canEscapeKeyClose={!blockDialog}
         canOutsideClickClose={!blockDialog}
         onClose={() => setShowBackfillSetup(false)}
-        style={{width: 800, background: Colors.WHITE}}
+        style={{width: 800}}
         title={`Launch ${partitionSet.name} backfill`}
         isOpen={showBackfillSetup}
       >
@@ -124,7 +125,7 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
             repoAddress={repoAddress}
           />
         )}
-      </Dialog>
+      </DialogWIP>
       <PartitionPagerContainer>
         {flagPipelineModeTuples && partitionSetsForMode.length <= 1 ? null : (
           <>

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -1,5 +1,5 @@
 import {gql, useLazyQuery, useMutation, useQuery} from '@apollo/client';
-import {Checkbox, Intent, NonIdealState, Classes, Colors, InputGroup} from '@blueprintjs/core';
+import {Checkbox, Intent, NonIdealState, Colors, InputGroup} from '@blueprintjs/core';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 import styled from 'styled-components/macro';
@@ -20,6 +20,7 @@ import {Alert} from '../ui/Alert';
 import {Box} from '../ui/Box';
 import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter} from '../ui/Dialog';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
@@ -397,8 +398,8 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
   const selectedString = partitionsToText(selected, partitionNames);
 
   return (
-    <div>
-      <div className={Classes.DIALOG_BODY}>
+    <>
+      <DialogBody>
         <div style={{display: 'flex', alignItems: 'center', marginBottom: 4}}>
           <strong style={{display: 'block'}}>Partitions</strong>
           <Checkbox
@@ -590,49 +591,44 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
             />
           </div>
         ) : null}
-      </div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div style={{display: 'flex', alignItems: 'center', justifyContent: 'flex-end'}}>
-          <TagEditor
-            tagsFromSession={tags}
-            onChange={setTags}
-            open={tagEditorOpen}
-            onRequestClose={() => setTagEditorOpen(false)}
-          />
-          {tags.length ? (
-            <div style={{border: '1px solid #ececec', borderBottom: 'none'}}>
-              <TagContainer
-                tags={{fromSession: tags}}
-                onRequestEdit={() => setTagEditorOpen(true)}
-              />
-            </div>
-          ) : (
-            <ButtonLink
-              color="#106ba3"
-              onClick={() => setTagEditorOpen(true)}
-              style={{margin: '9px  9px 0 9px'}}
-            >
-              + Add tags to backfill runs
-            </ButtonLink>
-          )}
-          <LaunchBackfillButton
-            partitionNames={selected}
-            partitionSetName={partitionSet.name}
-            reexecutionSteps={
-              !options.fromFailure && solidsFiltered.all.length < solids.length
-                ? stepRows.map((step) => step.name)
-                : undefined
-            }
-            fromFailure={options.fromFailure}
-            tags={tags}
-            onSubmit={onSubmit}
-            onSuccess={onSuccess}
-            onError={onError}
-            repoAddress={repoAddress}
-          />
-        </div>
-      </div>
-    </div>
+      </DialogBody>
+      <DialogFooter>
+        <TagEditor
+          tagsFromSession={tags}
+          onChange={setTags}
+          open={tagEditorOpen}
+          onRequestClose={() => setTagEditorOpen(false)}
+        />
+        {tags.length ? (
+          <div style={{border: '1px solid #ececec', borderBottom: 'none'}}>
+            <TagContainer tags={{fromSession: tags}} onRequestEdit={() => setTagEditorOpen(true)} />
+          </div>
+        ) : (
+          <ButtonLink
+            color="#106ba3"
+            onClick={() => setTagEditorOpen(true)}
+            style={{margin: '9px  9px 0 9px'}}
+          >
+            + Add tags to backfill runs
+          </ButtonLink>
+        )}
+        <LaunchBackfillButton
+          partitionNames={selected}
+          partitionSetName={partitionSet.name}
+          reexecutionSteps={
+            !options.fromFailure && solidsFiltered.all.length < solids.length
+              ? stepRows.map((step) => step.name)
+              : undefined
+          }
+          fromFailure={options.fromFailure}
+          tags={tags}
+          onSubmit={onSubmit}
+          onSuccess={onSuccess}
+          onError={onError}
+          repoAddress={repoAddress}
+        />
+      </DialogFooter>
+    </>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/plugins/generic.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/generic.tsx
@@ -1,51 +1,38 @@
-import {Button, Classes, Dialog} from '@blueprintjs/core';
+import {Button} from '@blueprintjs/core';
 import startCase from 'lodash/startCase';
 import * as React from 'react';
 
 import {IPluginSidebarProps} from '../plugins';
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 
-export class SidebarComponent extends React.Component<IPluginSidebarProps> {
-  state = {
-    open: false,
-  };
+export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
+  const [open, setOpen] = React.useState(false);
 
-  componentDidMount() {
-    document.addEventListener('show-kind-info', this.onClick);
+  React.useEffect(() => {
+    const onOpen = () => setOpen(true);
+    document.addEventListener('show-kind-info', onOpen);
+    return () => document.removeEventListener('show-kind-info', onOpen);
+  }, []);
+
+  const metadata = props.definition.metadata.sort((a, b) => a.key.localeCompare(b.key));
+
+  if (metadata.length === 0) {
+    return <span />;
   }
 
-  componentWillUnmount() {
-    document.removeEventListener('show-kind-info', this.onClick);
-  }
-
-  onClick = () => {
-    this.setState({
-      open: true,
-    });
-  };
-
-  render() {
-    const metadata = this.props.definition.metadata.sort((a, b) => a.key.localeCompare(b.key));
-
-    if (metadata.length === 0) {
-      return <span />;
-    }
-
-    return (
-      <div>
-        <Button icon="duplicate" onClick={this.onClick}>
-          View Metadata
-        </Button>
-        <Dialog
-          title={`Metadata: ${this.props.definition.name}`}
-          isOpen={this.state.open}
-          onClose={() =>
-            this.setState({
-              open: false,
-            })
-          }
-        >
+  return (
+    <div>
+      <Button icon="duplicate" onClick={() => setOpen(true)}>
+        View Metadata
+      </Button>
+      <DialogWIP
+        title={`Metadata: ${props.definition.name}`}
+        isOpen={open}
+        onClose={() => setOpen(false)}
+      >
+        <DialogBody>
           <div
-            className={Classes.DIALOG_BODY}
             style={{
               maxHeight: 400,
               overflow: 'scroll',
@@ -70,13 +57,11 @@ export class SidebarComponent extends React.Component<IPluginSidebarProps> {
               </tbody>
             </table>
           </div>
-          <div className={Classes.DIALOG_FOOTER}>
-            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-              <Button onClick={() => this.setState({open: false})}>Close</Button>
-            </div>
-          </div>
-        </Dialog>
-      </div>
-    );
-  }
-}
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP onClick={() => setOpen(false)}>Close</ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
+    </div>
+  );
+};

--- a/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/ipynb.tsx
@@ -1,73 +1,57 @@
-import {Button, Classes, Dialog} from '@blueprintjs/core';
+import {Button} from '@blueprintjs/core';
 import * as React from 'react';
 
 import {IPluginSidebarProps} from '../plugins';
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 
-export class SidebarComponent extends React.Component<IPluginSidebarProps> {
-  state = {
-    open: false,
-  };
+export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
+  const [open, setOpen] = React.useState(false);
 
-  componentDidMount() {
-    document.addEventListener('show-kind-info', this.onClick);
+  React.useEffect(() => {
+    const onOpen = () => setOpen(true);
+    document.addEventListener('show-kind-info', onOpen);
+    return () => document.removeEventListener('show-kind-info', onOpen);
+  }, []);
+
+  const metadata = props.definition.metadata;
+  const notebookPath = metadata.find((m) => m.key === 'notebook_path');
+  const repoLocName = props.repoAddress?.location;
+
+  if (!notebookPath) {
+    return <span />;
   }
 
-  componentWillUnmount() {
-    document.removeEventListener('show-kind-info', this.onClick);
-  }
-
-  onClick = () => {
-    this.setState({
-      open: true,
-    });
-  };
-
-  render() {
-    const metadata = this.props.definition.metadata;
-    const notebookPath = metadata.find((m) => m.key === 'notebook_path');
-    const repoLocName = this.props.repoAddress?.location;
-
-    if (!notebookPath) {
-      return <span />;
-    }
-
-    return (
-      <div>
-        <Button icon="duplicate" onClick={this.onClick}>
-          View Notebook
-        </Button>
-        <Dialog
-          icon="info-sign"
-          onClose={() =>
-            this.setState({
-              open: false,
-            })
-          }
-          style={{width: '80vw', maxWidth: 900, height: 615}}
-          title={notebookPath.value.split('/').pop()}
-          usePortal={true}
-          isOpen={this.state.open}
-        >
-          <div className={Classes.DIALOG_BODY} style={{margin: 0}}>
-            <iframe
-              title={notebookPath.value}
-              src={`${this.props.rootServerURI}/dagit/notebook?path=${encodeURIComponent(
-                notebookPath.value,
-              )}&repoLocName=${repoLocName}`}
-              sandbox=""
-              style={{border: 0, background: 'white'}}
-              seamless={true}
-              width="100%"
-              height={500}
-            />
-          </div>
-          <div className={Classes.DIALOG_FOOTER}>
-            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-              <Button onClick={() => this.setState({open: false})}>Close</Button>
-            </div>
-          </div>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <Button icon="duplicate" onClick={() => setOpen(true)}>
+        View Notebook
+      </Button>
+      <DialogWIP
+        icon="info"
+        onClose={() => setOpen(false)}
+        style={{width: '80vw', maxWidth: 900, height: 615}}
+        title={notebookPath.value.split('/').pop()}
+        usePortal={true}
+        isOpen={open}
+      >
+        <DialogBody>
+          <iframe
+            title={notebookPath.value}
+            src={`${props.rootServerURI}/dagit/notebook?path=${encodeURIComponent(
+              notebookPath.value,
+            )}&repoLocName=${repoLocName}`}
+            sandbox=""
+            style={{border: 0, background: 'white'}}
+            seamless={true}
+            width="100%"
+            height={500}
+          />
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP onClick={() => setOpen(false)}>Close</ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
+    </div>
+  );
+};

--- a/js_modules/dagit/packages/core/src/plugins/sql.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/sql.tsx
@@ -1,71 +1,54 @@
-import {Button, Classes, Dialog} from '@blueprintjs/core';
+import {Button} from '@blueprintjs/core';
 import * as React from 'react';
 
 import {IPluginSidebarProps} from '../plugins';
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {HighlightedCodeBlock} from '../ui/HighlightedCodeBlock';
 
-export class SidebarComponent extends React.Component<IPluginSidebarProps> {
-  state = {
-    open: false,
-  };
+export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
+  const [open, setOpen] = React.useState(false);
 
-  componentDidMount() {
-    document.addEventListener('show-kind-info', this.onClick);
+  React.useEffect(() => {
+    const onClose = () => setOpen(true);
+    document.addEventListener('show-kind-info', onClose);
+    return () => document.removeEventListener('show-kind-info', onClose);
+  }, []);
+
+  const metadata = props.definition.metadata;
+  const sql = metadata.find((m) => m.key === 'sql');
+  if (!sql) {
+    return <span />;
   }
 
-  componentWillUnmount() {
-    document.removeEventListener('show-kind-info', this.onClick);
-  }
-
-  onClick = () => {
-    this.setState({
-      open: true,
-    });
-  };
-
-  render() {
-    const metadata = this.props.definition.metadata;
-    const sql = metadata.find((m) => m.key === 'sql');
-    if (!sql) {
-      return <span />;
-    }
-
-    return (
-      <div>
-        <Button icon="duplicate" onClick={this.onClick}>
-          View SQL
-        </Button>
-        <Dialog
-          icon="info-sign"
-          onClose={() =>
-            this.setState({
-              open: false,
-            })
-          }
-          style={{width: '80vw', maxWidth: 900, height: 615}}
-          title={`SQL: ${this.props.definition.name}`}
-          usePortal={true}
-          isOpen={this.state.open}
-        >
-          <div className={Classes.DIALOG_BODY} style={{margin: 0}}>
-            <HighlightedCodeBlock
-              language="sql"
-              value={sql.value}
-              style={{
-                height: 510,
-                padding: 10,
-                overflow: 'scroll',
-                fontSize: '0.9em',
-              }}
-            />
-          </div>
-          <div className={Classes.DIALOG_FOOTER}>
-            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-              <Button onClick={() => this.setState({open: false})}>Close</Button>
-            </div>
-          </div>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <Button icon="duplicate" onClick={() => setOpen(true)}>
+        View SQL
+      </Button>
+      <DialogWIP
+        icon="info"
+        onClose={() => setOpen(false)}
+        style={{width: '80vw', maxWidth: 900, height: 615}}
+        title={`SQL: ${props.definition.name}`}
+        isOpen={open}
+      >
+        <DialogBody>
+          <HighlightedCodeBlock
+            language="sql"
+            value={sql.value}
+            style={{
+              height: 510,
+              padding: 10,
+              overflow: 'scroll',
+              fontSize: '0.9em',
+            }}
+          />
+        </DialogBody>
+        <DialogFooter>
+          <ButtonWIP onClick={() => setOpen(false)}>Close</ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
+    </div>
+  );
+};

--- a/js_modules/dagit/packages/core/src/runs/DeletionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/DeletionDialog.tsx
@@ -1,8 +1,10 @@
 import {useMutation} from '@apollo/client';
-import {Button, Classes, Dialog, ProgressBar} from '@blueprintjs/core';
+import {ProgressBar} from '@blueprintjs/core';
 import * as React from 'react';
 
+import {ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
 import {Mono} from '../ui/Text';
@@ -189,32 +191,32 @@ export const DeletionDialog = (props: Props) => {
       case 'initial':
         return (
           <>
-            <Button intent="none" onClick={onClose}>
+            <ButtonWIP intent="none" onClick={onClose}>
               Cancel
-            </Button>
-            <Button intent="danger" onClick={mutate}>
+            </ButtonWIP>
+            <ButtonWIP intent="danger" onClick={mutate}>
               {`Yes, delete ${`${count} ${count === 1 ? 'run' : 'runs'}`}`}
-            </Button>
+            </ButtonWIP>
             {terminatableCount ? (
-              <Button intent="primary" onClick={onTerminateInstead}>
+              <ButtonWIP intent="primary" onClick={onTerminateInstead}>
                 {`Terminate ${`${terminatableCount} ${
                   terminatableCount === 1 ? 'run' : 'runs'
                 }`} instead`}
-              </Button>
+              </ButtonWIP>
             ) : null}
           </>
         );
       case 'deleting':
         return (
-          <Button intent="danger" disabled>
+          <ButtonWIP intent="danger" disabled>
             Deleting…
-          </Button>
+          </ButtonWIP>
         );
       case 'completed':
         return (
-          <Button intent="primary" onClick={onClose}>
+          <ButtonWIP intent="primary" onClick={onClose}>
             Done
-          </Button>
+          </ButtonWIP>
         );
     }
   };
@@ -267,7 +269,7 @@ export const DeletionDialog = (props: Props) => {
   const canQuicklyClose = state.step !== 'deleting';
 
   return (
-    <Dialog
+    <DialogWIP
       isOpen={isOpen}
       title="Delete runs"
       canEscapeKeyClose={canQuicklyClose}
@@ -275,15 +277,13 @@ export const DeletionDialog = (props: Props) => {
       isCloseButtonShown={canQuicklyClose}
       onClose={onClose}
     >
-      <div className={Classes.DIALOG_BODY}>
+      <DialogBody>
         <Group direction="column" spacing={24}>
           {progressContent()}
           {completionContent()}
         </Group>
-      </div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>{buttons()}</div>
-      </div>
-    </Dialog>
+      </DialogBody>
+      <DialogFooter>{buttons()}</DialogFooter>
+    </DialogWIP>
   );
 };

--- a/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
@@ -1,5 +1,4 @@
 import {gql} from '@apollo/client';
-import {Button, Classes, Colors, Dialog, Position} from '@blueprintjs/core';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -7,7 +6,9 @@ import styled from 'styled-components/macro';
 
 import {copyValue} from '../app/DomUtils';
 import {assertUnreachable} from '../app/Util';
+import {ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
 import {Markdown} from '../ui/Markdown';
@@ -210,7 +211,7 @@ const PythonArtifactLink = ({
   <>
     <Tooltip
       hoverOpenDelay={100}
-      position={Position.TOP}
+      position="top"
       content={`${module}.${name}`}
       usePortal
       modifiers={{
@@ -229,46 +230,30 @@ const MetadataEntryModalAction: React.FunctionComponent<{
   content: () => React.ReactNode;
   copyContent: () => string;
 }> = (props) => {
-  const [isExpanded, setExpanded] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
   return (
     <>
-      <MetadataEntryAction onClick={() => setExpanded(true)}>{props.children}</MetadataEntryAction>
-      {isExpanded && (
-        <Dialog
-          icon="info-sign"
-          usePortal={true}
-          style={{width: 'auto', minWidth: 400, maxWidth: '80vw'}}
-          title={props.label}
-          onClose={() => setExpanded(false)}
-          isOpen={true}
-        >
-          <MetadataEntryModalContent>{props.content()}</MetadataEntryModalContent>
-          <div className={Classes.DIALOG_FOOTER}>
-            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-              <Button onClick={(e: React.MouseEvent) => copyValue(e, props.copyContent())}>
-                Copy
-              </Button>
-              <Button intent="primary" autoFocus={true} onClick={() => setExpanded(false)}>
-                Close
-              </Button>
-            </div>
-          </div>
-        </Dialog>
-      )}
+      <MetadataEntryAction onClick={() => setOpen(true)}>{props.children}</MetadataEntryAction>
+      <DialogWIP
+        icon="info"
+        style={{width: 'auto', minWidth: 400, maxWidth: '80vw'}}
+        title={props.label}
+        onClose={() => setOpen(false)}
+        isOpen={open}
+      >
+        <DialogBody>{props.content()}</DialogBody>
+        <DialogFooter>
+          <ButtonWIP onClick={(e: React.MouseEvent) => copyValue(e, props.copyContent())}>
+            Copy
+          </ButtonWIP>
+          <ButtonWIP intent="primary" autoFocus={true} onClick={() => setOpen(false)}>
+            Close
+          </ButtonWIP>
+        </DialogFooter>
+      </DialogWIP>
     </>
   );
 };
-
-const MetadataEntryModalContent = styled.div`
-  font-size: 13px;
-  overflow: auto;
-  max-height: 500px;
-  background: ${Colors.WHITE};
-  border-top: 1px solid ${Colors.LIGHT_GRAY3};
-  padding: 20px;
-  margin: 0;
-  margin-bottom: 20px;
-`;
 
 const MetadataEntryAction = styled.a`
   text-decoration: underline;

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -1,11 +1,12 @@
 import {gql} from '@apollo/client';
-import {AnchorButton, Button, Classes, Colors, Dialog} from '@blueprintjs/core';
+import {AnchorButton, Button, Colors} from '@blueprintjs/core';
 import {Tooltip2 as Tooltip} from '@blueprintjs/popover2';
 import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {PipelineRunStatus} from '../types/globalTypes';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {HighlightedCodeBlock} from '../ui/HighlightedCodeBlock';
 import {MetadataTable} from '../ui/MetadataTable';
@@ -125,14 +126,13 @@ export const RunConfigDialog: React.FC<{run: RunFragment}> = ({run}) => {
           />
         </Tooltip>
       </Group>
-
-      <Dialog
+      <DialogWIP
         isOpen={showDialog}
         onClose={() => setShowDialog(false)}
         style={{width: '800px'}}
         title="Run configuration"
       >
-        <div className={Classes.DIALOG_BODY}>
+        <DialogBody>
           <Group direction="column" spacing={20}>
             <Group direction="column" spacing={12}>
               <div style={{fontSize: '16px', fontWeight: 600}}>Tags</div>
@@ -145,15 +145,13 @@ export const RunConfigDialog: React.FC<{run: RunFragment}> = ({run}) => {
               <HighlightedCodeBlock value={run?.runConfigYaml || ''} language="yaml" />
             </Group>
           </Group>
-        </div>
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button onClick={() => setShowDialog(false)} intent="primary">
-              OK
-            </Button>
-          </div>
-        </div>
-      </Dialog>
+        </DialogBody>
+        <DialogFooter>
+          <Button onClick={() => setShowDialog(false)} intent="primary">
+            OK
+          </Button>
+        </DialogFooter>
+      </DialogWIP>
     </div>
   );
 };

--- a/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
@@ -1,10 +1,12 @@
 import {useMutation} from '@apollo/client';
-import {Checkbox, Button, Classes, Dialog, ProgressBar} from '@blueprintjs/core';
+import {Checkbox, ProgressBar} from '@blueprintjs/core';
 import * as React from 'react';
 
 import {TerminatePipelinePolicy} from '../types/globalTypes';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
 import {Mono} from '../ui/Text';
@@ -229,37 +231,37 @@ export const TerminationDialog = (props: Props) => {
       case 'initial':
         if (!count) {
           return (
-            <Button intent="none" onClick={onClose}>
+            <ButtonWIP intent="none" onClick={onClose}>
               OK
-            </Button>
+            </ButtonWIP>
           );
         }
 
         return (
           <>
-            <Button intent="none" onClick={onClose}>
+            <ButtonWIP intent="none" onClick={onClose}>
               Cancel
-            </Button>
-            <Button intent="danger" onClick={mutate}>
+            </ButtonWIP>
+            <ButtonWIP intent="danger" onClick={mutate}>
               {`${state.mustForce ? 'Force termination for' : 'Terminate'} ${`${count} ${
                 count === 1 ? 'run' : 'runs'
               }`}`}
-            </Button>
+            </ButtonWIP>
           </>
         );
       case 'terminating':
         return (
-          <Button intent="danger" disabled>
+          <ButtonWIP intent="danger" disabled>
             {state.mustForce
               ? `Forcing termination for ${`${count} ${count === 1 ? 'run' : 'runs'}...`}`
               : `Terminating ${`${count} ${count === 1 ? 'run' : 'runs'}...`}`}
-          </Button>
+          </ButtonWIP>
         );
       case 'completed':
         return (
-          <Button intent="primary" onClick={onClose}>
+          <ButtonWIP intent="primary" onClick={onClose}>
             Done
-          </Button>
+          </ButtonWIP>
         );
     }
   };
@@ -324,7 +326,7 @@ export const TerminationDialog = (props: Props) => {
   const canQuicklyClose = state.step !== 'terminating';
 
   return (
-    <Dialog
+    <DialogWIP
       isOpen={isOpen}
       title="Terminate runs"
       canEscapeKeyClose={canQuicklyClose}
@@ -332,15 +334,13 @@ export const TerminationDialog = (props: Props) => {
       isCloseButtonShown={canQuicklyClose}
       onClose={onClose}
     >
-      <div className={Classes.DIALOG_BODY}>
+      <DialogBody>
         <Group direction="column" spacing={24}>
           {progressContent()}
           {completionContent()}
         </Group>
-      </div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>{buttons()}</div>
-      </div>
-    </Dialog>
+      </DialogBody>
+      <DialogFooter>{buttons()}</DialogFooter>
+    </DialogWIP>
   );
 };

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -1,14 +1,5 @@
 import {gql, useLazyQuery} from '@apollo/client';
-import {
-  Classes,
-  NonIdealState,
-  Colors,
-  Button,
-  Menu,
-  MenuItem,
-  Popover,
-  Dialog,
-} from '@blueprintjs/core';
+import {NonIdealState, Colors, Button, Menu, MenuItem, Popover} from '@blueprintjs/core';
 import * as qs from 'query-string';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -21,8 +12,10 @@ import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunTags} from '../runs/RunTags';
 import {InstigationStatus} from '../types/globalTypes';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
 import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {HighlightedCodeBlock} from '../ui/HighlightedCodeBlock';
 import {IconWIP} from '../ui/Icon';
@@ -301,98 +294,102 @@ const NextTickDialog: React.FC<{
     body = null;
   } else if (selectedRunRequest) {
     body = (
-      <>
-        {selectedRunRequest.tags.length ? (
-          <Box padding={12}>
-            <RunTags tags={selectedRunRequest.tags} />
-          </Box>
-        ) : null}
-        <ConfigBody>
-          <div ref={configRef}>
-            <HighlightedCodeBlock value={selectedRunRequest.runConfigYaml} language="yaml" />
-          </div>
-        </ConfigBody>
-      </>
+      <DialogBody>
+        <Group direction="column" spacing={12}>
+          {selectedRunRequest.tags.length ? <RunTags tags={selectedRunRequest.tags} /> : null}
+          <ConfigBody>
+            <div ref={configRef}>
+              <HighlightedCodeBlock value={selectedRunRequest.runConfigYaml} language="yaml" />
+            </div>
+          </ConfigBody>
+        </Group>
+      </DialogBody>
     );
   } else if (evaluationResult.error) {
     body = (
-      <Box margin={24}>
+      <DialogBody>
         <PythonErrorInfo error={evaluationResult.error} />
-      </Box>
+      </DialogBody>
     );
   } else if (evaluationResult.skipReason) {
     body = (
-      <Box margin={24}>
+      <DialogBody>
         <SkipWrapper>{evaluationResult.skipReason}</SkipWrapper>
-      </Box>
+      </DialogBody>
     );
   } else if (evaluationResult.runRequests) {
     body = (
-      <RunRequestBody>
-        <Table>
-          <thead>
-            <tr>
-              <th>Run key</th>
-              <th>Config</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {evaluationResult.runRequests.map((runRequest, idx) => {
-              if (!runRequest) {
-                return null;
-              }
-              return (
-                <tr key={idx}>
-                  <td>{runRequest.runKey || <span>&mdash;</span>}</td>
-                  <td>
-                    <ButtonLink onClick={() => setSelectedRunRequest(runRequest)} underline={false}>
-                      <Group direction="row" spacing={8} alignItems="center">
-                        <IconWIP name="open_in_new" color={ColorsWIP.Gray400} />
-                        <span>View config</span>
-                      </Group>
-                    </ButtonLink>
-                  </td>
-                  <td>
-                    <Popover
-                      content={
-                        <Menu>
-                          <MenuItem
-                            text="Open in Playground..."
-                            icon="edit"
-                            target="_blank"
-                            href={workspacePathFromAddress(
-                              repoAddress,
-                              `/pipelines/${schedule.pipelineName}/playground/setup?${qs.stringify({
-                                mode: schedule.mode,
-                                config: runRequest.runConfigYaml,
-                                solidSelection: schedule.solidSelection,
-                              })}`,
-                            )}
-                          />
-                        </Menu>
-                      }
-                      position="bottom"
-                    >
-                      <Button small minimal icon="chevron-down" />
-                    </Popover>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </Table>
-      </RunRequestBody>
+      <DialogBody>
+        <RunRequestBody>
+          <Table>
+            <thead>
+              <tr>
+                <th>Run key</th>
+                <th>Config</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evaluationResult.runRequests.map((runRequest, idx) => {
+                if (!runRequest) {
+                  return null;
+                }
+                return (
+                  <tr key={idx}>
+                    <td>{runRequest.runKey || <span>&mdash;</span>}</td>
+                    <td>
+                      <ButtonLink
+                        onClick={() => setSelectedRunRequest(runRequest)}
+                        underline={false}
+                      >
+                        <Group direction="row" spacing={8} alignItems="center">
+                          <IconWIP name="open_in_new" color={ColorsWIP.Gray400} />
+                          <span>View config</span>
+                        </Group>
+                      </ButtonLink>
+                    </td>
+                    <td>
+                      <Popover
+                        content={
+                          <Menu>
+                            <MenuItem
+                              text="Open in Playground..."
+                              icon="edit"
+                              target="_blank"
+                              href={workspacePathFromAddress(
+                                repoAddress,
+                                `/pipelines/${
+                                  schedule.pipelineName
+                                }/playground/setup?${qs.stringify({
+                                  mode: schedule.mode,
+                                  config: runRequest.runConfigYaml,
+                                  solidSelection: schedule.solidSelection,
+                                })}`,
+                              )}
+                            />
+                          </Menu>
+                        }
+                        position="bottom"
+                      >
+                        <Button small minimal icon="chevron-down" />
+                      </Popover>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </RunRequestBody>
+      </DialogBody>
     );
   }
 
   return (
-    <Dialog
-      usePortal={true}
+    <DialogWIP
       onClose={() => close()}
       style={{width: '50vw'}}
       title={
-        <Box flex={{direction: 'row'}}>
+        <Box flex={{direction: 'row', gap: 4}}>
           <TimestampDisplay timestamp={tickTimestamp} timezone={schedule.executionTimezone} />
           {selectedRunRequest?.runKey ? <div>: {selectedRunRequest?.runKey}</div> : null}
         </Box>
@@ -400,27 +397,22 @@ const NextTickDialog: React.FC<{
       isOpen={isOpen}
     >
       {body}
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          {selectedRunRequest ? (
-            <Button
-              autoFocus={false}
-              onClick={(e: React.MouseEvent<any, MouseEvent>) => {
-                copyValue(
-                  e,
-                  configRef && configRef.current ? configRef.current.innerText : '' || '',
-                );
-              }}
-            >
-              Copy
-            </Button>
-          ) : null}
-          <Button intent="primary" autoFocus={true} onClick={() => close()}>
-            OK
-          </Button>
-        </div>
-      </div>
-    </Dialog>
+      <DialogFooter>
+        {selectedRunRequest ? (
+          <ButtonWIP
+            autoFocus={false}
+            onClick={(e: React.MouseEvent<any, MouseEvent>) => {
+              copyValue(e, configRef && configRef.current ? configRef.current.innerText : '' || '');
+            }}
+          >
+            Copy
+          </ButtonWIP>
+        ) : null}
+        <ButtonWIP intent="primary" autoFocus={true} onClick={() => close()}>
+          OK
+        </ButtonWIP>
+      </DialogFooter>
+    </DialogWIP>
   );
 };
 
@@ -457,24 +449,14 @@ const ConfigBody = styled.div`
   font-size: 14px;
   overflow: scroll;
   background: ${Colors.WHITE};
-  border-top: 1px solid ${Colors.LIGHT_GRAY3};
-  padding: 20px;
-  margin: 0;
-  margin-bottom: 20px;
 `;
 
 const RunRequestBody = styled.div`
   font-size: 13px;
-  background: ${Colors.WHITE};
-  border-top: 1px solid ${Colors.LIGHT_GRAY3};
-  padding: 20px;
-  margin: 0;
-  margin-bottom: 20px;
 `;
 
 const SkipWrapper = styled.div`
   background-color: #fdfcf2;
-  padding: 1em 2em;
   border: 1px solid ${Colors.GOLD5};
   border-radius: 3px;
 `;

--- a/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
@@ -77,7 +77,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   font-size: 14px;
   line-height: 20px;
   padding: 6px 12px;
-  transition: background 100ms, box-shadow 150ms, filter 100ms;
+  transition: background 100ms, box-shadow 150ms, filter 100ms, opacity 150ms;
   user-select: none;
 
   ${({$stroke}) => ($stroke ? DEFAULT_STROKE : NO_STROKE)}

--- a/js_modules/dagit/packages/core/src/ui/Dialog.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Dialog.stories.tsx
@@ -45,16 +45,14 @@ export const Simple = () => {
             </div>
           </Group>
         </DialogBody>
-        <DialogFooter
-          buttons={[
-            <ButtonWIP key="cancel" intent="none" onClick={() => setOpen(false)}>
-              Cancel
-            </ButtonWIP>,
-            <ButtonWIP key="action" intent="primary" onClick={() => setOpen(false)}>
-              Perform action
-            </ButtonWIP>,
-          ]}
-        />
+        <DialogFooter>
+          <ButtonWIP intent="none" onClick={() => setOpen(false)}>
+            Cancel
+          </ButtonWIP>
+          <ButtonWIP intent="primary" onClick={() => setOpen(false)}>
+            Perform action
+          </ButtonWIP>
+        </DialogFooter>
       </DialogWIP>
     </>
   );

--- a/js_modules/dagit/packages/core/src/ui/Dialog.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Dialog.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import {Dialog as BlueprintDialog} from '@blueprintjs/core';
 import * as React from 'react';
 import styled, {createGlobalStyle} from 'styled-components/macro';
@@ -7,11 +8,28 @@ import {ColorsWIP} from './Colors';
 import {Group} from './Group';
 import {IconName, IconWIP} from './Icon';
 
-interface Props extends Omit<React.ComponentProps<typeof BlueprintDialog>, 'backdropClassName'> {}
+interface Props
+  extends Omit<
+    React.ComponentProps<typeof BlueprintDialog>,
+    'title' | 'icon' | 'backdropClassName'
+  > {
+  title?: React.ReactNode;
+  icon?: IconName;
+}
 
 export const DialogWIP: React.FC<Props> = (props) => {
-  const {...rest} = props;
-  return <BlueprintDialog {...rest} backdropClassName="dagit-backdrop" className="dagit-dialog" />;
+  const {icon, title, children, ...rest} = props;
+  return (
+    <BlueprintDialog
+      {...rest}
+      portalClassName="dagit-portal"
+      backdropClassName="dagit-backdrop"
+      className="dagit-dialog"
+    >
+      {title ? <DialogHeader icon={icon} label={title} /> : null}
+      {children}
+    </BlueprintDialog>
+  );
 };
 
 interface HeaderProps {
@@ -44,7 +62,6 @@ export const DialogBody: React.FC = (props) => {
 };
 
 interface DialogFooterProps {
-  buttons?: React.ReactNode[];
   left?: React.ReactFragment;
 }
 
@@ -56,9 +73,7 @@ export const DialogFooter: React.FC<DialogFooterProps> = (props) => {
       flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
     >
       <div>{props.left}</div>
-      <Group direction="row" spacing={12} alignItems="center">
-        {props.buttons}
-      </Group>
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>{props.children}</Box>
     </Box>
   );
 };
@@ -66,47 +81,52 @@ export const DialogFooter: React.FC<DialogFooterProps> = (props) => {
 const DialogHeaderText = styled.div`
   font-size: 16px;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
 `;
 
 export const GlobalDialogStyle = createGlobalStyle`
-  .bp3-overlay-backdrop {
+  .dagit-portal .bp3-overlay-backdrop {
     background-color: rgba(189, 186, 183, 0.7);
   }
 
-  .bp3-dialog-container {
+  .dagit-portal .bp3-dialog-container {
     display: grid;
     grid-template-rows: minmax(40px, 1fr) auto minmax(40px, 2fr);
     grid-template-columns: 40px 8fr 40px;
   }
 
-  .bp3-dialog {
+  .dagit-portal .bp3-dialog {
     background-color: ${ColorsWIP.White};
     border-radius: 4px;
     box-shadow: rgba(0, 0, 0, 0.12) 0px 2px 12px;
     grid-row: 2;
     grid-column: 2;
     margin: 0 auto;
+    overflow: hidden;
     padding: 0;
   }
 
-  .bp3-dialog > :first-child {
+  .dagit-portal .bp3-dialog > :first-child {
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
   }
 
-  .bp3-dialog > :last-child {
+  .dagit-portal .bp3-dialog > :last-child {
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
 
-  .bp3-dialog-container.bp3-overlay-enter > .bp3-dialog,
-  .bp3-dialog-container.bp3-overlay-appear > .bp3-dialog {
+  .dagit-portal .bp3-dialog-container.bp3-overlay-enter > .bp3-dialog,
+  .dagit-portal .bp3-dialog-container.bp3-overlay-appear > .bp3-dialog {
     opacity: 0;
     transform:scale(0.95);
   }
 
-  .bp3-dialog-container.bp3-overlay-enter-active > .bp3-dialog,
-  .bp3-dialog-container.bp3-overlay-appear-active > .bp3-dialog {
+  .dagit-portal .bp3-dialog-container.bp3-overlay-enter-active > .bp3-dialog,
+  .dagit-portal .bp3-dialog-container.bp3-overlay-appear-active > .bp3-dialog {
     opacity: 1;
     transform: scale(1);
     transition-delay: 0;
@@ -115,12 +135,12 @@ export const GlobalDialogStyle = createGlobalStyle`
     transition-timing-function: ease-in-out;
   }
 
-  .bp3-dialog-container.bp3-overlay-exit > .bp3-dialog {
+  .dagit-portal .bp3-dialog-container.bp3-overlay-exit > .bp3-dialog {
     opacity: 1;
     transform: scale(1);
   }
 
-  .bp3-dialog-container.bp3-overlay-exit-active > .bp3-dialog{
+  .dagit-portal .bp3-dialog-container.bp3-overlay-exit-active > .bp3-dialog {
     opacity: 0;
     transform: scale(0.95);
     transition-delay:0;

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationErrorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationErrorDialog.tsx
@@ -1,9 +1,10 @@
-import {Button, Classes, Dialog} from '@blueprintjs/core';
 import * as React from 'react';
 
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
 import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
+import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 
 interface Props {
   location: string;
@@ -17,45 +18,47 @@ interface Props {
 export const RepositoryLocationErrorDialog: React.FC<Props> = (props) => {
   const {isOpen, error, location, reloading, onTryReload, onDismiss} = props;
   return (
-    <Dialog
-      isOpen={isOpen}
+    <DialogWIP
+      icon="error"
       title="Repository location error"
+      isOpen={isOpen}
       canEscapeKeyClose={false}
       canOutsideClickClose={false}
       style={{width: '90%'}}
     >
-      <ErrorContents location={location} error={error} />
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button onClick={onTryReload} loading={reloading} intent="primary">
-            Reload again
-          </Button>
-          <Button onClick={onDismiss}>Dismiss</Button>
-        </div>
-      </div>
-    </Dialog>
+      <DialogBody>
+        <ErrorContents location={location} error={error} />
+      </DialogBody>
+      <DialogFooter>
+        <ButtonWIP onClick={onTryReload} loading={reloading} intent="primary">
+          Reload again
+        </ButtonWIP>
+        <ButtonWIP onClick={onDismiss}>Dismiss</ButtonWIP>
+      </DialogFooter>
+    </DialogWIP>
   );
 };
 
 export const RepositoryLocationNonBlockingErrorDialog: React.FC<Props> = (props) => {
   const {isOpen, error, location, reloading, onTryReload, onDismiss} = props;
   return (
-    <Dialog
-      isOpen={isOpen}
+    <DialogWIP
+      icon="error"
       title="Repository location error"
+      isOpen={isOpen}
       style={{width: '90%'}}
       onClose={onDismiss}
     >
-      <ErrorContents location={location} error={error} />
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button onClick={onTryReload} loading={reloading} intent="primary">
-            Reload
-          </Button>
-          <Button onClick={onDismiss}>Close</Button>
-        </div>
-      </div>
-    </Dialog>
+      <DialogBody>
+        <ErrorContents location={location} error={error} />
+      </DialogBody>
+      <DialogFooter>
+        <ButtonWIP onClick={onTryReload} loading={reloading} intent="primary">
+          Reload
+        </ButtonWIP>
+        <ButtonWIP onClick={onDismiss}>Close</ButtonWIP>
+      </DialogFooter>
+    </DialogWIP>
   );
 };
 
@@ -63,11 +66,11 @@ const ErrorContents: React.FC<{
   location: string;
   error: PythonErrorFragment | {message: string} | null;
 }> = ({location, error}) => (
-  <div className={Classes.DIALOG_BODY}>
+  <>
     <Box margin={{bottom: 12}}>
       Error loading <strong>{location}</strong>. Try reloading the repository location after
       resolving the issue.
     </Box>
     {error ? <PythonErrorInfo error={error} /> : null}
-  </div>
+  </>
 );


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Replace existing Blueprint `Dialog` with `DialogWIP`, lint against the Blueprint version. Additionally:

- Change the API of `DialogFooter` so that it just accepts children that are expected to be right-aligned.
- Change the API of `DialogWIP` to accept `icon: IconName` and `title: React.ReactNode` as props, which makes it a bit easier to do this refactor.

## Test Plan

View dialogs throughout Dagit, verify proper rendering and behavior.