### PR TITLE
[crag-core][PipelineRun 1/ ] PipelineRun -> DagsterRun

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -178,7 +178,7 @@ from dagster.core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_
 from dagster.core.storage.io_manager import IOManager, IOManagerDefinition, io_manager
 from dagster.core.storage.mem_io_manager import mem_io_manager
 from dagster.core.storage.memoizable_io_manager import MemoizableIOManager
-from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, DagsterRun
+from dagster.core.storage.pipeline_run import DagsterRun, PipelineRun, PipelineRunStatus
 from dagster.core.storage.root_input_manager import (
     RootInputManager,
     RootInputManagerDefinition,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -178,7 +178,7 @@ from dagster.core.storage.fs_io_manager import custom_path_fs_io_manager, fs_io_
 from dagster.core.storage.io_manager import IOManager, IOManagerDefinition, io_manager
 from dagster.core.storage.mem_io_manager import mem_io_manager
 from dagster.core.storage.memoizable_io_manager import MemoizableIOManager
-from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, DagsterRun
 from dagster.core.storage.root_input_manager import (
     RootInputManager,
     RootInputManagerDefinition,
@@ -325,6 +325,7 @@ __all__ = [
     "OutputContext",
     "build_output_context",
     "PipelineRun",
+    "DagsterRun",
     "PipelineRunStatus",
     "default_executors",
     "execute_pipeline_iterator",

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -36,8 +36,8 @@ from dagster.core.errors import (
 )
 from dagster.core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
-    PipelineRun,
     DagsterRun,
+    PipelineRun,
     PipelineRunStatsSnapshot,
     PipelineRunStatus,
     PipelineRunsFilter,

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -37,6 +37,7 @@ from dagster.core.errors import (
 from dagster.core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     PipelineRun,
+    DagsterRun,
     PipelineRunStatsSnapshot,
     PipelineRunStatus,
     PipelineRunsFilter,
@@ -817,7 +818,7 @@ class DagsterInstance:
             else None
         )
 
-        return PipelineRun(
+        return DagsterRun(
             pipeline_name=pipeline_name,
             run_id=run_id,
             run_config=run_config,

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -2,7 +2,7 @@ import warnings
 from collections import namedtuple
 from datetime import datetime
 from enum import Enum
-from typing import NamedTuple, Dict, Any
+from typing import Any, Dict, NamedTuple
 
 from dagster import check
 from dagster.core.origin import PipelinePythonOrigin
@@ -10,9 +10,9 @@ from dagster.core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
 from dagster.core.utils import make_new_run_id
 from dagster.serdes import (
     DefaultNamedTupleSerializer,
+    register_serdes_tuple_fallbacks,
     unpack_inner_value,
     whitelist_for_serdes,
-    register_serdes_tuple_fallbacks,
 )
 from dagster.serdes.serdes import WhitelistMap
 

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -196,7 +196,7 @@ def pipeline_run_from_storage(
             "Found unhandled arguments from stored PipelineRun: {args}".format(args=kwargs.keys())
         )
 
-    return PipelineRun(  # pylint: disable=redundant-keyword-arg
+    return DagsterRun(  # pylint: disable=redundant-keyword-arg
         pipeline_name=pipeline_name,
         run_id=run_id,
         run_config=run_config,
@@ -373,6 +373,14 @@ class PipelineRun(
     @staticmethod
     def tags_for_partition_set(partition_set, partition):
         return {PARTITION_NAME_TAG: partition.name, PARTITION_SET_TAG: partition_set.name}
+
+
+class DagsterRun(PipelineRun):
+    """Serializable internal representation of a dagster run, as stored in a
+    :py:class:`~dagster.core.storage.runs.RunStorage`.
+
+    Subclasses PipelineRun for backcompat purposes. DagsterRun is the actual initialized class used throughout the system.
+    """
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -16,7 +16,7 @@ from dagster.core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
 from dagster.core.snap import create_pipeline_snapshot_id
-from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, PipelineRunsFilter
+from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus, PipelineRunsFilter
 from dagster.core.storage.runs.migration import RUN_DATA_MIGRATIONS
 from dagster.core.storage.runs.sql_run_storage import SqlRunStorage
 from dagster.core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
@@ -82,7 +82,7 @@ class TestRunStorage:
         root_run_id=None,
         pipeline_snapshot_id=None,
     ):
-        return PipelineRun(
+        return DagsterRun(
             pipeline_name=pipeline_name,
             run_id=run_id,
             run_config=None,
@@ -693,7 +693,7 @@ class TestRunStorage:
             pytest.skip("storage cannot delete")
 
         run_id = "some_run_id"
-        run = PipelineRun(run_id=run_id, pipeline_name="a_pipeline", tags={"foo": "bar"})
+        run = DagsterRun(run_id=run_id, pipeline_name="a_pipeline", tags={"foo": "bar"})
 
         storage.add_run(run)
 
@@ -708,7 +708,7 @@ class TestRunStorage:
         double_run_id = "double_run_id"
         pipeline_def = PipelineDefinition(name="some_pipeline", solid_defs=[])
 
-        run = PipelineRun(run_id=double_run_id, pipeline_name=pipeline_def.name)
+        run = DagsterRun(run_id=double_run_id, pipeline_name=pipeline_def.name)
 
         assert storage.add_run(run)
         with pytest.raises(DagsterRunAlreadyExists):
@@ -739,7 +739,7 @@ class TestRunStorage:
 
         pipeline_snapshot_id = create_pipeline_snapshot_id(pipeline_snapshot)
 
-        run_with_snapshot = PipelineRun(
+        run_with_snapshot = DagsterRun(
             run_id=run_with_snapshot_id,
             pipeline_name=pipeline_def.name,
             pipeline_snapshot_id=pipeline_snapshot_id,
@@ -768,7 +768,7 @@ class TestRunStorage:
         run_with_snapshot_id = "lkasjdflkjasdf"
         pipeline_def = PipelineDefinition(name="some_pipeline", solid_defs=[])
 
-        run_with_missing_snapshot = PipelineRun(
+        run_with_missing_snapshot = DagsterRun(
             run_id=run_with_snapshot_id,
             pipeline_name=pipeline_def.name,
             pipeline_snapshot_id="nope",

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -17,7 +17,6 @@ from dagster import (
     solid,
 )
 from dagster.cli.debug import DebugRunPayload
-from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus
 from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.errors import DagsterInstanceMigrationRequired
 from dagster.core.events import DagsterEvent
@@ -25,6 +24,7 @@ from dagster.core.events.log import EventLogEntry
 from dagster.core.instance import DagsterInstance, InstanceRef
 from dagster.core.storage.event_log.migration import migrate_event_log_data
 from dagster.core.storage.event_log.sql_event_log import SqlEventLogStorage
+from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus
 from dagster.serdes.serdes import (
     WhitelistMap,
     _deserialize_json,

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -17,6 +17,7 @@ from dagster import (
     solid,
 )
 from dagster.cli.debug import DebugRunPayload
+from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus
 from dagster.core.definitions.dependency import NodeHandle
 from dagster.core.errors import DagsterInstanceMigrationRequired
 from dagster.core.events import DagsterEvent
@@ -527,3 +528,30 @@ def test_solid_handle_node_handle():
     result = _deserialize_json(test_str, legacy_env)
     assert isinstance(result, SolidHandle)
     assert result.name == test_handle.name
+
+
+def test_pipeline_run_dagster_run():
+    # serialize in current code
+    test_run = DagsterRun(pipeline_name="test")
+    test_str = serialize_dagster_namedtuple(test_run)
+
+    # deserialize in "legacy" code
+    legacy_env = WhitelistMap.create()
+
+    @_whitelist_for_serdes(legacy_env)
+    class PipelineRun(
+        namedtuple(
+            "_PipelineRun",
+            "pipeline_name run_id run_config mode solid_selection solids_to_execute "
+            "step_keys_to_execute status tags root_run_id parent_run_id "
+            "pipeline_snapshot_id execution_plan_snapshot_id external_pipeline_origin "
+            "pipeline_code_origin",
+        )
+    ):
+        pass
+
+    _whitelist_for_serdes(legacy_env)(PipelineRunStatus)
+
+    result = _deserialize_json(test_str, legacy_env)
+    assert isinstance(result, PipelineRun)
+    assert result.pipeline_name == test_run.pipeline_name

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -27,7 +27,7 @@ from dagster.core.execution.resources_init import (
     resource_initialization_event_generator,
 )
 from dagster.core.instance import DagsterInstance
-from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus
 from dagster.core.system_config.objects import ResolvedRunConfig
 from dagster.core.utils import make_new_run_id
 from dagster.loggers import colored_console_logger
@@ -236,7 +236,7 @@ class Manager:
         # construct stubbed PipelineRun for notebook exploration...
         # The actual pipeline run during pipeline execution will be serialized and reconstituted
         # in the `reconstitute_pipeline_context` call
-        pipeline_run = PipelineRun(
+        pipeline_run = DagsterRun(
             pipeline_name=pipeline_def.name,
             run_id=run_id,
             run_config=run_config,


### PR DESCRIPTION
This will break folks who, for whatever reason, are creating their own PipelineRun. It keeps compatibility for people using PipelineRun for instance checks or type annotations.