### PR TITLE
Monitoring daemon

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/docker-compose.yml
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  test-postgres-db-docker:
+    image: postgres:11
+    container_name: test-postgres-db-docker
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: "test"
+      POSTGRES_USER: "test"
+      POSTGRES_DB: "test"
+    networks:
+      - postgres
+
+networks:
+  postgres:
+    driver: bridge
+    name: postgres

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -1,0 +1,236 @@
+import os
+import time
+from contextlib import contextmanager
+
+from dagster import seven
+from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.test_utils import instance_for_test, poll_for_finished_run
+from dagster.daemon.controller import all_daemons_healthy
+from dagster.serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
+from dagster.utils.merger import merge_dicts
+from dagster.utils.test.postgres_instance import postgres_instance_for_test
+from dagster.utils.yaml_utils import load_yaml_from_path
+from dagster_test.test_project import (
+    ReOriginatedExternalPipelineForTest,
+    find_local_test_image,
+    get_buildkite_registry_config,
+    get_test_project_docker_image,
+    get_test_project_environments_path,
+    get_test_project_recon_pipeline,
+    get_test_project_workspace_and_external_pipeline,
+)
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+
+
+@contextmanager
+def docker_postgres_instance(overrides=None, conn_args=None):
+    with postgres_instance_for_test(
+        __file__,
+        "test-postgres-db-docker",
+        overrides=overrides,
+        conn_args=conn_args,
+    ) as instance:
+        yield instance
+
+
+@contextmanager
+def start_daemon(timeout=60):
+    p = open_ipc_subprocess(["dagster-daemon", "run"])
+    try:
+        yield
+    finally:
+        interrupt_ipc_subprocess(p)
+        seven.wait_for_process(p, timeout=timeout)
+
+
+def test_monitoring():
+    # with setup_instance() as instance:
+    with instance_for_test(
+        {
+            "run_monitoring": {"enabled": True, "poll_interval_seconds": 5},
+            "run_launcher": {
+                "class": "DockerRunLauncher",
+                "module": "dagster_docker",
+                "config": {},
+            },
+        }
+    ) as instance:
+        with start_daemon():
+            time.sleep(5)
+            assert all_daemons_healthy(instance)
+
+
+def test_docker_monitoring():
+    docker_image = get_test_project_docker_image()
+
+    launcher_config = {
+        "env_vars": [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+        ],
+        "networks": ["container:test-postgres-db-docker"],
+        "container_kwargs": {
+            # "auto_remove": True,
+            "volumes": ["/var/run/docker.sock:/var/run/docker.sock"],
+        },
+    }
+
+    if IS_BUILDKITE:
+        launcher_config["registry"] = get_buildkite_registry_config()
+    else:
+        find_local_test_image(docker_image)
+
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
+        {
+            "solids": {
+                "multiply_the_word_slow": {
+                    "inputs": {"word": "bar"},
+                    "config": {"factor": 2, "sleep_time": 10},
+                }
+            },
+            "execution": {"docker": {"config": {}}},
+        },
+    )
+
+    with docker_postgres_instance(
+        {
+            "run_monitoring": {"enabled": True},
+            "run_launcher": {
+                "class": "DockerRunLauncher",
+                "module": "dagster_docker",
+                "config": launcher_config,
+            },
+        }
+    ) as instance:
+        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_docker_slow", docker_image)
+        with get_test_project_workspace_and_external_pipeline(
+            instance, "demo_pipeline_docker_slow", container_image=docker_image
+        ) as (
+            workspace,
+            orig_pipeline,
+        ):
+            with start_daemon():
+                external_pipeline = ReOriginatedExternalPipelineForTest(
+                    orig_pipeline, container_image=docker_image
+                )
+
+                run = instance.create_run_for_pipeline(
+                    pipeline_def=recon_pipeline.get_definition(),
+                    run_config=run_config,
+                    external_pipeline_origin=external_pipeline.get_external_origin(),
+                    pipeline_code_origin=external_pipeline.get_python_origin(),
+                )
+
+                instance.launch_run(run.run_id, workspace)
+
+                start_time = time.time()
+                while time.time() - start_time < 60:
+                    run = instance.get_run_by_id(run.run_id)
+                    if run.status == PipelineRunStatus.STARTED:
+                        break
+                    assert run.status == PipelineRunStatus.STARTING
+                    time.sleep(1)
+
+                time.sleep(3)
+
+                instance.run_launcher._get_container(  # pylint:disable=protected-access
+                    instance.get_run_by_id(run.run_id)
+                ).stop()
+
+                # daemon resumes the run
+                poll_for_finished_run(instance, run.run_id, timeout=60)
+
+                for log in instance.all_logs(run.run_id):
+                    print(str(log) + "\n")  # pylint: disable=print-call
+                assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+
+
+def test_docker_monitoring_run_out_of_attempts():
+    docker_image = get_test_project_docker_image()
+
+    launcher_config = {
+        "env_vars": [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+        ],
+        "networks": ["container:test-postgres-db-docker"],
+        "container_kwargs": {
+            # "auto_remove": True,
+            "volumes": ["/var/run/docker.sock:/var/run/docker.sock"],
+        },
+    }
+
+    if IS_BUILDKITE:
+        launcher_config["registry"] = get_buildkite_registry_config()
+    else:
+        find_local_test_image(docker_image)
+
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
+        {
+            "solids": {
+                "multiply_the_word_slow": {
+                    "inputs": {"word": "bar"},
+                    "config": {"factor": 2, "sleep_time": 10},
+                }
+            },
+            "execution": {"docker": {"config": {}}},
+        },
+    )
+
+    with docker_postgres_instance(
+        {
+            "run_monitoring": {
+                "enabled": True,
+                "max_resume_run_attempts": 0,
+                "poll_interval_seconds": 5,
+            },
+            "run_launcher": {
+                "class": "DockerRunLauncher",
+                "module": "dagster_docker",
+                "config": launcher_config,
+            },
+        }
+    ) as instance:
+        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_docker_slow", docker_image)
+        with get_test_project_workspace_and_external_pipeline(
+            instance, "demo_pipeline_docker_slow", container_image=docker_image
+        ) as (
+            workspace,
+            orig_pipeline,
+        ):
+            with start_daemon():
+                external_pipeline = ReOriginatedExternalPipelineForTest(
+                    orig_pipeline, container_image=docker_image
+                )
+
+                run = instance.create_run_for_pipeline(
+                    pipeline_def=recon_pipeline.get_definition(),
+                    run_config=run_config,
+                    external_pipeline_origin=external_pipeline.get_external_origin(),
+                    pipeline_code_origin=external_pipeline.get_python_origin(),
+                )
+
+                instance.launch_run(run.run_id, workspace)
+
+                start_time = time.time()
+                while time.time() - start_time < 60:
+                    run = instance.get_run_by_id(run.run_id)
+                    if run.status == PipelineRunStatus.STARTED:
+                        break
+                    assert run.status == PipelineRunStatus.STARTING
+                    time.sleep(1)
+
+                time.sleep(3)
+
+                instance.run_launcher._get_container(  # pylint:disable=protected-access
+                    instance.get_run_by_id(run.run_id)
+                ).stop(timeout=0)
+
+                poll_for_finished_run(instance, run.run_id, timeout=60)
+
+                for log in instance.all_logs(run.run_id):
+                    print(str(log) + "\n")  # pylint: disable=print-call
+                assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -3,11 +3,21 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
-passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
+passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG POSTGRES_TEST_DB_HOST
 deps =
   objgraph
   -e ../../../python_modules/dagster[test]
+  -e ../../../python_modules/dagster-graphql
   -e ../../../python_modules/dagster-test
+  -e ../../../python_modules/libraries/dagster-aws
+  -e ../../../python_modules/libraries/dagster-pandas
+  -e ../../../python_modules/libraries/dagster-gcp
+  -e ../../../python_modules/libraries/dagster-celery
+  -e ../../../python_modules/libraries/dagster-celery-docker
+  -e ../../../python_modules/libraries/dagster-k8s
+  -e ../../../python_modules/libraries/dagster-celery-k8s
+  -e ../../../python_modules/libraries/dagster-postgres
+  -e ../../../python_modules/libraries/dagster-docker
 whitelist_externals =
   /bin/bash
   echo

--- a/integration_tests/test_suites/daemon-test-suite/utils.py
+++ b/integration_tests/test_suites/daemon-test-suite/utils.py
@@ -1,20 +1,7 @@
 import contextlib
-import os
 
 from dagster import seven
-from dagster.core.instance import DagsterInstance
 from dagster.serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
-
-
-@contextlib.contextmanager
-def setup_instance(dagster_home, instance_config):
-    os.environ["DAGSTER_HOME"] = dagster_home
-
-    with open(os.path.join(dagster_home, "dagster.yaml"), "w") as file:
-        file.write(instance_config)
-
-    with DagsterInstance.get() as instance:
-        yield instance
 
 
 @contextlib.contextmanager

--- a/python_modules/dagster/dagster/core/instance/config.py
+++ b/python_modules/dagster/dagster/core/instance/config.py
@@ -110,4 +110,15 @@ def dagster_instance_config_schema():
         "telemetry": Field({"enabled": Field(Bool, is_required=False)}),
         "instance_class": config_field_for_configurable_class(),
         "python_logs": python_logs_config_schema(),
+        "run_monitoring": Field(
+            {
+                "enabled": Field(
+                    Bool,
+                    is_required=False,
+                ),
+                "start_timeout_seconds": Field(int, is_required=False),
+                "max_resume_run_attempts": Field(int, is_required=False),
+                "poll_interval_seconds": Field(int, is_required=False),
+            },
+        ),
     }

--- a/python_modules/dagster/dagster/core/instance/ref.py
+++ b/python_modules/dagster/dagster/core/instance/ref.py
@@ -204,7 +204,7 @@ class InstanceRef(
             defaults["run_launcher"],
         )
 
-        settings_keys = {"telemetry", "python_logs"}
+        settings_keys = {"telemetry", "python_logs", "run_monitoring"}
         settings = {key: config_value.get(key) for key in settings_keys if config_value.get(key)}
 
         return InstanceRef(

--- a/python_modules/dagster/dagster/core/launcher/__init__.py
+++ b/python_modules/dagster/dagster/core/launcher/__init__.py
@@ -1,2 +1,2 @@
-from .base import LaunchRunContext, RunLauncher
+from .base import CheckRunHealthResult, LaunchRunContext, RunLauncher, WorkerStatus
 from .default_run_launcher import DefaultRunLauncher

--- a/python_modules/dagster/dagster/core/launcher/base.py
+++ b/python_modules/dagster/dagster/core/launcher/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import NamedTuple, Optional
 
 from dagster.core.instance import MayHaveInstanceWeakref
@@ -15,10 +16,28 @@ class LaunchRunContext(NamedTuple):
     pipeline_run: PipelineRun
     workspace: Optional[IWorkspace]
     resume_from_failure: bool = False
+    resume_attempt_number: Optional[int] = None
 
     @property
     def pipeline_code_origin(self) -> Optional[PipelinePythonOrigin]:
         return self.pipeline_run.pipeline_code_origin
+
+
+class WorkerStatus(Enum):
+    RUNNING = "RUNNING"
+    NOT_FOUND = "NOT_FOUND"
+    FAILED = "FAILED"
+    SUCCESS = "SUCCESS"
+    UNKNOWN = "UNKNOWN"
+
+
+class CheckRunHealthResult(NamedTuple):
+    """
+    Result of a check_run_worker_health call.
+    """
+
+    status: WorkerStatus
+    message: Optional[str] = None
 
 
 class RunLauncher(ABC, MayHaveInstanceWeakref):
@@ -61,3 +80,13 @@ class RunLauncher(ABC, MayHaveInstanceWeakref):
 
     def join(self, timeout=30):
         pass
+
+    @property
+    def supports_check_run_worker_health(self):
+        """
+        Whether the run launcher supports check_run_worker_health.
+        """
+        return False
+
+    def check_run_worker_health(self, run: PipelineRun) -> CheckRunHealthResult:
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/daemon/controller.py
+++ b/python_modules/dagster/dagster/daemon/controller.py
@@ -13,6 +13,7 @@ from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
 from dagster.daemon.daemon import (
     BackfillDaemon,
     DagsterDaemon,
+    MonitoringDaemon,
     SchedulerDaemon,
     SensorDaemon,
     get_default_daemon_logger,
@@ -285,6 +286,8 @@ def create_daemon_of_type(daemon_type, instance):
         )
     elif daemon_type == BackfillDaemon.daemon_type():
         return BackfillDaemon(interval_seconds=DEFAULT_DAEMON_INTERVAL_SECONDS)
+    elif daemon_type == MonitoringDaemon.daemon_type():
+        return MonitoringDaemon(interval_seconds=instance.run_monitoring_poll_interval_seconds)
     else:
         raise Exception(f"Unexpected daemon type {daemon_type}")
 

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -8,6 +8,7 @@ import pendulum
 from dagster import DagsterInstance, check
 from dagster.core.workspace import IWorkspace
 from dagster.daemon.backfill import execute_backfill_iteration
+from dagster.daemon.monitoring import execute_monitoring_iteration
 from dagster.daemon.sensor import execute_sensor_iteration_loop
 from dagster.daemon.types import DaemonHeartbeat
 from dagster.scheduler import execute_scheduler_iteration
@@ -245,3 +246,12 @@ class BackfillDaemon(DagsterDaemon):
 
     def run_iteration(self, instance, workspace):
         yield from execute_backfill_iteration(instance, workspace, self._logger)
+
+
+class MonitoringDaemon(DagsterDaemon):
+    @classmethod
+    def daemon_type(cls):
+        return "MONITORING"
+
+    def run_iteration(self, instance, workspace):
+        yield from execute_monitoring_iteration(instance, workspace, self._logger)

--- a/python_modules/dagster/dagster/daemon/monitoring/__init__.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/__init__.py
@@ -1,0 +1,1 @@
+from .monitoring_daemon import RESUME_RUN_LOG_MESSAGE, execute_monitoring_iteration

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -1,0 +1,106 @@
+import sys
+import time
+
+from dagster import DagsterInstance, check
+from dagster.core.events import DagsterEventType
+from dagster.core.launcher import WorkerStatus
+from dagster.core.storage.pipeline_run import (
+    IN_PROGRESS_RUN_STATUSES,
+    PipelineRunStatus,
+    PipelineRunsFilter,
+)
+from dagster.utils.error import serializable_error_info_from_exc_info
+
+RESUME_RUN_LOG_MESSAGE = "Launching a new run worker to resume run"
+
+DEFAULT_START_TIMEOUT_SECONDS = 180
+DEFAULT_MAX_RESUME_RUN_ATTEMPTS = 2
+
+
+def monitor_starting_run(instance: DagsterInstance, run, logger):
+    check.invariant(run.status == PipelineRunStatus.STARTING)
+    run_stats = instance.get_run_stats(run.run_id)
+
+    start_timeout_seconds = instance.run_monitoring_settings.get(
+        "start_timeout", DEFAULT_START_TIMEOUT_SECONDS
+    )
+
+    check.invariant(
+        run_stats.launch_time is not None, "Run in status STARTING doesn't have a launch time."
+    )
+    if time.time() - run_stats.launch_time >= start_timeout_seconds:
+        msg = (
+            f"Run {run.run_id} has been running for {time.time() - run_stats.launch_time} seconds, "
+            f"which is longer than the timeout of {start_timeout_seconds} seconds to start. "
+            "Marking run failed"
+        )
+        logger.info(msg)
+        instance.report_run_failed(run, msg)
+
+    # TODO: consider attempting to resume the run, if the run worker is in a bad status
+
+
+def count_resume_run_attempts(instance: DagsterInstance, run):
+    events = instance.all_logs(run.run_id, of_type=DagsterEventType.ENGINE_EVENT)
+    return len([event for event in events if event.message == RESUME_RUN_LOG_MESSAGE])
+
+
+def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
+    check.invariant(run.status == PipelineRunStatus.STARTED)
+    check_health_result = instance.run_launcher.check_run_worker_health(run)
+    if check_health_result.status != WorkerStatus.RUNNING:
+        max_resume_run_attempts = instance.run_monitoring_settings.get(
+            "max_resume_run_attempts", DEFAULT_MAX_RESUME_RUN_ATTEMPTS
+        )
+        num_prev_attempts = count_resume_run_attempts(instance, run)
+        if num_prev_attempts < max_resume_run_attempts:
+            msg = (
+                f"Detected that run worker status is {check_health_result.status}. Resuming run {run.run_id} with "
+                "a new worker."
+            )
+            logger.info(msg)
+            instance.report_engine_event(msg, run)
+            attempt_number = num_prev_attempts + 1
+            instance.resume_run(
+                run.run_id,
+                workspace,
+                attempt_number,
+            )
+        else:
+            msg = (
+                f"Detected that run worker status is {check_health_result.status}. Marking run {run.run_id} as "
+                "failed, because it has surpassed the configured maximum attempts to resume the run: {max_resume_run_attempts}."
+            )
+            logger.info(msg)
+            instance.report_run_failed(run, msg)
+
+
+def execute_monitoring_iteration(instance, workspace, logger, _debug_crash_flags=None):
+    check.invariant(
+        instance.run_launcher.supports_check_run_worker_health, "Must use a supported run launcher"
+    )
+
+    # TODO: consider limiting number of runs to fetch
+    runs = instance.get_runs(filters=PipelineRunsFilter(statuses=IN_PROGRESS_RUN_STATUSES))
+
+    logger.info(f"Collected {len(runs)} runs for monitoring")
+
+    for run in runs:
+        try:
+            logger.info(f"Checking run {run.run_id}")
+
+            if run.status == PipelineRunStatus.STARTING:
+                monitor_starting_run(instance, run, logger)
+            elif run.status == PipelineRunStatus.STARTED:
+                monitor_started_run(instance, workspace, run, logger)
+            elif run.status == PipelineRunStatus.CANCELING:
+                # TODO: implement canceling timeouts
+                pass
+            else:
+                check.invariant(False, f"Unexpected run status: {run.status}")
+        except Exception:  # pylint: disable=broad-except
+            error_info = serializable_error_info_from_exc_info(sys.exc_info())
+            logger.error(f"Hit error while monitoring run {run.run_id}: " f"{str(error_info)}")
+            yield error_info
+        else:
+            yield

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -133,6 +133,21 @@ def test_submit_run():
             assert instance.run_coordinator.queue()[0].run_id == "foo-bar"
 
 
+def test_get_required_daemon_types():
+    from dagster.daemon.daemon import (
+        SensorDaemon,
+        BackfillDaemon,
+        SchedulerDaemon,
+    )
+
+    with instance_for_test() as instance:
+        assert instance.get_required_daemon_types() == [
+            SensorDaemon.daemon_type(),
+            BackfillDaemon.daemon_type(),
+            SchedulerDaemon.daemon_type(),
+        ]
+
+
 def test_dagster_home_not_set():
     with environ({"DAGSTER_HOME": ""}):
         with pytest.raises(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -1,0 +1,153 @@
+# pylint: disable=redefined-outer-name
+
+import logging
+import os
+import time
+
+import pytest
+from dagster.core.events import DagsterEvent, DagsterEventType
+from dagster.core.events.log import EventLogEntry
+from dagster.core.launcher import CheckRunHealthResult, RunLauncher, WorkerStatus
+from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.test_utils import (
+    create_run_for_test,
+    create_test_daemon_workspace,
+    environ,
+    instance_for_test,
+)
+from dagster.daemon import get_default_daemon_logger
+from dagster.daemon.monitoring.monitoring_daemon import monitor_started_run, monitor_starting_run
+from dagster.serdes import ConfigurableClass
+
+
+class TestRunLauncher(RunLauncher, ConfigurableClass):
+    def __init__(self, inst_data=None):
+        self._inst_data = inst_data
+        self.launch_run_calls = 0
+        super().__init__()
+
+    @property
+    def inst_data(self):
+        return self._inst_data
+
+    @classmethod
+    def config_type(cls):
+        return {}
+
+    @staticmethod
+    def from_config_value(inst_data, config_value):
+        return TestRunLauncher(inst_data=inst_data)
+
+    def launch_run(self, context):
+        self.launch_run_calls += 1
+
+    def join(self, timeout=30):
+        pass
+
+    def can_terminate(self, run_id):
+        raise NotImplementedError()
+
+    def terminate(self, run_id):
+        raise NotImplementedError()
+
+    @property
+    def supports_check_run_worker_health(self):
+        return True
+
+    def check_run_worker_health(self, _run):
+        return (
+            CheckRunHealthResult(WorkerStatus.RUNNING, "")
+            if os.environ.get("DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT") == "healthy"
+            else CheckRunHealthResult(WorkerStatus.NOT_FOUND, "")
+        )
+
+
+@pytest.fixture
+def instance():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_tests.daemon_tests.test_monitoring_daemon",
+                "class": "TestRunLauncher",
+            },
+            "run_monitoring": {"enabled": True},
+        },
+    ) as instance:
+        yield instance
+
+
+@pytest.fixture
+def workspace():
+    with create_test_daemon_workspace() as workspace:
+        yield workspace
+
+
+@pytest.fixture
+def logger():
+    return get_default_daemon_logger("MonitoringDaemon")
+
+
+def report_starting_event(instance, run, timestamp):
+    launch_started_event = DagsterEvent(
+        event_type_value=DagsterEventType.PIPELINE_STARTING.value,
+        pipeline_name=run.pipeline_name,
+    )
+
+    event_record = EventLogEntry(
+        message="",
+        user_message="",
+        level=logging.INFO,
+        pipeline_name=run.pipeline_name,
+        run_id=run.run_id,
+        error_info=None,
+        timestamp=timestamp,
+        dagster_event=launch_started_event,
+    )
+
+    instance.handle_new_event(event_record)
+
+
+def test_monitor_starting(instance, logger):
+    run = create_run_for_test(
+        instance,
+        pipeline_name="foo",
+    )
+    report_starting_event(instance, run, timestamp=time.time())
+    monitor_starting_run(
+        instance,
+        instance.get_run_by_id(run.run_id),
+        logger,
+    )
+    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTING
+
+    run = create_run_for_test(instance, pipeline_name="foo")
+    report_starting_event(instance, run, timestamp=time.time() - 1000)
+
+    monitor_starting_run(
+        instance,
+        instance.get_run_by_id(run.run_id),
+        logger,
+    )
+    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
+
+
+def test_monitor_started(instance, workspace, logger):
+
+    run = create_run_for_test(instance, pipeline_name="foo", status=PipelineRunStatus.STARTED)
+    with environ({"DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT": "healthy"}):
+        monitor_started_run(instance, workspace, run, logger)
+        assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+        assert instance.run_launcher.launch_run_calls == 0
+
+    monitor_started_run(instance, workspace, run, logger)
+    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+    assert instance.run_launcher.launch_run_calls == 1
+
+    monitor_started_run(instance, workspace, run, logger)
+    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+    assert instance.run_launcher.launch_run_calls == 2
+
+    # exausted the 3 attempts
+    monitor_started_run(instance, workspace, run, logger)
+    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
+    assert instance.run_launcher.launch_run_calls == 2

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -128,7 +128,8 @@ def test_recovery():
                 "class": "DockerRunLauncher",
                 "module": "dagster_docker",
                 "config": launcher_config,
-            }
+            },
+            "run_monitoring": {"enabled": True},
         }
     ) as instance:
         recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_docker_slow", docker_image)
@@ -163,8 +164,8 @@ def test_recovery():
 
             instance.run_launcher._get_container(  # pylint:disable=protected-access
                 instance.get_run_by_id(run.run_id)
-            ).stop(timeout=0)
-            instance.resume_run(run.run_id, workspace)
+            ).stop()
+            instance.resume_run(run.run_id, workspace, attempt_number=1)
             poll_for_finished_run(instance, run.run_id, timeout=60)
 
             for log in instance.all_logs(run.run_id):


### PR DESCRIPTION
Internal doc: https://elementl.quip.com/fbtHABb8oLai/Monitoring-Daemon

Daemon that polls in progress runs to check that they are progressing.

RFC:
- How should this be configured on the instance? Example config: timeout before marking launched run as failed. number of times to try to recover the run worker. Should it go under `settings`? Or should we create a ConfigurableClass for it (I don't think that's necessary?)
- New API on run launcher