### PR TITLE
Use ephemeral directory in dagster cli

### DIFF
--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -2,7 +2,6 @@ import os
 import re
 import sys
 import textwrap
-import warnings
 
 import click
 import pendulum
@@ -37,7 +36,6 @@ from dagster.core.host_representation import (
 from dagster.core.host_representation.external_data import ExternalPartitionSetExecutionParamData
 from dagster.core.host_representation.selector import PipelineSelector
 from dagster.core.instance import DagsterInstance
-from dagster.core.instance.config import is_dagster_home_set
 from dagster.core.snap import PipelineSnapshot, SolidInvocationSnap
 from dagster.core.storage.tags import MEMOIZED_RUN_TAG
 from dagster.core.telemetry import log_external_repo_stats, telemetry_wrapper
@@ -51,6 +49,7 @@ from dagster.utils.interrupts import capture_interrupts
 from tabulate import tabulate
 
 from .config_scaffolder import scaffold_pipeline_config
+from .utils import get_instance_for_service
 
 
 @click.group(name="pipeline")
@@ -76,7 +75,9 @@ def pipeline_list_command(**kwargs):
 
 
 def execute_list_command(cli_args, print_fn, using_job_op_graph_apis=False):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_service(
+        "``dagster job list``" if using_job_op_graph_apis else "``dagster pipeline list``"
+    ) as instance:
         with get_external_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
         ) as external_repository:
@@ -342,14 +343,8 @@ def add_step_to_table(memoized_plan):
 )
 def pipeline_execute_command(**kwargs):
     with capture_interrupts():
-        if is_dagster_home_set():
-            with DagsterInstance.get() as instance:
-                execute_execute_command(instance, kwargs)
-        else:
-            warnings.warn(
-                "DAGSTER_HOME is not set, no metadata will be recorded for this execution.\n",
-            )
-            execute_execute_command(DagsterInstance.ephemeral(), kwargs)
+        with get_instance_for_service("``dagster pipeline execute``") as instance:
+            execute_execute_command(instance, kwargs)
 
 
 @telemetry_wrapper
@@ -610,7 +605,7 @@ def do_execute_command(
 )
 @click.option("--run-id", type=click.STRING, help="The ID to give to the launched pipeline run")
 def pipeline_launch_command(**kwargs):
-    with DagsterInstance.get() as instance:
+    with get_instance_for_service("``dagster pipeline launch``") as instance:
         return execute_launch_command(instance, kwargs)
 
 

--- a/python_modules/dagster/dagster/cli/utils.py
+++ b/python_modules/dagster/dagster/cli/utils.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+from contextlib import contextmanager
+
+import click
+from dagster.core.instance import DagsterInstance, is_dagster_home_set
+
+
+@contextmanager
+def get_instance_for_service(service_name):
+    if is_dagster_home_set():
+        with DagsterInstance.get() as instance:
+            yield instance
+    else:
+        # make the temp dir in the cwd since default temp dir roots
+        # have issues with FS notif based event log watching
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tempdir:
+            click.echo(
+                f"Using temporary directory {tempdir} for storage. This will be removed when {service_name} exits.\n"
+                "To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.\n"
+            )
+            with DagsterInstance.local_temp(tempdir) as instance:
+                yield instance

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -478,8 +478,9 @@ def test_multiproc_invalid():
         ],
     )
     # which is invalid for multiproc
-    assert add_result.exit_code != 0
-    assert "DagsterUnmetExecutorRequirementsError" in add_result.output
+    assert add_result.exit_code == 0
+    # Echoed message to let user know that we've utilized temporary storage in order to run job / pipeline.
+    assert re.match(r"Using temporary directory [a-zA-Z0-9/_]+ for storage", add_result.output)
 
 
 def test_tags_pipeline_or_job():


### PR DESCRIPTION
Changes dagster cli to use ephemeral directory instead of fully ephemeral instance, to accompany the fact that default executor is multiproc.