### PR TITLE
[dagit] Use job icon in nav for now

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
@@ -84,7 +84,7 @@ export const FlatContentList: React.FC<Props> = (props) => {
                 {name}
                 {isJob ? null : (
                   <Tooltip content="Legacy pipeline" placement="top">
-                    <IconWIP name="nightlight" color={ColorsWIP.Gray300} />
+                    <IconWIP name="job" color={ColorsWIP.Gray300} />
                   </Tooltip>
                 )}
               </Label>


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Use a more sane icon for pipelines in nav for now, instead of that nighlight icon, while @braunjj works on something better.

## Test Plan

View nav in Dagit.