### PR TITLE
[crag config 3/3] revamp config schema for nested graphs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -617,7 +617,7 @@ class PendingNodeInvocation:
             solid_retry_policy=self.retry_policy,
         )
 
-        run_config = {"ops": config if config is not None else {}}
+        run_config = {"graph": config if config is not None else {}}
 
         return core_execute_in_process(
             node=self.node_def,

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -914,8 +914,7 @@ def do_composition(
     fn: Callable,
     provided_input_defs: List[InputDefinition],
     provided_output_defs: Optional[List[OutputDefinition]],
-    config_schema: Any,
-    config_fn: Optional[Callable[[Any], Any]],
+    config_mapping: Optional[ConfigMapping],
     ignore_output_from_composition_fn: bool,
 ) -> Tuple[
     List[InputMapping],
@@ -938,8 +937,9 @@ def do_composition(
             explicitly provided to the decorator by the user.
         provided_output_defs(List[OutputDefinition]): List of output definitions
             explicitly provided to the decorator by the user.
-        config_schema(Any): Config schema provided to decorator by user.
-        config_fn(Callable): Config fn provided to decorator by user.
+        config_mapping (Any): Config mapping provided to decorator by user. In
+            pipeline/composite_solid case, this would have been constructed from a user-provided
+            config_schema and config_fn.
         ignore_output_from_composite_fn(Bool): Because of backwards compatibility
             issues, pipelines ignore the return value out of the mapping if
             the user has not explicitly provided the output definitions.
@@ -1036,10 +1036,6 @@ def do_composition(
             )
         output_mappings.append(mapping)
 
-    config_mapping = _get_validated_config_mapping(
-        graph_name, config_schema, config_fn, decorator_name
-    )
-
     return (
         input_mappings,
         output_mappings,
@@ -1050,8 +1046,11 @@ def do_composition(
     )
 
 
-def _get_validated_config_mapping(
-    name: str, config_schema: Any, config_fn: Optional[Callable[[Any], Any]], decorator_name: str
+def get_validated_config_mapping(
+    name: str,
+    config_schema: Any,
+    config_fn: Optional[Callable[[Any], Any]],
+    decorator_name: str,
 ) -> Optional[ConfigMapping]:
     if config_fn is None and config_schema is None:
         return None

--- a/python_modules/dagster/dagster/core/definitions/decorators/composite_solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/composite_solid.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from dagster import check
 
-from ..composition import do_composition
+from ..composition import do_composition, get_validated_config_mapping
 from ..input import InputDefinition
 from ..output import OutputDefinition
 from ..solid import CompositeSolidDefinition
@@ -33,6 +33,10 @@ class _CompositeSolid:
         if not self.name:
             self.name = fn.__name__
 
+        config_mapping = get_validated_config_mapping(
+            self.name, self.config_schema, self.config_fn, decorator_name="composite_solid"
+        )
+
         (
             input_mappings,
             output_mappings,
@@ -46,8 +50,7 @@ class _CompositeSolid:
             fn,
             self.input_defs,
             self.output_defs,
-            self.config_schema,
-            self.config_fn,
+            config_mapping,
             ignore_output_from_composition_fn=False,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/graph.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from dagster import check
 from dagster.utils.backcompat import experimental_decorator
 
+from ..config import ConfigMapping
 from ..graph import GraphDefinition
 from ..input import GraphIn, InputDefinition
 from ..output import GraphOut, OutputDefinition
@@ -19,6 +20,7 @@ class _Graph:
         ins: Optional[Dict[str, GraphIn]] = None,
         out: Optional[Union[GraphOut, Dict[str, GraphOut]]] = None,
         tags: Optional[Dict[str, Any]] = None,
+        config_mapping: Optional[ConfigMapping] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
@@ -30,6 +32,7 @@ class _Graph:
         self.ins = ins
         self.out = out
         self.tags = tags
+        self.config_mapping = check.opt_inst_param(config_mapping, "config_mapping", ConfigMapping)
 
     def __call__(self, fn: Callable[..., Any]) -> GraphDefinition:
         check.callable_param(fn, "fn")
@@ -68,8 +71,7 @@ class _Graph:
             provided_input_defs=input_defs,
             provided_output_defs=output_defs,
             ignore_output_from_composition_fn=False,
-            config_schema=None,
-            config_fn=None,
+            config_mapping=self.config_mapping,
         )
 
         graph_def = GraphDefinition(
@@ -96,6 +98,7 @@ def graph(
     ins: Optional[Dict[str, GraphIn]] = None,
     out: Optional[Union[GraphOut, Dict[str, GraphOut]]] = None,
     tags: Optional[Dict[str, Any]] = None,
+    config_mapping: Optional[ConfigMapping] = None,
 ) -> Union[_Graph, GraphDefinition]:
     """Create a graph with the specified parameters from the decorated composition function.
 
@@ -151,4 +154,5 @@ def graph(
         ins=ins,
         out=out,
         tags=tags,
+        config_mapping=config_mapping,
     )

--- a/python_modules/dagster/dagster/core/definitions/decorators/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/pipeline.py
@@ -57,7 +57,14 @@ class _Pipeline:
         if not self.name:
             self.name = fn.__name__
 
-        from dagster.core.definitions.decorators.composite_solid import do_composition
+        from dagster.core.definitions.decorators.composite_solid import (
+            do_composition,
+            get_validated_config_mapping,
+        )
+
+        config_mapping = get_validated_config_mapping(
+            self.name, self.config_schema, self.config_fn, decorator_name="pipeline"
+        )
 
         (
             input_mappings,
@@ -72,8 +79,7 @@ class _Pipeline:
             fn,
             self.input_defs,
             self.output_defs,
-            self.config_schema,
-            self.config_fn,
+            config_mapping,
             ignore_output_from_composition_fn=not self.did_pass_outputs,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
+++ b/python_modules/dagster/dagster/core/definitions/definition_config_schema.py
@@ -105,20 +105,38 @@ class ConfiguredDefinitionConfigSchema(IDefinitionConfigSchema):
     def as_field(self) -> Field:
         return self._current_field
 
-    def _invoke_user_config_fn(self, processed_config: Dict[str, Any]) -> Dict[str, Any]:
+    def _invoke_user_config_fn(self, processed_config: Dict[str, Any]) -> Any:
+        from .graph import GraphDefinition
+        from .solid import CompositeSolidDefinition
+
         with user_code_error_boundary(
             DagsterConfigMappingFunctionError,
             _get_user_code_error_str_lambda(self.parent_def),
         ):
-            return {"config": self._config_fn(processed_config.get("config", {}))}
+            if isinstance(self.parent_def, GraphDefinition) and not isinstance(
+                self.parent_def, CompositeSolidDefinition
+            ):
+                return self._config_fn(processed_config)
+            else:
+                return {"config": self._config_fn(processed_config.get("config", {}))}
 
-    def resolve_config(self, processed_config: Dict[str, Any]) -> EvaluateValueResult:
-        check.dict_param(processed_config, "processed_config")
+    def resolve_config(self, processed_config: Any) -> EvaluateValueResult:
+        from .graph import GraphDefinition
+        from .solid import CompositeSolidDefinition
+
         # Validate resolved config against the inner definitions's config_schema (on self).
-        config_evr = process_config(
-            {"config": self.parent_def.config_field or {}},
-            self._invoke_user_config_fn(processed_config),
-        )
+        if isinstance(self.parent_def, GraphDefinition) and not isinstance(
+            self.parent_def, CompositeSolidDefinition
+        ):
+            config_evr = process_config(
+                self.parent_def.config_field.config_type if self.parent_def.config_field else {},
+                self._invoke_user_config_fn(processed_config),
+            )
+        else:
+            config_evr = process_config(
+                {"config": self.parent_def.config_field or {}},
+                self._invoke_user_config_fn(processed_config),
+            )
         if config_evr.success:
             return self.parent_def.apply_config_mapping(config_evr.value)  # Recursive step
         else:

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -196,6 +196,10 @@ class GraphDefinition(NodeDefinition):
         return list(set(self._node_dict.values()))
 
     @property
+    def nodes(self) -> List[Node]:
+        return list(set(self._node_dict.values()))
+
+    @property
     def node_dict(self) -> Dict[str, Node]:
         return self._node_dict
 

--- a/python_modules/dagster/dagster/core/definitions/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/graph.py
@@ -523,15 +523,13 @@ class GraphDefinition(NodeDefinition):
         resource_defs: Optional[Dict[str, ResourceDefinition]],
         executor_def: "ExecutorDefinition",
     ) -> ConfigType:
-        from .pipeline import PipelineDefinition
+        from .job import JobDefinition
 
         return (
-            PipelineDefinition(
+            JobDefinition(
                 name=self.name,
                 graph_def=self,
-                mode_defs=[
-                    ModeDefinition(resource_defs=resource_defs, executor_defs=[executor_def])
-                ],
+                mode_def=ModeDefinition(resource_defs=resource_defs, executor_defs=[executor_def]),
             )
             .get_run_config_schema("default")
             .run_config_schema_type

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -1053,6 +1053,7 @@ def _create_run_config_schema(
         RunConfigSchemaCreationData(
             pipeline_name=pipeline_def.name,
             solids=pipeline_def.graph.solids,
+            graph_def=pipeline_def.graph,
             dependency_structure=pipeline_def.graph.dependency_structure,
             mode_definition=mode_definition,
             logger_defs=mode_definition.loggers,

--- a/python_modules/dagster/dagster/core/definitions/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline.py
@@ -1030,8 +1030,10 @@ def _create_run_config_schema(
     from .run_config import (
         RunConfigSchemaCreationData,
         construct_config_type_dictionary,
-        define_run_config_schema_type,
+        define_run_config_schema_type_for_pipeline,
+        define_run_config_schema_type_for_job,
     )
+    from .job import JobDefinition
     from .run_config_schema import RunConfigSchema
 
     # When executing with a subset pipeline, include the missing solids
@@ -1049,19 +1051,21 @@ def _create_run_config_schema(
     else:
         ignored_solids = []
 
-    run_config_schema_type = define_run_config_schema_type(
-        RunConfigSchemaCreationData(
-            pipeline_name=pipeline_def.name,
-            solids=pipeline_def.graph.solids,
-            graph_def=pipeline_def.graph,
-            dependency_structure=pipeline_def.graph.dependency_structure,
-            mode_definition=mode_definition,
-            logger_defs=mode_definition.loggers,
-            ignored_solids=ignored_solids,
-            required_resources=required_resources,
-            is_using_graph_job_op_apis=pipeline_def._is_using_graph_job_op_apis,  # pylint: disable=protected-access
-        )
+    creation_data = RunConfigSchemaCreationData(
+        pipeline_name=pipeline_def.name,
+        solids=pipeline_def.graph.solids,
+        graph_def=pipeline_def.graph,
+        dependency_structure=pipeline_def.graph.dependency_structure,
+        mode_definition=mode_definition,
+        logger_defs=mode_definition.loggers,
+        ignored_solids=ignored_solids,
+        required_resources=required_resources,
+        is_using_graph_job_op_apis=pipeline_def._is_using_graph_job_op_apis,  # pylint: disable=protected-access
     )
+    if isinstance(pipeline_def, JobDefinition):
+        run_config_schema_type = define_run_config_schema_type_for_job(creation_data)
+    else:
+        run_config_schema_type = define_run_config_schema_type_for_pipeline(creation_data)
 
     if mode_definition.config_mapping:
         outer_config_type = mode_definition.config_mapping.config_schema.config_type

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, cast
 
 from dagster.config import Field, Permissive, Selector
 from dagster.config.config_type import ALL_CONFIG_BUILTINS, Array, ConfigType
@@ -65,6 +65,7 @@ def def_config_field(configurable_def: ConfigurableDefinition, is_required: bool
 class RunConfigSchemaCreationData(NamedTuple):
     pipeline_name: str
     solids: List[Node]
+    graph_def: GraphDefinition
     dependency_structure: DependencyStructure
     mode_definition: ModeDefinition
     logger_defs: Dict[str, LoggerDefinition]
@@ -149,15 +150,20 @@ def define_run_config_schema_type(creation_data: RunConfigSchemaCreationData) ->
         ),
     }
 
-    nodes_field = Field(
-        define_solid_dictionary_cls(
-            solids=creation_data.solids,
-            ignored_solids=creation_data.ignored_solids,
-            dependency_structure=creation_data.dependency_structure,
-            resource_defs=creation_data.mode_definition.resource_defs,
-            is_using_graph_job_op_apis=creation_data.is_using_graph_job_op_apis,
+    if creation_data.graph_def.has_config_mapping:
+        config_schema = cast(IDefinitionConfigSchema, creation_data.graph_def.config_schema)
+        nodes_field = Field({"config": config_schema.as_field()})
+    else:
+        nodes_field = Field(
+            define_solid_dictionary_cls(
+                solids=creation_data.solids,
+                ignored_solids=creation_data.ignored_solids,
+                dependency_structure=creation_data.dependency_structure,
+                resource_defs=creation_data.mode_definition.resource_defs,
+                is_using_graph_job_op_apis=creation_data.is_using_graph_job_op_apis,
+            )
         )
-    )
+
     if creation_data.is_using_graph_job_op_apis:
         fields["ops"] = nodes_field
         field_aliases = {"ops": "solids"}

--- a/python_modules/dagster/dagster/core/system_config/objects.py
+++ b/python_modules/dagster/dagster/core/system_config/objects.py
@@ -213,7 +213,7 @@ class ResolvedRunConfig(
         config_mapped_logger_configs = config_map_loggers(pipeline_def, config_value, mode)
 
         node_key = (
-            "ops"
+            "graph"
             if pipeline_def._is_using_graph_job_op_apis  # pylint: disable=protected-access
             else "solids"
         )

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -660,3 +660,107 @@ def test_output_for_node_non_standard_name():
     result = basic.execute_in_process()
 
     assert result.output_for_node("my_op", "foo") == 5
+
+
+def test_top_level_config_mapping_graph():
+    @op(config_schema=str)
+    def my_op(context):
+        return context.op_config
+
+    def _config_fn(_):
+        return {"my_op": {"config": "foo"}}
+
+    @graph(config_mapping=ConfigMapping(config_fn=_config_fn))
+    def my_graph():
+        my_op()
+
+    result = my_graph.execute_in_process()
+
+    assert result.success
+    assert result.output_for_node("my_op") == "foo"
+
+
+def test_top_level_config_mapping_config_schema():
+    @op(config_schema=str)
+    def my_op(context):
+        return context.op_config
+
+    def _config_fn(outer):
+        return {"my_op": {"config": outer}}
+
+    @graph(config_mapping=ConfigMapping(config_fn=_config_fn, config_schema=str))
+    def my_graph():
+        my_op()
+
+    result = my_graph.to_job().execute_in_process(run_config={"ops": {"config": "foo"}})
+
+    assert result.success
+    assert result.output_for_node("my_op") == "foo"
+
+    my_job = my_graph.to_job(config={"ops": {"config": "foo"}})
+    result = my_job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("my_op") == "foo"
+
+
+def test_nested_graph_config_mapping():
+    @op(config_schema=str)
+    def my_op(context):
+        return context.op_config
+
+    def _nested_config_fn(outer):
+        return {"my_op": {"config": outer}}
+
+    @graph(config_mapping=ConfigMapping(config_fn=_nested_config_fn, config_schema=str))
+    def my_nested_graph():
+        my_op()
+
+    def _config_fn(outer):
+        return {"my_nested_graph": {"config": outer}}
+
+    @graph(config_mapping=ConfigMapping(config_fn=_config_fn, config_schema=str))
+    def my_graph():
+        my_nested_graph()
+
+    result = my_graph.to_job().execute_in_process(run_config={"ops": {"config": "foo"}})
+
+    assert result.success
+    assert result.output_for_node("my_nested_graph.my_op") == "foo"
+
+
+def test_top_level_graph_config_mapping_failure():
+    @op(config_schema=str)
+    def my_op(context):
+        return context.op_config
+
+    def _nested_config_fn(_):
+        return "foo"
+
+    @graph(config_mapping=ConfigMapping(config_fn=_nested_config_fn))
+    def my_nested_graph():
+        my_op()
+
+    with pytest.raises(
+        DagsterInvalidConfigError,
+        match="In pipeline 'my_nested_graph', top level graph 'my_nested_graph' has a configuration error.",
+    ):
+        my_nested_graph.execute_in_process()
+
+
+def test_top_level_graph_outer_config_failure():
+    @op(config_schema=str)
+    def my_op(context):
+        return context.op_config
+
+    def _config_fn(outer):
+        return {"my_op": {"config": outer}}
+
+    @graph(config_mapping=ConfigMapping(config_fn=_config_fn, config_schema=str))
+    def my_graph():
+        my_op()
+
+    with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at path root:ops:config"):
+        my_graph.to_job().execute_in_process(run_config={"ops": {"config": {"bad_type": "foo"}}})
+
+    with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at path root:config"):
+        my_graph.to_job(config={"ops": {"config": {"bad_type": "foo"}}})

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -653,12 +653,12 @@ def test_top_level_config_mapping_config_schema():
     def my_graph():
         my_op()
 
-    result = my_graph.to_job().execute_in_process(run_config={"graph": {"config": "foo"}})
+    result = my_graph.to_job().execute_in_process(run_config={"graph": "foo"})
 
     assert result.success
     assert result.output_for_node("my_op") == "foo"
 
-    my_job = my_graph.to_job(config={"graph": {"config": "foo"}})
+    my_job = my_graph.to_job(config={"graph": "foo"})
     result = my_job.execute_in_process()
     assert result.success
     assert result.output_for_node("my_op") == "foo"
@@ -677,13 +677,13 @@ def test_nested_graph_config_mapping():
         my_op()
 
     def _config_fn(outer):
-        return {"my_nested_graph": {"config": outer}}
+        return {"my_nested_graph": outer}
 
     @graph(config_mapping=ConfigMapping(config_fn=_config_fn, config_schema=str))
     def my_graph():
         my_nested_graph()
 
-    result = my_graph.to_job().execute_in_process(run_config={"graph": {"config": "foo"}})
+    result = my_graph.to_job().execute_in_process(run_config={"graph": "foo"})
 
     assert result.success
     assert result.output_for_node("my_nested_graph.my_op") == "foo"
@@ -720,10 +720,10 @@ def test_top_level_graph_outer_config_failure():
     def my_graph():
         my_op()
 
-    with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at path root:graph:config"):
+    with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at path root:graph"):
         my_graph.to_job().execute_in_process(run_config={"graph": {"config": {"bad_type": "foo"}}})
 
-    with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at path root:config"):
+    with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at the root."):
         my_graph.to_job(config={"graph": {"config": {"bad_type": "foo"}}})
 
 
@@ -751,7 +751,7 @@ def test_graph_with_configured():
             name="my_graph", config_or_config_fn=_configured_use_fn, config_schema=str
         )
         .to_job()
-        .execute_in_process(run_config={"graph": {"config": "foo"}})
+        .execute_in_process(run_config={"graph": "foo"})
     )
 
     assert result.success


### PR DESCRIPTION
This PR changes a few things about the config schema of nested graphs:
- Remove input/output config schema on graphs
- Remove additional layer of indirection when using config mapping (ie, `my_graph: config: blah` becomes `my_graph: blah`).
- Implementation is definitely kinda wonky. There's places we could consolidate and delegate. My worry is having the code in a dual state like this for long will be potentially very confusing. There's probably a larger refactor of how config schema is generated that needs to happen (we get config schema delegated from objects rather than passing objects in), but I think that's not crucial for 0.13.0.