### PR TITLE
feat(helm): add fields to override redis connection strings

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
@@ -10,6 +10,8 @@ class Redis(BaseModel):
     port: int
     brokerDbNumber: int
     backendDbNumber: int
+    brokerUrl: str
+    backendUrl: str
 
     class Config:
         extra = Extra.allow

--- a/helm/dagster/schema/schema_tests/test_redis.py
+++ b/helm/dagster/schema/schema_tests/test_redis.py
@@ -69,3 +69,20 @@ def test_celery_backend_with_redis_with_password(template: HelmTemplate):
 
     assert configmap.data["DAGSTER_K8S_CELERY_BROKER"] == expected_celery_broker
     assert configmap.data["DAGSTER_K8S_CELERY_BACKEND"] == expected_celery_backend
+
+
+def test_celery_backend_override_connection_string(template: HelmTemplate):
+    broker_url = "host:6380,password=password,ssl=True"
+    backend_url = "host:6381,password=password,ssl=True"
+    helm_values = DagsterHelmValues.construct(
+        redis=Redis.construct(
+            enabled=True,
+            brokerUrl=broker_url,
+            backendUrl=backend_url,
+        ),
+    )
+
+    [configmap] = template.render(helm_values)
+
+    assert configmap.data["DAGSTER_K8S_CELERY_BROKER"] == broker_url
+    assert configmap.data["DAGSTER_K8S_CELERY_BACKEND"] == backend_url

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -156,7 +156,8 @@ Celery options
 pyamqp://{{ .Values.rabbitmq.rabbitmq.username }}:{{ .Values.rabbitmq.rabbitmq.password }}@{{ include "dagster.rabbitmq.fullname" . }}:{{ .Values.rabbitmq.service.port }}//
 {{- else if .Values.redis.enabled -}}
 {{- $password := ternary (printf ":%s@" .Values.redis.password) "" .Values.redis.usePassword -}}
-redis://{{ $password }}{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.brokerDbNumber | default 0}}
+{{- $connectionUrl := printf "redis://%s%s:%g/%g" $password .Values.redis.host .Values.redis.port (.Values.redis.brokerDbNumber | default 0) -}}
+{{- ternary .Values.redis.brokerUrl $connectionUrl (not (empty .Values.redis.brokerUrl)) }}
 {{- end -}}
 {{- end -}}
 
@@ -165,7 +166,8 @@ redis://{{ $password }}{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Val
 rpc://
 {{- else if .Values.redis.enabled -}}
 {{- $password := ternary (printf ":%s@" .Values.redis.password) "" .Values.redis.usePassword -}}
-redis://{{ $password }}{{ .Values.redis.host }}:{{ .Values.redis.port }}/{{ .Values.redis.backendDbNumber | default 0}}
+{{- $connectionUrl := printf "redis://%s%s:%g/%g" $password .Values.redis.host .Values.redis.port (.Values.redis.backendDbNumber | default 0) -}}
+{{- ternary .Values.redis.backendUrl $connectionUrl (not (empty .Values.redis.brokerUrl)) }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -663,6 +663,14 @@
                 "backendDbNumber": {
                     "title": "Backenddbnumber",
                     "type": "integer"
+                },
+                "brokerUrl": {
+                    "title": "Brokerurl",
+                    "type": "string"
+                },
+                "backendUrl": {
+                    "title": "Backendurl",
+                    "type": "string"
                 }
             },
             "required": [
@@ -673,7 +681,9 @@
                 "host",
                 "port",
                 "brokerDbNumber",
-                "backendDbNumber"
+                "backendDbNumber",
+                "brokerUrl",
+                "backendUrl"
             ]
         },
         "Flower": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -623,6 +623,11 @@ redis:
   # Set DB number for Redis backend DB (default 0)
   backendDbNumber: 0
 
+  # If your Redis connection needs configuration options, you can use this field to specific the
+  # exact connection URL needed, rather than letting it be constructed from the Helm values.
+  brokerUrl: ""
+  backendUrl: ""
+
 ####################################################################################################
 # Flower: (Optional) The flower web interface for diagnostics and debugging Celery queues & workers
 ####################################################################################################


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Redis connection strings can take in key value pairs (e.g. https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options).
Rather than trying to format all these cases, allow the user to specific a formatted connection string by themselves.


## Test Plan
pytest
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


