### PR TITLE
Wrap error raised in `handle_output` of IO Manager in user_code_error_boundary

### DIFF
--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -244,7 +244,7 @@ class DagsterExecutionLoadInputError(DagsterUserCodeExecutionError):
 
 
 class DagsterExecutionHandleOutputError(DagsterUserCodeExecutionError):
-    """Indicates an error occurred while loading an input for a step."""
+    """Indicates an error occurred while handling an output for a step."""
 
     def __init__(self, *args, **kwargs):
         self.step_key = check.str_param(kwargs.pop("step_key"), "step_key")

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -1,5 +1,4 @@
 import inspect
-
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union, cast
 
@@ -492,6 +491,11 @@ def _store_output(
 
     manager_materializations = []
     manager_metadata_entries = []
+
+    # output_manager.handle_output is either a generator function, or a normal function with or
+    # without a return value. In the case that handle_output is a normal function, we need to
+    # catch errors should they be raised before a return value. We can do this by wrapping
+    # handle_output in a generator so that errors will be caught within iterate_with_context.
 
     if not inspect.isgeneratorfunction(output_manager.handle_output):
 

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -488,7 +488,13 @@ def _store_output(
     output_manager = step_context.get_io_manager(step_output_handle)
     output_context = step_context.get_output_context(step_output_handle)
 
-    handle_output_res = output_manager.handle_output(output_context, output.value)
+    with user_code_error_boundary(
+        DagsterExecutionHandleOutputError,
+        msg_fn=lambda: (f'Error occurred while handling output of step "{step_context.step.key}":'),
+        step_key=step_context.step.key,
+        output_name="",
+    ):
+        handle_output_res = output_manager.handle_output(output_context, output.value)
 
     manager_materializations = []
     manager_metadata_entries = []

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -488,43 +488,33 @@ def _store_output(
     output_manager = step_context.get_io_manager(step_output_handle)
     output_context = step_context.get_output_context(step_output_handle)
 
-    with user_code_error_boundary(
-        DagsterExecutionHandleOutputError,
-        msg_fn=lambda: (f'Error occurred while handling output of step "{step_context.step.key}":'),
-        step_key=step_context.step.key,
-        output_name="",
-    ):
-        handle_output_res = output_manager.handle_output(output_context, output.value)
-
     manager_materializations = []
     manager_metadata_entries = []
-    if handle_output_res is not None:
-        for elt in iterate_with_context(
-            lambda: solid_execution_error_boundary(
-                DagsterExecutionHandleOutputError,
-                msg_fn=lambda: (
-                    f'Error occurred while handling output "{output_context.name}" of '
-                    f'step "{step_context.step.key}":'
-                ),
-                step_context=step_context,
-                step_key=step_context.step.key,
-                output_name=output_context.name,
-            ),
-            ensure_gen(handle_output_res),
-        ):
-            if isinstance(elt, AssetMaterialization):
-                manager_materializations.append(elt)
-            elif isinstance(elt, (EventMetadataEntry, PartitionMetadataEntry)):
-                experimental_functionality_warning(
-                    "Yielding metadata from an IOManager's handle_output() function"
-                )
-                manager_metadata_entries.append(elt)
-            else:
-                raise DagsterInvariantViolationError(
-                    f"IO manager on output {output_def.name} has returned "
-                    f"value {elt} of type {type(elt).__name__}. The return type can only be "
-                    "one of AssetMaterialization, EventMetadataEntry, PartitionMetadataEntry."
-                )
+    with user_code_error_boundary(
+        DagsterExecutionHandleOutputError,
+        msg_fn=lambda: (
+            f'Error occurred while handling output "{output_context.name}" of '
+            f'step "{step_context.step.key}":'
+        ),
+        step_key=step_context.step.key,
+        output_name=output_context.name,
+    ):
+        handle_output_res = output_manager.handle_output(output_context, output.value)
+        if handle_output_res is not None:
+            for elt in ensure_gen(handle_output_res):
+                if isinstance(elt, AssetMaterialization):
+                    manager_materializations.append(elt)
+                elif isinstance(elt, (EventMetadataEntry, PartitionMetadataEntry)):
+                    experimental_functionality_warning(
+                        "Yielding metadata from an IOManager's handle_output() function"
+                    )
+                    manager_metadata_entries.append(elt)
+                else:
+                    raise DagsterInvariantViolationError(
+                        f"IO manager on output {output_def.name} has returned "
+                        f"value {elt} of type {type(elt).__name__}. The return type can only be "
+                        "one of AssetMaterialization, EventMetadataEntry, PartitionMetadataEntry."
+                    )
 
     # do not alter explicitly created AssetMaterializations
     for materialization in manager_materializations:

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -1,3 +1,5 @@
+import inspect
+
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union, cast
 
@@ -490,31 +492,44 @@ def _store_output(
 
     manager_materializations = []
     manager_metadata_entries = []
-    with user_code_error_boundary(
-        DagsterExecutionHandleOutputError,
-        msg_fn=lambda: (
-            f'Error occurred while handling output "{output_context.name}" of '
-            f'step "{step_context.step.key}":'
+
+    if not inspect.isgeneratorfunction(output_manager.handle_output):
+
+        def _gen_fn():
+            gen_output = output_manager.handle_output(output_context, output.value)
+            if gen_output:
+                yield gen_output
+
+        handle_output_gen = _gen_fn()
+    else:
+        handle_output_gen = output_manager.handle_output(output_context, output.value)
+
+    for elt in iterate_with_context(
+        lambda: solid_execution_error_boundary(
+            DagsterExecutionHandleOutputError,
+            msg_fn=lambda: (
+                f'Error occurred while handling output "{output_context.name}" of '
+                f'step "{step_context.step.key}":'
+            ),
+            step_context=step_context,
+            step_key=step_context.step.key,
+            output_name=output_context.name,
         ),
-        step_key=step_context.step.key,
-        output_name=output_context.name,
+        handle_output_gen,
     ):
-        handle_output_res = output_manager.handle_output(output_context, output.value)
-        if handle_output_res is not None:
-            for elt in ensure_gen(handle_output_res):
-                if isinstance(elt, AssetMaterialization):
-                    manager_materializations.append(elt)
-                elif isinstance(elt, (EventMetadataEntry, PartitionMetadataEntry)):
-                    experimental_functionality_warning(
-                        "Yielding metadata from an IOManager's handle_output() function"
-                    )
-                    manager_metadata_entries.append(elt)
-                else:
-                    raise DagsterInvariantViolationError(
-                        f"IO manager on output {output_def.name} has returned "
-                        f"value {elt} of type {type(elt).__name__}. The return type can only be "
-                        "one of AssetMaterialization, EventMetadataEntry, PartitionMetadataEntry."
-                    )
+        if isinstance(elt, AssetMaterialization):
+            manager_materializations.append(elt)
+        elif isinstance(elt, (EventMetadataEntry, PartitionMetadataEntry)):
+            experimental_functionality_warning(
+                "Yielding metadata from an IOManager's handle_output() function"
+            )
+            manager_metadata_entries.append(elt)
+        else:
+            raise DagsterInvariantViolationError(
+                f"IO manager on output {output_def.name} has returned "
+                f"value {elt} of type {type(elt).__name__}. The return type can only be "
+                "one of AssetMaterialization, EventMetadataEntry, PartitionMetadataEntry."
+            )
 
     # do not alter explicitly created AssetMaterializations
     for materialization in manager_materializations:

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
@@ -662,6 +662,33 @@ def test_error_boundary_with_gen():
     assert step_failure.event_specific_data.error.cls_name == "DagsterExecutionHandleOutputError"
 
 
+def test_handle_output_exception_raised():
+    class ErrorIOManager(IOManager):
+        def load_input(self, context):
+            pass
+
+        def handle_output(self, context, obj):
+            raise ValueError("handle output error")
+
+    @io_manager
+    def error_io_manager(_):
+        return ErrorIOManager()
+
+    @op
+    def basic_op():
+        return 5
+
+    @job(resource_defs={"io_manager": error_io_manager})
+    def single_op_job():
+        basic_op()
+
+    result = single_op_job.execute_in_process(raise_on_error=False)
+    step_failure = [
+        event for event in result.all_node_events if event.event_type_value == "STEP_FAILURE"
+    ][0]
+    assert step_failure.event_specific_data.error.cls_name == "DagsterExecutionHandleOutputError"
+
+
 def test_output_identifier_dynamic_memoization():
     context = build_output_context(version="foo", mapping_key="bar", step_key="baz", name="buzz")
 


### PR DESCRIPTION
This PR fixes #4508 by catching exceptions that occur in the `handle_output()` method of an IO manager before outputs are yielded. Previously, only errors raised after an output was yielded would be wrapped in `user_code_error_boundary`. 

Screenshot of behavior after fix:
![Screen Shot 2021-11-11 at 1 15 36 PM](https://user-images.githubusercontent.com/29110579/141370411-74ed522a-1ff0-4729-baa8-3c229e922504.png)

 