### PR TITLE
unpin chardet

### DIFF
--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -36,9 +36,6 @@ if __name__ == "__main__":
             f"dagster{pin}",
             "dask[dataframe]>=1.2.2",
             "distributed>=1.28.1",
-            # resolve issue with aiohttp pin of chardet for aiohttp<=3.7.3, req'd by dask-kubernetes
-            # https://github.com/dagster-io/dagster/issues/3539
-            "chardet<4.0",
         ],
         extras_require={
             "yarn": ["dask-yarn"],


### PR DESCRIPTION
## Summary
aiohttp had a listed incompatibility with the the latest version of the chardet dependency.  Their latest releases of `3.7.4` and `3.8` have relaxed this dep upper bound.

Lingering clean up for https://github.com/dagster-io/dagster/issues/3539

## Test Plan
BK

