### PR TITLE
Reduce dependencies that bring in regex

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -90,7 +90,6 @@ if __name__ == "__main__":
             "docker": ["docker"],
             "test": [
                 "astroid>=2.3.3,<2.5",
-                "black==20.8b1",
                 "coverage==5.3",
                 "docker",
                 "flake8>=3.7.8",

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -14,7 +14,7 @@ from dagster.core.executor.step_delegating.step_handler.base import StepHandler,
 from dagster.serdes.utils import hash_str
 from dagster.utils import merge_dicts
 from dagster.utils.backcompat import experimental
-from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
+from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config
 
 
 @executor(
@@ -134,8 +134,6 @@ class DockerStepHandler(StepHandler):
 
         if not step_image:
             raise Exception("No docker image specified by the executor config or repository")
-
-        validate_docker_image(step_image)
 
         try:
             step_container = self._create_step_container(

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -12,7 +12,7 @@ from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
 from dagster.grpc.types import ExecuteRunArgs, ResumeRunArgs
 from dagster.serdes import ConfigurableClass
-from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
+from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config
 
 DOCKER_CONTAINER_ID_TAG = "docker/container_id"
 
@@ -100,8 +100,6 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
 
         if not docker_image:
             raise Exception("No docker image specified by the instance config or repository")
-
-        validate_docker_image(docker_image)
 
         if not context.resume_from_failure:
             command = ExecuteRunArgs(

--- a/python_modules/libraries/dagster-docker/dagster_docker/utils.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/utils.py
@@ -1,5 +1,4 @@
 from dagster import Array, Field, Permissive, StringSource, check
-from docker_image import reference
 
 DOCKER_CONFIG_SCHEMA = {
     "image": Field(
@@ -60,15 +59,3 @@ def validate_docker_config(network, networks, container_kwargs):
             raise Exception(
                 "'network' cannot be used in 'container_kwargs'. Use the 'network' config key instead."
             )
-
-
-def validate_docker_image(docker_image):
-    try:
-        # validate that the docker image name is valid
-        reference.Reference.parse(docker_image)
-    except Exception as e:
-        raise Exception(
-            "Docker image name {docker_image} is not correctly formatted".format(
-                docker_image=docker_image
-            )
-        ) from e

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -301,9 +301,7 @@ def test_launch_docker_invalid_image():
 
             with pytest.raises(
                 Exception,
-                match=re.escape(
-                    "Docker image name _invalid_format_image is not correctly formatted"
-                ),
+                match=re.escape("invalid reference format"),
             ):
                 instance.launch_run(run.run_id, workspace)
 

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -31,6 +31,6 @@ if __name__ == "__main__":
             "Operating System :: OS Independent",
         ],
         packages=find_packages(exclude=["test"]),
-        install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
+        install_requires=[f"dagster{pin}", "docker"],
         zip_safe=False,
     )

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -46,6 +46,7 @@ def main(quiet):
 
     install_targets += [
         "awscli",
+        "black==20.8b1",
         "-e python_modules/dagster[test]",
         "-e python_modules/dagster-graphql",
         "-e python_modules/dagster-test",


### PR DESCRIPTION
Summary:
regex regularly pushes and breaks our builds while we wait for the wheels to build. We don't really need it in dagster[test], and its brought in by a docker validation library that only gives us a marginally better error message when a malformed docker image is used. Remove both of those deps.

Sadly papermill still brings in black and thus regex, but dagstermill is included in many fewer builds.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.