### PR TITLE
[rfc] Add with_resources method to job

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
@@ -1,0 +1,54 @@
+import pytest
+from dagster import DagsterInvariantViolationError, job, op, resource
+
+
+def get_job():
+    @op(required_resource_keys={"foo"})
+    def requires_foo(context):
+        return context.resources.foo
+
+    @resource
+    def foo_resource():
+        return "i am foo"
+
+    @job(resource_defs={"foo": foo_resource})
+    def my_job():
+        requires_foo()
+
+    return my_job
+
+
+def test_with_resources():
+    my_job = get_job()
+
+    result = my_job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("requires_foo") == "i am foo"
+
+    @resource
+    def injected_foo():
+        return "i am injected foo"
+
+    new_job = my_job.with_resources({"foo": injected_foo})
+    result = new_job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("requires_foo") == "i am injected foo"
+
+
+def test_with_resources_value():
+    my_job = get_job()
+
+    new_job = my_job.with_resources({"foo": "i am injected foo"})
+    result = new_job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("requires_foo") == "i am injected foo"
+
+
+def test_with_resources_nonexistent_key():
+    my_job = get_job()
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Attempted to remap resource 'bar' in job 'my_job', but no such resource exists on job.",
+    ):
+        my_job.with_resources({"bar": "blah"})


### PR DESCRIPTION
This is for the testing story where I have a single job, I don't care about organizing my job outside of test and prod. I just want to replace my prod resources with test resources.

One interesting question here is what happens to provided config? I think maybe you have to re-provide the config parameter, or maybe it just gets washed away. Bc since resources are changing it might end up being totally wrong.