### PR TITLE
Fixup prefixed IO manager tests

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -1,5 +1,4 @@
 from dagster import In, Int, Out, Output, job, op, resource
-
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.utils import construct_s3_client
 


### PR DESCRIPTION
This test was failing initially because of a syntax error. But once I
fixed that, it continued to fail because no outputs were actually being
written.

I switched from the existing pattern of building and traversing the
execution plan by hand to our new `job.execute_in_process()` method and
it helped pinpoint the issue to us not yielding an `Output()` from our
job.

I like this test implementation because I think it makes the behavior
under test easier to understand - we expect to see two keys written to
S3 and we expect them to contain the appropriate outputs. I've made
a similar change to the other test and also added a few readability
refactors.