### PR TITLE
Add namespace attribute to job, not graph

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/job.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job.py
@@ -76,8 +76,8 @@ class _Job:
             positional_inputs=positional_inputs,
             tags=self.tags,
         )
-        update_wrapper(graph_def, fn)
-        return graph_def.to_job(
+
+        job_def = graph_def.to_job(
             description=self.description or format_docstring_for_description(fn),
             resource_defs=self.resource_defs,
             config=self.config,
@@ -87,6 +87,8 @@ class _Job:
             hooks=self.hooks,
             version_strategy=self.version_strategy,
         )
+        update_wrapper(job_def, fn)
+        return job_def
 
 
 def job(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
@@ -74,3 +74,19 @@ def test_non_reconstructable_job_error():
         match="you must wrap the ``to_job`` call in a function at module scope",
     ):
         reconstructable(basic_job)
+
+
+@job
+def my_namespace_job():
+    @op
+    def inner_op():
+        pass
+
+    inner_op()
+
+
+def test_reconstructable_job_namespace():
+    with instance_for_test() as instance:
+        result = execute_pipeline(reconstructable(my_namespace_job), instance=instance)
+
+        assert result.success


### PR DESCRIPTION
We were adding namespace attribute to the underlying graph, not the job, which was causing errors with reconstructable.