### PR TITLE
Don't allow grpc servers to fail due to heartbeat failure before the startup code times out

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/core/host_representation/grpc_server_registry.py
@@ -85,6 +85,8 @@ class ProcessGrpcServerRegistry(GrpcServerRegistry):
         # returned by this registry have at least one GrpcServerRepositoryLocation hitting the
         # server with a heartbeat while you want the process to stay running.
         heartbeat_ttl,
+        # How long to wait for the server to start up and receive connections before timing out
+        startup_timeout,
     ):
         # ProcessRegistryEntry map of servers being currently returned, keyed by origin ID
         self._active_entries = {}
@@ -98,6 +100,7 @@ class ProcessGrpcServerRegistry(GrpcServerRegistry):
 
         self._reload_interval = check.int_param(reload_interval, "reload_interval")
         self._heartbeat_ttl = check.int_param(heartbeat_ttl, "heartbeat_ttl")
+        self._startup_timeout = check.int_param(startup_timeout, "startup_timeout")
 
         self._lock = threading.Lock()
 
@@ -175,6 +178,7 @@ class ProcessGrpcServerRegistry(GrpcServerRegistry):
                     heartbeat=True,
                     heartbeat_timeout=self._heartbeat_ttl,
                     fixed_server_id=new_server_id,
+                    startup_timeout=self._startup_timeout,
                 )
                 self._all_processes.append(server_process)
             except Exception:  # pylint: disable=broad-except

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -205,10 +205,15 @@ class ManagedGrpcPythonEnvRepositoryLocationOrigin(
     def create_test_location(self):
         from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
         from .grpc_server_registry import ProcessGrpcServerRegistry
-        from dagster.core.workspace.context import DAGIT_GRPC_SERVER_HEARTBEAT_TTL
+        from dagster.core.workspace.context import (
+            DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
+            DAGIT_GRPC_SERVER_STARTUP_TIMEOUT,
+        )
 
         with ProcessGrpcServerRegistry(
-            reload_interval=0, heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL
+            reload_interval=0,
+            heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
+            startup_timeout=DAGIT_GRPC_SERVER_STARTUP_TIMEOUT,
         ) as grpc_server_registry:
             with DynamicWorkspace(grpc_server_registry) as workspace:
                 with workspace.get_location(self) as location:

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -47,7 +47,8 @@ if TYPE_CHECKING:
     )
 
 
-DAGIT_GRPC_SERVER_HEARTBEAT_TTL = 30
+DAGIT_GRPC_SERVER_HEARTBEAT_TTL = 45
+DAGIT_GRPC_SERVER_STARTUP_TIMEOUT = 30
 
 
 class BaseWorkspaceRequestContext(IWorkspace):
@@ -403,7 +404,9 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         else:
             self._grpc_server_registry = self._stack.enter_context(
                 ProcessGrpcServerRegistry(
-                    reload_interval=0, heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL
+                    reload_interval=0,
+                    heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,
+                    startup_timeout=DAGIT_GRPC_SERVER_STARTUP_TIMEOUT,
                 )
             )
 

--- a/python_modules/dagster/dagster/daemon/controller.py
+++ b/python_modules/dagster/dagster/daemon/controller.py
@@ -41,6 +41,7 @@ HEARTBEAT_CHECK_INTERVAL = 15
 
 DAEMON_GRPC_SERVER_RELOAD_INTERVAL = 60
 DAEMON_GRPC_SERVER_HEARTBEAT_TTL = 120
+DAEMON_GRPC_SERVER_STARTUP_TIMEOUT = 30
 
 
 def _sorted_quoted(strings):
@@ -58,6 +59,7 @@ def create_daemon_grpc_server_registry():
     return ProcessGrpcServerRegistry(
         reload_interval=DAEMON_GRPC_SERVER_RELOAD_INTERVAL,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
+        startup_timeout=DAEMON_GRPC_SERVER_STARTUP_TIMEOUT,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_grpc_server_registry.py
@@ -53,7 +53,9 @@ def test_error_repo_in_registry():
             python_file=file_relative_path(__file__, "error_repo.py"),
         ),
     )
-    with ProcessGrpcServerRegistry(reload_interval=5, heartbeat_ttl=10) as registry:
+    with ProcessGrpcServerRegistry(
+        reload_interval=5, heartbeat_ttl=10, startup_timeout=5
+    ) as registry:
         # Repository with a loading error does not raise an exception
         endpoint = registry.get_grpc_endpoint(error_origin)
 
@@ -91,7 +93,9 @@ def test_process_server_registry():
         ),
     )
 
-    with ProcessGrpcServerRegistry(reload_interval=5, heartbeat_ttl=10) as registry:
+    with ProcessGrpcServerRegistry(
+        reload_interval=5, heartbeat_ttl=10, startup_timeout=5
+    ) as registry:
         with DynamicWorkspace(registry) as workspace:
             endpoint_one = registry.get_grpc_endpoint(origin)
             location_one = workspace.get_location(origin)
@@ -166,7 +170,9 @@ def test_registry_multithreading():
         ),
     )
 
-    with ProcessGrpcServerRegistry(reload_interval=300, heartbeat_ttl=600) as registry:
+    with ProcessGrpcServerRegistry(
+        reload_interval=300, heartbeat_ttl=600, startup_timeout=30
+    ) as registry:
         endpoint = registry.get_grpc_endpoint(origin)
 
         threads = []
@@ -196,7 +202,7 @@ class TestMockProcessGrpcServerRegistry(ProcessGrpcServerRegistry):
     def __init__(self):
         self.mocked_loadable_target_origin = None
         super(TestMockProcessGrpcServerRegistry, self).__init__(
-            reload_interval=300, heartbeat_ttl=600
+            reload_interval=300, heartbeat_ttl=600, startup_timeout=30
         )
 
     def supports_origin(self, repository_location_origin):

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_that_times_out.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_that_times_out.py
@@ -1,0 +1,9 @@
+"""isort:skip_file"""
+
+import time
+
+time.sleep(20)
+
+from dagster_tests.general_tests.grpc_tests.grpc_repo import (  # pylint:disable=unused-import
+    bar_repo,
+)


### PR DESCRIPTION
Don't allow grpc servers to fail due to heartbeat failure before the startup code times out

Summary:
Some recent changes to the gRPC server startup have produced strange/confusing error behavior when the server starts up correctly, but is not reachable from dagit (for example, because it's behind a VPN, or takes a sup\
er long time to load). Because our heartbeat timeout is shorter than our tiemout, the first indication they see that something goes wrong is 'the gRPC server exited with error code 0'. This is confusing.

Solve this in two ways:
- ensure that we timeout before the hearbeat expires (by bumping up the hearteat a bit, and ensuring the timeout is always less than the heartbeat TTL)
- include the test of the most recent connection error when it timesout. This helps with things like the VPN case where the error gives some clues why it might be timing out.
