### PR TITLE
[dagit] Fix Icon in Chrome/Safari

### DIFF
--- a/js_modules/dagit/packages/core/src/execute/__snapshots__/ConfigEditorModePicker.test.tsx.snap
+++ b/js_modules/dagit/packages/core/src/execute/__snapshots__/ConfigEditorModePicker.test.tsx.snap
@@ -19,28 +19,16 @@ exports[`renders error mode 1`] = `
       >
         <div
           aria-label="error"
-          className="Icon__IconWrapper-ovocpb-0 hYrlEN"
+          className="Icon__IconWrapper-ovocpb-0 dzDLkn"
           role="img"
-          style={
-            Object {
-              "background": "rgba(23, 22, 21, 1)",
-              "maskImage": "url('error.svg')",
-            }
-          }
         />
         <span>
           Invalid Mode Selection
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 hYrlEN"
+          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
           role="img"
-          style={
-            Object {
-              "background": "rgba(23, 22, 21, 1)",
-              "maskImage": "url('expand_more.svg')",
-            }
-          }
         />
       </button>
     </div>
@@ -70,14 +58,8 @@ exports[`renders multi mode pipelines 1`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 hYrlEN"
+          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
           role="img"
-          style={
-            Object {
-              "background": "rgba(23, 22, 21, 1)",
-              "maskImage": "url('expand_more.svg')",
-            }
-          }
         />
       </button>
     </div>
@@ -107,14 +89,8 @@ exports[`renders multi mode pipelines 2`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 hYrlEN"
+          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
           role="img"
-          style={
-            Object {
-              "background": "rgba(23, 22, 21, 1)",
-              "maskImage": "url('expand_more.svg')",
-            }
-          }
         />
       </button>
     </div>
@@ -145,14 +121,8 @@ exports[`renders single mode pipelines 1`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 hYrlEN"
+          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
           role="img"
-          style={
-            Object {
-              "background": "rgba(23, 22, 21, 1)",
-              "maskImage": "url('expand_more.svg')",
-            }
-          }
         />
       </button>
     </div>
@@ -183,14 +153,8 @@ exports[`renders single mode pipelines 2`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 hYrlEN"
+          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
           role="img"
-          style={
-            Object {
-              "background": "rgba(23, 22, 21, 1)",
-              "maskImage": "url('expand_more.svg')",
-            }
-          }
         />
       </button>
     </div>

--- a/js_modules/dagit/packages/core/src/ui/Icon.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Icon.tsx
@@ -111,28 +111,29 @@ interface Props {
   size?: 16 | 20 | 24 | 48;
 }
 
-export const IconWIP = (props: Props) => {
+export const IconWIP = React.memo((props: Props) => {
   const {color = ColorsWIP.Dark, name, size = 16} = props;
   let img = Icons[name] || '';
   if (typeof img === 'object' && 'default' in img) {
     // in Dagit but not in Storybook due to webpack config differences
     img = img.default;
   }
-  return (
-    <IconWrapper
-      role="img"
-      $size={size}
-      aria-label={name}
-      style={{background: color, maskImage: `url('${img}')`}}
-    />
-  );
-};
+  return <IconWrapper role="img" $size={size} $img={img} $color={color} aria-label={name} />;
+});
 
-export const IconWrapper = styled.div<{$size: number}>`
+interface WrapperProps {
+  $color: string;
+  $size: number;
+  $img: string;
+}
+
+export const IconWrapper = styled.div<WrapperProps>`
+  background: ${(p) => p.$color};
   width: ${(p) => p.$size}px;
   height: ${(p) => p.$size}px;
   flex-shrink: 0;
   flex-grow: 0;
+  mask-image: url(${(p) => p.$img});
   mask-size: cover;
   object-fit: cover;
 `;


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Use the styled-components `mask-image` for Icon to ensure that Chrome and Safari can render icons correctly.

## Test Plan

View Dagit, verify that icons render in Chrome and Safari.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.