### PR TITLE
[dagit] Improve performance of the partitions UI and launch backfill modal

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
@@ -1,4 +1,3 @@
-import {isEqual} from 'lodash';
 import * as React from 'react';
 import {Line} from 'react-chartjs-2';
 import styled from 'styled-components/macro';

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
@@ -75,7 +75,7 @@ export const PartitionGraph = ({
           },
           x: {
             id: 'x',
-            title: {display: true, text: 'Partition'},
+            title: {display: true, text: title},
           },
         }
       : undefined;

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
@@ -18,28 +18,25 @@ interface PartitionGraphProps {
   title?: string;
   yLabel?: string;
   isJob: boolean;
+  hiddenStepKeys: string[];
 }
 
-export const PartitionGraph = React.forwardRef((props: PartitionGraphProps, ref) => {
-  const {
-    runsByPartitionName,
-    getPipelineDataForRun,
-    getStepDataForRun,
-    title,
-    yLabel,
-    isJob,
-  } = props;
+export const PartitionGraph = ({
+  runsByPartitionName,
+  getPipelineDataForRun,
+  getStepDataForRun,
+  title,
+  yLabel,
+  isJob,
+  hiddenStepKeys,
+}: PartitionGraphProps) => {
   const [hiddenPartitions, setHiddenPartitions] = React.useState<{[name: string]: boolean}>(
     () => ({}),
   );
   const chart = React.useRef<any>(null);
 
-  React.useImperativeHandle(ref, () => ({
-    getChartInstance: () => chart.current?.chartInstance,
-  }));
-
   const onGraphClick = React.useCallback((event: MouseEvent) => {
-    const instance = chart.current?.chartInstance;
+    const instance = chart.current;
     if (!instance) {
       return;
     }
@@ -83,8 +80,10 @@ export const PartitionGraph = React.forwardRef((props: PartitionGraphProps, ref)
           },
         }
       : undefined;
+
     return {
       title: titleOptions,
+      animation: false,
       scales,
       plugins: {
         legend: {
@@ -126,6 +125,9 @@ export const PartitionGraph = React.forwardRef((props: PartitionGraphProps, ref)
 
       const stepDataforRun = getStepDataForRun(run);
       Object.keys(stepDataforRun).forEach((stepKey) => {
+        if (hiddenStepKeys.includes(stepKey)) {
+          return;
+        }
         stepData[stepKey] = [
           ...(stepData[stepKey] || []),
           {x: partitionName, y: !hidden ? stepDataforRun[stepKey] : undefined},
@@ -143,15 +145,20 @@ export const PartitionGraph = React.forwardRef((props: PartitionGraphProps, ref)
   };
 
   const {pipelineData, stepData} = buildDatasetData();
+  const allLabel = isJob ? 'Total job' : 'Total pipeline';
   const graphData = {
     labels: Object.keys(runsByPartitionName),
     datasets: [
-      {
-        label: isJob ? 'Total job' : 'Total pipeline',
-        data: pipelineData,
-        borderColor: ColorsWIP.Gray500,
-        backgroundColor: 'rgba(0,0,0,0)',
-      },
+      ...(hiddenStepKeys.includes(allLabel)
+        ? []
+        : [
+            {
+              label: allLabel,
+              data: pipelineData,
+              borderColor: ColorsWIP.Gray500,
+              backgroundColor: 'rgba(0,0,0,0)',
+            },
+          ]),
       ...Object.keys(stepData).map((stepKey) => ({
         label: stepKey,
         data: stepData[stepKey],
@@ -161,20 +168,15 @@ export const PartitionGraph = React.forwardRef((props: PartitionGraphProps, ref)
     ],
   };
 
+  // Passing graphData as a closure prevents ChartJS from trying to isEqual, which is fairly
+  // unlikely to save a render and is time consuming given the size of the data structure.
+  // We have a useMemo around the entire <PartitionGraphSet /> and there aren't many extra renders.
   return (
     <PartitionGraphContainer>
-      <LineMemoized
-        type="line"
-        data={graphData}
-        height={100}
-        options={defaultOptions}
-        ref={chart}
-      />
+      <Line type="line" data={() => graphData} height={100} options={defaultOptions} ref={chart} />
     </PartitionGraphContainer>
   );
-});
-
-const LineMemoized = React.memo(Line, isEqual);
+};
 
 const _fillPartitions = (partitionNames: string[], points: Point[]) => {
   const pointData = {};

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
@@ -617,7 +617,7 @@ const PartitionStepSquare: React.FC<{
     <Popover
       interactionKind="click"
       placement="bottom-start"
-      onOpened={() => setOpened(true)}
+      onOpening={() => setOpened(true)}
       onClosed={() => setOpened(false)}
       content={
         <MenuWIP>

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
@@ -29,6 +29,7 @@ import {
   GridScrollContainer,
   LeftLabel,
   TopLabel,
+  topLabelHeightForLabels,
   TopLabelTilted,
 } from './RunMatrixUtils';
 import {RunTagsTokenizingField} from './RunTagsTokenizingField';
@@ -173,6 +174,7 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
     visibleRangeStart + visibleCount,
   );
   const [minUnix, maxUnix] = timeboundsOfPartitions(partitionColumns);
+  const topLabelHeight = topLabelHeightForLabels(partitionColumns.map((p) => p.name));
 
   return (
     <PartitionRunMatrixContainer>
@@ -245,7 +247,7 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
       >
         <GridFloatingContainer floating={viewport.left > 0}>
           <GridColumn disabled style={{flex: 1, flexShrink: 1, overflow: 'hidden'}}>
-            <TopLabel></TopLabel>
+            <TopLabel style={{height: topLabelHeight}} />
             <LeftLabel style={{paddingLeft: 24}}>Number of Runs</LeftLabel>
             <Divider />
             {stepRows.map((step) => (
@@ -261,7 +263,7 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
           </GridColumn>
           {options.showPrevious && (
             <GridColumn disabled>
-              <TopLabel />
+              <TopLabel style={{height: topLabelHeight}} />
               <LeftLabel
                 style={{width: 42}}
                 onClick={() =>
@@ -291,7 +293,7 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
             </GridColumn>
           )}
           <GridColumn disabled>
-            <TopLabel />
+            <TopLabel style={{height: topLabelHeight}} />
             <LeftLabel
               style={{width: 42, paddingRight: 8}}
               onClick={() =>
@@ -341,7 +343,7 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
                   left: (idx + visibleRangeStart) * BOX_SIZE,
                 }}
               >
-                <TopLabelTilted label={p.name} />
+                <TopLabelTilted $height={topLabelHeight} label={p.name} />
                 {p.runsLoaded ? (
                   <LeftLabel style={{textAlign: 'center'}}>{p.runs.length}</LeftLabel>
                 ) : (

--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -73,15 +73,6 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
     }
   }, [error]);
 
-  const allStepKeys = new Set<string>();
-  partitions.forEach((partition) => {
-    partition.runs.forEach((run) => {
-      run.stepStats.forEach((stat) => {
-        allStepKeys.add(stat.stepKey);
-      });
-    });
-  });
-
   const launchButton = () => {
     if (!canLaunchPartitionBackfill) {
       return (
@@ -170,11 +161,7 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
         <OptionsContainer>
           <strong>Run steps</strong>
         </OptionsContainer>
-        <PartitionGraphSet
-          isJob={isJob}
-          partitions={partitions}
-          allStepKeys={Array.from(allStepKeys).sort()}
-        />
+        <PartitionGraphSet isJob={isJob} partitions={partitions} />
       </div>
     </div>
   );

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -37,7 +37,7 @@ import {
   GridFloatingContainer,
   GridScrollContainer,
   LeftLabel,
-  TITLE_HEIGHT,
+  topLabelHeightForLabels,
   TopLabel,
   TopLabelTilted,
 } from './RunMatrixUtils';
@@ -419,6 +419,8 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
     visibleRangeStart + visibleCount,
   );
 
+  const topLabelHeight = topLabelHeightForLabels(partitionNames);
+
   return (
     <>
       <DialogBody>
@@ -544,7 +546,7 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
           {query && (
             <GridFloatingContainer floating={true}>
               <GridColumn disabled>
-                <TopLabel></TopLabel>
+                <TopLabel style={{height: topLabelHeight}} />
                 {stepRows.map((step) => (
                   <LeftLabel style={{paddingLeft: step.x}} key={step.name}>
                     {step.name}
@@ -559,8 +561,8 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
                 width: partitionNames.length * BOX_SIZE,
                 position: 'relative',
                 height: query
-                  ? stepRows.length * BOX_SIZE + TITLE_HEIGHT
-                  : BOX_SIZE + TITLE_HEIGHT + 25,
+                  ? stepRows.length * BOX_SIZE + topLabelHeight
+                  : BOX_SIZE + topLabelHeight + 25,
               }}
             >
               {visiblePartitionNames.map((partitionName, idx) => (
@@ -580,7 +582,7 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
                   onMouseUp={() => onPartitionMouseUp(partitionName)}
                   onMouseOver={() => onPartitionMouseOver(partitionName)}
                 >
-                  <TopLabelTilted label={partitionName} />
+                  <TopLabelTilted $height={topLabelHeight} label={partitionName} />
                   {!options.reexecute ? (
                     <div
                       className={`square ${

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -32,10 +32,12 @@ import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
 import {
+  BOX_SIZE,
   GridColumn,
   GridFloatingContainer,
   GridScrollContainer,
   LeftLabel,
+  TITLE_HEIGHT,
   TopLabel,
   TopLabelTilted,
 } from './RunMatrixUtils';
@@ -43,6 +45,7 @@ import {LaunchPartitionBackfill} from './types/LaunchPartitionBackfill';
 import {PartitionStatusQuery} from './types/PartitionStatusQuery';
 import {PartitionsBackfillSelectorQuery} from './types/PartitionsBackfillSelectorQuery';
 
+const OVERSCROLL = 200;
 const DEFAULT_RUN_LAUNCHER_NAME = 'DefaultRunLauncher';
 
 interface BackfillOptions {
@@ -141,7 +144,7 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, pipelineName);
 
-  const {containerProps} = useViewport({
+  const {containerProps, viewport} = useViewport({
     initialOffset: React.useCallback((el) => ({left: el.scrollWidth - el.clientWidth, top: 0}), []),
   });
 
@@ -409,6 +412,13 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
 
   const selectedString = partitionsToText(selected, partitionNames);
 
+  const visibleRangeStart = Math.max(0, Math.floor((viewport.left - OVERSCROLL) / BOX_SIZE));
+  const visibleCount = Math.ceil((viewport.width + OVERSCROLL * 2) / BOX_SIZE);
+  const visiblePartitionNames = partitionNames.slice(
+    visibleRangeStart,
+    visibleRangeStart + visibleCount,
+  );
+
   return (
     <>
       <DialogBody>
@@ -544,11 +554,25 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
             </GridFloatingContainer>
           )}
           <GridScrollContainer {...containerProps}>
-            <div style={{display: 'flex', paddingLeft: 10}}>
-              {partitionNames.map((partitionName, idx) => (
+            <div
+              style={{
+                width: partitionNames.length * BOX_SIZE,
+                position: 'relative',
+                height: query
+                  ? stepRows.length * BOX_SIZE + TITLE_HEIGHT
+                  : BOX_SIZE + TITLE_HEIGHT + 25,
+              }}
+            >
+              {visiblePartitionNames.map((partitionName, idx) => (
                 <GridColumn
                   key={partitionName}
-                  style={{zIndex: partitionNames.length - idx, userSelect: 'none'}}
+                  style={{
+                    zIndex: partitionNames.length - (idx + visibleRangeStart),
+                    width: BOX_SIZE,
+                    position: 'absolute',
+                    userSelect: 'none',
+                    left: (idx + visibleRangeStart) * BOX_SIZE,
+                  }}
                   disabled={statusesLoading || !selectablePartitions.includes(partitionName)}
                   focused={selected.includes(partitionName)}
                   multiselectFocused={currentRangeSelection.includes(partitionName)}
@@ -587,51 +611,12 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
 
         {!instance.daemonHealth.daemonStatus.healthy ? (
           <div style={{marginTop: 10}}>
-            <Alert
-              intent="warning"
-              title="The backfill daemon is not running."
-              description={
-                <div>
-                  See the{' '}
-                  <a
-                    href="https://docs.dagster.io/deployment/dagster-daemon"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    dagster-daemon documentation
-                  </a>{' '}
-                  for more information on how to deploy the dagster-daemon process.
-                </div>
-              }
-            />
+            <DaemonNotRunningAlert />
           </div>
         ) : null}
         {usingDefaultRunLauncher && !instance.runQueuingSupported ? (
           <div style={{marginTop: 10}}>
-            <Alert
-              intent="warning"
-              title={
-                <div>
-                  Using the default run launcher <code>{DEFAULT_RUN_LAUNCHER_NAME}</code> for
-                  launching backfills without a queued run coordinator is not advised.
-                </div>
-              }
-              description={
-                <div>
-                  Check your instance configuration in <code>dagster.yaml</code> to either configure{' '}
-                  the{' '}
-                  <a
-                    href="https://docs.dagster.io/deployment/run-coordinator"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    queued run coordinator
-                  </a>{' '}
-                  or to configure a run launcher more appropriate for launching a large number of
-                  jobs.
-                </div>
-              }
-            />
+            <UsingDefaultLauncherAlert />
           </div>
         ) : null}
       </DialogBody>
@@ -916,3 +901,48 @@ const LAUNCH_PARTITION_BACKFILL_MUTATION = gql`
   }
   ${PYTHON_ERROR_FRAGMENT}
 `;
+
+const DaemonNotRunningAlert: React.FC = () => (
+  <Alert
+    intent="warning"
+    title="The backfill daemon is not running."
+    description={
+      <div>
+        See the{' '}
+        <a
+          href="https://docs.dagster.io/deployment/dagster-daemon"
+          target="_blank"
+          rel="noreferrer"
+        >
+          dagster-daemon documentation
+        </a>{' '}
+        for more information on how to deploy the dagster-daemon process.
+      </div>
+    }
+  />
+);
+
+const UsingDefaultLauncherAlert: React.FC = () => (
+  <Alert
+    intent="warning"
+    title={
+      <div>
+        Using the default run launcher <code>{DEFAULT_RUN_LAUNCHER_NAME}</code> for launching
+        backfills without a queued run coordinator is not advised.
+      </div>
+    }
+    description={
+      <div>
+        Check your instance configuration in <code>dagster.yaml</code> to either configure the{' '}
+        <a
+          href="https://docs.dagster.io/deployment/run-coordinator"
+          target="_blank"
+          rel="noreferrer"
+        >
+          queued run coordinator
+        </a>{' '}
+        or to configure a run launcher more appropriate for launching a large number of jobs.
+      </div>
+    }
+  />
+);

--- a/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
@@ -220,10 +220,10 @@ export const TopLabel = styled.div`
   display: flex;
 `;
 
-const TITLE_HEIGHT = 55;
+export const TITLE_HEIGHT = 55;
 const ROTATION_DEGREES = 41;
 
-export const TopLabelTilted: React.FC<{label: string}> = ({label}) => {
+export const TopLabelTilted: React.FC<{label: string}> = React.memo(({label}) => {
   const node = React.useRef<HTMLDivElement>(null);
   const [tooltip, showTooltip] = React.useState(false);
 
@@ -254,7 +254,7 @@ export const TopLabelTilted: React.FC<{label: string}> = ({label}) => {
   ) : (
     content
   );
-};
+});
 
 const TopLabelTiltedInner = styled.div`
   position: relative;

--- a/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunMatrixUtils.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {ColorsWIP} from '../ui/Colors';
-import {Tooltip} from '../ui/Tooltip';
 
 export const BOX_SIZE = 32;
 
@@ -220,49 +219,29 @@ export const TopLabel = styled.div`
   display: flex;
 `;
 
-export const TITLE_HEIGHT = 55;
+const TITLE_MARGIN_BOTTOM = 15;
 const ROTATION_DEGREES = 41;
 
-export const TopLabelTilted: React.FC<{label: string}> = React.memo(({label}) => {
-  const node = React.useRef<HTMLDivElement>(null);
-  const [tooltip, showTooltip] = React.useState(false);
+export function topLabelHeightForLabels(labels: string[]) {
+  const maxlength = Math.max(...labels.map((p) => p.length));
+  return (maxlength > 10 ? maxlength * 4.9 : 55) + TITLE_MARGIN_BOTTOM;
+}
 
-  // On mount, measure whether the height of the rotated text is greater than the container.
-  // If so, we'll display a tooltip so that the text can be made visible on hover.
-  React.useEffect(() => {
-    if (node.current) {
-      const nodeWidth = node.current.offsetWidth;
-      const rotatedHeight = Math.sin(ROTATION_DEGREES * (Math.PI / 180)) * nodeWidth;
-      if (rotatedHeight > TITLE_HEIGHT) {
-        showTooltip(true);
-      }
-    }
-  }, []);
-
-  const content = (
-    <TopLabelTiltedInner>
-      <div className="tilted" ref={node}>
-        {label}
-      </div>
+export const TopLabelTilted: React.FC<{label: string; $height: number}> = ({label, $height}) => {
+  return (
+    <TopLabelTiltedInner style={{height: $height - TITLE_MARGIN_BOTTOM}}>
+      <div className="tilted">{label}</div>
     </TopLabelTiltedInner>
   );
-
-  return tooltip ? (
-    <Tooltip placement="bottom" content={label}>
-      {content}
-    </Tooltip>
-  ) : (
-    content
-  );
-});
+};
 
 const TopLabelTiltedInner = styled.div`
   position: relative;
-  height: ${TITLE_HEIGHT}px;
+  height: unset; /* provide via style tag */
   padding: 4px;
   padding-bottom: 0;
   min-width: 15px;
-  margin-bottom: 15px;
+  margin-bottom: ${TITLE_MARGIN_BOTTOM}px;
   align-items: end;
   display: flex;
   line-height: normal;

--- a/js_modules/dagit/packages/core/src/partitions/useChunkedPartitionsQuery.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useChunkedPartitionsQuery.tsx
@@ -300,16 +300,22 @@ function assemblePartitions(data: DataState) {
   // extensively in our display layer as React keys. To create unique empty partitions
   // we use different numbers of zero-width space characters
   const results: PartitionRuns[] = [];
+  const byName: {[name: string]: PartitionRuns} = {};
 
-  data.partitionNames.forEach((name, idx) =>
-    results.push({
+  data.partitionNames.forEach((name, idx) => {
+    byName[name] = {
       name,
       runsLoaded: idx >= data.loadingCursorIdx,
-      runs: data.runs.filter((r) =>
-        r.tags.some((t) => t.key === DagsterTag.Partition && t.value === name),
-      ),
-    }),
-  );
+      runs: [],
+    };
+    results.push(byName[name]);
+  });
+
+  data.runs.forEach((r) => {
+    const partitionName = r.tags.find((t) => t.key === DagsterTag.Partition)?.value || '';
+    byName[partitionName]?.runs.push(r);
+  });
+
   return results;
 }
 


### PR DESCRIPTION
This PR addresses several performance problems in the partition UI:

## Summary
- Properly virtualize the long horizontal list of partitions in the launch backfill modal (This should address client-side slowness when toggling partitions in https://github.com/dagster-io/dagster/issues/5408)

- Switch data loader's assemblePartitions algorithm from O(x * y) to O(x + y) (was taking ~60ms per render when loading a years worth of partitions + runs in my local db)

- Graph perf: move memo, stop internal isEqual, stop animating transitions / changes in the graphs entirely.  This brings the total re-render time of all six graphs down to 105ms from ~800ms for me when showing "all time".

- Virtualize tilted labels because they contain tooltips now

- Fix issue with partition run "circle" actions menu closing if you move too fast

- Fix issue with "toggling steps" not doing anything - imperative setup was pretty fragile

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.