### PR TITLE
preserve partition set history across pipeline => job migration

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -46,6 +46,8 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
   const [stepQuery = '', setStepQuery] = useQueryPersistedState<string>({queryKey: 'stepQuery'});
   const [showBackfillSetup, setShowBackfillSetup] = React.useState(false);
   const [blockDialog, setBlockDialog] = React.useState(false);
+  const repo = useRepository(repoAddress);
+  const isJob = isThisThingAJob(repo, pipelineName);
   const {
     loading,
     error,
@@ -54,7 +56,13 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
     paginationProps,
     pageSize,
     setPageSize,
-  } = useChunkedPartitionsQuery(partitionSet.name, runTags, repoAddress);
+  } = useChunkedPartitionsQuery(
+    partitionSet.name,
+    runTags,
+    repoAddress,
+    // only query by job name if there is only one partition set
+    isJob && partitionSets.length === 1 ? pipelineName : undefined,
+  );
   const {canLaunchPartitionBackfill} = usePermissions();
   const onSubmit = React.useCallback(() => setBlockDialog(true), []);
   React.useEffect(() => {
@@ -64,9 +72,6 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
       });
     }
   }, [error]);
-
-  const repo = useRepository(repoAddress);
-  const isJob = isThisThingAJob(repo, pipelineName);
 
   const allStepKeys = new Set<string>();
   partitions.forEach((partition) => {


### PR DESCRIPTION
## Summary
If a job has only a single partition set, we preserve this history by dropping the partition set name run filter.  This is because the new partitioning scheme is job-based (not schedule-based), and it's now impossible to reconcile the name in a backwards-compatible way.

This does have the effect of smoooshing together runs across different partition sets in the history for a job, but only if the job_name matches and if the partition name matches.

Although the predominant case in a partitioned job world is that we only have a single partition set (constructed under the hood), we still have to guard against the multiple partition_set world, because it's conceivable that we've constructed a job using the `@job` decorator, but are still scheduling it with different schedules using the old `daily_schedule` decorator.

## Test Plan
Converted a pre-crag pipeline to post-crag job,  saw history preserved.

