### PR TITLE
Add CodeVersionStrategy

### DIFF
--- a/docs/sphinx/sections/api/apidocs/memoization.rst
+++ b/docs/sphinx/sections/api/apidocs/memoization.rst
@@ -12,6 +12,8 @@ Versioning
 
 .. autoclass:: VersionStrategy
 
+.. autoclass:: SourceHashVersionStrategy
+
 Memoization
 -----------
 .. currentmodule:: dagster

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -118,7 +118,7 @@ from dagster.core.definitions.utils import (
     config_from_pkg_resources,
     config_from_yaml_strings,
 )
-from dagster.core.definitions.version_strategy import VersionStrategy
+from dagster.core.definitions.version_strategy import CodeVersionStrategy, VersionStrategy
 from dagster.core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterError,
@@ -463,4 +463,5 @@ __all__ = [
     "VersionStrategy",
     "MEMOIZED_RUN_TAG",
     "MemoizableIOManager",
+    "CodeVersionStrategy",
 ]

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -118,7 +118,7 @@ from dagster.core.definitions.utils import (
     config_from_pkg_resources,
     config_from_yaml_strings,
 )
-from dagster.core.definitions.version_strategy import CodeVersionStrategy, VersionStrategy
+from dagster.core.definitions.version_strategy import SourceHashVersionStrategy, VersionStrategy
 from dagster.core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterError,
@@ -463,5 +463,5 @@ __all__ = [
     "VersionStrategy",
     "MEMOIZED_RUN_TAG",
     "MemoizableIOManager",
-    "CodeVersionStrategy",
+    "SourceHashVersionStrategy",
 ]

--- a/python_modules/dagster/dagster/core/definitions/version_strategy.py
+++ b/python_modules/dagster/dagster/core/definitions/version_strategy.py
@@ -13,14 +13,14 @@ if TYPE_CHECKING:
 
 class SolidVersionContext(
     namedtuple(
-        "SolidVersionContext",
+        "_SolidVersionContext",
         "solid_def solid_config",
     )
 ):
     """Version-specific solid context.
     Attributes:
-        solid_def (SolidDefinition): The definition of the versioned solid
-        solid_config (Any): The parsed config received by the versioned solid
+        solid_def (SolidDefinition): The definition of the solid to compute a version for.
+        solid_config (Any): The parsed config to be passed to the solid during execution.
     """
 
     def __new__(
@@ -39,14 +39,15 @@ class SolidVersionContext(
 
 class ResourceVersionContext(
     namedtuple(
-        "SolidVersionContext",
+        "_ResourceVersionContext",
         "resource_def resource_config",
     )
 ):
-    """Version-specific solid context.
+    """Version-specific resource context.
+
     Attributes:
-        resource_def (ResourceDefinition): The definition of the versioned resource
-        resource_config (Any): The parsed config received by the versioned resource
+        resource_def (ResourceDefinition): The definition of the resource whose version will be computed.
+        resource_config (Any): The parsed config to be passed to the resource during execution.
     """
 
     def __new__(
@@ -86,7 +87,7 @@ class VersionStrategy(ABC):
         return None
 
 
-class CodeVersionStrategy(VersionStrategy):
+class SourceHashVersionStrategy(VersionStrategy):
     def _get_source_hash(self, fn):
         code_as_str = inspect.getsource(fn)
         return hashlib.sha1(code_as_str.encode("utf-8")).hexdigest()
@@ -94,7 +95,5 @@ class CodeVersionStrategy(VersionStrategy):
     def get_solid_version(self, context: SolidVersionContext) -> str:
         return self._get_source_hash(context.solid_def.compute_fn.decorated_fn)
 
-    def get_resource_version(
-        self, context: ResourceVersionContext  # pylint: disable=unused-argument
-    ) -> Optional[str]:
+    def get_resource_version(self, context: ResourceVersionContext) -> Optional[str]:
         return self._get_source_hash(context.resource_def.resource_fn)

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -3,7 +3,6 @@ import hashlib
 import pytest
 from dagster import (
     Bool,
-    SourceHashVersionStrategy,
     DagsterInvariantViolationError,
     Float,
     IOManagerDefinition,
@@ -12,6 +11,7 @@ from dagster import (
     ModeDefinition,
     Output,
     OutputDefinition,
+    SourceHashVersionStrategy,
     String,
     composite_solid,
     dagster_type_loader,

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -3,7 +3,7 @@ import hashlib
 import pytest
 from dagster import (
     Bool,
-    CodeVersionStrategy,
+    SourceHashVersionStrategy,
     DagsterInvariantViolationError,
     Float,
     IOManagerDefinition,
@@ -887,7 +887,7 @@ def test_code_versioning_strategy():
     def my_op():
         return 5
 
-    @job(version_strategy=CodeVersionStrategy())
+    @job(version_strategy=SourceHashVersionStrategy())
     def call_the_op():
         my_op()
 


### PR DESCRIPTION
Ideally makes it quite easy to get up and running with memoization. You just plug this into your job, and it will "work". Won't pick up changes that you make to fxns called within each op.