### PR TITLE
update make dev_install notes

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -44,7 +44,7 @@ We love to see our community members get involved! If you are planning to contri
    git clone git@github.com:dagster-io/dagster.git
    ```
 
-5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (sanity_check, which is part of rebuild_dagit) require POSIX compliant shells and will fail on CMD and powershell -- if developing on windows, using something like WSL or git-bash is recommended.
+5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (sanity_check, which is part of rebuild_dagit) require POSIX compliant shells and will fail on CMD and powershell -- if developing on windows, using something like WSL or git-bash is recommended. Note also that if this command fails while installing python packages, the problem might be resolved by ensuring you are running an up-to-date version of `pip` (upgrade with `pip install -U pip`).
 
    ```bash
    make dev_install

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -14,19 +14,12 @@ def main(quiet):
     Especially on macOS, there are still many missing wheels for Python 3.9, which means that some
     dependencies may have to be built from source. You may find yourself needing to install system
     packages such as freetype, gfortran, etc.; on macOS, Homebrew should suffice.
-
-    Tensorflow is still not available for 3.9 (2020-12-10), so we have put conditional logic in place
-    around examples, etc., that make use of it. https://github.com/tensorflow/tensorflow/issues/44485
-
-    Pyarrow is still not available for 3.9 (2020-12-10). https://github.com/apache/arrow/pull/8386
-
-    As a consequence of pyarrow, the snowflake connector also is not yet avaialble for 3.9 (2020-12-10).
-    https://github.com/snowflakedb/snowflake-connector-python/issues/562
     """
 
     # Previously, we did a pip install --upgrade pip here. We have removed that and instead
-    # depend on the user to ensure an up-to-date pip is installed and available. For context, there
-    # is a lengthy discussion here: https://github.com/pypa/pip/issues/5599
+    # depend on the user to ensure an up-to-date pip is installed and available. If you run into
+    # build errors, try this first. For context, there is a lengthy discussion here:
+    # https://github.com/pypa/pip/issues/5599
 
     # On machines with less memory, pyspark install will fail... see:
     # https://stackoverflow.com/a/31526029/11295366


### PR DESCRIPTION
* Remove outdated Python 3.9 notes
* Advise contributors to ensure using up-to-date pip if they have build errors.

## Summary

This is just a minor internal documentation change based on my experiencing setting up my dev environment. I ran into build errors on Python 3.8 that were fixed by updating pip, and also noticed some notes on 3.9 compatibility were outdated.

## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.