### PR TITLE
Tiny fix for spinner hiding box labels in the Gantt chart

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.stories.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.stories.tsx
@@ -1,6 +1,7 @@
 import {Meta} from '@storybook/react/types-6-0';
 import React, {useState} from 'react';
 
+import {CustomTooltipProvider} from '../app/CustomTooltipProvider';
 import {extractMetadataFromLogs} from '../runs/RunMetadataProvider';
 import {RunMetadataProviderMessageFragment} from '../runs/types/RunMetadataProviderMessageFragment';
 import {StorybookProvider} from '../testing/StorybookProvider';
@@ -58,20 +59,20 @@ const APOLLO_MOCKS = {
 };
 
 const GRAPH: IGanttNode[] = [
-  {name: 'A', inputs: [], outputs: [{dependedBy: [{solid: {name: 'B'}}]}]},
+  {name: 'A', inputs: [], outputs: [{dependedBy: [{solid: {name: 'B_very_long_step_name'}}]}]},
   {
-    name: 'B',
+    name: 'B_very_long_step_name',
     inputs: [{dependsOn: [{solid: {name: 'A'}}]}],
     outputs: [{dependedBy: [{solid: {name: 'C'}}, {solid: {name: 'D'}}]}],
   },
   {
     name: 'C',
-    inputs: [{dependsOn: [{solid: {name: 'B'}}]}],
+    inputs: [{dependsOn: [{solid: {name: 'B_very_long_step_name'}}]}],
     outputs: [{dependedBy: [{solid: {name: 'E'}}]}],
   },
   {
     name: 'D',
-    inputs: [{dependsOn: [{solid: {name: 'B'}}]}],
+    inputs: [{dependsOn: [{solid: {name: 'B_very_long_step_name'}}]}],
     outputs: [{dependedBy: [{solid: {name: 'E'}}]}],
   },
   {
@@ -153,43 +154,43 @@ const LOGS: RunMetadataProviderMessageFragment[] = [
   {
     message: 'Started execution of step "B".',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'ExecutionStepStartEvent',
   },
   {
     message: 'Got input "numbers" of type "[Int]". (Type check passed).',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'ExecutionStepInputEvent',
   },
   {
     message: 'Execution of step "B" failed and has requested a retry in 2 seconds.',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'ExecutionStepUpForRetryEvent',
   },
   {
     message: 'Started re-execution (attempt # 2) of step "retry_solid".',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'ExecutionStepRestartEvent',
   },
   {
     message: 'Yielded output "result" of type "Any". (Type check passed).',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'ExecutionStepOutputEvent',
   },
   {
     message: 'Handled output "result" using IO manager "io_manager"',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'HandledOutputEvent',
   },
   {
     message: 'Finished execution of step "B" in 33ms.',
     timestamp: '0',
-    stepKey: 'B',
+    stepKey: 'B_very_long_step_name',
     __typename: 'ExecutionStepSuccessEvent',
   },
   {
@@ -378,6 +379,7 @@ export default {
 export const EmptyStateCase = () => {
   return (
     <StorybookProvider apolloProps={{mocks: APOLLO_MOCKS}}>
+      <CustomTooltipProvider />
       <div style={{width: '100%', height: 400}}>
         <GanttChartLoadingState runId={'r2'} />
       </div>
@@ -392,6 +394,7 @@ export const InteractiveCase = (argValues: any) => {
   const metadata = extractMetadataFromLogs(LOGS.slice(0, argValues.progress));
   return (
     <StorybookProvider apolloProps={{mocks: APOLLO_MOCKS}}>
+      <CustomTooltipProvider />
       <div style={{width: '100%', height: 400}}>
         <GanttChart
           key={metadata.mostRecentLogAt}

--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -704,8 +704,11 @@ const GanttChartContainer = styled.div`
   .box {
     height: ${BOX_HEIGHT - BOX_MARGIN_Y * 2}px;
     padding: 3px;
+    padding-right: 1px;
     border: 1px solid transparent;
     border-radius: 2px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
     transition: top ${CSS_DURATION}ms linear, left ${CSS_DURATION}ms linear,
       width ${CSS_DURATION}ms linear, height ${CSS_DURATION}ms linear;

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -72,7 +72,9 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
     return null;
   }
 
-  const runs = (group.runs || []).filter((g) => g !== null);
+  // BG Note: the g.stats check is a fix for our storybook tests, something is wrong with the
+  // apollo mocks for stats and I cannot figure it out.
+  const runs = (group.runs || []).filter((g) => g !== null && g.stats);
 
   return (
     <SidebarSection title={runs[0] ? `${runs[0].pipelineName} (${runs.length})` : ''}>


### PR DESCRIPTION
## Summary
Updated rendering of the Gantt chart, with the partial label shown alongside the spinner. Per discussion with Josh we're inserting ellipsis as well!

<img width="667" alt="image" src="https://user-images.githubusercontent.com/1037212/140384863-033a58f9-354f-4adf-986a-dab8222e4c3f.png">

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.