### PR TITLE
DaskClusterTypes refactoring

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -14,7 +14,7 @@ DaskClusterTypes = {
         "slurm": ("SLURM", "dask_jobqueue", "SLURMCluster"),
         "oar": ("OAR", "dask_jobqueue", "OARCluster"),
         "kube": ("Kubernetes", "dask_kubernetes", "KubeCluster"),
-        "azureml": ("Azure ML", "dask_cloudprovider", "AzureMLCluster"),
+        "azurevm": ("Azure VM", "dask_cloudprovider.azure", "AzureVMCluster"),
         "ecs": ("AWS ECS", "dask_cloudprovider.aws", "ECSCluster"),
         "fargate": ("AWS ECS on Fargate", "dask_cloudprovider.aws", "FargateCluster"),
     }.items()

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -15,8 +15,8 @@ DaskClusterTypes = {
         "oar": ("OAR", "dask_jobqueue", "OARCluster"),
         "kube": ("Kubernetes", "dask_kubernetes", "KubeCluster"),
         "azureml": ("Azure ML", "dask_cloudprovider", "AzureMLCluster"),
-        "ecs": ("AWS ECS", "dask_cloudprovider", "ECSCluster"),
-        "fargate": ("AWS ECS on Fargate", "dask_cloudprovider", "FargateCluster"),
+        "ecs": ("AWS ECS", "dask_cloudprovider.aws", "ECSCluster"),
+        "fargate": ("AWS ECS on Fargate", "dask_cloudprovider.aws", "FargateCluster"),
     }.items()
 }
 


### PR DESCRIPTION
## Summary
Almost a year ago [PR #153](https://github.com/dask/dask-cloudprovider/pull/153) to dask-cloudprovider was made to require cluster manager to be imported by specifying their sub-packages, yet `DaskClusterTypes` of this project has not been updated. This PR updates the 3 Dask cloud providers.

AzuzeML provider was renamed in [PR #175](https://github.com/dask/dask-cloudprovider/pull/175) to AzureVM also a year ago. This PR propagates that change as well.
