### PR TITLE
Use executable path when making execute_run and execute_step calls

### DIFF
--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import List
 
 from dagster import check
 from dagster.core.code_pointer import CodePointer
@@ -11,7 +12,7 @@ from dagster.core.host_representation.origin import (
 )
 from dagster.core.instance.ref import InstanceRef
 from dagster.core.origin import PipelinePythonOrigin
-from dagster.serdes import whitelist_for_serdes
+from dagster.serdes import serialize_dagster_namedtuple, whitelist_for_serdes
 from dagster.utils.error import SerializableErrorInfo
 
 
@@ -62,6 +63,16 @@ class ExecuteRunArgs(namedtuple("_ExecuteRunArgs", "pipeline_origin pipeline_run
             pipeline_run_id=check.str_param(pipeline_run_id, "pipeline_run_id"),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
         )
+
+    def get_command_args(self) -> List[str]:
+        return [
+            self.pipeline_origin.executable_path,
+            "-m",
+            "dagster",
+            "api",
+            "execute_run",
+            serialize_dagster_namedtuple(self),
+        ]
 
 
 @whitelist_for_serdes
@@ -130,6 +141,16 @@ class ExecuteStepArgs(
                 should_verify_step, "should_verify_step", False
             ),
         )
+
+    def get_command_args(self) -> List[str]:
+        return [
+            self.pipeline_origin.executable_path,
+            "-m",
+            "dagster",
+            "api",
+            "execute_step",
+            serialize_dagster_namedtuple(self),
+        ]
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -11,7 +11,6 @@ from dagster.core.execution.retries import RetryMode
 from dagster.core.executor.step_delegating import StepDelegatingExecutor, StepHandler
 from dagster.core.storage.fs_io_manager import fs_io_manager
 from dagster.core.test_utils import instance_for_test
-from dagster.serdes import serialize_dagster_namedtuple
 
 
 class TestStepHandler(StepHandler):
@@ -35,14 +34,7 @@ class TestStepHandler(StepHandler):
         TestStepHandler.launch_step_count += 1
         print("TestStepHandler Launching Step!")  # pylint: disable=print-call
         TestStepHandler.processes.append(
-            subprocess.Popen(
-                [
-                    "dagster",
-                    "api",
-                    "execute_step",
-                    serialize_dagster_namedtuple(step_handler_context.execute_step_args),
-                ]
-            )
+            subprocess.Popen(step_handler_context.execute_step_args.get_command_args())
         )
         return []
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -3,7 +3,7 @@ import dagster
 from dagster import Field, check
 from dagster.core.launcher.base import LaunchRunContext, RunLauncher
 from dagster.grpc.types import ExecuteRunArgs
-from dagster.serdes import ConfigurableClass, serialize_dagster_namedtuple
+from dagster.serdes import ConfigurableClass
 from dagster.utils.backcompat import experimental
 
 from .tasks import default_ecs_task_definition, default_ecs_task_metadata
@@ -94,15 +94,12 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
         image = pipeline_origin.repository_origin.container_image
         task_definition = self._task_definition(metadata, image)["family"]
 
-        input_json = serialize_dagster_namedtuple(
-            ExecuteRunArgs(
-                pipeline_origin=pipeline_origin,
-                pipeline_run_id=run.run_id,
-                instance_ref=self._instance.get_ref(),
-            )
+        args = ExecuteRunArgs(
+            pipeline_origin=pipeline_origin,
+            pipeline_run_id=run.run_id,
+            instance_ref=self._instance.get_ref(),
         )
-        command = ["dagster", "api", "execute_run", input_json]
-
+        command = args.get_command_args()
         # Run a task using the same network configuration as this processes's
         # task.
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -376,8 +376,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             job_name = "dagster-job-%s" % (k8s_name_key)
             pod_name = "dagster-job-%s" % (k8s_name_key)
 
-        input_json = serialize_dagster_namedtuple(execute_step_args)
-        args = ["dagster", "api", "execute_step", input_json]
+        args = execute_step_args.get_command_args()
 
         job = construct_dagster_k8s_job(
             job_config, args, job_name, user_defined_k8s_config, pod_name, component="step_worker"

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -9,7 +9,7 @@ from dagster.core.execution.retries import RetryMode
 from dagster.core.launcher import LaunchRunContext, RunLauncher
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
-from dagster.serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from dagster.serdes import ConfigurableClass, ConfigurableClassData
 from dagster.utils import frozentags, merge_dicts
 from dagster.utils.error import serializable_error_info_from_exc_info
 from dagster_k8s.job import (
@@ -213,19 +213,17 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
 
         from dagster.cli.api import ExecuteRunArgs
 
-        input_json = serialize_dagster_namedtuple(
-            # depends on DagsterInstance.get() returning the same instance
-            # https://github.com/dagster-io/dagster/issues/2757
-            ExecuteRunArgs(
-                pipeline_origin=pipeline_origin,
-                pipeline_run_id=run.run_id,
-                instance_ref=None,
-            )
+        # depends on DagsterInstance.get() returning the same instance
+        # https://github.com/dagster-io/dagster/issues/2757
+        run_args = ExecuteRunArgs(
+            pipeline_origin=pipeline_origin,
+            pipeline_run_id=run.run_id,
+            instance_ref=None,
         )
 
         job = construct_dagster_k8s_job(
             job_config,
-            args=["dagster", "api", "execute_run", input_json],
+            args=run_args.get_command_args(),
             job_name=job_name,
             pod_name=pod_name,
             component="run_worker",

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -11,7 +11,6 @@ from dagster.core.executor.base import Executor
 from dagster.core.executor.init import InitExecutorContext
 from dagster.core.executor.step_delegating import StepDelegatingExecutor
 from dagster.core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
-from dagster.serdes import serialize_dagster_namedtuple
 from dagster.serdes.utils import hash_str
 from dagster.utils import merge_dicts
 from dagster.utils.backcompat import experimental
@@ -114,12 +113,7 @@ class DockerStepHandler(StepHandler):
             ),
             detach=True,
             network=self._networks[0] if len(self._networks) else None,
-            command=[
-                "dagster",
-                "api",
-                "execute_step",
-                serialize_dagster_namedtuple(execute_step_args),
-            ],
+            command=execute_step_args.get_command_args(),
             environment=(
                 {env_name: os.getenv(env_name) for env_name in self._env_vars}
                 if self._env_vars

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -11,7 +11,6 @@ from dagster.core.executor.step_delegating import StepDelegatingExecutor
 from dagster.core.executor.step_delegating.step_handler import StepHandler
 from dagster.core.executor.step_delegating.step_handler.base import StepHandlerContext
 from dagster.core.types.dagster_type import Optional
-from dagster.serdes.serdes import serialize_dagster_namedtuple
 from dagster.utils import frozentags, merge_dicts
 from dagster.utils.backcompat import experimental
 from dagster_k8s.launcher import K8sRunLauncher
@@ -156,8 +155,7 @@ class K8sStepHandler(StepHandler):
         job_name = "dagster-job-%s" % (k8s_name_key)
         pod_name = "dagster-job-%s" % (k8s_name_key)
 
-        input_json = serialize_dagster_namedtuple(step_handler_context.execute_step_args)
-        args = ["dagster", "api", "execute_step", input_json]
+        args = step_handler_context.execute_step_args.get_command_args()
 
         job_config = self._job_config
         if not job_config.job_image:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -7,7 +7,7 @@ from dagster.core.events import EngineEventData
 from dagster.core.launcher import LaunchRunContext, RunLauncher
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
-from dagster.serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from dagster.serdes import ConfigurableClass, ConfigurableClassData
 from dagster.utils import frozentags, merge_dicts
 from dagster.utils.error import serializable_error_info_from_exc_info
 
@@ -286,17 +286,14 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             {DOCKER_IMAGE_TAG: job_config.job_image},
         )
 
-        input_json = serialize_dagster_namedtuple(
-            ExecuteRunArgs(
-                pipeline_origin=pipeline_origin,
-                pipeline_run_id=run.run_id,
-                instance_ref=None,
-            )
+        run_args = ExecuteRunArgs(
+            pipeline_origin=pipeline_origin,
+            pipeline_run_id=run.run_id,
+            instance_ref=None,
         )
-
         job = construct_dagster_k8s_job(
             job_config=job_config,
-            args=["dagster", "api", "execute_run", input_json],
+            args=run_args.get_command_args(),
             job_name=job_name,
             pod_name=pod_name,
             component="run_worker",


### PR DESCRIPTION
Summary:
A couple of different users lately have asked for the ability to have a single Docker image with multiple venvs in it, using different grpc server entry points in the same image. We are shockingly close to being able to support that - the executable path is even passed all the way through, but then we don't use it when spinning up the pods / containers /etc. - this changes that by including the executable path in the command.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.