### PR TITLE
Fix k8s component names

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -380,7 +380,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
         args = ["dagster", "api", "execute_step", input_json]
 
         job = construct_dagster_k8s_job(
-            job_config, args, job_name, user_defined_k8s_config, pod_name
+            job_config, args, job_name, user_defined_k8s_config, pod_name, component="step_worker"
         )
 
         # Running list of events generated from this task execution

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -228,7 +228,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             args=["dagster", "api", "execute_run", input_json],
             job_name=job_name,
             pod_name=pod_name,
-            component="run_coordinator",
+            component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
             env_vars=env_vars,
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -299,7 +299,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             args=["dagster", "api", "execute_run", input_json],
             job_name=job_name,
             pod_name=pod_name,
-            component="run_coordinator",
+            component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
         )
 


### PR DESCRIPTION
Run coordinators were renamed to run workers long ago.