### PR TITLE
remove no-longer-existent hacker news column

### DIFF
--- a/examples/hacker_news/hacker_news/ops/download_items.py
+++ b/examples/hacker_news/hacker_news/ops/download_items.py
@@ -3,15 +3,7 @@ from typing import Tuple
 from dagster import Out, Output, op
 from pandas import DataFrame
 from pyspark.sql import DataFrame as SparkDF
-from pyspark.sql.types import (
-    ArrayType,
-    BooleanType,
-    DoubleType,
-    LongType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, StructField, StructType
 
 HN_ACTION_SCHEMA = StructType(
     [
@@ -22,7 +14,6 @@ HN_ACTION_SCHEMA = StructType(
         StructField("by", StringType()),
         StructField("text", StringType()),
         StructField("kids", ArrayType(LongType())),
-        StructField("dead", BooleanType()),
         StructField("score", DoubleType()),
         StructField("title", StringType()),
         StructField("descendants", DoubleType()),


### PR DESCRIPTION
The download pipeline was failing with
```
pyspark.sql.utils.AnalysisException: cannot resolve '`dead`' given input columns: [by, descendants, id, kids, parent, score, text, time, title, type, url];
'Project [id#1L, parent#2, time#4L, type#5, by#0, text#3, kids#7, 'dead, score#8, title#9, descendants#6, url#10]
+- Filter (type#5 = comment)
+- Relation[by#0,id#1L,parent#2,text#3,time#4L,type#5,descendants#6,kids#7,score#8,title#9,url#10] parquet
```

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Reproduced the error locally, then verified that it no longer existed after the fix.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.