### PR TITLE
[dagit-bb] Make LaunchButton use new bb styles

### DIFF
--- a/js_modules/dagit/packages/core/src/execute/ExecutionSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/execute/ExecutionSessionContainer.tsx
@@ -689,7 +689,7 @@ const ExecutionSessionContainer: React.FC<IExecutionSessionContainerProps> = (pr
           </>
         }
       />
-      <div style={{position: 'absolute', bottom: 14, right: 14, zIndex: 1}}>
+      <div style={{position: 'absolute', bottom: 12, right: 12, zIndex: 1}}>
         <LaunchRootExecutionButton
           pipelineName={pipeline.name}
           getVariables={buildExecutionVariables}

--- a/js_modules/dagit/packages/core/src/execute/LaunchButton.tsx
+++ b/js_modules/dagit/packages/core/src/execute/LaunchButton.tsx
@@ -1,10 +1,12 @@
-// eslint-disable-next-line no-restricted-imports
-import {Button, Icon, IconName, Menu, MenuItem, Popover, Position} from '@blueprintjs/core';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {ShortcutHandler} from '../app/ShortcutHandler';
-import {Box} from '../ui/Box';
+import {ButtonWIP} from '../ui/Button';
+import {ColorsWIP} from '../ui/Colors';
+import {IconWIP, IconName} from '../ui/Icon';
+import {MenuWIP, MenuItemWIP} from '../ui/Menu';
+import {Popover} from '../ui/Popover';
 import {Spinner} from '../ui/Spinner';
 import {Tooltip} from '../ui/Tooltip';
 
@@ -52,12 +54,11 @@ function useLaunchButtonCommonState({runCount, disabled}: {runCount: number; dis
 }
 
 interface LaunchButtonProps {
-  small?: boolean;
   config: LaunchButtonConfiguration;
   runCount: number;
 }
 
-export const LaunchButton = ({config, runCount, small}: LaunchButtonProps) => {
+export const LaunchButton = ({config, runCount}: LaunchButtonProps) => {
   const {forced, status, onConfigSelected} = useLaunchButtonCommonState({
     runCount,
     disabled: config.disabled,
@@ -73,10 +74,10 @@ export const LaunchButton = ({config, runCount, small}: LaunchButtonProps) => {
     >
       <ButtonWithConfiguration
         status={status}
-        small={small}
         {...config}
         {...forced}
         onClick={onClick}
+        disabled={status === 'disabled'}
       />
     </ShortcutHandler>
   );
@@ -84,7 +85,6 @@ export const LaunchButton = ({config, runCount, small}: LaunchButtonProps) => {
 
 interface LaunchButtonDropdownProps {
   title: string;
-  small?: boolean;
   primary: LaunchButtonConfiguration;
   options: LaunchButtonConfiguration[];
   disabled?: boolean;
@@ -95,7 +95,6 @@ interface LaunchButtonDropdownProps {
 
 export const LaunchButtonDropdown = ({
   title,
-  small,
   primary,
   options,
   disabled,
@@ -117,7 +116,6 @@ export const LaunchButtonDropdown = ({
     >
       <ButtonWithConfiguration
         status={status}
-        small={small}
         title={title}
         joined="right"
         icon={icon}
@@ -132,12 +130,12 @@ export const LaunchButtonDropdown = ({
         disabled={status === LaunchButtonStatus.Disabled}
         position="bottom-right"
         content={
-          <Menu>
+          <MenuWIP>
             {options.map((option, idx) => (
               <Tooltip
                 key={idx}
                 hoverOpenDelay={300}
-                position={Position.LEFT}
+                position="left"
                 openOnTargetFocus={false}
                 targetTagName="div"
                 content={option.tooltip || ''}
@@ -146,19 +144,19 @@ export const LaunchButtonDropdown = ({
                   text={option.title}
                   disabled={option.disabled}
                   onClick={() => onConfigSelected(option)}
-                  icon={option.icon === 'dagster-spinner' ? 'blank' : option.icon}
+                  icon={option.icon !== 'dagster-spinner' ? option.icon : undefined}
                 />
               </Tooltip>
             ))}
-          </Menu>
+          </MenuWIP>
         }
       >
         <ButtonContainer
           role="button"
           status={status}
-          small={small}
-          style={{minWidth: 'initial', padding: '0 15px'}}
-          icon={'caret-down'}
+          style={{minWidth: 'initial'}}
+          icon={<IconWIP name="arrow_drop_down" />}
+          intent="primary"
           joined={'left'}
         />
       </Popover>
@@ -173,7 +171,6 @@ interface ButtonWithConfigurationProps {
   icon?: IconName | JSX.Element | 'dagster-spinner';
   joined?: 'left' | 'right';
   tooltip?: string | JSX.Element;
-  small?: boolean;
   onClick?: () => void;
   disabled?: boolean;
 }
@@ -184,109 +181,57 @@ const ButtonWithConfiguration: React.FunctionComponent<ButtonWithConfigurationPr
   tooltip,
   icon,
   title,
-  small,
   status,
   style,
   onClick,
   joined,
   disabled,
 }) => {
-  const sizeStyles = small ? {height: 24, minWidth: 120, paddingLeft: 15, paddingRight: 15} : {};
-
   return (
-    <Tooltip
-      position={Position.LEFT}
-      openOnTargetFocus={false}
-      targetTagName="div"
-      content={tooltip || ''}
-    >
+    <Tooltip position="left" openOnTargetFocus={false} targetTagName="div" content={tooltip || ''}>
       <ButtonContainer
         role="button"
-        style={{...sizeStyles, ...style}}
+        intent="primary"
+        style={{...style}}
         status={status}
         onClick={onClick}
         joined={joined}
         disabled={disabled}
+        icon={
+          icon === 'dagster-spinner' ? (
+            <Spinner purpose="body-text" fillColor={ColorsWIP.White} />
+          ) : typeof icon === 'string' ? (
+            <IconWIP name={icon} size={16} style={{textAlign: 'center', marginRight: 5}} />
+          ) : (
+            icon
+          )
+        }
       >
-        {icon === 'dagster-spinner' ? (
-          <Box padding={{right: 8}}>
-            <Spinner purpose="body-text" />
-          </Box>
-        ) : (
-          <Icon
-            icon={icon}
-            iconSize={small ? 12 : 17}
-            style={{textAlign: 'center', marginRight: 5}}
-          />
-        )}
-        <ButtonText>{title}</ButtonText>
+        <MaxwidthText>{title}</MaxwidthText>
       </ButtonContainer>
     </Tooltip>
   );
 };
 
-const ButtonContainer = styled(Button)<{
+const ButtonContainer = styled(ButtonWIP)<{
   status: LaunchButtonStatus;
-  small?: boolean;
   joined?: 'right' | 'left';
 }>`
-  &&& {
-    height: ${({small}) => (small ? '24' : '30')}px;
-    flex-shrink: 0;
-    background: ${({status}) =>
-      ({
-        disabled: 'linear-gradient(to bottom, rgb(145, 145, 145) 30%, rgb(130, 130, 130) 100%);',
-        ready: 'linear-gradient(to bottom, rgb(36, 145, 235) 30%, rgb(27, 112, 187) 100%);',
-        starting: 'linear-gradient(to bottom, rgb(21, 89, 150) 30%, rgb(21, 89, 150) 100%);',
-      }[status])};
-    border-top: 1px solid rgba(255, 255, 255, 0.25);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
-    border-radius: 3px;
-    border-top-${({joined}) => joined}-radius: 0;
-    border-bottom-${({joined}) => joined}-radius: 0;
-    transition: background 200ms linear;
-    justify-content: center;
-    align-items: center;
-    display: inline-flex;
-    color: ${({status}) => (status === 'disabled' ? 'rgba(255,255,255,0.5)' : 'white')};
-    cursor: ${({status}) => (status !== 'ready' ? 'normal' : 'pointer')};
-    z-index: 2;
-    min-width: 150px;
-    margin-left: ${({joined}) => (joined ? '0' : '6px')};
-    padding: 0 25px;
-    min-height: 0;
-
-    &:hover,
-    &.bp3-active {
-      background: ${({status}) =>
-        ({
-          disabled: 'linear-gradient(to bottom, rgb(145, 145, 145) 30%, rgb(130, 130, 130) 100%);',
-          ready: 'linear-gradient(to bottom, rgb(27, 112, 187) 30%, rgb(21, 89, 150) 100%);',
-          starting: 'linear-gradient(to bottom, rgb(21, 89, 150) 30%, rgb(21, 89, 150) 100%);',
-        }[status])};
-    }
-
-    path.bp3-spinner-head {
-      stroke: white;
-    }
-
-    .bp3-icon {
-      color: ${({status}) => (status === 'disabled' ? 'rgba(255,255,255,0.5)' : 'white')};
-    }
-    .bp3-button-text {
-      display: flex;
-      align-items: center;
-    }
-  }
+  border-top-${({joined}) => joined}-radius: 0;
+  border-bottom-${({joined}) => joined}-radius: 0;
+  border-left: ${({joined}) =>
+    joined === 'left' ? `1px solid rgba(255,255,255,0.2)` : 'transparent'};
+  cursor: ${({status}) => (status !== 'ready' ? 'normal' : 'pointer')};
+  margin-left: ${({joined}) => (joined ? '0' : '6px')};
 `;
 
-const ButtonText = styled.span`
+const MaxwidthText = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 350px;
 `;
 
-const LaunchMenuItem = styled(MenuItem)`
+const LaunchMenuItem = styled(MenuItemWIP)`
   max-width: 200px;
 `;

--- a/js_modules/dagit/packages/core/src/execute/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/execute/LaunchRootExecutionButton.tsx
@@ -42,17 +42,15 @@ export const LaunchRootExecutionButton: React.FunctionComponent<LaunchRootExecut
   };
 
   return (
-    <div style={{marginRight: 20}}>
-      <LaunchButton
-        runCount={1}
-        config={{
-          icon: 'send-to',
-          onClick: onLaunch,
-          title: 'Launch Execution',
-          disabled: props.disabled || !canLaunchPipelineExecution,
-          tooltip: !canLaunchPipelineExecution ? DISABLED_MESSAGE : undefined,
-        }}
-      />
-    </div>
+    <LaunchButton
+      runCount={1}
+      config={{
+        icon: 'open_in_new',
+        onClick: onLaunch,
+        title: 'Launch Execution',
+        disabled: props.disabled || !canLaunchPipelineExecution,
+        tooltip: !canLaunchPipelineExecution ? DISABLED_MESSAGE : undefined,
+      }}
+    />
   );
 };

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -732,7 +732,7 @@ const LaunchBackfillButton: React.FC<{
         runCount={count}
         config={{
           title: buttonTitle,
-          icon: 'send-to',
+          icon: 'open_in_new',
           disabled: !count || loading,
           onClick: onLaunch,
         }}

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -1,5 +1,3 @@
-import {IconName} from '@blueprintjs/core';
-import {IconNames} from '@blueprintjs/icons';
 import * as React from 'react';
 
 import {SharedToaster} from '../app/DomUtils';
@@ -10,7 +8,7 @@ import {PipelineRunStatus} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {ButtonWIP} from '../ui/Button';
 import {Group} from '../ui/Group';
-import {IconWIP} from '../ui/Icon';
+import {IconName, IconWIP} from '../ui/Icon';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
 
@@ -123,7 +121,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
     (run.status === PipelineRunStatus.FAILURE || run.status === PipelineRunStatus.CANCELED);
 
   const full: LaunchButtonConfiguration = {
-    icon: 'repeat',
+    icon: 'cached',
     scope: '*',
     title: 'All Steps in Root Run',
     tooltip: 'Re-execute the pipeline run from scratch',
@@ -132,7 +130,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   };
 
   const same: LaunchButtonConfiguration = {
-    icon: 'select',
+    icon: 'linear_scale',
     scope: selectionOfCurrentRun?.query || '*',
     title: 'Same Steps',
     disabled:
@@ -151,7 +149,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   };
 
   const selected: LaunchButtonConfiguration = {
-    icon: 'select',
+    icon: 'op',
     scope: selection.query,
     title: selection.keys.length > 1 ? 'Selected Steps' : 'Selected Step',
     disabled: !selection.present || !(selection.finished || selection.failed),
@@ -169,7 +167,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   };
 
   const fromSelected: LaunchButtonConfiguration = {
-    icon: 'inheritance',
+    icon: 'arrow_forward',
     title: 'From Selected',
     disabled: !isFinalStatus || selection.keys.length !== 1,
     tooltip: 'Re-execute the pipeline downstream from the selected steps',
@@ -194,7 +192,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   };
 
   const fromFailure: LaunchButtonConfiguration = {
-    icon: 'redo',
+    icon: 'arrow_forward',
     title: 'From Failure',
     disabled: !isFailedWithPlan,
     tooltip: !isFailedWithPlan
@@ -231,7 +229,6 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
       <Box flex={{direction: 'row'}}>
         <LaunchButtonDropdown
           runCount={1}
-          small={true}
           primary={primary}
           options={options}
           title={primary.scope === '*' ? `Re-execute All (*)` : `Re-execute (${primary.scope})`}
@@ -257,7 +254,7 @@ function usePipelineAvailabilityErrorForRun(
 
   if (run?.pipeline.__typename === 'UnknownPipeline') {
     return {
-      icon: IconNames.ERROR,
+      icon: 'error',
       tooltip: `"${run.pipeline.name}" could not be found.`,
       disabled: true,
     };
@@ -278,7 +275,7 @@ function usePipelineAvailabilityErrorForRun(
     if (matchType === 'origin-only') {
       // Only the repo is a match.
       return {
-        icon: IconNames.WARNING_SIGN,
+        icon: 'warning',
         tooltip: `The pipeline "${run.pipeline.name}" may be a different version from the original pipeline run.`,
         disabled: false,
       };
@@ -287,7 +284,7 @@ function usePipelineAvailabilityErrorForRun(
     if (matchType === 'snapshot-only') {
       // Only the snapshot ID matched, but not the repo.
       return {
-        icon: IconNames.WARNING_SIGN,
+        icon: 'warning',
         tooltip: (
           <Group direction="column" spacing={4}>
             <div>{`The pipeline "${run.pipeline.name}" is not in the same repository as the original pipeline run.`}</div>
@@ -308,7 +305,7 @@ function usePipelineAvailabilityErrorForRun(
 
     // Only the pipeline name matched. This could be from any repo in the workspace.
     return {
-      icon: IconNames.WARNING_SIGN,
+      icon: 'warning',
       tooltip: `The pipeline "${run.pipeline.name}" may be a different version from the original pipeline run.`,
       disabled: false,
     };
@@ -332,7 +329,7 @@ function usePipelineAvailabilityErrorForRun(
   );
 
   return {
-    icon: IconNames.ERROR,
+    icon: 'error',
     tooltip,
     disabled: true,
   };

--- a/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
@@ -98,7 +98,11 @@ const StyledButton = styled.button<StyledButtonProps>`
     box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
   }
 
-  ${SpinnerWrapper},
+  ${SpinnerWrapper} {
+    align-self: center;
+    display: block;
+  }
+
   ${IconWrapper} {
     color: ${({$textColor}) => $textColor};
     background-color: ${({$textColor}) => $textColor};

--- a/js_modules/dagit/packages/core/src/ui/Menu.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Menu.tsx
@@ -85,10 +85,7 @@ const StyledMenuItem = styled(MenuItem)<StyledMenuItemProps>`
   line-height: 20px;
   padding: 6px 8px 6px 12px;
   transition: background-color 50ms, box-shadow 150ms;
-
-  ${IconWrapper} {
-    padding-top: 2px;
-  }
+  align-items: center;
 
   &.bp3-disabled ${IconWrapper} {
     opacity: 0.5;


### PR DESCRIPTION
- Removes all the blueprint from the launch button!
- Removes a lot of the custom CSS we'd applied to make the button look nice
- Consolidates "launching" and "disabled" states to use the base button's disabled state, which seems fine to me
- Switches icons to our new Material set

Note: The dropdown portion of the button is still interactable when you're launching a run. This was the existing behavior and looks slightly odd but /might/ be intentional + useful because it allows you to start more than one run?

Todo: The distance between the button and the edge of the window is wrong, but I think the parent element padding was fixed in another diff? Might need to take a pass through those bars tomorrow.

<img width="1734" alt="image" src="https://user-images.githubusercontent.com/1037212/136892853-a73d725a-605d-4bce-ad28-78e1f232964b.png">
<img width="1734" alt="image" src="https://user-images.githubusercontent.com/1037212/136892868-d4e10aef-77b4-4bca-ba93-fe88f145400f.png">
