### PR TITLE
remove getting-started top material

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -90,9 +90,9 @@ if __name__ == "__main__":
 dagster job execute -f hello_world.py
 ```
 
-## If You Get Stuck
+---
 
-If you have questions on getting started, we'd love to hear from you:
+To learn more about Dagster, head over to the [Tutorial](/tutorial). And if you get stuck or have any other questions, we'd love to hear from you on Slack:
 
 <p align="center">
   <a href="https://dagster-slackin.herokuapp.com/" target="_blank">

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -4,31 +4,7 @@
   Dagster is a data orchestrator for machine learning, analytics, and ETL
 </p>
 
-<div className="md:col-span-3 flex flex-wrap md:flex-nowrap items-center bg-gable-green rounded-2xl py-6 md:py-2 px-6 md:pr-5 space-y-4 md:space-y-0 md:space-x-8">
-  <p className="flex-auto text-gray-100 text-lg">
-    {" "}
-    New to Dagster? Learn all about it in a short tutorial.
-  </p>
-  <a
-    href="/tutorial"
-    className="flex-none border border-1 bg-gable-green hover:no-underline border-gray-100 hover:bg-white hover:text-gable-green shadow-none transition-colors duration-200 text-white font-semibold rounded-full py-3 px-4 no-underline"
-  >
-    Take the Tutorial
-  </a>
-</div>
-
-Or read about:
-
-- Dagster’s [Concepts](/concepts)
-- [How to deploy Dagster](/deployment)
-- [How to integrate Dagster with other tools](/integrations)
-- [Best practices guides](/guides)
-- Dagster’s full [API Reference](/\_apidocs)
-- Dagster's open source [Community](/community)
-
-## Quick Start
-
-### Installing Dagster
+## Installing Dagster
 
 To install Dagster and Dagit into an existing Python environment, run:
 
@@ -38,7 +14,7 @@ pip install dagster
 
 This will install the latest stable version of the core Dagster packages in your current Python environment.
 
-### Writing a Job
+## Writing a Job
 
 Let's get your first job up and running.
 
@@ -65,7 +41,7 @@ Save the code above in a file named `hello_world.py`.
 
 You can execute the job in three different ways: [Dagit](/concepts/dagit/dagit), [Dagster Python API](/concepts/ops-jobs-graphs/job-execution#python-apis), or [Dagster CLI](/\_apidocs/cli#dagster-pipeline-execute).
 
-### Running the Job in Dagit
+## Running the Job in Dagit
 
 It's highly recommended to use Dagit with Dagster. Dagit is a web-based interface for viewing and interacting with Dagster objects.
 
@@ -97,7 +73,7 @@ width={4032}
 height={2454}
 />
 
-### Other Options to Run Dagster Jobs
+## Other Options to Run Dagster Jobs
 
 You can also execute the job without the UI in the following methods:
 

--- a/docs/content/tutorial/intro-tutorial/setup.mdx
+++ b/docs/content/tutorial/intro-tutorial/setup.mdx
@@ -25,4 +25,4 @@ This installs a few packages:
 - **Dagit**: the UI for developing and operating Dagster jobs, including a DAG browser, a type-aware config editor, and a live execution interface.
 - **Requests**: not part of Dagster. Our examples will use it to download data from the internet.
 
-You can also follow the [Quick Start](/getting-started#quick-start) section to make sure you have installed the packages and set up the environment properly.
+You can also check out our [Getting Started](/getting-started) page to make sure you have installed the packages and set up the environment properly.


### PR DESCRIPTION
## Summary

Per discussion with @sryza @yuhan on Nov 2, this removes the top material from the Getting Started docs page.