### PR TITLE
[caprisun] add compute kind to asset defs

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -24,6 +24,14 @@ def test_asset_with_inputs():
     assert my_asset.input_defs[0].get_asset_key(None) == AssetKey("arg1")
 
 
+def test_asset_with_compute_kind():
+    @asset(compute_kind="sql")
+    def my_asset(arg1):
+        return arg1
+
+    assert my_asset.tags == {"kind": "sql"}
+
+
 def test_asset_with_inputs_and_namespace():
     @asset(namespace="my_namespace")
     def my_asset(arg1):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -61,6 +61,7 @@ def _dbt_node_to_asset(
         },
         required_resource_keys={"dbt"},
         io_manager_key=io_manager_key,
+        compute_kind="dbt",
     )
     def _node_asset(context):
         context.resources.dbt.run(models=[".".join([node_info["package_name"], node_info["name"]])])

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -28,6 +28,7 @@ def assert_assets_match_project(assets):
         assert name == asset.name
         assert len(asset.output_defs) == 1
         assert f'["{name}"]' == asset.output_defs[0].hardcoded_asset_key.to_string()
+        assert asset.tags == {"kind": "dbt"}
 
     job = build_assets_job(
         "jarb", assets, resource_defs={"dbt": ResourceDefinition.none_resource()}


### PR DESCRIPTION
Adds a string to represent the kind of computation that produces the asset, e.g. "dbt" or "spark". It can be displayed in Dagit as a badge on the asset.