### PR TITLE
Revert "Enable memoization on every executor"

### DIFF
--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
@@ -12,7 +12,6 @@ import pytest
 from dagster import check
 from dagster.cli.debug import export_run
 from dagster.core.instance import DagsterInstance, InstanceType
-from dagster.core.instance.ref import InstanceRef
 from dagster.core.run_coordinator import DefaultRunCoordinator, QueuedRunCoordinator
 from dagster.core.scheduler import DagsterDaemonScheduler
 from dagster.core.storage.noop_compute_log_manager import NoOpComputeLogManager
@@ -306,10 +305,8 @@ def dagster_instance_for_k8s_run_launcher(
 ):  # pylint: disable=redefined-outer-name
     tempdir = DagsterInstance.temp_storage()
 
-    instance_ref = InstanceRef.from_dir(tempdir)
-
     with DagsterInstance(
-        instance_type=InstanceType.PERSISTENT,
+        instance_type=InstanceType.EPHEMERAL,
         local_artifact_storage=LocalArtifactStorage(tempdir),
         run_storage=PostgresRunStorage(helm_postgres_url_for_k8s_run_launcher),
         event_storage=PostgresEventLogStorage(helm_postgres_url_for_k8s_run_launcher),
@@ -318,7 +315,6 @@ def dagster_instance_for_k8s_run_launcher(
         run_coordinator=DefaultRunCoordinator(),
         run_launcher=run_launcher,
         settings={"run_monitoring": {"enabled": True}},
-        ref=instance_ref,
     ) as instance:
         yield instance
 

--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/test_integration.py
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/test_integration.py
@@ -18,11 +18,9 @@ from dagster_k8s_test_infra.helm import TEST_AWS_CONFIGMAP_NAME
 from dagster_k8s_test_infra.integration_utils import image_pull_policy
 from dagster_test.test_project import (
     ReOriginatedExternalPipelineForTest,
-    cleanup_memoized_results,
     get_test_project_environments_path,
     get_test_project_workspace_and_external_pipeline,
 )
-from dagster_test.test_project.test_pipelines.repo import define_memoization_pipeline
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
@@ -569,67 +567,3 @@ def test_execute_on_celery_k8s_with_hard_failure(  # pylint: disable=redefined-o
                         break
             time.sleep(5)
         assert step_failure_found
-
-
-def _get_step_events(event_logs):
-    return [
-        event_log.dagster_event
-        for event_log in event_logs
-        if event_log.dagster_event is not None and event_log.dagster_event.is_step_event
-    ]
-
-
-def test_memoization_on_celery_k8s(  # pylint: disable=redefined-outer-name
-    dagster_docker_image, dagster_instance, helm_namespace
-):
-    run_config = merge_dicts(
-        merge_yamls([os.path.join(get_test_project_environments_path(), "env_s3.yaml")]),
-        get_celery_engine_config(
-            dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
-        ),
-    )
-
-    # Clean up any residual outputs that may have been left by failed runs.
-    cleanup_memoized_results(define_memoization_pipeline(), "celery", dagster_instance, run_config)
-
-    try:
-        pipeline_name = "memoization_pipeline"
-        with get_test_project_workspace_and_external_pipeline(dagster_instance, pipeline_name) as (
-            workspace,
-            external_pipeline,
-        ):
-            reoriginated_pipeline = ReOriginatedExternalPipelineForTest(external_pipeline)
-
-            runs = []
-            for _ in range(2):
-                run = create_run_for_test(
-                    dagster_instance,
-                    pipeline_name=pipeline_name,
-                    run_config=run_config,
-                    mode="celery",
-                    external_pipeline_origin=reoriginated_pipeline.get_external_origin(),
-                    pipeline_code_origin=reoriginated_pipeline.get_python_origin(),
-                )
-
-                dagster_instance.launch_run(run.run_id, workspace)
-
-                result = wait_for_job_and_get_raw_logs(
-                    job_name="dagster-run-%s" % run.run_id, namespace=helm_namespace
-                )
-
-                assert "PIPELINE_SUCCESS" in result, "no match, result: {}".format(result)
-
-                runs.append(run)
-
-            unmemoized_run = runs[0]
-            step_events = _get_step_events(dagster_instance.all_logs(unmemoized_run.run_id))
-            assert len(step_events) == 4
-
-            memoized_run = runs[1]
-            step_events = _get_step_events(dagster_instance.all_logs(memoized_run.run_id))
-            assert len(step_events) == 0
-
-    finally:
-        cleanup_memoized_results(
-            define_memoization_pipeline(), "celery", dagster_instance, run_config
-        )

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
@@ -27,12 +27,10 @@ from dagster_k8s_test_infra.integration_utils import image_pull_policy
 from dagster_test.test_project import (
     IS_BUILDKITE,
     ReOriginatedExternalPipelineForTest,
-    cleanup_memoized_results,
     get_test_project_docker_image,
     get_test_project_environments_path,
     get_test_project_external_pipeline_hierarchy,
 )
-from dagster_test.test_project.test_pipelines.repo import define_memoization_pipeline
 
 
 @pytest.mark.integration
@@ -188,14 +186,6 @@ def test_k8s_executor_combine_configs(
     assert TEST_OTHER_IMAGE_PULL_SECRET_NAME in image_pull_secrets_names
 
 
-def _get_step_execution_events(events):
-    return [
-        event
-        for event in events
-        if ("Executing step" in event.message and "in Kubernetes job" in event.message)
-    ]
-
-
 def _launch_executor_run(
     run_config,
     dagster_instance_for_k8s_run_launcher,
@@ -239,7 +229,16 @@ def _launch_executor_run(
         assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()
 
         events = dagster_instance_for_k8s_run_launcher.all_logs(run.run_id)
-        assert len(_get_step_execution_events(events)) == num_steps
+        assert (
+            len(
+                [
+                    event
+                    for event in events
+                    if ("Executing step" in event.message and "in Kubernetes job" in event.message)
+                ]
+            )
+            == num_steps
+        )
 
         return run.run_id
 
@@ -462,7 +461,6 @@ def test_k8s_executor_resource_requirements(
         assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()
 
 
-@pytest.mark.integration
 def test_execute_on_k8s_retry_pipeline(  # pylint: disable=redefined-outer-name
     dagster_instance_for_k8s_run_launcher, helm_namespace_for_k8s_run_launcher, dagster_docker_image
 ):
@@ -535,86 +533,3 @@ def test_execute_on_k8s_retry_pipeline(  # pylint: disable=redefined-outer-name
         assert DagsterEventType.STEP_SUCCESS in [
             event.dagster_event.event_type for event in all_logs if event.is_dagster_event
         ]
-
-
-@pytest.mark.integration
-def test_memoization_k8s_executor(
-    dagster_instance_for_k8s_run_launcher, helm_namespace_for_k8s_run_launcher, dagster_docker_image
-):
-    run_config = merge_dicts(
-        load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
-        {
-            "execution": {
-                "k8s": {
-                    "config": {
-                        "job_namespace": helm_namespace_for_k8s_run_launcher,
-                        "job_image": dagster_docker_image,
-                        "image_pull_policy": image_pull_policy(),
-                        "env_config_maps": ["dagster-pipeline-env"]
-                        + ([TEST_AWS_CONFIGMAP_NAME] if not IS_BUILDKITE else []),
-                    }
-                }
-            },
-        },
-    )
-
-    # Clean up any residual outputs that may have been left by failed runs.
-    cleanup_memoized_results(
-        define_memoization_pipeline(), "k8s", dagster_instance_for_k8s_run_launcher, run_config
-    )
-
-    # wrap in try-catch to ensure that memoized results are always cleaned from s3 bucket
-    try:
-        pipeline_name = "memoization_pipeline"
-
-        with get_test_project_external_pipeline_hierarchy(
-            dagster_instance_for_k8s_run_launcher, pipeline_name
-        ) as (workspace, location, _repo, external_pipeline):
-
-            reoriginated_pipeline = ReOriginatedExternalPipelineForTest(external_pipeline)
-
-            runs = []
-            for _ in range(2):
-                run = create_run_for_test(
-                    dagster_instance_for_k8s_run_launcher,
-                    pipeline_name=pipeline_name,
-                    run_config=run_config,
-                    tags=None,
-                    mode="k8s",
-                    pipeline_snapshot=external_pipeline.pipeline_snapshot,
-                    execution_plan_snapshot=location.get_external_execution_plan(
-                        external_pipeline,
-                        run_config,
-                        "k8s",
-                        None,
-                        None,
-                        instance=dagster_instance_for_k8s_run_launcher,
-                    ).execution_plan_snapshot,
-                    external_pipeline_origin=reoriginated_pipeline.get_external_origin(),
-                    pipeline_code_origin=reoriginated_pipeline.get_python_origin(),
-                )
-                dagster_instance_for_k8s_run_launcher.launch_run(run.run_id, workspace)
-
-                result = wait_for_job_and_get_raw_logs(
-                    job_name="dagster-run-%s" % run.run_id,
-                    namespace=helm_namespace_for_k8s_run_launcher,
-                )
-
-                assert "PIPELINE_SUCCESS" in result, "no match, result: {}".format(result)
-
-                runs.append(run)
-
-            # We expect that first run should have to run the step, since it has not yet been
-            # memoized.
-            unmemoized_run = runs[0]
-            events = dagster_instance_for_k8s_run_launcher.all_logs(unmemoized_run.run_id)
-            assert len(_get_step_execution_events(events)) == 1
-
-            # We expect that second run should not have to run the step, since it has been memoized.
-            memoized_run = runs[1]
-            events = dagster_instance_for_k8s_run_launcher.all_logs(memoized_run.run_id)
-            assert len(_get_step_execution_events(events)) == 0
-    finally:
-        cleanup_memoized_results(
-            define_memoization_pipeline(), "k8s", dagster_instance_for_k8s_run_launcher, run_config
-        )

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_integration.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_integration.py
@@ -226,10 +226,6 @@ def test_k8s_run_launcher_terminate(
         os.path.join(get_test_project_environments_path(), "env_s3.yaml")
     )
 
-    run_config = load_yaml_from_path(
-        os.path.join(get_test_project_environments_path(), "env_s3.yaml")
-    )
-
     with get_test_project_external_pipeline_hierarchy(
         dagster_instance_for_k8s_run_launcher, pipeline_name
     ) as (

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -21,7 +21,6 @@ from dagster import (
     OutputDefinition,
     RetryRequested,
     String,
-    VersionStrategy,
     default_executors,
     file_relative_path,
     fs_io_manager,
@@ -43,15 +42,12 @@ from dagster_gcp.gcs import gcs_pickle_io_manager, gcs_resource
 IS_BUILDKITE = bool(os.getenv("BUILDKITE"))
 
 
-def celery_mode_defs(resources=None, name="default"):
+def celery_mode_defs(resources=None):
     from dagster_celery import celery_executor
     from dagster_celery_k8s import celery_k8s_job_executor
 
-    resources = resources if resources else {"s3": s3_resource}
-    resources = merge_dicts(resources, {"io_manager": s3_pickle_io_manager})
     return [
         ModeDefinition(
-            name=name,
             resource_defs=resources
             if resources
             else {"s3": s3_resource, "io_manager": s3_pickle_io_manager},
@@ -62,9 +58,6 @@ def celery_mode_defs(resources=None, name="default"):
 
 def k8s_mode_defs(resources=None, name="default"):
     from dagster_k8s.executor import k8s_job_executor
-
-    resources = resources if resources else {"s3": s3_resource}
-    resources = merge_dicts(resources, {"io_manager": s3_pickle_io_manager})
 
     return [
         ModeDefinition(
@@ -654,25 +647,6 @@ def define_volume_mount_pipeline():
     return volume_mount_pipeline
 
 
-def define_memoization_pipeline():
-    @solid
-    def foo_solid():
-        return "foo"
-
-    class BasicVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
-            return "foo"
-
-    @pipeline(
-        mode_defs=k8s_mode_defs(name="k8s") + celery_mode_defs(name="celery"),
-        version_strategy=BasicVersionStrategy(),
-    )
-    def memoization_pipeline():
-        foo_solid()
-
-    return memoization_pipeline
-
-
 def define_demo_execution_repo():
     @repository
     def demo_execution_repo():
@@ -702,7 +676,6 @@ def define_demo_execution_repo():
                 "hard_failer": define_hard_failer,
                 "demo_k8s_executor_pipeline": define_demo_k8s_executor_pipeline,
                 "volume_mount_pipeline": define_volume_mount_pipeline,
-                "memoization_pipeline": define_memoization_pipeline,
             },
             "jobs": {
                 "demo_error_job": demo_error_job,

--- a/python_modules/dagster/dagster/api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/api/snapshot_execution_plan.py
@@ -2,7 +2,6 @@ from dagster import check
 from dagster.core.errors import DagsterUserCodeProcessError
 from dagster.core.execution.plan.state import KnownExecutionState
 from dagster.core.host_representation.origin import ExternalPipelineOrigin
-from dagster.core.instance import DagsterInstance
 from dagster.core.snap.execution_plan_snapshot import (
     ExecutionPlanSnapshot,
     ExecutionPlanSnapshotErrorData,
@@ -20,7 +19,6 @@ def sync_get_external_execution_plan_grpc(
     solid_selection=None,
     step_keys_to_execute=None,
     known_state=None,
-    instance=None,
 ):
     from dagster.grpc.client import DagsterGrpcClient
 
@@ -32,7 +30,6 @@ def sync_get_external_execution_plan_grpc(
     check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
     check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id")
     check.opt_inst_param(known_state, "known_state", KnownExecutionState)
-    check.opt_inst_param(instance, "instance", DagsterInstance)
 
     result = check.inst(
         deserialize_json_to_dagster_namedtuple(
@@ -45,7 +42,6 @@ def sync_get_external_execution_plan_grpc(
                     step_keys_to_execute=step_keys_to_execute,
                     pipeline_snapshot_id=pipeline_snapshot_id,
                     known_state=known_state,
-                    instance_ref=instance.get_ref() if instance else None,
                 )
             ),
         ),

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -525,7 +525,6 @@ def _create_external_pipeline_run(
         pipeline_mode,
         step_keys_to_execute=None,
         known_state=None,
-        instance=instance,
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -718,7 +718,6 @@ def _get_execution_plan_from_run(
         run_config=pipeline_run.run_config,
         mode=pipeline_run.mode,
         step_keys_to_execute=pipeline_run.step_keys_to_execute,
-        instance=instance,
     )
 
 

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -245,7 +245,6 @@ def create_backfill_run(
         external_partition_set.mode,
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
-        instance=instance,
     )
 
     return instance.create_run(

--- a/python_modules/dagster/dagster/core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process.py
@@ -34,7 +34,6 @@ def core_execute_in_process(
         pipeline,
         run_config=run_config,
         mode=mode_def.name,
-        instance=instance,
     )
 
     output_capture: Dict[StepOutputHandle, Any] = {}

--- a/python_modules/dagster/dagster/core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/core/execution/plan/active.py
@@ -9,7 +9,7 @@ from dagster.core.errors import (
 )
 from dagster.core.events import DagsterEvent
 from dagster.core.execution.context.system import PlanOrchestrationContext
-from dagster.core.execution.plan.state import KnownExecutionState, StepOutputVersionData
+from dagster.core.execution.plan.state import KnownExecutionState
 from dagster.core.execution.retries import RetryMode, RetryState
 from dagster.core.storage.tags import PRIORITY_TAG
 from dagster.utils.interrupts import pop_captured_interrupt
@@ -32,7 +32,6 @@ class ActiveExecution:
         retry_mode: RetryMode,
         retry_state: RetryState,
         sort_key_fn: Optional[Callable[[ExecutionStep], float]] = None,
-        step_output_versions: Optional[List[StepOutputVersionData]] = None,
     ):
         self._plan: ExecutionPlan = check.inst_param(
             execution_plan, "execution_plan", ExecutionPlan
@@ -46,10 +45,6 @@ class ActiveExecution:
                 "sort_key_fn",
             )
             or _default_sort_key
-        )
-
-        self._step_output_versions = check.opt_list_param(
-            step_output_versions, "step_output_versions", of_type=StepOutputVersionData
         )
 
         self._context_guard: bool = False  # Prevent accidental direct use
@@ -464,7 +459,6 @@ class ActiveExecution:
         return KnownExecutionState(
             previous_retry_attempts=self._retry_state.snapshot_attempts(),
             dynamic_mappings=dict(self._successful_dynamic_outputs),
-            step_output_versions=self._step_output_versions,
         )
 
     def _prep_for_dynamic_outputs(self, step: ExecutionStep):

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -124,7 +124,6 @@ class RepositoryLocation(AbstractContextManager):
         mode: str,
         step_keys_to_execute: Optional[List[str]],
         known_state: Optional[KnownExecutionState],
-        instance: Optional[DagsterInstance] = None,
     ) -> ExternalExecutionPlan:
         pass
 
@@ -316,14 +315,12 @@ class InProcessRepositoryLocation(RepositoryLocation):
         mode: str,
         step_keys_to_execute: Optional[List[str]],
         known_state: Optional[KnownExecutionState],
-        instance: Optional[DagsterInstance] = None,
     ) -> ExternalExecutionPlan:
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         check.dict_param(run_config, "run_config")
         check.str_param(mode, "mode")
         check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
         check.opt_inst_param(known_state, "known_state", KnownExecutionState)
-        check.opt_inst_param(instance, "instance", DagsterInstance)
 
         execution_plan = create_execution_plan(
             pipeline=self.get_reconstructable_pipeline(
@@ -333,7 +330,6 @@ class InProcessRepositoryLocation(RepositoryLocation):
             mode=mode,
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
-            instance=instance,
         )
         return ExternalExecutionPlan(
             execution_plan_snapshot=snapshot_from_execution_plan(
@@ -615,14 +611,12 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         mode: str,
         step_keys_to_execute: Optional[List[str]],
         known_state: Optional[KnownExecutionState],
-        instance: Optional[DagsterInstance] = None,
     ) -> ExternalExecutionPlan:
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         check.dict_param(run_config, "run_config")
         check.str_param(mode, "mode")
         check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
         check.opt_inst_param(known_state, "known_state", KnownExecutionState)
-        check.opt_inst_param(instance, "instance", DagsterInstance)
 
         execution_plan_snapshot_or_error = sync_get_external_execution_plan_grpc(
             api_client=self.client,
@@ -633,7 +627,6 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             solid_selection=external_pipeline.solid_selection,
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
-            instance=instance,
         )
 
         return ExternalExecutionPlan(

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -707,7 +707,6 @@ class DagsterInstance:
         pipeline_code_origin=None,
     ):
         from dagster.core.execution.plan.plan import ExecutionPlan
-        from dagster.core.execution.api import create_execution_plan
         from dagster.core.snap import snapshot_from_execution_plan
 
         check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
@@ -744,11 +743,10 @@ class DagsterInstance:
             step_keys_to_execute = execution_plan.step_keys_to_execute
 
         else:
-            execution_plan = create_execution_plan(
-                pipeline=InMemoryPipeline(pipeline_def),
-                run_config=run_config,
-                mode=mode,
-                instance=self,
+            resolved_run_config = ResolvedRunConfig.build(pipeline_def, run_config, mode)
+            execution_plan = ExecutionPlan.build(
+                InMemoryPipeline(pipeline_def),
+                resolved_run_config,
                 tags=tags,
             )
 

--- a/python_modules/dagster/dagster/core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/execution_plan_snapshot.py
@@ -43,6 +43,7 @@ class ExecutionPlanSnapshot(
             ("step_keys_to_execute", List[str]),
             ("initial_known_state", Optional[KnownExecutionState]),
             ("snapshot_version", Optional[int]),
+            ("step_output_versions", List[str]),
             ("executor_name", Optional[str]),
         ],
     )
@@ -62,6 +63,7 @@ class ExecutionPlanSnapshot(
         step_keys_to_execute: Optional[List[str]] = None,
         initial_known_state: Optional[KnownExecutionState] = None,
         snapshot_version: Optional[int] = None,
+        step_output_versions: Optional[List["StepOutputVersionData"]] = None,
         executor_name: Optional[str] = None,
     ):
         return super(ExecutionPlanSnapshot, cls).__new__(
@@ -78,6 +80,9 @@ class ExecutionPlanSnapshot(
                 KnownExecutionState,
             ),
             snapshot_version=check.opt_int_param(snapshot_version, "snapshot_version"),
+            step_output_versions=check.opt_list_param(
+                step_output_versions, "step_output_versions", of_type=StepOutputVersionData
+            ),
             executor_name=check.opt_str_param(executor_name, "executor_name"),
         )
 
@@ -105,6 +110,12 @@ class ExecutionPlanSnapshotErrorData(namedtuple("_ExecutionPlanSnapshotErrorData
             cls,
             error=check.opt_inst_param(error, "error", SerializableErrorInfo),
         )
+
+
+@whitelist_for_serdes
+class StepOutputVersionData(NamedTuple):
+    step_output_handle: StepOutputHandle
+    version: str
 
 
 @whitelist_for_serdes
@@ -254,6 +265,18 @@ def snapshot_from_execution_plan(execution_plan, pipeline_snapshot_id):
     check.inst_param(execution_plan, "execution_plan", ExecutionPlan)
     check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id")
 
+    step_output_versions = check.opt_dict_param(
+        execution_plan.step_output_versions,
+        "execution_plan.step_output_versions",
+        key_type=StepOutputHandle,
+        value_type=str,
+    )
+
+    step_output_versions_list = [
+        StepOutputVersionData(step_output_handle=step_output_handle, version=version)
+        for step_output_handle, version in step_output_versions.items()
+    ]
+
     return ExecutionPlanSnapshot(
         steps=sorted(
             list(map(_snapshot_from_execution_step, execution_plan.steps)), key=lambda es: es.key
@@ -263,5 +286,6 @@ def snapshot_from_execution_plan(execution_plan, pipeline_snapshot_id):
         step_keys_to_execute=execution_plan.step_keys_to_execute,
         initial_known_state=execution_plan.known_state,
         snapshot_version=CURRENT_SNAPSHOT_VERSION,
+        step_output_versions=step_output_versions_list,
         executor_name=execution_plan.executor_name,
     )

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -199,7 +199,6 @@ class BaseWorkspaceRequestContext(IWorkspace):
             mode=mode,
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
-            instance=self.instance,
         )
 
     def get_external_partition_config(

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -456,7 +456,6 @@ def _create_sensor_run(
         target_data.mode,
         step_keys_to_execute=None,
         known_state=None,
-        instance=instance,
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 

--- a/python_modules/dagster/dagster/grpc/impl.py
+++ b/python_modules/dagster/dagster/grpc/impl.py
@@ -43,7 +43,6 @@ from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.grpc.types import ExecutionPlanSnapshotArgs
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 from dagster.serdes.ipc import IPCErrorMessage
-from dagster.seven import nullcontext
 from dagster.utils import start_termination_thread
 from dagster.utils.error import serializable_error_info_from_exc_info
 from dagster.utils.interrupts import capture_interrupts
@@ -116,22 +115,18 @@ def _run_in_subprocess(
         execute_run_args = deserialize_json_to_dagster_namedtuple(serialized_execute_run_args)
         check.inst_param(execute_run_args, "execute_run_args", ExecuteExternalPipelineArgs)
 
-        with (
-            DagsterInstance.from_ref(execute_run_args.instance_ref)
-            if execute_run_args.instance_ref
-            else nullcontext()
-        ) as instance:
-            pipeline_run = instance.get_run_by_id(execute_run_args.pipeline_run_id)
+        instance = DagsterInstance.from_ref(execute_run_args.instance_ref)
+        pipeline_run = instance.get_run_by_id(execute_run_args.pipeline_run_id)
 
-            if not pipeline_run:
-                raise DagsterRunNotFoundError(
-                    "gRPC server could not load run {run_id} in order to execute it. Make sure that the gRPC server has access to your run storage.".format(
-                        run_id=execute_run_args.pipeline_run_id
-                    ),
-                    invalid_run_id=execute_run_args.pipeline_run_id,
-                )
+        if not pipeline_run:
+            raise DagsterRunNotFoundError(
+                "gRPC server could not load run {run_id} in order to execute it. Make sure that the gRPC server has access to your run storage.".format(
+                    run_id=execute_run_args.pipeline_run_id
+                ),
+                invalid_run_id=execute_run_args.pipeline_run_id,
+            )
 
-            pid = os.getpid()
+        pid = os.getpid()
 
     except:
         serializable_error_info = serializable_error_info_from_exc_info(sys.exc_info())
@@ -352,8 +347,6 @@ def get_external_execution_plan_snapshot(recon_pipeline, args):
             else recon_pipeline
         )
 
-        instance = DagsterInstance.from_ref(args.instance_ref) if args.instance_ref else None
-
         return snapshot_from_execution_plan(
             create_execution_plan(
                 pipeline=pipeline,
@@ -361,7 +354,6 @@ def get_external_execution_plan_snapshot(recon_pipeline, args):
                 mode=args.mode,
                 step_keys_to_execute=args.step_keys_to_execute,
                 known_state=args.known_state,
-                instance=instance,
             ),
             args.pipeline_snapshot_id,
         )

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -21,7 +21,7 @@ class ExecutionPlanSnapshotArgs(
     namedtuple(
         "_ExecutionPlanSnapshotArgs",
         "pipeline_origin solid_selection run_config mode step_keys_to_execute pipeline_snapshot_id "
-        "known_state instance_ref",
+        "known_state",
     )
 ):
     def __new__(
@@ -33,7 +33,6 @@ class ExecutionPlanSnapshotArgs(
         step_keys_to_execute,
         pipeline_snapshot_id,
         known_state=None,
-        instance_ref=None,
     ):
         return super(ExecutionPlanSnapshotArgs, cls).__new__(
             cls,
@@ -48,7 +47,6 @@ class ExecutionPlanSnapshotArgs(
             ),
             pipeline_snapshot_id=check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id"),
             known_state=check.opt_inst_param(known_state, "known_state", KnownExecutionState),
-            instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
@@ -17,6 +17,7 @@ snapshots['test_create_execution_plan_with_dep 1'] = '''{
     "solid_one",
     "solid_two"
   ],
+  "step_output_versions": [],
   "steps": [
     {
       "__class__": "ExecutionStepSnap",
@@ -139,6 +140,7 @@ snapshots['test_create_noop_execution_plan 1'] = '''{
   "step_keys_to_execute": [
     "noop_solid"
   ],
+  "step_output_versions": [],
   "steps": [
     {
       "__class__": "ExecutionStepSnap",
@@ -192,6 +194,7 @@ snapshots['test_create_noop_execution_plan_with_tags 1'] = '''{
   "step_keys_to_execute": [
     "noop_solid"
   ],
+  "step_output_versions": [],
   "steps": [
     {
       "__class__": "ExecutionStepSnap",
@@ -263,6 +266,7 @@ snapshots['test_create_with_composite 1'] = '''{
     "comp_2.add_one",
     "add"
   ],
+  "step_output_versions": [],
   "steps": [
     {
       "__class__": "ExecutionStepSnap",

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -80,7 +80,7 @@ def test_fs_io_manager_memoization():
         my_op()
 
     class MyVersionStrategy(VersionStrategy):
-        def get_solid_version(self, _):
+        def get_solid_version(self, solid_def):
             return "foo"
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_memoized_dev_loop.py
@@ -121,14 +121,14 @@ def test_memoization_with_default_strategy():
             unmemoized_plan = create_execution_plan(my_job, instance=instance)
             assert len(unmemoized_plan.step_keys_to_execute) == 1
 
-            result = my_job.execute_in_process(instance=instance)
+            result = my_job.execute_in_process()
             assert result.success
             assert len(recorder) == 1
 
             execution_plan = create_execution_plan(my_job, instance=instance)
             assert len(execution_plan.step_keys_to_execute) == 0
 
-            result = my_job.execute_in_process(instance=instance)
+            result = my_job.execute_in_process()
             assert result.success
             assert len(recorder) == 1
 
@@ -207,7 +207,7 @@ def test_version_strategy_depends_from_context():
     run_config = {"solids": {"my_op": {"config": {"arg": "foo"}}}}
 
     @op
-    def my_op():
+    def my_op(context):
         graph_executed.append("executed")
 
     @graph

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -1,11 +1,11 @@
 import io
 import pickle
 
-from dagster import Field, MemoizableIOManager, StringSource, check, io_manager
+from dagster import Field, IOManager, StringSource, check, io_manager
 from dagster.utils import PICKLE_PROTOCOL
 
 
-class PickledObjectS3IOManager(MemoizableIOManager):
+class PickledObjectS3IOManager(IOManager):
     def __init__(
         self,
         s3_bucket,
@@ -19,10 +19,6 @@ class PickledObjectS3IOManager(MemoizableIOManager):
 
     def _get_path(self, context):
         return "/".join([self.s3_prefix, "storage", *context.get_output_identifier()])
-
-    def has_output(self, context):
-        key = self._get_path(context)
-        return self._has_object(key)
 
     def _rm_object(self, key):
         check.str_param(key, "key")

--- a/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
@@ -31,14 +31,12 @@ def core_celery_execution_loop(pipeline_context, execution_plan, step_execution_
 
     executor = pipeline_context.executor
 
-    # If there are no step keys to execute, then any io managers will not be used.
-    if len(execution_plan.step_keys_to_execute) > 0:
-        # https://github.com/dagster-io/dagster/issues/2440
-        check.invariant(
-            execution_plan.artifacts_persisted,
-            "Cannot use in-memory storage with Celery, use filesystem (on top of NFS or "
-            "similar system that allows files to be available to all nodes), S3, or GCS",
-        )
+    # https://github.com/dagster-io/dagster/issues/2440
+    check.invariant(
+        execution_plan.artifacts_persisted,
+        "Cannot use in-memory storage with Celery, use filesystem (on top of NFS or "
+        "similar system that allows files to be available to all nodes), S3, or GCS",
+    )
 
     app = make_app(executor.app_args())
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
@@ -7,7 +7,6 @@ from dagster import (
     Output,
     OutputDefinition,
     RetryRequested,
-    VersionStrategy,
     default_executors,
     fs_io_manager,
     lambda_solid,
@@ -324,26 +323,3 @@ def fooqueue(context):
 @pipeline(mode_defs=celery_mode_defs)
 def multiqueue_pipeline():
     fooqueue()
-
-
-@solid
-def bar_solid():
-    return "bar"
-
-
-class BasicVersionStrategy(VersionStrategy):
-    def get_solid_version(self, _):
-        return "bar"
-
-
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-            executor_defs=default_executors + [celery_executor],
-        )
-    ],
-    version_strategy=BasicVersionStrategy(),
-)
-def bar_pipeline():
-    bar_solid()

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -306,18 +306,3 @@ def test_engine_error():
                         },
                         instance=instance,
                     )
-
-
-def test_memoization_celery_executor(dagster_celery_worker):
-    with instance_for_test() as instance:
-        with execute_pipeline_on_celery(
-            "bar_pipeline", instance=instance, run_config={"execution": {"celery": {}}}
-        ) as result:
-            assert result.success
-            assert result.output_for_solid("bar_solid") == "bar"
-
-        with execute_pipeline_on_celery(
-            "bar_pipeline", instance=instance, run_config={"execution": {"celery": {}}}
-        ) as result:
-            assert result.success
-            assert len(result.step_event_list) == 0

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -120,7 +120,6 @@ def query_on_dask_worker(
     step_keys,
     mode,
     instance_ref,
-    known_state,
 ):  # pylint: disable=unused-argument
     """Note that we need to pass "dependencies" to ensure Dask sequences futures during task
     scheduling, even though we do not use this argument within the function.
@@ -136,7 +135,6 @@ def query_on_dask_worker(
             run_config=run_config,
             step_keys_to_execute=step_keys,
             mode=mode,
-            known_state=known_state,
         )
 
         return execute_plan(
@@ -261,7 +259,6 @@ class DaskExecutor(Executor):
                         [step.key],
                         plan_context.pipeline_run.mode,
                         instance.get_ref(),
-                        execution_plan.known_state,
                         key=dask_task_name,
                         resources=get_dask_resource_requirements(step.tags),
                     )


### PR DESCRIPTION
Reverts dagster-io/dagster#5506. I thought internal builds were passing, but they are not.