### PR TITLE
[dagit-bb] Left nav style changes

### DIFF
--- a/js_modules/dagit/packages/core/src/app/App.tsx
+++ b/js_modules/dagit/packages/core/src/app/App.tsx
@@ -24,7 +24,7 @@ export const App: React.FC = (props) => {
 
 const Main = styled.div<{$navOpen: boolean}>`
   height: 100%;
-  margin-left: 280px;
+  margin-left: 332px;
   width: calc(100% - 280px);
 
   @media (max-width: 1440px) {

--- a/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
@@ -1,10 +1,10 @@
 import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {InstigationStatus} from '../types/globalTypes';
-import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {IconWIP} from '../ui/Icon';
 import {Tooltip} from '../ui/Tooltip';
@@ -89,7 +89,7 @@ export const FlatContentList: React.FC<Props> = (props) => {
                 <Label $hasIcon={!!(schedule || sensor)}>
                   {name}
                   {modeName !== 'default' ? (
-                    <span style={{color: ColorsWIP.Gray400}}>{` : ${modeName}`}</span>
+                    <span style={{color: ColorsWIP.Gray600}}>{` : ${modeName}`}</span>
                   ) : null}
                 </Label>
               ),
@@ -154,28 +154,31 @@ const JobItem: React.FC<JobItemProps> = (props) => {
         Sensor: <strong>{sensor?.name}</strong>
       </>
     );
+    const path = schedule ? `/schedules/${schedule.name}` : `/sensors/${sensor?.name}`;
 
     return (
-      <IconWithTooltip content={tooltipContent} inheritDarkTheme={false}>
-        <IconWIP
-          name={whichIcon}
-          color={status === InstigationStatus.RUNNING ? ColorsWIP.Green500 : ColorsWIP.Gray600}
-        />
+      <IconWithTooltip content={tooltipContent}>
+        <Link to={workspacePathFromAddress(repoAddress, path)}>
+          <IconWIP
+            name={whichIcon}
+            color={status === InstigationStatus.RUNNING ? ColorsWIP.Green500 : ColorsWIP.Gray600}
+          />
+        </Link>
       </IconWithTooltip>
     );
   };
 
   return (
-    <Item
-      key={jobName}
-      className={`${jobName === selector && repoPath === jobRepoPath ? 'selected' : ''}`}
-      to={workspacePathFromAddress(repoAddress, `/jobs/${jobName}`)}
-    >
-      <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+    <ItemContainer>
+      <Item
+        key={jobName}
+        className={`${jobName === selector && repoPath === jobRepoPath ? 'selected' : ''}`}
+        to={workspacePathFromAddress(repoAddress, `/jobs/${jobName}`)}
+      >
         <div>{label}</div>
-        {icon()}
-      </Box>
-    </Item>
+      </Item>
+      {icon()}
+    </ItemContainer>
   );
 };
 
@@ -256,12 +259,24 @@ const NAV_QUERY = gql`
 const Label = styled.div<{$hasIcon: boolean}>`
   overflow: hidden;
   text-overflow: ellipsis;
-  width: ${({$hasIcon}) => ($hasIcon ? '224px' : '256px')};
+  width: ${({$hasIcon}) => ($hasIcon ? '218px' : '236px')};
 `;
 
 const IconWithTooltip = styled(Tooltip)`
-  .bp3-icon:focus,
-  .bp3-icon:active {
+  position: absolute;
+  right: 8px;
+  top: 6px;
+
+  & a:focus,
+  & a:active {
     outline: none;
+  }
+`;
+
+const ItemContainer = styled.div`
+  position: relative;
+
+  :hover {
+    background-color: ${ColorsWIP.Gray10};
   }
 `;

--- a/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
@@ -22,17 +22,17 @@ const LeftNavContainer = styled.div<{$open: boolean}>`
   top: 64px;
   bottom: 0;
   left: 0;
-  width: 280px;
+  padding-top: 16px;
+  width: 332px;
   display: flex;
   flex-shrink: 0;
   flex-direction: column;
   justify-content: start;
-  background: ${ColorsWIP.Gray900};
-  border-right: 1px solid ${ColorsWIP.Gray700};
+  background: ${ColorsWIP.Gray100};
+  box-shadow: 1px 0px 0px ${ColorsWIP.KeylineGray};
 
   @media (max-width: 1440px) {
-    box-shadow: 2px 0px 0px ${ColorsWIP.Gray200};
-    transform: translateX(${({$open}) => ($open ? '0' : '-280px')});
+    transform: translateX(${({$open}) => ($open ? '0' : '-332px')});
     transition: transform 150ms ease-in-out;
   }
 `;

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -1,8 +1,11 @@
 import memoize from 'lodash/memoize';
 import * as React from 'react';
 import {useRouteMatch} from 'react-router-dom';
+import styled from 'styled-components/macro';
 
+import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
+import {IconWIP} from '../ui/Icon';
 import {
   DagsterRepoOption,
   getRepositoryOptionHash,
@@ -132,32 +135,53 @@ const LoadedRepositorySection: React.FC<{allRepos: DagsterRepoOption[]}> = ({all
   }, [allRepos, visibleRepos]);
 
   return (
-    <div
-      className="bp3-dark"
-      style={{
-        background: ColorsWIP.Gray900,
-        color: ColorsWIP.White,
-        display: 'flex',
-        flex: 1,
-        overflow: 'none',
-        flexDirection: 'column',
-        minHeight: 0,
-      }}
-    >
+    <Container>
+      <ListContainer>
+        <Box
+          flex={{direction: 'row', alignItems: 'center', gap: 8}}
+          padding={{horizontal: 24, bottom: 12}}
+        >
+          <IconWIP name="job" />
+          <span style={{fontSize: '16px', fontWeight: 600}}>Jobs and pipelines</span>
+        </Box>
+        {visibleRepos.size ? (
+          <FlatContentList {...match?.params} repos={visibleOptions} />
+        ) : (
+          <EmptyState>Select a repository to see a list of jobs and pipelines.</EmptyState>
+        )}
+      </ListContainer>
+      <RepositoryLocationStateObserver />
       <RepoNavItem
         allRepos={allRepos.map(buildDetails)}
         selected={visibleRepos}
         onToggle={toggleRepo}
       />
-      <RepositoryLocationStateObserver />
-      {visibleRepos.size ? (
-        <div style={{display: 'flex', flex: 1, flexDirection: 'column', minHeight: 0}}>
-          <FlatContentList {...match?.params} repos={visibleOptions} />
-        </div>
-      ) : null}
-    </div>
+    </Container>
   );
 };
+
+const Container = styled.div`
+  background: ${ColorsWIP.Gray100};
+  color: ${ColorsWIP.Gray900};
+  display: flex;
+  flex: 1;
+  overflow: none;
+  flex-direction: column;
+  min-height: 0;
+`;
+
+const ListContainer = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+`;
+
+const EmptyState = styled.div`
+  color: ${ColorsWIP.Gray400};
+  line-height: 20px;
+  padding: 6px 24px 0;
+`;
 
 export const LeftNavRepositorySection = React.memo(() => {
   const {allRepos, loading} = React.useContext(WorkspaceContext);

--- a/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {Button} from '@blueprintjs/core';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -7,11 +5,11 @@ import styled from 'styled-components/macro';
 import {usePermissions} from '../app/Permissions';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {Box} from '../ui/Box';
-import {ButtonLink} from '../ui/ButtonLink';
+import {ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
+import {DialogFooter, DialogHeader, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
 import {IconWIP, IconWrapper} from '../ui/Icon';
-import {Popover} from '../ui/Popover';
 import {Spinner} from '../ui/Spinner';
 import {Tooltip} from '../ui/Tooltip';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
@@ -31,13 +29,9 @@ export const RepoNavItem: React.FC<Props> = (props) => {
   const {allRepos, selected, onToggle} = props;
   const [open, setOpen] = React.useState(false);
 
-  const onInteraction = React.useCallback((nextState: boolean) => {
-    setOpen(nextState);
-  }, []);
-
   const summary = () => {
     if (allRepos.length === 0) {
-      return <span style={{color: ColorsWIP.Gray600}}>No repositories</span>;
+      return <span style={{color: ColorsWIP.Gray700}}>No repositories</span>;
     }
     if (allRepos.length === 1) {
       return <SingleRepoSummary repoAddress={allRepos[0].repoAddress} />;
@@ -46,56 +40,40 @@ export const RepoNavItem: React.FC<Props> = (props) => {
       const selectedRepo = Array.from(selected)[0];
       return <SingleRepoSummary repoAddress={selectedRepo.repoAddress} />;
     }
-    return (
-      <span style={{color: ColorsWIP.Gray100, fontWeight: 500, userSelect: 'none'}}>
-        {`${selected.size} of ${allRepos.length} shown`}
-      </span>
-    );
+    return <span>{`${selected.size} of ${allRepos.length} shown`}</span>;
   };
 
   return (
     <Box
-      background={ColorsWIP.Gray900}
-      border={{side: 'horizontal', width: 1, color: ColorsWIP.Gray800}}
-      padding={{vertical: 8, horizontal: 12}}
+      background={ColorsWIP.Gray50}
+      padding={{vertical: 12, left: 24, right: 20}}
+      border={{side: 'top', width: 1, color: ColorsWIP.KeylineGray}}
     >
-      <Box flex={{justifyContent: 'space-between'}}>
-        <div style={{color: ColorsWIP.Gray400, fontSize: '10.5px', textTransform: 'uppercase'}}>
-          Repository
-        </div>
+      <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+          <IconWIP name="folder" />
+          <div style={{userSelect: 'none'}}>{summary()}</div>
+        </Box>
         {allRepos.length > 1 ? (
-          <Popover
-            canEscapeKeyClose
-            isOpen={open}
-            onInteraction={onInteraction}
-            modifiers={{offset: {enabled: true, options: {offset: [0, 16]}}}}
-            placement="right"
-            popoverClassName="bp3-dark"
-            content={
-              <div style={{maxWidth: '600px', borderRadius: '3px'}}>
-                <Box
-                  padding={{vertical: 2, left: 8, right: 4}}
-                  background={ColorsWIP.Gray800}
-                  flex={{alignItems: 'center', justifyContent: 'space-between'}}
-                >
-                  <div style={{fontSize: '12px', color: ColorsWIP.Gray400}}>
-                    {`Repositories (${selected.size} of ${allRepos.length} selected)`}
-                  </div>
-                  <Button icon="cross" small minimal onClick={() => setOpen(false)} />
-                </Box>
-                <Box padding={16}>
-                  <RepoSelector options={allRepos} onToggle={onToggle} selected={selected} />
-                </Box>
-              </div>
-            }
-          >
-            <ButtonLink color={ColorsWIP.Gray200} underline="hover">
-              <span style={{fontSize: '11px', position: 'relative', top: '-4px'}}>Filter</span>
-            </ButtonLink>
-          </Popover>
+          <DialogWIP canEscapeKeyClose isOpen={open} style={{width: 'auto'}}>
+            <DialogHeader icon="repo" label="Repositories" />
+            <div>
+              <Box padding={{vertical: 8, horizontal: 24}}>
+                {`${selected.size} of ${allRepos.length} selected`}
+              </Box>
+              <RepoSelector options={allRepos} onToggle={onToggle} selected={selected} />
+            </div>
+            <DialogFooter>
+              <Box padding={{top: 8}}>
+                <ButtonWIP intent="none" onClick={() => setOpen(false)}>
+                  Done
+                </ButtonWIP>
+              </Box>
+            </DialogFooter>
+          </DialogWIP>
         ) : null}
+        <ButtonWIP onClick={() => setOpen(true)}>Filter</ButtonWIP>
       </Box>
-      {summary()}
     </Box>
   );
 };
@@ -119,7 +97,7 @@ const SingleRepoSummary: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
               shortcutFilter={(e) => e.code === 'KeyR' && e.altKey}
             >
               <ReloadTooltip
-                inheritDarkTheme={false}
+                placement="top"
                 content={
                   <Reloading>
                     {reloading ? (
@@ -136,7 +114,7 @@ const SingleRepoSummary: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
                   <Spinner purpose="body-text" />
                 ) : (
                   <StyledButton onClick={tryReload}>
-                    <IconWIP name="refresh" color={ColorsWIP.Gray200} />
+                    <IconWIP name="refresh" color={ColorsWIP.Gray900} />
                   </StyledButton>
                 )}
               </ReloadTooltip>
@@ -149,7 +127,7 @@ const SingleRepoSummary: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
 };
 
 const SingleRepoNameLink = styled(Link)`
-  color: ${ColorsWIP.Gray100};
+  color: ${ColorsWIP.Gray900};
   display: block;
   max-width: 234px;
   overflow-x: hidden;
@@ -157,13 +135,12 @@ const SingleRepoNameLink = styled(Link)`
   transition: color 100ms linear;
 
   && {
-    color: ${ColorsWIP.Gray100};
-    font-weight: 500;
+    color: ${ColorsWIP.Gray900};
   }
 
   &&:hover,
   &&:active {
-    color: ${ColorsWIP.Gray50};
+    color: ${ColorsWIP.Gray800};
     text-decoration: none;
   }
 `;
@@ -176,9 +153,10 @@ const ReloadTooltip = styled(Tooltip)`
 
 const StyledButton = styled.button`
   background-color: transparent;
-  border: 0;
+  border: none;
   cursor: pointer;
   display: block;
+  font-size: 12px;
   padding: 0;
   margin: 0;
 

--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -9,7 +9,10 @@ import {ColorsWIP} from '../ui/Colors';
 import {Group} from '../ui/Group';
 import {IconWIP, IconWrapper} from '../ui/Icon';
 import {Spinner} from '../ui/Spinner';
+import {Table} from '../ui/Table';
 import {Caption} from '../ui/Text';
+import {Tooltip} from '../ui/Tooltip';
+import {FontFamily} from '../ui/styles';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
@@ -32,60 +35,65 @@ export const RepoSelector: React.FC<Props> = (props) => {
   const {canReloadRepositoryLocation} = usePermissions();
 
   return (
-    <Group direction="column" spacing={16}>
-      {options.map((option) => {
-        const {repoAddress, metadata} = option;
-        const addressString = repoAddressAsString(repoAddress);
-        const checked = selected.has(option);
-        return (
-          <Box key={addressString} flex={{direction: 'row', alignItems: 'flex-start'}}>
-            {options.length > 1 ? (
-              <Checkbox
-                checked={checked}
-                onChange={(e) => {
-                  if (e.target instanceof HTMLInputElement) {
-                    onToggle(option);
-                  }
-                }}
-                id={`switch-${addressString}`}
-                style={{marginRight: '4px'}}
-              />
-            ) : null}
-            <RepoLabel htmlFor={`switch-${addressString}`}>
-              <Group direction="column" spacing={4}>
-                <Box flex={{direction: 'row'}} title={addressString}>
-                  <RepoName>{repoAddress.name}</RepoName>
-                  <RepoLocation>{`@${repoAddress.location}`}</RepoLocation>
-                </Box>
-                <Group direction="column" spacing={2}>
-                  {metadata.map(({key, value}) => (
-                    <Caption
-                      style={{color: ColorsWIP.Gray400}}
-                      key={key}
-                    >{`${key}: ${value}`}</Caption>
-                  ))}
-                </Group>
-              </Group>
-            </RepoLabel>
-            <Box margin={{left: 16, top: 1}} style={{lineHeight: 1}}>
-              <BrowseLink to={workspacePathFromAddress(repoAddress)}>Browse</BrowseLink>
-            </Box>
-            {canReloadRepositoryLocation ? <ReloadButton repoAddress={repoAddress} /> : null}
-          </Box>
-        );
-      })}
-    </Group>
+    <Table>
+      <tbody>
+        {options.map((option) => {
+          const {repoAddress, metadata} = option;
+          const addressString = repoAddressAsString(repoAddress);
+          const checked = selected.has(option);
+          return (
+            <tr key={addressString}>
+              <td>
+                <Checkbox
+                  checked={checked}
+                  onChange={(e) => {
+                    if (e.target instanceof HTMLInputElement) {
+                      onToggle(option);
+                    }
+                  }}
+                  id={`switch-${addressString}`}
+                />
+              </td>
+              <td>
+                <RepoLabel htmlFor={`switch-${addressString}`}>
+                  <Group direction="column" spacing={4}>
+                    <Box flex={{direction: 'row'}} title={addressString}>
+                      <RepoName>{repoAddress.name}</RepoName>
+                      <RepoLocation>{`@${repoAddress.location}`}</RepoLocation>
+                    </Box>
+                    <Group direction="column" spacing={2}>
+                      {metadata.map(({key, value}) => (
+                        <Caption
+                          style={{color: ColorsWIP.Gray400, fontFamily: FontFamily.monospace}}
+                          key={key}
+                        >{`${key}: ${value}`}</Caption>
+                      ))}
+                    </Group>
+                  </Group>
+                </RepoLabel>
+              </td>
+              <td>
+                <Link to={workspacePathFromAddress(repoAddress)}>Browse</Link>
+              </td>
+              {canReloadRepositoryLocation ? (
+                <td>
+                  <ReloadButton repoAddress={repoAddress} />
+                </td>
+              ) : null}
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
   );
 };
 
 const RepoLabel = styled.label`
   cursor: pointer;
-  flex-grow: 1;
-  font-size: 14px;
+  display: block;
   font-weight: 500;
   line-height: 1;
   overflow: hidden;
-  padding: 0;
   position: relative;
   top: 1px;
   transition: filter 50ms linear;
@@ -103,37 +111,38 @@ const RepoLabel = styled.label`
 `;
 
 const RepoName = styled.div`
-  color: ${ColorsWIP.Gray50};
+  color: ${ColorsWIP.Gray800};
 `;
 
 const RepoLocation = styled.div`
-  color: ${ColorsWIP.Gray400};
-`;
-
-const BrowseLink = styled(Link)`
-  line-height: 1;
-
-  && {
-    color: ${ColorsWIP.Gray200};
-  }
-
-  &&:hover,
-  &&:active {
-    color: ${ColorsWIP.Gray400};
-  }
+  color: ${ColorsWIP.Gray700};
+  font-family: ${FontFamily.monospace};
 `;
 
 const ReloadButton: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {
   return (
     <ReloadRepositoryLocationButton location={repoAddress.location}>
       {({tryReload, reloading}) => (
-        <ReloadButtonInner onClick={tryReload}>
-          {reloading ? (
-            <Spinner purpose="body-text" />
-          ) : (
-            <IconWIP name="refresh" color={ColorsWIP.Gray200} />
-          )}
-        </ReloadButtonInner>
+        <Tooltip
+          placement="right"
+          content={
+            reloading ? (
+              'Reloading…'
+            ) : (
+              <>
+                Reload <strong>{repoAddress.location}</strong>
+              </>
+            )
+          }
+        >
+          <ReloadButtonInner onClick={tryReload}>
+            {reloading ? (
+              <Spinner purpose="body-text" />
+            ) : (
+              <IconWIP name="refresh" color={ColorsWIP.Gray200} />
+            )}
+          </ReloadButtonInner>
+        </Tooltip>
       )}
     </ReloadRepositoryLocationButton>
   );
@@ -144,14 +153,18 @@ const ReloadButtonInner = styled.button`
   border: 0;
   cursor: pointer;
   padding: 2px;
-  margin: -2px 0 0 8px;
   outline: none;
 
+  ${IconWrapper} {
+    background-color: ${ColorsWIP.Gray600};
+    transition: background-color 100ms;
+  }
+
   :hover ${IconWrapper} {
-    color: ${ColorsWIP.Gray500};
+    background-color: ${ColorsWIP.Gray800};
   }
 
   :focus ${IconWrapper} {
-    color: ${ColorsWIP.Gray100};
+    background-color: ${ColorsWIP.Link};
   }
 `;

--- a/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
@@ -6,50 +6,47 @@ import {ColorsWIP} from '../ui/Colors';
 export const Items = styled.div`
   flex: 1;
   overflow: auto;
+  padding: 0 12px;
   &::-webkit-scrollbar {
-    width: 11px;
+    width: 8px;
   }
 
   scrollbar-width: thin;
-  scrollbar-color: ${ColorsWIP.Gray600} ${ColorsWIP.Gray900};
+  scrollbar-color: ${ColorsWIP.Gray200} ${ColorsWIP.Gray200};
 
   &::-webkit-scrollbar-track {
-    background: ${ColorsWIP.Gray900};
+    background: ${ColorsWIP.Gray100};
   }
   &::-webkit-scrollbar-thumb {
-    background-color: ${ColorsWIP.Gray600};
+    background-color: ${ColorsWIP.Gray200};
     border-radius: 6px;
-    border: 3px solid ${ColorsWIP.Gray900};
+    border: 3px solid ${ColorsWIP.Gray200};
   }
 `;
 
 export const Item = styled(Link)`
-  font-size: 13px;
+  border-radius: 8px;
+  font-size: 14px;
   text-overflow: ellipsis;
   overflow: hidden;
-  padding: 8px 12px;
-  padding-left: 8px;
-  border-left: 4px solid transparent;
-  border-bottom: 1px solid transparent;
+  padding: 6px 12px;
   display: block;
-  color: ${ColorsWIP.Gray100} !important;
+  color: ${ColorsWIP.Gray900} !important;
   user-select: none;
 
   &:hover {
     text-decoration: none;
-    color: ${ColorsWIP.White} !important;
   }
+
   &:focus {
     outline: 0;
   }
+
   &.focused {
     border-left: 4px solid ${ColorsWIP.Gray400};
   }
+
   &.selected {
-    border-left: 4px solid ${ColorsWIP.Blue500};
-    border-bottom: 1px solid ${ColorsWIP.Gray900};
-    background: ${ColorsWIP.Dark};
-    font-weight: 600;
-    color: ${ColorsWIP.White} !important;
+    background: ${ColorsWIP.Gray200};
   }
 `;

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -63,7 +63,7 @@ export const RepositoryLink: React.FC<{repoAddress: RepoAddress}> = ({repoAddres
 };
 
 const RepositoryName = styled(Link)`
-  max-width: 400px;
+  max-width: 300px;
   overflow: hidden;
   text-overflow: ellipsis;
 `;


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Significant changes to the left nav to more closely match new designs.

- Increase width of left nav to allow more space for job/pipeline names and filter controls.
- Changes to filter controls, move down to bottom of nav.
- Make the sensor/schedule icon link to the sensor/schedule
- Render the repo filter in a dialog instead of a popover

<img width="656" alt="Screen Shot 2021-10-08 at 12 01 15 PM" src="https://user-images.githubusercontent.com/2823852/136595416-c630f407-7930-4e80-929a-8e33df8ecfa7.png">
<img width="332" alt="Screen Shot 2021-10-08 at 12 01 25 PM" src="https://user-images.githubusercontent.com/2823852/136595419-e69998c2-b189-437b-a781-c1df57425f9a.png">

## Test Plan

View left nav in Dagit, verify proper rendering and behavior.

- Empty state
- One repo selected
- Multiple repos selected
- Repo filter dialog behavior
- Hover/selected state of job items in nav
- Short viewport scrollbar behavior
- Expand viewport width, verify close/open behavior of nav