### PR TITLE
remove run_date param from dbt demo job

### DIFF
--- a/examples/hacker_news/hacker_news/jobs/dbt_metrics.py
+++ b/examples/hacker_news/hacker_news/jobs/dbt_metrics.py
@@ -32,7 +32,6 @@ DBT_RESOURCES_PROD = {
     "dbt_assets": ResourceDefinition.hardcoded_resource(
         SnowflakeQueryDbtAssetResource(SNOWFLAKE_CONF, "hacker_news_dbt")
     ),
-    "run_date": ResourceDefinition.string_resource(),
 }
 
 DBT_RESOURCES_STAGING = {
@@ -44,7 +43,6 @@ DBT_RESOURCES_STAGING = {
     "dbt_assets": ResourceDefinition.hardcoded_resource(
         SnowflakeQueryDbtAssetResource(SNOWFLAKE_CONF, "hacker_news_dbt_dev")
     ),
-    "run_date": ResourceDefinition.string_resource(),
 }
 
 

--- a/examples/hacker_news/hacker_news/legacy/pipelines/dbt_pipeline.py
+++ b/examples/hacker_news/hacker_news/legacy/pipelines/dbt_pipeline.py
@@ -32,7 +32,6 @@ PROD_RESOURCES = {
     "dbt_assets": ResourceDefinition.hardcoded_resource(
         SnowflakeQueryDbtAssetResource(SNOWFLAKE_CONF, "hacker_news_dbt")
     ),
-    "run_date": ResourceDefinition.string_resource(),
 }
 
 DEV_RESOURCES = {
@@ -44,7 +43,6 @@ DEV_RESOURCES = {
     "dbt_assets": ResourceDefinition.hardcoded_resource(
         SnowflakeQueryDbtAssetResource(SNOWFLAKE_CONF, "hacker_news_dbt_dev")
     ),
-    "run_date": ResourceDefinition.string_resource(),
 }
 
 

--- a/examples/hacker_news/hacker_news/ops/dbt.py
+++ b/examples/hacker_news/hacker_news/ops/dbt.py
@@ -3,12 +3,12 @@ from dagster_dbt import DbtCliOutput
 
 
 @op(
-    required_resource_keys={"dbt", "run_date", "dbt_assets"},
+    required_resource_keys={"dbt", "dbt_assets"},
     out=Out(dagster_type=DbtCliOutput),
     tags={"kind": "dbt"},
 )
 def hn_dbt_run(context):
-    dbt_cli_output = context.resources.dbt.run(vars={"run_date": context.resources.run_date})
+    dbt_cli_output = context.resources.dbt.run()
     # here, we use a resource to determine which AssetMaterialization events to yield for
     # a given DbtCliOutput. This is done so we can swap out this implementation between modes,
     # as dbt will output to different locations depending on which profile is being used.

--- a/examples/hacker_news/hacker_news_dbt/macros/day_diff_from_run.sql
+++ b/examples/hacker_news/hacker_news_dbt/macros/day_diff_from_run.sql
@@ -2,6 +2,6 @@
     DATEDIFF(
         day,
         "{{start}}"::timestamp,
-        '{{ var("run_date") }}'::timestamp
+        current_date()
     )
 {% endmacro %}


### PR DESCRIPTION
A couple reasons to do this:
* The dbt sensor is currently broken because it's not passing the right config. Passing the right config is a little non-trivial, because of the way I refactored the sensors.
* The way the parameter works doesn't seem entirely sensible to me. In the hypothetical situation where the job is used, I suspect that someone coming to the `comments_agg` table on day X would expect it to display stats relative to day X.  However, if someone backfills a partition of the download pipeline that's at day X - 50, the sensor would kick off a run that overwrites the contents of the `comments_agg` table with stats that are relative to X - 50.

**Testing**
Ran the pipeline without config from local Dagit