### PR TITLE
fix(dagster-mysql): allow environment to source connection string

### DIFF
--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -33,7 +33,7 @@ def get_conn(conn_string):
 def mysql_config():
     return Selector(
         {
-            "mysql_url": str,
+            "mysql_url": StringSource,
             "mysql_db": {
                 "username": StringSource,
                 "password": StringSource,


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Resolves https://github.com/dagster-io/dagster/issues/5413.
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
N/A
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

