### PR TITLE
chore(buildkite): ensure graphql schema is always built

### DIFF
--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -29,6 +29,7 @@ commands =
   yarn workspace @dagit/core jest --collectCoverage --watchAll=false
   yarn workspace @dagit/core check-prettier
   yarn workspace @dagit/core check-lint
+  git diff --exit-code
 
 [testenv:pylint]
 whitelist_externals =


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
As the title.


## Test Plan
example failed run: https://buildkite.com/dagster/dagster/builds/21730#8197bad5-9b55-49ab-82d2-2802a3e542cf
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

