### PR TITLE
dagster types on asset definitions

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, DagsterInvalidDefinitionError, SolidDefinition
+from dagster import AssetKey, DagsterInvalidDefinitionError, SolidDefinition, String
 from dagster.core.asset_defs import AssetIn, asset
 
 
@@ -30,6 +30,14 @@ def test_asset_with_compute_kind():
         return arg1
 
     assert my_asset.tags == {"kind": "sql"}
+
+
+def test_asset_with_dagster_type():
+    @asset(dagster_type=String)
+    def my_asset(arg1):
+        return arg1
+
+    assert my_asset.output_defs[0].dagster_type.display_name == "String"
 
 
 def test_asset_with_inputs_and_namespace():


### PR DESCRIPTION
I was initially a little bit conflicted about whether this was a good idea - in the past, we've talked about the possibility moving from Dagster types towards a more full-fledged runtime validation system.

On further thought though, I came to the conclusion that a decision to evolve Dagster validation is orthogonal from asset vs. op, so better not to block asset validation on figuring out the future of dagster types. 