### PR TITLE
Fix error in re-execution of a dynamic pipeline

### DIFF
--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -1316,7 +1316,7 @@ def _compute_step_maps(step_dict, step_handles_to_execute, known_state):
             for key in step.resolved_by_step_keys:
                 if key not in step_keys_to_execute:
                     raise DagsterInvariantViolationError(
-                        f'Unresolved ExecutionStep "{step.key}" is resolved by "{step.resolved_by_step_key}" '
+                        f'Unresolved ExecutionStep "{step.key}" is resolved by "{key}" '
                         "which is not part of the current step selection"
                     )
 


### PR DESCRIPTION
Summary:
This happened when I tried to run a pipeline with lots of dynamic outputs by a user with lots of dynamic outputs. This was calling a method that did not exist on the collect version of this class.

Based on https://dagster.phacility.com/D7289#change-DsMVnB8AgF1e this seems to have been the intention (and the error I was seeing no longer happens)

Test Plan: Test test_reexec_from_parent_dynamic_fails still succeeds. I do not quite have the dynamic pipeline wherewithal to identify a test case that covers the collect case though...

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.