### PR TITLE
Helm ingress template compatible with k8s v1.22

### DIFF
--- a/helm/dagster/schema/schema_tests/test_ingress.py
+++ b/helm/dagster/schema/schema_tests/test_ingress.py
@@ -1,5 +1,5 @@
 import pytest
-from kubernetes.client import models
+from kubernetes.client.models import V1Ingress
 from schema.charts.dagster.subschema.dagit import Dagit
 from schema.charts.dagster.subschema.ingress import (
     DagitIngressConfiguration,
@@ -18,7 +18,7 @@ def helm_template() -> HelmTemplate:
         helm_dir_path="helm/dagster",
         subchart_paths=["charts/dagster-user-deployments"],
         output="templates/ingress.yaml",
-        model=models.ExtensionsV1beta1Ingress,
+        model=V1Ingress,
     )
 
 

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -191,3 +191,13 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
 DAGSTER_K8S_PIPELINE_RUN_IMAGE: {{ include "dagster.dagsterImage.name" (list $ .Values.pipelineRun.image) | quote }}
 DAGSTER_K8S_PIPELINE_RUN_IMAGE_PULL_POLICY: "{{ .Values.pipelineRun.image.pullPolicy }}"
 {{- end -}}
+
+{{/* Allow Kubernetes Version to be overridden. Credit to https://github.com/prometheus-community/helm-charts for Regex. */}}
+{{- define "kubeVersion" -}}
+  {{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+  {{/* Special use case for Amazon EKS, Google GKE */}}
+  {{- if and (regexMatch "\\d+\\.\\d+\\.\\d+-(?:eks|gke).+" $kubeVersion) (not .Values.kubeVersionOverride) -}}
+    {{- $kubeVersion = regexFind "\\d+\\.\\d+\\.\\d+" $kubeVersion -}}
+  {{- end -}}
+  {{- $kubeVersion -}}
+{{- end -}}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -201,3 +201,13 @@ DAGSTER_K8S_PIPELINE_RUN_IMAGE_PULL_POLICY: "{{ .Values.pipelineRun.image.pullPo
   {{- end -}}
   {{- $kubeVersion -}}
 {{- end -}}
+
+{{/* Assigns an ingress path port to the correct key based on its type */}}
+{{- define "ingress.service.port" -}}
+  {{- $portType := typeOf .servicePort }}
+  {{- if eq $portType "string" }}
+  name: {{ .servicePort }}
+  {{- else }}
+  number: {{ .servicePort }}
+  {{- end }}
+{{- end }}

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -52,7 +52,13 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
-                port: {{ .servicePort }}
+                port:
+                  {{- $portType := typeOf .servicePort }}
+                  {{- if eq $portType "string" }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ .servicePort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -81,7 +87,13 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
-                port: {{ .servicePort }}
+                port:
+                  {{- $portType := typeOf .servicePort }}
+                  {{- if eq $portType "string" }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ .servicePort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -100,7 +112,13 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
-                port: {{ .servicePort }}
+                port:
+                  {{- $portType := typeOf .servicePort }}
+                  {{- if eq $portType "string" }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ .servicePort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -129,7 +147,13 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
-                port: {{ .servicePort }}
+                port:
+                  {{- $portType := typeOf .servicePort }}
+                  {{- if eq $portType "string" }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ .servicePort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -149,7 +173,13 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
-                port: {{ .servicePort }}
+                port:
+                  {{- $portType := typeOf .servicePort }}
+                  {{- if eq $portType "string" }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ .servicePort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -163,7 +193,8 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ template "dagster.fullname" . }}-flower-service
-                port: {{ .Values.flower.service.port }}
+                port:
+                  number: {{ .Values.flower.service.port }}
               {{- else }}
               serviceName: {{ template "dagster.fullname" . }}-flower-service
               servicePort: {{ .Values.flower.service.port }}
@@ -177,7 +208,13 @@ spec:
               {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
-                port: {{ .servicePort }}
+                port:
+                  {{- $portType := typeOf .servicePort }}
+                  {{- if eq $portType "string" }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ .servicePort }}
+                  {{- end }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -1,5 +1,15 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+# See: https://github.com/apache/airflow/blob/main/chart/templates/webserver/webserver-ingress.yaml
+#      https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+{{- $apiIsStable := semverCompare ">= 1.19.x" (include "kubeVersion" .) -}}
+{{- $dagitPathType := .Values.ingress.dagit.pathType | default "Prefix"}}
+{{- $readOnlyDagitPathType := .Values.ingress.readOnlyDagit.pathType | default "Prefix"}}
+{{- $flowerPathType := .Values.ingress.flower.pathType | default "Prefix"}}
+{{- if $apiIsStable }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "dagster.fullname" . }}-ingress
@@ -10,7 +20,9 @@ metadata:
     {{ $key }}: {{ $value | squote }}
     {{- end }}
 spec:
-  # See: https://github.com/helm/charts/blob/master/stable/airflow/templates/ingress-web.yaml
+  {{- if and .Values.ingress.ingressClassName $apiIsStable }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   tls:
     {{- if .Values.ingress.dagit.tls.enabled }}
     - hosts:
@@ -33,19 +45,47 @@ spec:
         paths:
           {{- range .Values.ingress.dagit.precedingPaths }}
           - path: {{ .path }}
+            {{- if $apiIsStable }}
+            pathType: {{ $dagitPathType }}
+            {{- end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .serviceName }}
+                port: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
           - path: {{ .Values.ingress.dagit.path | default "/*" }}
+            {{ if $apiIsStable }}
+            pathType: {{ $dagitPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ include "dagster.dagit.fullname" . }}
+                port:
+                  number: {{ .Values.dagit.service.port | default 80 }}
+              {{- else }}
               serviceName: {{ include "dagster.dagit.fullname" . }}
               servicePort: {{ .Values.dagit.service.port | default 80 }}
+              {{- end }}
           {{- range .Values.ingress.dagit.succeedingPaths }}
           - path: {{ .path }}
+            {{ if $apiIsStable }}
+            pathType: {{ $dagitPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .serviceName }}
+                port: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
     {{- if .Values.dagit.enableReadOnly }}
     - host: {{ .Values.ingress.readOnlyDagit.host }}
@@ -53,19 +93,47 @@ spec:
         paths:
           {{- range .Values.ingress.readOnlyDagit.precedingPaths }}
           - path: {{ .path }}
+            {{ if $apiIsStable }}
+            pathType: {{ $readOnlyDagitPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .serviceName }}
+                port: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
           - path: {{ .Values.ingress.readOnlyDagit.path | default "/*" }}
+            {{ if $apiIsStable }}
+            pathType: {{ $readOnlyDagitPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ template "dagster.dagit.fullname" dict "Values" .Values "Release" .Release "dagitReadOnly" true }}
+                port:
+                  number: {{ .Values.dagit.service.port | default 80 }}
+              {{- else }}
               serviceName: {{ template "dagster.dagit.fullname" dict "Values" .Values "Release" .Release "dagitReadOnly" true }}
               servicePort: {{ .Values.dagit.service.port | default 80 }}
+              {{- end }}
           {{- range .Values.ingress.readOnlyDagit.succeedingPaths }}
           - path: {{ .path }}
+            {{ if $apiIsStable }}
+            pathType: {{ $readOnlyDagitPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .serviceName }}
+                port: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
     {{end}}
     {{- if .Values.flower.enabled }}
@@ -74,19 +142,46 @@ spec:
         paths:
           {{- range .Values.ingress.flower.precedingPaths }}
           - path: {{ .path }}
+            {{ if $apiIsStable }}
+            pathType: {{ $flowerPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .serviceName }}
+                port: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
           - path: {{ .Values.ingress.flower.path | default "/*" }}
+            {{ if $apiIsStable }}
+            pathType: {{ $flowerPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ template "dagster.fullname" . }}-flower-service
+                port: {{ .Values.flower.service.port }}
+              {{- else }}
               serviceName: {{ template "dagster.fullname" . }}-flower-service
               servicePort: {{ .Values.flower.service.port }}
+              {{- end }}
           {{- range .Values.ingress.flower.succeedingPaths }}
           - path: {{ .path }}
+            {{ if $apiIsStable }}
+            pathType: {{ $flowerPathType }}
+            {{ end }}
             backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ .serviceName }}
+                port: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
     {{end}}
 {{end}}

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -53,12 +53,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  {{- $portType := typeOf .servicePort }}
-                  {{- if eq $portType "string" }}
-                  name: {{ .servicePort }}
-                  {{- else }}
-                  number: {{ .servicePort }}
-                  {{- end }}
+                  {{- include "ingress.service.port" . | indent 16 }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -88,12 +83,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  {{- $portType := typeOf .servicePort }}
-                  {{- if eq $portType "string" }}
-                  name: {{ .servicePort }}
-                  {{- else }}
-                  number: {{ .servicePort }}
-                  {{- end }}
+                  {{- include "ingress.service.port" . | indent 16 }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -113,12 +103,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  {{- $portType := typeOf .servicePort }}
-                  {{- if eq $portType "string" }}
-                  name: {{ .servicePort }}
-                  {{- else }}
-                  number: {{ .servicePort }}
-                  {{- end }}
+                  {{- include "ingress.service.port" . | indent 16 }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -148,12 +133,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  {{- $portType := typeOf .servicePort }}
-                  {{- if eq $portType "string" }}
-                  name: {{ .servicePort }}
-                  {{- else }}
-                  number: {{ .servicePort }}
-                  {{- end }}
+                  {{- include "ingress.service.port" . | indent 16 }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -174,12 +154,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  {{- $portType := typeOf .servicePort }}
-                  {{- if eq $portType "string" }}
-                  name: {{ .servicePort }}
-                  {{- else }}
-                  number: {{ .servicePort }}
-                  {{- end }}
+                  {{- include "ingress.service.port" . | indent 16 }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
@@ -209,12 +184,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  {{- $portType := typeOf .servicePort }}
-                  {{- if eq $portType "string" }}
-                  name: {{ .servicePort }}
-                  {{- else }}
-                  number: {{ .servicePort }}
-                  {{- end }}
+                  {{- include "ingress.service.port" . | indent 16 }}
               {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -690,12 +690,17 @@ ingress:
 
   annotations: {}
 
+  # Specify ingressClassName for Kubernetes >= 1.19
+  ingressClassName: ""
+
   dagit:
     # Ingress hostname for Dagit e.g. dagit.mycompany.com
     # This variable allows customizing the route pattern in the ingress. Some
     # ingress controllers may only support "/", whereas some may need "/*".
     # NOTE: Dagit doesn't yet support hosting on a path, e.g. mycompany.com/dagit.
     path: "/*"
+    # pathType is only for k8s >= 1.19
+    pathType: Prefix
     # NOTE: do NOT keep trailing slash. For root configuration, set as empty string
     # See: https://github.com/dagster-io/dagster/issues/2073
     host: ""
@@ -728,6 +733,8 @@ ingress:
     # ingress controllers may only support "/", whereas some may need "/*".
     # NOTE: Dagit doesn't yet support hosting on a path, e.g. mycompany.com/dagit.
     path: "/*"
+    # pathType is only for k8s >= 1.19
+    pathType: Prefix
     # NOTE: do NOT keep trailing slash. For root configuration, set as empty string
     # See: https://github.com/dagster-io/dagster/issues/2073
     host: ""
@@ -760,6 +767,8 @@ ingress:
     # if path is '/flower', Flower will be accessible at 'mycompany.com/flower'
     # NOTE: do NOT keep trailing slash. For root configuration, set as empty string
     path: ""
+    # pathType is only for k8s >= 1.18
+    pathType: Prefix
 
     tls:
       enabled: false


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
As of Kubernetes v1.22 the Ingress API no longer supports the `extensions/v1beta1` spec ([ref](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22)). With the `networking.k8s.io/v1` API version being available since k8s v1.19, and that being the oldest version I can deploy against in GCP, the timing seems right to update this template.

I have added additional templating to produce the newer Ingress YAML when the deployment target is running k8s 1.19 or later.

When trying deployment with this new template, I made the bare minimum changes to `values`.
```yaml
ingress:
  enabled: true

  annotations: {}

  # Specify ingressClassName for Kubernetes >= 1.19
  ingressClassName: "nginx"

  dagit:
    # Ingress hostname for Dagit e.g. dagit.mycompany.com
    # This variable allows customizing the route pattern in the ingress. Some
    # ingress controllers may only support "/", whereas some may need "/*".
    # NOTE: Dagit doesn't yet support hosting on a path, e.g. mycompany.com/dagit.
    path: "/"
    # pathType is only for k8s >= 1.19
    pathType: Prefix
    # NOTE: do NOT keep trailing slash. For root configuration, set as empty string
    # See: https://github.com/dagster-io/dagster/issues/2073
    host: "dagit.wkk8s.dev"
```

**_If there is a plan is to drop support for k8s versions before 1.19, the ingress template could then drop all of the `$apiIsStable` complexity._**

Feature-request ticket: #6050

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

1. Ran `helm lint` -> no issues found.
2. Ran the unmodified `test_ingress.py` tests -> all passed.
2. Updated the Helm template `model` of `test_ingress.py` to use `V1Ingress` -> tests continue to pass.
3. Created local clusters (minikube) with k8s versions `1.19.16`, `,1.21.6`, and `1.22.2` and deployed (Dagster v0.13.2) using the updated Helm chart and the `values` specified in the summary above. I configured Ingress for Dagit using nginx in all cases. Using Dagit in the browser and executing the `single_pod_job` example graph worked in all cases.

Attempted to start a cluster with K8s ~1.15 since the chart states it supports `>=1.15` however these attempts failed. Before spending more time trying to spin up older K8s versions, I figured I would start this PR process and get feedback on additional testing requirements.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.