### PR TITLE
Launch cli don't create ephemeral instance

### DIFF
--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -144,8 +144,8 @@ def job_execute_command(**kwargs):
 @click.option("--tags", type=click.STRING, help="JSON string of tags to use for this job run")
 @click.option("--run-id", type=click.STRING, help="The ID to give to the launched job run")
 def job_launch_command(**kwargs):
-    with get_instance_for_service("``dagster job launch``") as instance:
-        return execute_launch_command(instance, kwargs, using_job_op_graph_apis=True)
+    with DagsterInstance.get() as instance:
+        return execute_launch_command(instance, kwargs)
 
 
 @job_cli.command(

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -613,7 +613,7 @@ def do_execute_command(
 )
 @click.option("--run-id", type=click.STRING, help="The ID to give to the launched pipeline/job run")
 def pipeline_launch_command(**kwargs):
-    with get_instance_for_service("``dagster pipeline launch``") as instance:
+    with DagsterInstance.get() as instance:
         return execute_launch_command(instance, kwargs)
 
 


### PR DESCRIPTION
Previously we were creating an ephemeral instance / temp dir when launching a job. Doing this cleans up before run gets executed (execution happens async). We should just not do this.