### PR TITLE
[dagit-bb] Initial pass at run details page styling, with side effects

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -446,9 +446,8 @@ const AssetsTable = ({
           <tr>
             {canWipeAssets ? (
               <th style={{width: 50}}>
-                <div style={{display: 'flex', alignItems: 'center'}}>
+                <div style={{display: 'flex', alignItems: 'center', gap: 5}}>
                   <Checkbox
-                    style={{marginBottom: 0, marginTop: 1}}
                     indeterminate={checkedPaths.size > 0 && checkedPaths.size !== sorted.length}
                     checked={checkedPaths.size === sorted.length}
                     onChange={onChangeAll}

--- a/js_modules/dagit/packages/core/src/execute/__snapshots__/ConfigEditorModePicker.test.tsx.snap
+++ b/js_modules/dagit/packages/core/src/execute/__snapshots__/ConfigEditorModePicker.test.tsx.snap
@@ -13,13 +13,13 @@ exports[`renders error mode 1`] = `
       onKeyDown={[Function]}
     >
       <button
-        className="BaseButton__StyledButton-sc-1bn4i2e-0 iUvkxa"
+        className="BaseButton__StyledButton-sc-1bn4i2e-0 eVixNz"
         data-test-id="mode-picker-button"
         title="Current execution mode"
       >
         <div
           aria-label="error"
-          className="Icon__IconWrapper-ovocpb-0 dzDLkn"
+          className="Icon__IconWrapper-ovocpb-0 gmBOTS"
           role="img"
         />
         <span>
@@ -27,7 +27,7 @@ exports[`renders error mode 1`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
+          className="Icon__IconWrapper-ovocpb-0 gkQziu"
           role="img"
         />
       </button>
@@ -49,7 +49,7 @@ exports[`renders multi mode pipelines 1`] = `
       onKeyDown={[Function]}
     >
       <button
-        className="BaseButton__StyledButton-sc-1bn4i2e-0 bGSldS"
+        className="BaseButton__StyledButton-sc-1bn4i2e-0 iBafTn"
         data-test-id="mode-picker-button"
         title="Current execution mode"
       >
@@ -58,7 +58,7 @@ exports[`renders multi mode pipelines 1`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
+          className="Icon__IconWrapper-ovocpb-0 gkQziu"
           role="img"
         />
       </button>
@@ -80,7 +80,7 @@ exports[`renders multi mode pipelines 2`] = `
       onKeyDown={[Function]}
     >
       <button
-        className="BaseButton__StyledButton-sc-1bn4i2e-0 bGSldS"
+        className="BaseButton__StyledButton-sc-1bn4i2e-0 iBafTn"
         data-test-id="mode-picker-button"
         title="Current execution mode"
       >
@@ -89,7 +89,7 @@ exports[`renders multi mode pipelines 2`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
+          className="Icon__IconWrapper-ovocpb-0 gkQziu"
           role="img"
         />
       </button>
@@ -111,7 +111,7 @@ exports[`renders single mode pipelines 1`] = `
       onKeyDown={[Function]}
     >
       <button
-        className="BaseButton__StyledButton-sc-1bn4i2e-0 bGSldS"
+        className="BaseButton__StyledButton-sc-1bn4i2e-0 iBafTn"
         data-test-id="mode-picker-button"
         disabled={true}
         title="To add a mode, add a ModeDefinition to the pipeline."
@@ -121,7 +121,7 @@ exports[`renders single mode pipelines 1`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
+          className="Icon__IconWrapper-ovocpb-0 gkQziu"
           role="img"
         />
       </button>
@@ -143,7 +143,7 @@ exports[`renders single mode pipelines 2`] = `
       onKeyDown={[Function]}
     >
       <button
-        className="BaseButton__StyledButton-sc-1bn4i2e-0 bGSldS"
+        className="BaseButton__StyledButton-sc-1bn4i2e-0 iBafTn"
         data-test-id="mode-picker-button"
         disabled={true}
         title="To add a mode, add a ModeDefinition to the pipeline."
@@ -153,7 +153,7 @@ exports[`renders single mode pipelines 2`] = `
         </span>
         <div
           aria-label="expand_more"
-          className="Icon__IconWrapper-ovocpb-0 ilmjbT"
+          className="Icon__IconWrapper-ovocpb-0 gkQziu"
           role="img"
         />
       </button>

--- a/js_modules/dagit/packages/core/src/gantt/Constants.ts
+++ b/js_modules/dagit/packages/core/src/gantt/Constants.ts
@@ -49,9 +49,11 @@ export enum GanttChartMode {
 
 export const MIN_SCALE = 0.0002;
 export const MAX_SCALE = 0.5;
-export const LEFT_INSET = 5;
-export const FLAT_INSET_FROM_PARENT = 15;
-export const BOX_HEIGHT = 30;
+export const LEFT_INSET = 16;
+export const TOP_INSET = 16;
+export const BOTTOM_INSET = 16;
+export const FLAT_INSET_FROM_PARENT = 16;
+export const BOX_HEIGHT = 34;
 export const BOX_MARGIN_Y = 5;
 export const BOX_SPACING_X = 20;
 export const BOX_WIDTH = 100;

--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -618,7 +618,7 @@ const GanttLine = React.memo(
     depNotDrawn: boolean;
   } & Bounds) => {
     const border = `${LINE_SIZE}px ${dotted ? 'dotted' : 'solid'} ${
-      darkened ? ColorsWIP.Gray900 : ColorsWIP.Gray100
+      darkened ? ColorsWIP.Gray700 : ColorsWIP.Gray300
     }`;
 
     const maxXAvoidingOverlap = maxX + (depIdx % 10) * LINE_SIZE;

--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -19,6 +19,7 @@ import {Spinner} from '../ui/Spinner';
 import {SplitPanelContainer} from '../ui/SplitPanelContainer';
 
 import {
+  BOTTOM_INSET,
   BOX_DOT_MARGIN_Y,
   BOX_DOT_SIZE,
   BOX_DOT_WIDTH_CUTOFF,
@@ -37,6 +38,7 @@ import {
   LINE_SIZE,
   MAX_SCALE,
   MIN_SCALE,
+  TOP_INSET,
 } from './Constants';
 import {isDynamicStep} from './DynamicStepSupport';
 import {
@@ -284,7 +286,7 @@ const GanttChartInner = (props: GanttChartInnerProps) => {
   );
   const layoutSize = {
     width: Math.max(0, ...layout.boxes.map((b) => b.x + b.width + BOX_SPACING_X)),
-    height: Math.max(0, ...layout.boxes.map((b) => b.y * BOX_HEIGHT + BOX_HEIGHT)),
+    height: Math.max(0, ...layout.boxes.map((b) => TOP_INSET + b.y * BOX_HEIGHT + BOTTOM_INSET)),
   };
 
   React.useEffect(() => {
@@ -555,9 +557,9 @@ interface Bounds {
 const boundsForBox = (a: GanttChartPlacement): Bounds => {
   return {
     minX: a.x,
-    minY: a.y * BOX_HEIGHT,
+    minY: TOP_INSET + a.y * BOX_HEIGHT,
     maxX: a.x + a.width,
-    maxY: a.y * BOX_HEIGHT + BOX_HEIGHT,
+    maxY: TOP_INSET + a.y * BOX_HEIGHT + BOX_HEIGHT,
   };
 };
 
@@ -581,7 +583,7 @@ const boundsForLine = (a: GanttChartBox, b: GanttChartBox): Bounds => {
 
   // Line comes out of the center of the right side of the box
   const minX = Math.min(a.x + a.width, b.x + b.width);
-  const minY = straight ? a.y * BOX_HEIGHT + aCenterY : a.y * BOX_HEIGHT + aCenterY;
+  const minY = TOP_INSET + (straight ? a.y * BOX_HEIGHT + aCenterY : a.y * BOX_HEIGHT + aCenterY);
 
   // Line ends on the center left edge of the box if it is on the
   // same line, or drops into the top center of the box if it's below.
@@ -589,8 +591,8 @@ const boundsForLine = (a: GanttChartBox, b: GanttChartBox): Bounds => {
     ? Math.max(a.x, b.x)
     : Math.max(a.x + a.width / 2, b.x + (bIsDot ? BOX_DOT_SIZE : b.width) / 2);
   const maxY = straight
-    ? b.y * BOX_HEIGHT + bCenterY
-    : b.y * BOX_HEIGHT + (bIsDot ? BOX_DOT_MARGIN_Y : BOX_MARGIN_Y);
+    ? TOP_INSET + b.y * BOX_HEIGHT + bCenterY
+    : TOP_INSET + b.y * BOX_HEIGHT + (bIsDot ? BOX_DOT_MARGIN_Y : BOX_MARGIN_Y);
 
   return {minX, minY, maxX, maxY};
 };
@@ -640,7 +642,7 @@ const GanttLine = React.memo(
             style={{
               width: 1,
               left: maxXAvoidingOverlap,
-              top: minY,
+              top: minY - LINE_SIZE / 2,
               height: maxY - minY,
               borderRight: border,
               zIndex: darkened ? 100 : 1,
@@ -674,7 +676,7 @@ const GanttChartContainer = styled.div`
   }
 
   .chart-element {
-    font-size: 11px;
+    font-size: 12px;
     transition: top ${CSS_DURATION}ms linear, left ${CSS_DURATION}ms linear;
     display: inline-block;
     position: absolute;
@@ -693,15 +695,13 @@ const GanttChartContainer = styled.div`
     width: ${BOX_DOT_SIZE}px;
     height: ${BOX_DOT_SIZE}px;
     border: 1px solid transparent;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     border-radius: ${BOX_DOT_SIZE / 2}px;
   }
 
   .box {
     height: ${BOX_HEIGHT - BOX_MARGIN_Y * 2}px;
-    padding: 2px;
+    padding: 3px;
     border: 1px solid transparent;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     border-radius: 2px;
 
     transition: top ${CSS_DURATION}ms linear, left ${CSS_DURATION}ms linear,

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
@@ -21,8 +21,6 @@ export interface BuildLayoutParams {
   mode: GanttChartMode;
 }
 
-const ROUNDING_GRADIENT = 'linear-gradient(180deg, rgba(255,255,255,0.15), rgba(0,0,0,0.1))';
-
 export const buildLayout = (params: BuildLayoutParams) => {
   const {nodes, mode} = params;
 
@@ -233,7 +231,7 @@ const addChildren = (boxes: GanttChartBox[], box: GanttChartBox, params: BuildLa
 const ColorsForStates = {
   [IStepState.RETRY_REQUESTED]: ColorsWIP.Yellow500,
   [IStepState.RUNNING]: ColorsWIP.Gray400,
-  [IStepState.SUCCEEDED]: ColorsWIP.Green700,
+  [IStepState.SUCCEEDED]: ColorsWIP.Green500,
   [IStepState.FAILED]: ColorsWIP.Red500,
   [IStepState.SKIPPED]: 'rgb(173, 185, 152)',
 };
@@ -250,13 +248,13 @@ export const boxStyleFor = (
     !context.metadata.startedPipelineAt &&
     context.options.mode !== GanttChartMode.WATERFALL_TIMED
   ) {
-    return {background: `${ROUNDING_GRADIENT}, #2491eb`};
+    return {background: `#2491eb`};
   }
 
   // Step has started and has state? Return state color.
   if (state && state !== IStepState.PREPARING) {
     return {
-      background: `${ROUNDING_GRADIENT}, ${ColorsForStates[state] || ColorsWIP.Gray400}`,
+      background: `${ColorsForStates[state] || ColorsWIP.Gray400}`,
     };
   }
 
@@ -265,7 +263,6 @@ export const boxStyleFor = (
     color: ColorsWIP.Gray200,
     background: ColorsWIP.White,
     border: `1.5px dotted ${ColorsWIP.Gray200}`,
-    boxShadow: `none`,
   };
 };
 

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/macro';
 
 import {formatElapsedTime} from '../app/Util';
 import {ColorsWIP} from '../ui/Colors';
+import {FontFamily} from '../ui/styles';
 
 import {CSS_DURATION, GanttViewport, LEFT_INSET} from './Constants';
 
@@ -171,18 +172,19 @@ export const GanttChartTimescale = ({
   );
 };
 
+const TICKS_ROW_HEIGHT = 32;
+
 const TimescaleContainer = styled.div`
   width: 100%;
 
   & .tick {
     position: absolute;
-    padding-top: 3px;
+    padding-top: 7px;
     width: ${TICK_LABEL_WIDTH}px;
-    height: 20px;
+    height: ${TICKS_ROW_HEIGHT}px;
     box-sizing: border-box;
     transition: left ${CSS_DURATION}ms linear, width ${CSS_DURATION}ms linear;
     text-align: center;
-    font-size: 11px;
   }
   & .tick.duration {
     color: ${ColorsWIP.Gray500};
@@ -212,7 +214,7 @@ const TimescaleContainer = styled.div`
 
   & .fog-of-war {
     position: absolute;
-    background: rgb(203, 216, 224, 0.3);
+    background: ${ColorsWIP.Gray50};
     transition: left ${CSS_DURATION}ms linear;
     top: 0px;
     bottom: 0px;
@@ -221,20 +223,21 @@ const TimescaleContainer = styled.div`
 `;
 
 const TimescaleTicksContainer = styled.div`
-  height: 20px;
+  height: ${TICKS_ROW_HEIGHT}px;
   z-index: 4;
   position: relative;
-  background: ${ColorsWIP.Gray100};
+  background: ${ColorsWIP.White};
   display: flex;
-  color: ${ColorsWIP.Gray400};
-  font-size: 11px;
-  border-bottom: 1px solid ${ColorsWIP.Gray200};
+  color: ${ColorsWIP.Gray500};
+  font-size: 13px;
+  font-family: ${FontFamily.monospace};
+  border-bottom: 1px solid ${ColorsWIP.KeylineGray};
   overflow: hidden;
 `;
 
 const TimescaleLinesContainer = styled.div`
   z-index: 0;
-  top: 20px;
+  top: ${TICKS_ROW_HEIGHT}px;
   left: 0;
   position: absolute;
   pointer-events: none;

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartTimescale.tsx
@@ -19,7 +19,7 @@ const msToSubsecondLabel = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
 // We use the first configuration that places ticks at least 80 pixels apart
 // at the rendered scale.
 //
-const TICK_LABEL_WIDTH = 40;
+const TICK_LABEL_WIDTH = 56;
 const TICK_CONFIG = [
   {
     tickIntervalMs: 0.5 * 1000,
@@ -154,7 +154,7 @@ export const GanttChartTimescale = ({
           <div
             className="line highlight"
             key={`highlight-${idx}`}
-            style={{left: (ms - startMs) * pxPerMs, transform}}
+            style={{left: (ms - startMs) * pxPerMs + (idx === 0 ? -1 : 0), transform}}
           />
         ))}
         {nowMs > startMs && (
@@ -193,22 +193,19 @@ const TimescaleContainer = styled.div`
   }
   & .tick.highlight {
     color: white;
-    margin-top: 1px;
-    padding-top: 2px;
-    height: 17px;
-    background: linear-gradient(to bottom, #949493 0%, #757573 100%);
-    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    height: ${TICKS_ROW_HEIGHT + 2}px;
+    background: ${ColorsWIP.Gray900};
   }
   & .line {
     position: absolute;
-    border-left: 1px solid #eee;
+    border-left: 1px solid #f0f0f0;
     transition: left ${CSS_DURATION}ms linear;
     top: 0px;
     bottom: 0px;
   }
   & .line.highlight {
-    border-left: 1px solid #949493;
-    z-index: 3;
+    border-left: 2px solid ${ColorsWIP.Gray900};
+    z-index: 1111;
     top: -1px;
   }
 
@@ -231,7 +228,7 @@ const TimescaleTicksContainer = styled.div`
   color: ${ColorsWIP.Gray500};
   font-size: 13px;
   font-family: ${FontFamily.monospace};
-  border-bottom: 1px solid ${ColorsWIP.KeylineGray};
+  box-shadow: inset 0 -1px ${ColorsWIP.KeylineGray};
   overflow: hidden;
 `;
 

--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -193,5 +193,6 @@ const Elapsed = styled.div`
 
 const EmptyNotice = styled.div`
   font-size: 12px;
-  padding: 12px;
+  padding: 7px 24px;
+  color: ${ColorsWIP.Gray400};
 `;

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -31,7 +31,7 @@ export const RunGroupPanel: React.FC<{runId: string}> = ({runId}) => {
   const group = queryResult.data?.runGroupOrError;
 
   if (!group || group.__typename === 'RunGroupNotFoundError') {
-    return <div />;
+    return null;
   }
   if (group.__typename === 'PythonError') {
     return (
@@ -57,7 +57,7 @@ export const RunGroupPanel: React.FC<{runId: string}> = ({runId}) => {
   }
 
   if (group.runs?.length === 1) {
-    return <div />;
+    return null;
   }
 
   const runs = (group.runs || []).filter((g) => g !== null);
@@ -143,12 +143,11 @@ const RUN_GROUP_PANEL_QUERY = gql`
 const RunGroupRun = styled(Link)<{selected: boolean}>`
   align-items: flex-start;
   background: ${({selected}) => (selected ? ColorsWIP.Gray100 : ColorsWIP.White)};
-  padding: 3px 6px;
+  padding: 3px 6px 3px 24px;
   font-size: 13px;
   line-height: 20px;
   display: flex;
   position: relative;
-  padding-left: 6px;
   &:hover {
     text-decoration: none;
     background: ${({selected}) => (selected ? ColorsWIP.Gray100 : ColorsWIP.Gray50)};
@@ -159,8 +158,8 @@ const ThinLine = styled.div`
   position: absolute;
   top: 17px;
   width: 1px;
-  border-right: 1px solid rgba(0, 0, 0, 0.2);
-  left: 11px;
+  background: ${ColorsWIP.Gray300};
+  left: 29px;
   z-index: 2;
 `;
 
@@ -179,12 +178,12 @@ const RootTag = (
       borderRadius: 2,
       fontSize: 12,
       lineHeight: '14px',
-      background: 'rgb(118, 144, 188, 0.5)',
-      color: 'white',
+      background: ColorsWIP.Gray300,
+      color: ColorsWIP.White,
       padding: '0 4px',
       fontWeight: 400,
       userSelect: 'none',
-      marginLeft: 4,
+      marginLeft: 12,
     }}
   >
     ROOT

--- a/js_modules/dagit/packages/core/src/gantt/VizComponents.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/VizComponents.tsx
@@ -3,12 +3,11 @@ import styled from 'styled-components/macro';
 import {ColorsWIP} from '../ui/Colors';
 
 export const OptionsContainer = styled.div`
-min-height: 40px;
+min-height: 56px;
 display: flex;
 align-items: center;
-padding: 5px 15px;
-border-bottom: 1px solid #A7B6C2;
-box-shadow: 0 1px 3px rgba(0,0,0,0.07);
+padding: 5px 12px;
+border-bottom: 1px solid ${ColorsWIP.KeylineGray};
 background: ${ColorsWIP.White};
 flex-shrink: 0;
 flex-wrap: wrap;
@@ -16,13 +15,10 @@ z-index: 3;
 }`;
 
 export const OptionsDivider = styled.div`
-  width: 1px;
+  width: 30px;
   height: 25px;
-  padding-left: 7px;
-  margin-left: 7px;
-  border-left: 1px solid ${ColorsWIP.Gray100};
 `;
 
 export const OptionsSpacer = styled.div`
-  width: 15px;
+  width: 30px;
 `;

--- a/js_modules/dagit/packages/core/src/gantt/ZoomSlider.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/ZoomSlider.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP} from '../ui/Colors';
+import {SliderStyles} from '../ui/Slider';
 
 /**
  * Renders a horizontal slider that lets you adjust the graph's relative zoom from 1-100.
@@ -10,7 +14,8 @@ export const ZoomSlider: React.FunctionComponent<{
   onChange: (v: number) => void;
 }> = React.memo((props) => {
   return (
-    <div
+    <ZoomSliderContainer
+      $fillColor={ColorsWIP.Gray600}
       className="bp3-slider bp3-slider-unlabeled"
       onMouseDown={(e: React.MouseEvent) => {
         const rect = e.currentTarget.closest('.bp3-slider')!.getBoundingClientRect();
@@ -48,6 +53,10 @@ export const ZoomSlider: React.FunctionComponent<{
         style={{left: `calc(${props.value}% - 8px)`}}
         tabIndex={0}
       />
-    </div>
+    </ZoomSliderContainer>
   );
 });
+
+const ZoomSliderContainer = styled.div`
+  ${SliderStyles}
+`;

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -1,4 +1,3 @@
-import {Slider} from '@blueprintjs/core';
 import animate from 'amator';
 import * as React from 'react';
 import styled from 'styled-components/macro';
@@ -6,6 +5,7 @@ import styled from 'styled-components/macro';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {IconWIP} from '../ui/Icon';
+import {Slider} from '../ui/Slider';
 
 export interface SVGViewportInteractor {
   onMouseDown(viewport: SVGViewport, event: React.MouseEvent<HTMLDivElement>): void;

--- a/js_modules/dagit/packages/core/src/partitions/SliceSlider.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SliceSlider.tsx
@@ -1,7 +1,9 @@
-import {Intent, MultiSlider} from '@blueprintjs/core';
+import {Intent} from '@blueprintjs/core';
 import moment from 'moment-timezone';
 import React from 'react';
 import styled from 'styled-components/macro';
+
+import {MultiSlider} from '../ui/Slider';
 
 export const SliceSlider: React.FunctionComponent<{
   maxUnix: number;

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
@@ -31,21 +31,21 @@ export const SidebarSection: React.FC<ISidebarSectionProps> = (props) => {
   }, [storageKey]);
 
   return (
-    <div>
+    <>
       <CollapsingHeaderBar onClick={onToggle}>
         {title}
-        <DisclosureIcon name={open ? 'expand_more' : 'chevron_left'} />
+        <IconWIP
+          size={24}
+          name="arrow_drop_down"
+          style={{transform: open ? 'rotate(0)' : 'rotate(-90deg)'}}
+        />
       </CollapsingHeaderBar>
       <Collapse isOpen={open}>
         <div>{children}</div>
       </Collapse>
-    </div>
+    </>
   );
 };
-
-const DisclosureIcon = styled(IconWIP)`
-  opacity: 0.5;
-`;
 
 export const SidebarTitle = styled.h3`
   font-family: ${FontFamily.monospace};
@@ -75,7 +75,7 @@ export const SidebarSubhead = styled.div`
 `;
 
 export const SectionItemContainer = styled.div`
-  border-bottom: 1px solid ${ColorsWIP.Gray100};
+  border-bottom: 1px solid ${ColorsWIP.KeylineGray};
   margin-bottom: 20px;
   padding-bottom: 20px;
   font-size: 0.8rem;
@@ -89,17 +89,20 @@ export const SectionItemContainer = styled.div`
 // Internal
 
 const CollapsingHeaderBar = styled.div`
-  padding: 6px;
-  padding-left: 12px;
-  background: linear-gradient(to bottom, ${ColorsWIP.Gray50}, ${ColorsWIP.Gray100});
-  border-top: 1px solid ${ColorsWIP.Gray100};
-  border-bottom: 1px solid ${ColorsWIP.Gray100};
-  color: ${ColorsWIP.Gray600};
+  height: 32px;
+  padding-left: 24px;
+  background: ${ColorsWIP.White};
+  border-top: 1px solid ${ColorsWIP.KeylineGray};
+  border-bottom: 1px solid ${ColorsWIP.KeylineGray};
+  color: ${ColorsWIP.Gray900};
   cursor: pointer;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  text-transform: uppercase;
-  font-size: 0.75rem;
+  font-size: 12px;
+  font-weight: 700;
   user-select: none;
+  &:first-child {
+    border-top: 0;
+  }
 `;

--- a/js_modules/dagit/packages/core/src/runs/CellTruncationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/CellTruncationProvider.tsx
@@ -31,12 +31,13 @@ const OverflowButton = styled.button`
   user-select: none;
   font-size: 12px;
   font-weight: 500;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(100, 100, 100, 0.7);
   border-radius: 4px;
-  padding: 12px 24px;
+  line-height: 32px;
+  padding: 0 12px;
   color: ${ColorsWIP.White};
   &:hover {
-    background: rgba(0, 0, 0, 0.6);
+    background: rgba(100, 100, 100, 0.85);
   }
 
   &:focus,

--- a/js_modules/dagit/packages/core/src/runs/LogsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsFilterInput.tsx
@@ -141,7 +141,6 @@ export const LogsFilterInput: React.FC<Props> = (props) => {
         }
     }
   };
-
   return (
     <Popover
       isOpen={shown && suggestions.length > 0}
@@ -169,7 +168,6 @@ export const LogsFilterInput: React.FC<Props> = (props) => {
         onFocus={() => dispatch({type: 'show-popover'})}
         onBlur={() => dispatch({type: 'hide-popover'})}
         onKeyDown={onKeyDown}
-        style={{}}
       />
     </Popover>
   );

--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -273,7 +273,7 @@ const UnstructuredMemoizedContent: React.FC<{
   >
     <SolidColumn stepKey={node.stepKey} />
     <EventTypeColumn>{node.level}</EventTypeColumn>
-    <Box padding={{left: 4}} style={{flex: 1}}>
+    <Box padding={{horizontal: 12}} style={{flex: 1}}>
       {node.message}
     </Box>
     <TimestampColumn time={node.timestamp} />

--- a/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
@@ -33,7 +33,7 @@ export const Row = styled.div<{level: LogLevel; highlighted: boolean}>`
   flex-direction: row;
   align-items: baseline;
   overflow: hidden;
-  border-top: 1px solid ${ColorsWIP.Gray100};
+  border-top: 1px solid ${ColorsWIP.KeylineGray};
   background: ${({highlighted, level}) => (highlighted ? '#ffe39f' : bgcolorForLevel(level))};
   &:hover {
     background: ${({highlighted}) => (highlighted ? '#ffe39f' : 'white')};
@@ -53,8 +53,7 @@ export const StructuredContent = styled.div`
   background: rgba(255, 255, 255, 0.5);
   color: ${ColorsWIP.Gray900};
   box-sizing: border-box;
-  border-left: 1px solid ${ColorsWIP.Gray100};
-  border-right: 1px solid ${ColorsWIP.Gray100};
+  border-left: 1px solid ${ColorsWIP.KeylineGray};
   word-break: break-word;
   white-space: pre-wrap;
   font-family: ${FontFamily.monospace};
@@ -102,7 +101,7 @@ export const SolidColumn = (props: {stepKey: string | false | null}) => {
 const SolidColumnContainer = styled.div`
   width: 250px;
   flex-shrink: 0;
-  padding: 4px;
+  padding: 4px 12px;
 `;
 
 const SolidColumnTooltipStyle = JSON.stringify({
@@ -155,7 +154,7 @@ export const TimestampColumn: React.FC<{time: string | null}> = React.memo((prop
 
 const TimestampColumnContainer = styled.div`
   flex-shrink: 0;
-  padding: 4px 4px 4px 8px;
+  padding: 4px 4px 4px 12px;
 
   a:link,
   a:visited,

--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -270,7 +270,7 @@ const DefaultContent: React.FunctionComponent<{
           </TagWIP>
         )}
       </EventTypeColumn>
-      <Box padding={{left: 4}} style={{flex: 1}}>
+      <Box padding={{horizontal: 12}} style={{flex: 1}}>
         {message}
         {children}
       </Box>
@@ -328,7 +328,7 @@ const FailureContent: React.FunctionComponent<{
           {eventType}
         </TagWIP>
       </EventTypeColumn>
-      <Box padding={{left: 4}} style={{flex: 1}}>
+      <Box padding={{horizontal: 12}} style={{flex: 1}}>
         {contextMessage}
         {errorMessage}
         <MetadataEntries entries={metadataEntries} />

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -93,7 +93,7 @@ export const LogsScrollingTable: React.FC<ILogsScrollingTableProps> = (props) =>
   return (
     <ColumnWidthsProvider onWidthsChanged={() => table.current && table.current.didResize()}>
       <Headers />
-      <div style={{flex: 1, minHeight: 0}}>
+      <div style={{flex: 1, minHeight: 0, marginTop: -1}}>
         <AutoSizer>
           {({width, height}) => (
             <LogsScrollingTableSized

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
@@ -10,7 +10,7 @@ const ColumnWidths = Object.assign(
   {
     eventType: 140,
     solid: 150,
-    timestamp: 112,
+    timestamp: 117,
   },
   getJSONForKey(ColumnWidthsStorageKey),
 );
@@ -149,8 +149,9 @@ const HeadersContainer = styled.div`
   display: flex;
   color: ${ColorsWIP.Gray400};
   text-transform: uppercase;
-  font-size: 11px;
-  border-bottom: 1px solid #cbd4da;
+  font-size: 12px;
+  border-bottom: 1px solid ${ColorsWIP.KeylineGray};
+  z-index: 2;
 `;
 
 const HeaderContainer = styled.div`
@@ -158,7 +159,8 @@ const HeaderContainer = styled.div`
   position: relative;
   user-select: none;
   display: inline-block;
-  padding: 4px 8px;
+  padding: 0 12px;
+  line-height: 32px;
 `;
 
 // eslint-disable-next-line no-unexpected-multiline
@@ -177,6 +179,6 @@ const HeaderDragHandle = styled.div<{
   & > div {
     width: 1px;
     height: 100%;
-    background: ${({isDragging}) => (isDragging ? ColorsWIP.Gray600 : ColorsWIP.Gray100)};
+    background: ${({isDragging}) => (isDragging ? ColorsWIP.Gray400 : ColorsWIP.KeylineGray)};
   }
 `;

--- a/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
@@ -7,7 +7,6 @@ import {Box} from '../ui/Box';
 import {ButtonWIP} from '../ui/Button';
 import {ButtonGroup} from '../ui/ButtonGroup';
 import {Checkbox} from '../ui/Checkbox';
-import {ColorsWIP} from '../ui/Colors';
 import {Group} from '../ui/Group';
 import {IconName, IconWIP} from '../ui/Icon';
 import {MenuItemWIP} from '../ui/Menu';

--- a/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {useCopyToClipboard} from '../app/browser';
+import {OptionsContainer, OptionsDivider} from '../gantt/VizComponents';
 import {Box} from '../ui/Box';
 import {ButtonWIP} from '../ui/Button';
 import {ButtonGroup} from '../ui/ButtonGroup';
@@ -62,7 +63,7 @@ export const LogsToolbar: React.FC<ILogsToolbarProps> = (props) => {
     computeLogUrl,
   } = props;
   return (
-    <LogsToolbarContainer>
+    <OptionsContainer>
       <ButtonGroup
         activeItems={new Set([logType])}
         buttons={[
@@ -71,7 +72,7 @@ export const LogsToolbar: React.FC<ILogsToolbarProps> = (props) => {
         ]}
         onClick={(id) => onSetLogType(id)}
       />
-      <LogsToolbarDivider />
+      <OptionsDivider />
       {logType === 'structured' ? (
         <StructuredLogToolbar filter={filter} onSetFilter={onSetFilter} steps={steps} />
       ) : (
@@ -85,7 +86,7 @@ export const LogsToolbar: React.FC<ILogsToolbarProps> = (props) => {
           computeLogUrl={computeLogUrl}
         />
       )}
-    </LogsToolbarContainer>
+    </OptionsContainer>
   );
 };
 
@@ -277,7 +278,7 @@ const StructuredLogToolbar = ({
           Hide non-matches
         </NonMatchCheckbox>
       ) : null}
-      <LogsToolbarDivider />
+      <OptionsDivider />
       <Group direction="row" spacing={4} alignItems="center">
         {Object.keys(LogLevel).map((level) => {
           const enabled = filter.levels[level];
@@ -307,7 +308,7 @@ const StructuredLogToolbar = ({
           );
         })}
       </Group>
-      {selectedStep && <LogsToolbarDivider />}
+      {selectedStep && <OptionsDivider />}
       <div style={{minWidth: 15, flex: 1}} />
       <div style={{marginRight: '8px'}}>
         <ButtonWIP
@@ -325,31 +326,12 @@ const StructuredLogToolbar = ({
   );
 };
 
-const LogsToolbarContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  background: ${ColorsWIP.White};
-  align-items: center;
-  padding: 4px 8px;
-  border-bottom: 1px solid ${ColorsWIP.Gray300};
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
-  z-index: 2;
-`;
-
 const NonMatchCheckbox = styled(Checkbox)`
   &&& {
     margin: 0 4px 0 12px;
   }
 
   white-space: nowrap;
-`;
-
-const LogsToolbarDivider = styled.div`
-  display: inline-block;
-  width: 1px;
-  height: 30px;
-  margin: 0 8px;
-  border-right: 1px solid ${ColorsWIP.Gray100};
 `;
 
 const FilterButton = styled.button`

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -352,5 +352,4 @@ const LogsContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: #f1f6f9;
 `;

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -145,9 +145,8 @@ export const RunTable = (props: RunTableProps) => {
         <tr>
           <th colSpan={2}>
             {canTerminateOrDelete ? (
-              <div style={{display: 'flex', alignItems: 'center'}}>
+              <div style={{display: 'flex', alignItems: 'center', gap: 5}}>
                 <Checkbox
-                  style={{marginBottom: 0, marginTop: 1}}
                   indeterminate={checkedRuns.size > 0 && checkedRuns.size !== runs.length}
                   checked={checkedRuns.size === runs.length}
                   onChange={onChangeAll}

--- a/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
@@ -115,8 +115,13 @@ const StyledButton = styled.button<StyledButtonProps>`
     margin-left: 4px;
   }
 
-  ${SpinnerWrapper}:first-child:last-child,
-  ${IconWrapper}:first-child:last-child {
+  ${SpinnerWrapper}:first-child:last-child {
     margin: 2px -4px;
+   }
+   ${IconWrapper}:first-child:last-child {
+      margin: 0px -5px;
+      width: 20px;
+      height: 20px;
+    }
   }
 `;

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -158,6 +158,7 @@ const Base = ({
   disabled = false,
   indeterminate = false,
   fillColor = ColorsWIP.Gray800,
+  children, // not passed to input
   ...rest
 }: Props) => {
   const uid = useRef(id || uniqueId('checkbox-'));
@@ -194,8 +195,10 @@ export const Checkbox = styled(Base)`
   color: ${({disabled}) => (disabled ? DISABLED_COLOR : ColorsWIP.Gray900)};
   cursor: pointer;
   gap: 8px;
-  margin-top: -3px;
-  margin-left: -3px;
+
+  svg {
+    margin: -3px;
+  }
 
   input[type='checkbox'] {
     position: absolute;

--- a/js_modules/dagit/packages/core/src/ui/Colors.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Colors.tsx
@@ -10,6 +10,7 @@ export const ColorsWIP = {
   Gray200: 'rgba(218, 216, 214, 1)',
   Gray100: 'rgba(245, 244, 242, 1)',
   Gray50: 'rgba(250, 249, 247, 1)',
+  KeylineGray: 'rgba(233, 232, 232, 1)',
   Gray10: 'rgba(35, 31, 27, 0.03)',
   White: 'rgba(255, 255, 255, 1)',
   LightPurple: 'rgba(222, 221, 255, 1)',

--- a/js_modules/dagit/packages/core/src/ui/Icon.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Icon.tsx
@@ -109,16 +109,26 @@ interface Props {
   color?: string;
   name: IconName;
   size?: 16 | 20 | 24 | 48;
+  style?: React.CSSProperties;
 }
 
 export const IconWIP = React.memo((props: Props) => {
-  const {color = ColorsWIP.Dark, name, size = 16} = props;
+  const {color = ColorsWIP.Dark, name, size = 16, style} = props;
   let img = Icons[name] || '';
   if (typeof img === 'object' && 'default' in img) {
     // in Dagit but not in Storybook due to webpack config differences
     img = img.default;
   }
-  return <IconWrapper role="img" $size={size} $img={img} $color={color} aria-label={name} />;
+  return (
+    <IconWrapper
+      role="img"
+      $size={size}
+      $img={img}
+      $color={color}
+      aria-label={name}
+      style={style}
+    />
+  );
 });
 
 interface WrapperProps {
@@ -136,4 +146,5 @@ export const IconWrapper = styled.div<WrapperProps>`
   mask-image: url(${(p) => p.$img});
   mask-size: cover;
   object-fit: cover;
+  transition: transform 150ms linear;
 `;

--- a/js_modules/dagit/packages/core/src/ui/Slider.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Slider.tsx
@@ -24,7 +24,7 @@ export const MultiSlider: React.FC<MultiSliderProps & {fillColor?: string}> & {
 
 MultiSlider.Handle = BlueprintMultiSlider.Handle;
 
-const StylesShared = css<{$fillColor: string}>`
+export const SliderStyles = css<{$fillColor: string}>`
   .bp3-slider-track {
     height: 8px;
     .bp3-slider-progress {
@@ -61,8 +61,8 @@ const StylesShared = css<{$fillColor: string}>`
 `;
 
 const StyledMultiSlider = styled(BlueprintMultiSlider)<{$fillColor: string}>`
-  ${StylesShared}
+  ${SliderStyles}
 `;
 const StyledSlider = styled(BlueprintSlider)<{$fillColor: string}>`
-  ${StylesShared}
+  ${SliderStyles}
 `;

--- a/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
@@ -6,7 +6,7 @@ import {ButtonGroup} from './ButtonGroup';
 import {ColorsWIP} from './Colors';
 import {IconWIP} from './Icon';
 
-const DIVIDER_THICKNESS = 4;
+const DIVIDER_THICKNESS = 2;
 
 interface SplitPanelContainerProps {
   axis?: 'horizontal' | 'vertical';
@@ -192,22 +192,23 @@ export const SecondPanelToggle = ({container, axis}: PanelToggleProps) => {
   );
 };
 
+// Note: -1px margins here let the divider cover the last 1px of the previous box, hiding
+// any scrollbar border it might have.
+
 const DividerWrapper = {
   horizontal: styled.div<{resizing: boolean}>`
     width: ${DIVIDER_THICKNESS}px;
     z-index: 1;
-    background: ${ColorsWIP.White};
-    border-left: 1px solid ${(p) => (p.resizing ? ColorsWIP.Gray200 : ColorsWIP.Gray100)};
-    border-right: 1px solid ${(p) => (p.resizing ? ColorsWIP.Gray400 : ColorsWIP.Gray200)};
+    background: ${(p) => (p.resizing ? ColorsWIP.Gray400 : ColorsWIP.KeylineGray)};
+    margin-left: -1px;
     overflow: visible;
     position: relative;
   `,
   vertical: styled.div<{resizing: boolean}>`
     height: ${DIVIDER_THICKNESS}px;
     z-index: 1;
-    background: ${ColorsWIP.White};
-    border-top: 1px solid ${(p) => (p.resizing ? ColorsWIP.Gray200 : ColorsWIP.Gray100)};
-    border-bottom: 1px solid ${(p) => (p.resizing ? ColorsWIP.Gray400 : ColorsWIP.Gray200)};
+    background: ${(p) => (p.resizing ? ColorsWIP.Gray400 : ColorsWIP.KeylineGray)};
+    margin-top: -1px;
     overflow: visible;
     position: relative;
   `,

--- a/js_modules/dagit/packages/core/src/ui/Table.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Table.tsx
@@ -14,7 +14,7 @@ export const Table = styled(HTMLTable)<TableProps>`
 
   & tr th,
   & tr td {
-    box-shadow: inset 0 1px 0 rgba(35, 31, 27, 0.1), inset 1px 0 0 rgba(35, 31, 27, 0.1) !important;
+    box-shadow: inset 0 1px 0 ${ColorsWIP.KeylineGray}, inset 1px 0 0 ${ColorsWIP.KeylineGray} !important;
   }
 
   & tr th {
@@ -34,7 +34,7 @@ export const Table = styled(HTMLTable)<TableProps>`
   }
 
   & tr:last-child td {
-    box-shadow: inset 0 1px 0 rgba(35, 31, 27, 0.1), inset 1px 0 0 rgba(35, 31, 27, 0.1),
-      inset 0 -1px 0 rgba(35, 31, 27, 0.1) !important;
+    box-shadow: inset 0 1px 0 ${ColorsWIP.KeylineGray}, inset 1px 0 0 ${ColorsWIP.KeylineGray},
+      inset 0 -1px 0 ${ColorsWIP.KeylineGray} !important;
   }
 `;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1037212/136084857-faae7aef-fce8-4fc6-9847-5e5a2ca05ec8.png)


## Summary
Side effects:
- The icons in buttons with only an icon are now 20px
- The draggable dividers provided by SplitPanelContainer are KeylineGray
- The checkbox margin: -3px has been tweaked so that if they are a child of a flexbox with align center, they are still centered
- The collapsing sidebar elements are shared and have updated in the pipeline explorer as well.
- 
Remaining todos on this screen:
- Filter bar for logs is too small
- Re-execute button
- Header
- Potentially moving around the actual controls (so far changes are just styling but BB proposed layout changes as well)



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.