### PR TITLE
[dagit] Some left nav and empty state cleanup

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
@@ -275,8 +275,4 @@ const IconWithTooltip = styled(Tooltip)`
 
 const ItemContainer = styled.div`
   position: relative;
-
-  :hover {
-    background-color: ${ColorsWIP.Gray10};
-  }
 `;

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -146,8 +146,13 @@ const LoadedRepositorySection: React.FC<{allRepos: DagsterRepoOption[]}> = ({all
         </Box>
         {visibleRepos.size ? (
           <FlatContentList {...match?.params} repos={visibleOptions} />
-        ) : (
+        ) : allRepos.length > 0 ? (
           <EmptyState>Select a repository to see a list of jobs and pipelines.</EmptyState>
+        ) : (
+          <EmptyState>
+            There are no repositories in this workspace. Add a repository to see a list of jobs and
+            pipelines.
+          </EmptyState>
         )}
       </ListContainer>
       <RepositoryLocationStateObserver />

--- a/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoNavItem.tsx
@@ -52,38 +52,40 @@ export const RepoNavItem: React.FC<Props> = (props) => {
       <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
         <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
           <IconWIP name="folder" />
-          <div style={{userSelect: 'none'}}>{summary()}</div>
+          <SummaryText>{summary()}</SummaryText>
         </Box>
         {allRepos.length > 1 ? (
-          <DialogWIP
-            canOutsideClickClose
-            canEscapeKeyClose
-            isOpen={open}
-            style={{width: 'auto'}}
-            onClose={() => setOpen(false)}
-          >
-            <DialogHeader icon="repo" label="Repositories" />
-            <div>
-              <Box padding={{vertical: 8, horizontal: 24}}>
-                {`${selected.size} of ${allRepos.length} selected`}
-              </Box>
-              <RepoSelector
-                options={allRepos}
-                onBrowse={() => setOpen(false)}
-                onToggle={onToggle}
-                selected={selected}
-              />
-            </div>
-            <DialogFooter>
-              <Box padding={{top: 8}}>
-                <ButtonWIP intent="none" onClick={() => setOpen(false)}>
-                  Done
-                </ButtonWIP>
-              </Box>
-            </DialogFooter>
-          </DialogWIP>
+          <>
+            <DialogWIP
+              canOutsideClickClose
+              canEscapeKeyClose
+              isOpen={open}
+              style={{width: 'auto'}}
+              onClose={() => setOpen(false)}
+            >
+              <DialogHeader icon="repo" label="Repositories" />
+              <div>
+                <Box padding={{vertical: 8, horizontal: 24}}>
+                  {`${selected.size} of ${allRepos.length} selected`}
+                </Box>
+                <RepoSelector
+                  options={allRepos}
+                  onBrowse={() => setOpen(false)}
+                  onToggle={onToggle}
+                  selected={selected}
+                />
+              </div>
+              <DialogFooter>
+                <Box padding={{top: 8}}>
+                  <ButtonWIP intent="none" onClick={() => setOpen(false)}>
+                    Done
+                  </ButtonWIP>
+                </Box>
+              </DialogFooter>
+            </DialogWIP>
+            <ButtonWIP onClick={() => setOpen(true)}>Filter</ButtonWIP>
+          </>
         ) : null}
-        <ButtonWIP onClick={() => setOpen(true)}>Filter</ButtonWIP>
       </Box>
     </Box>
   );
@@ -136,6 +138,13 @@ const SingleRepoSummary: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
     </Group>
   );
 };
+
+const SummaryText = styled.div`
+  user-select: none;
+
+  /* Line-height preserves container height even when no button is visible. */
+  line-height: 32px;
+`;
 
 const SingleRepoNameLink = styled(Link)`
   color: ${ColorsWIP.Gray900};

--- a/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryContentList.tsx
@@ -36,6 +36,7 @@ export const Item = styled(Link)`
 
   &:hover {
     text-decoration: none;
+    background-color: ${ColorsWIP.Gray10};
   }
 
   &:focus {

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
@@ -106,7 +106,15 @@ export const RepositoryLocationsList = () => {
   }
 
   if (!locationEntries.length) {
-    return <NonIdealState icon="error" title="No repository locations!" />;
+    return (
+      <Box padding={{vertical: 32}}>
+        <NonIdealState
+          icon="folder"
+          title="No repository locations"
+          description="When you add a repository location to this workspace, it will appear here."
+        />
+      </Box>
+    );
   }
 
   return (

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceOverviewRoot.tsx
@@ -29,21 +29,25 @@ export const WorkspaceOverviewRoot = () => {
 
     if (error) {
       return (
-        <NonIdealState
-          icon="error"
-          title="Error loading repositories"
-          description="Could not load repositories in this workspace."
-        />
+        <Box padding={{vertical: 32}}>
+          <NonIdealState
+            icon="error"
+            title="Error loading repositories"
+            description="Could not load repositories in this workspace."
+          />
+        </Box>
       );
     }
 
     if (!options.length) {
       return (
-        <NonIdealState
-          icon="visibility"
-          title="Empty workspace"
-          description="There are no repositories in this workspace."
-        />
+        <Box padding={{vertical: 32}}>
+          <NonIdealState
+            icon="folder"
+            title="No repositories"
+            description="When you add a repository to this workspace, it will appear here."
+          />
+        </Box>
       );
     }
 

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -5,6 +5,7 @@ import {useFeatureFlags} from '../app/Flags';
 import {PipelineRoot} from '../pipelines/PipelineRoot';
 import {ScheduleRoot} from '../schedules/ScheduleRoot';
 import {SensorRoot} from '../sensors/SensorRoot';
+import {Box} from '../ui/Box';
 import {MainContent} from '../ui/MainContent';
 import {NonIdealState} from '../ui/NonIdealState';
 
@@ -55,18 +56,20 @@ const RepoRouteContainer: React.FC<{repoPath: string}> = (props) => {
   // the repo path in the URL, it means we aren't able to load this repo.
   if (!matchingRepo) {
     return (
-      <NonIdealState
-        icon="error"
-        title="Unknown repository"
-        description={
-          <div>
+      <Box padding={{vertical: 64}}>
+        <NonIdealState
+          icon="error"
+          title="Unknown repository"
+          description={
             <div>
-              <strong>{repoPath}</strong>
+              <div>
+                <strong>{repoPath}</strong>
+              </div>
+              {'  is not loaded in the current workspace.'}
             </div>
-            {'  is not loaded in the current workspace.'}
-          </div>
-        }
-      />
+          }
+        />
+      </Box>
     );
   }
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Some left nav and empty state cleanup.

- Left nav item hover states should should have border-radius
- Don't show the repo filter button if <1 repo
- Preserve height of repo filter section even if no button
- Modify empty state paddings in a few places
- Modify empty state text in left nav and on workspace page

## Test Plan

View Dagit, verify changes described above.