### PR TITLE
Remove unused workspace gql query and export query for other files to use

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -6,7 +6,6 @@ import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {PageHeader} from '../ui/PageHeader';
 import {Heading, Subheading} from '../ui/Text';
-import {REPOSITORY_LOCATIONS_FRAGMENT} from '../workspace/WorkspaceContext';
 
 import {DaemonList} from './DaemonList';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
@@ -43,16 +42,12 @@ export const InstanceHealthPage = () => {
   );
 };
 
-const INSTANCE_HEALTH_QUERY = gql`
+export const INSTANCE_HEALTH_QUERY = gql`
   query InstanceHealthQuery {
     instance {
       ...InstanceHealthFragment
     }
-    workspaceOrError {
-      ...RepositoryLocationsFragment
-    }
   }
 
   ${INSTANCE_HEALTH_FRAGMENT}
-  ${REPOSITORY_LOCATIONS_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceHealthQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceHealthQuery.ts
@@ -3,8 +3,6 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RepositoryLocationLoadStatus } from "./../../types/globalTypes";
-
 // ====================================================
 // GraphQL query operation: InstanceHealthQuery
 // ====================================================
@@ -43,58 +41,6 @@ export interface InstanceHealthQuery_instance {
   daemonHealth: InstanceHealthQuery_instance_daemonHealth;
 }
 
-export interface InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_displayMetadata {
-  __typename: "RepositoryMetadata";
-  key: string;
-  value: string;
-}
-
-export interface InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
-  __typename: "RepositoryLocation";
-  id: string;
-  isReloadSupported: boolean;
-  serverId: string | null;
-  name: string;
-}
-
-export interface InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
-  __typename: "PythonError";
-  message: string;
-}
-
-export type InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation | InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError;
-
-export interface InstanceHealthQuery_workspaceOrError_Workspace_locationEntries {
-  __typename: "WorkspaceLocationEntry";
-  id: string;
-  name: string;
-  loadStatus: RepositoryLocationLoadStatus;
-  displayMetadata: InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_displayMetadata[];
-  updatedTimestamp: number;
-  locationOrLoadError: InstanceHealthQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
-}
-
-export interface InstanceHealthQuery_workspaceOrError_Workspace {
-  __typename: "Workspace";
-  locationEntries: InstanceHealthQuery_workspaceOrError_Workspace_locationEntries[];
-}
-
-export interface InstanceHealthQuery_workspaceOrError_PythonError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface InstanceHealthQuery_workspaceOrError_PythonError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: InstanceHealthQuery_workspaceOrError_PythonError_cause | null;
-}
-
-export type InstanceHealthQuery_workspaceOrError = InstanceHealthQuery_workspaceOrError_Workspace | InstanceHealthQuery_workspaceOrError_PythonError;
-
 export interface InstanceHealthQuery {
   instance: InstanceHealthQuery_instance;
-  workspaceOrError: InstanceHealthQuery_workspaceOrError;
 }

--- a/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
+++ b/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
@@ -3,14 +3,6 @@ import {writeFileSync} from 'fs';
 
 import {buildClientSchema, getIntrospectionQuery, printSchema} from 'graphql';
 
-const pyVer = execSync('python3 --version').toString();
-const verMatch = pyVer.match(/Python ([\d.]*)/);
-if (!(verMatch != null && verMatch.length >= 2 && parseFloat(verMatch[1]) >= 3.6)) {
-  const errMsg =
-    pyVer !== '' ? pyVer : 'nothing on stdout indicating no python or a version earlier than 3.4';
-  throw new Error(`Must use Python version >= 3.6 got ${errMsg}`);
-}
-
 console.log('Downloading schema...');
 
 // https://github.com/dagster-io/dagster/issues/2623


### PR DESCRIPTION
Not sure if this actually matters, but was confused that this page was loading workspace info but not showing it. 

Test plan:
Loaded http://localhost:3001/instance/health properly