### PR TITLE
Fix race condition during termination in StepDelegatingExecutor

### DIFF
--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
@@ -90,7 +90,7 @@ class StepDelegatingExecutor(Executor):
             running_steps: Dict[str, ExecutionStep] = {}
 
             last_check_step_health_time = pendulum.now("UTC")
-            while (not active_execution.is_complete and not stopping) or running_steps:
+            while not active_execution.is_complete and not stopping:
                 events = []
 
                 if active_execution.check_for_interrupts():
@@ -113,7 +113,6 @@ class StepDelegatingExecutor(Executor):
                                 running_steps,
                             )
                         )
-                    running_steps.clear()
 
                 events.extend(
                     self._pop_events(


### PR DESCRIPTION
Current behavior in the StepDelegatingExecutor is unintended and prone to a race condition. The executor sends the termination to the steps, then clears its internal state of which steps are executing, then collects and processes one more round of events, then exits. So it does not actually wait for steps to terminate, it just waits an arbitrary amount of time. If a step happens to actually terminate and the events get processed by the executor while it's doing this silly extra loop, then the executor crashes because it sees a STEP_FAIL event for a step it doesn't believe is in flight.

There is a good argument to make the executor actually wait for the steps to complete, e.g. just remove the `inflight_steps.clear()`. However, this is prone to the issue that the executor is operating on a grace period once it receives the termination request. If it overstays its welcome, it's killed and the run is left hanging in CANCELING state. We should find a way to fix that and make the executor wait, but for now we can clean up the silly race condition.

It's not super clear how to test this, since it's the same behavior except in a rare race condition. Maybe we can mock that out. But I also think we could leave a ticket for that and rely on the existing coverage.