### PR TITLE
Resume runs from failure in StepDelegatingExecutor

### DIFF
--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -15,7 +15,7 @@ from dagster.core.test_utils import mock_system_timezone
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.grpc import DagsterGrpcClient, DagsterGrpcServer
 from dagster.grpc.impl import core_execute_run
-from dagster.grpc.types import ExecuteRunArgs, ExecuteStepArgs
+from dagster.grpc.types import ExecuteRunArgs, ExecuteStepArgs, ResumeRunArgs
 from dagster.serdes import deserialize_as, serialize_dagster_namedtuple
 from dagster.seven import nullcontext
 from dagster.utils.hosted_user_process import recon_pipeline_from_origin
@@ -54,7 +54,10 @@ def execute_run_command(input_json):
                 buffer.append(serialize_dagster_namedtuple(event))
 
             _execute_run_command_body(
-                recon_pipeline, args.pipeline_run_id, instance, send_to_buffer
+                recon_pipeline,
+                args.pipeline_run_id,
+                instance,
+                send_to_buffer,
             )
 
             for line in buffer:
@@ -78,6 +81,63 @@ def _execute_run_command_body(recon_pipeline, pipeline_run_id, instance, write_s
     finally:
         instance.report_engine_event(
             "Process for run exited (pid: {pid}).".format(pid=pid),
+            pipeline_run,
+        )
+
+
+@api_cli.command(
+    name="resume_run",
+    help=(
+        "[INTERNAL] This is an internal utility. Users should generally not invoke this command "
+        "interactively."
+    ),
+)
+@click.argument("input_json", type=click.STRING)
+def resume_run_command(input_json):
+    with capture_interrupts():
+        args = deserialize_as(input_json, ResumeRunArgs)
+        recon_pipeline = recon_pipeline_from_origin(args.pipeline_origin)
+
+        with (
+            DagsterInstance.from_ref(args.instance_ref)
+            if args.instance_ref
+            else DagsterInstance.get()
+        ) as instance:
+            buffer = []
+
+            def send_to_buffer(event):
+                buffer.append(serialize_dagster_namedtuple(event))
+
+            _resume_run_command_body(
+                recon_pipeline,
+                args.pipeline_run_id,
+                instance,
+                send_to_buffer,
+            )
+
+            for line in buffer:
+                click.echo(line)
+
+
+def _resume_run_command_body(recon_pipeline, pipeline_run_id, instance, write_stream_fn):
+
+    pipeline_run = instance.get_run_by_id(pipeline_run_id)
+
+    pid = os.getpid()
+    instance.report_engine_event(
+        "Started process for resuming pipeline (pid: {pid}).".format(pid=pid),
+        pipeline_run,
+        EngineEventData.in_process(pid, marker_end="cli_api_subprocess_init"),
+    )
+
+    try:
+        for event in core_execute_run(
+            recon_pipeline, pipeline_run, instance, resume_from_failure=True
+        ):
+            write_stream_fn(event)
+    finally:
+        instance.report_engine_event(
+            "Process for pipeline exited (pid: {pid}).".format(pid=pid),
             pipeline_run,
         )
 

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -163,11 +163,13 @@ class PlanOrchestrationContext(IPlanContext):
         log_manager: DagsterLogManager,
         executor: Executor,
         output_capture: Optional[Dict[StepOutputHandle, Any]],
+        resume_from_failure: bool = False,
     ):
         self._plan_data = plan_data
         self._log_manager = log_manager
         self._executor = executor
         self._output_capture = output_capture
+        self._resume_from_failure = resume_from_failure
 
     @property
     def plan_data(self) -> PlanData:
@@ -201,6 +203,10 @@ class PlanOrchestrationContext(IPlanContext):
             step=step,
             output_capture=self.output_capture,
         )
+
+    @property
+    def resume_from_failure(self) -> bool:
+        return self._resume_from_failure
 
 
 class StepOrchestrationContext(PlanOrchestrationContext, IStepContext):

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -283,6 +283,7 @@ class PlanOrchestrationContextManager(ExecutionContextManager[PlanOrchestrationC
         raise_on_error: Optional[bool] = False,
         output_capture: Optional[Dict["StepOutputHandle", Any]] = None,
         executor_defs: Optional[List[ExecutorDefinition]] = None,
+        resume_from_failure=False,
     ):
         event_generator = context_event_generator(
             pipeline,
@@ -293,6 +294,7 @@ class PlanOrchestrationContextManager(ExecutionContextManager[PlanOrchestrationC
             raise_on_error,
             executor_defs,
             output_capture,
+            resume_from_failure=resume_from_failure,
         )
         super(PlanOrchestrationContextManager, self).__init__(event_generator)
 
@@ -310,6 +312,7 @@ def orchestration_context_event_generator(
     raise_on_error: bool,
     executor_defs: Optional[List[ExecutorDefinition]],
     output_capture: Optional[Dict["StepOutputHandle", Any]],
+    resume_from_failure: bool = False,
 ) -> Generator[Union[DagsterEvent, PlanOrchestrationContext], None, None]:
     check.invariant(executor_defs is None)
     context_creation_data = create_context_creation_data(
@@ -330,6 +333,7 @@ def orchestration_context_event_generator(
             log_manager=log_manager,
             executor=executor,
             output_capture=output_capture,
+            resume_from_failure=resume_from_failure,
         )
 
         _validate_plan_with_context(execution_context, execution_plan)

--- a/python_modules/dagster/dagster/core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/core/execution/host_mode.py
@@ -73,6 +73,7 @@ def host_mode_execution_context_event_generator(
     raise_on_error,
     executor_defs,
     output_capture,
+    resume_from_failure: bool = False,
 ):
     check.inst_param(execution_plan, "execution_plan", ExecutionPlan)
     check.inst_param(pipeline, "pipeline", ReconstructablePipeline)
@@ -118,6 +119,7 @@ def host_mode_execution_context_event_generator(
             log_manager=log_manager,
             executor=executor,
             output_capture=None,
+            resume_from_failure=resume_from_failure,
         )
 
         yield execution_context
@@ -127,7 +129,7 @@ def host_mode_execution_context_event_generator(
             user_facing_exc_info = (
                 # pylint does not know original_exc_info exists is is_user_code_error is true
                 # pylint: disable=no-member
-                dagster_error.original_exc_info
+                dagster_error.original_exc_info  # type: ignore
                 if dagster_error.is_user_code_error
                 else sys.exc_info()
             )
@@ -142,7 +144,7 @@ def host_mode_execution_context_event_generator(
                 error_info=error_info,
             )
             log_manager.log_dagster_event(
-                level=logging.ERROR, msg=event.message, dagster_event=event
+                level=logging.ERROR, msg=event.message, dagster_event=event  # type: ignore
             )
             yield event
         else:

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
@@ -8,12 +8,11 @@ from dagster.core.execution.context.system import PlanOrchestrationContext
 from dagster.core.execution.plan.plan import ExecutionPlan
 from dagster.core.execution.plan.step import ExecutionStep
 from dagster.core.execution.retries import RetryMode
-from dagster.core.executor.step_delegating.step_handler.base import StepHandlerContext
+from dagster.core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
 from dagster.grpc.types import ExecuteStepArgs
 from dagster.utils.backcompat import experimental
 
 from ..base import Executor
-from .step_handler import StepHandler
 
 
 @experimental
@@ -88,6 +87,51 @@ class StepDelegatingExecutor(Executor):
         with execution_plan.start(retry_mode=self.retries) as active_execution:
             running_steps: Dict[str, ExecutionStep] = {}
 
+            if pipeline_context.resume_from_failure:
+                yield DagsterEvent.engine_event(
+                    pipeline_context,
+                    "Resuming execution from failure",
+                    EngineEventData(),
+                )
+
+                events = self._pop_events(
+                    pipeline_context.plan_data.instance,
+                    pipeline_context.plan_data.pipeline_run.run_id,
+                )
+                for dagster_event in events:
+                    yield dagster_event
+
+                possibly_in_flight_steps = active_execution.rebuild_from_events(events)
+                for step in possibly_in_flight_steps:
+
+                    yield DagsterEvent.engine_event(
+                        pipeline_context,
+                        "Checking on status of possibly launched steps",
+                        EngineEventData(),
+                        step.handle,
+                    )
+
+                    # TODO: check if failure event included. For now, hacky assumption that
+                    # we don't log anything on successful check
+                    if self._step_handler.check_step_health(
+                        self._get_step_handler_context(pipeline_context, [step], active_execution)
+                    ):
+                        # health check failed, launch the step
+                        launch_events = self._log_new_events(
+                            self._step_handler.launch_step(
+                                self._get_step_handler_context(
+                                    pipeline_context, [step], active_execution
+                                )
+                            ),
+                            pipeline_context,
+                            {step.key: step for step in possibly_in_flight_steps},
+                        )
+                        for dagster_event in launch_events:
+                            yield dagster_event
+                            active_execution.handle_event(dagster_event)
+
+                    running_steps[step.key] = step
+
             last_check_step_health_time = pendulum.now("UTC")
             while not active_execution.is_complete:
                 events = []
@@ -153,7 +197,7 @@ class StepDelegatingExecutor(Executor):
                         )
                     )
 
-                for dagster_event in events:
+                for dagster_event in events:  # type: ignore
                     yield dagster_event
                     active_execution.handle_event(dagster_event)
 

--- a/python_modules/dagster/dagster/core/launcher/base.py
+++ b/python_modules/dagster/dagster/core/launcher/base.py
@@ -14,6 +14,7 @@ class LaunchRunContext(NamedTuple):
 
     pipeline_run: PipelineRun
     workspace: Optional[IWorkspace]
+    resume_from_failure: bool = False
 
     @property
     def pipeline_code_origin(self) -> Optional[PipelinePythonOrigin]:

--- a/python_modules/dagster/dagster/grpc/impl.py
+++ b/python_modules/dagster/dagster/grpc/impl.py
@@ -65,7 +65,7 @@ def _report_run_failed_if_not_finished(instance, pipeline_run_id):
         yield instance.report_run_failed(pipeline_run)
 
 
-def core_execute_run(recon_pipeline, pipeline_run, instance):
+def core_execute_run(recon_pipeline, pipeline_run, instance, resume_from_failure=False):
     check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline)
     check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
     check.inst_param(instance, "instance", DagsterInstance)
@@ -83,7 +83,9 @@ def core_execute_run(recon_pipeline, pipeline_run, instance):
         return
 
     try:
-        yield from execute_run_iterator(recon_pipeline, pipeline_run, instance)
+        yield from execute_run_iterator(
+            recon_pipeline, pipeline_run, instance, resume_from_failure=resume_from_failure
+        )
     except (KeyboardInterrupt, DagsterExecutionInterruptedError):
         yield from _report_run_failed_if_not_finished(instance, pipeline_run.run_id)
         yield instance.report_engine_event(

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -19,7 +19,8 @@ from dagster.utils.error import SerializableErrorInfo
 class ExecutionPlanSnapshotArgs(
     namedtuple(
         "_ExecutionPlanSnapshotArgs",
-        "pipeline_origin solid_selection run_config mode step_keys_to_execute pipeline_snapshot_id known_state",
+        "pipeline_origin solid_selection run_config mode step_keys_to_execute pipeline_snapshot_id "
+        "known_state",
     )
 ):
     def __new__(
@@ -52,6 +53,21 @@ class ExecutionPlanSnapshotArgs(
 class ExecuteRunArgs(namedtuple("_ExecuteRunArgs", "pipeline_origin pipeline_run_id instance_ref")):
     def __new__(cls, pipeline_origin, pipeline_run_id, instance_ref):
         return super(ExecuteRunArgs, cls).__new__(
+            cls,
+            pipeline_origin=check.inst_param(
+                pipeline_origin,
+                "pipeline_origin",
+                PipelinePythonOrigin,
+            ),
+            pipeline_run_id=check.str_param(pipeline_run_id, "pipeline_run_id"),
+            instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
+        )
+
+
+@whitelist_for_serdes
+class ResumeRunArgs(namedtuple("_ResumeRunArgs", "pipeline_origin pipeline_run_id instance_ref")):
+    def __new__(cls, pipeline_origin, pipeline_run_id, instance_ref):
+        return super(ResumeRunArgs, cls).__new__(
             cls,
             pipeline_origin=check.inst_param(
                 pipeline_origin,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -1,0 +1,149 @@
+import pytest
+from dagster import job, op
+from dagster.core.errors import DagsterInvariantViolationError
+from dagster.core.events import DagsterEvent, DagsterEventType
+from dagster.core.execution.api import create_execution_plan
+from dagster.core.execution.plan.objects import StepSuccessData
+from dagster.core.execution.plan.outputs import StepOutputData, StepOutputHandle
+from dagster.core.execution.retries import RetryMode
+
+
+def define_foo_job():
+    @op
+    def foo_op():
+        pass
+
+    @job
+    def foo_job():
+        foo_op()
+
+    return foo_job
+
+
+def test_recover_with_step_in_flight():
+    foo_job = define_foo_job()
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Execution finished without completing the execution plan",
+    ):
+        with create_execution_plan(foo_job).start(RetryMode.DISABLED) as active_execution:
+            steps = active_execution.get_steps_to_execute()
+            assert len(steps) == 1
+            step_1 = steps[0]
+            assert step_1.key == "foo_op"
+
+            active_execution.handle_event(
+                DagsterEvent(
+                    DagsterEventType.STEP_START.value,
+                    pipeline_name=foo_job.name,
+                    step_key=step_1.key,
+                )
+            )
+
+    # CRASH!- we've closed the active execution. Now we recover, spinning up a new one
+
+    with create_execution_plan(foo_job).start(RetryMode.DISABLED) as active_execution:
+        possibly_in_flight_steps = active_execution.rebuild_from_events(
+            [
+                DagsterEvent(
+                    DagsterEventType.STEP_START.value,
+                    pipeline_name=foo_job.name,
+                    step_key=step_1.key,
+                )
+            ]
+        )
+        assert possibly_in_flight_steps == [step_1]
+
+        assert not active_execution.get_steps_to_execute()
+
+        active_execution.handle_event(
+            DagsterEvent(
+                DagsterEventType.STEP_SUCCESS.value,
+                pipeline_name=foo_job.name,
+                event_specific_data=StepSuccessData(duration_ms=10.0),
+                step_key=step_1.key,
+            )
+        )
+
+
+def define_two_op_job():
+    @op
+    def foo_op():
+        pass
+
+    @op
+    def bar_op(_data):
+        pass
+
+    @job
+    def two_op_job():
+        bar_op(foo_op())
+
+    return two_op_job
+
+
+def test_recover_in_between_steps():
+    two_op_job = define_two_op_job()
+
+    events = [
+        DagsterEvent(
+            DagsterEventType.STEP_START.value,
+            pipeline_name=two_op_job.name,
+            step_key="foo_op",
+        ),
+        DagsterEvent(
+            DagsterEventType.STEP_OUTPUT.value,
+            pipeline_name=two_op_job.name,
+            event_specific_data=StepOutputData(
+                StepOutputHandle(step_key="foo_op", output_name="result")
+            ),
+            step_key="foo_op",
+        ),
+        DagsterEvent(
+            DagsterEventType.STEP_SUCCESS.value,
+            pipeline_name=two_op_job.name,
+            event_specific_data=StepSuccessData(duration_ms=10.0),
+            step_key="foo_op",
+        ),
+    ]
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Execution finished without completing the execution plan",
+    ):
+        with create_execution_plan(two_op_job).start(RetryMode.DISABLED) as active_execution:
+            steps = active_execution.get_steps_to_execute()
+            assert len(steps) == 1
+            step_1 = steps[0]
+            assert step_1.key == "foo_op"
+
+            active_execution.handle_event(events[0])
+            active_execution.handle_event(events[1])
+            active_execution.handle_event(events[2])
+
+    # CRASH!- we've closed the active execution. Now we recover, spinning up a new one
+
+    with create_execution_plan(two_op_job).start(RetryMode.DISABLED) as active_execution:
+        possibly_in_flight_steps = active_execution.rebuild_from_events(events)
+        assert len(possibly_in_flight_steps) == 1
+        step_2 = possibly_in_flight_steps[0]
+        assert step_2.key == "bar_op"
+
+        assert not active_execution.get_steps_to_execute()
+
+        active_execution.handle_event(
+            DagsterEvent(
+                DagsterEventType.STEP_START.value,
+                pipeline_name=two_op_job.name,
+                step_key="bar_op",
+            )
+        )
+        active_execution.handle_event(
+            DagsterEvent(
+                DagsterEventType.STEP_SUCCESS.value,
+                pipeline_name=two_op_job.name,
+                event_specific_data=StepSuccessData(duration_ms=10.0),
+                step_key="bar_op",
+            )
+        )

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -1,9 +1,10 @@
 import os
+import time
 
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.test_utils import poll_for_finished_run
 from dagster.utils.merger import merge_dicts
-from dagster.utils.yaml_utils import merge_yamls
+from dagster.utils.yaml_utils import load_yaml_from_path, merge_yamls
 from dagster_test.test_project import (
     ReOriginatedExternalPipelineForTest,
     find_local_test_image,
@@ -85,4 +86,87 @@ def test_image_on_pipeline():
             for log in instance.all_logs(run.run_id):
                 print(log)  # pylint: disable=print-call
 
+            assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+
+
+def test_recovery():
+    docker_image = get_test_project_docker_image()
+
+    launcher_config = {
+        "env_vars": [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+        ],
+        "networks": ["container:test-postgres-db-docker"],
+        "container_kwargs": {
+            "auto_remove": True,
+            "volumes": ["/var/run/docker.sock:/var/run/docker.sock"],
+        },
+    }
+
+    if IS_BUILDKITE:
+        launcher_config["registry"] = get_buildkite_registry_config()
+    else:
+        find_local_test_image(docker_image)
+
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
+        {
+            "solids": {
+                "multiply_the_word_slow": {
+                    "inputs": {"word": "bar"},
+                    "config": {"factor": 2, "sleep_time": 10},
+                }
+            },
+            "execution": {"docker": {"config": {}}},
+        },
+    )
+
+    with docker_postgres_instance(
+        overrides={
+            "run_launcher": {
+                "class": "DockerRunLauncher",
+                "module": "dagster_docker",
+                "config": launcher_config,
+            }
+        }
+    ) as instance:
+        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_docker_slow", docker_image)
+        with get_test_project_workspace_and_external_pipeline(
+            instance, "demo_pipeline_docker_slow", container_image=docker_image
+        ) as (
+            workspace,
+            orig_pipeline,
+        ):
+            external_pipeline = ReOriginatedExternalPipelineForTest(
+                orig_pipeline, container_image=docker_image
+            )
+
+            run = instance.create_run_for_pipeline(
+                pipeline_def=recon_pipeline.get_definition(),
+                run_config=run_config,
+                external_pipeline_origin=external_pipeline.get_external_origin(),
+                pipeline_code_origin=external_pipeline.get_python_origin(),
+            )
+
+            instance.launch_run(run.run_id, workspace)
+
+            start_time = time.time()
+            while time.time() - start_time < 60:
+                run = instance.get_run_by_id(run.run_id)
+                if run.status == PipelineRunStatus.STARTED:
+                    break
+                assert run.status == PipelineRunStatus.STARTING
+                time.sleep(1)
+
+            time.sleep(3)
+
+            instance.run_launcher._get_container(  # pylint:disable=protected-access
+                instance.get_run_by_id(run.run_id)
+            ).stop(timeout=0)
+            instance.resume_run(run.run_id, workspace)
+            poll_for_finished_run(instance, run.run_id, timeout=60)
+
+            for log in instance.all_logs(run.run_id):
+                print(str(log) + "\n")  # pylint: disable=print-call
             assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS


### PR DESCRIPTION
- Add a `resume_from_failure` (is this the right name?) arg to the run launcher context. This gets threaded down to the executor.
- The StepDelegatingExecutor passes the existing events to the ActiveExecution, which returns a list of which steps may have been launched, but have yet to emit a started event. 
- The executor uses health checks to establish if the steps have been launched (TODO race condition here: a very fast step may go from no having started to complete, before the health check occurs. Which would result in launching the step twice) and launches any that fail the health check.

I believe this is backcompat, since we're adding an optional field

Tested using docker run launcher + executor: launch a run, wait for it to start, wait a bit, then kill the run worker. Then launch a recovery run worker