### PR TITLE
remove hacker_news_assets dbt test

### DIFF
--- a/examples/hacker_news_assets/hacker_news_assets_tests/test_pipelines/test_dbt_pipeline.py
+++ b/examples/hacker_news_assets/hacker_news_assets_tests/test_pipelines/test_dbt_pipeline.py
@@ -1,6 +1,0 @@
-from hacker_news_assets.pipelines.dbt_pipeline import activity_stats
-
-
-def test_activity_forecast():
-    result = activity_stats.execute_in_process()
-    assert result.success


### PR DESCRIPTION
This test is querying the live database, and is now failing.  The non-assets version of the demo jobs does not have an equivalent test.  We should test this at some point, but I think best to take it out for now.