### PR TITLE
Migrate Executor.execute arguments to crag

### DIFF
--- a/python_modules/dagster/dagster/core/executor/base.py
+++ b/python_modules/dagster/dagster/core/executor/base.py
@@ -5,12 +5,12 @@ from dagster.core.execution.retries import RetryMode
 
 class Executor(abc.ABC):  # pylint: disable=no-init
     @abc.abstractmethod
-    def execute(self, pipeline_context, execution_plan):
+    def execute(self, plan_context, execution_plan):
         """
         For the given context and execution plan, orchestrate a series of sub plan executions in a way that satisfies the whole plan being executed.
 
         Args:
-            pipeline_context (PlanOrchestrationContext): The pipeline orchestration context.
+            plan_context (PlanOrchestrationContext): The plan's orchestration context.
             execution_plan (ExecutionPlan): The plan to execute.
 
         Returns:

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
@@ -46,40 +46,40 @@ class StepDelegatingExecutor(Executor):
         return [event.dagster_event for event in events if event.is_dagster_event]
 
     def _get_step_handler_context(
-        self, pipeline_context, steps, active_execution
+        self, plan_context, steps, active_execution
     ) -> StepHandlerContext:
         return StepHandlerContext(
-            instance=pipeline_context.instance,
+            instance=plan_context.plan_data.instance,
             execute_step_args=ExecuteStepArgs(
-                pipeline_origin=pipeline_context.reconstructable_pipeline.get_python_origin(),
-                pipeline_run_id=pipeline_context.pipeline_run.run_id,
+                pipeline_origin=plan_context.reconstructable_pipeline.get_python_origin(),
+                pipeline_run_id=plan_context.pipeline_run.run_id,
                 step_keys_to_execute=[step.key for step in steps],
-                instance_ref=pipeline_context.instance.get_ref(),
+                instance_ref=plan_context.plan_data.instance.get_ref(),
                 retry_mode=self.retries,
                 known_state=active_execution.get_known_state(),
             ),
             step_tags={step.key: step.tags for step in steps},
-            pipeline_run=pipeline_context.pipeline_run,
+            pipeline_run=plan_context.pipeline_run,
         )
 
-    def _log_new_events(self, events, pipeline_context, running_steps):
+    def _log_new_events(self, events, plan_context, running_steps):
         # Note: this could lead to duplicated events if the returned events were already logged
         # (they shouldn't be)
         for event in events:
             log_step_event(
-                pipeline_context.for_step(running_steps[event.step_key]),
+                plan_context.for_step(running_steps[event.step_key]),
                 event,
             )
         return events
 
-    def execute(self, pipeline_context: PlanOrchestrationContext, execution_plan: ExecutionPlan):
-        check.inst_param(pipeline_context, "pipeline_context", PlanOrchestrationContext)
+    def execute(self, plan_context: PlanOrchestrationContext, execution_plan: ExecutionPlan):
+        check.inst_param(plan_context, "plan_context", PlanOrchestrationContext)
         check.inst_param(execution_plan, "execution_plan", ExecutionPlan)
 
         self._event_cursor = -1  # pylint: disable=attribute-defined-outside-init
 
         yield DagsterEvent.engine_event(
-            pipeline_context,
+            plan_context,
             f"Starting execution with step handler {self._step_handler.name}",
             EngineEventData(),
         )
@@ -87,16 +87,16 @@ class StepDelegatingExecutor(Executor):
         with execution_plan.start(retry_mode=self.retries) as active_execution:
             running_steps: Dict[str, ExecutionStep] = {}
 
-            if pipeline_context.resume_from_failure:
+            if plan_context.resume_from_failure:
                 yield DagsterEvent.engine_event(
-                    pipeline_context,
+                    plan_context,
                     "Resuming execution from failure",
                     EngineEventData(),
                 )
 
                 events = self._pop_events(
-                    pipeline_context.instance,
-                    pipeline_context.run_id,
+                    plan_context.instance,
+                    plan_context.run_id,
                 )
                 for dagster_event in events:
                     yield dagster_event
@@ -105,7 +105,7 @@ class StepDelegatingExecutor(Executor):
                 for step in possibly_in_flight_steps:
 
                     yield DagsterEvent.engine_event(
-                        pipeline_context,
+                        plan_context,
                         "Checking on status of possibly launched steps",
                         EngineEventData(),
                         step.handle,
@@ -114,16 +114,16 @@ class StepDelegatingExecutor(Executor):
                     # TODO: check if failure event included. For now, hacky assumption that
                     # we don't log anything on successful check
                     if self._step_handler.check_step_health(
-                        self._get_step_handler_context(pipeline_context, [step], active_execution)
+                        self._get_step_handler_context(plan_context, [step], active_execution)
                     ):
                         # health check failed, launch the step
                         launch_events = self._log_new_events(
                             self._step_handler.launch_step(
                                 self._get_step_handler_context(
-                                    pipeline_context, [step], active_execution
+                                    plan_context, [step], active_execution
                                 )
                             ),
-                            pipeline_context,
+                            plan_context,
                             {step.key: step for step in possibly_in_flight_steps},
                         )
                         for dagster_event in launch_events:
@@ -137,9 +137,9 @@ class StepDelegatingExecutor(Executor):
                 events = []
 
                 if active_execution.check_for_interrupts():
-                    if not pipeline_context.instance.run_will_resume(pipeline_context.run_id):
+                    if not plan_context.instance.run_will_resume(plan_context.run_id):
                         yield DagsterEvent.engine_event(
-                            pipeline_context,
+                            plan_context,
                             "Executor received termination signal, forwarding to steps",
                             EngineEventData.interrupted(list(running_steps.keys())),
                         )
@@ -149,16 +149,16 @@ class StepDelegatingExecutor(Executor):
                                 self._log_new_events(
                                     self._step_handler.terminate_step(
                                         self._get_step_handler_context(
-                                            pipeline_context, [step], active_execution
+                                            plan_context, [step], active_execution
                                         )
                                     ),
-                                    pipeline_context,
+                                    plan_context,
                                     running_steps,
                                 )
                             )
                     else:
                         yield DagsterEvent.engine_event(
-                            pipeline_context,
+                            plan_context,
                             "Executor received termination signal, not forwarding to steps because "
                             "run will be resumed",
                             EngineEventData(
@@ -175,8 +175,8 @@ class StepDelegatingExecutor(Executor):
 
                 events.extend(
                     self._pop_events(
-                        pipeline_context.instance,
-                        pipeline_context.run_id,
+                        plan_context.instance,
+                        plan_context.run_id,
                     )
                 )
 
@@ -190,10 +190,10 @@ class StepDelegatingExecutor(Executor):
                             self._log_new_events(
                                 self._step_handler.check_step_health(
                                     self._get_step_handler_context(
-                                        pipeline_context, [step], active_execution
+                                        plan_context, [step], active_execution
                                     )
                                 ),
-                                pipeline_context,
+                                plan_context,
                                 running_steps,
                             )
                         )
@@ -204,10 +204,10 @@ class StepDelegatingExecutor(Executor):
                         self._log_new_events(
                             self._step_handler.launch_step(
                                 self._get_step_handler_context(
-                                    pipeline_context, [step], active_execution
+                                    plan_context, [step], active_execution
                                 )
                             ),
-                            pipeline_context,
+                            plan_context,
                             running_steps,
                         )
                     )
@@ -223,10 +223,10 @@ class StepDelegatingExecutor(Executor):
                     ):
                         assert isinstance(dagster_event.step_key, str)
                         del running_steps[dagster_event.step_key]
-                        active_execution.verify_complete(pipeline_context, dagster_event.step_key)
+                        active_execution.verify_complete(plan_context, dagster_event.step_key)
 
                 # process skips from failures or uncovered inputs
-                for event in active_execution.plan_events_iterator(pipeline_context):
+                for event in active_execution.plan_events_iterator(plan_context):
                     yield event
 
                 time.sleep(self._sleep_seconds)

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -194,11 +194,11 @@ class CeleryK8sJobExecutor(Executor):
     def retries(self):
         return self._retries
 
-    def execute(self, pipeline_context, execution_plan):
+    def execute(self, plan_context, execution_plan):
         from dagster_celery.core_execution_loop import core_celery_execution_loop
 
         return core_celery_execution_loop(
-            pipeline_context, execution_plan, step_execution_fn=_submit_task_k8s_job
+            plan_context, execution_plan, step_execution_fn=_submit_task_k8s_job
         )
 
     def app_args(self):
@@ -211,22 +211,22 @@ class CeleryK8sJobExecutor(Executor):
         }
 
 
-def _submit_task_k8s_job(app, pipeline_context, step, queue, priority, known_state):
+def _submit_task_k8s_job(app, plan_context, step, queue, priority, known_state):
     user_defined_k8s_config = get_user_defined_k8s_config(step.tags)
 
-    pipeline_origin = pipeline_context.reconstructable_pipeline.get_python_origin()
+    pipeline_origin = plan_context.reconstructable_pipeline.get_python_origin()
 
     execute_step_args = ExecuteStepArgs(
         pipeline_origin=pipeline_origin,
-        pipeline_run_id=pipeline_context.pipeline_run.run_id,
+        pipeline_run_id=plan_context.pipeline_run.run_id,
         step_keys_to_execute=[step.key],
-        instance_ref=pipeline_context.instance.get_ref(),
-        retry_mode=pipeline_context.executor.retries.for_inner_plan(),
+        instance_ref=plan_context.instance.get_ref(),
+        retry_mode=plan_context.executor.retries.for_inner_plan(),
         known_state=known_state,
         should_verify_step=True,
     )
 
-    job_config = pipeline_context.executor.job_config
+    job_config = plan_context.executor.job_config
     if not job_config.job_image:
         job_config = job_config.with_image(pipeline_origin.repository_origin.container_image)
 
@@ -237,11 +237,11 @@ def _submit_task_k8s_job(app, pipeline_context, step, queue, priority, known_sta
     task_signature = task.si(
         execute_step_args_packed=pack_value(execute_step_args),
         job_config_dict=job_config.to_dict(),
-        job_namespace=pipeline_context.executor.job_namespace,
+        job_namespace=plan_context.executor.job_namespace,
         user_defined_k8s_config_dict=user_defined_k8s_config.to_dict(),
-        load_incluster_config=pipeline_context.executor.load_incluster_config,
-        job_wait_timeout=pipeline_context.executor.job_wait_timeout,
-        kubeconfig_file=pipeline_context.executor.kubeconfig_file,
+        load_incluster_config=plan_context.executor.load_incluster_config,
+        job_wait_timeout=plan_context.executor.job_wait_timeout,
+        kubeconfig_file=plan_context.executor.kubeconfig_file,
     )
 
     return task_signature.apply_async(


### PR DESCRIPTION
I don't think this breaks anyone? It probably breaks linters though for people who have written their own executors (assuming people have actually done that).