### PR TITLE
filter repo graphs view to only include top-level graphs from jobs

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
@@ -43,6 +43,8 @@ const REPOSITORY_GRAPHS_LIST_QUERY = gql`
           id
           description
           name
+          isJob
+          graphName
         }
       }
       ... on RepositoryNotFoundError {
@@ -56,6 +58,12 @@ interface Props {
   repoAddress: RepoAddress;
 }
 
+interface Item {
+  name: string;
+  description: string | null;
+  path: string;
+  repoAddress: RepoAddress;
+}
 export const RepositoryGraphsList: React.FC<Props> = (props) => {
   const {repoAddress} = props;
   const repositorySelector = repoAddressToSelector(repoAddress);
@@ -70,10 +78,13 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
     if (!repo || repo.__typename !== 'Repository') {
       return null;
     }
-    const items = repo.pipelines.map((pipeline) => ({
-      name: pipeline.name,
-      path: `/graphs/${pipeline.name}`,
-      description: pipeline.description,
+    const jobGraphNames = new Set<string>(
+      repo.pipelines.filter((p) => p.isJob).map((p) => p.graphName),
+    );
+    const items: Item[] = Array.from(jobGraphNames).map((graphName) => ({
+      name: graphName,
+      path: `/graphs/${graphName}`,
+      description: null,
       repoAddress,
     }));
 

--- a/js_modules/dagit/packages/core/src/workspace/types/RepositoryGraphsListQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RepositoryGraphsListQuery.ts
@@ -54,6 +54,8 @@ export interface RepositoryGraphsListQuery_repositoryOrError_Repository_pipeline
   id: string;
   description: string | null;
   name: string;
+  isJob: boolean;
+  graphName: string;
 }
 
 export interface RepositoryGraphsListQuery_repositoryOrError_Repository {


### PR DESCRIPTION
## Summary
Make sure that the repo graphs tab only shows graphs, not top-level pipelines.

## Test Plan
None

