### PR TITLE
make sure we populate step key in the storage layer

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1264,6 +1264,7 @@ records = instance.get_event_records(
             pipeline_name=pipeline_run.pipeline_name,
             message=message,
             event_specific_data=engine_event_data,
+            step_key=step_key,
         )
         event_record = EventLogEntry(
             message=message,

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1296,3 +1296,29 @@ class TestEventLogStorage:
 
         assert len(event_list) == len(safe_events)
         assert all([isinstance(event, EventLogEntry) for event in event_list])
+
+    def test_engine_event_markers(self, storage):
+        @solid
+        def return_one(_):
+            return 1
+
+        @pipeline
+        def a_pipe():
+            return_one()
+
+        with instance_for_test() as instance:
+            if not storage._instance:  # pylint: disable=protected-access
+                storage.register_instance(instance)
+
+            run_id = make_new_run_id()
+            run = instance.create_run_for_pipeline(a_pipe, run_id=run_id)
+
+            instance.report_engine_event(
+                "blah blah", run, EngineEventData(marker_start="FOO"), step_key="return_one"
+            )
+            instance.report_engine_event(
+                "blah blah", run, EngineEventData(marker_end="FOO"), step_key="return_one"
+            )
+            logs = storage.get_logs_for_run(run_id)
+            for entry in logs:
+                assert entry.step_key == "return_one"


### PR DESCRIPTION
## Summary
We weren't storing step_key at the top-level for engine events.  This PR makes it available for the sql-based storage engines to query by step.

This is a prerequisite for calculating summary stats at the step level efficiently at the storage layer, rather than calculating stats from the raw logs client-side.  This should bring down the gantt chart rendering of a finished run dramatically for runs with very long event logs.

The engine-event markers are calculated using the step_key, to depict resource initialization time. 

## Test Plan
BK
