### PR TITLE
[dagit] Allow selection on GraphQueryInput

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -111,11 +111,20 @@ export const GraphQueryInput = React.memo(
         }
       }
 
-      return lastElementName && !suffix
-        ? uniq(available)
-            .sort()
-            .filter((n) => n.startsWith(lastElementName))
-        : [];
+      const lastElementLower = lastElementName?.toLowerCase();
+      const matching =
+        lastElementLower && !suffix
+          ? uniq(available)
+              .sort()
+              .filter((n) => n.toLowerCase().startsWith(lastElementLower))
+          : [];
+
+      // No need to show a match if our string exactly matches the one suggestion.
+      if (matching.length === 1 && matching[0].toLowerCase() === lastElementLower) {
+        return [];
+      }
+
+      return matching;
     }, [lastElementName, props.items, suffix]);
 
     const onConfirmSuggestion = (suggestion: string) => {


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

When the user chooses a solid in `GraphQueryInput` via return key or click, populate the input with that value.

I believe I had changed this previously because complete string matches were being ignored, but I think I went too far with the fix.

Also allow non-lowercase strings to match.

## Test Plan

View Playground and Partition set step selector. Type solid/step names, verify behavior described above.