### PR TITLE
Update Python GraphQL Client to use post-CRAG GraphQL types

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -1,6 +1,6 @@
-CLIENT_SUBMIT_PIPELINE_RUN_MUTATION = """
+CLIENT_SUBMIT_RUN_MUTATION = """
 mutation($executionParams: ExecutionParams!) {
-  launchPipelineExecution(executionParams: $executionParams) {
+  launchRun(executionParams: $executionParams) {
     __typename
 
     ... on InvalidStepError {
@@ -10,7 +10,7 @@ mutation($executionParams: ExecutionParams!) {
       stepKey
       invalidOutputName
     }
-    ... on LaunchPipelineRunSuccess {
+    ... on LaunchRunSuccess {
       run {
         runId
       }
@@ -21,10 +21,10 @@ mutation($executionParams: ExecutionParams!) {
     ... on PresetNotFoundError {
       message
     }
-    ... on PipelineRunConflict {
+    ... on RunConflict {
       message
     }
-    ... on PipelineConfigValidationInvalid {
+    ... on RunConfigValidationInvalid {
       errors {
         __typename
         message
@@ -93,14 +93,14 @@ mutation ($repositoryLocationName: String!) {
 }
 """
 
-GET_PIPELINE_RUN_STATUS_QUERY = """
+GET_RUN_STATUS_QUERY = """
 query($runId: ID!) {
-  pipelineRunOrError(runId: $runId) {
+  runOrError(runId: $runId) {
     __typename
-    ... on PipelineRun {
+    ... on Run {
         status
     }
-    ... on PipelineRunNotFoundError {
+    ... on RunNotFoundError {
       message
     }
     ... on PythonError {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_status.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_status.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.storage.pipeline_run import RunStatus
 from dagster_graphql import DagsterGraphQLClientError
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
@@ -13,8 +13,8 @@ from .conftest import MockClient, python_client_test_suite
 
 @python_client_test_suite
 def test_get_run_status_success(mock_client: MockClient):
-    expected_result = PipelineRunStatus.SUCCESS
-    response = {"pipelineRunOrError": {"__typename": "PipelineRun", "status": expected_result}}
+    expected_result = RunStatus.SUCCESS
+    response = {"runOrError": {"__typename": "Run", "status": expected_result}}
     mock_client.mock_gql_client.execute.return_value = response
 
     actual_result = mock_client.python_client.get_run_status("foo")
@@ -24,7 +24,7 @@ def test_get_run_status_success(mock_client: MockClient):
 @python_client_test_suite
 def test_get_run_status_fails_with_python_error(mock_client: MockClient):
     error_type, error_msg = "PythonError", "something exploded"
-    response = {"pipelineRunOrError": {"__typename": error_type, "message": error_msg}}
+    response = {"runOrError": {"__typename": error_type, "message": error_msg}}
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
@@ -36,7 +36,7 @@ def test_get_run_status_fails_with_python_error(mock_client: MockClient):
 @python_client_test_suite
 def test_get_run_status_fails_with_pipeline_run_not_found_error(mock_client: MockClient):
     error_type, error_msg = "RunNotFoundError", "The specified pipeline run does not exist"
-    response = {"pipelineRunOrError": {"__typename": error_type, "message": error_msg}}
+    response = {"runOrError": {"__typename": error_type, "message": error_msg}}
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
@@ -81,7 +81,7 @@ class TestGetRunStatusWithClient(ExecutingGraphQLContextTestMatrix):
 
             status = graphql_client.get_run_status(run_id)
 
-            if status == PipelineRunStatus.SUCCESS:
+            if status == RunStatus.SUCCESS:
                 break
 
             time.sleep(3)

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -35,6 +35,8 @@ class PipelineRunStatus(Enum):
     CANCELED = "CANCELED"
 
 
+RunStatus = Enum('RunStatus', {key.value:key.value for key in PipelineRunStatus})
+
 # These statuses that indicate a run may be using compute resources
 IN_PROGRESS_RUN_STATUSES = [
     PipelineRunStatus.STARTING,


### PR DESCRIPTION
Updates Python GraphQL Client to use post-CRAG GraphQL query types. Migrates usage of `PipelineRunStatus` to `RunStatus` enum.