### PR TITLE
[dagit-bb] Updated colors/style for config page

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -9,7 +9,7 @@ import {HighlightedCodeBlock} from '../ui/HighlightedCodeBlock';
 import {IconWIP} from '../ui/Icon';
 import {PageHeader} from '../ui/PageHeader';
 import {Spinner} from '../ui/Spinner';
-import {Heading, Subheading} from '../ui/Text';
+import {Code, Heading, Subheading} from '../ui/Text';
 
 import {InstanceTabs} from './InstanceTabs';
 import {InstanceConfigQuery} from './types/InstanceConfigQuery';
@@ -20,8 +20,18 @@ const YamlShimStyle = createGlobalStyle`
     padding: 0;
   }
 
-  .hljs-attr {
-    color: ${ColorsWIP.Blue700};
+  .config-yaml {
+    .hljs-attr {
+      color: ${ColorsWIP.Blue700};
+    }
+
+    .hljs-string {
+      color: ${ColorsWIP.Green700};
+    }
+
+    .hljs-number {
+      color: ${ColorsWIP.Red700};
+    }
   }
 `;
 
@@ -64,21 +74,31 @@ export const InstanceConfig = React.memo(() => {
   return (
     <>
       <PageHeader title={<Heading>Instance status</Heading>} tabs={<InstanceTabs tab="config" />} />
+      <Box
+        padding={{vertical: 16, horizontal: 24}}
+        border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
+      >
+        <Subheading>
+          Dagster version: <Code style={{fontSize: '16px'}}>{data.version}</Code>
+        </Subheading>
+      </Box>
+      <YamlShimStyle />
       <Box padding={{vertical: 16, horizontal: 24}}>
-        <Box padding={{bottom: 16}}>
-          <Subheading>{`Dagster ${data.version}`}</Subheading>
-        </Box>
-        <YamlShimStyle />
         {sections.map((section) => {
           const [id] = section.split(/\:/);
           const hashForSection = `#${id}`;
           return (
-            <Box flex={{direction: 'row', alignItems: 'flex-start'}} padding={8} key={id} id={id}>
+            <Box
+              flex={{direction: 'row', alignItems: 'flex-start'}}
+              padding={{vertical: 8}}
+              key={id}
+              id={id}
+            >
               <ConfigLink to={`/instance/config${hashForSection}`} key={id}>
                 <IconWIP name="link" color={ColorsWIP.Gray300} />
               </ConfigLink>
               <ConfigSection highlighted={hash === hashForSection}>
-                <HighlightedCodeBlock value={section} language="yaml" />
+                <HighlightedCodeBlock value={section} language="yaml" className="config-yaml" />
               </ConfigSection>
             </Box>
           );

--- a/js_modules/dagit/packages/core/src/ui/HighlightedCodeBlock.tsx
+++ b/js_modules/dagit/packages/core/src/ui/HighlightedCodeBlock.tsx
@@ -19,6 +19,7 @@ hljs.registerLanguage('yaml', yaml);
 interface Props {
   value: string;
   language: 'yaml' | 'sql';
+  className?: string;
   style?: React.CSSProperties;
 }
 

--- a/js_modules/dagit/packages/core/src/ui/Text.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Text.tsx
@@ -34,8 +34,8 @@ export const Caption = styled.span<TextProps>`
 `;
 
 export const Code = styled.span`
-  background-color: ${ColorsWIP.Gray100};
-  border-radius: 3px;
+  background-color: ${ColorsWIP.Blue50};
+  border-radius: 2px;
   font-family: ${FontFamily.monospace};
   font-size: 14px;
   padding: 2px 4px;


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Use colors from editor in https://github.com/dagster-io/dagster/pull/5119 for the config yaml block page, along with a handful of other style changes.

<img width="457" alt="Screen Shot 2021-10-12 at 10 08 30 AM" src="https://user-images.githubusercontent.com/2823852/136982170-1e94fadf-6fce-4de7-8d43-d0bcccd57c7f.png">

## Test Plan

View config page.