### PR TITLE
Set a fixed pip version when running tox suites

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -3,6 +3,7 @@ envlist = py38-sphinx
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE
 
 deps =

--- a/examples/airflow_ingest/tox.ini
+++ b/examples/airflow_ingest/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   pendulum==1.4.4

--- a/examples/airline_demo/tox.ini
+++ b/examples/airline_demo/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-graphql

--- a/examples/basic_pyspark/tox.ini
+++ b/examples/basic_pyspark/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/basic_pyspark_crag/tox.ini
+++ b/examples/basic_pyspark_crag/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/dbt_example/tox.ini
+++ b/examples/dbt_example/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE DAGSTER_DBT_EXAMPLE_PGHOST
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/deploy_docker/tox.ini
+++ b/examples/deploy_docker/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE DEPLOY_DOCKER_DAGIT_HOST
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/deploy_ecs/tox.ini
+++ b/examples/deploy_ecs/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE DEPLOY_DOCKER_DAGIT_HOST
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/deploy_k8s/tox.ini
+++ b/examples/deploy_k8s/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_DB_HOST BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/emr_pyspark/tox.ini
+++ b/examples/emr_pyspark/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/emr_pyspark_crag/tox.ini
+++ b/examples/emr_pyspark_crag/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/ge_example/tox.ini
+++ b/examples/ge_example/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/hacker_news/tox.ini
+++ b/examples/hacker_news/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38, 37, 36},pylint,mypy
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/hacker_news_assets/tox.ini
+++ b/examples/hacker_news_assets/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38, 37, 36},pylint,mypy
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/memoized_development/tox.ini
+++ b/examples/memoized_development/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/presentation/tox.ini
+++ b/examples/presentation/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/run_attribution_example/tox.ini
+++ b/examples/run_attribution_example/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/software_defined_assets/tox.ini
+++ b/examples/software_defined_assets/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/examples/user_in_loop/tox.ini
+++ b/examples/user_in_loop/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint,mypy
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../../python_modules/dagster[test]

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../../python_modules/dagster[test]

--- a/integration_tests/test_suites/backcompat-test-suite/tox.ini
+++ b/integration_tests/test_suites/backcompat-test-suite/tox.ini
@@ -3,6 +3,7 @@ envlist=py{38,37,36}-{unix,windows}-{dagit-latest-release,dagit-earliest-release
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE BACKCOMPAT_TESTS_DAGIT_HOST EARLIEST_TESTED_RELEASE
 
 deps =

--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows}-{default,markusercodedeployment,markdaemon
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
 deps =
   -e ../../../python_modules/dagster[test]

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG POSTGRES_TEST_DB_HOST
 deps =
   objgraph

--- a/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-integration-test-suite/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows}-{default},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
 deps =
   -e ../../../python_modules/dagster[test]

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE
 
 deps =

--- a/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-example-tmpl/tox.ini.tmpl
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows},pylint
 skipsdist = True
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../python_modules/dagster[test]

--- a/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/tox.ini.tmpl
@@ -2,6 +2,7 @@
 envlist = py{38,37,36,27}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../dagster[test]

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   objgraph

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -3,6 +3,7 @@ envlist = py{38,37,36}-{unix,windows}-{not_graphql_context_test_suite,in_memory_
 
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../dagster[test]

--- a/python_modules/dagster-graphql/tox_postgres.ini
+++ b/python_modules/dagster-graphql/tox_postgres.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows}-{graphql_context_variants,postgres_instance_multi_location,postgres_instance_managed_grpc_env,postgres_instance_deployed_grpc_env},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_HOST
 deps =
   -e ../dagster[test]

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../dagster[test]

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows}-{api_tests,cli_tests,core_tests,daemon_tests,general_tests,scheduler_tests,scheduler_tests_old_pendulum},pylint,mypy
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE DAGSTER_DOCKER_* GRPC_SERVER_HOST
 setenv =
   !windows: COVERAGE_ARGS = --cov=dagster --cov-append --cov-report=

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows}-{default,requiresairflowdb},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME AIRFLOW_HOME AWS_* BUILDKITE CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG, POSTGRES_TEST_DB_HOST
 setenv =
   SLUGIFY_USES_TEXT_UNIDECODE = yes

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE SSH_*
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE SSH_*
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID DAGSTER_DOCKER_* POSTGRES_TEST_DB_HOST
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME CI_PULL_REQUEST COVERALLS_REPO_TOKEN DASK_ADDRESS AWS_* BUILDKITE DAGSTER_*
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN DASK_ADDRESS AWS_* BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN DATABRICKS_* BUILDKITE SSH_*
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE POSTGRES_TEST_DB_DBT_HOST DBT_TARGET_PATH
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME CI_* COVERALLS_REPO_TOKEN BUILDKITE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID DAGSTER_DOCKER_* DOCKER_* GOOGLE_* POSTGRES_TEST_DB_HOST
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN MYSQL_TEST_* BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_* BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN TWILIO_*
 deps =
   -e ../../dagster[test]

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{38,37,36}-{papermill1,papermill2}-{unix,windows},pylint
 
 [testenv]
+pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
   papermill1: papermill<2.0.0


### PR DESCRIPTION
Summary:
Right now when you run a tox suite, it uses the default virtualenv version that's installed in the automation library, which is 19. We could increase that version, but it's probably good to be able to rely that all our tox suites are running on the same version. Luckily, there is a tox flag that provides this.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.