### PR TITLE
[dagster_shell] Defer environ copy to solid run time

### DIFF
--- a/python_modules/libraries/dagster-shell/dagster_shell/solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/solids.py
@@ -22,10 +22,8 @@ def shell_op_config():
     return {
         "env": Field(
             Noneable(Permissive()),
-            default_value=os.environ.copy(),
             is_required=False,
-            description="An optional dict of environment variables to pass to the subprocess. "
-            "Defaults to using os.environ.copy().",
+            description="An optional dict of environment variables to pass to the subprocess.",
         ),
         "output_logging": Field(
             Enum(
@@ -65,10 +63,10 @@ def core_shell(dagster_decorator, decorator_name):
         config_schema=shell_op_config(),
     )
     def shell_fn(context, shell_command):
-
-        output, return_code = execute(
-            shell_command=shell_command, log=context.log, **context.op_config
-        )
+        op_config = context.op_config.copy()
+        if not op_config.get("env"):
+            op_config["env"] = os.environ.copy()
+        output, return_code = execute(shell_command=shell_command, log=context.log, **op_config)
 
         if return_code:
             raise Failure(
@@ -201,9 +199,10 @@ def core_create_shell_command(
         tags=tags,
     )
     def _shell_fn(context):
-        output, return_code = execute(
-            shell_command=shell_command, log=context.log, **context.op_config
-        )
+        op_config = context.op_config.copy()
+        if not op_config.get("env"):
+            op_config["env"] = os.environ.copy()
+        output, return_code = execute(shell_command=shell_command, log=context.log, **op_config)
 
         if return_code:
             raise Failure(
@@ -328,8 +327,11 @@ def core_create_shell_script(
         **kwargs,
     )
     def _shell_script_fn(context):
+        op_config = context.op_config.copy()
+        if not op_config.get("env"):
+            op_config["env"] = os.environ.copy()
         output, return_code = execute_script_file(
-            shell_script_path=shell_script_path, log=context.log, **context.op_config
+            shell_script_path=shell_script_path, log=context.log, **op_config
         )
 
         if return_code:


### PR DESCRIPTION
## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
I implemented `env.environ.copy()` at solid run time instead of copying at solid init time in the `dagster_shell` library. This bugfix allow the shell execution to take into account its host environment variables when the config entry `env` is empty. It is related to [this](https://github.com/dagster-io/dagster/issues/4267) issue.




## Test Plan
I added two unit tests named `test_shell_script_solid_run_time_config` and `test_shell_script_solid_run_time_config_composite` which replicate existing tests. They ensure that the shell script has access to its host defined environment variables when no solid configuration is provided. 
Test were run in a virtualenv using python 3.7.4 on wsl Ubuntu 20.04.1.




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.