### PR TITLE
exclude auto-generated builds from devtoolsf from the oss compatibility check

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -19,8 +19,11 @@ def dagster():
     branch_name = os.getenv("BUILDKITE_BRANCH")
     build_creator_email = os.getenv("BUILDKITE_BUILD_CREATOR_EMAIL")
 
-    if build_creator_email and build_creator_email.endswith("@elementl.com"):
-
+    if (
+        build_creator_email
+        and build_creator_email.endswith("@elementl.com")
+        and build_creator_email != "devtools@elementl.com"
+    ):
         if branch_name == "master" or is_release_branch(branch_name):
             pipeline_name = "internal"
             trigger_branch = branch_name


### PR DESCRIPTION
Summary:
Buildkite fails these anyways, so might as well prevent the logspew.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.