### PR TITLE
Fix docker-compose down fixture

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -74,11 +74,7 @@ def docker_compose_down(docker_compose_yml, context, service):
     compose_command += [
         "--file",
         str(docker_compose_yml),
-        "down",
-    ]
-
-    if service:
-        compose_command.append(service)
+    ] + (["rm", "-s", service] if service else ["down"])
 
     subprocess.check_call(compose_command)
 


### PR DESCRIPTION
Summary:
This was recently changed to remove a single service, but 'docker-compose down <service name>' is not a valid command. 'docker-compose rm -s service' is, so use that instead?

Test Plan: BK, run tests locally, no more invalid command errors

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.