### PR TITLE
Some small make dev_install perf improvements

### DIFF
--- a/examples/airline_demo/setup.py
+++ b/examples/airline_demo/setup.py
@@ -43,7 +43,6 @@ setup(
             "seaborn",
             "sqlalchemy-redshift>=0.7.2",
             "SQLAlchemy-Utils==0.33.8",
-            'tensorflow; python_version < "3.9"',
         ],
         "airflow": [
             "dagster_airflow",

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -100,9 +100,6 @@ def main(quiet):
     # image build!
     cmd = ["pip", "install"] + install_targets
 
-    # Second, install with dependencies. Now, pip will see that the editable installs already
-    # exist and will use them instead of trying to find the projects on pypi.
-    cmd += ["&&", "pip", "install"] + install_targets
     if quiet:
         cmd.append(quiet)
 


### PR DESCRIPTION
Summary:
Two small changes here to the make dev_install script:
- At one point we were installing our modules twice, once without deps, and then once with. But then the --no-deps arg was removed, so now we're just running the exact same command twice for no good reason :)
- Remove tensorflow, which isn't being used and contributes literal GB to the make dev_install build

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.