### PR TITLE
nicer descriptions from multi-line docstrings without spaces at front

### DIFF
--- a/python_modules/dagster/dagster/core/decorator_utils.py
+++ b/python_modules/dagster/dagster/core/decorator_utils.py
@@ -57,6 +57,17 @@ def positional_arg_name_list(params: List[funcsigs.Parameter]) -> List[str]:
 
 def format_docstring_for_description(fn: Callable) -> Optional[str]:
     if fn.__doc__ is not None:
-        return textwrap.dedent(fn.__doc__).strip()
+        docstring = fn.__doc__
+        if docstring[0].isspace():
+            return textwrap.dedent(docstring).strip()
+        else:
+            first_newline_pos = docstring.find("\n")
+            if first_newline_pos == -1:
+                return docstring
+            else:
+                return (
+                    docstring[: first_newline_pos + 1]
+                    + textwrap.dedent(docstring[first_newline_pos + 1 :]).strip()
+                )
     else:
         return None

--- a/python_modules/dagster/dagster_tests/core_tests/test_decorator_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_decorator_utils.py
@@ -1,4 +1,8 @@
-from dagster.core.decorator_utils import get_function_params, validate_expected_params
+from dagster.core.decorator_utils import (
+    format_docstring_for_description,
+    get_function_params,
+    validate_expected_params,
+)
 
 
 def decorated_function_one_positional():
@@ -32,3 +36,30 @@ def test_required_positional_parameters_not_missing():
 
     fn_params = get_function_params(decorated_function_one_positional())
     assert validate_expected_params(fn_params, positionals) == "baz"
+
+
+def test_format_docstring_for_description():
+    def multiline_indented_docstring():
+        """
+        abc
+        123
+        """
+
+    multiline_indented_docstring_expected = "abc\n123"
+
+    assert (
+        format_docstring_for_description(multiline_indented_docstring)
+        == multiline_indented_docstring_expected
+    )
+
+    def no_indentation_at_start():
+        """abc
+        123
+        """
+
+    no_indentation_at_start_expected = "abc\n123"
+
+    assert (
+        format_docstring_for_description(no_indentation_at_start)
+        == no_indentation_at_start_expected
+    )


### PR DESCRIPTION
we infer solid/op/pipeline/graph/job descriptions from their docstrings. previously, if you did something like this:

```
    def no_indentation_at_start():
        """Here is  some header information

        Here is some more detailed information.
        """
```

The docstring would come out looking weird, and the markdown renderer would think the lower line was more indented than the higher one and render the lower one in a monospace font.