### PR TITLE
Select only jobs in job CLI command

### DIFF
--- a/python_modules/dagster/dagster/cli/job.py
+++ b/python_modules/dagster/dagster/cli/job.py
@@ -145,7 +145,7 @@ def job_execute_command(**kwargs):
 @click.option("--run-id", type=click.STRING, help="The ID to give to the launched job run")
 def job_launch_command(**kwargs):
     with get_instance_for_service("``dagster job launch``") as instance:
-        return execute_launch_command(instance, kwargs)
+        return execute_launch_command(instance, kwargs, using_job_op_graph_apis=True)
 
 
 @job_cli.command(
@@ -157,7 +157,7 @@ def job_launch_command(**kwargs):
 @python_job_target_argument
 @click.option("--print-only-required", default=False, is_flag=True)
 def job_scaffold_command(**kwargs):
-    execute_scaffold_command(kwargs, click.echo)
+    execute_scaffold_command(kwargs, click.echo, using_job_op_graph_apis=True)
 
 
 @job_cli.command(

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -87,7 +87,11 @@ def execute_list_command(cli_args, print_fn, using_job_op_graph_apis=False):
             print_fn(title)
             print_fn("*" * len(title))
             first = True
-            for pipeline in external_repository.get_all_external_pipelines():
+            for pipeline in (
+                external_repository.get_external_jobs()
+                if using_job_op_graph_apis
+                else external_repository.get_all_external_pipelines()
+            ):
                 pipeline_title = "{pipeline_or_job}: {name}".format(
                     pipeline_or_job="Job" if using_job_op_graph_apis else "Pipeline",
                     name=pipeline.name,
@@ -614,7 +618,7 @@ def pipeline_launch_command(**kwargs):
 
 
 @telemetry_wrapper
-def execute_launch_command(instance, kwargs):
+def execute_launch_command(instance, kwargs, using_job_op_graph_apis=False):
     preset = kwargs.get("preset")
     mode = kwargs.get("mode")
     check.inst_param(instance, "instance", DagsterInstance)
@@ -626,7 +630,7 @@ def execute_launch_command(instance, kwargs):
             repo_location, kwargs.get("repository")
         )
         external_pipeline = get_external_pipeline_or_job_from_external_repo(
-            external_repo, kwargs.get("pipeline_or_job")
+            external_repo, kwargs.get("pipeline_or_job"), using_job_op_graph_apis
         )
 
         log_external_repo_stats(
@@ -671,8 +675,10 @@ def pipeline_scaffold_command(**kwargs):
     execute_scaffold_command(kwargs, click.echo)
 
 
-def execute_scaffold_command(cli_args, print_fn):
-    pipeline_origin = get_pipeline_or_job_python_origin_from_kwargs(cli_args)
+def execute_scaffold_command(cli_args, print_fn, using_job_op_graph_apis=False):
+    pipeline_origin = get_pipeline_or_job_python_origin_from_kwargs(
+        cli_args, using_job_op_graph_apis
+    )
     pipeline = recon_pipeline_from_origin(pipeline_origin)
     skip_non_required = cli_args["print_only_required"]
     do_scaffold_command(pipeline.get_definition(), print_fn, skip_non_required)

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/extra_repo.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/extra_repo.py
@@ -1,4 +1,4 @@
-from dagster import lambda_solid, pipeline, repository
+from dagster import job, lambda_solid, pipeline, repository
 
 
 @lambda_solid
@@ -11,8 +11,11 @@ def extra_pipeline():
     do_something()
 
 
+@job
+def extra_job():
+    do_something()
+
+
 @repository
 def extra():
-    return {
-        "pipelines": {"extra": extra_pipeline},
-    }
+    return {"pipelines": {"extra": extra_pipeline}, "jobs": {"extra_job": extra_job}}

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/repo_pipeline_and_job.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/repo_pipeline_and_job.py
@@ -1,0 +1,26 @@
+from dagster import job, op, pipeline, repository, solid
+
+
+@op
+def my_op():
+    pass
+
+
+@job
+def my_job():
+    my_op()
+
+
+@solid
+def my_solid():
+    pass
+
+
+@pipeline
+def my_pipeline():
+    my_solid()
+
+
+@repository
+def my_repo():
+    return [my_job, my_pipeline]

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -19,6 +19,7 @@ from dagster import (
     String,
     execute_pipeline,
     graph,
+    job,
     lambda_solid,
     op,
     pipeline,
@@ -87,6 +88,11 @@ qux_job = qux.to_job(
     ),
     tags={"foo": "bar"},
 )
+
+
+@job
+def quux_job():
+    do_something_op()
 
 
 def define_qux_job():
@@ -191,10 +197,10 @@ def bar():
         "pipelines": {
             "foo": foo_pipeline,
             "baz": baz_pipeline,
-            "qux": qux_job,
             "partitioned_scheduled_pipeline": partitioned_scheduled_pipeline,
             "memoizable": memoizable_pipeline,
         },
+        "jobs": {"qux": qux_job, "quux": quux_job},
         "schedules": define_bar_schedules(),
         "partition_sets": define_bar_partitions(),
         "sensors": define_bar_sensors(),

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -197,6 +197,29 @@ def test_job_execute_command_runner(cli_args):
         )
 
 
+def test_job_command_only_selects_job():
+    with instance_for_test() as instance:
+        job_kwargs = {
+            "workspace": None,
+            "pipeline_or_job": "my_job",
+            "python_file": file_relative_path(__file__, "repo_pipeline_and_job.py"),
+            "module_name": None,
+            "attribute": "my_repo",
+        }
+        pipeline_kwargs = job_kwargs.copy()
+        pipeline_kwargs["pipeline_or_job"] = "my_pipeline"
+
+        result = execute_execute_command(
+            kwargs=job_kwargs, instance=instance, using_job_op_graph_apis=True
+        )
+        assert result.success
+
+        with pytest.raises(Exception, match="not found in repository"):
+            result = execute_execute_command(
+                kwargs=pipeline_kwargs, instance=instance, using_job_op_graph_apis=True
+            )
+
+
 def test_output_execute_log_stdout(capfd):
     with instance_for_test(
         overrides={

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -215,7 +215,7 @@ def test_job_command_only_selects_job():
         assert result.success
 
         with pytest.raises(Exception, match="not found in repository"):
-            result = execute_execute_command(
+            execute_execute_command(
                 kwargs=pipeline_kwargs, instance=instance, using_job_op_graph_apis=True
             )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -362,3 +362,27 @@ def test_launch_using_memoization():
             assert result.exit_code == 0
             run = instance.get_run_by_id("second")
             assert len(run.step_keys_to_execute) == 0
+
+
+def test_job_launch_only_selects_job():
+    job_kwargs = {
+        "workspace": None,
+        "pipeline_or_job": "my_job",
+        "python_file": file_relative_path(__file__, "repo_pipeline_and_job.py"),
+        "module_name": None,
+        "attribute": "my_repo",
+    }
+    pipeline_kwargs = job_kwargs.copy()
+    pipeline_kwargs["pipeline_or_job"] = "my_pipeline"
+
+    runner = CliRunner()
+
+    with default_cli_test_instance() as instance:
+        execute_launch_command(
+            instance,
+            job_kwargs,
+            using_job_op_graph_apis=True,
+        )
+
+        with pytest.raises(Exception, match="not found in repository"):
+            execute_launch_command(instance, pipeline_kwargs, using_job_op_graph_apis=True)

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
@@ -362,3 +362,15 @@ def test_list_command():
                 },
                 no_print,
             )
+
+
+def test_job_command_only_selects_job(capsys):
+    with instance_for_test():
+        runner = CliRunner()
+        result = runner.invoke(
+            job_list_command,
+            ["-f", file_relative_path(__file__, "repo_pipeline_and_job.py"), "-a", "my_repo"],
+        )
+
+        assert "my_job" in result.output
+        assert not "my_pipeline" in result.output

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
@@ -40,6 +40,10 @@ def assert_correct_bar_repository_output(result):
         "Pipeline: partitioned_scheduled_pipeline\n"
         "Solids: (Execution Order)\n"
         "    do_something\n"
+        "******************\n"
+        "Pipeline: quux_job\n"
+        "Solids: (Execution Order)\n"
+        "    do_something_op\n"
         "*************\n"
         "Pipeline: qux\n"
         "Solids: (Execution Order)\n"
@@ -53,24 +57,9 @@ def assert_correct_job_list_bar_repository_output(result):
     assert result.output == (
         "Repository bar\n"
         "**************\n"
-        "Job: baz\n"
-        "Description:\n"
-        "Not much tbh\n"
+        "Job: quux_job\n"
         "Ops: (Execution Order)\n"
-        "    do_input\n"
-        "********\n"
-        "Job: foo\n"
-        "Ops: (Execution Order)\n"
-        "    do_something\n"
-        "    do_input\n"
-        "***************\n"
-        "Job: memoizable\n"
-        "Ops: (Execution Order)\n"
-        "    my_solid\n"
-        "***********************************\n"
-        "Job: partitioned_scheduled_pipeline\n"
-        "Ops: (Execution Order)\n"
-        "    do_something\n"
+        "    do_something_op\n"
         "********\n"
         "Job: qux\n"
         "Ops: (Execution Order)\n"
@@ -87,6 +76,10 @@ def assert_correct_extra_repository_output(result):
         "Pipeline: extra\n"
         "Solids: (Execution Order)\n"
         "    do_something\n"
+        "*******************\n"
+        "Pipeline: extra_job\n"
+        "Solids: (Execution Order)\n"
+        "    do_something\n"
     )
 
 
@@ -95,7 +88,7 @@ def assert_correct_job_list_extra_repository_output(result):
     assert result.output == (
         "Repository extra\n"
         "****************\n"
-        "Job: extra\n"
+        "Job: extra_job\n"
         "Ops: (Execution Order)\n"
         "    do_something\n"
     )
@@ -125,6 +118,7 @@ def test_list_command_grpc_socket():
             )
 
             result = runner.invoke(pipeline_list_command, ["--grpc-socket", api_client.socket])
+            print(result.output)
             assert_correct_bar_repository_output(result)
 
             result = runner.invoke(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_list_command.py
@@ -118,7 +118,6 @@ def test_list_command_grpc_socket():
             )
 
             result = runner.invoke(pipeline_list_command, ["--grpc-socket", api_client.socket])
-            print(result.output)
             assert_correct_bar_repository_output(result)
 
             result = runner.invoke(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -94,3 +94,33 @@ def test_print_command_baz():
             ],
         )
         assert res.exit_code == 0, res.stdout
+
+
+def test_job_command_only_selects_job():
+    job_kwargs = {
+        "workspace": None,
+        "pipeline_or_job": "my_job",
+        "python_file": file_relative_path(__file__, "repo_pipeline_and_job.py"),
+        "module_name": None,
+        "attribute": "my_repo",
+    }
+    pipeline_kwargs = job_kwargs.copy()
+    pipeline_kwargs["pipeline_or_job"] = "my_pipeline"
+
+    with instance_for_test() as instance:
+        execute_print_command(
+            instance=instance,
+            verbose=False,
+            cli_args=job_kwargs,
+            print_fn=no_print,
+            using_job_op_graph_apis=True,
+        )
+
+        with pytest.raises(Exception, match="not found in repository"):
+            execute_print_command(
+                instance,
+                verbose=False,
+                cli_args=pipeline_kwargs,
+                print_fn=no_print,
+                using_job_op_graph_apis=True,
+            )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_print_command.py
@@ -90,7 +90,7 @@ def test_print_command_baz():
                 "-a",
                 "bar",
                 "-j",
-                "baz",
+                "quux_job",
             ],
         )
         assert res.exit_code == 0, res.stdout


### PR DESCRIPTION
`dagster job` CLI commands should select only jobs while `dagster pipeline` CLI commands should select jobs and pipelines for backcompat purposes. This PR modifies job CLI to select only jobs and not pipelines.