### PR TITLE
[crag-core][rfc] Add pipeline_def.coerce_to_job method

### DIFF
--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -241,11 +241,14 @@ def execute_step_command(input_json):
                 args.pipeline_origin
             ).subset_for_execution_from_existing_pipeline(pipeline_run.solids_to_execute)
 
+            pipeline_def = recon_pipeline.get_definition()
+            job_def = pipeline_def.coerce_to_job(
+                mode=pipeline_run.mode, run_config=pipeline_run.run_config
+            )
             execution_plan = create_execution_plan(
-                recon_pipeline,
+                job_def,
                 run_config=pipeline_run.run_config,
                 step_keys_to_execute=args.step_keys_to_execute,
-                mode=pipeline_run.mode,
                 known_state=args.known_state,
             )
 

--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -102,10 +102,10 @@ def execute_list_versions_command(instance, kwargs):
     job = recon_pipeline_from_origin(job_origin)
     run_config = get_run_config_from_file_list(config)
 
+    job_def = job.get_definition().coerce_to_job(run_config=run_config)
+
     memoized_plan = create_execution_plan(
-        job,
-        run_config=run_config,
-        mode="default",
+        job_def,
         instance=instance,
         tags={MEMOIZED_RUN_TAG: "true"},
     )

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -276,10 +276,12 @@ def execute_list_versions_command(instance, kwargs):
     pipeline = recon_pipeline_from_origin(pipeline_origin)
     run_config = get_run_config_from_file_list(config)
 
+    pipeline_def = pipeline.get_definition()
+    job_def = pipeline_def.coerce_to_job(mode=mode, run_config=run_config)
+
     memoized_plan = create_execution_plan(
-        pipeline,
+        job_def,
         run_config=run_config,
-        mode=mode,
         instance=instance,
         tags={MEMOIZED_RUN_TAG: "true"},
     )

--- a/python_modules/dagster/dagster/core/definitions/job.py
+++ b/python_modules/dagster/dagster/core/definitions/job.py
@@ -4,8 +4,10 @@ from dagster import check
 from dagster.core.definitions.policy import RetryPolicy
 from dagster.core.selector.subset_selector import OpSelectionData, parse_solid_selection
 
+from .executor import ExecutorDefinition
 from .graph import GraphDefinition
 from .hook import HookDefinition
+from .logger import LoggerDefinition
 from .mode import ModeDefinition
 from .partition import PartitionSetDefinition
 from .pipeline import PipelineDefinition
@@ -218,6 +220,27 @@ class JobDefinition(PipelineDefinition):
             )
 
         return self._cached_partition_set
+
+    @property
+    def mode_def(self):
+        return self.mode_definitions[0]
+
+    @property
+    def executor_def(self) -> ExecutorDefinition:
+        return self.mode_def.executor_defs[0]
+
+    @property
+    def resource_defs(self) -> Dict[str, ResourceDefinition]:
+        return self.mode_def.resource_defs
+
+    @property
+    def loggers(self) -> Dict[str, LoggerDefinition]:
+        return self.mode_def.loggers
+
+    def coerce_to_job(
+        self, mode: Optional[str] = None, run_config: Optional[Dict[str, Any]] = None
+    ) -> "JobDefinition":
+        return self
 
 
 def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -29,9 +29,10 @@ def core_execute_in_process(
     pipeline_def = ephemeral_pipeline
     mode_def = pipeline_def.get_mode_definition()
     pipeline = InMemoryPipeline(pipeline_def)
+    job_def = pipeline_def.coerce_to_job(mode=mode_def.name, run_config=run_config)
 
     execution_plan = create_execution_plan(
-        pipeline,
+        job_def,
         run_config=run_config,
         mode=mode_def.name,
     )

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -159,10 +159,12 @@ def step_run_ref_to_step_context(
         step_run_ref.pipeline_run.solids_to_execute
     )
 
+    job_def = pipeline.get_definition().coerce_to_job(
+        mode=step_run_ref.pipeline_run.mode, run_config=step_run_ref.run_config
+    )
     execution_plan = create_execution_plan(
-        pipeline,
+        job_def,
         step_run_ref.run_config,
-        mode=step_run_ref.pipeline_run.mode,
         step_keys_to_execute=[step_run_ref.step_key],
     )
 

--- a/python_modules/dagster/dagster/core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/core/executor/multiprocess.py
@@ -52,10 +52,12 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
         pipeline = self.recon_pipeline
         with DagsterInstance.from_ref(self.instance_ref) as instance:
             start_termination_thread(self.term_event)
+            job_def = pipeline.get_definition().coerce_to_job(
+                mode=self.pipeline_run.mode, run_config=self.run_config
+            )
             execution_plan = create_execution_plan(
-                pipeline=pipeline,
+                job_def,
                 run_config=self.run_config,
-                mode=self.pipeline_run.mode,
                 step_keys_to_execute=[self.step_key],
                 known_state=self.known_state,
             )

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -320,16 +320,15 @@ class InProcessRepositoryLocation(RepositoryLocation):
         check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
         check.opt_inst_param(known_state, "known_state", KnownExecutionState)
 
+        pipeline = self.get_reconstructable_pipeline(
+            external_pipeline.name
+        ).subset_for_execution_from_existing_pipeline(external_pipeline.solids_to_execute)
+        job_def = pipeline.get_definition().coerce_to_job(mode=mode, run_config=run_config)
         return ExternalExecutionPlan(
             execution_plan_snapshot=snapshot_from_execution_plan(
                 create_execution_plan(
-                    pipeline=self.get_reconstructable_pipeline(
-                        external_pipeline.name
-                    ).subset_for_execution_from_existing_pipeline(
-                        external_pipeline.solids_to_execute
-                    ),
+                    job_def,
                     run_config=run_config,
-                    mode=mode,
                     step_keys_to_execute=step_keys_to_execute,
                     known_state=known_state,
                 ),

--- a/python_modules/dagster/dagster/grpc/impl.py
+++ b/python_modules/dagster/dagster/grpc/impl.py
@@ -347,11 +347,13 @@ def get_external_execution_plan_snapshot(recon_pipeline, args):
             else recon_pipeline
         )
 
+        job_def = pipeline.get_definition().coerce_to_job(
+            mode=args.mode, run_config=args.run_config
+        )
         return snapshot_from_execution_plan(
             create_execution_plan(
-                pipeline=pipeline,
+                job_def,
                 run_config=args.run_config,
-                mode=args.mode,
                 step_keys_to_execute=args.step_keys_to_execute,
                 known_state=args.known_state,
             ),

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -782,7 +782,7 @@ class TestRunStorage:
         from dagster.core.snap import snapshot_from_execution_plan
 
         pipeline_def = PipelineDefinition(name="some_pipeline", solid_defs=[])
-        execution_plan = create_execution_plan(pipeline_def)
+        execution_plan = create_execution_plan(pipeline_def.coerce_to_job())
         ep_snapshot = snapshot_from_execution_plan(
             execution_plan, pipeline_def.get_pipeline_snapshot_id()
         )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/factory.py
@@ -108,12 +108,9 @@ class DagsterOperatorParameters(
     ):
         pipeline_def = recon_repo.get_definition().get_pipeline(pipeline_name)
 
-        if mode is None:
-            mode = pipeline_def.get_default_mode_name()
+        job_def = pipeline_def.coerce_to_job(mode=mode, run_config=run_config)
 
-        mode_def = pipeline_def.get_mode_definition(mode)
-
-        check_storage_specified(pipeline_def, mode_def)
+        check_storage_specified(job_def)
 
         return super(DagsterOperatorParameters, cls).__new__(
             cls,
@@ -200,7 +197,8 @@ def _make_airflow_dag(
     if mode is None:
         mode = pipeline.get_default_mode_name()
 
-    execution_plan = create_execution_plan(pipeline, run_config, mode=mode)
+    job_def = pipeline.get_definition().coerce_to_job(mode=mode, run_config=run_config)
+    execution_plan = create_execution_plan(job_def, run_config)
 
     tasks = {}
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/docker_operator.py
@@ -208,13 +208,17 @@ class DagsterDockerOperator(DockerOperator):
 
     def _should_skip(self, pipeline_run):
         recon_pipeline = self.recon_repo.get_reconstructable_pipeline(self.pipeline_name)
+        subset_recon_pipeline = recon_pipeline.subset_for_execution_from_existing_pipeline(
+            pipeline_run.solids_to_execute
+        )
+
+        job_def = subset_recon_pipeline.get_definition().coerce_to_job(
+            mode=self.mode, run_config=self.run_config
+        )
         execution_plan = create_execution_plan(
-            recon_pipeline.subset_for_execution_from_existing_pipeline(
-                pipeline_run.solids_to_execute
-            ),
+            job_def,
             run_config=self.run_config,
             step_keys_to_execute=self.step_keys,
-            mode=self.mode,
         )
         return should_skip_step(execution_plan, instance=self.instance, run_id=pipeline_run.run_id)
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/operators/util.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/operators/util.py
@@ -66,8 +66,8 @@ def get_aws_environment():
     return default_env
 
 
-def check_storage_specified(pipeline_def, mode_def):
-    if not can_isolate_steps(pipeline_def, mode_def):
+def check_storage_specified(job_def):
+    if not can_isolate_steps(job_def):
         raise AirflowException(
             "DAGs created using dagster-airflow run each step in its own process, but your "
             "pipeline includes solid outputs that will not be stored somewhere where other "
@@ -116,11 +116,13 @@ def invoke_steps_within_python_operator(
                 pipeline_name
             ).subset_for_execution_from_existing_pipeline(pipeline_run.solids_to_execute)
 
+            job_def = recon_pipeline.get_definition().coerce_to_job(
+                mode=mode, run_config=run_config
+            )
             execution_plan = create_execution_plan(
-                recon_pipeline,
+                job_def,
                 run_config=run_config,
                 step_keys_to_execute=step_keys,
-                mode=mode,
             )
             if should_skip_step(execution_plan, instance, pipeline_run.run_id):
                 raise AirflowSkipException(

--- a/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
@@ -34,10 +34,12 @@ def create_task(celery_app, **task_kwargs):
 
         step_keys_str = ", ".join(execute_step_args.step_keys_to_execute)
 
+        job_def = pipeline.get_definition().coerce_to_job(
+            mode=pipeline_run.mode, run_config=pipeline_run.run_config
+        )
         execution_plan = create_execution_plan(
-            pipeline,
+            job_def,
             pipeline_run.run_config,
-            mode=pipeline_run.mode,
             step_keys_to_execute=execute_step_args.step_keys_to_execute,
             known_state=execute_step_args.known_state,
         )

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -130,11 +130,12 @@ def query_on_dask_worker(
             pipeline_run.solids_to_execute
         )
 
+        job_def = subset_pipeline.get_definition().coerce_to_job(run_config=run_config, mode=mode)
+
         execution_plan = create_execution_plan(
-            subset_pipeline,
+            job_def,
             run_config=run_config,
             step_keys_to_execute=step_keys,
-            mode=mode,
         )
 
         return execute_plan(


### PR DESCRIPTION
One way we can start to migrate the core over to crag. Proof-of-concepted by converting `create_execution_plan` to use job definitions only.

Essentially, a job is a pipeline with its mode and executor determined. To do this, we need run_config and a mode name.

Very broken, but curious if people had thoughts on the approach.