### PR TITLE
[rfc] @job-ified migration guide

### DIFF
--- a/docs/content/guides/dagster/graph_job_op.mdx
+++ b/docs/content/guides/dagster/graph_job_op.mdx
@@ -1,17 +1,17 @@
 ---
-title: Migrating to Ops, Graphs, and Jobs | Dagster
-description: This guide describes how to migrate code to the new Graph, Job, and Op APIs.
+title: Migrating to Ops, Jobs, and Graphs | Dagster
+description: This guide describes how to migrate code to the new Job, Op, and Graph APIs.
 ---
 
-# Migrating to Ops, Graphs, and Jobs
+# Migrating to Ops, Jobs, and Graphs
 
 Ops, Graphs, and Jobs, are an experimental set of APIs that aim to simplify and give more accessible names to some of Dagster's core concepts. This guide describes how to migrate code that uses Pipelines, Modes, Presets, and Partition Sets to the new APIs.
 
 A detailed API reference for the new APIs can be found [here](/\_apidocs/experimental).
 
-Migrating a pipeline to a graph does not require migrating all your other pipelines to graphs. Graphs, jobs, and pipelines can co-exist peacefully in Python.
+Migrating a pipeline to jobs does not require migrating all your other pipelines to jobs. Graphs, jobs, and pipelines can co-exist peacefully in Python.
 
-In Dagit, graphs and jobs will be displayed as pipelines. You can also toggle Dagit to switch to a view that's better suited to the new APIs. Click the gear icon in the upper right corner, and then toggle "Experimental Core APIs (Job & Graph)". After flipping this toggle, Dagit will display a job for each mode in each pipeline.
+In Dagit, jobs will be displayed as pipelines. You can also toggle Dagit to switch to a view that's better suited to the new APIs. Click the gear icon in the upper right corner, and then toggle "Experimental Core APIs (Job & Graph)". After flipping this toggle, Dagit will display a job for each mode in each pipeline.
 
 ## A simple pipeline
 
@@ -31,10 +31,10 @@ def do_it_all():
     do_something()
 ```
 
-And here's an equivalent <PyObject module="dagster" object="graph" /> containing a single <PyObject module="dagster" object="op" />:
+And here's an equivalent <PyObject module="dagster" object="job" /> containing a single <PyObject module="dagster" object="op" />:
 
 ```python file=/guides/dagster/graph_job_op/simple_graph.py
-from dagster import graph, op
+from dagster import job, op
 
 
 @op
@@ -42,18 +42,18 @@ def do_something():
     ...
 
 
-@graph
+@job
 def do_it_all():
     do_something()
 ```
 
-Note that graphs can be built out of solids as well as ops. So you don't need to convert all your solids to ops in order to use <PyObject module="dagster" object="graph" decorator />.
+Note that jobs can be built out of solids as well as ops. So you don't need to convert all your solids to ops in order to use <PyObject module="dagster" object="graph" decorator />.
 
-In both cases, you can load the pipeline / graph in Dagit with:
+In both cases, you can load the pipeline / job in Dagit with:
 
     dagit -f <path/to/file>
 
-If you want to execute the graph in process, instead of using <PyObject module="dagster" object="execute_pipeline" />, you can invoke its <PyObject module="dagster" object="GraphDefinition" method="execute_in_process" /> method.
+If you want to execute the job in process, instead of using <PyObject module="dagster" object="execute_pipeline" />, you can invoke its <PyObject module="dagster" object="GraphDefinition" method="execute_in_process" /> method.
 
 ```python file=/guides/dagster/graph_job_op/execute_simple_graph.py startafter=start_execute endbefore=end_execute
 do_it_all.execute_in_process()
@@ -84,10 +84,10 @@ def do_it_all():
     do_something()
 ```
 
-With the new APIs, supplying resources to a graph involves building a job from it:
+With the new APIs, resources are supplied directly to a job:
 
 ```python file=/guides/dagster/graph_job_op/graph_with_resources.py
-from dagster import graph, op, resource
+from dagster import job, op, resource
 
 
 @resource
@@ -100,12 +100,9 @@ def do_something():
     ...
 
 
-@graph
+@job(resource_defs={"external_service": external_service})
 def do_it_all():
     do_something()
-
-
-do_it_all_job = do_it_all.to_job(resource_defs={"external_service": external_service})
 ```
 
 ### A pipeline with a test mode
@@ -145,12 +142,12 @@ def test_do_it_all():
     execute_pipeline(do_it_all, mode="test")
 ```
 
-This made it difficult to construct mock resources that were specific to a particular test. It also used string indirection instead of object pointers for referring to the mode (`mode="test"`), which is error-prone. With the new APIs, you can supply those resources at the time you execute the pipeline in the test:
+This made it difficult to construct mock resources that were specific to a particular test. It also used string indirection instead of object pointers for referring to the mode (`mode="test"`), which is error-prone. With the new APIs, you can override the resources to a job at the time you execute:
 
 ```python file=/guides/dagster/graph_job_op/graph_job_test.py
 from unittest.mock import MagicMock
 
-from dagster import graph, op, resource
+from dagster import job, op, resource
 
 
 @resource
@@ -163,16 +160,13 @@ def do_something():
     ...
 
 
-@graph
+@job(resource_defs={"external_service": external_service})
 def do_it_all():
     do_something()
 
 
-do_it_all_job = do_it_all.to_job(resource_defs={"external_service": external_service})
-
-
 def test_do_it_all():
-    do_it_all.execute_in_process(resources={"external_service": MagicMock()})
+    do_it_all.with_resources({"external_service": MagicMock()}).execute_in_process()
 ```
 
 ### A pipeline with prod and dev modes
@@ -221,6 +215,8 @@ These modes typically correspond to different [Dagster Instances](/deployment/da
 With this setup, both modes show up on both instances . This is awkward because, even though the production mode shows up on the development instance, it's not meant to be executed there. And vice versa with the dev mode and the production instance.
 
 With the new APIs, the convention is to include development jobs and production jobs in separate [repositories](/concepts/repositories-workspaces/repositories). Then the [workspace](/concepts/repositories-workspaces/workspaces) for the production instance can point to the repository with the production jobs, and the workspace for the development instance can point to the development jobs.
+
+So that we don't have to re-write the computation graph that underlies each job, we can use the <PyObject object="graph"/> decorator to define the computation graph independently, and then create two different jobs from it using the <PyObject object="GraphDefinition" method="to_job" /> method.
 
 ```python file=/guides/dagster/graph_job_op/prod_dev_jobs.py startafter=start endbefore=end
 @graph
@@ -279,10 +275,10 @@ def do_it_all():
     do_something()
 ```
 
-With the new APIs, you can accomplish this by supplying config when building the job.
+With the new APIs, you can accomplish this by supplying config to the job.
 
 ```python file=/guides/dagster/graph_job_op/graph_with_config.py
-from dagster import graph, op
+from dagster import job, op
 
 
 @op(config_schema={"param": str})
@@ -290,14 +286,12 @@ def do_something(_):
     ...
 
 
-@graph
+default_config = {"ops": {"do_something": {"config": {"param": "some_val"}}}}
+
+
+@job(config=default_config)
 def do_it_all():
     do_something()
-
-
-do_it_all_job = do_it_all.to_job(
-    config={"solids": {"do_something": {"config": {"param": "some_val"}}}}
-)
 ```
 
 Unlike with presets, this config will be used, by default, any time the job is launched, not just when it's launched from the Dagit Playground. I.e. it will also be used when launching the job via a schedule, sensor, `do_it_all_job.execute_in_process` or the GraphQL API. In all these cases, it can instead be overridden with config specified at runtime.
@@ -305,18 +299,21 @@ Unlike with presets, this config will be used, by default, any time the job is l
 Alternatively, you can provide "partial" config via a <PyObject module="dagster" object="ConfigMapping" />.
 
 ```python file=/guides/dagster/graph_job_op/graph_with_config_mapping.py startafter=start endbefore=end
-do_it_all_job = do_it_all.to_job(
-    config=ConfigMapping(
-        config_fn=lambda conf: {"solids": {"do_something": {"config": {"param": conf["arg"]}}}},
-        config_schema={"arg": str},
-    )
+config_mapping = ConfigMapping(
+    config_fn=lambda conf: {"solids": {"do_something": {"config": {"param": conf["arg"]}}}},
+    config_schema={"arg": str},
 )
+
+
+@job(config=config_mapping)
+def do_it_all():
+    do_something()
 ```
 
 Then, when running the job, you only need to supply more compact config:
 
 ```python file=/guides/dagster/graph_job_op/graph_with_config_mapping.py startafter=start_execute endbefore=end_execute
-do_it_all_job.execute_in_process(run_config={"arg": "some_value"})
+do_it_all.execute_in_process(run_config={"arg": "some_value"})
 ```
 
 ## Schedules
@@ -349,10 +346,10 @@ def do_it_all_repository():
     return [do_it_all, do_it_all_schedule]
 ```
 
-With the new APIs, a schedule targets a pipeline by referencing the graph or job object.
+With the new APIs, a schedule targets a job or graph by referencing the job/graph object.
 
 ```python file=/guides/dagster/graph_job_op/graph_with_schedule.py
-from dagster import ScheduleDefinition, graph, op
+from dagster import ScheduleDefinition, job, op
 
 
 @op
@@ -360,7 +357,7 @@ def do_something():
     ...
 
 
-@graph
+@job
 def do_it_all():
     do_something()
 
@@ -368,7 +365,7 @@ def do_it_all():
 do_it_all_schedule = ScheduleDefinition(cron_schedule="0 0 * * *", job=do_it_all)
 ```
 
-This makes it easier to catch errors and makes it possible to reference the graph or job from the schedule.
+This makes it easier to catch errors and makes it possible to reference the job/graph from the schedule.
 
 The same pattern works for sensors.
 
@@ -399,7 +396,7 @@ def do_it_all_schedule(context):
 With the new APIs, you can simply reference the graph or job object:
 
 ```python file=/guides/dagster/graph_job_op/graph_with_schedule_return_config.py
-from dagster import graph, op, schedule
+from dagster import job, op, schedule
 
 
 @op(config_schema={"date": str})
@@ -407,12 +404,12 @@ def do_something(_):
     ...
 
 
-@graph
+@job
 def do_it_all():
     do_something()
 
 
-@schedule(cron_schedule="0 0 * * *", job=do_it_all.to_job(), execution_timezone="US/Central")
+@schedule(cron_schedule="0 0 * * *", job=do_it_all, execution_timezone="US/Central")
 def do_it_all_schedule(context):
     date = context.scheduled_execution_time.strftime("%Y-%m-%d")
     return {"solids": {"do_something": {"config": {"date": date}}}}
@@ -449,7 +446,7 @@ def do_it_all_schedule():
 With the new APIs, you can supply the config in one place (the job), and it will both show up in the Playground and be used by the schedule.
 
 ```python file=/guides/dagster/graph_job_op/graph_with_config_and_schedule.py
-from dagster import ScheduleDefinition, graph, op
+from dagster import ScheduleDefinition, job, op
 
 
 @op(config_schema={"param": str})
@@ -457,15 +454,15 @@ def do_something(_):
     ...
 
 
-@graph
+config = {"solids": {"do_something": {"config": {"param": "some_val"}}}}
+
+
+@job(config=config)
 def do_it_all():
     do_something()
 
 
-do_it_all_schedule = ScheduleDefinition(
-    job=do_it_all.to_job(config={"solids": {"do_something": {"config": {"param": "some_val"}}}}),
-    cron_schedule="0 0 * * *",
-)
+do_it_all_schedule = ScheduleDefinition(job=do_it_all, cron_schedule="0 0 * * *")
 ```
 
 ### Partition Schedules
@@ -500,10 +497,10 @@ def do_it_all_repo():
     return [do_it_all, do_it_all_schedule]
 ```
 
-With the graph APIs, you can first define a partitioning for the job. These partitions exist independently of any schedule, and can be used for backfills. A schedule can then be derived from that partitioning, while providing execution time information. The resulting schedule can be independently passed to a repository, and the underlying job will be inferred.
+With the job APIs, you can first define a graph, and then a job with partitioning. These partitions exist independently of any schedule, and can be used for backfills. A schedule can then be derived from that partitioning, while providing execution time information. The resulting schedule can be independently passed to a repository, and the underlying job will be inferred.
 
 ```python file=/guides/dagster/graph_job_op/graph_with_partition_schedule.py
-from dagster import daily_partitioned_config, graph, op, repository, schedule_from_partitions
+from dagster import daily_partitioned_config, op, repository, schedule_from_partitions, job
 
 
 @op(config_schema={"date": str})
@@ -511,18 +508,17 @@ def do_something_with_config(context):
     return context.op_config["date"]
 
 
-@graph
-def do_it_all():
-    do_something_with_config()
-
-
 @daily_partitioned_config(start_date="2020-01-01")
 def do_it_all_config(start, _end):
     return {"solids": {"do_something_with_config": {"config": {"date": str(start)}}}}
 
 
-do_it_all_job = do_it_all.to_job(config=do_it_all_config)
-do_it_all_schedule = schedule_from_partitions(do_it_all_job)
+@job(config=do_it_all_config)
+def do_it_all():
+    do_something_with_config()
+
+
+do_it_all_schedule = schedule_from_partitions(do_it_all)
 
 
 @repository

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_job_test.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_job_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from dagster import graph, op, resource
+from dagster import job, op, resource
 
 
 @resource
@@ -13,13 +13,10 @@ def do_something():
     ...
 
 
-@graph
+@job(resource_defs={"external_service": external_service})
 def do_it_all():
     do_something()
 
 
-do_it_all_job = do_it_all.to_job(resource_defs={"external_service": external_service})
-
-
 def test_do_it_all():
-    do_it_all.execute_in_process(resources={"external_service": MagicMock()})
+    do_it_all.with_resources({"external_service": MagicMock()}).execute_in_process()

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_config.py
@@ -1,4 +1,4 @@
-from dagster import graph, op
+from dagster import job, op
 
 
 @op(config_schema={"param": str})
@@ -6,11 +6,9 @@ def do_something(_):
     ...
 
 
-@graph
+default_config = {"ops": {"do_something": {"config": {"param": "some_val"}}}}
+
+
+@job(config=default_config)
 def do_it_all():
     do_something()
-
-
-do_it_all_job = do_it_all.to_job(
-    config={"solids": {"do_something": {"config": {"param": "some_val"}}}}
-)

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_config_and_schedule.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_config_and_schedule.py
@@ -1,4 +1,4 @@
-from dagster import ScheduleDefinition, graph, op
+from dagster import ScheduleDefinition, job, op
 
 
 @op(config_schema={"param": str})
@@ -6,12 +6,12 @@ def do_something(_):
     ...
 
 
-@graph
+config = {"solids": {"do_something": {"config": {"param": "some_val"}}}}
+
+
+@job(config=config)
 def do_it_all():
     do_something()
 
 
-do_it_all_schedule = ScheduleDefinition(
-    job=do_it_all.to_job(config={"solids": {"do_something": {"config": {"param": "some_val"}}}}),
-    cron_schedule="0 0 * * *",
-)
+do_it_all_schedule = ScheduleDefinition(job=do_it_all, cron_schedule="0 0 * * *")

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_config_mapping.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_config_mapping.py
@@ -1,4 +1,4 @@
-from dagster import ConfigMapping, graph, op
+from dagster import ConfigMapping, job, op
 
 
 @op(config_schema={"param": str})
@@ -6,22 +6,22 @@ def do_something(_):
     ...
 
 
-@graph
+# start
+config_mapping = ConfigMapping(
+    config_fn=lambda conf: {"solids": {"do_something": {"config": {"param": conf["arg"]}}}},
+    config_schema={"arg": str},
+)
+
+
+@job(config=config_mapping)
 def do_it_all():
     do_something()
 
 
-# start
-do_it_all_job = do_it_all.to_job(
-    config=ConfigMapping(
-        config_fn=lambda conf: {"solids": {"do_something": {"config": {"param": conf["arg"]}}}},
-        config_schema={"arg": str},
-    )
-)
 # end
 
 
 def execute_do_it_all():
     # start_execute
-    do_it_all_job.execute_in_process(run_config={"arg": "some_value"})
+    do_it_all.execute_in_process(run_config={"arg": "some_value"})
     # end_execute

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_partition_schedule.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_partition_schedule.py
@@ -1,4 +1,4 @@
-from dagster import daily_partitioned_config, graph, op, repository, schedule_from_partitions
+from dagster import daily_partitioned_config, op, repository, schedule_from_partitions, job
 
 
 @op(config_schema={"date": str})
@@ -6,18 +6,17 @@ def do_something_with_config(context):
     return context.op_config["date"]
 
 
-@graph
-def do_it_all():
-    do_something_with_config()
-
-
 @daily_partitioned_config(start_date="2020-01-01")
 def do_it_all_config(start, _end):
     return {"solids": {"do_something_with_config": {"config": {"date": str(start)}}}}
 
 
-do_it_all_job = do_it_all.to_job(config=do_it_all_config)
-do_it_all_schedule = schedule_from_partitions(do_it_all_job)
+@job(config=do_it_all_config)
+def do_it_all():
+    do_something_with_config()
+
+
+do_it_all_schedule = schedule_from_partitions(do_it_all)
 
 
 @repository

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_resources.py
@@ -1,4 +1,4 @@
-from dagster import graph, op, resource
+from dagster import job, op, resource
 
 
 @resource
@@ -11,9 +11,6 @@ def do_something():
     ...
 
 
-@graph
+@job(resource_defs={"external_service": external_service})
 def do_it_all():
     do_something()
-
-
-do_it_all_job = do_it_all.to_job(resource_defs={"external_service": external_service})

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_schedule.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_schedule.py
@@ -1,4 +1,4 @@
-from dagster import ScheduleDefinition, graph, op
+from dagster import ScheduleDefinition, job, op
 
 
 @op
@@ -6,7 +6,7 @@ def do_something():
     ...
 
 
-@graph
+@job
 def do_it_all():
     do_something()
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_schedule_return_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/graph_with_schedule_return_config.py
@@ -1,4 +1,4 @@
-from dagster import graph, op, schedule
+from dagster import job, op, schedule
 
 
 @op(config_schema={"date": str})
@@ -6,12 +6,12 @@ def do_something(_):
     ...
 
 
-@graph
+@job
 def do_it_all():
     do_something()
 
 
-@schedule(cron_schedule="0 0 * * *", job=do_it_all.to_job(), execution_timezone="US/Central")
+@schedule(cron_schedule="0 0 * * *", job=do_it_all, execution_timezone="US/Central")
 def do_it_all_schedule(context):
     date = context.scheduled_execution_time.strftime("%Y-%m-%d")
     return {"solids": {"do_something": {"config": {"date": date}}}}

--- a/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/simple_graph.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/graph_job_op/simple_graph.py
@@ -1,4 +1,4 @@
-from dagster import graph, op
+from dagster import job, op
 
 
 @op
@@ -6,6 +6,6 @@ def do_something():
     ...
 
 
-@graph
+@job
 def do_it_all():
     do_something()


### PR DESCRIPTION
This re-tools the migration guide to use `@job`, and de-emphasize graph.

I think the only weird bits here are when config is involved. Specifically, weird that you're kind of defining config in code before you've written your dsl. This is especially weird with the daily_partitioned_config_piece.