### PR TITLE
[dagit] Fix delay in Run UI, reload data in the sidebar on run status changes

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -72,7 +72,12 @@ export const GanttStatusPanel: React.FunctionComponent<GanttStatusPanelProps> = 
 
   return (
     <div style={{overflowY: 'auto'}}>
-      <RunGroupPanel runId={runId} />
+      <RunGroupPanel
+        runId={runId}
+        runStatusLastChangedAt={
+          metadata.exitedAt || metadata.startedProcessAt || metadata.startedPipelineAt || 0
+        }
+      />
       <SidebarSection title={`${isFinished ? 'Not Executed' : 'Preparing'} (${preparing.length})`}>
         <div>
           {preparing.length === 0 ? (

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -279,15 +279,15 @@ const RunWithData: React.FunctionComponent<RunWithDataProps> = ({
   };
 
   const gantt = (metadata: IRunMetadataDict) => {
-    if (logs.loading) {
+    if (logs.loading || !run) {
       return <GanttChartLoadingState runId={runId} />;
     }
 
-    if (run?.status === 'QUEUED') {
+    if (run.status === 'QUEUED') {
       return <QueuedState runId={runId} />;
     }
 
-    if (run?.executionPlan && runtimeGraph) {
+    if (run.executionPlan && runtimeGraph) {
       return (
         <GanttChart
           options={{


### PR DESCRIPTION
This PR fixes two bugs I noticed in the runs UI:

- When the logs come in and indicate that the run has exited, the Gantt chart stops and the logs stop, but the favicon and the sidebar still show the run as "in progress". This is because the RunGroupPanel reloads the run every 15s and isn't connected to the log stream. This PR passes the "last meaningful status change timestamp" to the RunGroupPanel so it knows to reload immediately when the run stops.

- When the Gantt view is loading it briefly showed "Could not build execution plan" even though this was not accurate. 