### PR TITLE
Test step delegating executor on toys repo

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/sleepy.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/sleepy.py
@@ -54,10 +54,7 @@ def will_fail(i):
 
 
 @graph(
-    description=(
-        "Demo diamond-shaped graph that has four-path parallel structure of ops.  Execute "
-        "with the `multi` preset to take advantage of multi-process parallelism."
-    ),
+    description=("Demo diamond-shaped graph that has four-path parallel structure of ops."),
 )
 def sleepy():
     giver_res = giver()

--- a/python_modules/dagster-test/dagster_test_tests/test_graph_job_op_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_graph_job_op_toys.py
@@ -1,50 +1,56 @@
 import pytest
-from dagster import (
-    DagsterResourceFunctionError,
-    DagsterTypeCheckDidNotPass,
-    execute_pipeline,
-    reconstructable,
-)
+from dagster import DagsterResourceFunctionError, DagsterTypeCheckDidNotPass, multiprocess_executor
 from dagster.core.events import DagsterEventType
-from dagster.core.test_utils import instance_for_test
+from dagster.core.storage.fs_io_manager import fs_io_manager
 from dagster.utils import file_relative_path
 from dagster.utils.temp_file import get_temp_dir
 from dagster_test.graph_job_op_toys.asset_lineage import asset_lineage_job
-from dagster_test.graph_job_op_toys.branches import branch_failed_job, branch_job
+from dagster_test.graph_job_op_toys.branches import branch
 from dagster_test.graph_job_op_toys.composition import composition_job
-from dagster_test.graph_job_op_toys.dynamic import dynamic_job
+from dagster_test.graph_job_op_toys.dynamic import dynamic
 from dagster_test.graph_job_op_toys.error_monster import (
     define_errorable_resource,
     error_monster,
     errorable_io_manager,
 )
-from dagster_test.graph_job_op_toys.hammer import hammer_default_executor_job
-from dagster_test.graph_job_op_toys.log_spew import log_spew_job
-from dagster_test.graph_job_op_toys.longitudinal import IntentionalRandomFailure, longitudinal_job
-from dagster_test.graph_job_op_toys.many_events import many_events_job, many_events_subset_job
+from dagster_test.graph_job_op_toys.hammer import hammer
+from dagster_test.graph_job_op_toys.log_spew import log_spew
+from dagster_test.graph_job_op_toys.longitudinal import IntentionalRandomFailure, longitudinal
+from dagster_test.graph_job_op_toys.many_events import many_events
 from dagster_test.graph_job_op_toys.pyspark_assets.pyspark_assets_job import (
     dir_resources,
     pyspark_assets,
 )
 from dagster_test.graph_job_op_toys.repo import toys_repository
-from dagster_test.graph_job_op_toys.resources import lots_of_resources, resource_job, resource_ops
-from dagster_test.graph_job_op_toys.retries import retry_job
+from dagster_test.graph_job_op_toys.resources import lots_of_resources, resource_ops
+from dagster_test.graph_job_op_toys.retries import retry
 from dagster_test.graph_job_op_toys.schedules import longitudinal_schedule
-from dagster_test.graph_job_op_toys.sleepy import sleepy_job
+from dagster_test.graph_job_op_toys.sleepy import sleepy
+from dagster_tests.execution_tests.engine_tests.test_step_delegating_executor import (
+    test_step_delegating_executor,
+)
+
+
+@pytest.fixture(name="executor_def", params=[multiprocess_executor, test_step_delegating_executor])
+def executor_def_fixture(request):
+    return request.param
 
 
 def test_repo():
     assert toys_repository
 
 
-def test_dynamic_job():
-    assert dynamic_job.execute_in_process().success
+def test_dynamic_job(executor_def):
+    assert dynamic.to_job(executor_def=executor_def).execute_in_process().success
 
 
-def test_longitudinal_job():
+def test_longitudinal_job(executor_def):
     partition_set = longitudinal_schedule().get_partition_set()
     try:
-        result = longitudinal_job.execute_in_process(
+        result = longitudinal.to_job(
+            resource_defs={"io_manager": fs_io_manager},
+            executor_def=executor_def,
+        ).execute_in_process(
             run_config=partition_set.run_config_for_partition(partition_set.get_partitions()[0]),
         )
         assert result.success
@@ -52,12 +58,14 @@ def test_longitudinal_job():
         pass
 
 
-def test_many_events_job():
-    assert many_events_job.execute_in_process().success
+def test_many_events_job(executor_def):
+    assert many_events.to_job(executor_def=executor_def).execute_in_process().success
 
 
-def test_many_events_subset_job():
-    result = many_events_subset_job.execute_in_process()
+def test_many_events_subset_job(executor_def):
+    result = many_events.to_job(
+        op_selection=["many_materializations_and_passing_expectations*"], executor_def=executor_def
+    ).execute_in_process()
     assert result.success
 
     executed_step_keys = [
@@ -68,45 +76,72 @@ def test_many_events_subset_job():
     assert len(executed_step_keys) == 3
 
 
-def get_sleepy():
-    return sleepy_job
+def test_sleepy_job(executor_def):
+    assert (
+        lambda: sleepy.to_job(
+            config={
+                "ops": {"giver": {"config": [2, 2, 2, 2]}},
+            },
+            executor_def=executor_def,
+        )
+        .execute_in_process()
+        .success
+    )
 
 
-def test_sleepy_job():
-    with instance_for_test() as instance:
-        assert execute_pipeline(reconstructable(get_sleepy), instance=instance).success
+def test_branch_job(executor_def):
+    assert (
+        branch.to_job(
+            config={
+                "ops": {"root": {"config": {"sleep_secs": [0, 10]}}},
+            },
+            executor_def=executor_def,
+        )
+        .execute_in_process()
+        .success
+    )
 
 
-def test_branch_job():
-    assert branch_job.execute_in_process().success
-
-
-def test_branch_job_failed():
+def test_branch_job_failed(executor_def):
     with pytest.raises(Exception):
-        assert not branch_failed_job.execute_in_process().success
+        assert (
+            not branch.to_job(
+                name="branch_failed",
+                config={
+                    "ops": {"root": {"config": {"sleep_secs": [-10, 30]}}},
+                },
+                executor_def=executor_def,
+            )
+            .execute_in_process()
+            .success
+        )
 
 
-def test_spew_pipeline():
-    assert log_spew_job.execute_in_process().success
+def test_spew_pipeline(executor_def):
+    assert log_spew.to_job(executor_def=executor_def).execute_in_process().success
 
 
-def test_hammer_job():
-    assert hammer_default_executor_job.execute_in_process().success
+def test_hammer_job(executor_def):
+    assert hammer.to_job(executor_def=executor_def).execute_in_process().success
 
 
-def test_resource_job_no_config():
-    result = resource_job.execute_in_process()
+def test_resource_job_no_config(executor_def):
+    result = resource_ops.to_job(
+        resource_defs=lots_of_resources, executor_def=executor_def
+    ).execute_in_process()
     assert result.output_for_node("one") == 2
 
 
-def test_resource_job_with_config():
+def test_resource_job_with_config(executor_def):
     result = resource_ops.to_job(
-        config={"resources": {"R1": {"config": 2}}}, resource_defs=lots_of_resources
+        config={"resources": {"R1": {"config": 2}}},
+        resource_defs=lots_of_resources,
+        executor_def=executor_def,
     ).execute_in_process()
     assert result.output_for_node("one") == 3
 
 
-def test_pyspark_assets_job():
+def test_pyspark_assets_job(executor_def):
     with get_temp_dir() as temp_dir:
         run_config = {
             "solids": {
@@ -147,12 +182,12 @@ def test_pyspark_assets_job():
         }
 
         result = pyspark_assets.to_job(
-            config=run_config, resource_defs=dir_resources
+            config=run_config, resource_defs=dir_resources, executor_def=executor_def
         ).execute_in_process()
         assert result.success
 
 
-def test_error_monster_success():
+def test_error_monster_success(executor_def):
     assert (
         error_monster.to_job(
             resource_defs={
@@ -167,13 +202,14 @@ def test_error_monster_success():
                 },
                 "resources": {"errorable_resource": {"config": {"throw_on_resource_init": False}}},
             },
+            executor_def=executor_def,
         )
         .execute_in_process()
         .success
     )
 
 
-def test_error_monster_success_error_on_resource():
+def test_error_monster_success_error_on_resource(executor_def):
     with pytest.raises(DagsterResourceFunctionError):
         error_monster.to_job(
             resource_defs={
@@ -188,10 +224,11 @@ def test_error_monster_success_error_on_resource():
                 },
                 "resources": {"errorable_resource": {"config": {"throw_on_resource_init": True}}},
             },
+            executor_def=executor_def,
         ).execute_in_process()
 
 
-def test_error_monster_type_error():
+def test_error_monster_type_error(executor_def):
     with pytest.raises(DagsterTypeCheckDidNotPass):
         error_monster.to_job(
             resource_defs={
@@ -206,6 +243,7 @@ def test_error_monster_type_error():
                 },
                 "resources": {"errorable_resource": {"config": {"throw_on_resource_init": False}}},
             },
+            executor_def=executor_def,
         ).execute_in_process()
 
 
@@ -236,5 +274,22 @@ def test_asset_lineage_job():
     ).success
 
 
-def test_retry_job():
-    assert retry_job.execute_in_process().success
+def test_retry_job(executor_def):
+    assert (
+        retry.to_job(
+            config={
+                "ops": {
+                    "retry_op": {
+                        "config": {
+                            "delay": 0.2,
+                            "work_on_attempt": 2,
+                            "max_retries": 1,
+                        }
+                    }
+                }
+            },
+            executor_def=executor_def,
+        )
+        .execute_in_process()
+        .success
+    )


### PR DESCRIPTION
This was the easiest way to get more test coverage on the step delegating executor, but not very pretty. Is there a way to do this without co-opting the job tests and re-supplying config/resources/etc.?