### PR TITLE
[dagit] Unify dialog wash color

### DIFF
--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -152,7 +152,7 @@ export const SearchDialog: React.FC<{theme: 'dark' | 'light'; searchPlaceholder:
         </SearchTrigger>
       </ShortcutHandler>
       <Overlay
-        backdropProps={{style: {backgroundColor: 'rgba(0, 0, 0, .35)'}}}
+        backdropProps={{style: {backgroundColor: ColorsWIP.WashGray}}}
         isOpen={shown}
         onClose={() => dispatch({type: 'hide-dialog'})}
         transitionDuration={100}

--- a/js_modules/dagit/packages/core/src/ui/Colors.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Colors.tsx
@@ -11,6 +11,7 @@ export const ColorsWIP = {
   Gray100: 'rgba(245, 244, 242, 1)',
   Gray50: 'rgba(250, 249, 247, 1)',
   KeylineGray: 'rgba(233, 232, 232, 1)',
+  WashGray: 'rgba(0, 0, 0, .35)',
   Gray10: 'rgba(35, 31, 27, 0.03)',
   White: 'rgba(255, 255, 255, 1)',
   LightPurple: 'rgba(222, 221, 255, 1)',

--- a/js_modules/dagit/packages/core/src/ui/Dialog.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Dialog.tsx
@@ -41,7 +41,7 @@ export const DialogHeader: React.FC<HeaderProps> = (props) => {
   const {icon, label} = props;
   return (
     <Box
-      background={ColorsWIP.Gray50}
+      background={ColorsWIP.White}
       padding={{vertical: 16, horizontal: 20}}
       border={{side: 'bottom', width: 1, color: ColorsWIP.Gray200}}
     >
@@ -89,7 +89,7 @@ const DialogHeaderText = styled.div`
 
 export const GlobalDialogStyle = createGlobalStyle`
   .dagit-portal .bp3-overlay-backdrop {
-    background-color: rgba(189, 186, 183, 0.7);
+    background-color: ${ColorsWIP.WashGray};
   }
 
   .dagit-portal .bp3-dialog-container {


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Unify search dialog and general `Dialog` wash into a single common color.

Also change `DialogHeader` to use a white background.

## Test Plan

View dialogs in Dagit.