### PR TITLE
[config revamp 3/n] disallow composite solid within graph or job

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -107,6 +107,14 @@ def is_in_composition() -> bool:
     return bool(_composition_stack)
 
 
+def is_using_graph_job_op_apis():
+    if not is_in_composition():
+        return False
+    else:
+        source_decorator = _composition_stack[0].source
+        return source_decorator == "@job" or source_decorator == "@graph"
+
+
 def assert_in_composition(name: str) -> None:
     if len(_composition_stack) < 1:
         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/core/definitions/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/solid.py
@@ -344,6 +344,19 @@ class CompositeSolidDefinition(GraphDefinition):
             config=config_mapping,
         )
 
+    def __call__(self, *args, **kwargs):
+        from .composition import is_using_graph_job_op_apis
+
+        if is_using_graph_job_op_apis():
+            raise DagsterInvalidDefinitionError(
+                "Attempted to invoke composite solid within the context of a Dagster job or graph. "
+                "Composite solids are deprecated in favor of @graph, and not supported within the "
+                "job and graph APIs. In order to convert your composite solid to a graph, refer to the "
+                "migration guide: "
+                "https://docs.dagster.io/guides/dagster/graph_job_op#composite-solids."
+            )
+        super(CompositeSolidDefinition, self).__call__(*args, **kwargs)
+
     def all_dagster_types(self) -> Iterator[DagsterType]:
         yield from self.all_input_output_types()
 


### PR DESCRIPTION
Explicitly disallow composite solids to be nested within graphs or jobs. Link back to migration guide in error message.