### PR TITLE
fix asset graph links

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -58,7 +58,9 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
     }
     const items = repo.assetNodes.map((asset) => ({
       name: asset.assetKey.path.join(' > '),
-      path: `/assets/${asset.assetKey.path.map(encodeURIComponent).join('/')}`,
+      path: `/jobs/${asset.jobName}:default/${asset.assetKey.path
+        .map(encodeURIComponent)
+        .join('/')}`,
       description: asset.description,
       repoAddress,
     }));


### PR DESCRIPTION
We removed the custom asset graph root entry point, needed to update the link paths.

Will probably want to cherry-pick this for `0.12.5`

## Test Plan
BK

