### PR TITLE
remove version pin from dagster-test

### DIFF
--- a/python_modules/dagster-test/dagster_test/__init__.py
+++ b/python_modules/dagster-test/dagster_test/__init__.py
@@ -1,1 +1,0 @@
-from .version import __version__

--- a/python_modules/dagster-test/dagster_test/version.py
+++ b/python_modules/dagster-test/dagster_test/version.py
@@ -1,1 +1,0 @@
-__version__ = "dev"

--- a/python_modules/dagster-test/dagster_test_tests/test_version.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_version.py
@@ -1,5 +1,0 @@
-from dagster_test.version import __version__
-
-
-def test_version():
-    assert __version__

--- a/python_modules/dagster-test/setup.py
+++ b/python_modules/dagster-test/setup.py
@@ -1,23 +1,9 @@
-from typing import Dict
-
 from setuptools import find_packages, setup  # type: ignore
 
-
-def get_version() -> str:
-    version: Dict[str, str] = {}
-    with open("dagster_test/version.py") as fp:
-        exec(fp.read(), version)  # pylint: disable=W0122
-
-    return version["__version__"]
-
-
 if __name__ == "__main__":
-    ver = get_version()
-    # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
     setup(
         name="dagster-test",
-        version=ver,
+        version="dev",
         author="Elementl",
         author_email="hello@elementl.com",
         license="Apache-2.0",
@@ -32,7 +18,7 @@ if __name__ == "__main__":
         ],
         packages=find_packages(exclude=["test"]),
         install_requires=[
-            f"dagster{pin}",
+            "dagster",
             "pyspark",
         ],
         zip_safe=False,


### PR DESCRIPTION
Summary:
This library never has its version upgraded since it is never published, so it doesn't make sense to pin it. My hunch is this may help with weird test failures in the RC branch.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.