### PR TITLE
Fix DockerRunLauncher example for run launcher

### DIFF
--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -400,7 +400,7 @@ run_launcher:
 # start_marker_run_launcher_docker
 
 run_launcher:
-  module: dagster_docker.launcher
+  module: dagster_docker
   class: DockerRunLauncher
 
 # end_marker_run_launcher_docker


### PR DESCRIPTION
## Summary
In the Dagster Instance documentation, the module "dagster_docker.launcher" used for the example is wrong. It will fail when trying to import the "DockerRunLauncher".