### PR TITLE
fix input type inference for @asset

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -195,11 +195,11 @@ def build_asset_ins(
         if input_name in asset_ins:
             metadata = asset_ins[input_name].metadata or {}
             namespace = asset_ins[input_name].namespace
-            dagster_type = Any if asset_ins[input_name].managed else Nothing
+            dagster_type = None if asset_ins[input_name].managed else Nothing
         else:
             metadata = {}
             namespace = None
-            dagster_type = Any
+            dagster_type = None
 
         asset_key = AssetKey(list(filter(None, [namespace or asset_namespace, input_name])))
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -103,3 +103,11 @@ def test_all_fields():
     output_def = my_asset.output_defs[0]
     assert output_def.io_manager_key == "my_io_key"
     assert output_def.metadata["metakey"] == "metaval"
+
+
+def test_infer_input_dagster_type():
+    @asset
+    def my_asset(_input1: str):
+        pass
+
+    assert my_asset.input_defs[0].dagster_type.display_name == "String"

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -4,6 +4,7 @@ import pytest
 from dagster import (
     DagsterInvalidDefinitionError,
     DagsterType,
+    In,
     InputDefinition,
     Int,
     composite_solid,
@@ -11,6 +12,7 @@ from dagster import (
     execute_solid,
     lambda_solid,
     make_python_type_usable_as_dagster_type,
+    op,
     pipeline,
     solid,
     usable_as_dagster_type,
@@ -451,7 +453,30 @@ def test_unregistered_type_annotation_input():
     def my_pipeline():
         solid2(solid1())
 
+    assert solid2.input_defs[0].dagster_type.display_name == "MyClass"
     execute_pipeline(my_pipeline)
+
+
+def test_unregistered_type_annotation_input_op():
+    class MyClass:
+        pass
+
+    @op
+    def op2(_, _input1: MyClass):
+        pass
+
+    assert op2.input_defs[0].dagster_type.display_name == "MyClass"
+
+
+def test_unregistered_type_annotation_input_op_merge():
+    class MyClass:
+        pass
+
+    @op(ins={"_input1": In()})
+    def op2(_input1: MyClass):
+        pass
+
+    assert op2.input_defs[0].dagster_type.display_name == "MyClass"
 
 
 def test_use_auto_type_twice():


### PR DESCRIPTION
Prior to this PR, we fail to construct our Dagster type using the Python type from the type annotation of the argument to the @asset-decorated function. 

I also added a test to verify that the problem wasn't caused by the underlying Op machinery.