### PR TITLE
Fix invalid s3 key error

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -31,7 +31,7 @@ def get_s3_keys(bucket, prefix="", since_key=None, s3_session=None):
 
     sorted_keys = [obj["Key"] for obj in sorted(contents, key=lambda x: x["LastModified"])]
 
-    if not since_key:
+    if not since_key or since_key not in sorted_keys:
         return sorted_keys
 
     for idx, key in enumerate(sorted_keys):


### PR DESCRIPTION
Fixes issue #5016.

Providing a run key corresponding to a file that has since been deleted causes the `dagster_aws.s3.sensor.get_s3_keys` method to return no keys. This PR fixes the issue by checking if the key is valid.

Tested locally via Dagit.