### PR TITLE
show the asset graph view if there exists at least one asset node

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -141,7 +141,7 @@ export const PipelineExplorerContainer: React.FC<{
 
         const repositoryAssets =
           repositoryOrError.__typename === 'Repository' ? repositoryOrError.assetNodes : [];
-        const isAssetGraph = result.solidHandles.every((handle) =>
+        const isAssetGraph = result.solidHandles.some((handle) =>
           repositoryAssets.some(
             (asset) =>
               asset.opName === handle.handleID && asset.jobName === explorerPath.pipelineName,
@@ -149,6 +149,20 @@ export const PipelineExplorerContainer: React.FC<{
         );
 
         if (flagAssetGraph && isAssetGraph) {
+          const unrepresentedSolids = result.solidHandles.filter(
+            (handle) =>
+              !repositoryAssets.some(
+                (asset) =>
+                  asset.opName === handle.handleID && asset.jobName === explorerPath.pipelineName,
+              ),
+          );
+          if (unrepresentedSolids.length) {
+            console.error(
+              `The following ops are not represented in the ${
+                explorerPath.pipelineName
+              } asset graph: ${unrepresentedSolids.map((h) => h.solid.name).join(', ')}`,
+            );
+          }
           return (
             <AssetGraphExplorer
               repoAddress={repoAddress!}


### PR DESCRIPTION
## Summary
For a graph that has incomplete coverage, still show the asset graph.  It may be that some ops do not get represented, but that's fine (they can always toggle the flag back to see the computational view).  We now log the op handles that are not bound to an asset node so that the authors can go back and fix.

## Test Plan
Turned on the asset graph feature flag, rendered incomplete asset job.


