### PR TITLE
improve Runs view load time by querying pipelineName directly off of run without loading pipeline snapshot

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/types/LaunchedRunListQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/LaunchedRunListQuery.ts
@@ -10,11 +10,6 @@ import { RunsFilter, RunStatus } from "./../../types/globalTypes";
 // GraphQL query operation: LaunchedRunListQuery
 // ====================================================
 
-export interface LaunchedRunListQuery_pipelineRunsOrError_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface LaunchedRunListQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -62,7 +57,6 @@ export interface LaunchedRunListQuery_pipelineRunsOrError_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: LaunchedRunListQuery_pipelineRunsOrError_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: LaunchedRunListQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunListForStepQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunListForStepQuery.ts
@@ -10,11 +10,6 @@ import { RunsFilter, RunStatus } from "./../../types/globalTypes";
 // GraphQL query operation: PartitionRunListForStepQuery
 // ====================================================
 
-export interface PartitionRunListForStepQuery_pipelineRunsOrError_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface PartitionRunListForStepQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -62,7 +57,6 @@ export interface PartitionRunListForStepQuery_pipelineRunsOrError_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: PartitionRunListForStepQuery_pipelineRunsOrError_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PartitionRunListForStepQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRootQuery.ts
@@ -10,11 +10,6 @@ import { RunsFilter, RunStatus } from "./../../types/globalTypes";
 // GraphQL query operation: PipelineRunsRootQuery
 // ====================================================
 
-export interface PipelineRunsRootQuery_pipelineRunsOrError_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface PipelineRunsRootQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -62,7 +57,6 @@ export interface PipelineRunsRootQuery_pipelineRunsOrError_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: PipelineRunsRootQuery_pipelineRunsOrError_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PipelineRunsRootQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -293,9 +293,7 @@ const PIPELINE_ENVIRONMENT_YAML_QUERY = gql`
     pipelineRunOrError(runId: $runId) {
       ... on Run {
         id
-        pipeline {
-          name
-        }
+        pipelineName
         pipelineSnapshotId
         runConfigYaml
         ...RunFragmentForRepositoryMatch

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -35,6 +35,7 @@ export const RunFragments = {
       }
       rootRunId
       parentRunId
+      pipelineName
       pipeline {
         __typename
         ... on PipelineReference {

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -10,9 +10,7 @@ import {RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT} from './RunMetadataProvider';
 export const RUN_FRAGMENT_FOR_REPOSITORY_MATCH = gql`
   fragment RunFragmentForRepositoryMatch on Run {
     id
-    pipeline {
-      name
-    }
+    pipelineName
     pipelineSnapshotId
     repositoryOrigin {
       id

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -155,9 +155,6 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
     mode
     rootRunId
     parentRunId
-    pipeline {
-      name
-    }
     pipelineSnapshotId
     pipelineName
     repositoryOrigin {

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -123,7 +123,7 @@ export function getReexecutionVariables(input: {
     selector: {
       repositoryLocationName,
       repositoryName,
-      pipelineName: 'pipelineName' in run ? run.pipelineName : run.pipeline.name,
+      pipelineName: run.pipelineName,
       solidSelection: 'solidSelection' in run ? run.solidSelection : run.pipeline.solidSelection,
     },
   };

--- a/js_modules/dagit/packages/core/src/runs/types/PipelineEnvironmentYamlQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/PipelineEnvironmentYamlQuery.ts
@@ -12,11 +12,6 @@ export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_RunNotFoundErro
   __typename: "RunNotFoundError" | "PythonError";
 }
 
-export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -27,7 +22,7 @@ export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_repositoryO
 export interface PipelineEnvironmentYamlQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  pipeline: PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_pipeline;
+  pipelineName: string;
   pipelineSnapshotId: string | null;
   runConfigYaml: string;
   repositoryOrigin: PipelineEnvironmentYamlQuery_pipelineRunOrError_Run_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -115,6 +115,7 @@ export interface RunFragment {
   pipelineSnapshotId: string | null;
   executionPlan: RunFragment_executionPlan | null;
   stepKeysToExecute: string[] | null;
+  pipelineName: string;
   repositoryOrigin: RunFragment_repositoryOrigin | null;
   stats: RunFragment_stats;
   stepStats: RunFragment_stepStats[];

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -111,11 +111,11 @@ export interface RunFragment {
   tags: RunFragment_tags[];
   rootRunId: string | null;
   parentRunId: string | null;
+  pipelineName: string;
   pipeline: RunFragment_pipeline;
   pipelineSnapshotId: string | null;
   executionPlan: RunFragment_executionPlan | null;
   stepKeysToExecute: string[] | null;
-  pipelineName: string;
   repositoryOrigin: RunFragment_repositoryOrigin | null;
   stats: RunFragment_stats;
   stepStats: RunFragment_stepStats[];

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragmentForRepositoryMatch.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragmentForRepositoryMatch.ts
@@ -8,11 +8,6 @@
 // GraphQL fragment: RunFragmentForRepositoryMatch
 // ====================================================
 
-export interface RunFragmentForRepositoryMatch_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface RunFragmentForRepositoryMatch_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -23,7 +18,7 @@ export interface RunFragmentForRepositoryMatch_repositoryOrigin {
 export interface RunFragmentForRepositoryMatch {
   __typename: "Run";
   id: string;
-  pipeline: RunFragmentForRepositoryMatch_pipeline;
+  pipelineName: string;
   pipelineSnapshotId: string | null;
   repositoryOrigin: RunFragmentForRepositoryMatch_repositoryOrigin | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -116,10 +116,10 @@ export interface RunRootQuery_pipelineRunOrError_Run {
   tags: RunRootQuery_pipelineRunOrError_Run_tags[];
   rootRunId: string | null;
   parentRunId: string | null;
+  pipelineName: string;
   pipelineSnapshotId: string | null;
   executionPlan: RunRootQuery_pipelineRunOrError_Run_executionPlan | null;
   stepKeysToExecute: string[] | null;
-  pipelineName: string;
   repositoryOrigin: RunRootQuery_pipelineRunOrError_Run_repositoryOrigin | null;
   stats: RunRootQuery_pipelineRunOrError_Run_stats;
   stepStats: RunRootQuery_pipelineRunOrError_Run_stepStats[];

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -119,6 +119,7 @@ export interface RunRootQuery_pipelineRunOrError_Run {
   pipelineSnapshotId: string | null;
   executionPlan: RunRootQuery_pipelineRunOrError_Run_executionPlan | null;
   stepKeysToExecute: string[] | null;
+  pipelineName: string;
   repositoryOrigin: RunRootQuery_pipelineRunOrError_Run_repositoryOrigin | null;
   stats: RunRootQuery_pipelineRunOrError_Run_stats;
   stepStats: RunRootQuery_pipelineRunOrError_Run_stepStats[];

--- a/js_modules/dagit/packages/core/src/runs/types/RunTableRunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTableRunFragment.ts
@@ -10,11 +10,6 @@ import { RunStatus } from "./../../types/globalTypes";
 // GraphQL fragment: RunTableRunFragment
 // ====================================================
 
-export interface RunTableRunFragment_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface RunTableRunFragment_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -62,7 +57,6 @@ export interface RunTableRunFragment {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: RunTableRunFragment_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: RunTableRunFragment_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRootQuery.ts
@@ -10,11 +10,6 @@ import { RunsFilter, RunStatus } from "./../../types/globalTypes";
 // GraphQL query operation: RunsRootQuery
 // ====================================================
 
-export interface RunsRootQuery_pipelineRunsOrError_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface RunsRootQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -62,7 +57,6 @@ export interface RunsRootQuery_pipelineRunsOrError_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: RunsRootQuery_pipelineRunsOrError_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: RunsRootQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/schedules/types/PreviousRunsForScheduleQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/PreviousRunsForScheduleQuery.ts
@@ -14,11 +14,6 @@ export interface PreviousRunsForScheduleQuery_pipelineRunsOrError_InvalidPipelin
   __typename: "InvalidPipelineRunsFilterError" | "PythonError";
 }
 
-export interface PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -66,7 +61,6 @@ export interface PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PreviousRunsForScheduleQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/PreviousRunsForSensorQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/PreviousRunsForSensorQuery.ts
@@ -14,11 +14,6 @@ export interface PreviousRunsForSensorQuery_pipelineRunsOrError_InvalidPipelineR
   __typename: "InvalidPipelineRunsFilterError" | "PythonError";
 }
 
-export interface PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -66,7 +61,6 @@ export interface PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PreviousRunsForSensorQuery_pipelineRunsOrError_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/PreviousRunsFragment.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/PreviousRunsFragment.ts
@@ -14,11 +14,6 @@ export interface PreviousRunsFragment_InvalidPipelineRunsFilterError {
   __typename: "InvalidPipelineRunsFilterError" | "PythonError";
 }
 
-export interface PreviousRunsFragment_Runs_results_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-}
-
 export interface PreviousRunsFragment_Runs_results_repositoryOrigin {
   __typename: "RepositoryOrigin";
   id: string;
@@ -66,7 +61,6 @@ export interface PreviousRunsFragment_Runs_results {
   mode: string;
   rootRunId: string | null;
   parentRunId: string | null;
-  pipeline: PreviousRunsFragment_Runs_results_pipeline;
   pipelineSnapshotId: string | null;
   pipelineName: string;
   repositoryOrigin: PreviousRunsFragment_Runs_results_repositoryOrigin | null;

--- a/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
+++ b/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
@@ -23,7 +23,7 @@ export const useRepositoryForRun = (
       return null;
     }
 
-    const pipelineName = run.pipeline.name;
+    const pipelineName = run.pipelineName;
     // Try to match the pipeline name within the specified origin, if possible.
     const origin = run.repositoryOrigin;
 
@@ -47,7 +47,7 @@ export const useRepositoryForRun = (
       return null;
     }
 
-    const pipelineName = run.pipeline.name;
+    const pipelineName = run.pipelineName;
     const snapshotId = run.pipelineSnapshotId;
 
     // Find the repository that contains the specified pipeline name and snapshot ID, if any.
@@ -66,7 +66,7 @@ export const useRepositoryForRun = (
       return null;
     }
 
-    const pipelineName = run.pipeline.name;
+    const pipelineName = run.pipelineName;
 
     // There is no origin repo. Find any repos that might contain a matching pipeline name.
     const possibleMatches = findRepoContainingPipeline(options, pipelineName);


### PR DESCRIPTION
## Summary

For my local dev environment, almost 50% of the query time for the runs view is spent deserializing the pipeline snapshot for every single run.

We should introduce some sort of in-memory LRU cache for the pipeline snapshot in the run storage layer in a separate diff (most likely, we're deserializing the same structure over and over again based on the snapshot id), but we can actually be more aggressive on the runs view because we're doing all of this deserialization to load the pipeline snapshot to get *the name* of the pipeline, which we already have directly on the stored run.

Before (see the sections labeled execute_pipeline):
<img width="1904" alt="Screen Shot 2021-11-11 at 11 36 30 AM" src="https://user-images.githubusercontent.com/1040172/141358628-adbd8a20-31d2-42ed-8203-da107a96890d.png">

After:
<img width="1904" alt="Screen Shot 2021-11-11 at 11 37 10 AM" src="https://user-images.githubusercontent.com/1040172/141358721-c7558868-623d-447f-88ef-912f1eb41316.png">

## Test Plan
BK


