### PR TITLE
Allow None for celery-k8s config

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -350,7 +350,7 @@ def _get_validated_celery_k8s_executor_config(run_config):
         )
 
     execution_config_schema = resolve_to_config_type(celery_k8s_config())
-    execution_run_config = run_config["execution"][CELERY_K8S_CONFIG_KEY].get("config", {})
+    execution_run_config = (run_config["execution"][CELERY_K8S_CONFIG_KEY] or {}).get("config", {})
     res = process_config(execution_config_schema, execution_run_config)
 
     check.invariant(

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -25,6 +25,22 @@ from dagster_k8s.job import UserDefinedDagsterK8sConfig
 from dagster_test.test_project import get_test_project_workspace_and_external_pipeline
 
 
+def test_empty_celery_config():
+    res = _get_validated_celery_k8s_executor_config({"execution": {CELERY_K8S_CONFIG_KEY: None}})
+
+    assert res == {
+        "backend": "rpc://",
+        "retries": {"enabled": {}},
+        "image_pull_policy": "IfNotPresent",
+        "volume_mounts": [],
+        "volumes": [],
+        "load_incluster_config": True,
+        "job_namespace": "default",
+        "repo_location_name": "<<in_process>>",
+        "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
+    }
+
+
 def test_get_validated_celery_k8s_executor_config():
     res = _get_validated_celery_k8s_executor_config(
         {"execution": {CELERY_K8S_CONFIG_KEY: {"config": {"job_image": "foo"}}}}


### PR DESCRIPTION
Summary:
Other executors seem to allow this, and a user ran into it here when they set
```
execution:
  celery-k8s:
```
in a preset: https://dagster.slack.com/archives/C01U954MEER/p1634320899268600?thread_ts=1634253088.252800&cid=C01U954MEER

Test Plan: Integration

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.