### PR TITLE
[dagit] Flex-wrap asset names in table

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -481,7 +481,7 @@ const AssetEntryRow: React.FC<{
         ) : null}
         <td>
           <Link to={linkUrl}>
-            <Box flex={{alignItems: 'center', wrap: 'wrap'}}>
+            <Box flex={{alignItems: 'center', wrap: 'wrap'}} style={{wordBreak: 'break-word'}}>
               {path
                 .map((p, i) => <span key={i}>{p}</span>)
                 .reduce(


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Add flex-wrap and word-break styles to make long asset names wrap nicely in the catalog root table.

## Test Plan

View Assets table in Dagit, verify that long key paths wrap nicely in the table. Also force an asset name to be a very long string of letters, verify that it breaks correctly.