### PR TITLE
Custom rendering for URL location metadata

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
@@ -14,9 +14,9 @@ import {Table} from '../ui/Table';
 import {TagWIP} from '../ui/TagWIP';
 import {Caption} from '../ui/Text';
 import {Tooltip} from '../ui/Tooltip';
-import {RepositoryRemoteLocationLink} from './RepositoryRemoteLocationLink';
 
 import {RepositoryLocationNonBlockingErrorDialog} from './RepositoryLocationErrorDialog';
+import {RepositoryRemoteLocationLink} from './RepositoryRemoteLocationLink';
 import {WorkspaceContext} from './WorkspaceContext';
 import {RootRepositoriesQuery_workspaceOrError_Workspace_locationEntries as LocationOrError} from './types/RootRepositoriesQuery';
 
@@ -99,8 +99,6 @@ const ReloadButton: React.FC<{
   );
 };
 
-
-
 export const RepositoryLocationsList = () => {
   const {locationEntries, loading} = React.useContext(WorkspaceContext);
 
@@ -137,18 +135,19 @@ export const RepositoryLocationsList = () => {
                 <strong>{location.name}</strong>
                 <div>
                   {location.displayMetadata.map((metadata, idx) => {
-                    const name = metadata.key === "url" ? "source" : metadata.key;
-                    const display = metadata.key === "url" ?
-                      <RepositoryRemoteLocationLink repositoryUrl={metadata.value} />
-                      : metadata.value;
+                    const name = metadata.key === 'url' ? 'source' : metadata.key;
+                    const display =
+                      metadata.key === 'url' ? (
+                        <RepositoryRemoteLocationLink repositoryUrl={metadata.value} />
+                      ) : (
+                        metadata.value
+                      );
 
                     return (
                       <div key={idx}>
                         <Caption style={{wordBreak: 'break-word'}}>
                           {`${name}: `}
-                          <span style={{color: ColorsWIP.Gray400}}>
-                            {display}
-                          </span>
+                          <span style={{color: ColorsWIP.Gray400}}>{display}</span>
                         </Caption>
                       </div>
                     );

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryRemoteLocationLink.test.ts
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryRemoteLocationLink.test.ts
@@ -2,19 +2,27 @@ import {formatRepositoryUrl} from './RepositoryRemoteLocationLink';
 
 describe('formatRepositoryUrl', () => {
   it('formats GitHub and GitLab URLs as expected', () => {
-    const githubHttps = formatRepositoryUrl('https://github.com/dagster-io/dagster/tree/f04aaa/integration_tests/scripts');
+    const githubHttps = formatRepositoryUrl(
+      'https://github.com/dagster-io/dagster/tree/f04aaa/integration_tests/scripts',
+    );
     expect(githubHttps).toBe('dagster-io/dagster@f04aaa');
 
-    const githubHttp = formatRepositoryUrl('https://github.com/dagster-io/dagster/tree/f04aaa/integration_tests/scripts');
+    const githubHttp = formatRepositoryUrl(
+      'https://github.com/dagster-io/dagster/tree/f04aaa/integration_tests/scripts',
+    );
     expect(githubHttp).toBe('dagster-io/dagster@f04aaa');
 
     const githubRoot = formatRepositoryUrl('https://github.com/dagster-io/dagster/tree/0.9.10');
     expect(githubRoot).toBe('dagster-io/dagster@0.9.10');
 
-    const gitlabHttps = formatRepositoryUrl('https://gitlab.com/gitlab-org/gitlab/-/blob/0c153c/doc/user/project');
+    const gitlabHttps = formatRepositoryUrl(
+      'https://gitlab.com/gitlab-org/gitlab/-/blob/0c153c/doc/user/project',
+    );
     expect(gitlabHttps).toBe('gitlab-org/gitlab@0c153c');
 
-    const gitlabHttp = formatRepositoryUrl('http://gitlab.com/gitlab-org/gitlab/-/blob/0c153c/doc/user/project');
+    const gitlabHttp = formatRepositoryUrl(
+      'http://gitlab.com/gitlab-org/gitlab/-/blob/0c153c/doc/user/project',
+    );
     expect(gitlabHttp).toBe('gitlab-org/gitlab@0c153c');
 
     const gitlabRoot = formatRepositoryUrl('http://gitlab.com/gitlab-org/gitlab/-/tree/v14.3.3-ee');

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryRemoteLocationLink.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryRemoteLocationLink.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 
 import {ColorsWIP} from '../ui/Colors';
@@ -8,11 +7,10 @@ export const formatRepositoryUrl = (url: string): string => {
   try {
     const urlObj = new URL(url);
     let org, repo, tag;
-    if (urlObj.host === "github.com") {
-      [, org, repo, , tag] = urlObj.pathname.split("/", 7);
-    }
-    else if (urlObj.host === "gitlab.com") {
-      [, org, repo, , , tag] = urlObj.pathname.split("/", 8);
+    if (urlObj.host === 'github.com') {
+      [, org, repo, , tag] = urlObj.pathname.split('/', 7);
+    } else if (urlObj.host === 'gitlab.com') {
+      [, org, repo, , , tag] = urlObj.pathname.split('/', 8);
     }
     if (org && repo && tag) {
       return `${org}/${repo}@${tag}`;
@@ -23,14 +21,19 @@ export const formatRepositoryUrl = (url: string): string => {
   return url;
 };
 
-export const RepositoryRemoteLocationLink: React.FC<{repositoryUrl: string}> = ({repositoryUrl}) => {
+export const RepositoryRemoteLocationLink: React.FC<{repositoryUrl: string}> = ({
+  repositoryUrl,
+}) => {
   const formattedUrl = formatRepositoryUrl(repositoryUrl);
 
   return (
     <a href={repositoryUrl} target="_blank" rel="noopener noreferrer">
-      <IconWIP color={ColorsWIP.Link} name="link" style={{display: 'inline-block', verticalAlign: 'middle'}} />
-      {' '}
+      <IconWIP
+        color={ColorsWIP.Link}
+        name="link"
+        style={{display: 'inline-block', verticalAlign: 'middle'}}
+      />{' '}
       {formattedUrl}
     </a>
-  )
-}
+  );
+};


### PR DESCRIPTION
## Summary
Adds custom Workspace page rendering for the `url` metadata field.

The `url` field is rendered as a link with a link icon by default. If identified as a GitHub or GitLab link, it is also formatted to show just the organization and repository name as well as the hash. This will be used with the [Cloud CI GitHub Action](https://github.com/dagster-io/dagster-cloud-ci-action/tree/main/test) and other CI/CD providers.


![Screen Shot 2021-10-18 at 11 25 32 AM](https://user-images.githubusercontent.com/10215173/137789408-7af3f51b-4e5f-4e7f-ae6e-759503cdc630.png)

## Test Plan
Tested locally.
