### PR TITLE
dagster-k8s run worker fault tolerance

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Extra  # pylint: disable=no-name-in-module
 
@@ -77,3 +77,4 @@ class Daemon(BaseModel):
     livenessProbe: kubernetes.LivenessProbe
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
+    runMonitoring: Dict[str, Any]

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -146,3 +146,19 @@ def test_queued_run_coordinator_unique_values(
     assert instance["run_coordinator"]["config"]["tag_concurrency_limits"] == [
         {"key": "foo", "value": {"applyLimitPerUniqueValue": True}, "limit": 1}
     ]
+
+
+def test_run_monitoring(
+    instance_template: HelmTemplate,
+):  # pylint: disable=redefined-outer-name
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct(runMonitoring={"enabled": True})
+    )
+
+    configmaps = instance_template.render(helm_values)
+
+    assert len(configmaps) == 1
+
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert instance["run_monitoring"]["enabled"] == True

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -91,3 +91,12 @@ data:
       {{- else if eq $computeLogManagerType "CustomComputeLogManager" }}
         {{- include "dagsterYaml.computeLogManager.custom" . | indent 6 -}}
       {{- end }}
+
+    {{- if and (.Values.dagsterDaemon.enabled) (.Values.dagsterDaemon.runMonitoring.enabled) }}
+    {{- $runMonitoring := .Values.dagsterDaemon.runMonitoring }}
+    run_monitoring:
+      enabled: {{ $runMonitoring.enabled }}
+      start_timeout_seconds:  {{ $runMonitoring.startTimeoutSeconds }}
+      max_resume_run_attempts: {{ $runMonitoring.maxResumeRunAttempts }}
+      poll_interval_seconds: {{ $runMonitoring.pollIntervalSeconds }}
+    {{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2055,6 +2055,10 @@
                 },
                 "annotations": {
                     "$ref": "#/definitions/Annotations"
+                },
+                "runMonitoring": {
+                    "title": "Runmonitoring",
+                    "type": "object"
                 }
             },
             "required": [
@@ -2073,7 +2077,8 @@
                 "resources",
                 "livenessProbe",
                 "startupProbe",
-                "annotations"
+                "annotations",
+                "runMonitoring"
             ]
         },
         "Busybox": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -343,7 +343,6 @@ runLauncher:
   config:
     # This configuration will only be used if the K8sRunLauncher is selected
     k8sRunLauncher:
-
       # Change with caution! If you're using a fixed tag for pipeline run images, changing the
       # image pull policy to anything other than "Always" will use a cached/stale image, which is
       # almost certainly not what you want.
@@ -412,7 +411,6 @@ runLauncher:
       #     mountPath: /opt/dagster/test_folder
       #     subPath: test_file.yaml
       volumeMounts: []
-
 
     # This configuration will only be used if the CeleryK8sRunLauncher is selected
     celeryK8sRunLauncher:
@@ -832,6 +830,19 @@ dagsterDaemon:
     #     module: ~
     #     class: ~
     #     config: {}
+
+  # Experimental feature to add fault tolerance to Dagster runs. The new Monitoring Daemon will
+  # perform health checks on run workers. If a run doesn't start within the timeout, it will be
+  # marked as failed. If a run had started but then the run worker crashed, the daemon will attempt
+  # to resume the run with a new run worker.
+  runMonitoring:
+    enabled: false
+    # Timeout for runs to start (avoids runs hanging in STARTED)
+    startTimeoutSeconds: 180
+    # Max number of times to attempt to resume a run with a new run worker
+    maxResumeRunAttempts: 3
+    # How often to check on in progress runs
+    pollIntervalSeconds: 120
 
   # Additional environment variables to set.
   # A Kubernetes ConfigMap will be created with these environment variables. See:

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
@@ -314,6 +314,7 @@ def dagster_instance_for_k8s_run_launcher(
         compute_log_manager=NoOpComputeLogManager(),
         run_coordinator=DefaultRunCoordinator(),
         run_launcher=run_launcher,
+        settings={"run_monitoring": {"enabled": True}},
     ) as instance:
         yield instance
 

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_k8s_monitoring.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_k8s_monitoring.py
@@ -1,0 +1,103 @@
+import os
+import time
+
+import pytest
+from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.test_utils import create_run_for_test, poll_for_finished_run
+from dagster.utils import load_yaml_from_path, merge_dicts
+from dagster_k8s.job import get_job_name_from_run_id
+from dagster_k8s.utils import delete_job
+from dagster_k8s_test_infra.helm import TEST_AWS_CONFIGMAP_NAME
+from dagster_k8s_test_infra.integration_utils import image_pull_policy
+from dagster_test.test_project import (
+    IS_BUILDKITE,
+    ReOriginatedExternalPipelineForTest,
+    get_test_project_environments_path,
+    get_test_project_external_pipeline_hierarchy,
+)
+
+
+def log_run_events(instance, run_id):
+    for log in instance.all_logs(run_id):
+        print(str(log) + "\n")  # pylint: disable=print-call
+
+
+@pytest.mark.integration
+def test_k8s_run_monitoring(
+    dagster_instance_for_k8s_run_launcher,
+    helm_namespace_for_k8s_run_launcher,
+    dagster_docker_image,
+):
+    run_config = merge_dicts(
+        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
+        {
+            "execution": {
+                "k8s": {
+                    "config": {
+                        "job_namespace": helm_namespace_for_k8s_run_launcher,
+                        "image_pull_policy": image_pull_policy(),
+                        "env_config_maps": ["dagster-pipeline-env"]
+                        + ([TEST_AWS_CONFIGMAP_NAME] if not IS_BUILDKITE else []),
+                    }
+                }
+            },
+        },
+    )
+    _launch_run_and_wait_for_resume(
+        run_config,
+        dagster_instance_for_k8s_run_launcher,
+        helm_namespace_for_k8s_run_launcher,
+        dagster_docker_image=dagster_docker_image,
+    )
+
+
+def _launch_run_and_wait_for_resume(
+    run_config,
+    instance,
+    namespace,
+    pipeline_name="slow_pipeline",
+    dagster_docker_image=None,
+):
+    tags = {"key": "value"}
+
+    with get_test_project_external_pipeline_hierarchy(instance, pipeline_name) as (
+        workspace,
+        location,
+        _repo,
+        external_pipeline,
+    ):
+        reoriginated_pipeline = ReOriginatedExternalPipelineForTest(
+            external_pipeline, container_image=dagster_docker_image
+        )
+        run = create_run_for_test(
+            instance,
+            pipeline_name=pipeline_name,
+            run_config=run_config,
+            tags=tags,
+            mode="k8s",
+            pipeline_snapshot=external_pipeline.pipeline_snapshot,
+            execution_plan_snapshot=location.get_external_execution_plan(
+                external_pipeline, run_config, "k8s", None, None
+            ).execution_plan_snapshot,
+            external_pipeline_origin=reoriginated_pipeline.get_external_origin(),
+            pipeline_code_origin=reoriginated_pipeline.get_python_origin(),
+        )
+
+        try:
+            instance.launch_run(run.run_id, workspace)
+
+            start_time = time.time()
+            while time.time() - start_time < 60:
+                run = instance.get_run_by_id(run.run_id)
+                if run.status == PipelineRunStatus.STARTED:
+                    break
+                assert run.status == PipelineRunStatus.STARTING
+                time.sleep(1)
+
+            time.sleep(5)
+            assert delete_job(get_job_name_from_run_id(run.run_id), namespace)
+
+            poll_for_finished_run(instance, run.run_id, timeout=120)
+            assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+        finally:
+            log_run_events(instance, run.run_id)

--- a/python_modules/dagster-test/Dockerfile
+++ b/python_modules/dagster-test/Dockerfile
@@ -34,6 +34,9 @@ RUN pip install \
 
 RUN ! (pip list --exclude-editable | grep -e dagster -e dagit)
 
+# Force pypi to avoid a conflict between various dagster deps
+RUN pip install 'pyparsing<3.0.0' --force-reinstall
+
 WORKDIR /dagster_test/test_project/
 
 EXPOSE 80

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -89,6 +89,16 @@ class ResumeRunArgs(namedtuple("_ResumeRunArgs", "pipeline_origin pipeline_run_i
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
         )
 
+    def get_command_args(self) -> List[str]:
+        return [
+            self.pipeline_origin.executable_path,
+            "-m",
+            "dagster",
+            "api",
+            "resume_run",
+            serialize_dagster_namedtuple(self),
+        ]
+
 
 @whitelist_for_serdes
 class ExecuteExternalPipelineArgs(

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -3,6 +3,7 @@ import re
 import pytest
 import yaml
 from dagster import PipelineDefinition, check, execute_pipeline, pipeline, solid
+from dagster.check import CheckError
 from dagster.config import Field
 from dagster.core.errors import (
     DagsterHomeNotSetError,
@@ -138,6 +139,7 @@ def test_get_required_daemon_types():
         SensorDaemon,
         BackfillDaemon,
         SchedulerDaemon,
+        MonitoringDaemon,
     )
 
     with instance_for_test() as instance:
@@ -146,6 +148,60 @@ def test_get_required_daemon_types():
             BackfillDaemon.daemon_type(),
             SchedulerDaemon.daemon_type(),
         ]
+
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_tests.daemon_tests.test_monitoring_daemon",
+                "class": "TestRunLauncher",
+            },
+            "run_monitoring": {"enabled": True},
+        }
+    ) as instance:
+        assert instance.get_required_daemon_types() == [
+            SensorDaemon.daemon_type(),
+            BackfillDaemon.daemon_type(),
+            SchedulerDaemon.daemon_type(),
+            MonitoringDaemon.daemon_type(),
+        ]
+
+
+def test_run_monitoring():
+    with pytest.raises(CheckError):
+        with instance_for_test(
+            overrides={
+                "run_monitoring": {"enabled": True},
+            }
+        ):
+            pass
+
+    settings = {"enabled": True}
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_tests.daemon_tests.test_monitoring_daemon",
+                "class": "TestRunLauncher",
+            },
+            "run_monitoring": settings,
+        }
+    ) as instance:
+        assert instance.run_monitoring_enabled
+        assert instance.run_monitoring_settings == settings
+        assert instance.run_monitoring_max_resume_run_attempts == 3
+
+    settings = {"enabled": True, "max_resume_run_attempts": 5}
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster_tests.daemon_tests.test_monitoring_daemon",
+                "class": "TestRunLauncher",
+            },
+            "run_monitoring": settings,
+        }
+    ) as instance:
+        assert instance.run_monitoring_enabled
+        assert instance.run_monitoring_settings == settings
+        assert instance.run_monitoring_max_resume_run_attempts == 5
 
 
 def test_dagster_home_not_set():

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -147,7 +147,11 @@ def test_monitor_started(instance, workspace, logger):
     assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
     assert instance.run_launcher.launch_run_calls == 2
 
+    monitor_started_run(instance, workspace, run, logger)
+    assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
+    assert instance.run_launcher.launch_run_calls == 3
+
     # exausted the 3 attempts
     monitor_started_run(instance, workspace, run, logger)
     assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
-    assert instance.run_launcher.launch_run_calls == 2
+    assert instance.run_launcher.launch_run_calls == 3

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -175,8 +175,10 @@ def get_user_defined_k8s_config(tags):
     )
 
 
-def get_job_name_from_run_id(run_id):
-    return "dagster-run-{}".format(run_id)
+def get_job_name_from_run_id(run_id, resume_attempt_number=None):
+    return "dagster-run-{}".format(run_id) + (
+        "" if not resume_attempt_number else "-{}".format(resume_attempt_number)
+    )
 
 
 @whitelist_for_serdes


### PR DESCRIPTION
Add support for the monitoring daemon on dagster-k8s. This entails:
- support resume_run and check_run_worker_health on the launcher
- helm support
- integration tests

This diff has exposed a gap in the check_run_worker_health API that can be fixed in a later diff- that api should include the resume attempt number. Here, we recalculate that unnecessarily.