### PR TITLE
Link to tracked asset_sensor assets on Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
@@ -13,28 +13,30 @@ export const AssetLink: React.FC<{
 }> = ({path, displayIcon, url, trailingSlash}) => {
   const linkUrl = url ? url : `/instance/assets/${path.map(encodeURIComponent).join('/')}`;
 
-  return (<Box flex={{direction: 'row', alignItems: 'center', display: 'inline-flex'}}>
-    {displayIcon ?
-      <Box margin={{right: 8}}><IconWIP name="asset" color={ColorsWIP.Gray400} /></Box>
-      : null
-    }
-    <Link to={linkUrl}>
-      <span style={{wordBreak: 'break-word'}}>
-        {path
-          .map((p, i) => <span key={i}>{p}</span>)
-          .reduce(
-            (accum, curr, ii) => [
-              ...accum,
-              ii > 0 ? (
-                <React.Fragment key={`${ii}-space`}>&nbsp;{`>`}&nbsp;</React.Fragment>
-              ) : null,
-              curr,
-            ],
-            [] as React.ReactNode[],
-          )}
-        {trailingSlash ? '/' : null}
-      </span>
-    </Link>
-  </Box>
+  return (
+    <Box flex={{direction: 'row', alignItems: 'center', display: 'inline-flex'}}>
+      {displayIcon ? (
+        <Box margin={{right: 8}}>
+          <IconWIP name="asset" color={ColorsWIP.Gray400} />
+        </Box>
+      ) : null}
+      <Link to={linkUrl}>
+        <span style={{wordBreak: 'break-word'}}>
+          {path
+            .map((p, i) => <span key={i}>{p}</span>)
+            .reduce(
+              (accum, curr, ii) => [
+                ...accum,
+                ii > 0 ? (
+                  <React.Fragment key={`${ii}-space`}>&nbsp;{`>`}&nbsp;</React.Fragment>
+                ) : null,
+                curr,
+              ],
+              [] as React.ReactNode[],
+            )}
+          {trailingSlash ? '/' : null}
+        </span>
+      </Link>
+    </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetLink.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {Box} from '../ui/Box';
+import {ColorsWIP} from '../ui/Colors';
+import {IconWIP} from '../ui/Icon';
+
+export const AssetLink: React.FC<{
+  path: string[];
+  displayIcon?: boolean;
+  url?: string;
+  trailingSlash?: boolean;
+}> = ({path, displayIcon, url, trailingSlash}) => {
+  const linkUrl = url ? url : `/instance/assets/${path.map(encodeURIComponent).join('/')}`;
+
+  return (<Box flex={{direction: 'row', alignItems: 'center', display: 'inline-flex'}}>
+    {displayIcon ?
+      <Box margin={{right: 8}}><IconWIP name="asset" color={ColorsWIP.Gray400} /></Box>
+      : null
+    }
+    <Link to={linkUrl}>
+      <span style={{wordBreak: 'break-word'}}>
+        {path
+          .map((p, i) => <span key={i}>{p}</span>)
+          .reduce(
+            (accum, curr, ii) => [
+              ...accum,
+              ii > 0 ? (
+                <React.Fragment key={`${ii}-space`}>&nbsp;{`>`}&nbsp;</React.Fragment>
+              ) : null,
+              curr,
+            ],
+            [] as React.ReactNode[],
+          )}
+        {trailingSlash ? '/' : null}
+      </span>
+    </Link>
+  </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -1,6 +1,5 @@
 import {gql, RefetchQueriesFunction} from '@apollo/client';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
 
 import {useFeatureFlags} from '../app/Flags';
 import {usePermissions} from '../app/Permissions';
@@ -15,6 +14,7 @@ import {MenuItemWIP, MenuWIP} from '../ui/Menu';
 import {Popover} from '../ui/Popover';
 import {Table} from '../ui/Table';
 
+import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
 import {AssetTableFragment as Asset} from './types/AssetTableFragment';
 
@@ -165,23 +165,7 @@ const AssetEntryRow: React.FC<{
           </td>
         ) : null}
         <td>
-          <Link to={linkUrl}>
-            <Box flex={{alignItems: 'center', wrap: 'wrap'}} style={{wordBreak: 'break-word'}}>
-              {path
-                .map((p, i) => <span key={i}>{p}</span>)
-                .reduce(
-                  (accum, curr, ii) => [
-                    ...accum,
-                    ii > 0 ? (
-                      <React.Fragment key={`${ii}-space`}>&nbsp;{`>`}&nbsp;</React.Fragment>
-                    ) : null,
-                    curr,
-                  ],
-                  [] as React.ReactNode[],
-                )}
-              {isAssetEntry ? null : '/'}
-            </Box>
-          </Link>
+          <AssetLink path={path} url={linkUrl} trailingSlash={!isAssetEntry} />
         </td>
         {shouldShowAssetGraphColumns ? (
           <td>

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
@@ -137,6 +137,16 @@ export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_n
   mode: string;
 }
 
+export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_metadata_assetKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_metadata {
+  __typename: "SensorMetadata";
+  assetKeys: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_metadata_assetKeys[] | null;
+}
+
 export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors {
   __typename: "Sensor";
   id: string;
@@ -147,6 +157,7 @@ export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_n
   nextTick: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_nextTick | null;
   sensorState: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_sensorState;
   targets: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_targets[] | null;
+  metadata: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_metadata;
 }
 
 export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes {

--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {Link} from 'react-router-dom';
 
 import {AssetLink} from '../assets/AssetLink';
 import {TickTag} from '../instigation/InstigationTick';
@@ -170,20 +169,18 @@ export const SensorDetails: React.FC<{
             <td>Frequency</td>
             <td>{humanizeSensorInterval(sensor.minIntervalSeconds)}</td>
           </tr>
-          {
-            metadata.assetKeys && metadata.assetKeys.length ?
-              <tr>
-                <td>Monitored Assets</td>
-                <td>
-                  <Box flex={{direction: 'column', gap: 2}}>
-                    {metadata.assetKeys.map((key) => (
-                      <AssetLink path={key.path} displayIcon={true} />
-                    ))}
-                  </Box>
-                </td>
-              </tr>
-              : null
-          }
+          {metadata.assetKeys && metadata.assetKeys.length ? (
+            <tr>
+              <td>Monitored Assets</td>
+              <td>
+                <Box flex={{direction: 'column', gap: 2}}>
+                  {metadata.assetKeys.map((key) => (
+                    <AssetLink key={key.path.join('/')} path={key.path} displayIcon={true} />
+                  ))}
+                </Box>
+              </td>
+            </tr>
+          ) : null}
         </tbody>
       </MetadataTableWIP>
     </>

--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import {Link} from 'react-router-dom';
 
+import {AssetLink} from '../assets/AssetLink';
 import {TickTag} from '../instigation/InstigationTick';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -54,6 +56,7 @@ export const SensorDetails: React.FC<{
     name,
     sensorState: {status, ticks},
     targets,
+    metadata,
   } = sensor;
 
   const repo = useRepository(repoAddress);
@@ -167,6 +170,20 @@ export const SensorDetails: React.FC<{
             <td>Frequency</td>
             <td>{humanizeSensorInterval(sensor.minIntervalSeconds)}</td>
           </tr>
+          {
+            metadata.assetKeys && metadata.assetKeys.length ?
+              <tr>
+                <td>Monitored Assets</td>
+                <td>
+                  <Box flex={{direction: 'column', gap: 2}}>
+                    {metadata.assetKeys.map((key) => (
+                      <AssetLink path={key.path} displayIcon={true} />
+                    ))}
+                  </Box>
+                </td>
+              </tr>
+              : null
+          }
         </tbody>
       </MetadataTableWIP>
     </>

--- a/js_modules/dagit/packages/core/src/sensors/SensorFragment.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorFragment.tsx
@@ -21,6 +21,11 @@ export const SENSOR_FRAGMENT = gql`
       solidSelection
       mode
     }
+    metadata {
+      assetKeys {
+        path
+      }
+    }
   }
   ${INSTIGATION_STATE_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {AssetLink} from '../assets/AssetLink';
 import {TickTag} from '../instigation/InstigationTick';
 import {InstigatedRunStatus} from '../instigation/InstigationUtils';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -13,7 +14,6 @@ import {Tooltip} from '../ui/Tooltip';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
-import {AssetLink} from '../assets/AssetLink';
 
 import {humanizeSensorInterval} from './SensorDetails';
 import {SensorSwitch} from './SensorSwitch';
@@ -65,7 +65,7 @@ const SensorRow: React.FC<{
   sensor: SensorFragment;
 }> = ({repoAddress, sensor}) => {
   const repo = useRepository(repoAddress);
-  const {name, sensorState, metadata} = sensor;
+  const {name, sensorState} = sensor;
   const {ticks} = sensorState;
   const latestTick = ticks.length ? ticks[0] : null;
 
@@ -96,7 +96,7 @@ const SensorRow: React.FC<{
           {sensor.metadata.assetKeys && sensor.metadata.assetKeys.length ? (
             <Box flex={{direction: 'column', gap: 2}}>
               {sensor.metadata.assetKeys.map((key) => (
-                <AssetLink path={key.path} displayIcon={true} />
+                <AssetLink key={key.path.join('/')} path={key.path} displayIcon={true} />
               ))}
             </Box>
           ) : null}

--- a/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
@@ -13,6 +13,7 @@ import {Tooltip} from '../ui/Tooltip';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
+import {AssetLink} from '../assets/AssetLink';
 
 import {humanizeSensorInterval} from './SensorDetails';
 import {SensorSwitch} from './SensorSwitch';
@@ -64,7 +65,7 @@ const SensorRow: React.FC<{
   sensor: SensorFragment;
 }> = ({repoAddress, sensor}) => {
   const repo = useRepository(repoAddress);
-  const {name, sensorState} = sensor;
+  const {name, sensorState, metadata} = sensor;
   const {ticks} = sensorState;
   const latestTick = ticks.length ? ticks[0] : null;
 
@@ -89,6 +90,13 @@ const SensorRow: React.FC<{
                   pipelineHrefContext={repoAddress}
                   isJob={!!(repo && isThisThingAJob(repo, target.pipelineName))}
                 />
+              ))}
+            </Box>
+          ) : null}
+          {sensor.metadata.assetKeys && sensor.metadata.assetKeys.length ? (
+            <Box flex={{direction: 'column', gap: 2}}>
+              {sensor.metadata.assetKeys.map((key) => (
+                <AssetLink path={key.path} displayIcon={true} />
               ))}
             </Box>
           ) : null}

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
@@ -90,6 +90,16 @@ export interface SensorFragment_targets {
   mode: string;
 }
 
+export interface SensorFragment_metadata_assetKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface SensorFragment_metadata {
+  __typename: "SensorMetadata";
+  assetKeys: SensorFragment_metadata_assetKeys[] | null;
+}
+
 export interface SensorFragment {
   __typename: "Sensor";
   id: string;
@@ -100,4 +110,5 @@ export interface SensorFragment {
   nextTick: SensorFragment_nextTick | null;
   sensorState: SensorFragment_sensorState;
   targets: SensorFragment_targets[] | null;
+  metadata: SensorFragment_metadata;
 }

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
@@ -94,6 +94,16 @@ export interface SensorRootQuery_sensorOrError_Sensor_targets {
   mode: string;
 }
 
+export interface SensorRootQuery_sensorOrError_Sensor_metadata_assetKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface SensorRootQuery_sensorOrError_Sensor_metadata {
+  __typename: "SensorMetadata";
+  assetKeys: SensorRootQuery_sensorOrError_Sensor_metadata_assetKeys[] | null;
+}
+
 export interface SensorRootQuery_sensorOrError_Sensor {
   __typename: "Sensor";
   id: string;
@@ -104,6 +114,7 @@ export interface SensorRootQuery_sensorOrError_Sensor {
   nextTick: SensorRootQuery_sensorOrError_Sensor_nextTick | null;
   sensorState: SensorRootQuery_sensorOrError_Sensor_sensorState;
   targets: SensorRootQuery_sensorOrError_Sensor_targets[] | null;
+  metadata: SensorRootQuery_sensorOrError_Sensor_metadata;
 }
 
 export type SensorRootQuery_sensorOrError = SensorRootQuery_sensorOrError_SensorNotFoundError | SensorRootQuery_sensorOrError_Sensor;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
@@ -107,6 +107,16 @@ export interface SensorsRootQuery_sensorsOrError_Sensors_results_targets {
   mode: string;
 }
 
+export interface SensorsRootQuery_sensorsOrError_Sensors_results_metadata_assetKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface SensorsRootQuery_sensorsOrError_Sensors_results_metadata {
+  __typename: "SensorMetadata";
+  assetKeys: SensorsRootQuery_sensorsOrError_Sensors_results_metadata_assetKeys[] | null;
+}
+
 export interface SensorsRootQuery_sensorsOrError_Sensors_results {
   __typename: "Sensor";
   id: string;
@@ -117,6 +127,7 @@ export interface SensorsRootQuery_sensorsOrError_Sensors_results {
   nextTick: SensorsRootQuery_sensorsOrError_Sensors_results_nextTick | null;
   sensorState: SensorsRootQuery_sensorsOrError_Sensors_results_sensorState;
   targets: SensorsRootQuery_sensorsOrError_Sensors_results_targets[] | null;
+  metadata: SensorsRootQuery_sensorsOrError_Sensors_results_metadata;
 }
 
 export interface SensorsRootQuery_sensorsOrError_Sensors {


### PR DESCRIPTION
## Summary

Displays links to the assets tracked by `@asset_sensor`s on the Dagit sensor details page and
on the sensor list page.



<img width="443" alt="Screen Shot 2021-10-19 at 1 34 33 PM" src="https://user-images.githubusercontent.com/10215173/137990608-466bc2f5-bdfe-4ce5-9cd3-d60b3a9a7290.png">

<img width="697" alt="Screen Shot 2021-10-19 at 1 34 22 PM" src="https://user-images.githubusercontent.com/10215173/137990617-aba31a33-1160-4cea-9c20-e890603f2c23.png">

## Test Plan


Tested via Dagit.