### PR TITLE
[dagit] Keep filter input for Runs empty state

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -48,15 +48,18 @@ export const RunTable = (props: RunTableProps) => {
 
   if (runs.length === 0) {
     return (
-      <Box margin={{vertical: 64}}>
-        {nonIdealState || (
-          <NonIdealState
-            icon="run"
-            title="No runs to display"
-            description="Use the Playground to launch a run."
-          />
-        )}
-      </Box>
+      <div>
+        <Box padding={{vertical: 8, left: 24, right: 12}}>{actionBarComponents}</Box>
+        <Box margin={{vertical: 64}}>
+          {nonIdealState || (
+            <NonIdealState
+              icon="run"
+              title="No runs to display"
+              description="Use the Playground to launch a run."
+            />
+          )}
+        </Box>
+      </div>
     );
   }
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Make sure the filter input remains visible for Runs empty state.

## Test Plan

View Runs, add a filter tag. Verify that the filter input remains in place even when no runs are found.
