### PR TITLE
feat(helm): support redis password

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
@@ -3,6 +3,9 @@ from pydantic import BaseModel, Extra  # pylint: disable=no-name-in-module
 
 class Redis(BaseModel):
     enabled: bool
+    internal: bool
+    usePassword: bool
+    password: str
     host: str
     port: int
     brokerDbNumber: int

--- a/helm/dagster/schema/schema_tests/test_redis.py
+++ b/helm/dagster/schema/schema_tests/test_redis.py
@@ -1,0 +1,71 @@
+import pytest
+from kubernetes.client import models
+from schema.charts.dagster.subschema.redis import Redis
+from schema.charts.dagster.values import DagsterHelmValues
+from schema.utils.helm_template import HelmTemplate
+
+
+@pytest.fixture(name="template")
+def helm_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="templates/configmap-env-dagit.yaml",
+        model=models.V1ConfigMap,
+    )
+
+
+def test_celery_backend_with_redis_without_password(template: HelmTemplate):
+    redis_host = "host"
+    redis_port = 6379
+    broker_db_number = 20
+    backend_db_number = 21
+    helm_values = DagsterHelmValues.construct(
+        redis=Redis.construct(
+            enabled=True,
+            usePassword=False,
+            host=redis_host,
+            port=redis_port,
+            brokerDbNumber=broker_db_number,
+            backendDbNumber=backend_db_number,
+        ),
+    )
+
+    [configmap] = template.render(helm_values)
+
+    expected_celery_broker = f"redis://{redis_host}:{redis_port}/{broker_db_number}"
+    expected_celery_backend = f"redis://{redis_host}:{redis_port}/{backend_db_number}"
+
+    assert configmap.data["DAGSTER_K8S_CELERY_BROKER"] == expected_celery_broker
+    assert configmap.data["DAGSTER_K8S_CELERY_BACKEND"] == expected_celery_backend
+
+
+def test_celery_backend_with_redis_with_password(template: HelmTemplate):
+    redis_password = "password"
+    redis_host = "host"
+    redis_port = 6379
+    broker_db_number = 20
+    backend_db_number = 21
+    helm_values = DagsterHelmValues.construct(
+        redis=Redis.construct(
+            enabled=True,
+            usePassword=True,
+            password=redis_password,
+            host=redis_host,
+            port=redis_port,
+            brokerDbNumber=broker_db_number,
+            backendDbNumber=backend_db_number,
+        ),
+    )
+
+    [configmap] = template.render(helm_values)
+
+    expected_celery_broker = (
+        f"redis://:{redis_password}@{redis_host}:{redis_port}/{broker_db_number}"
+    )
+    expected_celery_backend = (
+        f"redis://:{redis_password}@{redis_host}:{redis_port}/{backend_db_number}"
+    )
+
+    assert configmap.data["DAGSTER_K8S_CELERY_BROKER"] == expected_celery_broker
+    assert configmap.data["DAGSTER_K8S_CELERY_BACKEND"] == expected_celery_backend

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -155,7 +155,8 @@ Celery options
 {{- if .Values.rabbitmq.enabled -}}
 pyamqp://{{ .Values.rabbitmq.rabbitmq.username }}:{{ .Values.rabbitmq.rabbitmq.password }}@{{ include "dagster.rabbitmq.fullname" . }}:{{ .Values.rabbitmq.service.port }}//
 {{- else if .Values.redis.enabled -}}
-redis://{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.brokerDbNumber | default 0}}
+{{- $password := ternary (printf ":%s@" .Values.redis.password) "" .Values.redis.usePassword -}}
+redis://{{ $password }}{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.brokerDbNumber | default 0}}
 {{- end -}}
 {{- end -}}
 
@@ -163,7 +164,8 @@ redis://{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.broke
 {{- if .Values.rabbitmq.enabled -}}
 rpc://
 {{- else if .Values.redis.enabled -}}
-redis://{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.backendDbNumber | default 0}}
+{{- $password := ternary (printf ":%s@" .Values.redis.password) "" .Values.redis.usePassword -}}
+redis://{{ $password }}{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.backendDbNumber | default 0}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -636,6 +636,18 @@
                     "title": "Enabled",
                     "type": "boolean"
                 },
+                "internal": {
+                    "title": "Internal",
+                    "type": "boolean"
+                },
+                "usePassword": {
+                    "title": "Usepassword",
+                    "type": "boolean"
+                },
+                "password": {
+                    "title": "Password",
+                    "type": "string"
+                },
                 "host": {
                     "title": "Host",
                     "type": "string"
@@ -655,6 +667,9 @@
             },
             "required": [
                 "enabled",
+                "internal",
+                "usePassword",
+                "password",
                 "host",
                 "port",
                 "brokerDbNumber",

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -608,6 +608,9 @@ redis:
   # Note: If `internal` is true, then redis pod will be created regardless of `enabled` flag.
   internal: false
 
+  usePassword: false
+  password: "test"
+
   # Redis host URL
   host: ""
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Add support for having a redis password in the Helm chart. Currently, we assume that
the redis cluster does not need authentication. Here, we break that assumption and 
construct the correct backend/broker urls if a password is configured. 

Also fix https://github.com/dagster-io/dagster/issues/4316, and set `.Values.redis.usePassword` 
to `false` by default.


## Test Plan
pytest
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
