### PR TITLE
clean up / consolidate logic for setting grpc server timeouts

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -1,5 +1,4 @@
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
+from dagster.core.test_utils import create_test_daemon_workspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
 from dagster_graphql.test.utils import (
@@ -33,13 +32,10 @@ query JobQuery($instigationSelector: InstigationSelector!) {
 
 
 def _create_sensor_tick(instance):
-    with ProcessGrpcServerRegistry() as grpc_server_registry:
-        with DynamicWorkspace(grpc_server_registry) as workspace:
-            list(
-                execute_sensor_iteration(
-                    instance, get_default_daemon_logger("SensorDaemon"), workspace
-                )
-            )
+    with create_test_daemon_workspace() as workspace:
+        list(
+            execute_sensor_iteration(instance, get_default_daemon_logger("SensorDaemon"), workspace)
+        )
 
 
 class TestNextTickRepository(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1,8 +1,7 @@
 import pendulum
 from dagster.core.definitions.run_request import JobType
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.scheduler.job import JobState, JobStatus
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
+from dagster.core.test_utils import create_test_daemon_workspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
 from dagster_graphql.test.utils import (
@@ -273,13 +272,10 @@ def test_sensor_next_ticks(graphql_context):
 
 
 def _create_tick(instance):
-    with ProcessGrpcServerRegistry() as grpc_server_registry:
-        with DynamicWorkspace(grpc_server_registry) as workspace:
-            list(
-                execute_sensor_iteration(
-                    instance, get_default_daemon_logger("SensorDaemon"), workspace
-                )
-            )
+    with create_test_daemon_workspace() as workspace:
+        list(
+            execute_sensor_iteration(instance, get_default_daemon_logger("SensorDaemon"), workspace)
+        )
 
 
 def test_sensor_tick_range(graphql_context):

--- a/python_modules/dagster/dagster/core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/core/host_representation/grpc_server_registry.py
@@ -52,10 +52,6 @@ class GrpcServerRegistry(AbstractContextManager):
         pass
 
 
-DEFAULT_PROCESS_CLEANUP_INTERVAL = 60
-DEFAULT_PROCESS_HEARTBEAT_INTERVAL = 120
-
-
 class ProcessRegistryEntry(
     namedtuple(
         "_ProcessRegistryEntry",
@@ -82,13 +78,13 @@ class ProcessGrpcServerRegistry(GrpcServerRegistry):
     def __init__(
         self,
         # How often to reload created processes in a background thread
-        reload_interval=DEFAULT_PROCESS_CLEANUP_INTERVAL,
+        reload_interval,
         # How long the process can live without a heartbeat before it dies. You should ensure
         # that either heartbeat_ttl is greater than reload_interval (so that the process will reload
         # before it ends due to heartbeat failure), or if reload_interval is 0, that any processes
         # returned by this registry have at least one GrpcServerRepositoryLocation hitting the
         # server with a heartbeat while you want the process to stay running.
-        heartbeat_ttl=DEFAULT_PROCESS_HEARTBEAT_INTERVAL,
+        heartbeat_ttl,
     ):
         # ProcessRegistryEntry map of servers being currently returned, keyed by origin ID
         self._active_entries = {}

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -205,8 +205,11 @@ class ManagedGrpcPythonEnvRepositoryLocationOrigin(
     def create_test_location(self):
         from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
         from .grpc_server_registry import ProcessGrpcServerRegistry
+        from dagster.core.workspace.context import DAGIT_GRPC_SERVER_HEARTBEAT_TTL
 
-        with ProcessGrpcServerRegistry(reload_interval=0, heartbeat_ttl=30) as grpc_server_registry:
+        with ProcessGrpcServerRegistry(
+            reload_interval=0, heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL
+        ) as grpc_server_registry:
             with DynamicWorkspace(grpc_server_registry) as workspace:
                 with workspace.get_location(self) as location:
                     yield location

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -20,7 +20,9 @@ from dagster.core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, PipelineRunsFilter
 from dagster.core.telemetry import cleanup_telemetry_logger
 from dagster.core.workspace.context import WorkspaceProcessContext
+from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
 from dagster.core.workspace.load_target import WorkspaceLoadTarget
+from dagster.daemon.controller import create_daemon_grpc_server_registry
 from dagster.serdes import ConfigurableClass
 from dagster.seven.compat.pendulum import create_pendulum_time, mock_pendulum_timezone
 from dagster.utils import merge_dicts
@@ -430,6 +432,14 @@ def in_process_test_workspace(instance, recon_repo):
         instance, TestInProcessWorkspaceLoadTarget(InProcessRepositoryLocationOrigin(recon_repo))
     ) as workspace_process_context:
         yield workspace_process_context.create_request_context()
+
+
+@contextmanager
+def create_test_daemon_workspace():
+    """ Creates a DynamicWorkspace suitable for passing into a DagsterDaemon loop when running tests."""
+    with create_daemon_grpc_server_registry() as grpc_server_registry:
+        with DynamicWorkspace(grpc_server_registry) as workspace:
+            yield workspace
 
 
 def remove_none_recursively(obj):

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -47,6 +47,9 @@ if TYPE_CHECKING:
     )
 
 
+DAGIT_GRPC_SERVER_HEARTBEAT_TTL = 30
+
+
 class BaseWorkspaceRequestContext(IWorkspace):
     """
     This class is a request-scoped object that stores (1) a reference to all repository locations
@@ -399,7 +402,9 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             )
         else:
             self._grpc_server_registry = self._stack.enter_context(
-                ProcessGrpcServerRegistry(reload_interval=0, heartbeat_ttl=30)
+                ProcessGrpcServerRegistry(
+                    reload_interval=0, heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL
+                )
             )
 
         self._location_entry_dict: Dict[str, WorkspaceLocationEntry] = OrderedDict()

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -18,12 +18,10 @@ from dagster.core.host_representation import (
     InProcessRepositoryLocationOrigin,
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.storage.pipeline_run import PipelineRunStatus, PipelineRunsFilter
 from dagster.core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG, PARTITION_SET_TAG
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import create_test_daemon_workspace, instance_for_test
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.backfill import execute_backfill_iteration
 from dagster.seven import IS_WINDOWS, get_system_temp_directory
@@ -219,10 +217,9 @@ def repos():
 @contextmanager
 def instance_for_context(external_repo_context, overrides=None):
     with instance_for_test(overrides) as instance:
-        with ProcessGrpcServerRegistry() as grpc_server_registry:
-            with DynamicWorkspace(grpc_server_registry) as workspace:
-                with external_repo_context() as external_repo:
-                    yield (instance, workspace, external_repo)
+        with create_test_daemon_workspace() as workspace:
+            with external_repo_context() as external_repo:
+                yield (instance, workspace, external_repo)
 
 
 def step_did_not_run(instance, run, step_name):

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -1,10 +1,12 @@
 import pendulum
 import pytest
 from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.instance import DagsterInstance
-from dagster.core.test_utils import cleanup_test_instance, get_crash_signals
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
+from dagster.core.test_utils import (
+    cleanup_test_instance,
+    create_test_daemon_workspace,
+    get_crash_signals,
+)
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.backfill import execute_backfill_iteration
 from dagster.seven import IS_WINDOWS, multiprocessing
@@ -24,18 +26,15 @@ def _test_backfill_in_subprocess(instance_ref, debug_crash_flags):
     )
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
-            with pendulum.test(
-                execution_datetime
-            ), ProcessGrpcServerRegistry() as grpc_server_registry:
-                with DynamicWorkspace(grpc_server_registry) as workspace:
-                    list(
-                        execute_backfill_iteration(
-                            instance,
-                            workspace,
-                            get_default_daemon_logger("BackfillDaemon"),
-                            debug_crash_flags=debug_crash_flags,
-                        )
+            with pendulum.test(execution_datetime), create_test_daemon_workspace() as workspace:
+                list(
+                    execute_backfill_iteration(
+                        instance,
+                        workspace,
+                        get_default_daemon_logger("BackfillDaemon"),
+                        debug_crash_flags=debug_crash_flags,
                     )
+                )
         finally:
             cleanup_test_instance(instance)
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -3,12 +3,14 @@
 from contextlib import contextmanager
 
 import pytest
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.host_representation.repository_location import GrpcServerRepositoryLocation
 from dagster.core.storage.pipeline_run import IN_PROGRESS_RUN_STATUSES, PipelineRunStatus
 from dagster.core.storage.tags import PRIORITY_TAG
-from dagster.core.test_utils import create_run_for_test, instance_for_test
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
+from dagster.core.test_utils import (
+    create_run_for_test,
+    create_test_daemon_workspace,
+    instance_for_test,
+)
 from dagster.daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster_tests.api_tests.utils import get_foo_pipeline_handle
 
@@ -51,7 +53,7 @@ def daemon_fixture():
 
 @pytest.fixture(name="workspace")
 def workspace_fixture():
-    with ProcessGrpcServerRegistry() as registry, DynamicWorkspace(registry) as workspace:
+    with create_test_daemon_workspace() as workspace:
         yield workspace
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -1,13 +1,15 @@
 import pendulum
 import pytest
 from dagster.core.definitions.run_request import JobType
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobState, JobStatus, JobTickStatus
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
-from dagster.core.test_utils import cleanup_test_instance, get_crash_signals
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
+from dagster.core.test_utils import (
+    cleanup_test_instance,
+    create_test_daemon_workspace,
+    get_crash_signals,
+)
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
 from dagster.seven import IS_WINDOWS, multiprocessing
@@ -19,18 +21,15 @@ from .test_sensor_run import instance_with_sensors, repos, wait_for_all_runs_to_
 def _test_launch_sensor_runs_in_subprocess(instance_ref, execution_datetime, debug_crash_flags):
     with DagsterInstance.from_ref(instance_ref) as instance:
         try:
-            with pendulum.test(
-                execution_datetime
-            ), ProcessGrpcServerRegistry() as grpc_server_registry:
-                with DynamicWorkspace(grpc_server_registry) as workspace:
-                    list(
-                        execute_sensor_iteration(
-                            instance,
-                            get_default_daemon_logger("SensorDaemon"),
-                            workspace,
-                            debug_crash_flags=debug_crash_flags,
-                        )
+            with pendulum.test(execution_datetime), create_test_daemon_workspace() as workspace:
+                list(
+                    execute_sensor_iteration(
+                        instance,
+                        get_default_daemon_logger("SensorDaemon"),
+                        workspace,
+                        debug_crash_flags=debug_crash_flags,
                     )
+                )
         finally:
             cleanup_test_instance(instance)
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -36,14 +36,12 @@ from dagster.core.host_representation import (
     InProcessRepositoryLocationOrigin,
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
-from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobState, JobStatus, JobTickStatus
 from dagster.core.storage.event_log.base import EventRecordsFilter
 from dagster.core.storage.pipeline_run import PipelineRunStatus
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import create_test_daemon_workspace, instance_for_test
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.controller import (
     DEFAULT_DAEMON_ERROR_INTERVAL_SECONDS,
@@ -309,10 +307,9 @@ def the_other_repo():
 @contextmanager
 def instance_with_sensors(external_repo_context, overrides=None):
     with instance_for_test(overrides) as instance:
-        with ProcessGrpcServerRegistry() as grpc_server_registry:
-            with DynamicWorkspace(grpc_server_registry) as workspace:
-                with external_repo_context() as external_repo:
-                    yield (instance, workspace, external_repo)
+        with create_test_daemon_workspace() as workspace:
+            with external_repo_context() as external_repo:
+                yield (instance, workspace, external_repo)
 
 
 @contextmanager


### PR DESCRIPTION
Summary:
As part of some fixes for grpc server startup related to timeouts, its useful to have a single constant to know how long a managed grpc server will live without heartbeats before timing out. This diff cleans up that logic and moves it into a couple of constants, one for dagit and one for the daemon

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.