### PR TITLE
show mode for non-default mode runs in job run history

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -254,7 +254,11 @@ const RunRow: React.FC<{
               <IconWIP name="open_in_new" color={ColorsWIP.Blue500} />
             </Link>
           </Box>
-          <RunTags tags={run.tags} mode={isJob ? null : run.mode} onSetFilter={onSetFilter} />
+          <RunTags
+            tags={run.tags}
+            mode={isJob ? (run.mode !== 'default' ? run.mode : null) : run.mode}
+            onSetFilter={onSetFilter}
+          />
         </Box>
       </td>
       <td>


### PR DESCRIPTION
We suppress the mode tag for jobs, since all runs created from a job will have a default mode.

However, because we preserve run history across the pipeline => job conversion, we want to show the mode for runs produced while the job was a pipeline.


## Test Plan
Created pipeline with named mode, created runs, converted to a job, rendered runs page
