### PR TITLE
[dagit] Prefer the /ops/ naming of solids explorer URLs

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -113,6 +113,7 @@ const LoadedRepositorySection: React.FC<{allRepos: DagsterRepoOption[]}> = ({all
     '/workspace/:repoPath/pipelines/:selector/:tab?',
     '/workspace/:repoPath/jobs/:selector/:tab?',
     '/workspace/:repoPath/solids/:selector',
+    '/workspace/:repoPath/ops/:selector',
     '/workspace/:repoPath/schedules/:selector',
     '/workspace/:repoPath/sensors/:selector',
     '/:rootTab?',

--- a/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpsRoot.tsx
@@ -167,7 +167,7 @@ const OpsRootWithData: React.FC<Props & {usedSolids: Solid[]}> = (props) => {
 
   const onClickOp = (defName: string) => {
     history.replace(
-      workspacePathFromAddress(repoAddress, `/solids/${defName}?${querystring.stringify({q})}`),
+      workspacePathFromAddress(repoAddress, `/ops/${defName}?${querystring.stringify({q})}`),
     );
   };
 


### PR DESCRIPTION

## Summary
When navigating around the ops explorer, it was going to /solids and redirecting to /ops on every click.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.