### PR TITLE
Remove mode migration for runs table

### DIFF
--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -101,9 +101,6 @@ class InMemoryRunStorage(RunStorage):
             if filters.pipeline_name and filters.pipeline_name != run.pipeline_name:
                 return False
 
-            if filters.mode and filters.mode != run.mode:
-                return False
-
             if filters.tags and not all(
                 run.tags.get(key) == value for key, value in filters.tags.items()
             ):

--- a/python_modules/dagster/dagster/core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/core/storage/runs/migration.py
@@ -7,11 +7,9 @@ from ..tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from .schema import RunsTable
 
 RUN_PARTITIONS = "run_partitions"
-MODE_MIGRATION = "add_mode_column"
 
 RUN_DATA_MIGRATIONS = {
     RUN_PARTITIONS: lambda: migrate_run_partition,
-    MODE_MIGRATION: lambda: migrate_mode_column,
 }
 
 RUN_CHUNK_SIZE = 100
@@ -55,24 +53,3 @@ def migrate_run_partition(storage, print_fn=None):
             continue
 
         storage.add_run_tags(run.run_id, run.tags)
-
-
-def migrate_mode_column(storage, print_fn=None):
-    from dagster.core.storage.runs.sql_run_storage import SqlRunStorage
-
-    if not isinstance(storage, SqlRunStorage):
-        return
-
-    if print_fn:
-        print_fn("Querying run storage.")
-
-    with storage.connect() as conn:
-        for run in chunked_run_iterator(storage, print_fn):
-            conn.execute(
-                RunsTable.update()  # pylint: disable=no-value-for-parameter
-                .where(RunsTable.c.run_id == run.run_id)
-                .values(
-                    mode=run.mode,
-                    update_timestamp=pendulum.now("UTC"),
-                )
-            )

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/alembic/versions/7f2b1a4ca7a5_add_column_mode.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/alembic/versions/7f2b1a4ca7a5_add_column_mode.py
@@ -19,15 +19,16 @@ depends_on = None
 
 
 def upgrade():
-    bind = op.get_context().bind
-    inspector = reflection.Inspector.from_engine(bind)
-    has_tables = inspector.get_table_names()
+    # bind = op.get_context().bind
+    # inspector = reflection.Inspector.from_engine(bind)
+    # has_tables = inspector.get_table_names()
 
-    if "runs" in has_tables:
-        columns = [x.get("name") for x in inspector.get_columns("runs")]
-        with op.batch_alter_table("runs") as batch_op:
-            if "mode" not in columns:
-                batch_op.add_column(sa.Column("mode", sa.Text))
+    # if "runs" in has_tables:
+    #     columns = [x.get("name") for x in inspector.get_columns("runs")]
+    #     with op.batch_alter_table("runs") as batch_op:
+    #         if "mode" not in columns:
+    #             batch_op.add_column(sa.Column("mode", sa.Text))
+    pass
 
 
 def downgrade():

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -285,37 +285,6 @@ def test_event_log_asset_partition_migration():
         assert "partition" in set(get_sqlite3_columns(db_path, "event_logs"))
 
 
-def test_mode_column_migration():
-    src_dir = file_relative_path(__file__, "snapshot_0_11_16_pre_add_mode_column/sqlite")
-    with copy_directory(src_dir) as test_dir:
-
-        @pipeline
-        def _test():
-            pass
-
-        db_path = os.path.join(test_dir, "history", "runs.db")
-        assert get_current_alembic_version(db_path) == "72686963a802"
-        assert "mode" not in set(get_sqlite3_columns(db_path, "runs"))
-
-        # this migration was optional, so make sure things work before migrating
-        instance = DagsterInstance.from_ref(InstanceRef.from_dir(test_dir))
-        assert "mode" not in set(get_sqlite3_columns(db_path, "runs"))
-        assert instance.get_run_records()
-        assert instance.create_run_for_pipeline(_test)
-
-        instance.upgrade()
-
-        # Make sure the schema is migrated
-        assert "mode" in set(get_sqlite3_columns(db_path, "runs"))
-        assert instance.get_run_records()
-        assert instance.create_run_for_pipeline(_test)
-
-        instance._run_storage._alembic_downgrade(rev="72686963a802")
-
-        assert get_current_alembic_version(db_path) == "72686963a802"
-        assert "mode" not in set(get_sqlite3_columns(db_path, "runs"))
-
-
 def test_run_partition_migration():
     src_dir = file_relative_path(__file__, "snapshot_0_9_22_pre_run_partition/sqlite")
     with copy_directory(src_dir) as test_dir:


### PR DESCRIPTION
Now that mode is no longer being used to filter runs / pipelines have their own separate page, this can go away.