### PR TITLE
remove whitespace from descriptions that are inferred from docstrings

### DIFF
--- a/python_modules/dagster/dagster/core/decorator_utils.py
+++ b/python_modules/dagster/dagster/core/decorator_utils.py
@@ -1,3 +1,4 @@
+import textwrap
 from typing import Any, Callable, List, Optional, Set
 
 from dagster.seven import funcsigs
@@ -52,3 +53,10 @@ def positional_arg_name_list(params: List[funcsigs.Parameter]) -> List[str]:
         funcsigs.Parameter.POSITIONAL_ONLY,
     }
     return [p.name for p in params if p.kind in accepted_param_types]
+
+
+def format_docstring_for_description(fn: Callable) -> Optional[str]:
+    if fn.__doc__ is not None:
+        return textwrap.dedent(fn.__doc__).strip()
+    else:
+        return None

--- a/python_modules/dagster/dagster/core/definitions/decorators/composite_solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/composite_solid.py
@@ -2,6 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from dagster import check
+from dagster.core.decorator_utils import format_docstring_for_description
 
 from ..composition import do_composition, get_validated_config_mapping
 from ..input import InputDefinition
@@ -60,7 +61,7 @@ class _CompositeSolid:
             output_mappings=output_mappings,
             dependencies=dependencies,
             solid_defs=solid_defs,
-            description=self.description or fn.__doc__,
+            description=self.description or format_docstring_for_description(fn),
             config_mapping=config_mapping,
             positional_inputs=positional_inputs,
         )

--- a/python_modules/dagster/dagster/core/definitions/decorators/graph.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/graph.py
@@ -2,6 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from dagster import check
+from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.utils.backcompat import experimental_decorator
 
 from ..config import ConfigMapping
@@ -78,7 +79,7 @@ class _Graph:
             name=self.name,
             dependencies=dependencies,
             node_defs=solid_defs,
-            description=self.description or fn.__doc__,
+            description=self.description or format_docstring_for_description(fn),
             input_mappings=input_mappings,
             output_mappings=output_mappings,
             config=config_mapping,

--- a/python_modules/dagster/dagster/core/definitions/decorators/job.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job.py
@@ -2,6 +2,7 @@ from functools import update_wrapper
 from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Dict, Optional, Union
 
 from dagster import check
+from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.utils.backcompat import experimental_decorator
 
 from ..config import ConfigMapping
@@ -69,7 +70,7 @@ class _Job:
             name=self.name,
             dependencies=dependencies,
             node_defs=solid_defs,
-            description=self.description or fn.__doc__,
+            description=self.description or format_docstring_for_description(fn),
             input_mappings=input_mappings,
             output_mappings=output_mappings,
             config=config_mapping,
@@ -78,7 +79,7 @@ class _Job:
         )
         update_wrapper(graph_def, fn)
         return graph_def.to_job(
-            description=self.description,
+            description=self.description or format_docstring_for_description(fn),
             resource_defs=self.resource_defs,
             config=self.config,
             tags=self.tags,

--- a/python_modules/dagster/dagster/core/definitions/decorators/op.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op.py
@@ -2,6 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union
 
 from dagster import check
+from dagster.core.decorator_utils import format_docstring_for_description
 
 from ....seven.typing import get_origin
 from ....utils.backcompat import experimental_decorator
@@ -113,7 +114,7 @@ class _Op:
             output_defs=resolved_output_defs,
             compute_fn=compute_fn,
             config_schema=self.config_schema,
-            description=self.description or fn.__doc__,
+            description=self.description or format_docstring_for_description(fn),
             required_resource_keys=self.required_resource_keys,
             tags=self.tags,
             version=self.version,

--- a/python_modules/dagster/dagster/core/definitions/decorators/pipeline.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/pipeline.py
@@ -2,6 +2,7 @@ from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from dagster import check
+from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.core.definitions.policy import RetryPolicy
 from dagster.utils.backcompat import experimental_arg_warning
 
@@ -97,7 +98,7 @@ class _Pipeline:
                 positional_inputs=positional_inputs,
             ),
             tags=self.tags,
-            description=self.description or fn.__doc__,
+            description=self.description or format_docstring_for_description(fn),
             hook_defs=self.hook_defs,
             solid_retry_policy=self.solid_retry_policy,
             version_strategy=self.version_strategy,

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid.py
@@ -2,6 +2,7 @@ from functools import lru_cache, update_wrapper
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Set, Union, cast
 
 from dagster import check
+from dagster.core.decorator_utils import format_docstring_for_description
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.types.dagster_type import DagsterTypeKind
 from dagster.seven import funcsigs
@@ -113,7 +114,7 @@ class _Solid:
             output_defs=output_defs,
             compute_fn=compute_fn,
             config_schema=self.config_schema,
-            description=self.description or fn.__doc__,
+            description=self.description or format_docstring_for_description(fn),
             required_resource_keys=self.required_resource_keys,
             tags=self.tags,
             version=self.version,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_description_inference.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_description_inference.py
@@ -1,0 +1,15 @@
+from dagster import composite_solid, graph, job, op, solid
+
+
+def test_description_inference():
+    decorators = [job, op, graph, solid, composite_solid]
+    for decorator in decorators:
+
+        @decorator
+        def my_thing():
+            """
+            Here is some
+            multiline description.
+            """
+
+        assert my_thing.description == "\n".join(["Here is some", "multiline description."])


### PR DESCRIPTION
Noticed this because our asset graph entries only show the first line of a description, and they were empty for ops/assets with multiline descriptions.