### PR TITLE
remove upper bound on click pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         include_package_data=True,
         install_requires=[
             # cli
-            "click>=5.0,<9.0",
+            "click>=5.0",
             "coloredlogs>=6.1, <=14.0",
             # https://github.com/dagster-io/dagster/issues/4167
             "Jinja2<3.0",


### PR DESCRIPTION
Summary:
click 9.0 does not exist, so no need to pin this in this way.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.