### PR TITLE
allow additional celery args to be specified per-worker-queue in helm

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -19,6 +19,7 @@ class CeleryWorkerQueue(BaseModel):
     labels: Optional[kubernetes.Labels]
     nodeSelector: Optional[kubernetes.NodeSelector]
     configSource: Optional[dict]
+    additionalCeleryArgs: Optional[List[str]]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -60,7 +60,7 @@ spec:
           imagePullPolicy: {{ $celeryK8sRunLauncherConfig.image.pullPolicy }}
           image: {{ include "dagster.dagsterImage.name" (list $ $celeryK8sRunLauncherConfig.image) | quote }}
           command: ["dagster-celery"]
-          args: ["worker", "start", "-A", "dagster_celery_k8s.app", "-y", "{{ $.Values.global.dagsterHome }}/celery-config.yaml", "-q", "{{- $queue.name -}}"]
+          args: ["worker", "start", "-A", "dagster_celery_k8s.app", "-y", "{{ $.Values.global.dagsterHome }}/celery-config.yaml", "-q", "{{- $queue.name -}}", {{- if $queue.additionalCeleryArgs -}}"--", "{{- join "\",\"" $queue.additionalCeleryArgs -}}" {{- end -}}]
           env:
             - name: DAGSTER_PG_PASSWORD
               valueFrom:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1433,6 +1433,20 @@
                             "type": "null"
                         }
                     ]
+                },
+                "additionalCeleryArgs": {
+                    "title": "Additionalceleryargs",
+                    "items": {
+                        "type": "string"
+                    },
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -445,6 +445,7 @@ runLauncher:
           labels: {}
           nodeSelector: {}
           configSource: {}
+          additionalCeleryArgs: []
 
       # Additional environment variables to set on the celery/job containers
       # A Kubernetes ConfigMap will be created with these environment variables. See:

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -483,6 +483,7 @@ def helm_chart(namespace, docker_image, should_cleanup=True):
                             "name": "extra-queue-1",
                             "replicaCount": 1,
                             "labels": {"celery-label-key": "celery-label-value"},
+                            "additionalCeleryArgs": ["-E", "--concurrency", "3"],
                         },
                     ],
                     "livenessProbe": {


### PR DESCRIPTION
Lets you do things like set up task events on celery queues in the helm chart.

Test Plan: Integration