### PR TITLE
fix typos/outdated terminology in docs

### DIFF
--- a/docs/content/tutorial/advanced-tutorial/types.mdx
+++ b/docs/content/tutorial/advanced-tutorial/types.mdx
@@ -29,7 +29,7 @@ def download_csv(context):
     return [row for row in csv.DictReader(lines)]
 ```
 
-The `lines` object returned by Python's built-in `csv.DictReader` is a list of `collections.OrderedDict`, each of which represents one row of the dataset:
+The object returned by Python's built-in `csv.DictReader` is a list of `collections.OrderedDict`, each of which represents one row of the dataset:
 
 ```python
 [

--- a/docs/content/tutorial/intro-tutorial/connecting-solids.mdx
+++ b/docs/content/tutorial/intro-tutorial/connecting-solids.mdx
@@ -19,10 +19,10 @@ Dagster jobs model a _dataflow_ graph. In data pipelines, the reason that a late
 
 ## Let's Get Serial
 
-We'll expand the job we worked with in the first section of the tutorial into two ops:
+We'll expand the job we worked with in the first section of the tutorial into two ops that:
 
-- The first op will download the cereal data and return it as an output.
-- The second op will consume the cereal data produced by the first op and find the cereal with the most sugar.
+- Download the cereal data and return it as an output.
+- Consume the cereal data produced by the first op and find the cereal with the most sugar.
 
 This will allow us to re-run the code that finds the sugariest cereal without re-running the code that downloads the cereal data. If we spot a bug in our sugariness code, or if we decide we want to compute some other statistics about the cereal data, we won't need to re-download the data.
 

--- a/docs/content/tutorial/intro-tutorial/setup.mdx
+++ b/docs/content/tutorial/intro-tutorial/setup.mdx
@@ -19,7 +19,7 @@ If you haven't already, please read about our [Installation](/getting-started/in
 pip install dagster dagit requests
 ```
 
-This installs a few modules:
+This installs a few packages:
 
 - **Dagster**: the core programming model and abstraction stack; stateless, single-node, single-process and multi-process execution engines; and a CLI tool for driving those engines.
 - **Dagit**: the UI for developing and operating Dagster jobs, including a DAG browser, a type-aware config editor, and a live execution interface.

--- a/docs/content/tutorial/intro-tutorial/single-solid-pipeline.mdx
+++ b/docs/content/tutorial/intro-tutorial/single-solid-pipeline.mdx
@@ -25,7 +25,7 @@ Let's write our first Dagster op and save it as `hello_cereal.py`.
 
 A op is a unit of computation in a job. Typically, you'll define ops by annotating ordinary Python functions with the <PyObject module="dagster" object="op" displayText="@op" /> decorator.
 
-Our first op does three things: downloads a csv of cereal data, reads it into a list of dictionaries which each represent a row in the CSV, and logs the number of rows it finds.
+Our first op does three things: downloads a CSV of cereal data, reads it into a list of dictionaries which each represent a row in the CSV, and logs the number of rows it finds.
 
 ```python file=/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py startafter=start_solid_marker endbefore=end_solid_marker
 import requests
@@ -66,7 +66,7 @@ Assuming you’ve saved this job as `hello_cereal.py`, you can execute it via an
 
 ### Dagit
 
-To visualize your job (which only has one node) in Dagit, from the directory in which you've saved the job file, just run:
+To visualize your job (which only has one op) in Dagit, from the directory in which you've saved the job file, just run:
 
 ```bash
 dagit -f hello_cereal.py
@@ -98,7 +98,7 @@ height={946}
 
 The large upper left pane is empty here, but, in jobs with parameters, this is where you'll be able to edit job configuration on the fly.
 
-Click the "Launch Execution" button on the bottom right to execute this plan directly from Dagit. A new window should open, and you'll see a much more structured view of the stream of Dagster events start to appear in the left-hand pane.
+Click the "Launch Execution" button on the bottom right to execute this job directly from Dagit. A new window should open, and you'll see a much more structured view of the stream of Dagster events start to appear in the left-hand pane.
 
 If you have pop-up blocking enabled, you may need to tell your browser to allow pop-ups from 127.0.0.1—or, just navigate to the "Runs" tab to see this, and every run of your job.
 

--- a/docs/content/tutorial/intro-tutorial/testable.mdx
+++ b/docs/content/tutorial/intro-tutorial/testable.mdx
@@ -27,7 +27,7 @@ def test_find_highest_calorie_cereal():
     assert result == "hi-cal cereal"
 ```
 
-We'll also write a test for the entire pipeline. The <PyObject
+We'll also write a test for the entire job. The <PyObject
 module="dagster" object="JobDefinition" method="execute_in_process" /> method synchronously executes a job and returns a <PyObject module="dagster"
 object="ExecuteInProcessResult" />, whose methods let us investigate, in detail, the success or failure of execution, the outputs produced by ops, and (as we'll see later) other events associated with execution.
 


### PR DESCRIPTION
## Summary

These are just a few conservative typo/terminology corrections to the docs. Holding off on more subjective changes till we have a docs plan.

## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.