### PR TITLE
Sync example with text

### DIFF
--- a/docs/content/tutorial/intro-tutorial/single-solid-pipeline.mdx
+++ b/docs/content/tutorial/intro-tutorial/single-solid-pipeline.mdx
@@ -44,7 +44,7 @@ def hello_cereal(context):
 ```
 
 In this simple case, our solid takes no arguments except for the <PyObject module="dagster"
-object="SolidExecutionContext" displayText="context" /> in which it executes (provided by the Dagster framework as the first argument to solids who specify it), and also returns no outputs. Don't worry, we'll soon encounter solids that are much more dynamic.
+object="SolidExecutionContext" displayText="context" /> in which it executes (provided by the Dagster framework as the first argument to solids who specify it), and returns the rows of the file. Don't worry, we'll soon encounter solids that are much more dynamic.
 
 ## Hello, Pipeline!
 


### PR DESCRIPTION
The preceding code example returns the list of csv rows, but the text indicates no return. Opted to edit the text, but maybe there is a preference to remove the return from the example block?

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Half sentence change to the tutorial blurb to bring it in sync with the preceding code block.

## Test Plan

None

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.