### PR TITLE
Use pytz in croniter scheduler iterator rather than pendulum

### DIFF
--- a/python_modules/dagster/dagster/utils/schedules.py
+++ b/python_modules/dagster/dagster/utils/schedules.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Iterator, Optional
 
 import pendulum
+import pytz
 from croniter import croniter
 from dagster import check
 from dagster.seven.compat.pendulum import to_timezone
@@ -12,13 +13,14 @@ def schedule_execution_time_iterator(
 ) -> Iterator[datetime.datetime]:
     timezone_str = execution_timezone if execution_timezone else "UTC"
 
-    start_datetime = pendulum.from_timestamp(start_timestamp, tz=timezone_str)
+    utc_datetime = pytz.utc.localize(datetime.datetime.utcfromtimestamp(start_timestamp))
+    start_datetime = utc_datetime.astimezone(pytz.timezone(timezone_str))
 
     date_iter = croniter(cron_schedule, start_datetime)
 
     # Go back one iteration so that the next iteration is the first time that is >= start_datetime
     # and matches the cron schedule
-    next_date = to_timezone(pendulum.instance(date_iter.get_prev(datetime.datetime)), timezone_str)
+    next_date = date_iter.get_prev(datetime.datetime)
 
     cron_parts = cron_schedule.split(" ")
 
@@ -45,8 +47,10 @@ def schedule_execution_time_iterator(
         delta_fn = lambda d, num: d.add(hours=num)
         should_hour_change = True
 
-    while True:
-        if delta_fn:
+    if delta_fn:
+        # Use pendulums for intervals when possible
+        next_date = to_timezone(pendulum.instance(next_date), timezone_str)
+        while True:
             curr_hour = next_date.hour
 
             next_date_cand = delta_fn(next_date, 1)
@@ -67,9 +71,12 @@ def schedule_execution_time_iterator(
                 check.invariant(next_date_cand.hour == curr_hour)
 
             next_date = next_date_cand
-        else:
+            yield next_date
+    else:
+        # Otherwise fall back to croniter
+        while True:
             next_date = to_timezone(
                 pendulum.instance(date_iter.get_next(datetime.datetime)), timezone_str
             )
 
-        yield next_date
+            yield next_date

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -1,0 +1,25 @@
+from dagster.seven.compat.pendulum import create_pendulum_time
+from dagster.utils.schedules import schedule_execution_time_iterator
+
+
+def test_cron_schedule_advances_past_dst():
+    # In Australia/Sydney, DST is at 2AM on 10/3/21. Verify that we don't
+    # get stuck on the DST boundary.
+    start_time = create_pendulum_time(
+        year=2021, month=10, day=3, hour=1, minute=30, second=1, tz="Australia/Sydney"
+    )
+
+    time_iter = schedule_execution_time_iterator(
+        start_time.timestamp(), "*/15 * * * *", "Australia/Sydney"
+    )
+
+    for _i in range(6):
+        # 1:45, 3:00, 3:15, 3:30, 3:45, 4:00
+        next_time = next(time_iter)
+
+    assert (
+        next_time.timestamp()
+        == create_pendulum_time(
+            year=2021, month=10, day=3, hour=4, tz="Australia/Sydney"
+        ).timestamp()
+    )

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
             "pendulum",
             "protobuf>=3.13.0",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
             "python-dateutil",
+            "pytz",
             "rx>=1.6,<2",  # https://github.com/dagster-io/dagster/issues/4089
             "tabulate",
             "tqdm",


### PR DESCRIPTION
Summary:
croniter seems to work better with pytz than with pendulum (particularly pendulum 2 sadly). Users on pendulum 2 in australia were running into a version of this issue causing their scheduler to start hanging forever: https://github.com/taichino/croniter/issues/137

Instead, use pytz in the iterator

Test Plan: New test that was failing before (but only in pen, existing BK (will investigate extending further to cover more cron cases)

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.