### PR TITLE
Surface asset_sensor monitored assets using GraphQL api

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1173,12 +1173,17 @@ type Sensor {
   minIntervalSeconds: Int!
   description: String
   nextTick: FutureInstigationTick
+  metadata: SensorMetadata!
 }
 
 type Target {
   pipelineName: String!
   mode: String!
   solidSelection: [String!]
+}
+
+type SensorMetadata {
+  assetKeys: [AssetKey!]
 }
 
 type PipelinePreset {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -6,6 +6,7 @@ from dagster.core.workspace.permissions import Permissions
 from dagster_graphql.implementation.utils import capture_error, check_permission
 
 from ..implementation.fetch_sensors import get_sensor_next_tick, start_sensor, stop_sensor
+from .asset_key import GrapheneAssetKey
 from .errors import (
     GraphenePythonError,
     GrapheneRepositoryNotFoundError,
@@ -15,7 +16,6 @@ from .errors import (
 from .inputs import GrapheneSensorSelector
 from .instigation import GrapheneFutureInstigationTick, GrapheneInstigationState
 from .util import non_null_list
-from .asset_key import GrapheneAssetKey
 
 
 class GrapheneTarget(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -15,6 +15,7 @@ from .errors import (
 from .inputs import GrapheneSensorSelector
 from .instigation import GrapheneFutureInstigationTick, GrapheneInstigationState
 from .util import non_null_list
+from .asset_key import GrapheneAssetKey
 
 
 class GrapheneTarget(graphene.ObjectType):
@@ -36,6 +37,13 @@ class GrapheneTarget(graphene.ObjectType):
         )
 
 
+class GrapheneSensorMetadata(graphene.ObjectType):
+    assetKeys = graphene.List(graphene.NonNull(GrapheneAssetKey))
+
+    class Meta:
+        name = "SensorMetadata"
+
+
 class GrapheneSensor(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
     jobOriginId = graphene.NonNull(graphene.String)
@@ -45,6 +53,7 @@ class GrapheneSensor(graphene.ObjectType):
     minIntervalSeconds = graphene.NonNull(graphene.Int)
     description = graphene.String()
     nextTick = graphene.Field(GrapheneFutureInstigationTick)
+    metadata = graphene.NonNull(GrapheneSensorMetadata)
 
     class Meta:
         name = "Sensor"
@@ -68,6 +77,9 @@ class GrapheneSensor(graphene.ObjectType):
             minIntervalSeconds=external_sensor.min_interval_seconds,
             description=external_sensor.description,
             targets=[GrapheneTarget(target) for target in external_sensor.get_external_targets()],
+            metadata=GrapheneSensorMetadata(
+                assetKeys=external_sensor.metadata.asset_keys if external_sensor.metadata else None
+            ),
         )
 
     def resolve_id(self, _):

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -592,6 +592,10 @@ class ExternalSensor:
             SensorJobData(min_interval=self.min_interval_seconds),
         )
 
+    @property
+    def metadata(self):
+        return self._external_sensor_data.metadata
+
 
 class ExternalPartitionSet:
     def __init__(self, external_partition_set_data, handle):

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -20,6 +20,7 @@ from dagster.core.definitions import (
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.mode import DEFAULT_MODE_NAME
 from dagster.core.definitions.node_definition import NodeDefinition
+from dagster.core.definitions.sensor_definition import AssetSensorDefinition
 from dagster.core.definitions.partition import PartitionScheduleDefinition
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.snap import PipelineSnapshot
@@ -239,10 +240,20 @@ class ExternalTargetData(
 
 
 @whitelist_for_serdes
+class ExternalSensorMetadata(namedtuple("_ExternalSensorMetadata", "asset_keys")):
+    """Stores additional sensor metadata which is available on the Dagit frontend."""
+
+    def __new__(cls, asset_keys=None):
+        return super(ExternalSensorMetadata, cls).__new__(
+            cls, asset_keys=check.opt_nullable_list_param(asset_keys, "asset_keys")
+        )
+
+
+@whitelist_for_serdes
 class ExternalSensorData(
     namedtuple(
         "_ExternalSensorData",
-        "name pipeline_name solid_selection mode min_interval description target_dict",
+        "name pipeline_name solid_selection mode min_interval description target_dict metadata",
     )
 ):
     def __new__(
@@ -254,6 +265,7 @@ class ExternalSensorData(
         min_interval=None,
         description=None,
         target_dict=None,
+        metadata=None,
     ):
         if pipeline_name and not target_dict:
             # handle the legacy case where the ExternalSensorData was constructed from an earlier
@@ -281,6 +293,7 @@ class ExternalSensorData(
             min_interval=check.opt_int_param(min_interval, "min_interval"),
             description=check.opt_str_param(description, "description"),
             target_dict=check.opt_dict_param(target_dict, "target_dict", str, ExternalTargetData),
+            metadata=check.opt_inst_param(metadata, "metadata", ExternalSensorMetadata),
         )
 
 
@@ -583,6 +596,11 @@ def external_partition_set_data_from_def(partition_set_def):
 
 def external_sensor_data_from_def(sensor_def):
     first_target = sensor_def.targets[0] if sensor_def.targets else None
+
+    asset_keys = None
+    if isinstance(sensor_def, AssetSensorDefinition):
+        asset_keys = [sensor_def.asset_key]
+
     return ExternalSensorData(
         name=sensor_def.name,
         pipeline_name=first_target.pipeline_name if first_target else None,
@@ -598,6 +616,7 @@ def external_sensor_data_from_def(sensor_def):
         },
         min_interval=sensor_def.minimum_interval_seconds,
         description=sensor_def.description,
+        metadata=ExternalSensorMetadata(asset_keys=asset_keys),
     )
 
 

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -23,6 +23,7 @@ from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.definitions.sensor_definition import AssetSensorDefinition
 from dagster.core.definitions.partition import PartitionScheduleDefinition
 from dagster.core.errors import DagsterInvariantViolationError
+from dagster.core.definitions.partition import PartitionScheduleDefinition
 from dagster.core.snap import PipelineSnapshot
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils.error import SerializableErrorInfo

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -20,10 +20,9 @@ from dagster.core.definitions import (
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.mode import DEFAULT_MODE_NAME
 from dagster.core.definitions.node_definition import NodeDefinition
+from dagster.core.definitions.partition import PartitionScheduleDefinition
 from dagster.core.definitions.sensor_definition import AssetSensorDefinition
-from dagster.core.definitions.partition import PartitionScheduleDefinition
 from dagster.core.errors import DagsterInvariantViolationError
-from dagster.core.definitions.partition import PartitionScheduleDefinition
 from dagster.core.snap import PipelineSnapshot
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils.error import SerializableErrorInfo


### PR DESCRIPTION
## Summary

Passes along an `@asset_sensor`'s asset key and surfaces via GQL API.

Adds a new `ExternalSensorMetadata` class to `ExternalSensor` and `GrapheneSensorMetadata` to `GrapheneSensor`, which carry display metadata items. At the moment, this is just a list of `asset_keys`.

This is structured as a list in case we allow for more complex boolean asset sensors in the future, or allow users who write custom sensors which track multiple assets (the HN pipeline) to include this metadata manually.
