### PR TITLE
Migrate RetryPolicy and RunStatusSensorDefinition API doc to CRAG

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_sensor.py
@@ -251,21 +251,21 @@ def run_failure_sensor(
 class RunStatusSensorDefinition(SensorDefinition):
     """
     Define a sensor that reacts to a given status of pipeline execution, where the decorated
-    function will be run when a pipeline is at the given status.
+    function will be evaluated when a run is at the given status.
 
     Args:
         name (str): The name of the sensor. Defaults to the name of the decorated function.
-        pipeline_run_status (PipelineRunStatus): The status of pipeline execution which will be
+        pipeline_run_status (PipelineRunStatus): The status of a run which will be
             monitored by the sensor.
         run_status_sensor_fn (Callable[[RunStatusSensorContext], Union[SkipReason, PipelineRunReaction]]): The core
             evaluation function for the sensor. Takes a :py:class:`~dagster.RunStatusSensorContext`.
-        pipeline_selection (Optional[List[str]]): Names of the pipelines that will be monitored by
+        pipeline_selection (Optional[List[str]]): (legacy) Names of the pipelines that will be monitored by
             this sensor. Defaults to None, which means the alert will be sent when any pipeline in
             the repository fails.
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
             between sensor evaluations.
         description (Optional[str]): A human-readable description of the sensor.
-        job_selection (Optional[List[Union[PipelineDefinition, GraphDefinition]]]): The jobs that
+        job_selection (Optional[List[Union[JobDefinition, GraphDefinition]]]): The jobs that
             will be monitored by this sensor. Defaults to None, which means the alert will be sent
             when any job in the repository fails.
     """

--- a/python_modules/dagster/dagster/core/definitions/policy.py
+++ b/python_modules/dagster/dagster/core/definitions/policy.py
@@ -43,7 +43,7 @@ class RetryPolicy(
     ),
 ):
     """
-    A declarative policy for when to request retries when an exception occurs during solid execution.
+    A declarative policy for when to request retries when an exception occurs during op execution.
 
     Args:
         max_retries (int):


### PR DESCRIPTION
Some of the APIs referenced in `RunStatusSensorDefinition` are kinda difficult to migrate, might want to wait on landing until that's resolved.