### PR TITLE
avoid calling dagster a library in getting-started

### DIFF
--- a/docs/content-crag/getting-started.mdx
+++ b/docs/content-crag/getting-started.mdx
@@ -7,7 +7,7 @@
 <div className="md:col-span-3 flex flex-wrap md:flex-nowrap items-center bg-gradient-to-b from-blue-400 to-blue-500 shadow-lg rounded-2xl py-6 md:py-2 px-6 md:pr-5 space-y-4 md:space-y-0 md:space-x-8">
   <p className="flex-auto text-white text-lg">
     {" "}
-    New to Dagster? Learn all about the library in a short tutorial.
+    New to Dagster? Learn all about it in a short tutorial.
   </p>
   <a
     href="/tutorial"


### PR DESCRIPTION
We've had discussions about whether to call Dagster a "library", "framework", or "platform".  This defers taking a stand in our docs.