### PR TITLE
compare error code int to enum value

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/utils.py
@@ -40,13 +40,13 @@ def raise_for_rpc_error(context: SolidExecutionContext, resp: Response) -> None:
     error = resp.json().get("error")
     if error is not None:
         if error["code"] in [
-            DBTErrors.project_currently_compiling_error,
-            DBTErrors.runtime_error,
-            DBTErrors.server_error,
+            DBTErrors.project_currently_compiling_error.value,
+            DBTErrors.runtime_error.value,
+            DBTErrors.server_error.value,
         ]:
             context.log.warning(error["message"])
             raise RetryRequested(max_retries=5, seconds_to_wait=30)
-        elif error["code"] == DBTErrors.project_compile_failure_error:
+        elif error["code"] == DBTErrors.project_compile_failure_error.value:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[
@@ -56,7 +56,7 @@ def raise_for_rpc_error(context: SolidExecutionContext, resp: Response) -> None:
                     ),
                 ],
             )
-        elif error["code"] == DBTErrors.rpc_process_killed_error:
+        elif error["code"] == DBTErrors.rpc_process_killed_error.value:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[
@@ -67,7 +67,7 @@ def raise_for_rpc_error(context: SolidExecutionContext, resp: Response) -> None:
                     ),
                 ],
             )
-        elif error["code"] == DBTErrors.rpc_timeout_error:
+        elif error["code"] == DBTErrors.rpc_timeout_error.value:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

The error codes returned from the dbt RPC server were not properly being compared to known error codes. This means for example, if the dbt RPC server is still compiling, the dbt RPC solids will just go straight to failure instead of waiting and retrying.

This change compares the `int` error code to the value of the `enum` which are the same types.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
An example of a response from the dbt RPC server is:
```
{"error": {"code": 10010, "message": "RPC server is compiling the project, call the \"status\" method for compile status", "data": {"type": "RPCCompiling", "message": "Runtime Error\n  compile in progress", "tags": null}}, "id": "0c1d73f8-2877-11ec-b3de-0242ac110014", "jsonrpc": "2.0"}
```

`error["code"]` is `10010`, so `error["code"] == DBTErrors.project_currently_compiling_error.value`



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.