### PR TITLE
Fix bug in k8s executor retry

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -418,7 +418,7 @@ def define_step_retry_pipeline():
 
         raise RetryRequested()
 
-    @pipeline(mode_defs=celery_mode_defs())
+    @pipeline(mode_defs=celery_mode_defs() + k8s_mode_defs(name="k8s"))
     def retry_pipeline():
         fail_first_time()
 

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
@@ -55,7 +55,7 @@ class StepDelegatingExecutor(Executor):
                 pipeline_run_id=plan_context.pipeline_run.run_id,
                 step_keys_to_execute=[step.key for step in steps],
                 instance_ref=plan_context.plan_data.instance.get_ref(),
-                retry_mode=self.retries,
+                retry_mode=self.retries.for_inner_plan(),
                 known_state=active_execution.get_known_state(),
             ),
             step_tags={step.key: step.tags for step in steps},

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -140,6 +140,21 @@ class K8sStepHandler(StepHandler):
     def _batch_api(self):
         return self._fixed_k8s_client_batch_api or kubernetes.client.BatchV1Api()
 
+    def _get_k8s_step_job_name(self, step_handler_context):
+        step_key = step_handler_context.execute_step_args.step_keys_to_execute[0]
+
+        name_key = get_k8s_job_name(
+            step_handler_context.execute_step_args.pipeline_run_id,
+            step_key,
+        )
+
+        if step_handler_context.execute_step_args.known_state:
+            retry_state = step_handler_context.execute_step_args.known_state.get_retry_state()
+            if retry_state.get_attempt_count(step_key):
+                return "dagster-job-%s-%d" % (name_key, retry_state.get_attempt_count(step_key))
+
+        return "dagster-job-%s" % (name_key)
+
     def launch_step(self, step_handler_context: StepHandlerContext):
         events = []
 
@@ -148,12 +163,8 @@ class K8sStepHandler(StepHandler):
         ), "Launching multiple steps is not currently supported"
         step_key = step_handler_context.execute_step_args.step_keys_to_execute[0]
 
-        k8s_name_key = get_k8s_job_name(
-            step_handler_context.execute_step_args.pipeline_run_id,
-            step_key,
-        )
-        job_name = "dagster-job-%s" % (k8s_name_key)
-        pod_name = "dagster-job-%s" % (k8s_name_key)
+        job_name = self._get_k8s_step_job_name(step_handler_context)
+        pod_name = job_name
 
         args = step_handler_context.execute_step_args.get_command_args()
 
@@ -204,11 +215,7 @@ class K8sStepHandler(StepHandler):
         ), "Launching multiple steps is not currently supported"
         step_key = step_handler_context.execute_step_args.step_keys_to_execute[0]
 
-        k8s_name_key = get_k8s_job_name(
-            step_handler_context.execute_step_args.pipeline_run_id,
-            step_key,
-        )
-        job_name = "dagster-job-%s" % (k8s_name_key)
+        job_name = self._get_k8s_step_job_name(step_handler_context)
 
         job = self._batch_api.read_namespaced_job(namespace=self._job_namespace, name=job_name)
         if job.status.failed:
@@ -230,13 +237,8 @@ class K8sStepHandler(StepHandler):
         assert (
             len(step_handler_context.execute_step_args.step_keys_to_execute) == 1
         ), "Launching multiple steps is not currently supported"
-        step_key = step_handler_context.execute_step_args.step_keys_to_execute[0]
 
-        k8s_name_key = get_k8s_job_name(
-            step_handler_context.execute_step_args.pipeline_run_id,
-            step_key,
-        )
-        job_name = "dagster-job-%s" % (k8s_name_key)
+        job_name = self._get_k8s_step_job_name(step_handler_context)
 
         delete_job(job_name=job_name, namespace=self._job_namespace)
         return []


### PR DESCRIPTION
The k8s executor wasn't using the retry count in step job names. As a result, retries would fail with `jobs.batch \"dagster-job-0f8371e68cd5df2c19e77af087e2802d\" already exists`. Add proper support for retries.

Added retry test, checked that it failed before this change.