### PR TITLE
Add an execution section to migration guide

### DIFF
--- a/docs/content-crag/guides/dagster/graph_job_op.mdx
+++ b/docs/content-crag/guides/dagster/graph_job_op.mdx
@@ -836,3 +836,34 @@ def do_it_all():
     one, two = do_two_things()
     do_yet_more(one, two)
 ```
+
+### Executors
+
+Each mode on a pipeline could have multiple executors, but each job can only have one executor configured. This can be added via the `executor_def` argument to `to_job` and `@job`. Since there is only one executor per job, there is no need to specify the name of the executor in config anymore.
+
+```python file=/guides/dagster/graph_job_op/executor_config_job.py
+from dagster import job, multiprocess_executor
+
+
+@job(executor_def=multiprocess_executor, config={"execution": {"config": {"max_concurrent": 5}}})
+def do_it_all():
+    ...
+```
+
+The default executor for a pipeline was the in-process executor. For a job, the default executor can switch between multi-process and in-process configurations. By default, multi-process is enabled. Multi-process and in-process can be switched via config.
+
+```python file=/guides/dagster/graph_job_op/executor_config_switch.py
+from dagster import job
+
+
+# This job will run with multiprocessing execution
+@job
+def do_it_all():
+    ...
+
+
+# This job will run with in-process execution
+@job(config={"execution": {"config": {"in_process": {}}}})
+def do_it_all_in_proc():
+    ...
+```

--- a/examples/docs_snippets_crag/docs_snippets_crag/guides/dagster/graph_job_op/executor_config_job.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/guides/dagster/graph_job_op/executor_config_job.py
@@ -1,0 +1,6 @@
+from dagster import job, multiprocess_executor
+
+
+@job(executor_def=multiprocess_executor, config={"execution": {"config": {"max_concurrent": 5}}})
+def do_it_all():
+    ...

--- a/examples/docs_snippets_crag/docs_snippets_crag/guides/dagster/graph_job_op/executor_config_switch.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag/guides/dagster/graph_job_op/executor_config_switch.py
@@ -1,0 +1,13 @@
+from dagster import job
+
+
+# This job will run with multiprocessing execution
+@job
+def do_it_all():
+    ...
+
+
+# This job will run with in-process execution
+@job(config={"execution": {"config": {"in_process": {}}}})
+def do_it_all_in_proc():
+    ...

--- a/examples/docs_snippets_crag/docs_snippets_crag_tests/guides_tests/graph_job_op_tests/test_graph_job_op_examples.py
+++ b/examples/docs_snippets_crag/docs_snippets_crag_tests/guides_tests/graph_job_op_tests/test_graph_job_op_examples.py
@@ -6,6 +6,8 @@ from docs_snippets_crag.guides.dagster.graph_job_op import (
     composite_solid_ins_out,
     composite_solid_multi_out,
     execute_simple_graph,
+    executor_config_job,
+    executor_config_switch,
     graph_job_test,
     graph_with_config,
     graph_with_config_and_schedule,
@@ -40,6 +42,9 @@ jobs = [
     (nested_graphs, "do_it_all"),
     (nested_graphs_ins_out, "do_it_all"),
     (nested_graphs_multi_out, "do_it_all"),
+    (executor_config_job, "do_it_all"),
+    (executor_config_switch, "do_it_all"),
+    (executor_config_switch, "do_it_all_in_proc"),
 ]
 job_repos = [
     (prod_dev_jobs, "prod_repo"),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_all_snapshot_ids 1'] = '''{


### PR DESCRIPTION
Add a section on executors to the migration guide. Probably necessary now that config switching behavior has changed.