### PR TITLE
Don't mark a job as succeeded when an op calls sys.exit

### DIFF
--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -787,7 +787,7 @@ def pipeline_execution_iterator(
         pipeline_canceled_info = serializable_error_info_from_exc_info(sys.exc_info())
         if pipeline_context.raise_on_error:
             raise
-    except Exception:
+    except BaseException:
         pipeline_exception_info = serializable_error_info_from_exc_info(sys.exc_info())
         if pipeline_context.raise_on_error:
             raise  # finally block will run before this is re-raised

--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -284,7 +284,7 @@ def _dagster_event_sequence_for_step(step_context: StepExecutionContext) -> Iter
             raise dagster_error
 
     # case (6) in top comment
-    except Exception as unexpected_exception:
+    except BaseException as unexpected_exception:
         step_context.capture_step_exception(unexpected_exception)
         yield step_failure_event_from_exc_info(
             step_context,

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -377,7 +377,8 @@ def test_failure_multiprocessing():
 def sys_exit(context):
     context.log.info("Informational message")
     print("Crashy output to stdout")  # pylint: disable=print-call
-    sys.exit("Crashy output to stderr")
+    sys.stdout.flush()
+    os._exit(1)  # pylint: disable=W0212
 
 
 @pipeline(mode_defs=[default_mode_def_for_test])


### PR DESCRIPTION
Summary:
Noticed this when trying to test op crashes - this finally block incorrectly marks the pipeline as succeeded when a BaseException is raised that isn't an Exception (and isn't a KeyboardInterrupt).

The chart on https://docs.python.org/3/library/exceptions.html#exception-hierarchy seems to indicate that SystemException is the only class that this affects.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.