### PR TITLE
bug fix: make mdx links versionable

### DIFF
--- a/docs/next/components/Link.tsx
+++ b/docs/next/components/Link.tsx
@@ -31,7 +31,7 @@ const Link = ({ href, children, version }: LinkProps) => {
     return <NextLink href={versionedHref}>{children}</NextLink>;
   }
 
-  if (currentVersion == defaultVersion) {
+  if (currentVersion === defaultVersion) {
     const versionedHref = path.join("/", href);
     return <NextLink href={versionedHref}>{children}</NextLink>;
   }

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -286,6 +286,12 @@ const Experimental = () => {
 };
 
 export default {
+  a: ({ children, ...props }) => (
+    // Hydrate the links in raw MDX to include versions
+    <Link href={props.href}>
+      <a {...props}> {children}</a>
+    </Link>
+  ),
   img: ({ children, ...props }) => (
     <div className="mx-auto">
       <img {...(props as any)} />


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Bug report: https://dagster.slack.com/archives/C01U5LFUZJS/p1635193947004100
Cause: Links generated directly from MDX syntax (as opposed to using the <Link /> component) were not versioned.
This PR makes those links versioned.

## Test Plan
local dev works
vercel preview: older version content should no longer link to the latest version and should link to the current version instead


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.