### PR TITLE
Allow additional EnvVar config in container_config tags

### DIFF
--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -48,20 +48,3 @@ def within_docker():
         or os.path.isfile(cgroup_path)
         and any("docker" in line for line in open(cgroup_path))
     )
-
-
-def remove_none_recursively(obj):
-    """Remove none values from a dict. This is used here to support comparing provided config vs.
-    config we retrive from kubernetes, which returns all fields, even those which have no value
-    configured.
-    """
-    if isinstance(obj, (list, tuple, set)):
-        return type(obj)(remove_none_recursively(x) for x in obj if x is not None)
-    elif isinstance(obj, dict):
-        return type(obj)(
-            (remove_none_recursively(k), remove_none_recursively(v))
-            for k, v in obj.items()
-            if k is not None and v is not None
-        )
-    else:
-        return obj

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_job_spec.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_job_spec.py
@@ -4,7 +4,7 @@ import yaml
 from dagster import __version__ as dagster_version
 from dagster.core.definitions.utils import validate_tags
 from dagster.core.storage.pipeline_run import PipelineRun
-from dagster.core.test_utils import create_run_for_test
+from dagster.core.test_utils import create_run_for_test, remove_none_recursively
 from dagster.utils import load_yaml_from_path
 from dagster_k8s import construct_dagster_k8s_job
 from dagster_k8s.job import (
@@ -13,7 +13,7 @@ from dagster_k8s.job import (
     get_user_defined_k8s_config,
 )
 from dagster_k8s.test import wait_for_job_and_get_raw_logs
-from dagster_k8s_test_infra.integration_utils import image_pull_policy, remove_none_recursively
+from dagster_k8s_test_infra.integration_utils import image_pull_policy
 from dagster_test.test_project import (
     ReOriginatedExternalPipelineForTest,
     get_test_project_docker_image,

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -430,3 +430,20 @@ def in_process_test_workspace(instance, recon_repo):
         instance, TestInProcessWorkspaceLoadTarget(InProcessRepositoryLocationOrigin(recon_repo))
     ) as workspace_process_context:
         yield workspace_process_context.create_request_context()
+
+
+def remove_none_recursively(obj):
+    """Remove none values from a dict. This can be used to support comparing provided config vs.
+    config we retrive from kubernetes, which returns all fields, even those which have no value
+    configured.
+    """
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(remove_none_recursively(x) for x in obj if x is not None)
+    elif isinstance(obj, dict):
+        return type(obj)(
+            (remove_none_recursively(k), remove_none_recursively(v))
+            for k, v in obj.items()
+            if k is not None and v is not None
+        )
+    else:
+        return obj

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -513,7 +513,7 @@ def construct_dagster_k8s_job(
     user_defined_k8s_env_vars = user_defined_k8s_config.container_config.pop("env", [])
     for env_var in user_defined_k8s_env_vars:
         additional_k8s_env_vars.append(
-            kubernetes.client.V1EnvVar(name=env_var["name"], value=env_var["value"])
+            k8s_model_from_dict(kubernetes.client.models.V1EnvVar, env_var)
         )
 
     user_defined_k8s_env_from = user_defined_k8s_config.container_config.pop("env_from", [])


### PR DESCRIPTION
    Summary:
    Use the new model building utility to give the full range of V1EnvVar functionality in tag config
    
    Test Plan: BK
