### PR TITLE
docs search: use next public env vars instead of hardcoding

### DIFF
--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -119,9 +119,6 @@ export function Search() {
             indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME}
             apiKey={process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}
             appId={process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}
-            indexName="Testing"
-            apiKey="991c27897aafec73e6eff85912eed810"
-            appId="CTO1CV9T4R"
             navigator={{
               navigate({ itemUrl }) {
                 setIsOpen(false);

--- a/docs/next/components/Search.tsx
+++ b/docs/next/components/Search.tsx
@@ -65,7 +65,7 @@ export function Search() {
       <Head>
         <link
           rel="preconnect"
-          href="https://CTO1CV9T4R-dsn.algolia.net"
+          href={`https://${process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}-dsn.algolia.net`}
           crossOrigin="true"
         />
       </Head>
@@ -116,6 +116,9 @@ export function Search() {
               distinct: 1,
             }}
             onClose={onClose}
+            indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME}
+            apiKey={process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}
+            appId={process.env.NEXT_PUBLIC_ALGOLIA_APP_ID}
             indexName="Testing"
             apiKey="991c27897aafec73e6eff85912eed810"
             appId="CTO1CV9T4R"


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

although it's safe to expose the algolia search-only (i.e. read-only) api, when it's hardcoded inside the code, it becomes hard to update config in algolia - for example, renaming "Testing" to something else requires to check in code changes as opposed to just config changes.
 
same procedure as https://github.com/dagster-io/internal/pull/487



## Test Plan
wait to see if the preview's search works



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.