### PR TITLE
Speed up initial Run query by bypassing yaml transform for run config

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -287,6 +287,7 @@ type Run implements PipelineRun {
   executionPlan: ExecutionPlan
   stepKeysToExecute: [String!]
   runConfigYaml: String!
+  runConfig: RunConfigData!
   mode: String!
   tags: [PipelineTag!]!
   rootRunId: String
@@ -312,6 +313,7 @@ interface PipelineRun {
   executionPlan: ExecutionPlan
   stepKeysToExecute: [String!]
   runConfigYaml: String!
+  runConfig: RunConfigData!
   mode: String!
   tags: [PipelineTag!]!
   rootRunId: String
@@ -485,6 +487,8 @@ enum StepKind {
   UNRESOLVED_MAPPED
   UNRESOLVED_COLLECT
 }
+
+scalar RunConfigData
 
 type Asset {
   id: String!
@@ -1431,8 +1435,6 @@ enum EvaluationErrorReason {
   FIELDS_NOT_DEFINED
   SELECTOR_FIELD_ERROR
 }
-
-scalar RunConfigData
 
 union ExecutionPlanOrError = ExecutionPlan | RunConfigValidationInvalid | PipelineNotFoundError | InvalidSubsetError | PythonError
 

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -1,6 +1,7 @@
 import {gql, useLazyQuery, useMutation} from '@apollo/client';
 import * as qs from 'query-string';
 import * as React from 'react';
+import * as yaml from 'yaml';
 
 import {AppContext} from '../app/AppContext';
 import {showCustomAlert} from '../app/CustomAlertProvider';
@@ -130,9 +131,10 @@ export const RunActionsMenu: React.FC<{
                   icon="refresh"
                   onClick={async () => {
                     if (repoMatch && runConfigYaml) {
+                      const runConfig = yaml.parse(runConfigYaml);
                       const result = await reexecute({
                         variables: getReexecutionVariables({
-                          run: {...run, runConfigYaml},
+                          run: {...run, runConfig},
                           style: {type: 'all'},
                           repositoryLocationName: repoMatch.match.repositoryLocation.name,
                           repositoryName: repoMatch.match.repository.name,

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -1,5 +1,6 @@
 import {gql} from '@apollo/client';
 import * as React from 'react';
+import * as yaml from 'yaml';
 
 import {AppContext} from '../app/AppContext';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -116,6 +117,7 @@ export const RunDetails: React.FC<{
 export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({run, isJob}) => {
   const [showDialog, setShowDialog] = React.useState(false);
   const {rootServerURI} = React.useContext(AppContext);
+  const runConfigYaml = yaml.stringify(run.runConfig) || '';
   return (
     <div>
       <Group direction="row" spacing={8}>
@@ -147,7 +149,7 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
             </Group>
             <Group direction="column" spacing={12}>
               <div style={{fontSize: '16px', fontWeight: 600}}>Config</div>
-              <HighlightedCodeBlock value={run?.runConfigYaml || ''} language="yaml" />
+              <HighlightedCodeBlock value={runConfigYaml} language="yaml" />
             </Group>
           </Group>
         </DialogBody>

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -26,7 +26,7 @@ export const RunFragments = {
   RunFragment: gql`
     fragment RunFragment on Run {
       id
-      runConfigYaml
+      runConfig
       runId
       canTerminate
       status

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -1,6 +1,5 @@
 import {gql} from '@apollo/client';
 import * as React from 'react';
-import * as yaml from 'yaml';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -106,7 +106,7 @@ export type ReExecutionStyle =
   | {type: 'selection'; selection: StepSelection};
 
 export function getReexecutionVariables(input: {
-  run: (RunFragment | RunTableRunFragment) & {runConfigYaml: string};
+  run: (RunFragment | RunTableRunFragment) & {runConfig: any};
   style: ReExecutionStyle;
   repositoryLocationName: string;
   repositoryName: string;
@@ -119,7 +119,7 @@ export function getReexecutionVariables(input: {
 
   const executionParams: ExecutionParams = {
     mode: run.mode,
-    runConfigData: yaml.parse(run.runConfigYaml),
+    runConfigData: run.runConfig,
     executionMetadata: getBaseExecutionMetadata(run),
     selector: {
       repositoryLocationName,

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -103,7 +103,7 @@ export interface RunFragment_stepStats {
 export interface RunFragment {
   __typename: "Run";
   id: string;
-  runConfigYaml: string;
+  runConfig: any;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -108,7 +108,7 @@ export interface RunRootQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
   pipeline: RunRootQuery_pipelineRunOrError_Run_pipeline;
-  runConfigYaml: string;
+  runConfig: any;
   runId: string;
   canTerminate: boolean;
   status: RunStatus;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -30,6 +30,7 @@ from ..logs.events import (
 )
 from ..paging import GrapheneCursor
 from ..repository_origin import GrapheneRepositoryOrigin
+from ..runs import GrapheneRunConfigData
 from ..schedules.schedules import GrapheneSchedule
 from ..sensors import GrapheneSensor
 from ..solids import (
@@ -153,6 +154,7 @@ class GraphenePipelineRun(graphene.Interface):
     executionPlan = graphene.Field(GrapheneExecutionPlan)
     stepKeysToExecute = graphene.List(graphene.NonNull(graphene.String))
     runConfigYaml = graphene.NonNull(graphene.String)
+    runConfig = graphene.NonNull(GrapheneRunConfigData)
     mode = graphene.NonNull(graphene.String)
     tags = non_null_list(GraphenePipelineTag)
     rootRunId = graphene.Field(graphene.String)
@@ -191,6 +193,7 @@ class GrapheneRun(graphene.ObjectType):
     executionPlan = graphene.Field(GrapheneExecutionPlan)
     stepKeysToExecute = graphene.List(graphene.NonNull(graphene.String))
     runConfigYaml = graphene.NonNull(graphene.String)
+    runConfig = graphene.NonNull(GrapheneRunConfigData)
     mode = graphene.NonNull(graphene.String)
     tags = non_null_list(GraphenePipelineTag)
     rootRunId = graphene.Field(graphene.String)
@@ -282,6 +285,9 @@ class GrapheneRun(graphene.ObjectType):
         return yaml.dump(
             self._pipeline_run.run_config, default_flow_style=False, allow_unicode=True
         )
+
+    def resolve_runConfig(self, _graphene_info):
+        return self._pipeline_run.run_config
 
     def resolve_tags(self, _graphene_info):
         return [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -1,6 +1,6 @@
 import copy
-import yaml
 
+import yaml
 from dagster import execute_pipeline, lambda_solid, pipeline, repository
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.execution.api import execute_run

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -1,4 +1,5 @@
 import copy
+import yaml
 
 from dagster import execute_pipeline, lambda_solid, pipeline, repository
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
@@ -47,6 +48,7 @@ fragment RunHistoryRunFragment on PipelineRun {
       key
     }
   }
+  runConfig
   runConfigYaml
   mode
   canTerminate
@@ -278,6 +280,35 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
             read_context, DELETE_RUN_MUTATION, variables={"runId": run_id_two}
         )
         assert result.data["deletePipelineRun"]["__typename"] == "RunNotFoundError"
+
+    def test_run_config(self, graphql_context):
+        # This include needs to be here because its inclusion screws up
+        # other code in this file which reads itself to load a repo
+        from .utils import sync_execute_get_run_log_data
+
+        selector = infer_pipeline_selector(graphql_context, "multi_mode_with_resources")
+
+        payload_one = sync_execute_get_run_log_data(
+            context=graphql_context,
+            variables={
+                "executionParams": {
+                    "selector": selector,
+                    "mode": "add_mode",
+                    "runConfigData": {"resources": {"op": {"config": 2}}},
+                }
+            },
+        )
+        result = execute_dagster_graphql(
+            graphql_context, RUNS_QUERY, variables={"selector": selector}
+        )
+
+        runs = result.data["pipelineOrError"]["runs"]
+        assert len(runs) == 1
+        run = runs[0]
+        assert run["runConfig"] == {"resources": {"op": {"config": 2}}}
+        assert run["runConfigYaml"] == yaml.safe_dump(
+            run["runConfig"], default_flow_style=False, allow_unicode=True
+        )
 
 
 def get_repo_at_time_1():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -288,7 +288,7 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
 
         selector = infer_pipeline_selector(graphql_context, "multi_mode_with_resources")
 
-        payload_one = sync_execute_get_run_log_data(
+        sync_execute_get_run_log_data(
             context=graphql_context,
             variables={
                 "executionParams": {


### PR DESCRIPTION
## Summary

40% of the initial query time (`RunRootQuery`) on the Run page is spent calculating the run config yaml server-side.  This is especially pointless considering the fact that we are just calling `yaml.parse` in javascript to pass the run config right back to the server when we do a reexecution.

This diff creates a new `RunConfig` field on the `Run` graphql type, and uses that instead of the client-side yaml parse library.

We may want to remove the `runConfigYaml` field altogether from graphql and only do yaml transforms client-side.

## Test Plan
BK
