### PR TITLE
Fix bug in StepDelegatingExecutor on dynamic skips

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/dynamic_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/dynamic_job.py
@@ -1,0 +1,30 @@
+from dagster import DynamicOut, Out, job, op
+from dagster.core.definitions.events import DynamicOutput, Output
+
+from .test_step_delegating_executor import test_step_delegating_executor
+
+
+@op(out=DynamicOut(str))
+def dynamic():
+    for x in ["a", "b"]:
+        yield DynamicOutput(x, x)
+
+
+@op(out=Out(is_required=False))
+def optional(x):
+    if x == "a":
+        yield Output(x)
+
+
+@op
+def final(context, xs):
+    context.log.info(xs)
+
+
+def define_dynamic_skipping_job():
+    @job(executor_def=test_step_delegating_executor)
+    def dynamic_skipping_job():
+        xs = dynamic().map(optional)
+        xs.map(final)
+
+    return dynamic_skipping_job

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -119,6 +119,20 @@ def test_execute():
     assert TestStepHandler.saw_baz_solid
 
 
+def test_skip_execute():
+    from .dynamic_job import define_dynamic_skipping_job
+
+    TestStepHandler.reset()
+    with instance_for_test() as instance:
+        result = execute_pipeline(
+            reconstructable(define_dynamic_skipping_job),
+            instance=instance,
+        )
+        TestStepHandler.wait_for_processes()
+
+    assert result.success
+
+
 def test_execute_intervals():
     TestStepHandler.reset()
     with instance_for_test() as instance:


### PR DESCRIPTION
active_execution.plan_events_iterator(plan_context) needs to be called before active_execution.handle_event(dagster_event) is called on a STEP_SKIPPED event, or else you run in to the error `Attempted to mark step final[b] as complete that was not known to be in flight`.

There was a race condition where if a launched step could emit the STEP_SKIPPED and get picked up by the executor within one iteration, then you’d hit this error