### PR TITLE
Add resources_config argument to solid/op invocation

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -45,6 +45,7 @@ class UnboundSolidExecutionContext(SolidExecutionContext):
         self,
         solid_config: Any,
         resources_dict: Optional[Dict[str, Any]],
+        resources_config: Dict[str, Any],
         instance: Optional[DagsterInstance],
     ):  # pylint: disable=super-init-not-called
         from dagster.core.execution.context_creation_pipeline import initialize_console_manager
@@ -61,10 +62,13 @@ class UnboundSolidExecutionContext(SolidExecutionContext):
         # so ignore lint error
         self._instance = self._instance_cm.__enter__()  # pylint: disable=no-member
 
+        self._resources_config = resources_config
         # Open resource context manager
         self._resources_contain_cm = False
         self._resources_cm = build_resources(
-            check.opt_dict_param(resources_dict, "resources_dict", key_type=str), instance
+            resources=check.opt_dict_param(resources_dict, "resources_dict", key_type=str),
+            instance=instance,
+            resource_config=resources_config,
         )
         self._resources = self._resources_cm.__enter__()  # pylint: disable=no-member
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
@@ -197,6 +201,7 @@ class UnboundSolidExecutionContext(SolidExecutionContext):
             solid_def=solid_def,
             solid_config=solid_config,
             resources=self.resources,
+            resources_config=self._resources_config,
             instance=self.instance,
             log_manager=self.log,
             pdb=self.pdb,
@@ -266,6 +271,7 @@ class BoundSolidExecutionContext(SolidExecutionContext):
         solid_def: SolidDefinition,
         solid_config: Any,
         resources: "Resources",
+        resources_config: Dict[str, Any],
         instance: DagsterInstance,
         log_manager: DagsterLogManager,
         pdb: Optional[ForkedPdb],
@@ -282,6 +288,7 @@ class BoundSolidExecutionContext(SolidExecutionContext):
         self._tags = merge_dicts(self._solid_def.tags, tags) if tags else self._solid_def.tags
         self._hook_defs = hook_defs
         self._alias = alias if alias else self._solid_def.name
+        self._resources_config = resources_config
 
     @property
     def solid_config(self) -> Any:
@@ -331,6 +338,7 @@ class BoundSolidExecutionContext(SolidExecutionContext):
         run_config = {}
         if self._solid_config:
             run_config["solids"] = {self._solid_def.name: {"config": self._solid_config}}
+        run_config["resources"] = self._resources_config
         return run_config
 
     @property
@@ -393,8 +401,10 @@ class BoundSolidExecutionContext(SolidExecutionContext):
 
 def build_op_context(
     resources: Optional[Dict[str, Any]] = None,
-    config: Optional[Any] = None,
+    op_config: Any = None,
+    resources_config: Optional[Dict[str, Any]] = None,
     instance: Optional[DagsterInstance] = None,
+    config: Any = None,
 ) -> SolidExecutionContext:
     """Builds op execution context from provided parameters.
 
@@ -421,13 +431,27 @@ def build_op_context(
                 op_to_invoke(context)
     """
 
-    return build_solid_context(resources=resources, config=config, instance=instance)
+    if op_config and config:
+        raise DagsterInvalidInvocationError(
+            "Attempted to invoke ``build_op_context`` with both ``op_config``, and its "
+            "legacy version, ``config``. Please provide one or the other."
+        )
+
+    op_config = op_config if op_config else config
+    return build_solid_context(
+        resources=resources,
+        resources_config=resources_config,
+        solid_config=op_config,
+        instance=instance,
+    )
 
 
 def build_solid_context(
     resources: Optional[Dict[str, Any]] = None,
-    config: Optional[Any] = None,
+    solid_config: Any = None,
+    resources_config: Optional[Dict[str, Any]] = None,
     instance: Optional[DagsterInstance] = None,
+    config: Any = None,
 ) -> UnboundSolidExecutionContext:
     """Builds solid execution context from provided parameters.
 
@@ -439,7 +463,11 @@ def build_solid_context(
     Args:
         resources (Optional[Dict[str, Any]]): The resources to provide to the context. These can be
             either values or resource definitions.
-        config (Optional[Any]): The solid config to provide to the context.
+        solid_config (Optional[Any]): The solid config to provide to the context. The value provided
+            here will be available as ``context.solid_config``.
+        resources_config (Optional[Dict[str, Any]]): Configuration for any resource definitions
+            provided to the resources arg. The configuration under a specific key should match the
+            resource under a specific key in the resources dictionary.
         instance (Optional[DagsterInstance]): The dagster instance configured for the context.
             Defaults to DagsterInstance.ephemeral().
 
@@ -453,8 +481,17 @@ def build_solid_context(
                 solid_to_invoke(context)
     """
 
+    if solid_config and config:
+        raise DagsterInvalidInvocationError(
+            "Attempted to invoke ``build_solid_context`` with both ``solid_config``, and its "
+            "legacy version, ``config``. Please provide one or the other."
+        )
+
+    solid_config = solid_config if solid_config else config
+
     return UnboundSolidExecutionContext(
         resources_dict=check.opt_dict_param(resources, "resources", key_type=str),
-        solid_config=config,
+        resources_config=check.opt_dict_param(resources_config, "resources_config", key_type=str),
+        solid_config=solid_config,
         instance=check.opt_inst_param(instance, "instance", DagsterInstance),
     )


### PR DESCRIPTION
Makes certain cases wayyy more ergonomic. IE if I want to reuse my run_config dictionary, and there's no resources_config argument, I have to do this:
```python
build_solid_context(resources={
    "key1": the_resource.configured(run_config["resources"]["key1"]["config"])
    "key2": the_resource.configured(run_config["resources"]["key2"]["config"])
})
```
With a resources_config argument, it becomes this:
```python
build_solid_context(resources={
    "key1": the_resource
    "key2": the_resource
},
resources_config=run_config["resources"]
)
```