### PR TITLE
no intermediate storage in dagster-celery tests

### DIFF
--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/engine_config.yaml
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/engine_config.yaml
@@ -1,5 +1,3 @@
-intermediate_storage:
-  filesystem:
 execution:
   celery:
     config_source:

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
@@ -8,10 +8,10 @@ from dagster import (
     OutputDefinition,
     RetryRequested,
     default_executors,
+    fs_io_manager,
     lambda_solid,
     pipeline,
     solid,
-    fs_io_manager,
 )
 from dagster.core.test_utils import nesting_composite_pipeline
 from dagster_celery import celery_executor

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
@@ -11,11 +11,17 @@ from dagster import (
     lambda_solid,
     pipeline,
     solid,
+    fs_io_manager,
 )
 from dagster.core.test_utils import nesting_composite_pipeline
 from dagster_celery import celery_executor
 
-celery_mode_defs = [ModeDefinition(executor_defs=default_executors + [celery_executor])]
+celery_mode_defs = [
+    ModeDefinition(
+        executor_defs=default_executors + [celery_executor],
+        resource_defs={"io_manager": fs_io_manager},
+    )
+]
 
 
 # test_execute pipelines

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -118,7 +118,7 @@ def test_terminate_pipeline_on_celery(rabbitmq):
 
             with instance_for_test(temp_dir=tempdir) as instance:
                 run_config = {
-                    "intermediate_storage": {"filesystem": {"config": {"base_dir": tempdir}}},
+                    "resources": {"io_manager": {"config": {"base_dir": tempdir}}},
                     "execution": {"celery": {}},
                 }
 
@@ -298,9 +298,7 @@ def test_engine_error():
                     execute_pipeline(
                         ReconstructablePipeline.for_file(REPO_FILE, "engine_error"),
                         run_config={
-                            "intermediate_storage": {
-                                "filesystem": {"config": {"base_dir": storage}}
-                            },
+                            "resources": {"io_manager": {"config": {"base_dir": storage}}},
                             "execution": {
                                 "celery": {"config": {"config_source": {"task_always_eager": True}}}
                             },

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
@@ -43,7 +43,7 @@ def execute_pipeline_on_celery(
         ).subset_for_execution(subset)
         with _instance_wrapper(instance) as wrapped_instance:
             run_config = run_config or {
-                "intermediate_storage": {"filesystem": {"config": {"base_dir": tempdir}}},
+                "resources": {"io_manager": {"config": {"base_dir": tempdir}}},
                 "execution": {"celery": {}},
             }
             result = execute_pipeline(
@@ -59,7 +59,7 @@ def execute_pipeline_on_celery(
 def execute_eagerly_on_celery(pipeline_name, instance=None, tempdir=None, tags=None, subset=None):
     with tempfile.TemporaryDirectory() as tempdir:
         run_config = {
-            "intermediate_storage": {"filesystem": {"config": {"base_dir": tempdir}}},
+            "resources": {"io_manager": {"config": {"base_dir": tempdir}}},
             "execution": {"celery": {"config": {"config_source": {"task_always_eager": True}}}},
         }
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

resolves https://github.com/dagster-io/dagster/issues/4541

I don't think dagster-celery implementation depends on intermediate storage so just migrate the tests off of intermediate storage.




## Test Plan
bk



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [-] My change requires a change to the documentation and I have updated the documentation accordingly.
- [-] I have added tests to cover my changes.