### PR TITLE
remove progress bar from docs build tox output

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 [testenv]
 pip_version = pip==21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE
+install_command = pip install --progress-bar off {opts} {packages}
 
 deps =
   -r ./docs-requirements.txt


### PR DESCRIPTION
Summary:
The ASCII progress bar makes the buildkite output completely illegible (it's possible we should apply this to all the tox suites, but this is the particularly egregious one since it installs so much stuff)

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.