### PR TITLE
Don't set ECS tags if we're using short ARNs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 
+- Previously, the `EcsRunLauncher` tagged each ECS task with its corresponding Dagster Run ID. ECS tagging isn't supported for AWS accounts that have not yet [migrated to using the long ARN format](https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/). Now, the `EcsRunLauncher` only adds this tag if your AWS account has the long ARN format enabled.
 - Fixed a bug in the `k8s_job_executor` and `docker_executor` that could result in jobs exiting as `SUCCESS` before all ops have run.
 - Fixed a bug in the `k8s_job_executor` and `docker_executor` that could result in jobs failing when an op is skipped.
 

--- a/examples/deploy_ecs/docker-compose.yml
+++ b/examples/deploy_ecs/docker-compose.yml
@@ -68,6 +68,7 @@ services:
             - "ec2:DescribeNetworkInterfaces"
             - "ecs:DescribeTaskDefinition"
             - "ecs:DescribeTasks"
+            - "ecs:ListAccountSettings"
             - "ecs:RegisterTaskDefinition"
             - "ecs:RunTask"
             - "ecs:TagResource"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -86,6 +86,8 @@ class StubbedEcs:
         self.tasks = defaultdict(list)
         self.task_definitions = defaultdict(list)
         self.tags = defaultdict(list)
+        self.account_settings = {}
+        self.default_account_settings = {"taskLongArnFormat": "enabled"}
         self.stub_count = 0
 
     @stubbed
@@ -149,6 +151,34 @@ class StubbedEcs:
             expected_params={**kwargs},
         )
         return self.client.describe_tasks(**kwargs)
+
+    @stubbed
+    def list_account_settings(self, **kwargs):
+        """
+        Only taskLongArnFormat has a default value
+        """
+        if kwargs.get("effectiveSettings"):
+            account_settings = {
+                **self.default_account_settings,
+                **self.account_settings,
+            }
+        else:
+            account_settings = self.account_settings
+
+        account_settings = [
+            {
+                "name": key,
+                "value": value,
+            }
+            for key, value in account_settings.items()
+        ]
+
+        self.stubber.add_response(
+            method="list_account_settings",
+            service_response={"settings": account_settings},
+            expected_params={**kwargs},
+        )
+        return self.client.list_account_settings(**kwargs)
 
     @stubbed
     def list_tags_for_resource(self, **kwargs):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -242,6 +242,20 @@ class StubbedEcs:
         return self.client.list_tasks(**kwargs)
 
     @stubbed
+    def put_account_setting(self, **kwargs):
+        name = kwargs.get("name")
+        value = kwargs.get("value")
+        self.account_settings[name] = value
+
+        self.stubber.add_response(
+            method="put_account_setting",
+            service_response={"setting": {"name": name, "value": value}},
+            expected_params={**kwargs},
+        )
+
+        return self.client.put_account_setting(**kwargs)
+
+    @stubbed
     def register_task_definition(self, **kwargs):
         family = kwargs.get("family")
         # Revisions are 1 indexed

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -427,6 +427,4 @@ class StubbedEcs:
         task_arn_format_setting = [
             setting for setting in settings if setting["name"] == "taskLongArnFormat"
         ][0]
-        if task_arn_format_setting["value"] == "disabled":
-            return False
-        return True
+        return task_arn_format_setting["value"] != "disabled"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -187,7 +187,7 @@ class StubbedEcs:
         """
         arn = kwargs.get("resourceArn")
 
-        if self._task_exists(arn):
+        if self._task_exists(arn) and self._long_arn_enabled():
             self.stubber.add_response(
                 method="list_tags_for_resource",
                 service_response={"tags": self.tags.get(arn, [])},
@@ -388,7 +388,7 @@ class StubbedEcs:
         tags = kwargs.get("tags")
         arn = kwargs.get("resourceArn")
 
-        if self._task_exists(arn):
+        if self._task_exists(arn) and self._long_arn_enabled():
             self.stubber.add_response(
                 method="tag_resource",
                 service_response={},
@@ -421,3 +421,12 @@ class StubbedEcs:
 
     def _task_definition_arn(self, family, revision):
         return self._arn("task-definition", f"{family}:{revision}")
+
+    def _long_arn_enabled(self):
+        settings = self.list_account_settings(effectiveSettings=True)["settings"]
+        task_arn_format_setting = [
+            setting for setting in settings if setting["name"] == "taskLongArnFormat"
+        ][0]
+        if task_arn_format_setting["value"] == "disabled":
+            return False
+        return True

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -90,6 +90,12 @@ def test_list_tags_for_resource(ecs):
 
     assert ecs.list_tags_for_resource(resourceArn=arn)["tags"] == tags
 
+    # With the new ARN format disabled
+    ecs.put_account_setting(name="taskLongArnFormat", value="disabled")
+
+    with pytest.raises(ClientError):
+        ecs.list_tags_for_resource(resourceArn=arn)
+
 
 def test_list_task_definitions(ecs):
     assert not ecs.list_task_definitions()["taskDefinitionArns"]
@@ -296,3 +302,9 @@ def test_tag_resource(ecs):
     arn = ecs.run_task(taskDefinition="dagster")["tasks"][0]["taskArn"]
 
     ecs.tag_resource(resourceArn=arn, tags=tags)
+
+    # With the new ARN format disabled
+    ecs.put_account_setting(name="taskLongArnFormat", value="disabled")
+
+    with pytest.raises(ClientError):
+        ecs.tag_resource(resourceArn=arn, tags=tags)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -141,6 +141,21 @@ def test_list_tasks(ecs):
     assert other_cluster_dagster_family in response["taskArns"]
 
 
+def test_put_account_setting(ecs):
+    setting = ecs.put_account_setting(name="taskLongArnFormat", value="disabled")["setting"]
+    assert setting["name"] == "taskLongArnFormat"
+    assert setting["value"] == "disabled"
+
+    # It overrides the default settings
+    settings = ecs.list_account_settings(effectiveSettings=True)["settings"]
+    assert settings
+
+    task_arn_format_setting = [
+        setting for setting in settings if setting["name"] == "taskLongArnFormat"
+    ][0]
+    assert task_arn_format_setting["value"] == "disabled"
+
+
 def test_register_task_definition(ecs):
     response = ecs.register_task_definition(family="dagster", containerDefinitions=[])
     assert response["taskDefinition"]["family"] == "dagster"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -61,6 +61,19 @@ def test_describe_tasks(ecs):
     assert ecs.describe_tasks(tasks=[dagster_id], cluster="dagster") == dagster
 
 
+def test_list_account_settings(ecs):
+    assert not ecs.list_account_settings()["settings"]
+    assert not ecs.list_account_settings(effectiveSettings=False)["settings"]
+
+    settings = ecs.list_account_settings(effectiveSettings=True)["settings"]
+    assert settings
+
+    task_arn_format_setting = [
+        setting for setting in settings if setting["name"] == "taskLongArnFormat"
+    ][0]
+    assert task_arn_format_setting["value"] == "enabled"
+
+
 def test_list_tags_for_resource(ecs):
     invalid_arn = ecs._task_arn("invalid")
     with pytest.raises(ClientError):


### PR DESCRIPTION
ECS can only use tags if the account is using the new long ARN format.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids

Previously, we were adding a tag to the ECS task with the id of the
Dagster run. This drove no actual behavior - it's purely informational
metadata.

Now, we'll skip applying the tag if your account isn't using the new
long ARN format.