### PR TITLE
Mount AWS SecretsManager secrets as envvars in ECS

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -1,7 +1,6 @@
 import boto3
-import dagster
 from botocore.exceptions import ClientError
-from dagster import Field, check
+from dagster import Array, Field, StringSource, check
 from dagster.core.launcher.base import LaunchRunContext, RunLauncher
 from dagster.grpc.types import ExecuteRunArgs
 from dagster.serdes import ConfigurableClass
@@ -51,7 +50,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return {
             "task_definition": Field(
-                dagster.StringSource,
+                StringSource,
                 is_required=False,
                 description=(
                     "The task definition to use when launching new tasks. "
@@ -60,7 +59,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 ),
             ),
             "container_name": Field(
-                dagster.StringSource,
+                StringSource,
                 is_required=False,
                 default_value="run",
                 description=(
@@ -68,7 +67,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 ),
             ),
             "secrets": Field(
-                dagster.Array(dagster.String),
+                Array(StringSource),
                 is_required=False,
                 description=(
                     "An array of AWS Secrets Manager secrets arns. These secrets will "
@@ -76,7 +75,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 ),
             ),
             "secrets_tag": Field(
-                dagster.StringSource,
+                StringSource,
                 is_required=False,
                 default_value="dagster",
                 description=(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -12,7 +12,13 @@ from .tasks import default_ecs_task_definition, default_ecs_task_metadata
 
 @experimental
 class EcsRunLauncher(RunLauncher, ConfigurableClass):
-    def __init__(self, inst_data=None, task_definition=None, container_name="run"):
+    def __init__(
+        self,
+        inst_data=None,
+        task_definition=None,
+        container_name="run",
+        secrets_tag="dagster",
+    ):
         self._inst_data = inst_data
         self.ecs = boto3.client("ecs")
         self.ec2 = boto3.resource("ec2")
@@ -20,6 +26,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
 
         self.task_definition = task_definition
         self.container_name = container_name
+        self.secrets_tag = secrets_tag
 
         if self.task_definition:
             task_definition = self.ecs.describe_task_definition(taskDefinition=task_definition)
@@ -42,7 +49,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return {
             "task_definition": Field(
-                dagster.String,
+                dagster.StringSource,
                 is_required=False,
                 description=(
                     "The task definition to use when launching new tasks. "
@@ -51,11 +58,20 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 ),
             ),
             "container_name": Field(
-                dagster.String,
+                dagster.StringSource,
                 is_required=False,
                 default_value="run",
                 description=(
                     "The container name to use when launching new tasks. Defaults to 'run'."
+                ),
+            ),
+            "secrets_tag": Field(
+                dagster.StringSource,
+                is_required=False,
+                default_value="dagster",
+                description=(
+                    "AWS Secrets Manager secrets with this tag will be mounted as "
+                    "environment variables in the container. Defaults to 'dagster'."
                 ),
             ),
         }
@@ -203,9 +219,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             Filters=[
                 {
                     "Key": "tag-key",
-                    "Values": [
-                        "dagster",
-                    ],
+                    "Values": [self.secrets_tag],
                 },
             ],
         ):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -33,7 +33,13 @@ class EcsNoTasksFound(Exception):
 
 
 def default_ecs_task_definition(
-    ecs, metadata, image, container_name, command=None, environment=None
+    ecs,
+    metadata,
+    image,
+    container_name,
+    command=None,
+    environment=None,
+    secrets=None,
 ):
     # Start with the current process's task's definition but remove
     # extra keys that aren't useful for creating a new task definition
@@ -46,6 +52,12 @@ def default_ecs_task_definition(
         for key in expected_keys
         if key in metadata.task_definition.keys()
     )
+
+    if not environment:
+        environment = {}
+
+    if not secrets:
+        secrets = {}
 
     # The current process might not be running in a container that has the
     # pipeline's code installed. Inherit most of the process's container
@@ -66,9 +78,8 @@ def default_ecs_task_definition(
                 "entryPoint": [],
                 "command": command if command else [],
             },
-            {"environment": [{"key": key, "value": value} for key, value in environment.items()]}
-            if environment
-            else {},
+            {"environment": [{"key": key, "value": value} for key, value in environment.items()]},
+            {"secrets": [{"name": key, "valueFrom": value} for key, value in secrets.items()]},
         )
     )
     task_definition = {

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -53,11 +53,16 @@ def default_ecs_task_definition(
         if key in metadata.task_definition.keys()
     )
 
-    if not environment:
-        environment = {}
-
-    if not secrets:
-        secrets = {}
+    environment_dict = (
+        {"environment": [{"key": key, "value": value} for key, value in environment.items()]}
+        if environment
+        else {}
+    )
+    secrets_dict = (
+        {"secrets": [{"name": key, "valueFrom": value} for key, value in secrets.items()]}
+        if secrets
+        else {}
+    )
 
     # The current process might not be running in a container that has the
     # pipeline's code installed. Inherit most of the process's container
@@ -78,8 +83,8 @@ def default_ecs_task_definition(
                 "entryPoint": [],
                 "command": command if command else [],
             },
-            {"environment": [{"key": key, "value": value} for key, value in environment.items()]},
-            {"secrets": [{"name": key, "valueFrom": value} for key, value in secrets.items()]},
+            environment_dict,
+            secrets_dict,
         )
     )
     task_definition = {

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
@@ -35,3 +35,9 @@ def subnet(vpc):
 @pytest.fixture
 def security_group(vpc):
     return vpc.create_security_group(Description="test", GroupName="test")
+
+
+@pytest.fixture
+def secrets_manager(region):
+    with moto.mock_secretsmanager():
+        yield boto3.client("secretsmanager", region_name=region)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -59,13 +59,14 @@ def task(ecs, subnet, security_group, task_definition, assign_public_ip):
 
 
 @pytest.fixture
-def stub_aws(ecs, ec2, monkeypatch):
-    # Any call to boto3.client() will return ecs.
-    # Any call to boto3.resource() will return ec2.
-    # This only works because our launcher happens to use a client for ecs and
-    # a resource for ec2 - if that were to change or if new aws objects were to
-    # be introduced, this fixture would need to be refactored.
-    monkeypatch.setattr(boto3, "client", lambda *args, **kwargs: ecs)
+def stub_aws(ecs, ec2, secrets_manager, monkeypatch):
+    def mock_client(*args, **kwargs):
+        if "ecs" in args:
+            return ecs
+        if "secretsmanager" in args:
+            return secrets_manager
+
+    monkeypatch.setattr(boto3, "client", mock_client)
     monkeypatch.setattr(boto3, "resource", lambda *args, **kwargs: ec2)
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1,4 +1,5 @@
 # pylint: disable=protected-access
+# pylint: disable=unused-variable
 import dagster_aws
 import pytest
 from dagster.check import CheckError
@@ -186,3 +187,33 @@ def test_public_ip_assignment(ecs, ec2, instance, workspace, run, assign_public_
     attributes = eni.association_attribute or {}
 
     assert bool(attributes.get("PublicIp")) == assign_public_ip
+
+
+def test_secrets(ecs, secrets_manager, instance, workspace, run):
+    initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+
+    # Add a secret tagged with "dagster"
+    included_secret_id = secrets_manager.create_secret(
+        Name="included_secret",
+        SecretString="hello",
+        Tags=[{"Key": "dagster", "Value": "true"}],
+    )["ARN"]
+    # And an unrelated secret
+    excluded_secret_id = secrets_manager.create_secret(
+        Name="excluded_secret",
+        SecretString="hello",
+    )["ARN"]
+
+    instance.launch_run(run.run_id, workspace)
+
+    # A new task definition is created
+    task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    assert len(task_definitions) == len(initial_task_definitions) + 1
+    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    task_definition = task_definition["taskDefinition"]
+
+    # It includes secrets tagged with "dagster"
+    secrets = task_definition["containerDefinitions"][0]["secrets"]
+    assert len(secrets) == 1
+    assert {"name": "included_secret", "valueFrom": included_secret_id} in secrets

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
@@ -1,0 +1,51 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+from collections import namedtuple
+
+import pytest
+
+Secret = namedtuple("Secret", ["name", "arn"])
+
+
+@pytest.fixture
+def tagged_secret(secrets_manager):
+    # A secret tagged with "dagster"
+    name = "tagged_secret"
+    arn = secrets_manager.create_secret(
+        Name=name,
+        SecretString="hello",
+        Tags=[{"Key": "dagster", "Value": "true"}],
+    )["ARN"]
+
+    yield Secret(name, arn)
+
+
+@pytest.fixture
+def other_secret(secrets_manager):
+    # A secret without a tag
+    name = "other_secret"
+    arn = secrets_manager.create_secret(
+        Name=name,
+        SecretString="hello",
+    )["ARN"]
+
+    yield Secret(name, arn)
+
+
+def test_secrets(ecs, secrets_manager, instance, workspace, run, tagged_secret, other_secret):
+    initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+
+    instance.launch_run(run.run_id, workspace)
+
+    # A new task definition is created
+    task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    assert len(task_definitions) == len(initial_task_definitions) + 1
+    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    task_definition = task_definition["taskDefinition"]
+
+    # It includes tagged secrets
+    secrets = task_definition["containerDefinitions"][0]["secrets"]
+    assert len(secrets) == 1
+    assert {"name": tagged_secret.name, "valueFrom": tagged_secret.arn} in secrets

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
@@ -35,7 +35,7 @@ def other_secret(secrets_manager):
 
 @pytest.fixture
 def configured_secret(secrets_manager):
-    # A secret explicilty included in the launcher config
+    # A secret explicitly included in the launcher config
     name = "configured_secret"
     arn = secrets_manager.create_secret(
         Name=name,


### PR DESCRIPTION
When registering a new task definition, find any AWS SecretsManager
secret that's tagged with "dagster" and mount it as an environment
variable in the container.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-tutorial.html

This also upgrades to `moto>=2.0.0` so we our mock secretsmanager
doesn't randomize our secret ARN every time we list secrets:

https://github.com/spulec/moto/pull/3341