### PR TITLE
[dagit] Use new Tabs component for graph overview

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -157,7 +157,6 @@ const StepItem: React.FunctionComponent<{
 };
 
 const StepLabel = styled.div`
-  margin-left: 5px;
   overflow: hidden;
   text-overflow: ellipsis;
   flex: 1;
@@ -165,12 +164,13 @@ const StepLabel = styled.div`
 
 const StepItemContainer = styled.div<{selected: boolean}>`
   display: flex;
-  line-height: 28px;
-  height: 28px;
-  padding: 0 5px;
+  line-height: 32px;
+  height: 32px;
+  padding: 0 6px;
+  gap: 6px;
   align-items: center;
   border-bottom: 1px solid ${ColorsWIP.Gray200};
-  font-size: 13px;
+  font-size: 12px;
   ${({selected}) => selected && `background: ${ColorsWIP.Gray100};`}
 
   &:hover {
@@ -179,10 +179,10 @@ const StepItemContainer = styled.div<{selected: boolean}>`
 `;
 
 const StepStatusDot = styled.div`
-  width: 11px;
-  height: 11px;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
-  border-radius: 5.5px;
+  border-radius: 50%;
 `;
 
 const Elapsed = styled.div`
@@ -191,7 +191,8 @@ const Elapsed = styled.div`
 `;
 
 const EmptyNotice = styled.div`
+  height: 32px;
   font-size: 12px;
-  padding: 7px 24px;
+  padding: 8px 24px;
   color: ${ColorsWIP.Gray400};
 `;

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -13,6 +13,7 @@ import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
 import {Group} from '../ui/Group';
 import {IconWIP} from '../ui/Icon';
+import {FontFamily} from '../ui/styles';
 
 import {RunGroupPanelQuery} from './types/RunGroupPanelQuery';
 
@@ -143,8 +144,9 @@ const RUN_GROUP_PANEL_QUERY = gql`
 const RunGroupRun = styled(Link)<{selected: boolean}>`
   align-items: flex-start;
   background: ${({selected}) => (selected ? ColorsWIP.Gray100 : ColorsWIP.White)};
-  padding: 3px 6px 3px 24px;
-  font-size: 13px;
+  padding: 4px 6px 4px 24px;
+  font-family: ${FontFamily.monospace};
+  font-size: 14px;
   line-height: 20px;
   display: flex;
   position: relative;
@@ -156,9 +158,9 @@ const RunGroupRun = styled(Link)<{selected: boolean}>`
 
 const ThinLine = styled.div`
   position: absolute;
-  top: 17px;
+  top: 20px;
   width: 1px;
-  background: ${ColorsWIP.Gray300};
+  background: ${ColorsWIP.Gray200};
   left: 29px;
   z-index: 2;
 `;

--- a/js_modules/dagit/packages/core/src/pipelines/Description.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/Description.tsx
@@ -100,7 +100,7 @@ const Container = styled.div`
   font-size: 0.8rem;
   position: relative;
   p:last-child {
-    margin-bottom: 5px;
+    margin-bottom: 0;
   }
 `;
 

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
@@ -51,20 +51,19 @@ export const SidebarTitle = styled.h3`
   font-family: ${FontFamily.monospace};
   font-size: 16px;
   margin: 0;
-  margin-bottom: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
 export const SectionHeader = styled.h4`
   font-family: ${FontFamily.monospace};
-  font-size: 18px;
+  font-size: 16px;
   margin: 2px 0 0 0;
 `;
 
 export const SectionSmallHeader = styled.h4`
   font-family: ${FontFamily.monospace};
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 500;
   margin: 2px 0;
 `;
@@ -82,15 +81,14 @@ export const SectionItemContainer = styled.div`
   &:last-child {
     border-bottom: none;
     margin-bottom: 0;
-    padding-bottom: 5px;
+    padding-bottom: 8px;
   }
 `;
 
-// Internal
-
-const CollapsingHeaderBar = styled.div`
+export const CollapsingHeaderBar = styled.div`
   height: 32px;
   padding-left: 24px;
+  padding-right: 8px;
   background: ${ColorsWIP.White};
   border-top: 1px solid ${ColorsWIP.KeylineGray};
   border-bottom: 1px solid ${ColorsWIP.KeylineGray};

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineInfo.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineInfo.tsx
@@ -20,18 +20,18 @@ export const SidebarPipelineInfo: React.FC<ISidebarPipelineInfoProps> = ({pipeli
   const {flagPipelineModeTuples} = useFeatureFlags();
   return (
     <div>
-      <Box padding={12}>
+      <Box padding={{vertical: 16, horizontal: 24}}>
         <SidebarSubhead>{flagPipelineModeTuples ? 'Graph' : 'Pipeline'}</SidebarSubhead>
         <SidebarTitle>{breakOnUnderscores(pipeline.name)}</SidebarTitle>
       </Box>
       <SidebarSection title={'Description'}>
-        <Box padding={12}>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           <Description description={pipeline ? pipeline.description : NO_DESCRIPTION} />
         </Box>
       </SidebarSection>
       {!flagPipelineModeTuples && (
         <SidebarSection title={'Modes'} collapsedByDefault={true}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             {pipeline.modes.map((mode) => (
               <SidebarModeSection key={mode.name} mode={mode} />
             ))}

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineOrJobOverview.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineOrJobOverview.tsx
@@ -49,14 +49,14 @@ export const SidebarPipelineOrJobOverview: React.FC<{
         return (
           <div style={{overflowY: 'scroll'}}>
             <SidebarSection title={'Description'}>
-              <Box padding={12}>
+              <Box padding={{vertical: 16, horizontal: 24}}>
                 <Description
                   description={pipelineSnapshotOrError.description || 'No description provided'}
                 />
               </Box>
             </SidebarSection>
             <SidebarSection title={'Resources'}>
-              <Box padding={12}>
+              <Box padding={{vertical: 16, horizontal: 24}}>
                 {modes.map((mode) => (
                   <SidebarModeSection mode={mode} key={mode.name} />
                 ))}

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarSolidDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarSolidDefinition.tsx
@@ -84,7 +84,7 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
   return (
     <div>
       <SidebarSection title={'Definition'}>
-        <Box padding={12}>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           <SidebarSubhead>{subheadString}</SidebarSubhead>
           <SidebarTitle>{breakOnUnderscores(definition.name)}</SidebarTitle>
           <SolidTypeSignature definition={definition} />
@@ -92,21 +92,21 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
       </SidebarSection>
       {definition.description && (
         <SidebarSection title={'Description'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             <Description description={definition.description} />
           </Box>
         </SidebarSection>
       )}
       {definition.metadata && Plugin && Plugin.SidebarComponent && (
         <SidebarSection title={'Metadata'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             <Plugin.SidebarComponent definition={definition} repoAddress={repoAddress} />
           </Box>
         </SidebarSection>
       )}
       {configField && (
         <SidebarSection title={'Config'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             <ConfigTypeSchema
               type={configField.configType}
               typesInScope={configField.configType.recursiveConfigTypes}
@@ -116,7 +116,7 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
       )}
       {requiredResources && (
         <SidebarSection title={'Required Resources'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             {[...requiredResources].sort().map((requirement) => (
               <ResourceContainer key={requirement.resourceKey}>
                 <IconWIP name="resource" color={ColorsWIP.Gray700} />
@@ -127,7 +127,7 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
         </SidebarSection>
       )}
       <SidebarSection title={'Inputs'}>
-        <Box padding={12}>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           {definition.inputDefinitions.map((inputDef, idx) => (
             <SectionItemContainer key={idx}>
               <SectionSmallHeader>{breakOnUnderscores(inputDef.name)}</SectionSmallHeader>
@@ -141,7 +141,7 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
         </Box>
       </SidebarSection>
       <SidebarSection title={'Outputs'}>
-        <Box padding={12}>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           {definition.outputDefinitions.map((outputDef, idx) => (
             <SectionItemContainer key={idx}>
               <SectionSmallHeader>
@@ -159,7 +159,7 @@ export const SidebarSolidDefinition: React.FC<SidebarSolidDefinitionProps> = (pr
       </SidebarSection>
       {getInvocations && (
         <SidebarSection title={'All Invocations'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             <InvocationList
               invocations={getInvocations(definition.name)}
               onClickInvocation={onClickInvocation}

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarSolidInvocation.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarSolidInvocation.tsx
@@ -22,7 +22,7 @@ export const SidebarSolidInvocation: React.FC<ISidebarSolidInvocationProps> = (p
   return (
     <div>
       <SidebarSection title={'Invocation'}>
-        <Box padding={12}>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           <SidebarTitle>{breakOnUnderscores(solid.name)}</SidebarTitle>
           <DependencyTable>
             <tbody>

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarTabbedContainer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarTabbedContainer.tsx
@@ -1,14 +1,13 @@
 import {gql} from '@apollo/client';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
 
 import {SolidNameOrPath} from '../solids/SolidNameOrPath';
 import {TypeExplorerContainer} from '../typeexplorer/TypeExplorerContainer';
 import {TypeListContainer} from '../typeexplorer/TypeListContainer';
+import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
-import {Group} from '../ui/Group';
-import {IconName, IconWIP} from '../ui/Icon';
+import {Tab, Tabs} from '../ui/Tabs';
 import {RepoAddress} from '../workspace/types';
 
 import {PipelineExplorerJobContext} from './PipelineExplorerJobContext';
@@ -21,7 +20,6 @@ type TabKey = 'types' | 'info';
 
 interface TabDefinition {
   name: string;
-  icon: IconName;
   key: TabKey;
   content: () => React.ReactNode;
 }
@@ -60,7 +58,6 @@ export const SidebarTabbedContainer: React.FC<ISidebarTabbedContainerProps> = (p
   const TabDefinitions: Array<TabDefinition> = [
     {
       name: 'Info',
-      icon: 'schema',
       key: 'info',
       content: () =>
         solidHandleID ? (
@@ -93,7 +90,6 @@ export const SidebarTabbedContainer: React.FC<ISidebarTabbedContainerProps> = (p
     },
     {
       name: 'Types',
-      icon: 'menu_book',
       key: 'types',
       content: () =>
         typeName ? (
@@ -110,18 +106,16 @@ export const SidebarTabbedContainer: React.FC<ISidebarTabbedContainerProps> = (p
 
   return (
     <>
-      <TabContainer>
-        {TabDefinitions.map(({name, icon, key}) => (
-          <Tab key={key} active={key === activeTab}>
-            <Link to={{search: `?tab=${key}`}} key={key}>
-              <Group direction="row" spacing={8} alignItems="center">
-                <IconWIP name={icon} color={ColorsWIP.Blue500} />
-                {name}
-              </Group>
-            </Link>
-          </Tab>
-        ))}
-      </TabContainer>
+      <Box
+        padding={{horizontal: 24}}
+        border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
+      >
+        <Tabs selectedTabId={activeTab}>
+          {TabDefinitions.map(({name, key}) => (
+            <Tab id={key} key={key} title={<Link to={{search: `?tab=${key}`}}>{name}</Link>} />
+          ))}
+        </Tabs>
+      </Box>
       {TabDefinitions.find((t) => t.key === activeTab)?.content()}
     </>
   );
@@ -134,30 +128,4 @@ export const SIDEBAR_TABBED_CONTAINER_PIPELINE_FRAGMENT = gql`
   }
 
   ${SIDEBAR_PIPELINE_INFO_FRAGMENT}
-`;
-
-const TabContainer = styled.div`
-  width: 100%;
-  display: flex;
-  margin-top: 10px;
-  align-items: center;
-  justify-content: center;
-  border-bottom: 1px solid #ccc;
-`;
-
-const Tab = styled.div<{active: boolean}>`
-  color: ${(p) => (p.active ? ColorsWIP.Blue500 : ColorsWIP.Gray500)}
-  border-top: 3px solid transparent;
-  border-bottom: 3px solid ${(p) => (p.active ? ColorsWIP.Blue500 : 'transparent')};
-  text-decoration: none;
-  white-space: nowrap;
-  min-width: 40px;
-  padding: 0 10px;
-  display: flex;
-  height: 36px;
-  align-items: center;
-
-  :hover > * {
-    text-decoration: none;
-  }
 `;

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorer.tsx
@@ -27,13 +27,13 @@ export const TypeExplorer: React.FC<ITypeExplorerProps> = (props) => {
         </SidebarTitle>
       </Box>
       <SidebarSection title={'Description'}>
-        <Box padding={12}>
+        <Box padding={{vertical: 16, horizontal: 24}}>
           <Description description={description || 'No Description Provided'} />
         </Box>
       </SidebarSection>
       {inputSchemaType && (
         <SidebarSection title={'Input'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             <ConfigTypeSchema
               type={inputSchemaType}
               typesInScope={inputSchemaType.recursiveConfigTypes}
@@ -43,7 +43,7 @@ export const TypeExplorer: React.FC<ITypeExplorerProps> = (props) => {
       )}
       {outputSchemaType && (
         <SidebarSection title={'Output'}>
-          <Box padding={12}>
+          <Box padding={{vertical: 16, horizontal: 24}}>
             <ConfigTypeSchema
               type={outputSchemaType}
               typesInScope={outputSchemaType.recursiveConfigTypes}

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeList.tsx
@@ -1,11 +1,11 @@
 import {gql} from '@apollo/client';
-import {H3, UL} from '@blueprintjs/core';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {useFeatureFlags} from '../app/Flags';
 import {SidebarSection, SidebarSubhead, SidebarTitle} from '../pipelines/SidebarComponents';
 import {Box} from '../ui/Box';
+import {ColorsWIP} from '../ui/Colors';
 
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT, TypeWithTooltip} from './TypeWithTooltip';
 import {TypeListFragment} from './types/TypeListFragment';
@@ -32,26 +32,35 @@ function groupTypes(types: TypeListFragment[]): {[key: string]: TypeListFragment
 export const TypeList: React.FC<ITypeListProps> = (props) => {
   const {flagPipelineModeTuples} = useFeatureFlags();
   const groups = groupTypes(props.types);
+  console.log(groups);
   return (
     <>
       <SidebarSubhead />
-      <Box padding={12}>
+      <Box padding={{vertical: 16, horizontal: 24}}>
         <SidebarTitle>{flagPipelineModeTuples ? 'Graph types' : 'Pipeline types'}</SidebarTitle>
       </Box>
-      {Object.keys(groups).map((title, idx) => (
-        <SidebarSection key={idx} title={title} collapsedByDefault={idx !== 0}>
-          <Box padding={12}>
-            <UL>
-              {groups[title].map((type, i) => (
-                <TypeLI key={i}>
-                  <TypeWithTooltip type={type} />
-                </TypeLI>
-              ))}
-            </UL>
-          </Box>
-        </SidebarSection>
-      ))}
-      <H3 />
+      {Object.keys(groups).map((title, idx) => {
+        const typesForSection = groups[title];
+        const collapsedByDefault = idx !== 0 || groups[title].length === 0;
+
+        return (
+          <SidebarSection key={idx} title={title} collapsedByDefault={collapsedByDefault}>
+            <Box padding={{vertical: 16, horizontal: 24}}>
+              {typesForSection.length ? (
+                <StyledUL>
+                  {groups[title].map((type, i) => (
+                    <TypeLI key={i}>
+                      <TypeWithTooltip type={type} />
+                    </TypeLI>
+                  ))}
+                </StyledUL>
+              ) : (
+                <div style={{color: ColorsWIP.Gray500, fontSize: '12px'}}>None</div>
+              )}
+            </Box>
+          </SidebarSection>
+        );
+      })}
     </>
   );
 };
@@ -64,6 +73,14 @@ export const TYPE_LIST_FRAGMENT = gql`
   }
 
   ${DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT}
+`;
+
+const StyledUL = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
 `;
 
 const TypeLI = styled.li`


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Make changes to sidebar components in Job overview and Run detail page. Repair left padding, alignment, spacing in general. Use monospace for run group panel.

<img width="382" alt="Screen Shot 2021-10-11 at 4 07 16 PM" src="https://user-images.githubusercontent.com/2823852/136855910-1655d060-2204-40d2-bff5-1a315c3a556f.png">
<img width="389" alt="Screen Shot 2021-10-11 at 4 02 27 PM" src="https://user-images.githubusercontent.com/2823852/136855943-4ef1dd9a-17d5-4f42-b62f-56934dc95963.png">

## Test Plan

View locations that use the sidebar, verify rendering and collapse behavior.