### PR TITLE
Always pass through executable path to ReconstructablePipeline

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -175,6 +175,7 @@ class ReOriginatedExternalPipelineForTest(ExternalPipeline):
                             fn_name="define_demo_execution_repo",
                         ),
                         container_image=self._container_image,
+                        executable_path="python",
                     )
                 ),
                 repository_name="demo_execution_repo",
@@ -210,7 +211,9 @@ class ReOriginatedExternalScheduleForTest(ExternalSchedule):
                         pointer=FileCodePointer(
                             python_file="/dagster_test/test_project/test_pipelines/repo.py",
                             fn_name="define_demo_execution_repo",
-                        )
+                        ),
+                        container_image=self._container_image,
+                        executable_path="python",
                     )
                 ),
                 repository_name="demo_execution_repo",

--- a/python_modules/dagster/dagster/core/definitions/reconstructable.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstructable.py
@@ -28,17 +28,19 @@ def get_ephemeral_repository_name(pipeline_name):
 
 @whitelist_for_serdes
 class ReconstructableRepository(
-    namedtuple("_ReconstructableRepository", "pointer container_image")
+    namedtuple("_ReconstructableRepository", "pointer container_image executable_path")
 ):
     def __new__(
         cls,
         pointer,
         container_image=None,
+        executable_path=None,
     ):
         return super(ReconstructableRepository, cls).__new__(
             cls,
             pointer=check.inst_param(pointer, "pointer", CodePointer),
             container_image=check.opt_str_param(container_image, "container_image"),
+            executable_path=check.opt_str_param(executable_path, "executable_path"),
         )
 
     @lru_cache(maxsize=1)
@@ -66,7 +68,7 @@ class ReconstructableRepository(
 
     def get_python_origin(self):
         return RepositoryPythonOrigin(
-            executable_path=sys.executable,
+            executable_path=self.executable_path if self.executable_path else sys.executable,
             code_pointer=self.pointer,
             container_image=self.container_image,
         )

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -135,6 +135,8 @@ def step_context_to_step_run_ref(
                         ),
                         recon_pipeline.repository.pointer.fn_name,
                     ),
+                    container_image=recon_pipeline.repository.container_image,
+                    executable_path=recon_pipeline.repository.executable_path,
                 ),
                 pipeline_name=recon_pipeline.pipeline_name,
                 solids_to_execute=recon_pipeline.solids_to_execute,

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -298,6 +298,7 @@ class DagsterApiServer(DagsterApiServicer):
                 external_repository_origin.repository_name
             ],
             self._get_current_image(),
+            sys.executable,
         )
 
     def _recon_pipeline_from_origin(self, external_pipeline_origin):

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -66,6 +66,8 @@ class ExecuteRunArgs(namedtuple("_ExecuteRunArgs", "pipeline_origin pipeline_run
 
     def get_command_args(self) -> List[str]:
         return [
+            self.pipeline_origin.executable_path,
+            "-m",
             "dagster",
             "api",
             "execute_run",
@@ -89,6 +91,8 @@ class ResumeRunArgs(namedtuple("_ResumeRunArgs", "pipeline_origin pipeline_run_i
 
     def get_command_args(self) -> List[str]:
         return [
+            self.pipeline_origin.executable_path,
+            "-m",
             "dagster",
             "api",
             "resume_run",
@@ -150,6 +154,8 @@ class ExecuteStepArgs(
 
     def get_command_args(self) -> List[str]:
         return [
+            self.pipeline_origin.executable_path,
+            "-m",
             "dagster",
             "api",
             "execute_step",

--- a/python_modules/dagster/dagster/utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/utils/hosted_user_process.py
@@ -27,15 +27,13 @@ def recon_pipeline_from_origin(origin):
 
 def recon_repository_from_origin(origin):
     check.inst_param(origin, "origin", RepositoryPythonOrigin)
-    return ReconstructableRepository(origin.code_pointer, origin.container_image)
+    return ReconstructableRepository(
+        origin.code_pointer, origin.container_image, origin.executable_path
+    )
 
 
 def external_repo_from_def(repository_def, repository_handle):
     return ExternalRepository(external_repository_data_from_def(repository_def), repository_handle)
-
-
-def recon_repo_from_external_repo(external_repo):
-    return ReconstructableRepository(external_repo.get_python_origin().code_pointer)
 
 
 def external_pipeline_from_recon_pipeline(recon_pipeline, solid_selection, repository_handle):


### PR DESCRIPTION
Summary:
We missed a path where it was possible to lose track of the exeuctable path when launching a run and switch back to sys.executable. This diff ensures that every time we construct a ReconstructablePipeline from a PipelinePythonOrigin (e.g. in the run worker), it passes through the executable path if executable.

This allows us to bring back the codepath that - but I think we probably want to get a test up and running that explicitly checks that an executable path that is different than sys.executable is actually passed all the way through.

Test Plan: Canary test now passes

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.