### PR TITLE
RFC: op_selection on JobDefinition and to_job (step selection version)

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -543,7 +543,6 @@ class PendingNodeInvocation:
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
-        # op_selection backcompat v3
     ) -> "JobDefinition":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(
@@ -574,7 +573,6 @@ class PendingNodeInvocation:
         instance: Optional["DagsterInstance"] = None,
         resources: Optional[Dict[str, Any]] = None,
         raise_on_error: bool = True,
-        # op_selection backcompat v3
     ):
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -543,6 +543,7 @@ class PendingNodeInvocation:
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
+        # op_selection backcompat v3
     ) -> "JobDefinition":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(
@@ -573,6 +574,7 @@ class PendingNodeInvocation:
         instance: Optional["DagsterInstance"] = None,
         resources: Optional[Dict[str, Any]] = None,
         raise_on_error: bool = True,
+        # op_selection backcompat v3
     ):
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -985,3 +985,21 @@ class DependencyStructure:
                 return True
 
         return False
+
+    def has_deps_inside_op_selection(
+        self, input_handle: SolidInputHandle, resolved_op_selection: List[str]
+    ) -> bool:
+        # input is unconnected inside the current dependency structure
+        if not self.has_deps(input_handle):
+            return False
+
+        # full graph is being executed
+        if not resolved_op_selection:
+            return True
+
+        if self.has_dynamic_fan_in_dep(input_handle):
+            return True
+
+        # determine if the connected dependency is inside the op selection
+        source_handle = self.get_direct_dep(input_handle)
+        return source_handle.solid_name in resolved_op_selection

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -522,7 +522,6 @@ class GraphDefinition(NodeDefinition):
         instance: Optional["DagsterInstance"] = None,
         resources: Optional[Dict[str, Any]] = None,
         raise_on_error: bool = True,
-        # op_selection v2
     ):
         """
         Execute this graph in-process, collecting results in-memory.

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -379,7 +379,7 @@ class GraphDefinition(NodeDefinition):
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
-        op_selection: Optional[str] = None,
+        op_selection: Optional[List[str]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -379,6 +379,7 @@ class GraphDefinition(NodeDefinition):
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
         version_strategy: Optional[VersionStrategy] = None,
+        op_selection: Optional[str] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -443,6 +444,7 @@ class GraphDefinition(NodeDefinition):
             )
 
         hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)
+        op_selection = check.opt_list_param(op_selection, "op_selection", of_type=str)
         presets = []
         config_mapping = None
         partitioned_config = None
@@ -482,6 +484,7 @@ class GraphDefinition(NodeDefinition):
             tags=tags,
             hook_defs=hooks,
             version_strategy=version_strategy,
+            op_selection=op_selection,
         )
 
     def coerce_to_job(self):
@@ -519,6 +522,7 @@ class GraphDefinition(NodeDefinition):
         instance: Optional["DagsterInstance"] = None,
         resources: Optional[Dict[str, Any]] = None,
         raise_on_error: bool = True,
+        # op_selection v2
     ):
         """
         Execute this graph in-process, collecting results in-memory.

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -30,9 +30,11 @@ class JobDefinition(PipelineDefinition):
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         solid_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
+        op_selection: Optional[str] = None,
     ):
 
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None
+        self._op_selection = check.opt_list_param(op_selection, "op_selection", str)
 
         super(JobDefinition, self).__init__(
             name=name,
@@ -54,6 +56,7 @@ class JobDefinition(PipelineDefinition):
         run_config: Optional[Dict[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
         raise_on_error: bool = True,
+        # op_selection v2
     ) -> "InProcessGraphResult":
         """
         (Experimental) Execute the Job in-process, gathering results in-memory.
@@ -102,6 +105,7 @@ class JobDefinition(PipelineDefinition):
             hook_defs=self.hook_defs,
             tags=self.tags,
             version_strategy=self.version_strategy,
+            op_selection=self._op_selection,
         )
 
         return core_execute_in_process(
@@ -111,6 +115,7 @@ class JobDefinition(PipelineDefinition):
             instance=instance,
             output_capturing_enabled=True,
             raise_on_error=raise_on_error,
+            op_selection=self._op_selection,
         )
 
     def get_pipeline_subset_def(self, solids_to_execute: AbstractSet[str]) -> PipelineDefinition:

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -30,7 +30,7 @@ class JobDefinition(PipelineDefinition):
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         solid_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
-        op_selection: Optional[str] = None,
+        op_selection: Optional[List[str]] = None,
     ):
 
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional
 
 from dagster import check
 from dagster.core.definitions.policy import RetryPolicy
+from dagster.core.selector.subset_selector import UnresolvedOpSelection
 
 from .graph import GraphDefinition
 from .hook import HookDefinition
@@ -34,7 +35,9 @@ class JobDefinition(PipelineDefinition):
     ):
 
         self._cached_partition_set: Optional["PartitionSetDefinition"] = None
-        self._op_selection = check.opt_list_param(op_selection, "op_selection", str)
+        self._unresolved_op_selection = UnresolvedOpSelection(
+            selection=check.opt_list_param(op_selection, "op_selection", str),
+        )
 
         super(JobDefinition, self).__init__(
             name=name,
@@ -56,6 +59,7 @@ class JobDefinition(PipelineDefinition):
         run_config: Optional[Dict[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
         raise_on_error: bool = True,
+        op_selection: Optional[List[str]] = None,
     ) -> "InProcessGraphResult":
         """
         (Experimental) Execute the Job in-process, gathering results in-memory.
@@ -71,7 +75,14 @@ class JobDefinition(PipelineDefinition):
                 The instance to execute against, an ephemeral one will be used if none provided.
             raise_on_error (Optional[bool]): Whether or not to raise exceptions when they occur.
                 Defaults to ``True``.
-
+            op_selection (Optional[List[str]]): A list of op selection queries (including single op
+                names) to execute. For example:
+                * ``['some_op']``: selects ``some_op`` itself.
+                * ``['*some_op']``: select ``some_op`` and all its ancestors (upstream dependencies).
+                * ``['*some_op+++']``: select ``some_op``, all its ancestors, and its descendants
+                (downstream dependencies) within 3 levels down.
+                * ``['*some_op', 'other_op_a', 'other_op_b+']``: select ``some_op`` and all its
+                ancestors, ``other_op_a`` itself, and ``other_op_b`` and its direct child ops.
         Returns:
             InProcessGraphResult
 
@@ -80,6 +91,11 @@ class JobDefinition(PipelineDefinition):
         from dagster.core.execution.execute_in_process import core_execute_in_process
 
         run_config = check.opt_dict_param(run_config, "run_config")
+        unresolved_op_selection = UnresolvedOpSelection(
+            selection_scope=self._unresolved_op_selection.selection,
+            selection=check.opt_list_param(op_selection, "op_selection", str),
+        )
+
         check.invariant(
             len(self._mode_definitions) == 1,
             "execute_in_process only supported on job / single mode pipeline",
@@ -104,7 +120,8 @@ class JobDefinition(PipelineDefinition):
             hook_defs=self.hook_defs,
             tags=self.tags,
             version_strategy=self.version_strategy,
-            op_selection=self._op_selection,
+            # ??? this is not accurate but i dont have to provide the new value bc it's just ephemeral?
+            # unresolved_op_selection=unresolved_op_selection,
         )
 
         return core_execute_in_process(
@@ -114,7 +131,7 @@ class JobDefinition(PipelineDefinition):
             instance=instance,
             output_capturing_enabled=True,
             raise_on_error=raise_on_error,
-            op_selection=self._op_selection,
+            unresolved_op_selection=unresolved_op_selection,
         )
 
     def get_pipeline_subset_def(self, solids_to_execute: AbstractSet[str]) -> PipelineDefinition:

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -56,7 +56,6 @@ class JobDefinition(PipelineDefinition):
         run_config: Optional[Dict[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
         raise_on_error: bool = True,
-        # op_selection v2
     ) -> "InProcessGraphResult":
         """
         (Experimental) Execute the Job in-process, gathering results in-memory.

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -286,7 +286,9 @@ class PipelineDefinition:
     def dependencies(self):
         return self._graph_def.dependencies
 
-    def get_run_config_schema(self, mode: Optional[str] = None) -> "RunConfigSchema":
+    def get_run_config_schema(
+        self, mode: Optional[str] = None, resolved_op_selection: Optional[List[str]] = None
+    ) -> "RunConfigSchema":
         check.str_param(mode, "mode")
 
         mode_def = self.get_mode_definition(mode)
@@ -298,6 +300,7 @@ class PipelineDefinition:
             self,
             mode_def,
             self._resource_requirements[mode_def.name],
+            resolved_op_selection,
         )
         return self._cached_run_config_schemas[mode_def.name]
 
@@ -603,6 +606,7 @@ def _get_pipeline_subset_def(
     Only includes the solids which are in solids_to_execute.
     """
 
+    # TODO: enable sub op selection??????
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     check.set_param(solids_to_execute, "solids_to_execute", of_type=str)
     graph = pipeline_def.graph
@@ -1000,6 +1004,7 @@ def _create_run_config_schema(
     pipeline_def: PipelineDefinition,
     mode_definition: ModeDefinition,
     required_resources: Set[str],
+    resolved_op_selection: Optional[List[str]],
 ) -> "RunConfigSchema":
     from .run_config import (
         RunConfigSchemaCreationData,
@@ -1033,6 +1038,7 @@ def _create_run_config_schema(
             ignored_solids=ignored_solids,
             required_resources=required_resources,
             is_using_graph_job_op_apis=pipeline_def._is_using_graph_job_op_apis,  # pylint: disable=protected-access
+            resolved_op_selection=resolved_op_selection,
         )
     )
 

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -705,6 +705,7 @@ def create_execution_plan(
     known_state: KnownExecutionState = None,
     instance: Optional[DagsterInstance] = None,
     tags: Optional[Dict[str, str]] = None,
+    _resolved_op_selection: Optional[List[str]] = None,
 ) -> ExecutionPlan:
     pipeline = _check_pipeline(pipeline)
     pipeline_def = pipeline.get_definition()
@@ -715,7 +716,9 @@ def create_execution_plan(
     check.opt_inst_param(instance, "instance", DagsterInstance)
     tags = check.opt_dict_param(tags, "tags", key_type=str, value_type=str)
 
-    resolved_run_config = ResolvedRunConfig.build(pipeline_def, run_config, mode=mode)
+    resolved_run_config = ResolvedRunConfig.build(
+        pipeline_def, run_config, mode=mode, resolved_op_selection=_resolved_op_selection
+    )
 
     return ExecutionPlan.build(
         pipeline,

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -44,7 +44,7 @@ def core_execute_in_process(
         run_config=run_config,
         mode=mode_def.name,
     )
-    if op_selection:
+    if op_selection and op_selection != ["*"]:
         step_keys_to_execute = parse_step_selection(
             full_execution_plan.get_all_step_deps(), op_selection
         )

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -11,7 +11,10 @@ from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.execution.plan.outputs import StepOutputHandle
 from dagster.core.instance import DagsterInstance
-from dagster.core.selector.subset_selector import parse_step_selection
+from dagster.core.selector.subset_selector import (
+    UnresolvedOpSelection,
+    resolve_op_selection_to_step_keys_to_execute,
+)
 
 from .api import (
     ExecuteRunWithPlanIterable,
@@ -33,7 +36,7 @@ def core_execute_in_process(
     instance: Optional[DagsterInstance],
     output_capturing_enabled: bool,
     raise_on_error: bool,
-    op_selection: Optional[List[str]] = None,  # TODO: not nullable
+    unresolved_op_selection: Optional[UnresolvedOpSelection] = None,  # TODO: not nullable
 ):
     pipeline_def = ephemeral_pipeline
     mode_def = pipeline_def.get_mode_definition()
@@ -44,15 +47,39 @@ def core_execute_in_process(
         run_config=run_config,
         mode=mode_def.name,
     )
-    if op_selection and op_selection != ["*"]:
-        step_keys_to_execute = parse_step_selection(
-            full_execution_plan.get_all_step_deps(), op_selection
-        )
+
+    if unresolved_op_selection:
+        step_keys_to_execute = None
+
+        # something if wrong here
+        scoped_execution_plan = None
+        if unresolved_op_selection.selection_scope:
+            step_keys_to_execute = resolve_op_selection_to_step_keys_to_execute(
+                full_execution_plan, unresolved_op_selection.selection_scope
+            )
+        if unresolved_op_selection.selection:
+            # this is a laziest/easies way but not ideal - it generates execution plan twice
+            # in order to resolve two layers of selection
+            scoped_execution_plan = (
+                create_execution_plan(
+                    pipeline,
+                    run_config=run_config,
+                    mode=mode_def.name,
+                    step_keys_to_execute=step_keys_to_execute,
+                )
+                if step_keys_to_execute  # if the selection scope has been defined on job def
+                else None
+            )
+            step_keys_to_execute = resolve_op_selection_to_step_keys_to_execute(
+                execution_plan=scoped_execution_plan or full_execution_plan,
+                step_selection=unresolved_op_selection.selection,
+            )
+
         final_execution_plan = create_execution_plan(
             pipeline,
             run_config=run_config,
             mode=mode_def.name,
-            step_keys_to_execute=list(step_keys_to_execute),
+            step_keys_to_execute=list(step_keys_to_execute) if step_keys_to_execute else None,
         )
     else:
         final_execution_plan = full_execution_plan

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -11,6 +11,7 @@ from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.execution.plan.outputs import StepOutputHandle
 from dagster.core.instance import DagsterInstance
+from dagster.core.selector.subset_selector import parse_step_selection
 
 from .api import (
     ExecuteRunWithPlanIterable,
@@ -23,7 +24,6 @@ from .context_creation_pipeline import (
     orchestration_context_event_generator,
 )
 from .execution_results import InProcessGraphResult, InProcessOpResult
-from dagster.core.selector.subset_selector import parse_step_selection
 
 
 def core_execute_in_process(
@@ -44,15 +44,18 @@ def core_execute_in_process(
         run_config=run_config,
         mode=mode_def.name,
     )
-    step_keys_to_execute = parse_step_selection(
-        full_execution_plan.get_all_step_deps(), op_selection
-    )
-    final_execution_plan = create_execution_plan(
-        pipeline,
-        run_config=run_config,
-        mode=mode_def.name,
-        step_keys_to_execute=list(step_keys_to_execute),
-    )
+    if op_selection:
+        step_keys_to_execute = parse_step_selection(
+            full_execution_plan.get_all_step_deps(), op_selection
+        )
+        final_execution_plan = create_execution_plan(
+            pipeline,
+            run_config=run_config,
+            mode=mode_def.name,
+            step_keys_to_execute=list(step_keys_to_execute),
+        )
+    else:
+        final_execution_plan = full_execution_plan
 
     recorder: Dict[StepOutputHandle, Any] = {}
 

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from dagster import check
 from dagster.core.definitions import (
@@ -23,6 +23,7 @@ from .context_creation_pipeline import (
     orchestration_context_event_generator,
 )
 from .execution_results import InProcessGraphResult, InProcessOpResult
+from dagster.core.selector.subset_selector import parse_step_selection
 
 
 def core_execute_in_process(
@@ -32,12 +33,26 @@ def core_execute_in_process(
     instance: Optional[DagsterInstance],
     output_capturing_enabled: bool,
     raise_on_error: bool,
+    op_selection: Optional[List[str]] = None,  # TODO: not nullable
 ):
     pipeline_def = ephemeral_pipeline
     mode_def = pipeline_def.get_mode_definition()
     pipeline = InMemoryPipeline(pipeline_def)
 
-    execution_plan = create_execution_plan(pipeline, run_config=run_config, mode=mode_def.name)
+    full_execution_plan = create_execution_plan(
+        pipeline,
+        run_config=run_config,
+        mode=mode_def.name,
+    )
+    step_keys_to_execute = parse_step_selection(
+        full_execution_plan.get_all_step_deps(), op_selection
+    )
+    final_execution_plan = create_execution_plan(
+        pipeline,
+        run_config=run_config,
+        mode=mode_def.name,
+        step_keys_to_execute=list(step_keys_to_execute),
+    )
 
     recorder: Dict[StepOutputHandle, Any] = {}
 
@@ -50,12 +65,12 @@ def core_execute_in_process(
         )
 
         _execute_run_iterable = ExecuteRunWithPlanIterable(
-            execution_plan=execution_plan,
+            execution_plan=final_execution_plan,
             iterator=pipeline_execution_iterator,
             execution_context_manager=PlanOrchestrationContextManager(
                 context_event_generator=orchestration_context_event_generator,
                 pipeline=pipeline,
-                execution_plan=execution_plan,
+                execution_plan=final_execution_plan,
                 pipeline_run=pipeline_run,
                 instance=execute_instance,
                 run_config=run_config,

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -696,6 +696,7 @@ class DagsterInstance:
 
         else:
             resolved_run_config = ResolvedRunConfig.build(pipeline_def, run_config, mode)
+            print("??????????????")
             execution_plan = ExecutionPlan.build(
                 InMemoryPipeline(pipeline_def),
                 resolved_run_config,

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -208,6 +208,10 @@ def parse_solid_selection(pipeline_def, solid_selection):
     """
     check.list_param(solid_selection, "solid_selection", of_type=str)
 
+    # special case: select all
+    if len(solid_selection) == 1 and solid_selection[0] == "*":
+        return frozenset(pipeline_def.graph.node_names())
+
     graph = generate_dep_graph(pipeline_def)
     solids_set = set()
 
@@ -290,3 +294,16 @@ def resolve_op_selection_to_step_keys_to_execute(
 
     steps_set = parse_step_selection(execution_plan.get_all_step_deps(), step_selection)
     return list(steps_set) if steps_set else []
+
+
+# def resolve_op_selection(pipeline_def: PipelineDefinition, op_selection: List[str]) -> List[str]:
+
+#     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
+#     check.list_param(op_selection, "op_selection", of_type=str)
+
+#     # special case: select all
+#     if len(op_selection) == 1 and op_selection[0] == "*":
+#         return frozenset(pipeline_def.graph.node_names())
+
+#     steps_set = parse_step_selection(execution_plan.get_all_step_deps(), step_selection)
+#     return list(steps_set) if steps_set else []

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from collections import defaultdict
-from typing import List, NamedTuple, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 from dagster.core.definitions.dependency import DependencyStructure
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -220,7 +220,17 @@ class ResolvedRunConfig(
         solid_config_dict = composite_descent(
             pipeline_def, config_value.get(node_key, {}), mode_def.resource_defs
         )
-        # HERE!!! resolve run config properly with op_selection
+        # TODO: resolve run config properly with op_selection
+        # approach: pass in op_selection (step_keys_to_execute) here and use step_keys_to_execute to
+        #   resolve run config
+        # - Q: safe to mix step_keys and node def name?
+        #   -> A:
+        #       * new config syntax will work fine with the mix bc we can convert "sub_graph.my_op"
+        #         to "graph: sub_graph: my_op" and search to skip checking unselected ops.
+        #       * config mapping should work out of box if we do the recursively search-and-skip right
+        #    - follow up Q: what about back compact???
+        # - Q: possible to skip the check for unselected step_keys_to_execute? and resolve it in execution plan?????
+        #   -> A: no, thats gonna be a lot of code to change how execution plan is built
 
         return ResolvedRunConfig(
             solids=solid_config_dict,

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -220,6 +220,7 @@ class ResolvedRunConfig(
         solid_config_dict = composite_descent(
             pipeline_def, config_value.get(node_key, {}), mode_def.resource_defs
         )
+        # HERE!!! resolve run config properly with op_selection
 
         return ResolvedRunConfig(
             solids=solid_config_dict,

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -149,6 +149,7 @@ class ResolvedRunConfig(
         pipeline_def: PipelineDefinition,
         run_config: Optional[Dict[str, Any]] = None,
         mode: Optional[str] = None,
+        resolved_op_selection: Optional[List[str]] = None,
     ) -> "ResolvedRunConfig":
         """This method validates a given run config against the pipeline config schema. If
         successful, we instantiate an ResolvedRunConfig object.
@@ -163,7 +164,7 @@ class ResolvedRunConfig(
         check.opt_str_param(mode, "mode")
 
         mode = mode or pipeline_def.get_default_mode_name()
-        run_config_schema = pipeline_def.get_run_config_schema(mode)
+        run_config_schema = pipeline_def.get_run_config_schema(mode, resolved_op_selection)
 
         if run_config_schema.config_mapping:
             # add user code boundary

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -1,0 +1,58 @@
+from dagster import op, graph
+from dagster.core.events import DagsterEventType
+
+
+@op
+def return_one():
+    return 1
+
+
+@op
+def return_two():
+    return 2
+
+
+@op
+def adder(num1: int, num2: int):
+    return num1 + num2
+
+
+@op
+def add_one(num: int):
+    return num + 1
+
+
+@graph
+def do_it_all():
+    add_one(adder(return_one(), return_two()))
+
+
+def test_simple_op_selection_on_job_def():
+    my_subset_job = do_it_all.to_job(op_selection=["*adder"])
+    result = my_subset_job.execute_in_process()
+
+    assert result.success
+
+    executed_step_keys = [
+        evt.step_key for evt in result.event_list if evt.event_type == DagsterEventType.STEP_SUCCESS
+    ]
+    assert len(executed_step_keys) == 3
+    assert "add_one" not in [executed_step_keys]
+
+
+@graph
+def larger_graph():
+    do_it_all()
+    return_one()
+
+
+def test_nested_op_selection_on_job_def():
+    my_subset_job = larger_graph.to_job(op_selection=["*do_it_all.adder", "return_one"])
+    result = my_subset_job.execute_in_process()
+
+    assert result.success
+    executed_step_keys = [
+        evt.step_key for evt in result.event_list if evt.event_type == DagsterEventType.STEP_SUCCESS
+    ]
+    assert len(executed_step_keys) == 4
+    assert "add_one" not in [executed_step_keys]

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -1,4 +1,4 @@
-from dagster import graph, op, root_input_manager, In, DynamicOut, DynamicOutput
+from dagster import DynamicOut, DynamicOutput, In, graph, op, root_input_manager
 from dagster.core.events import DagsterEventType
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -1,4 +1,4 @@
-from dagster import graph, op
+from dagster import graph, op, root_input_manager, In, DynamicOut, DynamicOutput
 from dagster.core.events import DagsterEventType
 
 
@@ -68,3 +68,179 @@ def test_nested_op_selection_on_job_def():
     ]
     assert len(executed_step_keys) == 4
     assert "add_one" not in [executed_step_keys]
+
+
+def test_simple_op_selection_on_job_execution():
+    my_job = do_it_all.to_job()
+    result = my_job.execute_in_process(op_selection=["*adder"])
+
+    assert result.success
+
+    executed_step_keys = [
+        evt.step_key for evt in result.event_list if evt.event_type == DagsterEventType.STEP_SUCCESS
+    ]
+    assert len(executed_step_keys) == 3
+    assert "add_one" not in [executed_step_keys]
+
+
+def test_simple_op_selection_on_subset_execution():
+    my_subset_job = do_it_all.to_job(op_selection=["*adder"])
+    # option 1 - overwrites op_selection
+    result = my_subset_job.execute_in_process(op_selection=["*"])
+
+    assert result.success
+
+    executed_step_keys = [
+        evt.step_key for evt in result.event_list if evt.event_type == DagsterEventType.STEP_SUCCESS
+    ]
+    assert len(executed_step_keys) == 3
+    assert "add_one" not in [executed_step_keys]
+
+
+def test_unselected_extra_config_input():
+    @op
+    def root(_):
+        return "public.table_1"
+
+    @op(config_schema={"some_config": str})
+    def takes_input(_, input_table):
+        return input_table
+
+    @graph
+    def full():
+        takes_input(root())
+
+    # Requires passing some config to the op to bypass the op block level optionality
+    run_config = {"solids": {"takes_input": {"config": {"some_config": "a"}}}}
+
+    full_job = full.to_job()
+    assert full_job.execute_in_process(run_config=run_config).success
+
+    # Subselected job shouldn't require the unselected solid's config
+    # TODO: not working
+    assert full_job.execute_in_process(op_selection=["root"]).success
+    # Should also be able to ignore the extra input config
+    assert full_job.execute_in_process(run_config=run_config, op_selection=["root"]).success
+
+
+def test_extra_config_unsatisfied_input():
+    @op
+    def start(_, x):
+        return x
+
+    @op
+    def end(_, x=1):
+        return x
+
+    @graph
+    def testing():
+        end(start())
+
+    full_job = testing.to_job()
+
+    result = full_job.execute_in_process(
+        run_config={"solids": {"start": {"inputs": {"x": {"value": 4}}}}}
+    )
+    assert result.success
+    assert result.result_for_node("end").output_value() == 4
+
+    # test to ensure that if start is not being executed its input config is still allowed (and ignored)
+    # TODO: not working
+    subset_result = full_job.execute_in_process(
+        run_config={"solids": {"start": {"inputs": {"x": {"value": 4}}}}},
+        op_selection=["end"],
+    )
+    assert subset_result.success
+    assert subset_result.result_for_node("end").output_value() == 1
+
+
+def test_extra_config_unsatisfied_input_io_manager():
+    @root_input_manager(input_config_schema=int)
+    def config_io_man(context):
+        return context.config
+
+    @op(ins={"x": In(root_manager_key="my_loader")})
+    def start(_, x):
+        return x
+
+    @op
+    def end(_, x=1):
+        return x
+
+    @graph
+    def testing_io():
+        end(start())
+
+    full_job = testing_io.to_job(resource_defs={"my_loader": config_io_man})
+    result = full_job.execute_in_process(
+        run_config={
+            "solids": {"start": {"inputs": {"x": 4}}},
+        },
+    )
+    assert result.success
+    assert result.result_for_node("end").output_value() == 4
+
+    # test to ensure that if start is not being executed its input config is still allowed (and ignored)
+    # TODO: not working
+    subset_result = full_job.execute_in_process(
+        run_config={
+            "solids": {"start": {"inputs": {"x": 4}}},
+        },
+        op_selection=["end"],
+    )
+    assert subset_result.success
+    assert subset_result.result_for_node("end").output_value() == 1
+
+
+# TODO
+def test_op_selection_on_dynamic_orchestration():
+    @op
+    def num_range():
+        return 3
+
+    @op(out=DynamicOut())
+    def emit(num: int = 2):
+        for i in range(num):
+            yield DynamicOutput(value=i, mapping_key=str(i))
+
+    @op
+    def emit_ten(_):
+        return 10
+
+    @op
+    def multiply_by_two(context, y):
+        context.log.info("multiply_by_two is returning " + str(y * 2))
+        return y * 2
+
+    @op
+    def multiply_inputs(context, y, ten):
+        context.log.info("multiply_inputs is returning " + str(y * ten))
+        return y * ten
+
+    @op
+    def sum_numbers(_, nums):
+        return sum(nums)
+
+    @op
+    def echo(_, x: int) -> int:
+        return x
+
+    @graph
+    def dynamic_pipeline():
+        numbers = emit(num_range())
+        dynamic = numbers.map(lambda num: multiply_by_two(multiply_inputs(num, emit_ten())))
+        n = sum_numbers(dynamic.collect())
+        echo(n)  # test transitive downstream of collect
+
+    full_job = dynamic_pipeline.to_job()
+    result = full_job.execute_in_process()
+    assert result.success
+    assert result.result_for_node("echo").output_value() == 60
+
+    # TODO: not working
+    result = full_job.execute_in_process(
+        # run_config={"solids": {"emit": {"inputs": {"num": 2}}}},
+        op_selection=["emit*", "emit_ten"],
+    )
+    assert result.success
+    assert result.result_for_node("echo").output_value() == 20

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -1,4 +1,4 @@
-from dagster import op, graph
+from dagster import graph, op
 from dagster.core.events import DagsterEventType
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -40,6 +40,18 @@ def test_simple_op_selection_on_job_def():
     assert "add_one" not in [executed_step_keys]
 
 
+def test_select_all_on_job_def():
+    my_subset_job = do_it_all.to_job(op_selection=["*"])
+    result = my_subset_job.execute_in_process()
+
+    assert result.success
+
+    executed_step_keys = [
+        evt.step_key for evt in result.event_list if evt.event_type == DagsterEventType.STEP_SUCCESS
+    ]
+    assert len(executed_step_keys) == 4
+
+
 @graph
 def larger_graph():
     do_it_all()

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_with_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_with_config.py
@@ -204,6 +204,12 @@ def test_extra_config_input_bug():
         solid_selection=["root"],
     ).success
 
+    # subselected pipeline shouldn't require the unselected solid's config
+    assert execute_pipeline(
+        my_pipeline,
+        solid_selection=["root"],
+    ).success
+
 
 def test_extra_config_unsatisfied_input():
     @solid


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
API:
```
@graph
def do_it_all():
    d(c(a, b))

do_part_of_it = do_it_all.to_job(
    op_selection=["*c"]
)
do_part_of_it.execute_in_process()

do_another_part = do_it_all.to_job(
    op_selection=["c+"]
)

do_another_part.execute_in_process()
```

This implements `op_selection` as step_selection, not solid_selection.

Next steps: https://elementl.quip.com/UJzVAGaQcdNx/CRAG-Op-Selection#temp:C:RTG01395fc5ea0d4c0ba75333c6d


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.