### PR TITLE
Better handle schedule timestamp updates when a schedule is turned off and turned back on

### DIFF
--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -120,13 +120,14 @@ def launch_scheduled_runs_for_schedule(
 
     latest_tick = instance.get_latest_job_tick(schedule_state.job_origin_id)
 
-    if not latest_tick:
-        start_timestamp_utc = schedule_state.job_specific_data.start_timestamp
-    elif latest_tick.status == JobTickStatus.STARTED:
-        # Scheduler was interrupted while performing this tick, re-do it
-        start_timestamp_utc = latest_tick.timestamp
-    else:
-        start_timestamp_utc = latest_tick.timestamp + 1
+    start_timestamp_utc = schedule_state.job_specific_data.start_timestamp
+
+    if latest_tick:
+        if latest_tick.status == JobTickStatus.STARTED:
+            # Scheduler was interrupted while performing this tick, re-do it
+            start_timestamp_utc = max(start_timestamp_utc, latest_tick.timestamp)
+        else:
+            start_timestamp_utc = max(start_timestamp_utc, latest_tick.timestamp + 1)
 
     schedule_name = schedule_state.job_name
     repo_name = schedule_state.origin.external_repository_origin.repository_name


### PR DESCRIPTION
Summary:
Before we would look at the last tick no matter what, even if you turned the schedule off and back on. Use max instead to determine the start time.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.