### PR TITLE
Fixed _TypedPythonTuple appending elements to dagster_type

### DIFF
--- a/python_modules/dagster/dagster/core/types/python_tuple.py
+++ b/python_modules/dagster/dagster/core/types/python_tuple.py
@@ -74,7 +74,7 @@ class _TypedPythonTuple(DagsterType):
 
     @property
     def inner_types(self):
-        inner_types = self.dagster_types
+        inner_types = self.dagster_types.copy()
         for t in self.dagster_types:
             inner_types += t.inner_types
         return inner_types

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -15,6 +15,8 @@ from dagster import (
     ModeDefinition,
     Optional,
     OutputDefinition,
+    String,
+    Tuple,
     TypeCheck,
     check_dagster_type,
     execute_pipeline,
@@ -23,15 +25,13 @@ from dagster import (
     pipeline,
     resource,
     solid,
-    Tuple,
-    String,
 )
 from dagster.core.test_utils import default_mode_def_for_test
 from dagster.core.types.dagster_type import (
     DagsterType,
+    ListType,
     PythonObjectDagsterType,
     resolve_dagster_type,
-    ListType,
 )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -23,12 +23,15 @@ from dagster import (
     pipeline,
     resource,
     solid,
+    Tuple,
+    String,
 )
 from dagster.core.test_utils import default_mode_def_for_test
 from dagster.core.types.dagster_type import (
     DagsterType,
     PythonObjectDagsterType,
     resolve_dagster_type,
+    ListType,
 )
 
 
@@ -645,3 +648,14 @@ def test_make_usable_as_dagster_type_called_twice():
 
     with pytest.raises(DagsterInvalidDefinitionError):
         make_python_type_usable_as_dagster_type(AType, BDagsterType)
+
+
+def test_tuple_inner_types_not_mutable():
+    tuple_type = Tuple[List[String]]
+    inner_types_1st_call = list(tuple_type.inner_types)
+    inner_types = list(tuple_type.inner_types)
+    assert inner_types_1st_call == inner_types, "inner types mutated on subsequent calls"
+
+    assert isinstance(inner_types[0], ListType)
+    assert inner_types[0].inner_type == inner_types[1]
+    assert len(inner_types) == 2


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Encountered https://github.com/dagster-io/dagster/issues/5083 when using the `dagster.Tuple` type with inner types.

The issue itself is pretty silly - whenever the property `_TypedPythonTuple(...).inner_types` got accessed, the `_TypedPythonTuple(...).dagster_types` list was mutated. A simple `.copy` fixes this.
Thought about replacing the loop with a list comprehension, but the `.copy()` actually feels more readable.

And while I don't know what `.inner_types` is used for, it's pretty clear that you're not trying to mutate `.dagster_types` every time it gets accessed.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

No tests added.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.