### PR TITLE
Add labels to k8s jobs and podtemplates so that resulting k8s objects are labelled with dagster job/op names

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -185,6 +185,10 @@ class K8sStepHandler(StepHandler):
             pod_name=pod_name,
             component="step_worker",
             user_defined_k8s_config=user_defined_k8s_config,
+            k8s_labels={
+                "job": step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                "op": step_key,
+            },
         )
 
         events.append(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -438,6 +438,7 @@ def construct_dagster_k8s_job(
     user_defined_k8s_config=None,
     pod_name=None,
     component=None,
+    k8s_labels=None,
     env_vars=None,
 ):
     """Constructs a Kubernetes Job object for a dagster-graphql invocation.
@@ -452,6 +453,8 @@ def construct_dagster_k8s_job(
             in length. Defaults to "<job_name>-pod".
         component (str, optional): The name of the component, used to provide the Job label
             app.kubernetes.io/component. Defaults to None.
+        k8s_labels(Dict[str, str]): Additional labels to be attached to k8s jobs and pod templates.
+            The resulting labels are "dagster.io/<key>: <value_possibly_truncated>".
         env_vars(Dict[str, str]): Additional environment variables to add to the K8s Container.
 
     Returns:
@@ -470,6 +473,7 @@ def construct_dagster_k8s_job(
     pod_name = check.opt_str_param(pod_name, "pod_name", default=job_name + "-pod")
     check.opt_str_param(component, "component")
     check.opt_dict_param(env_vars, "env_vars", key_type=str, value_type=str)
+    check.opt_dict_param(k8s_labels, "k8s_labels", key_type=str, value_type=str)
 
     check.invariant(
         len(job_name) <= MAX_K8S_NAME_LEN,
@@ -484,7 +488,7 @@ def construct_dagster_k8s_job(
     )
 
     # See: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-    dagster_labels = {
+    k8s_common_labels = {
         "app.kubernetes.io/name": "dagster",
         "app.kubernetes.io/instance": "dagster",
         "app.kubernetes.io/version": dagster_version,
@@ -492,7 +496,15 @@ def construct_dagster_k8s_job(
     }
 
     if component:
-        dagster_labels["app.kubernetes.io/component"] = component
+        k8s_common_labels["app.kubernetes.io/component"] = component
+
+    additional_labels = {
+        # Truncate too long label values to fit into 63-characters limit.
+        # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+        f"dagster.io/{k}": v[:63]
+        for k, v in (k8s_labels or {}).items()
+    }
+    dagster_labels = merge_dicts(k8s_common_labels, additional_labels)
 
     env = [kubernetes.client.V1EnvVar(name="DAGSTER_HOME", value=job_config.dagster_home)]
     if job_config.postgres_password_secret:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -310,6 +310,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             pod_name=pod_name,
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
+            k8s_labels={
+                "job": pipeline_origin.pipeline_name,
+            },
         )
 
         self._instance.report_engine_event(


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Add k8s labels to k8s jobs and podtemplates:
    - K8s jobs/pods spawned as `K8sRunLauncher`: `dagster.io/job`.
    - K8s jobs/pods spawned as `k8s_job_executor`: `dagster.io/job` and `dagster.io/op`.
- Context/motivation:
    - We want to distinguish k8s jobs/pods based on dagster's identifiers such as job/op names.
        - Especially this is useful in the context of job/pod monitoring. With the added labels, we can filter k8s job/pod metrics by dagster's identifiers.
- Request for comments:
    - The prefix of the added labels `dagster.io/` is arbitrarily chosen.
    - It'd be nice if we can also add labels for dagster workspace names and repository names where the dagster job belongs, but I have no idea how to obtain the names.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
- Added a test case for the newly-added k8s labels.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.