### PR TITLE
docs fix: do not version external links

### DIFF
--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -287,8 +287,8 @@ const Experimental = () => {
 
 export default {
   a: ({ children, ...props }) => {
-    // Skip if in-page links
-    if (props.href.startsWith("#")) {
+    // Skip in-page links and external links
+    if (!props.href.startsWith("/")) {
       return <a {...props}>{children}</a>;
     }
     // Hydrate the links in raw MDX to include versions


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
resolves https://github.com/dagster-io/dagster/issues/5526
"Hacker News example project" link on https://docs.dagster.io/guides/dagster/example_project is broken as do other external links (e.g. https://docs.dagster.io/community) 

the cause was that we treated external links the same as inter-page links.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.