### PR TITLE
Fix bug with dynamic mapping in ExecuteInProcessResult

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_pipelines.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_pipelines.py
@@ -55,6 +55,13 @@ def test_dynamic():
     result = process_directory.execute_in_process()
     assert result.success
 
+    assert result.output_for_node("process_file") == {
+        "empty_stuff_bin": 0,
+        "program_py": 34,
+        "words_txt": 40,
+    }
+    assert result.output_for_node("summarize_directory") == 74
+
 
 def test_dep_dsl():
     result = define_dep_dsl_graph().execute_in_process(

--- a/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
@@ -138,7 +138,18 @@ def _filter_outputs_by_handle(
     step_key = str(node_handle)
     output_found = False
     for step_output_handle, value in output_dict.items():
-        if (
+
+        # For the mapped output case, where step keys are in the format
+        # "step_key[upstream_mapped_output_name]" within the step output handle.
+        if step_output_handle.step_key.startswith(f"{step_key}["):
+            output_found = True
+            key_start = step_output_handle.step_key.find("[")
+            key_end = step_output_handle.step_key.find("]")
+            upstream_mapped_output_name = step_output_handle.step_key[key_start + 1 : key_end]
+            mapped_outputs[upstream_mapped_output_name] = value
+
+        # For all other cases, search for exact match.
+        elif (
             step_key == step_output_handle.step_key
             and step_output_handle.output_name == output_name
         ):

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
@@ -58,14 +58,19 @@ def test_dynamic_output_values():
         yield DynamicOutput(1, "a")
         yield DynamicOutput(2, "b")
 
+    @op
+    def add_one(x):
+        return x + 1
+
     @graph
     def a():
-        two_outs()
+        two_outs().map(add_one)
 
     result = a.execute_in_process()
 
     assert result.success
     assert result.output_for_node("two_outs") == {"a": 1, "b": 2}
+    assert result.output_for_node("add_one") == {"a": 2, "b": 3}
 
 
 def test_execute_graph():


### PR DESCRIPTION
execute_in_process result object wasn't taking into account mapping case. This fixes.