### PR TITLE
add op_retry_policy to job and graph.to_job

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -566,7 +566,7 @@ class PendingNodeInvocation:
         logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
     ) -> "JobDefinition":
         if not isinstance(self.node_def, GraphDefinition):
@@ -577,7 +577,7 @@ class PendingNodeInvocation:
 
         tags = check.opt_dict_param(tags, "tags", key_type=str)
         hooks = check.opt_set_param(hooks, "hooks", HookDefinition)
-        retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
+        op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)
         job_hooks: Set[HookDefinition] = set()
         job_hooks.update(check.opt_set_param(hooks, "hooks", HookDefinition))
         job_hooks.update(self.hook_defs)
@@ -590,7 +590,7 @@ class PendingNodeInvocation:
             logger_defs=logger_defs,
             executor_def=executor_def,
             hooks=job_hooks,
-            retry_policy=retry_policy,
+            op_retry_policy=op_retry_policy,
             version_strategy=version_strategy,
         )
 
@@ -627,7 +627,7 @@ class PendingNodeInvocation:
             ),
             tags=self.tags,
             hook_defs=self.hook_defs,
-            solid_retry_policy=self.retry_policy,
+            op_retry_policy=self.retry_policy,
         )
 
         return core_execute_in_process(

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -566,6 +566,7 @@ class PendingNodeInvocation:
         logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
+        retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
     ) -> "JobDefinition":
         if not isinstance(self.node_def, GraphDefinition):
@@ -576,6 +577,7 @@ class PendingNodeInvocation:
 
         tags = check.opt_dict_param(tags, "tags", key_type=str)
         hooks = check.opt_set_param(hooks, "hooks", HookDefinition)
+        retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
         job_hooks: Set[HookDefinition] = set()
         job_hooks.update(check.opt_set_param(hooks, "hooks", HookDefinition))
         job_hooks.update(self.hook_defs)
@@ -588,6 +590,7 @@ class PendingNodeInvocation:
             logger_defs=logger_defs,
             executor_def=executor_def,
             hooks=job_hooks,
+            retry_policy=retry_policy,
             version_strategy=version_strategy,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/job.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job.py
@@ -10,6 +10,7 @@ from ..hook_definition import HookDefinition
 from ..job_definition import JobDefinition
 from ..logger_definition import LoggerDefinition
 from ..resource_definition import ResourceDefinition
+from ..policy import RetryPolicy
 from ..version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
@@ -28,6 +29,7 @@ class _Job:
         logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
+        op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
     ):
         self.name = name
@@ -38,6 +40,7 @@ class _Job:
         self.logger_defs = logger_defs
         self.executor_def = executor_def
         self.hooks = hooks
+        self.op_retry_policy = op_retry_policy
         self.version_strategy = version_strategy
 
     def __call__(self, fn: Callable[..., Any]) -> JobDefinition:
@@ -85,6 +88,7 @@ class _Job:
             logger_defs=self.logger_defs,
             executor_def=self.executor_def,
             hooks=self.hooks,
+            op_retry_policy=self.op_retry_policy,
             version_strategy=self.version_strategy,
         )
         update_wrapper(job_def, fn)
@@ -100,6 +104,7 @@ def job(
     logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
     hooks: Optional[AbstractSet[HookDefinition]] = None,
+    op_retry_policy: Optional[RetryPolicy] = None,
     version_strategy: Optional[VersionStrategy] = None,
 ) -> Union[_Job, JobDefinition]:
     """Creates a job with the specified parameters from the decorated graph/op invocation function.
@@ -141,6 +146,8 @@ def job(
             A dictionary of string logger identifiers to their implementations.
         executor_def (Optional[ExecutorDefinition]):
             How this Job will be executed. Defaults to :py:class:`multiprocess_executor` .
+        op_retry_policy (Optional[RetryPolicy]): The default retry policy for all ops in this job.
+            Only used if retry policy is not defined on the op definition or op invocation.
         version_strategy (Optional[VersionStrategy]):
             Defines how each op (and optionally, resource) in the job can be versioned. If
             provided, memoizaton will be enabled for this job.
@@ -159,5 +166,6 @@ def job(
         logger_defs=logger_defs,
         executor_def=executor_def,
         hooks=hooks,
+        op_retry_policy=op_retry_policy,
         version_strategy=version_strategy,
     )

--- a/python_modules/dagster/dagster/core/definitions/decorators/job.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job.py
@@ -9,8 +9,8 @@ from ..graph_definition import GraphDefinition
 from ..hook_definition import HookDefinition
 from ..job_definition import JobDefinition
 from ..logger_definition import LoggerDefinition
-from ..resource_definition import ResourceDefinition
 from ..policy import RetryPolicy
+from ..resource_definition import ResourceDefinition
 from ..version_strategy import VersionStrategy
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -22,6 +22,7 @@ from dagster.core.definitions.config import ConfigMapping
 from dagster.core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster.core.definitions.mode import ModeDefinition
 from dagster.core.definitions.resource_definition import ResourceDefinition
+from dagster.core.definitions.policy import RetryPolicy
 from dagster.core.definitions.utils import check_valid_name
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster.core.storage.io_manager import io_manager
@@ -401,6 +402,7 @@ class GraphDefinition(NodeDefinition):
         logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
+        retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
     ) -> "JobDefinition":
@@ -443,6 +445,8 @@ class GraphDefinition(NodeDefinition):
                 How this Job will be executed. Defaults to :py:class:`multi_or_in_process_executor`,
                 which can be switched between multi-process and in-process modes of execution. The
                 default mode of execution is multi-process.
+            retry_policy (Optional[RetryPolicy]): The default retry policy for all ops in this job.
+                Only used if retry policy is not defined on the op definition or op invocation.
             version_strategy (Optional[VersionStrategy]):
                 Defines how each solid (and optionally, resource) in the job can be versioned. If
                 provided, memoizaton will be enabled for this job.
@@ -469,6 +473,7 @@ class GraphDefinition(NodeDefinition):
             )
 
         hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)
+        retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
         op_selection = check.opt_list_param(op_selection, "op_selection", of_type=str)
         presets = []
         config_mapping = None
@@ -509,6 +514,7 @@ class GraphDefinition(NodeDefinition):
             tags=tags,
             hook_defs=hooks,
             version_strategy=version_strategy,
+            solid_retry_policy=retry_policy,
         ).get_job_def_for_op_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -514,7 +514,7 @@ class GraphDefinition(NodeDefinition):
             tags=tags,
             hook_defs=hooks,
             version_strategy=version_strategy,
-            solid_retry_policy=retry_policy,
+            retry_policy=retry_policy,
         ).get_job_def_for_op_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -21,8 +21,8 @@ from dagster.config.validate import process_config
 from dagster.core.definitions.config import ConfigMapping
 from dagster.core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster.core.definitions.mode import ModeDefinition
-from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.definitions.policy import RetryPolicy
+from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.definitions.utils import check_valid_name
 from dagster.core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster.core.storage.io_manager import io_manager
@@ -402,7 +402,7 @@ class GraphDefinition(NodeDefinition):
         logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
     ) -> "JobDefinition":
@@ -445,7 +445,7 @@ class GraphDefinition(NodeDefinition):
                 How this Job will be executed. Defaults to :py:class:`multi_or_in_process_executor`,
                 which can be switched between multi-process and in-process modes of execution. The
                 default mode of execution is multi-process.
-            retry_policy (Optional[RetryPolicy]): The default retry policy for all ops in this job.
+            op_retry_policy (Optional[RetryPolicy]): The default retry policy for all ops in this job.
                 Only used if retry policy is not defined on the op definition or op invocation.
             version_strategy (Optional[VersionStrategy]):
                 Defines how each solid (and optionally, resource) in the job can be versioned. If
@@ -473,7 +473,7 @@ class GraphDefinition(NodeDefinition):
             )
 
         hooks = check.opt_set_param(hooks, "hooks", of_type=HookDefinition)
-        retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
+        op_retry_policy = check.opt_inst_param(op_retry_policy, "op_retry_policy", RetryPolicy)
         op_selection = check.opt_list_param(op_selection, "op_selection", of_type=str)
         presets = []
         config_mapping = None
@@ -514,7 +514,7 @@ class GraphDefinition(NodeDefinition):
             tags=tags,
             hook_defs=hooks,
             version_strategy=version_strategy,
-            retry_policy=retry_policy,
+            op_retry_policy=op_retry_policy,
         ).get_job_def_for_op_selection(op_selection)
 
     def coerce_to_job(self):

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -31,7 +31,7 @@ class JobDefinition(PipelineDefinition):
         preset_defs: Optional[List[PresetDefinition]] = None,
         tags: Dict[str, Any] = None,
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
     ):
@@ -48,7 +48,7 @@ class JobDefinition(PipelineDefinition):
             preset_defs=preset_defs,
             tags=tags,
             hook_defs=hook_defs,
-            solid_retry_policy=retry_policy,
+            solid_retry_policy=op_retry_policy,
             graph_def=graph_def,
             version_strategy=version_strategy,
         )
@@ -135,7 +135,7 @@ class JobDefinition(PipelineDefinition):
             mode_def=in_proc_mode,
             hook_defs=self.hook_defs,
             tags=self.tags,
-            retry_policy=self._solid_retry_policy,
+            op_retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,
         ).get_job_def_for_op_selection(op_selection)
 
@@ -200,7 +200,7 @@ class JobDefinition(PipelineDefinition):
             preset_defs=self.preset_defs,
             tags=self.tags,
             hook_defs=self.hook_defs,
-            retry_policy=self._retry_policy,
+            op_retry_policy=self._solid_retry_policy,
             graph_def=subset_pipeline_def.graph,
             version_strategy=self.version_strategy,
             _op_selection_data=OpSelectionData(
@@ -244,7 +244,7 @@ class JobDefinition(PipelineDefinition):
             tags=self.tags,
             hook_defs=hook_defs | self.hook_defs,
             description=self._description,
-            retry_policy=self._retry_policy,
+            op_retry_policy=self._solid_retry_policy,
             _op_selection_data=self._op_selection_data,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -135,6 +135,7 @@ class JobDefinition(PipelineDefinition):
             mode_def=in_proc_mode,
             hook_defs=self.hook_defs,
             tags=self.tags,
+            solid_retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,
         ).get_job_def_for_op_selection(op_selection)
 

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -31,7 +31,7 @@ class JobDefinition(PipelineDefinition):
         preset_defs: Optional[List[PresetDefinition]] = None,
         tags: Dict[str, Any] = None,
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
-        solid_retry_policy: Optional[RetryPolicy] = None,
+        retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
     ):
@@ -48,7 +48,7 @@ class JobDefinition(PipelineDefinition):
             preset_defs=preset_defs,
             tags=tags,
             hook_defs=hook_defs,
-            solid_retry_policy=solid_retry_policy,
+            solid_retry_policy=retry_policy,
             graph_def=graph_def,
             version_strategy=version_strategy,
         )
@@ -135,7 +135,7 @@ class JobDefinition(PipelineDefinition):
             mode_def=in_proc_mode,
             hook_defs=self.hook_defs,
             tags=self.tags,
-            solid_retry_policy=self._solid_retry_policy,
+            retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,
         ).get_job_def_for_op_selection(op_selection)
 
@@ -200,7 +200,7 @@ class JobDefinition(PipelineDefinition):
             preset_defs=self.preset_defs,
             tags=self.tags,
             hook_defs=self.hook_defs,
-            solid_retry_policy=self._solid_retry_policy,
+            retry_policy=self._retry_policy,
             graph_def=subset_pipeline_def.graph,
             version_strategy=self.version_strategy,
             _op_selection_data=OpSelectionData(
@@ -244,7 +244,7 @@ class JobDefinition(PipelineDefinition):
             tags=self.tags,
             hook_defs=hook_defs | self.hook_defs,
             description=self._description,
-            solid_retry_policy=self._solid_retry_policy,
+            retry_policy=self._retry_policy,
             _op_selection_data=self._op_selection_data,
         )
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
resolves https://github.com/dagster-io/dagster/issues/5553

add `op_retry_policy` arg to the following APIs:
- `GraphDefinition.to_job`
- `PendingNodeInvocation.to_job` - when a graph is decorated by a hook, it becomes a PendingNodeInvocation
- `@job`

rename `solid_retry_policy` to `op_retry_policy` in `JobDefinition`

## Test Plan
bk



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [-] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.