### PR TITLE
[dagit] Make websocket provider handle existing state, initial failures

### DIFF
--- a/js_modules/dagit/packages/core/src/app/WebSocketProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/WebSocketProvider.tsx
@@ -57,6 +57,10 @@ export const WebSocketProvider: React.FC<Props> = (props) => {
   const debouncedSetter = React.useMemo(() => debounce(setStatus, DEBOUNCE_TIME), []);
 
   React.useEffect(() => {
+    // Note: In Firefox, we sometimes see websockets closed with the error message
+    // "The connection to wss://... was interrupted while the page was loading"
+    // The client reconnects, but we need to continue listening for state changes
+    // after "onError" below to realize that websockets are in fact supported.
     const availabilityListeners = [
       websocketClient.onConnected(() => setFinalAvailability('available')),
       websocketClient.onReconnected(() => setFinalAvailability('available')),


### PR DESCRIPTION

## Summary
This PR makes two small changes to Dagit's websocket provider, which determines whether websockets are available in the current Dagit deployment.

- If the socket is already open when the WebsocketProvider mounts for some reason (eg: if the provider is unmounted and remounted), no further state transitions are expected and it needs to set initial state.

- If the socket errors and then reconnects, we 1) don't stop listening for state changes when the error occurs and 2) listen for the reconnect and mark that websockets are available. 


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.