### PR TITLE
Enable querying for asset materializations after a given timestamp

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -548,6 +548,7 @@ type Asset {
     partitions: [String]
     partitionInLast: Int
     beforeTimestampMillis: String
+    afterTimestampMillis: String
     limit: Int
   ): [MaterializationEvent!]!
   definition: AssetNode
@@ -679,6 +680,7 @@ type AssetNode {
   assetObservations(
     partitions: [String]
     beforeTimestampMillis: String
+    afterTimestampMillis: String
     limit: Int
   ): [ObservationEvent!]!
 }

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -104,6 +104,7 @@ def get_asset_materializations(
     partitions=None,
     limit=None,
     before_timestamp=None,
+    after_timestamp=None,
 ):
     check.inst_param(asset_key, "asset_key", AssetKey)
     check.opt_int_param(limit, "limit")
@@ -115,6 +116,7 @@ def get_asset_materializations(
             asset_key=asset_key,
             asset_partitions=partitions,
             before_timestamp=before_timestamp,
+            after_timestamp=after_timestamp,
         ),
         limit=limit,
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -129,10 +129,12 @@ def get_asset_observations(
     partitions=None,
     limit=None,
     before_timestamp=None,
+    after_timestamp=None,
 ):
     check.inst_param(asset_key, "asset_key", AssetKey)
     check.opt_int_param(limit, "limit")
     check.opt_float_param(before_timestamp, "before_timestamp")
+    check.opt_float_param(after_timestamp, "after_timestamp")
     instance = graphene_info.context.instance
     event_records = instance.get_event_records(
         EventRecordsFilter(
@@ -140,6 +142,7 @@ def get_asset_observations(
             asset_key=asset_key,
             asset_partitions=partitions,
             before_timestamp=before_timestamp,
+            after_timestamp=after_timestamp,
         ),
         limit=limit,
     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -65,6 +65,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         non_null_list(GrapheneObservationEvent),
         partitions=graphene.List(graphene.String),
         beforeTimestampMillis=graphene.String(),
+        afterTimestampMillis=graphene.String(),
         limit=graphene.Int(),
     )
 
@@ -266,6 +267,15 @@ class GrapheneAssetNode(graphene.ObjectType):
         except ValueError:
             before_timestamp = None
 
+        try:
+            after_timestamp = (
+                int(kwargs.get("afterTimestampMillis")) / 1000.0
+                if kwargs.get("afterTimestampMillis")
+                else None
+            )
+        except ValueError:
+            before_timestamp = None
+
         return [
             GrapheneObservationEvent(event=event)
             for event in get_asset_observations(
@@ -273,6 +283,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 self._external_asset_node.asset_key,
                 kwargs.get("partitions"),
                 before_timestamp=before_timestamp,
+                after_timestamp=after_timestamp,
                 limit=kwargs.get("limit"),
             )
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -76,6 +76,7 @@ class GrapheneAsset(graphene.ObjectType):
         partitions=graphene.List(graphene.String),
         partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
+        afterTimestampMillis=graphene.String(),
         limit=graphene.Int(),
     )
     definition = graphene.Field("dagster_graphql.schema.asset_graph.GrapheneAssetNode")
@@ -101,6 +102,14 @@ class GrapheneAsset(graphene.ObjectType):
             )
         except ValueError:
             before_timestamp = None
+        try:
+            after_timestamp = (
+                int(kwargs.get("afterTimestampMillis")) / 1000.0
+                if kwargs.get("afterTimestampMillis")
+                else None
+            )
+        except ValueError:
+            after_timestamp = None
 
         limit = kwargs.get("limit")
         partitions = kwargs.get("partitions")
@@ -113,6 +122,7 @@ class GrapheneAsset(graphene.ObjectType):
             self.key,
             partitions=partitions,
             before_timestamp=before_timestamp,
+            after_timestamp=after_timestamp,
             limit=limit,
         )
         run_ids = [event.run_id for event in events]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -212,9 +212,7 @@ GET_ASSET_MATERIALIZATION_AFTER_TIMESTAMP = """
         assetOrError(assetKey: $assetKey) {
             ... on Asset {
                 assetMaterializations(afterTimestampMillis: $afterTimestamp) {
-                    materializationEvent {
-                        timestamp
-                    }
+                    timestamp
                 }
             }
         }
@@ -385,7 +383,7 @@ class TestAssetAwareEventLog(
         assert result.data["assetOrError"]
         materializations = result.data["assetOrError"]["assetMaterializations"]
         assert len(materializations) == 1
-        assert first_timestamp == int(materializations[0]["materializationEvent"]["timestamp"])
+        assert first_timestamp == int(materializations[0]["timestamp"])
 
         # Test afterTimestep before the first timestamp, which should return both results
         after_timestamp = first_timestamp - 1
@@ -412,7 +410,7 @@ class TestAssetAwareEventLog(
         assert result.data["assetOrError"]
         materializations = result.data["assetOrError"]["assetMaterializations"]
         assert len(materializations) == 1
-        assert second_timestamp == int(materializations[0]["materializationEvent"]["timestamp"])
+        assert second_timestamp == int(materializations[0]["timestamp"])
 
     def test_asset_node_in_pipeline(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "two_assets_job")

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -207,6 +207,20 @@ GET_MATERIALIZATION_COUNT_BY_PARTITION = """
     }
 """
 
+GET_ASSET_MATERIALIZATION_AFTER_TIMESTAMP = """
+    query AssetQuery($assetKey: AssetKeyInput!, $afterTimestamp: String) {
+        assetOrError(assetKey: $assetKey) {
+            ... on Asset {
+                assetMaterializations(afterTimestampMillis: $afterTimestamp) {
+                    materializationEvent {
+                        timestamp
+                    }
+                }
+            }
+        }
+    }
+"""
+
 
 def _create_run(graphql_context, pipeline_name, mode="default"):
     selector = infer_pipeline_selector(graphql_context, pipeline_name)
@@ -371,7 +385,34 @@ class TestAssetAwareEventLog(
         assert result.data["assetOrError"]
         materializations = result.data["assetOrError"]["assetMaterializations"]
         assert len(materializations) == 1
-        assert first_timestamp == int(materializations[0]["timestamp"])
+        assert first_timestamp == int(materializations[0]["materializationEvent"]["timestamp"])
+
+        # Test afterTimestep before the first timestamp, which should return both results
+        after_timestamp = first_timestamp - 1
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_MATERIALIZATION_AFTER_TIMESTAMP,
+            variables={"assetKey": {"path": ["a"]}, "afterTimestamp": after_timestamp},
+        )
+        assert result.data
+        assert result.data["assetOrError"]
+        materializations = result.data["assetOrError"]["assetMaterializations"]
+        assert len(materializations) == 2
+
+        # Test afterTimestamp between the two timestamps, which should only return the first result
+        after_timestamp = first_timestamp + 1
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_MATERIALIZATION_AFTER_TIMESTAMP,
+            variables={"assetKey": {"path": ["a"]}, "afterTimestamp": after_timestamp},
+        )
+        assert result.data
+        assert result.data["assetOrError"]
+        materializations = result.data["assetOrError"]["assetMaterializations"]
+        assert len(materializations) == 1
+        assert second_timestamp == int(materializations[0]["materializationEvent"]["timestamp"])
 
     def test_asset_node_in_pipeline(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "two_assets_job")


### PR DESCRIPTION
## Summary

Currently, the GQL API allows for asset materialization queries to optionally specify `beforeTimestampMillis` parameter, allowing the user to query for materializations before a given time. While functionality exists under-the-hood to find materializations *after* a given timestamp, this isn't surfaced via GQL.

This PR adds an optional `afterTimestampMillis` parameter that allows these queries to be made. This is especially useful for e.g. things like cross-deployment asset sensors, which can pass their cursor as `afterTimestampMillis` to find only new materializations.

## Test Plan

New unit tests, manual testing on GQL playground.