### PR TITLE
[intermediate-storage-removal] migrate core tests: remove "intermediate_storage" run config

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
@@ -13,6 +13,7 @@ from dagster import (
     pipeline,
     solid,
 )
+from dagster.core.test_utils import default_mode_def_for_test
 
 
 @solid(
@@ -71,12 +72,12 @@ def total(_, in_1, in_2, in_3, in_4):
         PresetDefinition(
             "multi",
             {
-                "intermediate_storage": {"filesystem": {}},
                 "execution": {"multiprocess": {}},
                 "solids": {"giver": {"config": [2, 2, 2, 2]}},
             },
         )
     ],
+    mode_defs=[default_mode_def_for_test],
 )
 def sleepy_pipeline():
     giver_res = giver()

--- a/python_modules/dagster-test/dagster_test/toys/branches.py
+++ b/python_modules/dagster-test/dagster_test/toys/branches.py
@@ -1,6 +1,16 @@
 from time import sleep
 
-from dagster import Field, Int, Output, OutputDefinition, PresetDefinition, pipeline, solid
+from dagster import (
+    Field,
+    Int,
+    ModeDefinition,
+    Output,
+    OutputDefinition,
+    PresetDefinition,
+    fs_io_manager,
+    pipeline,
+    solid,
+)
 
 
 @solid(
@@ -37,7 +47,6 @@ def branch(name, arg, solid_num):
         PresetDefinition(
             "sleep_failed",
             {
-                "intermediate_storage": {"filesystem": {}},
                 "execution": {"multiprocess": {}},
                 "solids": {"root": {"config": {"sleep_secs": [-10, 30]}}},
             },
@@ -45,12 +54,12 @@ def branch(name, arg, solid_num):
         PresetDefinition(
             "sleep",
             {
-                "intermediate_storage": {"filesystem": {}},
                 "execution": {"multiprocess": {}},
                 "solids": {"root": {"config": {"sleep_secs": [0, 10]}}},
             },
         ),
     ],
+    mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})],
 )
 def branch_pipeline():
     out_1, out_2 = root()

--- a/python_modules/dagster-test/dagster_test/toys/many_events.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_events.py
@@ -3,10 +3,12 @@ from dagster import (
     EventMetadata,
     ExpectationResult,
     InputDefinition,
+    ModeDefinition,
     Nothing,
     Output,
     OutputDefinition,
     file_relative_path,
+    fs_io_manager,
     pipeline,
     solid,
 )
@@ -175,7 +177,8 @@ def check_admins_both_succeed(_context):
     description=(
         "Demo pipeline that yields AssetMaterializations and ExpectationResults, along with the "
         "various forms of metadata that can be attached to them."
-    )
+    ),
+    mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})],
 )
 def many_events():
     raw_files_solids = [raw_file_solid() for raw_file_solid in create_raw_file_solids()]

--- a/python_modules/dagster-test/dagster_test/toys/resources.py
+++ b/python_modules/dagster-test/dagster_test/toys/resources.py
@@ -3,11 +3,13 @@ from dagster import (
     Int,
     ModeDefinition,
     execute_pipeline,
+    fs_io_manager,
     pipeline,
     reconstructable,
     resource,
     solid,
 )
+from dagster.utils import merge_dicts
 
 
 def define_resource(num):
@@ -18,7 +20,9 @@ def define_resource(num):
     return a_resource
 
 
-lots_of_resources = {"R" + str(r): define_resource(r) for r in range(20)}
+lots_of_resources = merge_dicts(
+    {"R" + str(r): define_resource(r) for r in range(20)}, {"io_manager": fs_io_manager}
+)
 
 
 @solid(required_resource_keys=set(lots_of_resources.keys()))
@@ -53,7 +57,6 @@ if __name__ == "__main__":
     result = execute_pipeline(
         reconstructable(resource_pipeline),
         run_config={
-            "intermediate_storage": {"filesystem": {}},
             "execution": {"multiprocessing": {}},
         },
     )

--- a/python_modules/dagster-test/dagster_test/toys/schedules.py
+++ b/python_modules/dagster-test/dagster_test/toys/schedules.py
@@ -87,7 +87,6 @@ def backfill_test_schedule():
             start=datetime.datetime(2020, 1, 5),
             delta_range="weeks",
         ),
-        run_config_fn_for_partition=lambda _: {"intermediate_storage": {"filesystem": {}}},
     )
 
     def _should_execute(context):
@@ -109,7 +108,6 @@ def materialization_schedule():
         name="many_events_minutely",
         pipeline_name="many_events",
         partition_fn=date_partition_range(start=datetime.datetime(2020, 1, 1)),
-        run_config_fn_for_partition=lambda _: {"intermediate_storage": {"filesystem": {}}},
     )
 
     def _should_execute(context):
@@ -210,7 +208,6 @@ def get_toys_schedules():
             name="many_events_every_min",
             cron_schedule="* * * * *",
             pipeline_name="many_events",
-            run_config_fn=lambda _: {"intermediate_storage": {"filesystem": {}}},
             execution_timezone=_toys_tz_info(),
         ),
     ]

--- a/python_modules/dagster-test/dagster_test/toys/unreliable.py
+++ b/python_modules/dagster-test/dagster_test/toys/unreliable.py
@@ -1,6 +1,6 @@
 from random import random
 
-from dagster import Field, pipeline, solid
+from dagster import Field, ModeDefinition, fs_io_manager, pipeline, solid
 
 DEFAULT_EXCEPTION_RATE = 0.3
 
@@ -20,7 +20,10 @@ def unreliable(context, num):
     return num
 
 
-@pipeline(description="Demo pipeline of chained solids that fail with a configurable probability.")
+@pipeline(
+    description="Demo pipeline of chained solids that fail with a configurable probability.",
+    mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})],
+)
 def unreliable_pipeline():
     one = unreliable.alias("one")
     two = unreliable.alias("two")

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -7,7 +7,7 @@ from contextlib import ExitStack, contextmanager
 
 import pendulum
 import yaml
-from dagster import Shape, check, composite_solid, pipeline, solid
+from dagster import ModeDefinition, Shape, check, composite_solid, fs_io_manager, pipeline, solid
 from dagster.config import Field
 from dagster.config.config_type import Array
 from dagster.core.host_representation.origin import (
@@ -447,3 +447,6 @@ def remove_none_recursively(obj):
         )
     else:
         return obj
+
+
+default_mode_def_for_test = ModeDefinition(resource_defs={"io_manager": fs_io_manager})

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -1,17 +1,18 @@
 import os
 import pickle
+
 import pytest
 from dagster import (
     DependencyDefinition,
     InputDefinition,
     Int,
+    ModeDefinition,
     OutputDefinition,
     PipelineDefinition,
     execute_pipeline,
+    fs_io_manager,
     lambda_solid,
     reexecute_pipeline,
-    ModeDefinition,
-    fs_io_manager,
 )
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.errors import (

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -1,3 +1,5 @@
+import os
+import pickle
 import pytest
 from dagster import (
     DependencyDefinition,
@@ -8,6 +10,8 @@ from dagster import (
     execute_pipeline,
     lambda_solid,
     reexecute_pipeline,
+    ModeDefinition,
+    fs_io_manager,
 )
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.errors import (
@@ -22,14 +26,9 @@ from dagster.core.execution.plan.plan import ExecutionPlan
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.intermediate_storage import build_fs_intermediate_storage
 from dagster.core.system_config.objects import ResolvedRunConfig
-from dagster.utils import merge_dicts
 
 
-def env_with_fs(run_config):
-    return merge_dicts(run_config, {"intermediate_storage": {"filesystem": {}}})
-
-
-def define_addy_pipeline():
+def define_addy_pipeline(using_file_system=False):
     @lambda_solid(input_defs=[InputDefinition("num", Int)], output_def=OutputDefinition(Int))
     def add_one(num):
         return num + 1
@@ -49,14 +48,17 @@ def define_addy_pipeline():
             "add_two": {"num": DependencyDefinition("add_one")},
             "add_three": {"num": DependencyDefinition("add_two")},
         },
+        mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})]
+        if using_file_system
+        else None,
     )
     return pipeline_def
 
 
 def test_execution_plan_reexecution():
-    pipeline_def = define_addy_pipeline()
+    pipeline_def = define_addy_pipeline(using_file_system=True)
     instance = DagsterInstance.ephemeral()
-    run_config = env_with_fs({"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}})
+    run_config = {"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}}
     result = execute_pipeline(
         pipeline_def,
         run_config=run_config,
@@ -65,11 +67,17 @@ def test_execution_plan_reexecution():
 
     assert result.success
 
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, result.run_id
-    )
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 4
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_two")).obj == 6
+    with open(
+        os.path.join(instance.storage_directory(), result.run_id, "add_one", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 4
+
+    with open(
+        os.path.join(instance.storage_directory(), result.run_id, "add_two", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 6
 
     ## re-execute add_two
 
@@ -98,22 +106,24 @@ def test_execution_plan_reexecution():
         pipeline_run=pipeline_run,
         instance=instance,
     )
-
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, result.run_id
+    assert not os.path.exists(
+        os.path.join(instance.storage_directory(), pipeline_run.run_id, "add_one", "result")
     )
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 4
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_two")).obj == 6
+    with open(
+        os.path.join(instance.storage_directory(), pipeline_run.run_id, "add_two", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 6
 
     assert not get_step_output_event(step_events, "add_one")
     assert get_step_output_event(step_events, "add_two")
 
 
 def test_execution_plan_wrong_run_id():
-    pipeline_def = define_addy_pipeline()
+    pipeline_def = define_addy_pipeline(using_file_system=True)
 
     unrun_id = "not_a_run"
-    run_config = env_with_fs({"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}})
+    run_config = {"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}}
 
     instance = DagsterInstance.ephemeral()
 
@@ -175,18 +185,23 @@ def test_execution_plan_reexecution_with_in_memory():
 
 
 def test_pipeline_step_key_subset_execution():
-    pipeline_def = define_addy_pipeline()
+    pipeline_def = define_addy_pipeline(using_file_system=True)
     instance = DagsterInstance.ephemeral()
-    run_config = env_with_fs({"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}})
+    run_config = {"solids": {"add_one": {"inputs": {"num": {"value": 3}}}}}
     result = execute_pipeline(pipeline_def, run_config=run_config, instance=instance)
 
     assert result.success
+    with open(
+        os.path.join(instance.storage_directory(), result.run_id, "add_one", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 4
 
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, result.run_id
-    )
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 4
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_two")).obj == 6
+    with open(
+        os.path.join(instance.storage_directory(), result.run_id, "add_two", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 6
 
     ## re-execute add_two
 
@@ -202,12 +217,18 @@ def test_pipeline_step_key_subset_execution():
 
     step_events = pipeline_reexecution_result.step_event_list
     assert step_events
-
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, result.run_id
+    assert not os.path.exists(
+        os.path.join(
+            instance.storage_directory(), pipeline_reexecution_result.run_id, "add_one", "result"
+        )
     )
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 4
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_two")).obj == 6
+    with open(
+        os.path.join(
+            instance.storage_directory(), pipeline_reexecution_result.run_id, "add_two", "result"
+        ),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 6
 
     assert not get_step_output_event(step_events, "add_one")
     assert get_step_output_event(step_events, "add_two")

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -6,11 +6,9 @@ from dagster import (
     DependencyDefinition,
     InputDefinition,
     Int,
-    ModeDefinition,
     OutputDefinition,
     PipelineDefinition,
     execute_pipeline,
-    fs_io_manager,
     lambda_solid,
     reexecute_pipeline,
 )
@@ -22,11 +20,10 @@ from dagster.core.errors import (
 )
 from dagster.core.events import get_step_output_event
 from dagster.core.execution.api import create_execution_plan, execute_plan
-from dagster.core.execution.plan.outputs import StepOutputHandle
 from dagster.core.execution.plan.plan import ExecutionPlan
 from dagster.core.instance import DagsterInstance
-from dagster.core.storage.intermediate_storage import build_fs_intermediate_storage
 from dagster.core.system_config.objects import ResolvedRunConfig
+from dagster.core.test_utils import default_mode_def_for_test
 
 
 def define_addy_pipeline(using_file_system=False):
@@ -49,9 +46,7 @@ def define_addy_pipeline(using_file_system=False):
             "add_two": {"num": DependencyDefinition("add_one")},
             "add_three": {"num": DependencyDefinition("add_two")},
         },
-        mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})]
-        if using_file_system
-        else None,
+        mode_defs=[default_mode_def_for_test] if using_file_system else None,
     )
     return pipeline_def
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
@@ -12,11 +12,11 @@ from dagster import (
     String,
     execute_pipeline,
     execute_pipeline_iterator,
+    fs_io_manager,
     pipeline,
     reconstructable,
     resource,
     solid,
-    fs_io_manager,
 )
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster.core.events import DagsterEventType

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
@@ -16,6 +16,7 @@ from dagster import (
     reconstructable,
     resource,
     solid,
+    fs_io_manager,
 )
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster.core.events import DagsterEventType
@@ -31,7 +32,7 @@ from dagster.core.execution.retries import RetryMode
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.utils import safe_tempfile_path, send_interrupt
-from dagster.utils.merger import deep_merge_dicts
+from dagster.utils.merger import deep_merge_dicts, merge_dicts
 
 RUN_CONFIG_BASE = {"solids": {"return_two": {"config": {"a": "b"}}}}
 
@@ -44,11 +45,13 @@ def make_run_config(scratch_dir, mode):
     return deep_merge_dicts(
         RUN_CONFIG_BASE,
         {
-            "resources": {
-                step_launcher_resource_key: {"config": {"scratch_dir": scratch_dir}}
-                for step_launcher_resource_key in step_launcher_resource_keys
-            },
-            "intermediate_storage": {"filesystem": {"config": {"base_dir": scratch_dir}}},
+            "resources": merge_dicts(
+                {"io_manager": {"config": {"base_dir": scratch_dir}}},
+                {
+                    step_launcher_resource_key: {"config": {"scratch_dir": scratch_dir}}
+                    for step_launcher_resource_key in step_launcher_resource_keys
+                },
+            ),
         },
     )
 
@@ -84,6 +87,7 @@ def define_basic_pipeline():
                 resource_defs={
                     "first_step_launcher": local_external_step_launcher,
                     "second_step_launcher": local_external_step_launcher,
+                    "io_manager": fs_io_manager,
                 },
             ),
             ModeDefinition(
@@ -91,6 +95,7 @@ def define_basic_pipeline():
                 resource_defs={
                     "first_step_launcher": no_step_launcher,
                     "second_step_launcher": local_external_step_launcher,
+                    "io_manager": fs_io_manager,
                 },
             ),
             ModeDefinition(
@@ -98,6 +103,7 @@ def define_basic_pipeline():
                 resource_defs={
                     "first_step_launcher": request_retry_local_external_step_launcher,
                     "second_step_launcher": request_retry_local_external_step_launcher,
+                    "io_manager": fs_io_manager,
                 },
             ),
         ]
@@ -128,6 +134,7 @@ def define_sleepy_pipeline():
                 "external",
                 resource_defs={
                     "first_step_launcher": local_external_step_launcher,
+                    "io_manager": fs_io_manager,
                 },
             ),
         ]
@@ -239,8 +246,12 @@ def test_interrupt_step_launcher(mode):
     with tempfile.TemporaryDirectory() as tmpdir:
         with safe_tempfile_path() as success_tempfile:
             sleepy_run_config = {
-                "resources": {"first_step_launcher": {"config": {"scratch_dir": tmpdir}}},
-                "intermediate_storage": {"filesystem": {"config": {"base_dir": tmpdir}}},
+                "resources": {
+                    "first_step_launcher": {
+                        "config": {"scratch_dir": tmpdir},
+                    },
+                    "io_manager": {"config": {"base_dir": tmpdir}},
+                },
                 "solids": {"sleepy_solid": {"config": {"tempfile": success_tempfile}}},
             }
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_host_run_worker.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_host_run_worker.py
@@ -3,11 +3,11 @@ import os
 from dagster import (
     ModeDefinition,
     executor,
+    fs_io_manager,
     pipeline,
     reconstructable,
     resource,
     solid,
-    fs_io_manager,
 )
 from dagster.core.definitions.reconstructable import ReconstructablePipeline
 from dagster.core.execution.api import create_execution_plan

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_host_run_worker.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_host_run_worker.py
@@ -1,6 +1,14 @@
 import os
 
-from dagster import ModeDefinition, executor, pipeline, reconstructable, resource, solid
+from dagster import (
+    ModeDefinition,
+    executor,
+    pipeline,
+    reconstructable,
+    resource,
+    solid,
+    fs_io_manager,
+)
 from dagster.core.definitions.reconstructable import ReconstructablePipeline
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.execution.host_mode import execute_run_host_mode
@@ -33,8 +41,12 @@ def solid_that_uses_adder_resource(context, number):
 
 @pipeline(
     mode_defs=[
-        ModeDefinition(name="add_one", resource_defs={"adder": add_one_resource}),
-        ModeDefinition(name="add_two", resource_defs={"adder": add_two_resource}),
+        ModeDefinition(
+            name="add_one", resource_defs={"adder": add_one_resource, "io_manager": fs_io_manager}
+        ),
+        ModeDefinition(
+            name="add_two", resource_defs={"adder": add_two_resource, "io_manager": fs_io_manager}
+        ),
     ]
 )
 def pipeline_with_mode():
@@ -73,7 +85,6 @@ def test_host_run_worker():
     with instance_for_test() as instance:
         run_config = {
             "solids": {"solid_that_uses_adder_resource": {"inputs": {"number": {"value": 4}}}},
-            "intermediate_storage": {"filesystem": {}},
             "execution": {"multiprocess": None},
         }
         execution_plan = create_execution_plan(
@@ -119,7 +130,6 @@ def test_custom_executor_fn():
     with instance_for_test() as instance:
         run_config = {
             "solids": {"solid_that_uses_adder_resource": {"inputs": {"number": {"value": 4}}}},
-            "intermediate_storage": {"filesystem": {}},
         }
         execution_plan = create_execution_plan(
             pipeline_with_mode,

--- a/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/launcher_tests/test_default_run_launcher.py
@@ -8,13 +8,13 @@ from contextlib import contextmanager
 import pytest
 from dagster import (
     DefaultRunLauncher,
+    ModeDefinition,
     file_relative_path,
+    fs_io_manager,
     pipeline,
     repository,
     seven,
     solid,
-    ModeDefinition,
-    fs_io_manager,
 )
 from dagster.core.errors import DagsterLaunchFailedError
 from dagster.core.storage.pipeline_run import PipelineRunStatus

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -19,6 +19,7 @@ from dagster import (
     reconstructable,
     resource,
     solid,
+    fs_io_manager,
 )
 from dagster.core.definitions import pipeline
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
@@ -939,7 +940,11 @@ def define_resource_teardown_failure_pipeline():
     return PipelineDefinition(
         name="resource_teardown_failure",
         solid_defs=[resource_solid],
-        mode_defs=[ModeDefinition(resource_defs={"a": resource_a, "b": resource_b})],
+        mode_defs=[
+            ModeDefinition(
+                resource_defs={"a": resource_a, "b": resource_b, "io_manager": fs_io_manager}
+            )
+        ],
     )
 
 
@@ -949,7 +954,6 @@ def test_multiprocessing_resource_teardown_failure():
         result = execute_pipeline(
             recon_pipeline,
             run_config={
-                "intermediate_storage": {"filesystem": {}},
                 "execution": {"multiprocess": {}},
             },
             instance=instance,

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -16,10 +16,10 @@ from dagster import (
     configured,
     execute_pipeline,
     execute_pipeline_iterator,
+    fs_io_manager,
     reconstructable,
     resource,
     solid,
-    fs_io_manager,
 )
 from dagster.core.definitions import pipeline
 from dagster.core.definitions.pipeline_base import InMemoryPipeline

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -23,6 +23,7 @@ from dagster import (
     pipeline,
     resource,
     solid,
+    fs_io_manager,
 )
 from dagster.core.types.dagster_type import (
     DagsterType,
@@ -402,14 +403,12 @@ def test_fan_in_custom_types_with_storage():
     def get_foo(_context, dicts):
         return dicts[0]["foo"]
 
-    @pipeline
+    @pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
     def dict_pipeline():
         # Fan-in
         get_foo([return_dict_1(), return_dict_2()])
 
-    pipeline_result = execute_pipeline(
-        dict_pipeline, run_config={"intermediate_storage": {"filesystem": {}}}
-    )
+    pipeline_result = execute_pipeline(dict_pipeline)
     assert pipeline_result.success
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -18,12 +18,12 @@ from dagster import (
     TypeCheck,
     check_dagster_type,
     execute_pipeline,
+    fs_io_manager,
     lambda_solid,
     make_python_type_usable_as_dagster_type,
     pipeline,
     resource,
     solid,
-    fs_io_manager,
 )
 from dagster.core.types.dagster_type import (
     DagsterType,

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -18,13 +18,13 @@ from dagster import (
     TypeCheck,
     check_dagster_type,
     execute_pipeline,
-    fs_io_manager,
     lambda_solid,
     make_python_type_usable_as_dagster_type,
     pipeline,
     resource,
     solid,
 )
+from dagster.core.test_utils import default_mode_def_for_test
 from dagster.core.types.dagster_type import (
     DagsterType,
     PythonObjectDagsterType,
@@ -403,7 +403,7 @@ def test_fan_in_custom_types_with_storage():
     def get_foo(_context, dicts):
         return dicts[0]["foo"]
 
-    @pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def dict_pipeline():
         # Fan-in
         get_foo([return_dict_1(), return_dict_2()])

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -111,8 +111,7 @@ def test_execute_pipeline_iterator_with_solid_selection_query():
 
 def test_reexecute_pipeline_with_step_selection_single_clause():
     instance = DagsterInstance.ephemeral()
-    run_config = {"intermediate_storage": {"filesystem": {}}}
-    pipeline_result_full = execute_pipeline(foo_pipeline, run_config=run_config, instance=instance)
+    pipeline_result_full = execute_pipeline(foo_pipeline, instance=instance)
     assert pipeline_result_full.success
     assert pipeline_result_full.result_for_solid("add_one").output_value() == 7
     assert len(pipeline_result_full.solid_result_list) == 5
@@ -120,7 +119,6 @@ def test_reexecute_pipeline_with_step_selection_single_clause():
     reexecution_result_full = reexecute_pipeline(
         foo_pipeline,
         parent_run_id=pipeline_result_full.run_id,
-        run_config=run_config,
         instance=instance,
     )
 
@@ -131,7 +129,6 @@ def test_reexecute_pipeline_with_step_selection_single_clause():
     reexecution_result_up = reexecute_pipeline(
         foo_pipeline,
         parent_run_id=pipeline_result_full.run_id,
-        run_config=run_config,
         instance=instance,
         step_selection=["*add_nums"],
     )
@@ -142,7 +139,6 @@ def test_reexecute_pipeline_with_step_selection_single_clause():
     reexecution_result_down = reexecute_pipeline(
         foo_pipeline,
         parent_run_id=pipeline_result_full.run_id,
-        run_config=run_config,
         instance=instance,
         step_selection=["add_nums++"],
     )
@@ -152,8 +148,7 @@ def test_reexecute_pipeline_with_step_selection_single_clause():
 
 def test_reexecute_pipeline_with_step_selection_multi_clauses():
     instance = DagsterInstance.ephemeral()
-    run_config = {"intermediate_storage": {"filesystem": {}}}
-    pipeline_result_full = execute_pipeline(foo_pipeline, run_config=run_config, instance=instance)
+    pipeline_result_full = execute_pipeline(foo_pipeline, instance=instance)
     assert pipeline_result_full.success
     assert pipeline_result_full.result_for_solid("add_one").output_value() == 7
     assert len(pipeline_result_full.solid_result_list) == 5
@@ -161,7 +156,6 @@ def test_reexecute_pipeline_with_step_selection_multi_clauses():
     result_multi_disjoint = reexecute_pipeline(
         foo_pipeline,
         parent_run_id=pipeline_result_full.run_id,
-        run_config=run_config,
         instance=instance,
         step_selection=["return_one", "return_two", "add_nums+"],
     )
@@ -171,7 +165,6 @@ def test_reexecute_pipeline_with_step_selection_multi_clauses():
     result_multi_overlap = reexecute_pipeline(
         foo_pipeline,
         parent_run_id=pipeline_result_full.run_id,
-        run_config=run_config,
         instance=instance,
         step_selection=["return_one++", "return_two", "add_nums+"],
     )
@@ -185,7 +178,6 @@ def test_reexecute_pipeline_with_step_selection_multi_clauses():
         reexecute_pipeline(
             foo_pipeline,
             parent_run_id=pipeline_result_full.run_id,
-            run_config=run_config,
             instance=instance,
             step_selection=["a", "*add_nums"],
         )
@@ -197,7 +189,6 @@ def test_reexecute_pipeline_with_step_selection_multi_clauses():
         reexecute_pipeline(
             foo_pipeline,
             parent_run_id=pipeline_result_full.run_id,
-            run_config=run_config,
             instance=instance,
             step_selection=["a+", "*b"],
         )
@@ -205,8 +196,7 @@ def test_reexecute_pipeline_with_step_selection_multi_clauses():
 
 def test_reexecute_pipeline_iterator():
     instance = DagsterInstance.ephemeral()
-    run_config = {"intermediate_storage": {"filesystem": {}}}
-    pipeline_result_full = execute_pipeline(foo_pipeline, run_config=run_config, instance=instance)
+    pipeline_result_full = execute_pipeline(foo_pipeline, instance=instance)
     assert pipeline_result_full.success
     assert pipeline_result_full.result_for_solid("add_one").output_value() == 7
     assert len(pipeline_result_full.solid_result_list) == 5
@@ -215,7 +205,6 @@ def test_reexecute_pipeline_iterator():
         reexecute_pipeline_iterator(
             foo_pipeline,
             parent_run_id=pipeline_result_full.run_id,
-            run_config=run_config,
             instance=instance,
         )
     )
@@ -226,7 +215,6 @@ def test_reexecute_pipeline_iterator():
         reexecute_pipeline_iterator(
             foo_pipeline,
             parent_run_id=pipeline_result_full.run_id,
-            run_config=run_config,
             instance=instance,
             step_selection=["*add_nums"],
         )

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -1,6 +1,6 @@
-from dagster.core.definitions.resource import resource
 import pytest
-from dagster import InputDefinition, lambda_solid, pipeline, ModeDefinition, fs_io_manager
+from dagster import InputDefinition, ModeDefinition, fs_io_manager, lambda_solid, pipeline
+from dagster.core.definitions.resource import resource
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster.core.selector.subset_selector import (
     MAX_NUM,

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -1,5 +1,6 @@
+from dagster.core.definitions.resource import resource
 import pytest
-from dagster import InputDefinition, lambda_solid, pipeline
+from dagster import InputDefinition, lambda_solid, pipeline, ModeDefinition, fs_io_manager
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster.core.selector.subset_selector import (
     MAX_NUM,
@@ -36,7 +37,7 @@ def add_one(num):
     return num + 1
 
 
-@pipeline
+@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
 def foo_pipeline():
     """
     return_one ---> add_nums --> multiply_two --> add_one

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -1,6 +1,5 @@
 import pytest
-from dagster import InputDefinition, ModeDefinition, fs_io_manager, lambda_solid, pipeline
-from dagster.core.definitions.resource import resource
+from dagster import InputDefinition, lambda_solid, pipeline
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster.core.selector.subset_selector import (
     MAX_NUM,
@@ -10,6 +9,7 @@ from dagster.core.selector.subset_selector import (
     parse_solid_selection,
     parse_step_selection,
 )
+from dagster.core.test_utils import default_mode_def_for_test
 
 
 @lambda_solid
@@ -37,7 +37,7 @@ def add_one(num):
     return num + 1
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
+@pipeline(mode_defs=[default_mode_def_for_test])
 def foo_pipeline():
     """
     return_one ---> add_nums --> multiply_two --> add_one

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -10,19 +10,15 @@ from dagster import (
     Int,
     OutputDefinition,
     PipelineDefinition,
-    fs_io_manager,
     lambda_solid,
     reconstructable,
 )
-from dagster.core.definitions.mode import ModeDefinition
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.execution.api import create_execution_plan, execute_plan
-from dagster.core.execution.plan.outputs import StepOutputHandle
 from dagster.core.execution.plan.plan import ExecutionPlan
 from dagster.core.instance import DagsterInstance
-from dagster.core.storage.intermediate_storage import build_fs_intermediate_storage
 from dagster.core.system_config.objects import ResolvedRunConfig
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 
 def define_inty_pipeline(using_file_system=False):
@@ -42,9 +38,7 @@ def define_inty_pipeline(using_file_system=False):
         name="basic_external_plan_execution",
         solid_defs=[return_one, add_one, user_throw_exception],
         dependencies={"add_one": {"num": DependencyDefinition("return_one")}},
-        mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})]
-        if using_file_system
-        else None,
+        mode_defs=[default_mode_def_for_test] if using_file_system else None,
     )
     return pipeline
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -1,3 +1,6 @@
+import os
+import pickle
+from dagster.core.definitions.mode import ModeDefinition
 import pytest
 from dagster import (
     DagsterEventType,
@@ -9,6 +12,7 @@ from dagster import (
     PipelineDefinition,
     lambda_solid,
     reconstructable,
+    fs_io_manager,
 )
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.execution.api import create_execution_plan, execute_plan
@@ -20,7 +24,7 @@ from dagster.core.system_config.objects import ResolvedRunConfig
 from dagster.core.test_utils import instance_for_test
 
 
-def define_inty_pipeline():
+def define_inty_pipeline(using_file_system=False):
     @lambda_solid
     def return_one():
         return 1
@@ -37,8 +41,15 @@ def define_inty_pipeline():
         name="basic_external_plan_execution",
         solid_defs=[return_one, add_one, user_throw_exception],
         dependencies={"add_one": {"num": DependencyDefinition("return_one")}},
+        mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})]
+        if using_file_system
+        else None,
     )
     return pipeline
+
+
+def define_reconstructable_inty_pipeline():
+    return define_inty_pipeline(using_file_system=True)
 
 
 def get_step_output(step_events, step_key, output_name="result"):
@@ -53,13 +64,11 @@ def get_step_output(step_events, step_key, output_name="result"):
 
 
 def test_using_file_system_for_subplan():
-    pipeline = define_inty_pipeline()
-
-    run_config = {"storage": {"filesystem": {}}}
+    pipeline = define_inty_pipeline(using_file_system=True)
 
     instance = DagsterInstance.ephemeral()
 
-    resolved_run_config = ResolvedRunConfig.build(pipeline, run_config=run_config)
+    resolved_run_config = ResolvedRunConfig.build(pipeline)
     execution_plan = ExecutionPlan.build(InMemoryPipeline(pipeline), resolved_run_config)
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=pipeline, execution_plan=execution_plan
@@ -71,34 +80,36 @@ def test_using_file_system_for_subplan():
             execution_plan.build_subset_plan(["return_one"], pipeline, resolved_run_config),
             InMemoryPipeline(pipeline),
             instance,
-            run_config=run_config,
             pipeline_run=pipeline_run,
         )
     )
 
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, pipeline_run.run_id
-    )
     assert get_step_output(return_one_step_events, "return_one")
-    assert intermediate_storage.has_intermediate(None, StepOutputHandle("return_one"))
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("return_one")).obj == 1
+    with open(
+        os.path.join(instance.storage_directory(), pipeline_run.run_id, "return_one", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 1
 
     add_one_step_events = list(
         execute_plan(
             execution_plan.build_subset_plan(["add_one"], pipeline, resolved_run_config),
             InMemoryPipeline(pipeline),
             instance,
-            run_config=run_config,
             pipeline_run=pipeline_run,
         )
     )
 
     assert get_step_output(add_one_step_events, "add_one")
-    assert intermediate_storage.has_intermediate(None, StepOutputHandle("add_one"))
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 2
+    with open(
+        os.path.join(instance.storage_directory(), pipeline_run.run_id, "add_one", "result"),
+        "rb",
+    ) as read_obj:
+        assert pickle.load(read_obj) == 2
 
 
 def test_using_intermediates_file_system_is_persistent():
+    # TODO: [intermediate-storage-removal] artifacts_persisted
     pipeline = define_inty_pipeline()
 
     run_config = {"intermediate_storage": {"filesystem": {}}}
@@ -110,103 +121,12 @@ def test_using_intermediates_file_system_is_persistent():
     assert execution_plan.artifacts_persisted
 
 
-def test_using_intermediates_file_system_for_subplan():
-    pipeline = define_inty_pipeline()
-
-    run_config = {"intermediate_storage": {"filesystem": {}}}
-
-    instance = DagsterInstance.ephemeral()
-    resolved_run_config = ResolvedRunConfig.build(
-        pipeline,
-        run_config=run_config,
-    )
-
-    execution_plan = ExecutionPlan.build(
-        InMemoryPipeline(pipeline),
-        resolved_run_config,
-    )
-    pipeline_run = instance.create_run_for_pipeline(
-        pipeline_def=pipeline, execution_plan=execution_plan
-    )
-    assert execution_plan.get_step_by_key("return_one")
-
-    return_one_step_events = list(
-        execute_plan(
-            execution_plan.build_subset_plan(["return_one"], pipeline, resolved_run_config),
-            InMemoryPipeline(pipeline),
-            instance,
-            run_config=run_config,
-            pipeline_run=pipeline_run,
-        )
-    )
-
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, pipeline_run.run_id
-    )
-    assert get_step_output(return_one_step_events, "return_one")
-    assert intermediate_storage.has_intermediate(None, StepOutputHandle("return_one"))
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("return_one")).obj == 1
-
-    add_one_step_events = list(
-        execute_plan(
-            execution_plan.build_subset_plan(["add_one"], pipeline, resolved_run_config),
-            InMemoryPipeline(pipeline),
-            instance,
-            run_config=run_config,
-            pipeline_run=pipeline_run,
-        )
-    )
-
-    assert get_step_output(add_one_step_events, "add_one")
-    assert intermediate_storage.has_intermediate(None, StepOutputHandle("add_one"))
-    assert intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 2
-
-
-def test_using_intermediates_to_override():
-    pipeline = define_inty_pipeline()
-
-    run_config = {"storage": {"filesystem": {}}, "intermediate_storage": {"in_memory": {}}}
-
-    instance = DagsterInstance.ephemeral()
-    resolved_run_config = ResolvedRunConfig.build(
-        pipeline,
-        run_config=run_config,
-    )
-    execution_plan = ExecutionPlan.build(
-        InMemoryPipeline(pipeline),
-        resolved_run_config,
-    )
-    pipeline_run = instance.create_run_for_pipeline(
-        pipeline_def=pipeline, execution_plan=execution_plan
-    )
-    assert execution_plan.get_step_by_key("return_one")
-
-    return_one_step_events = list(
-        execute_plan(
-            execution_plan.build_subset_plan(["return_one"], pipeline, resolved_run_config),
-            InMemoryPipeline(pipeline),
-            instance,
-            run_config=run_config,
-            pipeline_run=pipeline_run,
-        )
-    )
-
-    intermediate_storage = build_fs_intermediate_storage(
-        instance.intermediates_directory, pipeline_run.run_id
-    )
-    assert get_step_output(return_one_step_events, "return_one")
-    assert not intermediate_storage.has_intermediate(None, StepOutputHandle("return_one"))
-
-
 def test_using_file_system_for_subplan_multiprocessing():
     with instance_for_test() as instance:
-        run_config = {"storage": {"filesystem": {}}}
-
-        pipeline = reconstructable(define_inty_pipeline)
+        pipeline = reconstructable(define_reconstructable_inty_pipeline)
 
         resolved_run_config = ResolvedRunConfig.build(
             pipeline.get_definition(),
-            run_config=run_config,
         )
         execution_plan = ExecutionPlan.build(
             pipeline,
@@ -225,21 +145,17 @@ def test_using_file_system_for_subplan_multiprocessing():
                 ),
                 pipeline,
                 instance,
-                run_config=dict(run_config, execution={"multiprocess": {}}),
+                run_config=dict(execution={"multiprocess": {}}),
                 pipeline_run=pipeline_run,
             )
         )
 
-        intermediate_storage = build_fs_intermediate_storage(
-            instance.intermediates_directory, pipeline_run.run_id
-        )
-
         assert get_step_output(return_one_step_events, "return_one")
-        assert intermediate_storage.has_intermediate(None, StepOutputHandle("return_one"))
-        assert (
-            intermediate_storage.get_intermediate(None, Int, StepOutputHandle("return_one")).obj
-            == 1
-        )
+        with open(
+            os.path.join(instance.storage_directory(), pipeline_run.run_id, "return_one", "result"),
+            "rb",
+        ) as read_obj:
+            assert pickle.load(read_obj) == 1
 
         add_one_step_events = list(
             execute_plan(
@@ -248,79 +164,17 @@ def test_using_file_system_for_subplan_multiprocessing():
                 ),
                 pipeline,
                 instance,
-                run_config=dict(run_config, execution={"multiprocess": {}}),
+                run_config=dict(execution={"multiprocess": {}}),
                 pipeline_run=pipeline_run,
             )
         )
 
         assert get_step_output(add_one_step_events, "add_one")
-        assert intermediate_storage.has_intermediate(None, StepOutputHandle("add_one"))
-        assert (
-            intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 2
-        )
-
-
-def test_using_intermediate_file_system_for_subplan_multiprocessing():
-    with instance_for_test() as instance:
-
-        run_config = {"intermediate_storage": {"filesystem": {}}}
-
-        pipeline = reconstructable(define_inty_pipeline)
-
-        resolved_run_config = ResolvedRunConfig.build(
-            pipeline.get_definition(),
-            run_config=run_config,
-        )
-        execution_plan = ExecutionPlan.build(
-            pipeline,
-            resolved_run_config,
-        )
-        pipeline_run = instance.create_run_for_pipeline(
-            pipeline_def=pipeline.get_definition(), execution_plan=execution_plan
-        )
-
-        assert execution_plan.get_step_by_key("return_one")
-
-        return_one_step_events = list(
-            execute_plan(
-                execution_plan.build_subset_plan(
-                    ["return_one"], pipeline.get_definition(), resolved_run_config
-                ),
-                pipeline,
-                instance,
-                run_config=dict(run_config, execution={"multiprocess": {}}),
-                pipeline_run=pipeline_run,
-            )
-        )
-
-        intermediate_storage = build_fs_intermediate_storage(
-            instance.intermediates_directory, pipeline_run.run_id
-        )
-
-        assert get_step_output(return_one_step_events, "return_one")
-        assert intermediate_storage.has_intermediate(None, StepOutputHandle("return_one"))
-        assert (
-            intermediate_storage.get_intermediate(None, Int, StepOutputHandle("return_one")).obj
-            == 1
-        )
-
-        add_one_step_events = list(
-            execute_plan(
-                execution_plan.build_subset_plan(
-                    ["add_one"], pipeline.get_definition(), resolved_run_config
-                ),
-                pipeline,
-                instance,
-                run_config=dict(run_config, execution={"multiprocess": {}}),
-                pipeline_run=pipeline_run,
-            )
-        )
-
-        assert get_step_output(add_one_step_events, "add_one")
-        assert intermediate_storage.has_intermediate(None, StepOutputHandle("add_one"))
-        assert (
-            intermediate_storage.get_intermediate(None, Int, StepOutputHandle("add_one")).obj == 2
-        )
+        with open(
+            os.path.join(instance.storage_directory(), pipeline_run.run_id, "add_one", "result"),
+            "rb",
+        ) as read_obj:
+            assert pickle.load(read_obj) == 2
 
 
 def test_execute_step_wrong_step_key():
@@ -369,13 +223,11 @@ def test_execute_step_wrong_step_key():
 
 
 def test_using_file_system_for_subplan_missing_input():
-    pipeline = define_inty_pipeline()
-    run_config = {"storage": {"filesystem": {}}}
+    pipeline = define_inty_pipeline(using_file_system=True)
 
     instance = DagsterInstance.ephemeral()
     resolved_run_config = ResolvedRunConfig.build(
         pipeline,
-        run_config=run_config,
     )
     execution_plan = ExecutionPlan.build(
         InMemoryPipeline(pipeline),
@@ -389,25 +241,21 @@ def test_using_file_system_for_subplan_missing_input():
         execution_plan.build_subset_plan(["add_one"], pipeline, resolved_run_config),
         InMemoryPipeline(pipeline),
         instance,
-        run_config=run_config,
         pipeline_run=pipeline_run,
     )
     failures = [event for event in events if event.event_type_value == "STEP_FAILURE"]
     assert len(failures) == 1
     assert failures[0].step_key == "add_one"
-    assert "DagsterStepOutputNotFoundError" in failures[0].event_specific_data.error.message
+    assert "DagsterExecutionLoadInputError" in failures[0].event_specific_data.error.message
 
 
 def test_using_file_system_for_subplan_invalid_step():
-    pipeline = define_inty_pipeline()
-
-    run_config = {"storage": {"filesystem": {}}}
+    pipeline = define_inty_pipeline(using_file_system=True)
 
     instance = DagsterInstance.ephemeral()
 
     resolved_run_config = ResolvedRunConfig.build(
         pipeline,
-        run_config=run_config,
     )
     execution_plan = ExecutionPlan.build(
         InMemoryPipeline(pipeline),
@@ -423,6 +271,5 @@ def test_using_file_system_for_subplan_invalid_step():
             execution_plan.build_subset_plan(["nope.compute"], pipeline, resolved_run_config),
             InMemoryPipeline(pipeline),
             instance,
-            run_config=run_config,
             pipeline_run=pipeline_run,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from dagster.core.definitions.mode import ModeDefinition
+
 import pytest
 from dagster import (
     DagsterEventType,
@@ -10,10 +10,11 @@ from dagster import (
     Int,
     OutputDefinition,
     PipelineDefinition,
+    fs_io_manager,
     lambda_solid,
     reconstructable,
-    fs_io_manager,
 )
+from dagster.core.definitions.mode import ModeDefinition
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.execution.api import create_execution_plan, execute_plan
 from dagster.core.execution.plan.outputs import StepOutputHandle

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -19,7 +19,6 @@ from dagster import (
     check,
     execute_pipeline,
     execute_pipeline_iterator,
-    fs_io_manager,
     pipeline,
     reconstructable,
     reexecute_pipeline,
@@ -31,7 +30,11 @@ from dagster.core.definitions.graph import _create_adjacency_lists
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster.core.execution.results import SolidExecutionResult
 from dagster.core.instance import DagsterInstance
-from dagster.core.test_utils import instance_for_test, step_output_event_filter
+from dagster.core.test_utils import (
+    default_mode_def_for_test,
+    instance_for_test,
+    step_output_event_filter,
+)
 from dagster.core.utility_solids import (
     create_root_solid,
     create_solid_with_deps,
@@ -781,7 +784,7 @@ def retry_pipeline():
         solid_defs=[return_one, add_one],
         name="test",
         dependencies={"add_one": {"num": DependencyDefinition("return_one")}},
-        mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})],
+        mode_defs=[default_mode_def_for_test],
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -1,16 +1,8 @@
 import logging
 
 import pytest
-from dagster import (
-    ModeDefinition,
-    execute_pipeline,
-    fs_io_manager,
-    pipeline,
-    reconstructable,
-    resource,
-    solid,
-)
-from dagster.core.test_utils import instance_for_test
+from dagster import ModeDefinition, execute_pipeline, pipeline, reconstructable, resource, solid
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 
 def get_log_records(pipe, managed_loggers=None, python_logging_level=None, run_config=None):
@@ -244,7 +236,7 @@ def define_logging_pipeline():
         loggerA.debug("loggerA")
         loggerA.info("loggerA")
 
-    @pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def pipe():
         solidB(solidA())
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -1,7 +1,15 @@
 import logging
 
 import pytest
-from dagster import ModeDefinition, execute_pipeline, pipeline, reconstructable, resource, solid
+from dagster import (
+    ModeDefinition,
+    execute_pipeline,
+    pipeline,
+    reconstructable,
+    resource,
+    solid,
+    fs_io_manager,
+)
 from dagster.core.test_utils import instance_for_test
 
 
@@ -236,7 +244,7 @@ def define_logging_pipeline():
         loggerA.debug("loggerA")
         loggerA.info("loggerA")
 
-    @pipeline
+    @pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
     def pipe():
         solidB(solidA())
 
@@ -251,7 +259,6 @@ def test_multiprocess_logging(managed_loggers):
         managed_loggers=managed_loggers,
         python_logging_level="INFO",
         run_config={
-            "intermediate_storage": {"filesystem": {}},
             "execution": {"multiprocess": {}},
         },
     )

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -4,11 +4,11 @@ import pytest
 from dagster import (
     ModeDefinition,
     execute_pipeline,
+    fs_io_manager,
     pipeline,
     reconstructable,
     resource,
     solid,
-    fs_io_manager,
 )
 from dagster.core.test_utils import instance_for_test
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -11,13 +11,13 @@ import pytest
 from dagster import (
     Any,
     Field,
+    ModeDefinition,
     daily_partitioned_config,
+    fs_io_manager,
     graph,
     pipeline,
     repository,
     solid,
-    ModeDefinition,
-    fs_io_manager,
 )
 from dagster.core.definitions import Partition, PartitionSetDefinition
 from dagster.core.definitions.reconstructable import ReconstructableRepository

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_dynamic_execution.py
@@ -4,12 +4,10 @@ from dagster import (
     DynamicOutputDefinition,
     Field,
     InputDefinition,
-    ModeDefinition,
     Output,
     OutputDefinition,
     composite_solid,
     execute_pipeline,
-    fs_io_manager,
     pipeline,
     reconstructable,
     solid,
@@ -17,7 +15,7 @@ from dagster import (
 from dagster.core.errors import DagsterExecutionStepNotFoundError
 from dagster.core.execution.api import create_execution_plan, reexecute_pipeline
 from dagster.core.execution.plan.state import KnownExecutionState
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 from dagster.utils import merge_dicts
 
 
@@ -78,7 +76,7 @@ def dynamic_echo(_, nums):
         yield DynamicOutput(value=x, mapping_key=str(x))
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
+@pipeline(mode_defs=[default_mode_def_for_test])
 def dynamic_pipeline():
 
     numbers = emit(num_range())
@@ -87,7 +85,7 @@ def dynamic_pipeline():
     echo(n)  # test transitive downstream of collect
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
+@pipeline(mode_defs=[default_mode_def_for_test])
 def fan_repeat():
     one = emit(num_range()).map(multiply_by_two)
     two = dynamic_echo(one.collect()).map(multiply_by_two).map(echo)

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_priorities.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_priorities.py
@@ -1,5 +1,5 @@
 from dagster import execute_pipeline, pipeline, reconstructable, solid
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 
 @solid(tags={"dagster/priority": "-1"})
@@ -17,7 +17,7 @@ def high(_):
     pass
 
 
-@pipeline
+@pipeline(mode_defs=[default_mode_def_for_test])
 def priority_test():
     none()
     low()
@@ -45,7 +45,6 @@ def test_priorities_mp():
             pipe,
             {
                 "execution": {"multiprocess": {"config": {"max_concurrent": 1}}},
-                "intermediate_storage": {"filesystem": {}},
             },
             instance=instance,
         )

--- a/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
@@ -18,7 +18,7 @@ from dagster import (
     solid,
 )
 from dagster.core.errors import DagsterExecutionInterruptedError, raise_execution_interrupts
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 from dagster.utils import safe_tempfile_path, send_interrupt
 from dagster.utils.interrupts import capture_interrupts, check_captured_interrupt
 
@@ -46,7 +46,7 @@ def should_not_start(_context):
     assert False
 
 
-@pipeline
+@pipeline(mode_defs=[default_mode_def_for_test])
 def write_files_pipeline():
     write_a_file.alias("write_1")()
     write_a_file.alias("write_2")()
@@ -119,7 +119,6 @@ def test_interrupt_multiproc():
                         "write_4": {"config": {"tempfile": file_4}},
                     },
                     "execution": {"multiprocess": {"config": {"max_concurrent": 4}}},
-                    "intermediate_storage": {"filesystem": {}},
                 },
                 instance=instance,
             ):

--- a/python_modules/dagster/dagster_tests/execution_tests/test_markers.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_markers.py
@@ -1,5 +1,5 @@
 from dagster import execute_pipeline, lambda_solid, pipeline, reconstructable
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 
 def define_pipeline():
@@ -7,7 +7,7 @@ def define_pipeline():
     def ping():
         return "ping"
 
-    @pipeline
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def simple():
         ping()
 
@@ -21,7 +21,6 @@ def test_multiproc_markers():
             instance=instance,
             run_config={
                 "execution": {"multiprocess": {}},
-                "intermediate_storage": {"filesystem": {}},
             },
         )
         assert result.success

--- a/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
@@ -26,13 +26,13 @@ from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.execution.api import create_execution_plan, execute_plan
 from dagster.core.execution.retries import RetryMode
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 executors = pytest.mark.parametrize(
     "environment",
     [
-        {"intermediate_storage": {"filesystem": {}}},
-        {"intermediate_storage": {"filesystem": {}}, "execution": {"multiprocess": {}}},
+        {},
+        {"execution": {"multiprocess": {}}},
     ],
 )
 
@@ -63,7 +63,7 @@ def define_run_retry_pipeline():
     def downstream_of_failed(_, input_str):
         return input_str
 
-    @pipeline
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def pipe():
         start_fail, start_skip = two_outputs()
         downstream_of_failed(can_fail(start_fail))
@@ -118,7 +118,7 @@ def define_step_retry_pipeline():
             open(file, "a").close()
             raise RetryRequested()
 
-    @pipeline
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def step_retry():
         fail_first_time()
 
@@ -156,7 +156,7 @@ def define_retry_limit_pipeline():
     def three_max():
         raise RetryRequested(max_retries=3)
 
-    @pipeline
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def retry_limits():
         default_max()
         three_max()
@@ -227,7 +227,7 @@ def define_retry_wait_fixed_pipeline():
             open(file, "a").close()
             raise RetryRequested(seconds_to_wait=DELAY)
 
-    @pipeline
+    @pipeline(mode_defs=[default_mode_def_for_test])
     def step_retry():
         fail_first_and_wait()
 

--- a/python_modules/dagster/dagster_tests/general_tests/test_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_repository.py
@@ -7,6 +7,7 @@ from dagster import (
     ModeDefinition,
     PipelineDefinition,
     PresetDefinition,
+    fs_io_manager,
     repository,
     resource,
     solid,
@@ -66,7 +67,9 @@ def define_multi_mode_with_resources_pipeline():
         name="multi_mode_with_resources",
         solid_defs=[apply_to_three],
         mode_defs=[
-            ModeDefinition(name="add_mode", resource_defs={"op": adder_resource}),
+            ModeDefinition(
+                name="add_mode", resource_defs={"op": adder_resource, "io_manager": fs_io_manager}
+            ),
             ModeDefinition(name="mult_mode", resource_defs={"op": multer_resource}),
             ModeDefinition(
                 name="double_adder_mode",
@@ -90,7 +93,6 @@ def define_multi_mode_with_resources_pipeline():
                 run_config={
                     "resources": {"op": {"config": 2}},
                     "execution": {"multiprocess": {}},
-                    "intermediate_storage": {"filesystem": {}},
                 },
             ),
         ],


### PR DESCRIPTION
## Summary
migrate tests off of using "intermediate_storage" in run config to defining fs_io_manager on pipeline mode_def.

note that this migration is awkward for multiproc execution but we only expect that awkwardness prior to crag. in crag, bc job defaults to fs_io_manager.

... and a lot more diffs are on the way

## Test Plan
bk

