### PR TITLE
do not show error toaster on network error

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppError.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppError.tsx
@@ -32,10 +32,6 @@ export const errorLink = onError((response: ErrorResponse) => {
     graphQLErrors.forEach((error) => showGraphQLError(error as DagsterGraphQLError, operationName));
   }
   if (response.networkError) {
-    ErrorToaster.show({
-      message: `[Network error] ${response.networkError.message}`,
-      intent: 'danger',
-    });
     console.error('[Network error]', response.networkError);
   }
 });


### PR DESCRIPTION
## Summary
I guess this has marginal value, happens sporadically, and undermines user confidence.  We still log the error to the console, this PR just doesn't blast the user in the face with it.

Related issue: https://github.com/dagster-io/dagster/issues/5625

## Test Plan
Inspection, confirmed (by bringing down the graphql server) that the network error message was not blasted with the bright red toast)

