### PR TITLE
CLI Migration 1/2

### DIFF
--- a/python_modules/dagster/dagster/cli/__init__.py
+++ b/python_modules/dagster/dagster/cli/__init__.py
@@ -9,6 +9,7 @@ from .api import api_cli
 from .asset import asset_cli
 from .debug import debug_cli
 from .instance import instance_cli
+from .job import job_cli
 from .new_project import new_project_cli
 from .pipeline import pipeline_cli
 from .run import run_cli
@@ -20,6 +21,7 @@ def create_dagster_cli():
     commands = {
         "api": api_cli,
         "pipeline": pipeline_cli,
+        "job": job_cli,
         "run": run_cli,
         "instance": instance_cli,
         "schedule": schedule_cli,

--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -4,11 +4,11 @@ import click
 from dagster import __version__ as dagster_version
 from dagster import check
 from dagster.cli.pipeline import (
+    add_step_to_table,
+    execute_execute_command,
     execute_list_command,
     execute_print_command,
     get_run_config_from_file_list,
-    add_step_to_table,
-    execute_execute_command,
 )
 from dagster.cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,

--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -130,12 +130,12 @@ def execute_list_versions_command(instance, kwargs):
 
     config = list(check.opt_tuple_param(kwargs.get("config"), "config", default=(), of_type=str))
 
-    pipeline_origin = get_pipeline_or_job_python_origin_from_kwargs(kwargs, True)
-    pipeline = recon_pipeline_from_origin(pipeline_origin)
+    job_origin = get_pipeline_or_job_python_origin_from_kwargs(kwargs, True)
+    job = recon_pipeline_from_origin(job_origin)
     run_config = get_run_config_from_file_list(config)
 
     memoized_plan = create_execution_plan(
-        pipeline,
+        job,
         run_config=run_config,
         mode="default",
         instance=instance,

--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -1,0 +1,156 @@
+import os
+import re
+import sys
+import textwrap
+import warnings
+
+import click
+import pendulum
+import yaml
+from dagster import PipelineDefinition
+from dagster import __version__ as dagster_version
+from dagster import check, execute_pipeline
+from dagster.cli.workspace.cli_target import (
+    WORKSPACE_TARGET_WARNING,
+    get_external_pipeline_or_job_from_external_repo,
+    get_external_pipeline_or_job_from_kwargs,
+    get_external_repository_from_kwargs,
+    get_external_repository_from_repo_location,
+    get_pipeline_python_origin_from_kwargs,
+    get_repository_location_from_workspace,
+    get_workspace_from_kwargs,
+    job_target_argument,
+    python_pipeline_or_job_config_argument,
+    python_job_target_argument,
+    repository_target_argument,
+)
+from dagster.core.definitions.pipeline_base import IPipeline
+from dagster.core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
+from dagster.core.execution.api import create_execution_plan
+from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill, create_backfill_run
+from dagster.core.host_representation import (
+    ExternalPipeline,
+    ExternalRepository,
+    RepositoryHandle,
+    RepositoryLocation,
+)
+from dagster.core.host_representation.external_data import ExternalPartitionSetExecutionParamData
+from dagster.core.host_representation.selector import PipelineSelector
+from dagster.core.instance import DagsterInstance
+from dagster.core.instance.config import is_dagster_home_set
+from dagster.core.snap import PipelineSnapshot, SolidInvocationSnap
+from dagster.core.storage.tags import MEMOIZED_RUN_TAG
+from dagster.core.telemetry import log_external_repo_stats, telemetry_wrapper
+from dagster.core.utils import make_new_backfill_id
+from dagster.seven import IS_WINDOWS, JSONDecodeError, json
+from dagster.utils import DEFAULT_WORKSPACE_YAML_FILENAME, load_yaml_from_glob_list, merge_dicts
+from dagster.utils.error import serializable_error_info_from_exc_info
+from dagster.utils.hosted_user_process import recon_pipeline_from_origin
+from dagster.utils.indenting_printer import IndentingPrinter
+from dagster.utils.interrupts import capture_interrupts
+from tabulate import tabulate
+
+from dagster.cli.pipeline import (
+    execute_list_command,
+    execute_print_command,
+    get_run_config_from_file_list,
+    add_step_to_table,
+)
+
+from .config_scaffolder import scaffold_pipeline_config
+
+
+@click.group(name="job")
+def job_cli():
+    """
+    Commands for working with Dagster jobs.
+    """
+
+
+@job_cli.command(
+    name="list",
+    help="List the jobs in a repository. {warning}".format(warning=WORKSPACE_TARGET_WARNING),
+)
+@repository_target_argument
+def job_list_command(**kwargs):
+    return execute_list_command(kwargs, click.echo)
+
+
+def get_job_in_same_python_env_instructions(command_name):
+    return (
+        "This commands targets a job. The job can be specified in a number of ways:"
+        "\n\n1. dagster job {command_name} -f /path/to/file.py -a define_some_job"
+        "\n\n2. dagster job {command_name} -m a_module.submodule -a define_some_job"
+        "\n\n3. dagster job {command_name} -f /path/to/file.py -a define_some_repo -p <<job_name>>"
+        "\n\n4. dagster job {command_name} -m a_module.submodule -a define_some_repo -p <<job_name>>"
+    ).format(command_name=command_name)
+
+
+def get_job_instructions(command_name):
+    return (
+        "This commands targets a job. The job can be specified in a number of ways:"
+        "\n\n1. dagster job {command_name} -p <<job_name>> (works if .{default_filename} exists)"
+        "\n\n2. dagster job {command_name} -p <<job_name>> -w path/to/{default_filename}"
+        "\n\n3. dagster job {command_name} -f /path/to/file.py -a define_some_job"
+        "\n\n4. dagster job {command_name} -m a_module.submodule -a define_some_job"
+        "\n\n5. dagster job {command_name} -f /path/to/file.py -a define_some_repo -p <<job_name>>"
+        "\n\n6. dagster job {command_name} -m a_module.submodule -a define_some_repo -p <<job_name>>"
+    ).format(command_name=command_name, default_filename=DEFAULT_WORKSPACE_YAML_FILENAME)
+
+
+def get_partitioned_job_instructions(command_name):
+    return (
+        "This commands targets a partitioned job. The job and partition set must be "
+        "defined in a repository, which can be specified in a number of ways:"
+        "\n\n1. dagster job {command_name} -p <<job_name>> (works if .{default_filename} exists)"
+        "\n\n2. dagster job {command_name} -p <<job_name>> -w path/to/{default_filename}"
+        "\n\n3. dagster job {command_name} -f /path/to/file.py -a define_some_repo -p <<job_name>>"
+        "\n\n4. dagster job {command_name} -m a_module.submodule -a define_some_repo -p <<job_name>>"
+    ).format(command_name=command_name, default_filename=DEFAULT_WORKSPACE_YAML_FILENAME)
+
+
+@job_cli.command(
+    name="print",
+    help="Print a job.\n\n{instructions}".format(instructions=get_job_instructions("print")),
+)
+@click.option("--verbose", is_flag=True)
+@job_target_argument
+def job_print_command(verbose, **cli_args):
+
+    with DagsterInstance.get() as instance:
+        return execute_print_command(
+            instance, verbose, cli_args, click.echo, using_job_op_graph_apis=True
+        )
+
+
+@job_cli.command(
+    name="list_versions",
+    help="Display the freshness of memoized results for the given job.\n\n{instructions}".format(
+        instructions=get_job_in_same_python_env_instructions("list_versions")
+    ),
+)
+@python_job_target_argument
+@python_pipeline_or_job_config_argument("list_versions", True)
+def job_list_versions_command(**kwargs):
+    with DagsterInstance.get() as instance:
+        execute_list_versions_command(instance, kwargs)
+
+
+def execute_list_versions_command(instance, kwargs):
+    check.inst_param(instance, "instance", DagsterInstance)
+
+    config = list(check.opt_tuple_param(kwargs.get("config"), "config", default=(), of_type=str))
+
+    pipeline_origin = get_pipeline_python_origin_from_kwargs(True, kwargs)
+    pipeline = recon_pipeline_from_origin(pipeline_origin)
+    run_config = get_run_config_from_file_list(config)
+
+    memoized_plan = create_execution_plan(
+        pipeline,
+        run_config=run_config,
+        mode="default",
+        instance=instance,
+        tags={MEMOIZED_RUN_TAG: "true"},
+    )
+
+    add_step_to_table(memoized_plan)

--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -1,55 +1,8 @@
-import os
-import re
-import sys
-import textwrap
 import warnings
 
 import click
-import pendulum
-import yaml
-from dagster import PipelineDefinition
 from dagster import __version__ as dagster_version
-from dagster import check, execute_pipeline
-from dagster.cli.workspace.cli_target import (
-    WORKSPACE_TARGET_WARNING,
-    get_external_pipeline_or_job_from_external_repo,
-    get_external_pipeline_or_job_from_kwargs,
-    get_external_repository_from_kwargs,
-    get_external_repository_from_repo_location,
-    get_pipeline_or_job_python_origin_from_kwargs,
-    get_repository_location_from_workspace,
-    get_workspace_from_kwargs,
-    job_target_argument,
-    python_pipeline_or_job_config_argument,
-    python_job_target_argument,
-    repository_target_argument,
-)
-from dagster.core.definitions.pipeline_base import IPipeline
-from dagster.core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
-from dagster.core.execution.api import create_execution_plan
-from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill, create_backfill_run
-from dagster.core.host_representation import (
-    ExternalPipeline,
-    ExternalRepository,
-    RepositoryHandle,
-    RepositoryLocation,
-)
-from dagster.core.host_representation.external_data import ExternalPartitionSetExecutionParamData
-from dagster.core.host_representation.selector import PipelineSelector
-from dagster.core.instance import DagsterInstance
-from dagster.core.instance.config import is_dagster_home_set
-from dagster.core.snap import PipelineSnapshot, SolidInvocationSnap
-from dagster.core.storage.tags import MEMOIZED_RUN_TAG
-from dagster.core.telemetry import log_external_repo_stats, telemetry_wrapper
-from dagster.core.utils import make_new_backfill_id
-from dagster.seven import IS_WINDOWS, JSONDecodeError, json
-from dagster.utils import DEFAULT_WORKSPACE_YAML_FILENAME, load_yaml_from_glob_list, merge_dicts
-from dagster.utils.error import serializable_error_info_from_exc_info
-from dagster.utils.hosted_user_process import recon_pipeline_from_origin
-from dagster.utils.indenting_printer import IndentingPrinter
-from dagster.utils.interrupts import capture_interrupts
-from tabulate import tabulate
-
+from dagster import check
 from dagster.cli.pipeline import (
     execute_list_command,
     execute_print_command,
@@ -57,8 +10,21 @@ from dagster.cli.pipeline import (
     add_step_to_table,
     execute_execute_command,
 )
-
-from .config_scaffolder import scaffold_pipeline_config
+from dagster.cli.workspace.cli_target import (
+    WORKSPACE_TARGET_WARNING,
+    get_pipeline_or_job_python_origin_from_kwargs,
+    job_target_argument,
+    python_job_target_argument,
+    python_pipeline_or_job_config_argument,
+    repository_target_argument,
+)
+from dagster.core.execution.api import create_execution_plan
+from dagster.core.instance import DagsterInstance
+from dagster.core.instance.config import is_dagster_home_set
+from dagster.core.storage.tags import MEMOIZED_RUN_TAG
+from dagster.utils import DEFAULT_WORKSPACE_YAML_FILENAME
+from dagster.utils.hosted_user_process import recon_pipeline_from_origin
+from dagster.utils.interrupts import capture_interrupts
 
 
 @click.group(name="job")

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -12,15 +12,15 @@ from dagster import __version__ as dagster_version
 from dagster import check, execute_pipeline
 from dagster.cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
-    get_external_pipeline_from_external_repo,
-    get_external_pipeline_from_kwargs,
+    get_external_pipeline_or_job_from_external_repo,
+    get_external_pipeline_or_job_from_kwargs,
     get_external_repository_from_kwargs,
     get_external_repository_from_repo_location,
     get_pipeline_python_origin_from_kwargs,
     get_repository_location_from_workspace,
     get_workspace_from_kwargs,
     pipeline_target_argument,
-    python_pipeline_config_argument,
+    python_pipeline_or_job_config_argument,
     python_pipeline_target_argument,
     repository_target_argument,
 )
@@ -153,45 +153,56 @@ def get_partitioned_pipeline_instructions(command_name):
 @pipeline_target_argument
 def pipeline_print_command(verbose, **cli_args):
     with DagsterInstance.get() as instance:
-        return execute_print_command(instance, verbose, cli_args, click.echo)
+        return execute_print_command(instance, verbose, cli_args, click.echo, False)
 
 
-def execute_print_command(instance, verbose, cli_args, print_fn):
-    with get_external_pipeline_from_kwargs(
-        instance, version=dagster_version, kwargs=cli_args
+def execute_print_command(instance, verbose, cli_args, print_fn, using_job_op_graph_apis):
+    with get_external_pipeline_or_job_from_kwargs(
+        instance,
+        version=dagster_version,
+        using_job_op_graph_apis=using_job_op_graph_apis,
+        kwargs=cli_args,
     ) as external_pipeline:
         pipeline_snapshot = external_pipeline.pipeline_snapshot
 
         if verbose:
-            print_pipeline(pipeline_snapshot, print_fn=print_fn)
+            print_pipeline_or_job(
+                pipeline_snapshot,
+                print_fn=print_fn,
+                using_job_op_graph_apis=using_job_op_graph_apis,
+            )
         else:
-            print_solids(pipeline_snapshot, print_fn=print_fn)
+            print_solids_or_ops(
+                pipeline_snapshot,
+                print_fn=print_fn,
+                using_job_op_graph_apis=using_job_op_graph_apis,
+            )
 
 
-def print_solids(pipeline_snapshot, print_fn):
+def print_solids_or_ops(pipeline_snapshot, print_fn, using_job_op_graph_apis):
     check.inst_param(pipeline_snapshot, "pipeline", PipelineSnapshot)
     check.callable_param(print_fn, "print_fn")
 
     printer = IndentingPrinter(indent_level=2, printer=print_fn)
-    printer.line("Pipeline: {name}".format(name=pipeline_snapshot.name))
+    printer.line(f"{'Job' if using_job_op_graph_apis else 'Pipeline'}: {pipeline_snapshot.name}")
 
-    printer.line("Solids:")
+    printer.line(f"{'Ops' if using_job_op_graph_apis else 'Solids'}")
     for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
         with printer.with_indent():
-            printer.line("Solid: {name}".format(name=solid.solid_name))
+            printer.line(f"{'Op' if using_job_op_graph_apis else 'Solid'}: {solid.solid_name}")
 
 
-def print_pipeline(pipeline_snapshot, print_fn):
+def print_pipeline_or_job(pipeline_snapshot, print_fn, using_job_op_graph_apis):
     check.inst_param(pipeline_snapshot, "pipeline", PipelineSnapshot)
     check.callable_param(print_fn, "print_fn")
     printer = IndentingPrinter(indent_level=2, printer=print_fn)
-    printer.line("Pipeline: {name}".format(name=pipeline_snapshot.name))
+    printer.line(f"{'Job' if using_job_op_graph_apis else 'Pipeline'}: {pipeline_snapshot.name}")
     print_description(printer, pipeline_snapshot.description)
 
-    printer.line("Solids:")
+    printer.line(f"{'Ops' if using_job_op_graph_apis else 'Solids'}")
     for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
         with printer.with_indent():
-            print_solid(printer, pipeline_snapshot, solid)
+            print_solid_or_op(printer, pipeline_snapshot, solid, using_job_op_graph_apis)
 
 
 def print_description(printer, desc):
@@ -202,10 +213,12 @@ def print_description(printer, desc):
                 printer.line(format_description(desc, printer.current_indent_str))
 
 
-def print_solid(printer, pipeline_snapshot, solid_invocation_snap):
+def print_solid_or_op(printer, pipeline_snapshot, solid_invocation_snap, using_job_op_graph_apis):
     check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
     check.inst_param(solid_invocation_snap, "solid_invocation_snap", SolidInvocationSnap)
-    printer.line("Solid: {name}".format(name=solid_invocation_snap.solid_name))
+    printer.line(
+        f"{'Op' if using_job_op_graph_apis else 'Solid'}: {solid_invocation_snap.solid_name}"
+    )
     with printer.with_indent():
         printer.line("Inputs:")
         for input_dep_snap in solid_invocation_snap.input_dep_snaps:
@@ -226,7 +239,7 @@ def print_solid(printer, pipeline_snapshot, solid_invocation_snap):
     ),
 )
 @python_pipeline_target_argument
-@python_pipeline_config_argument("list_versions")
+@python_pipeline_or_job_config_argument("list_versions", False)
 @click.option(
     "--preset",
     type=click.STRING,
@@ -251,7 +264,7 @@ def execute_list_versions_command(instance, kwargs):
     if preset and config:
         raise click.UsageError("Can not use --preset with --config.")
 
-    pipeline_origin = get_pipeline_python_origin_from_kwargs(kwargs)
+    pipeline_origin = get_pipeline_python_origin_from_kwargs(False, kwargs)
     pipeline = recon_pipeline_from_origin(pipeline_origin)
     run_config = get_run_config_from_file_list(config)
 
@@ -262,7 +275,10 @@ def execute_list_versions_command(instance, kwargs):
         instance=instance,
         tags={MEMOIZED_RUN_TAG: "true"},
     )
+    add_step_to_table(memoized_plan)
 
+
+def add_step_to_table(memoized_plan):
     # the step keys that we need to execute are those which do not have their inputs populated.
     step_keys_not_stored = set(memoized_plan.step_keys_to_execute)
     table = []
@@ -291,7 +307,7 @@ def execute_list_versions_command(instance, kwargs):
     ),
 )
 @python_pipeline_target_argument
-@python_pipeline_config_argument("execute")
+@python_pipeline_or_job_config_argument("execute", False)
 @click.option(
     "--preset",
     type=click.STRING,
@@ -342,7 +358,7 @@ def execute_execute_command(instance, kwargs):
 
     tags = get_tags_from_args(kwargs)
 
-    pipeline_origin = get_pipeline_python_origin_from_kwargs(kwargs)
+    pipeline_origin = get_pipeline_python_origin_from_kwargs(False, kwargs)
     pipeline = recon_pipeline_from_origin(pipeline_origin)
     solid_selection = get_solid_selection_from_args(kwargs)
     result = do_execute_command(pipeline, instance, config, mode, tags, solid_selection, preset)
@@ -554,7 +570,7 @@ def do_execute_command(
     ),
 )
 @pipeline_target_argument
-@python_pipeline_config_argument("launch")
+@python_pipeline_or_job_config_argument("launch", False)
 @click.option(
     "--config-json",
     type=click.STRING,
@@ -603,8 +619,8 @@ def execute_launch_command(instance, kwargs):
         external_repo = get_external_repository_from_repo_location(
             repo_location, kwargs.get("repository")
         )
-        external_pipeline = get_external_pipeline_from_external_repo(
-            external_repo, kwargs.get("pipeline")
+        external_pipeline = get_external_pipeline_or_job_from_external_repo(
+            external_repo, kwargs.get("pipeline"), False
         )
 
         log_external_repo_stats(
@@ -650,8 +666,8 @@ def pipeline_scaffold_command(**kwargs):
 
 
 def execute_scaffold_command(cli_args, print_fn):
-    pipeline_origih = get_pipeline_python_origin_from_kwargs(cli_args)
-    pipeline = recon_pipeline_from_origin(pipeline_origih)
+    pipeline_origin = get_pipeline_python_origin_from_kwargs(False, cli_args)
+    pipeline = recon_pipeline_from_origin(pipeline_origin)
     skip_non_required = cli_args["print_only_required"]
     do_scaffold_command(pipeline.get_definition(), print_fn, skip_non_required)
 
@@ -841,9 +857,8 @@ def _execute_backfill_command_at_location(cli_args, print_fn, instance, workspac
         repo_location, cli_args.get("repository")
     )
 
-    external_pipeline = get_external_pipeline_from_external_repo(
-        external_repo,
-        cli_args.get("pipeline"),
+    external_pipeline = get_external_pipeline_or_job_from_external_repo(
+        external_repo, cli_args.get("pipeline"), False
     )
 
     noprompt = cli_args.get("noprompt")

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -626,8 +626,6 @@ def execute_launch_command(instance, kwargs):
         external_repo = get_external_repository_from_repo_location(
             repo_location, kwargs.get("repository")
         )
-        print("whyy")
-        print(kwargs)
         external_pipeline = get_external_pipeline_or_job_from_external_repo(
             external_repo, kwargs.get("pipeline_or_job")
         )

--- a/python_modules/dagster/dagster/cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/cli/workspace/cli_target.py
@@ -308,14 +308,16 @@ def target_with_config_option(command_name, using_job_op_graph_apis):
             "files at the key-level granularity. If the file is a pattern then you must "
             "enclose it in double quotes"
             "\n\nExample: "
-            "dagster {pipeline_or_job} {name} -f hello_world.py -p pandas_hello_world "
+            "dagster {pipeline_or_job} {name} -f hello_world.py {pipeline_or_job_flag} pandas_hello_world "
             '-c "pandas_hello_world/*.yaml"'
             "\n\nYou can also specify multiple files:"
             "\n\nExample: "
-            "dagster {pipeline_or_job} {name} -f hello_world.py -p pandas_hello_world "
+            "dagster {pipeline_or_job} {name} -f hello_world.py {pipeline_or_job_flag} pandas_hello_world "
             "-c pandas_hello_world/solids.yaml -c pandas_hello_world/env.yaml"
         ).format(
-            name=command_name, pipeline_or_job="job" if using_job_op_graph_apis else "pipeline"
+            name=command_name,
+            pipeline_or_job="job" if using_job_op_graph_apis else "pipeline",
+            pipeline_or_job_flag="-j" if using_job_op_graph_apis else "-p",
         ),
     )
 
@@ -439,7 +441,6 @@ def get_pipeline_or_job_python_origin_from_kwargs(kwargs, using_job_op_graph_api
                 'Pipeline/Job "{provided_pipeline_name}" not found in repository "{repository_name}". '
                 "Found {found_names} instead."
             ).format(
-                pipeline_or_job="Job" if using_job_op_graph_apis else "Pipeline",
                 provided_pipeline_name=provided_pipeline_name,
                 repository_name=repo_definition.name,
                 found_names=_sorted_quoted(pipeline_names),
@@ -661,7 +662,7 @@ def get_external_pipeline_or_job_from_external_repo(
     if provided_pipeline_or_job_name is None:
         raise click.UsageError(
             (
-                "Must provide {flag} as there is more than one pipeline "
+                "Must provide {flag} as there is more than one pipeline/job "
                 "in {repository}. Options are: {pipelines}."
             ).format(
                 flag='--job' if using_job_op_graph_apis else '--pipeline',

--- a/python_modules/dagster/dagster/cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/cli/workspace/cli_target.py
@@ -665,7 +665,7 @@ def get_external_pipeline_or_job_from_external_repo(
                 "Must provide {flag} as there is more than one pipeline/job "
                 "in {repository}. Options are: {pipelines}."
             ).format(
-                flag='--job' if using_job_op_graph_apis else '--pipeline',
+                flag="--job" if using_job_op_graph_apis else "--pipeline",
                 repository=external_repo.name,
                 pipelines=_sorted_quoted(external_pipelines.keys()),
             )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/file_with_local_import.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/file_with_local_import.py
@@ -1,4 +1,5 @@
 import dummy_local_file  # pylint:disable=import-error,unused-import
 from dagster_tests.cli_tests.command_tests.test_cli_commands import (  # pylint:disable=unused-import
     foo_pipeline,
+    qux_job,
 )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -16,12 +16,17 @@ from dagster import (
     ScheduleDefinition,
     execute_pipeline,
     lambda_solid,
+    op,
     pipeline,
     repository,
     solid,
     graph,
+    Output,
+    String,
+    Out,
 )
 from dagster.cli import ENV_PREFIX, cli
+from dagster.cli.job import job_execute_command
 from dagster.cli.pipeline import pipeline_execute_command
 from dagster.cli.run import run_delete_command, run_list_command, run_wipe_command
 from dagster.core.definitions.decorators.sensor import sensor
@@ -199,6 +204,50 @@ def stderr_pipeline():
     fail()
 
 
+@op
+def spew_op(context):
+    context.log.info("SPEW OP")
+
+
+@op
+def fail_op(context):
+    raise Exception("FAILURE OP")
+
+
+@graph
+def my_stdout():
+    spew_op()
+
+
+@graph
+def my_stderr():
+    fail_op()
+
+
+@op(
+    out={"out_1": Out(String), "out_2": Out(String)},
+)
+def root(context):
+    yield Output("foo", "out_1")
+    yield Output("bar", "out_2")
+
+
+@op
+def branch_op(context, value):
+    pass
+
+
+@graph
+def multiproc():
+    out_1, out_2 = root()
+    branch_op(out_1)
+    branch_op(out_2)
+
+
+# default executor_def is multiproc
+multiproc_job = multiproc.to_job()
+
+
 @contextmanager
 def _default_cli_test_instance_tempdir(temp_dir, overrides=None):
     default_overrides = {
@@ -245,7 +294,7 @@ def grpc_server_bar_kwargs(pipeline_name=None):
     with server_process.create_ephemeral_client() as client:
         args = {"grpc_host": client.host}
         if pipeline_name:
-            args["pipeline"] = "foo"
+            args["pipeline_or_job"] = "foo"
         if client.port:
             args["grpc_port"] = client.port
         if client.socket:
@@ -308,10 +357,10 @@ def launch_command_contexts():
     yield pytest.param(grpc_server_bar_pipeline_args())
 
 
-def pipeline_python_origin_contexts():
+def pipeline_or_job_python_origin_contexts(using_job_op_graph_apis=False):
     return [
-        args_with_default_cli_test_instance(pipeline_target_args)
-        for pipeline_target_args in valid_pipeline_python_origin_target_args()
+        args_with_default_cli_test_instance(target_args)
+        for target_args in valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis)
     ]
 
 
@@ -385,25 +434,30 @@ def grpc_server_backfill_args():
 def non_existant_python_origin_target_args():
     return {
         "workspace": None,
-        "pipeline": "foo",
+        "pipeline_or_job": "foo",
         "python_file": file_relative_path(__file__, "made_up_file.py"),
         "module_name": None,
         "attribute": "bar",
     }
 
 
-def valid_pipeline_python_origin_target_args():
+def valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis=False):
+    pipeline_or_job_name = 'qux' if using_job_op_graph_apis else 'foo'
+    pipeline_or_job_fn_name = 'qux_job' if using_job_op_graph_apis else 'foo_pipeline'
+    pipeline_or_job_def_name = (
+        'define_qux_job' if using_job_op_graph_apis else 'define_foo_pipeline'
+    )
     return [
         {
             "workspace": None,
-            "pipeline": "foo",
+            "pipeline_or_job": pipeline_or_job_name,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
             "attribute": "bar",
         },
         {
             "workspace": None,
-            "pipeline": "foo",
+            "pipeline_or_job": pipeline_or_job_name,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
             "attribute": "bar",
@@ -411,53 +465,53 @@ def valid_pipeline_python_origin_target_args():
         },
         {
             "workspace": None,
-            "pipeline": "foo",
+            "pipeline_or_job": pipeline_or_job_name,
             "python_file": None,
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
         },
         {
             "workspace": None,
-            "pipeline": "foo",
+            "pipeline_or_job": pipeline_or_job_name,
             "python_file": None,
             "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
         },
         {
             "workspace": None,
-            "pipeline": None,
+            "pipeline_or_job": None,
             "python_file": None,
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": "foo_pipeline",
+            "attribute": pipeline_or_job_fn_name,
         },
         {
             "workspace": None,
-            "pipeline": None,
+            "pipeline_or_job": None,
             "python_file": None,
             "package_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
-            "attribute": "foo_pipeline",
+            "attribute": pipeline_or_job_fn_name,
         },
         {
             "workspace": None,
-            "pipeline": None,
+            "pipeline_or_job": None,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
-            "attribute": "define_foo_pipeline",
+            "attribute": pipeline_or_job_def_name,
         },
         {
             "workspace": None,
-            "pipeline": None,
+            "pipeline_or_job": None,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
-            "attribute": "define_foo_pipeline",
+            "attribute": pipeline_or_job_def_name,
             "working_directory": os.path.dirname(__file__),
         },
         {
             "workspace": None,
-            "pipeline": None,
+            "pipeline_or_job": None,
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": None,
-            "attribute": "foo_pipeline",
+            "attribute": pipeline_or_job_fn_name,
         },
     ]
 
@@ -466,19 +520,19 @@ def valid_external_pipeline_target_args():
     return [
         {
             "workspace": (file_relative_path(__file__, "repository_file.yaml"),),
-            "pipeline": "foo",
+            "pipeline_or_job": "foo",
             "python_file": None,
             "module_name": None,
             "attribute": None,
         },
         {
             "workspace": (file_relative_path(__file__, "repository_module.yaml"),),
-            "pipeline": "foo",
+            "pipeline_or_job": "foo",
             "python_file": None,
             "module_name": None,
             "attribute": None,
         },
-    ] + [args for args in valid_pipeline_python_origin_target_args()]
+    ] + [args for args in valid_pipeline_or_job_python_origin_target_args()]
 
 
 def valid_pipeline_python_origin_target_cli_args():
@@ -689,7 +743,7 @@ def test_run_list_limit():
     with instance_for_test():
         runner = CliRunner()
 
-        runner_pipeline_execute(
+        runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -703,7 +757,7 @@ def test_run_list_limit():
             ],
         )
 
-        runner_pipeline_execute(
+        runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -736,17 +790,23 @@ def test_run_list_limit():
         assert shows_two_results.output.count("Pipeline: multi_mode_with_resources") == 2
 
 
-def runner_pipeline_execute(runner, cli_args):
-    result = runner.invoke(pipeline_execute_command, cli_args)
+def runner_pipeline_or_job_execute(runner, cli_args, using_job_op_graph_apis=False):
+    result = runner.invoke(
+        job_execute_command if using_job_op_graph_apis else pipeline_execute_command, cli_args
+    )
     if result.exit_code != 0:
         # CliRunner captures stdout so printing it out here
         raise Exception(
             (
-                "dagster pipeline execute commands with cli_args {cli_args} "
+                "dagster {pipeline_or_job} execute commands with cli_args {cli_args} "
                 'returned exit_code {exit_code} with stdout:\n"{stdout}" and '
                 '\nresult as string: "{result}"'
             ).format(
-                cli_args=cli_args, exit_code=result.exit_code, stdout=result.stdout, result=result
+                cli_args=cli_args,
+                exit_code=result.exit_code,
+                stdout=result.stdout,
+                result=result,
+                pipeline_or_job="job" if using_job_op_graph_apis else "pipeline",
             )
         )
     return result

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -10,20 +10,20 @@ import pytest
 from click.testing import CliRunner
 from dagster import (
     ModeDefinition,
+    Out,
+    Output,
     Partition,
     PartitionSetDefinition,
     PresetDefinition,
     ScheduleDefinition,
+    String,
     execute_pipeline,
+    graph,
     lambda_solid,
     op,
     pipeline,
     repository,
     solid,
-    graph,
-    Output,
-    String,
-    Out,
 )
 from dagster.cli import ENV_PREFIX, cli
 from dagster.cli.job import job_execute_command
@@ -442,10 +442,10 @@ def non_existant_python_origin_target_args():
 
 
 def valid_pipeline_or_job_python_origin_target_args(using_job_op_graph_apis=False):
-    pipeline_or_job_name = 'qux' if using_job_op_graph_apis else 'foo'
-    pipeline_or_job_fn_name = 'qux_job' if using_job_op_graph_apis else 'foo_pipeline'
+    pipeline_or_job_name = "qux" if using_job_op_graph_apis else "foo"
+    pipeline_or_job_fn_name = "qux_job" if using_job_op_graph_apis else "foo_pipeline"
     pipeline_or_job_def_name = (
-        'define_qux_job' if using_job_op_graph_apis else 'define_foo_pipeline'
+        "define_qux_job" if using_job_op_graph_apis else "define_foo_pipeline"
     )
     return [
         {

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -92,7 +92,6 @@ def test_empty_execute_command():
         assert result.exit_code == 2
         assert "Must specify a python file or module name" in result.output
 
-        runner = CliRunner()
         result = runner.invoke(job_execute_command, [])
         assert result.exit_code == 2
         assert "Must specify a python file or module name" in result.output
@@ -280,6 +279,22 @@ def test_more_than_one_pipeline_or_job():
                     "attribute": None,
                 },
                 instance=instance,
+            )
+
+        with pytest.raises(
+            UsageError,
+            match=re.escape("Must provide --job as there is more than one pipeline/job in bar. "),
+        ):
+            execute_execute_command(
+                kwargs={
+                    "repository_yaml": None,
+                    "pipeline_or_job": None,
+                    "python_file": file_relative_path(__file__, "test_cli_commands.py"),
+                    "module_name": None,
+                    "attribute": None,
+                },
+                instance=instance,
+                using_job_op_graph_apis=True,
             )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -5,6 +5,7 @@ import click
 import pytest
 from click import UsageError
 from click.testing import CliRunner
+from dagster.cli.job import job_execute_command
 from dagster.cli.pipeline import execute_execute_command, pipeline_execute_command
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.test_utils import instance_for_test, new_cwd
@@ -12,8 +13,10 @@ from dagster.utils import file_relative_path, merge_dicts
 
 from .test_cli_commands import (
     non_existant_python_origin_target_args,
-    pipeline_python_origin_contexts,
+    pipeline_or_job_python_origin_contexts,
     valid_pipeline_python_origin_target_cli_args,
+    valid_job_python_origin_target_cli_args,
+    runner_pipeline_or_job_execute,
 )
 
 
@@ -21,7 +24,7 @@ def test_execute_mode_command():
     runner = CliRunner()
 
     with instance_for_test():
-        add_result = runner_pipeline_execute(
+        add_result = runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -41,7 +44,7 @@ def test_execute_mode_command():
 
         assert add_result
 
-        mult_result = runner_pipeline_execute(
+        mult_result = runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -61,7 +64,7 @@ def test_execute_mode_command():
 
         assert mult_result
 
-        double_adder_result = runner_pipeline_execute(
+        double_adder_result = runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -89,11 +92,16 @@ def test_empty_execute_command():
         assert result.exit_code == 2
         assert "Must specify a python file or module name" in result.output
 
+        runner = CliRunner()
+        result = runner.invoke(job_execute_command, [])
+        assert result.exit_code == 2
+        assert "Must specify a python file or module name" in result.output
+
 
 def test_execute_preset_command():
     with instance_for_test():
         runner = CliRunner()
-        add_result = runner_pipeline_execute(
+        add_result = runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -130,13 +138,19 @@ def test_execute_preset_command():
         assert bad_res.exit_code == 2
 
 
-@pytest.mark.parametrize("gen_execute_args", pipeline_python_origin_contexts())
+@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts())
 def test_execute_command_no_env(gen_execute_args):
     with gen_execute_args as (cli_args, instance):
         execute_execute_command(kwargs=cli_args, instance=instance)
 
 
-@pytest.mark.parametrize("gen_execute_args", pipeline_python_origin_contexts())
+@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts(True))
+def test_job_execute_command_no_env(gen_execute_args):
+    with gen_execute_args as (cli_args, instance):
+        execute_execute_command(kwargs=cli_args, instance=instance, using_job_op_graph_apis=True)
+
+
+@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts())
 def test_execute_command_env(gen_execute_args):
     with gen_execute_args as (cli_args, instance):
         kwargs = merge_dicts(
@@ -149,15 +163,38 @@ def test_execute_command_env(gen_execute_args):
         )
 
 
+@pytest.mark.parametrize("gen_execute_args", pipeline_or_job_python_origin_contexts(True))
+def test_job_execute_command_env(gen_execute_args):
+    with gen_execute_args as (cli_args, instance):
+        kwargs = merge_dicts(
+            {"config": (file_relative_path(__file__, "default_log_error_env.yaml"),)},
+            cli_args,
+        )
+        execute_execute_command(kwargs=kwargs, instance=instance, using_job_op_graph_apis=True)
+
+
 @pytest.mark.parametrize("cli_args", valid_pipeline_python_origin_target_cli_args())
 def test_execute_command_runner(cli_args):
     runner = CliRunner()
     with instance_for_test():
-        runner_pipeline_execute(runner, cli_args)
+        runner_pipeline_or_job_execute(runner, cli_args)
 
-        runner_pipeline_execute(
+        runner_pipeline_or_job_execute(
             runner,
             ["--config", file_relative_path(__file__, "default_log_error_env.yaml")] + cli_args,
+        )
+
+
+@pytest.mark.parametrize("cli_args", valid_job_python_origin_target_cli_args())
+def test_job_execute_command_runner(cli_args):
+    runner = CliRunner()
+    with instance_for_test():
+        runner_pipeline_or_job_execute(runner, cli_args, True)
+
+        runner_pipeline_or_job_execute(
+            runner,
+            ["--config", file_relative_path(__file__, "default_log_error_env.yaml")] + cli_args,
+            True,
         )
 
 
@@ -182,6 +219,17 @@ def test_output_execute_log_stdout(capfd):
         # All pipeline execute output currently logged to stderr
         assert "HELLO WORLD" in captured.err
 
+        execute_execute_command(
+            kwargs={
+                "python_file": file_relative_path(__file__, "test_cli_commands.py"),
+                "attribute": "my_stdout",
+            },
+            instance=instance,
+        )
+
+        captured = capfd.readouterr()
+        assert "SPEW OP" in captured.err
+
 
 def test_output_execute_log_stderr(capfd):
     with instance_for_test(
@@ -203,17 +251,30 @@ def test_output_execute_log_stderr(capfd):
         captured = capfd.readouterr()
         assert "I AM SUPPOSED TO FAIL" in captured.err
 
+        with pytest.raises(click.ClickException, match=re.escape("resulted in failure")):
+            execute_execute_command(
+                kwargs={
+                    "python_file": file_relative_path(__file__, "test_cli_commands.py"),
+                    "attribute": "my_stderr",
+                },
+                instance=instance,
+            )
+        captured = capfd.readouterr()
+        assert "FAILURE OP" in captured.err
 
-def test_more_than_one_pipeline():
+
+def test_more_than_one_pipeline_or_job():
     with instance_for_test() as instance:
         with pytest.raises(
             UsageError,
-            match=re.escape("Must provide --pipeline as there is more than one pipeline in bar. "),
+            match=re.escape(
+                "Must provide --pipeline as there is more than one pipeline/job in bar. "
+            ),
         ):
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline": None,
+                    "pipeline_or_job": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": None,
@@ -225,19 +286,19 @@ def test_more_than_one_pipeline():
 def invalid_pipeline_python_origin_target_args():
     return [
         {
-            "pipeline": "foo",
+            "pipeline_or_job": "foo",
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": "bar",
         },
         {
-            "pipeline": "foo",
+            "pipeline_or_job": "foo",
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
             "attribute": None,
         },
         {
-            "pipeline": "foo",
+            "pipeline_or_job": "foo",
             "python_file": None,
             "working_directory": os.path.dirname(__file__),
             "module_name": "dagster_tests.cli_tests.command_tests.test_cli_commands",
@@ -276,7 +337,7 @@ def test_attribute_not_found():
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline": None,
+                    "pipeline_or_job": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": "nope",
@@ -297,7 +358,7 @@ def test_attribute_is_wrong_thing():
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline": None,
+                    "pipeline_or_job": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": "not_a_repo_or_pipeline",
@@ -318,7 +379,7 @@ def test_attribute_fn_returns_wrong_thing():
             execute_execute_command(
                 kwargs={
                     "repository_yaml": None,
-                    "pipeline": None,
+                    "pipeline_or_job": None,
                     "python_file": file_relative_path(__file__, "test_cli_commands.py"),
                     "module_name": None,
                     "attribute": "not_a_repo_or_pipeline_fn",
@@ -327,31 +388,26 @@ def test_attribute_fn_returns_wrong_thing():
             )
 
 
-def runner_pipeline_execute(runner, cli_args):
-    result = runner.invoke(pipeline_execute_command, cli_args)
-    if result.exit_code != 0:
-        # CliRunner captures stdout so printing it out here
-        raise Exception(
-            (
-                "dagster pipeline execute commands with cli_args {cli_args} "
-                'returned exit_code {exit_code} with stdout:\n"{stdout}" and '
-                '\nresult as string: "{result}"'
-            ).format(
-                cli_args=cli_args, exit_code=result.exit_code, stdout=result.stdout, result=result
-            )
-        )
-    return result
-
-
 def test_default_memory_run_storage():
     with instance_for_test() as instance:
         cli_args = {
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "atribute": "bar",
-            "pipeline": "foo",
+            "attribute": "bar",
+            "pipeline_or_job": "foo",
             "module_name": None,
         }
         result = execute_execute_command(kwargs=cli_args, instance=instance)
+        assert result.success
+
+        cli_args = {
+            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
+            "attribute": "bar",
+            "pipeline_or_job": "qux",
+            "module_name": None,
+        }
+        result = execute_execute_command(
+            kwargs=cli_args, instance=instance, using_job_op_graph_apis=True
+        )
         assert result.success
 
 
@@ -359,8 +415,8 @@ def test_override_with_in_memory_storage():
     with instance_for_test() as instance:
         cli_args = {
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "atribute": "bar",
-            "pipeline": "foo",
+            "attribute": "bar",
+            "pipeline_or_job": "foo",
             "module_name": None,
             "config": (file_relative_path(__file__, "in_memory_env.yaml"),),
         }
@@ -370,13 +426,27 @@ def test_override_with_in_memory_storage():
         )
         assert result.success
 
+        cli_args = {
+            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
+            "attribute": "bar",
+            "pipeline_or_job": "qux",
+            "module_name": None,
+            "config": (file_relative_path(__file__, "in_memory_env.yaml"),),
+        }
+        result = execute_execute_command(
+            kwargs=cli_args,
+            instance=instance,
+            using_job_op_graph_apis=True,
+        )
+        assert result.success
+
 
 def test_override_with_filesystem_storage():
     with instance_for_test() as instance:
         cli_args = {
             "python_file": file_relative_path(__file__, "test_cli_commands.py"),
-            "atribute": "bar",
-            "pipeline": "foo",
+            "attribute": "bar",
+            "pipeline_or_job": "foo",
             "module_name": None,
             "config": (file_relative_path(__file__, "filesystem_env.yaml"),),
         }
@@ -386,11 +456,24 @@ def test_override_with_filesystem_storage():
         )
         assert result.success
 
+        cli_args = {
+            "python_file": file_relative_path(__file__, "test_cli_commands.py"),
+            "attribute": "bar",
+            "pipeline_or_job": "qux",
+            "module_name": None,
+        }
+        result = execute_execute_command(
+            kwargs=cli_args,
+            instance=instance,
+            using_job_op_graph_apis=True,
+        )
+        assert result.success
+
 
 def test_multiproc():
     with instance_for_test():
         runner = CliRunner()
-        add_result = runner_pipeline_execute(
+        add_result = runner_pipeline_or_job_execute(
             runner,
             [
                 "-f",
@@ -402,6 +485,20 @@ def test_multiproc():
                 "-p",
                 "multi_mode_with_resources",  # pipeline name
             ],
+        )
+        assert add_result.exit_code == 0
+
+        assert "PIPELINE_SUCCESS" in add_result.output
+
+        add_result = runner_pipeline_or_job_execute(
+            runner,
+            [
+                "-f",
+                file_relative_path(__file__, "test_cli_commands.py"),
+                "-a",
+                "multiproc",
+            ],
+            True,
         )
         assert add_result.exit_code == 0
 
@@ -429,7 +526,7 @@ def test_multiproc_invalid():
     assert "DagsterUnmetExecutorRequirementsError" in add_result.output
 
 
-def test_tags_pipeline():
+def test_tags_pipeline_or_job():
     runner = CliRunner()
     with instance_for_test() as instance:
         result = runner.invoke(
@@ -443,6 +540,27 @@ def test_tags_pipeline():
                 '{ "foo": "bar" }',
                 "-p",
                 "foo",
+            ],
+        )
+        assert result.exit_code == 0
+        runs = instance.get_runs()
+        assert len(runs) == 1
+        run = runs[0]
+        assert len(run.tags) == 1
+        assert run.tags.get("foo") == "bar"
+
+    with instance_for_test() as instance:
+        result = runner.invoke(
+            job_execute_command,
+            [
+                "-m",
+                "dagster_tests.cli_tests.command_tests.test_cli_commands",
+                "-a",
+                "bar",
+                "--tags",
+                '{ "foo": "bar" }',
+                "-j",
+                "qux",
             ],
         )
         assert result.exit_code == 0
@@ -572,6 +690,21 @@ def test_empty_working_directory():
                     file_relative_path(__file__, "file_with_local_import.py"),
                     "-a",
                     "foo_pipeline",
+                ],
+            )
+            assert result.exit_code == 0
+            runs = instance.get_runs()
+            assert len(runs) == 1
+
+    with instance_for_test() as instance:
+        with new_cwd(os.path.dirname(__file__)):
+            result = runner.invoke(
+                job_execute_command,
+                [
+                    "-f",
+                    file_relative_path(__file__, "file_with_local_import.py"),
+                    "-a",
+                    "qux_job",
                 ],
             )
             assert result.exit_code == 0

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -14,9 +14,9 @@ from dagster.utils import file_relative_path, merge_dicts
 from .test_cli_commands import (
     non_existant_python_origin_target_args,
     pipeline_or_job_python_origin_contexts,
-    valid_pipeline_python_origin_target_cli_args,
-    valid_job_python_origin_target_cli_args,
     runner_pipeline_or_job_execute,
+    valid_job_python_origin_target_cli_args,
+    valid_pipeline_python_origin_target_cli_args,
 )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -38,6 +38,7 @@ def run_launch_cli(execution_args, instance, expected_count=None):
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_launch_pipeline(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
+        print(cli_args)
         run_launch(cli_args, instance, expected_count=1)
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
@@ -48,6 +48,37 @@ def assert_correct_bar_repository_output(result):
     )
 
 
+def assert_correct_job_list_bar_repository_output(result):
+    assert result.exit_code == 0
+    assert result.output == (
+        "Repository bar\n"
+        "**************\n"
+        "Job: baz\n"
+        "Description:\n"
+        "Not much tbh\n"
+        "Ops: (Execution Order)\n"
+        "    do_input\n"
+        "********\n"
+        "Job: foo\n"
+        "Ops: (Execution Order)\n"
+        "    do_something\n"
+        "    do_input\n"
+        "***************\n"
+        "Job: memoizable\n"
+        "Ops: (Execution Order)\n"
+        "    my_solid\n"
+        "***********************************\n"
+        "Job: partitioned_scheduled_pipeline\n"
+        "Ops: (Execution Order)\n"
+        "    do_something\n"
+        "********\n"
+        "Job: qux\n"
+        "Ops: (Execution Order)\n"
+        "    do_something\n"
+        "    do_input\n"
+    )
+
+
 def assert_correct_extra_repository_output(result):
     assert result.exit_code == 0
     assert result.output == (
@@ -55,6 +86,17 @@ def assert_correct_extra_repository_output(result):
         "****************\n"
         "Pipeline: extra\n"
         "Solids: (Execution Order)\n"
+        "    do_something\n"
+    )
+
+
+def assert_correct_job_list_extra_repository_output(result):
+    assert result.exit_code == 0
+    assert result.output == (
+        "Repository extra\n"
+        "****************\n"
+        "Job: extra\n"
+        "Ops: (Execution Order)\n"
         "    do_something\n"
     )
 
@@ -85,17 +127,8 @@ def test_list_command_grpc_socket():
             result = runner.invoke(pipeline_list_command, ["--grpc-socket", api_client.socket])
             assert_correct_bar_repository_output(result)
 
-            result = runner.invoke(job_list_command, ["--grpc-socket", api_client.socket])
-            assert_correct_bar_repository_output(result)
-
             result = runner.invoke(
                 pipeline_list_command,
-                ["--grpc-socket", api_client.socket, "--grpc-host", api_client.host],
-            )
-            assert_correct_bar_repository_output(result)
-
-            result = runner.invoke(
-                job_list_command,
                 ["--grpc-socket", api_client.socket, "--grpc-host", api_client.host],
             )
             assert_correct_bar_repository_output(result)
@@ -126,26 +159,11 @@ def test_list_command_deployed_grpc():
             )
             assert_correct_bar_repository_output(result)
 
-            result = runner.invoke(
-                job_list_command,
-                ["--grpc-port", api_client.port, "--grpc-host", api_client.host],
-            )
-            assert_correct_bar_repository_output(result)
-
             result = runner.invoke(pipeline_list_command, ["--grpc-port", api_client.port])
-            assert_correct_bar_repository_output(result)
-
-            result = runner.invoke(job_list_command, ["--grpc-port", api_client.port])
             assert_correct_bar_repository_output(result)
 
             result = runner.invoke(
                 pipeline_list_command,
-                ["--grpc-port", api_client.port, "--grpc-socket", "foonamedsocket"],
-            )
-            assert result.exit_code != 0
-
-            result = runner.invoke(
-                job_list_command,
                 ["--grpc-port", api_client.port, "--grpc-socket", "foonamedsocket"],
             )
             assert result.exit_code != 0
@@ -180,7 +198,7 @@ def test_list_command_cli():
             job_list_command,
             ["-f", file_relative_path(__file__, "test_cli_commands.py"), "-a", "bar"],
         )
-        assert_correct_bar_repository_output(result)
+        assert_correct_job_list_bar_repository_output(result)
 
         result = runner.invoke(
             pipeline_list_command,
@@ -206,7 +224,7 @@ def test_list_command_cli():
                 os.path.dirname(__file__),
             ],
         )
-        assert_correct_bar_repository_output(result)
+        assert_correct_job_list_bar_repository_output(result)
 
         result = runner.invoke(
             pipeline_list_command,
@@ -218,7 +236,7 @@ def test_list_command_cli():
             job_list_command,
             ["-m", "dagster_tests.cli_tests.command_tests.test_cli_commands", "-a", "bar"],
         )
-        assert_correct_bar_repository_output(result)
+        assert_correct_job_list_bar_repository_output(result)
 
         result = runner.invoke(
             pipeline_list_command, ["-w", file_relative_path(__file__, "workspace.yaml")]
@@ -228,7 +246,7 @@ def test_list_command_cli():
         result = runner.invoke(
             job_list_command, ["-w", file_relative_path(__file__, "workspace.yaml")]
         )
-        assert_correct_bar_repository_output(result)
+        assert_correct_job_list_bar_repository_output(result)
 
         result = runner.invoke(
             pipeline_list_command,
@@ -250,7 +268,7 @@ def test_list_command_cli():
                 file_relative_path(__file__, "override.yaml"),
             ],
         )
-        assert_correct_extra_repository_output(result)
+        assert_correct_job_list_extra_repository_output(result)
 
         result = runner.invoke(
             pipeline_list_command,
@@ -288,7 +306,7 @@ def test_list_command_cli():
             job_list_command,
             ["-m", "dagster_tests.cli_tests.command_tests.test_cli_commands"],
         )
-        assert_correct_bar_repository_output(result)
+        assert_correct_job_list_bar_repository_output(result)
 
         result = runner.invoke(
             pipeline_list_command, ["-f", file_relative_path(__file__, "test_cli_commands.py")]
@@ -298,7 +316,7 @@ def test_list_command_cli():
         result = runner.invoke(
             job_list_command, ["-f", file_relative_path(__file__, "test_cli_commands.py")]
         )
-        assert_correct_bar_repository_output(result)
+        assert_correct_job_list_bar_repository_output(result)
 
 
 def test_list_command():

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -24,7 +24,6 @@ def test_print_command_verbose(gen_pipeline_args):
             verbose=True,
             cli_args=cli_args,
             print_fn=no_print,
-            using_job_op_graph_apis=False,
         )
 
 
@@ -36,7 +35,6 @@ def test_print_command(gen_pipeline_args):
             verbose=False,
             cli_args=cli_args,
             print_fn=no_print,
-            using_job_op_graph_apis=False,
         )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -1,11 +1,13 @@
 import pytest
 from click.testing import CliRunner
+from dagster.cli.job import job_print_command
 from dagster.cli.pipeline import execute_print_command, pipeline_print_command
 from dagster.core.test_utils import instance_for_test
 from dagster.utils import file_relative_path
 
 from .test_cli_commands import (
     launch_command_contexts,
+    valid_external_job_target_cli_args,
     valid_external_pipeline_target_cli_args_no_preset,
 )
 
@@ -17,14 +19,24 @@ def no_print(_):
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_print_command_verbose(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
-        execute_print_command(instance=instance, verbose=True, cli_args=cli_args, print_fn=no_print)
+        execute_print_command(
+            instance=instance,
+            verbose=True,
+            cli_args=cli_args,
+            print_fn=no_print,
+            using_job_op_graph_apis=False,
+        )
 
 
 @pytest.mark.parametrize("gen_pipeline_args", launch_command_contexts())
 def test_print_command(gen_pipeline_args):
     with gen_pipeline_args as (cli_args, instance):
         execute_print_command(
-            instance=instance, verbose=False, cli_args=cli_args, print_fn=no_print
+            instance=instance,
+            verbose=False,
+            cli_args=cli_args,
+            print_fn=no_print,
+            using_job_op_graph_apis=False,
         )
 
 
@@ -41,6 +53,19 @@ def test_print_command_cli(pipeline_cli_args):
         assert result.exit_code == 0, result.stdout
 
 
+@pytest.mark.parametrize("job_cli_args", valid_external_job_target_cli_args())
+def test_job_print_command_cli(job_cli_args):
+    with instance_for_test():
+
+        runner = CliRunner()
+
+        result = runner.invoke(job_print_command, job_cli_args)
+        assert result.exit_code == 0, result.stdout
+
+        result = runner.invoke(job_print_command, ["--verbose"] + job_cli_args)
+        assert result.exit_code == 0, result.stdout
+
+
 def test_print_command_baz():
     with instance_for_test():
         runner = CliRunner()
@@ -53,6 +78,20 @@ def test_print_command_baz():
                 "-a",
                 "bar",
                 "-p",
+                "baz",
+            ],
+        )
+        assert res.exit_code == 0, res.stdout
+
+        res = runner.invoke(
+            job_print_command,
+            [
+                "--verbose",
+                "-f",
+                file_relative_path(__file__, "test_cli_commands.py"),
+                "-a",
+                "bar",
+                "-j",
                 "baz",
             ],
         )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_scaffold_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_scaffold_command.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from dagster.cli.pipeline import execute_scaffold_command, pipeline_scaffold_command
 
 from .test_cli_commands import (
-    valid_pipeline_python_origin_target_args,
+    valid_pipeline_or_job_python_origin_target_args,
     valid_pipeline_python_origin_target_cli_args,
 )
 
@@ -12,7 +12,7 @@ def no_print(_):
     return None
 
 
-@pytest.mark.parametrize("cli_args", valid_pipeline_python_origin_target_args())
+@pytest.mark.parametrize("cli_args", valid_pipeline_or_job_python_origin_target_args())
 def test_scaffold_command(cli_args):
     cli_args["print_only_required"] = True
     execute_scaffold_command(cli_args=cli_args, print_fn=no_print)

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
@@ -18,7 +18,7 @@ def load_pipeline_via_cli_runner(cli_args):
     @pipeline_target_argument
     def command(**kwargs):
         with get_external_pipeline_or_job_from_kwargs(
-            DagsterInstance.get(), "", False, kwargs
+            DagsterInstance.get(), "", kwargs
         ) as external_pipeline:
             capture_result["external_pipeline"] = external_pipeline
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
@@ -102,6 +102,6 @@ def test_must_provide_name_to_multi_pipeline():
 
     assert result.exit_code == 2
     assert (
-        """Must provide --pipeline as there is more than one pipeline in """
+        """Must provide --pipeline as there is more than one pipeline/job in """
         """multi_pipeline. Options are: ['pipeline_one', 'pipeline_two']."""
     ) in result.stdout

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_pipeline_load.py
@@ -2,7 +2,7 @@ import click
 import pytest
 from click.testing import CliRunner
 from dagster.cli.workspace.cli_target import (
-    get_external_pipeline_from_kwargs,
+    get_external_pipeline_or_job_from_kwargs,
     pipeline_target_argument,
 )
 from dagster.core.host_representation import ExternalPipeline
@@ -17,8 +17,8 @@ def load_pipeline_via_cli_runner(cli_args):
     @click.command(name="test_pipeline_command")
     @pipeline_target_argument
     def command(**kwargs):
-        with get_external_pipeline_from_kwargs(
-            DagsterInstance.get(), "", kwargs
+        with get_external_pipeline_or_job_from_kwargs(
+            DagsterInstance.get(), "", False, kwargs
         ) as external_pipeline:
             capture_result["external_pipeline"] = external_pipeline
 


### PR DESCRIPTION
Creates the job CLI group and migrates the following commands:

- `dagster job execute`
- `dagster job list`
- `dagster job list_versions`
- `dagster job print`

Remaining CLI commands will be migrated in the next PR.