### PR TITLE
[dagster-gcp] Replace get_bucket with bucket

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -60,10 +60,13 @@ class GCSComputeLogManager(ComputeLogManager, ConfigurableClass):
             self._bucket = (
                 storage.Client()
                 .from_service_account_info(credentials_info)
-                .get_bucket(self._bucket_name)
+                .bucket(self._bucket_name)
             )
         else:
-            self._bucket = storage.Client().get_bucket(self._bucket_name)
+            self._bucket = storage.Client().bucket(self._bucket_name)
+
+        # Check if the bucket exists
+        check.invariant(self._bucket.exists())
 
         # proxy calls to local compute log manager (for subscriptions, etc)
         if not local_dir:

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -58,7 +58,7 @@ class GCSFileManager(FileManager):
             # instigate download
             temp_file_obj = self._temp_file_manager.tempfile()
             temp_name = temp_file_obj.name
-            bucket_obj = self._client.get_bucket(file_handle.gcs_bucket)
+            bucket_obj = self._client.bucket(file_handle.gcs_bucket)
             bucket_obj.blob(file_handle.gcs_key).download_to_file(temp_file_obj)
             self._local_handle_cache[file_handle.gcs_path] = temp_name
 
@@ -92,7 +92,7 @@ class GCSFileManager(FileManager):
     def write(self, file_obj, mode="wb", ext=None):
         check_file_like_obj(file_obj)
         gcs_key = self.get_full_key(str(uuid.uuid4()) + (("." + ext) if ext is not None else ""))
-        bucket_obj = self._client.get_bucket(self._gcs_bucket)
+        bucket_obj = self._client.bucket(self._gcs_bucket)
         bucket_obj.blob(gcs_key).upload_from_file(file_obj)
         return GCSFileHandle(self._gcs_bucket, gcs_key)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -13,7 +13,7 @@ class PickledObjectGCSIOManager(IOManager):
     def __init__(self, bucket, client=None, prefix="dagster"):
         self.bucket = check.str_param(bucket, "bucket")
         self.client = client or storage.Client()
-        self.bucket_obj = self.client.get_bucket(bucket)
+        self.bucket_obj = self.client.bucket(bucket)
         check.invariant(self.bucket_obj.exists())
         self.prefix = check.str_param(prefix, "prefix")
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -70,7 +70,7 @@ def test_compute_log_manager(gcs_bucket):
             # Check GCS directly
             stderr_gcs = (
                 storage.Client()
-                .get_bucket(gcs_bucket)
+                .bucket(gcs_bucket)
                 .blob(f"my_prefix/storage/{result.run_id}/compute_logs/easy.err")
                 .download_as_bytes()
                 .decode("utf-8")
@@ -143,7 +143,7 @@ def test_compute_log_manager_with_envvar(gcs_bucket):
                 # Check GCS directly
                 stderr_gcs = (
                     storage.Client()
-                    .get_bucket(gcs_bucket)
+                    .bucket(gcs_bucket)
                     .blob(f"my_prefix/storage/{result.run_id}/compute_logs/easy.err")
                     .download_as_bytes()
                     .decode("utf-8")

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
@@ -20,7 +20,7 @@ def test_gcs_file_manager_write():
     assert file_handle.gcs_bucket == "some-bucket"
     assert file_handle.gcs_key.startswith("some-key/")
 
-    assert gcs_mock.get_bucket().blob().upload_from_file.call_count == 1
+    assert gcs_mock.bucket().blob().upload_from_file.call_count == 1
 
     file_handle = file_manager.write_data(foo_bytes, ext="foo")
 
@@ -30,7 +30,7 @@ def test_gcs_file_manager_write():
     assert file_handle.gcs_key.startswith("some-key/")
     assert file_handle.gcs_key[-4:] == ".foo"
 
-    assert gcs_mock.get_bucket().blob().upload_from_file.call_count == 2
+    assert gcs_mock.bucket().blob().upload_from_file.call_count == 2
 
 
 @mock.patch("dagster_gcp.gcs.resources.storage.client.Client")


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

When dagster accesses GCS it does that using the google-python-storage library.
In dagster's code, we use `get_bucket` very often, which gets the bucket object and **all its metadata**.

This is not really necessary most of the time since we care about creating objects and not the bucket's metadata.

Using this patch we should be able to do the same things that we have been doing until now (reading/writing files on GCS) but without:
 - Giving additional permissions to dagster (`storage.objectCreator` should be enough for us, but it isn't currently)
 - Saving a couple of HTTP calls since in the current state we get the bucket's metadata but we actually don't need it.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.