### PR TITLE
[dagit-bb] A few more UI tweaks for redesign

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -9,7 +9,7 @@ export const AssetNodeDefinition: React.FC<{assetNode: AssetNodeDefinitionFragme
   assetNode,
 }) => {
   return (
-    <div>
+    <div style={{paddingTop: 16, paddingLeft: 24}}>
       <Description description={assetNode.description} />
     </div>
   );

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeWithTooltip.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeWithTooltip.tsx
@@ -54,4 +54,5 @@ const TypeName = styled.code`
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+  vertical-align: middle;
 `;

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryLocationsList.tsx
@@ -102,7 +102,12 @@ export const RepositoryLocationsList = () => {
   const {locationEntries, loading} = React.useContext(WorkspaceContext);
 
   if (loading && !locationEntries.length) {
-    return <div style={{color: ColorsWIP.Gray400}}>Loading…</div>;
+    return (
+      <Box flex={{gap: 8, alignItems: 'center'}} padding={{horizontal: 24}}>
+        <Spinner purpose="body-text" />
+        <div>Loading...</div>
+      </Box>
+    );
   }
 
   if (!locationEntries.length) {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -274,6 +274,6 @@ const UpstreamNotice = styled.div`
   margin-top: -4px;
   margin-bottom: -4px;
   padding: 2.5px 5px;
-  margin-right: -8px;
+  margin-right: -6px;
   border-top-right-radius: 3px;
 `;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -40,11 +40,12 @@ export const SidebarAssetInfo: React.FC<{
       <SidebarSection title={'Materialization in Last Run'}>
         {node.assetMaterializations.length ? (
           <Box margin={12}>
+            <LatestMaterializationMetadata latest={node.assetMaterializations[0]} asOf={null} />
+
             <AssetCatalogLink to={`/instance/assets/${node.assetKey.path.join('/')}`}>
               {'View All in Asset Catalog '}
               <IconWIP name="open_in_new" color={ColorsWIP.Blue500} />
             </AssetCatalogLink>
-            <LatestMaterializationMetadata latest={node.assetMaterializations[0]} asOf={null} />
           </Box>
         ) : (
           <Box margin={12}>&mdash;</Box>
@@ -63,10 +64,9 @@ export const SidebarAssetInfo: React.FC<{
 };
 
 const AssetCatalogLink = styled(Link)`
-  position: absolute;
-  top: 5px;
-  right: 10px;
   display: flex;
   gap: 5px;
   align-items: center;
+  justify-content: flex-end;
+  margin-top: -10px;
 `;


### PR DESCRIPTION
This fixes a few problems I noticed when preparing for the all hands:
<img width="726" alt="Screen Shot 2021-10-20 at 1 51 20 PM" src="https://user-images.githubusercontent.com/1037212/138158992-063ef997-8ca2-4cbc-a1fc-2f0cfa7ea843.png">
<img width="372" alt="Screen Shot 2021-10-20 at 1 51 16 PM" src="https://user-images.githubusercontent.com/1037212/138158998-0ae6dedd-16ec-4bdb-ab1e-7df87f891f95.png">
<img width="310" alt="Screen Shot 2021-10-20 at 1 38 17 PM" src="https://user-images.githubusercontent.com/1037212/138159002-9dc62033-4d49-4c5c-9950-a1e9d1a0dce0.png">


