### PR TITLE
bugfix: should not load from logs when upstream is skipped

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -457,6 +457,11 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             if step_output_handle == record.dagster_event.event_specific_data.step_output_handle:
                 return True
 
+        # source is skipped so cannot load
+        for record in self.instance.all_logs(self.run_id, of_type=DagsterEventType.STEP_SKIPPED):
+            if step_output_handle.step_key == record.dagster_event.step_key:
+                return False
+
         # can load from a previous run
         if self._get_source_run_id_from_logs(step_output_handle):
             return True

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -457,13 +457,11 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             if step_output_handle == record.dagster_event.event_specific_data.step_output_handle:
                 return True
 
-        # source is skipped so cannot load
-        for record in self.instance.all_logs(self.run_id, of_type=DagsterEventType.STEP_SKIPPED):
-            if step_output_handle.step_key == record.dagster_event.step_key:
-                return False
-
-        # can load from a previous run
-        if self._get_source_run_id_from_logs(step_output_handle):
+        if (
+            self._should_load_from_previous_runs(step_output_handle)
+            # should and can load from a previous run
+            and self._get_source_run_id_from_logs(step_output_handle)
+        ):
             return True
 
         return False
@@ -486,33 +484,39 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             )
             # if the parent run has yielded an StepOutput event for the given step output,
             # we find the source run id
-            if [
-                r
-                for r in step_output_record
-                if r.dagster_event.step_key == step_output_handle.step_key
-                and r.dagster_event.step_output_data.output_name == step_output_handle.output_name
-            ]:
-                return source_run_id
-            else:
-                # else, keep looking backwards
-                source_run_id = run_id_to_parent_run_id.get(source_run_id)
+            for r in step_output_record:
+                if r.dagster_event.step_output_data.step_output_handle == step_output_handle:
+                    return source_run_id
+            # else, keep looking backwards
+            source_run_id = run_id_to_parent_run_id.get(source_run_id)
 
-        # when a fixed path is provided via io manager, it's able to run step subset using an execution
+        # When a fixed path is provided via io manager, it's able to run step subset using an execution
         # plan when the ascendant outputs were not previously created by dagster-controlled
         # computations. for example, in backfills, with fixed path io manager, we allow users to
         # "re-execute" runs with steps where the outputs weren't previously stored by dagster.
+
+        # Warn about this special case because it will also reach here when all previous runs have
+        # skipped yielding this output. From the logs, we have no easy way to differentiate the fixed
+        # path case and the skipping case, until we record the skipping info in KnownExecutionState,
+        # i.e. resolve https://github.com/dagster-io/dagster/issues/3511
+        self.log.warn(
+            f"No previously stored outputs found for source {step_output_handle}. "
+            "This is either because you are using an IO Manager that does not depend on run ID, "
+            "or because all the previous runs have skipped the output in conditional execution."
+        )
         return None
 
-    def _get_source_run_id(self, step_output_handle: StepOutputHandle) -> Optional[str]:
-        # determine if the step is not selected and
-        if (
-            # this is re-execution
+    def _should_load_from_previous_runs(self, step_output_handle: StepOutputHandle) -> bool:
+        return (  # this is re-execution
             self.pipeline_run.parent_run_id
             # we are not re-executing the entire pipeline
             and self.pipeline_run.step_keys_to_execute is not None
             # this step is not being executed
             and step_output_handle.step_key not in self.pipeline_run.step_keys_to_execute
-        ):
+        )
+
+    def _get_source_run_id(self, step_output_handle: StepOutputHandle) -> Optional[str]:
+        if self._should_load_from_previous_runs(step_output_handle):
             return self._get_source_run_id_from_logs(step_output_handle)
         else:
             return self.pipeline_run.run_id

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -5,6 +5,7 @@ from dagster import (
     DynamicOutput,
     DynamicOutputDefinition,
     execute_pipeline,
+    fs_io_manager,
     job,
     op,
     pipeline,
@@ -14,7 +15,7 @@ from dagster import (
 )
 from dagster.core.definitions.events import Output
 from dagster.core.definitions.output import DynamicOut, Out
-from dagster.core.errors import DagsterInvariantViolationError
+from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 
@@ -148,17 +149,94 @@ def test_reexec_from_parent_3():
         }
 
 
-def dynamic_job():
-    @op
-    def echo(x):
-        return x
+@op
+def echo(x):
+    return x
 
-    @op
-    def adder(ls: List[int]) -> int:
-        return sum(ls)
 
+@op
+def adder(ls: List[int]) -> int:
+    return sum(ls)
+
+
+@op(out=DynamicOut())
+def dynamic_op():
+    for i in range(10):
+        yield DynamicOutput(value=i, mapping_key=str(i))
+
+
+def dynamic_with_optional_output_job():
+    @op(out=DynamicOut(is_required=False))
+    def dynamic_optional_output_op(context):
+        for i in range(10):
+            if (
+                context.pipeline_run.parent_run_id
+                and i % 2 == 0  # re-execution run skipped odd numbers
+                or not context.pipeline_run.parent_run_id
+                and i % 2 == 1  # root run skipped even numbers
+            ):
+                yield DynamicOutput(value=i, mapping_key=str(i))
+
+    @job(resource_defs={"io_manager": fs_io_manager})
+    def _dynamic_with_optional_output_job():
+        dynamic_results = dynamic_optional_output_op().map(echo)
+        adder(dynamic_results.collect())
+
+    return _dynamic_with_optional_output_job
+
+
+def test_reexec_dynamic_with_optional_output_job_1():
+    with instance_for_test() as instance:
+        result = dynamic_with_optional_output_job().execute_in_process(instance=instance)
+
+        # re-execute all
+        re_result = reexecute_pipeline(
+            reconstructable(dynamic_with_optional_output_job),
+            parent_run_id=result.run_id,
+            instance=instance,
+        )
+        assert re_result.success
+        assert re_result.output_for_solid("adder") == sum([i for i in range(10) if i % 2 == 0])
+
+
+def test_reexec_dynamic_with_optional_output_job_2():
+    with instance_for_test() as instance:
+        result = dynamic_with_optional_output_job().execute_in_process(instance=instance)
+
+        # re-execute the step where the source yielded an output
+        re_result = reexecute_pipeline(
+            reconstructable(dynamic_with_optional_output_job),
+            parent_run_id=result.run_id,
+            instance=instance,
+            step_selection=["echo[1]"],
+        )
+        assert re_result.success
+        assert re_result.result_for_solid("echo").output_value() == {
+            "1": 1,
+        }
+
+
+def test_reexec_dynamic_with_optional_output_job_3():
+    with instance_for_test() as instance:
+        result = dynamic_with_optional_output_job().execute_in_process(instance=instance)
+
+        # re-execute the step where the source did not yield
+        # -> error because the dynamic step wont exist in execution plan
+        with pytest.raises(
+            DagsterExecutionStepNotFoundError,
+            match=r"Step selection refers to unknown step: echo\[0\]",
+        ):
+            reexecute_pipeline(
+                reconstructable(dynamic_with_optional_output_job),
+                parent_run_id=result.run_id,
+                instance=instance,
+                step_selection=["echo[0]"],
+            )
+
+
+def dynamic_with_transitive_optional_output_job():
     @op(out=Out(is_required=False))
-    def add_one(context, i: int) -> int:
+    def add_one_with_optional_output(context, i: int):
         if (
             context.pipeline_run.parent_run_id
             and i % 2 == 0  # re-execution run skipped odd numbers
@@ -167,27 +245,59 @@ def dynamic_job():
         ):
             yield Output(i + 1)
 
-    @op(out=DynamicOut())
-    def dynamic_op():
-        for i in range(10):
-            yield DynamicOutput(value=i, mapping_key=str(i))
-
-    @job
-    def _dynamic_job():
-        dynamic_results = dynamic_op().map(lambda n: echo(add_one(n)))
+    @job(resource_defs={"io_manager": fs_io_manager})
+    def _dynamic_with_transitive_optional_output_job():
+        dynamic_results = dynamic_op().map(lambda n: echo(add_one_with_optional_output(n)))
         adder(dynamic_results.collect())
 
-    return _dynamic_job
+    return _dynamic_with_transitive_optional_output_job
 
 
-def test_reexec_all_dynamic_with_partial_skip_fan_in():
+def test_reexec_dynamic_with_transitive_optional_output_job_1():
     with instance_for_test() as instance:
-        result = dynamic_job().execute_in_process(instance=instance)
+        result = dynamic_with_transitive_optional_output_job().execute_in_process(instance=instance)
         assert result.success
         assert result.output_for_node("adder") == sum([i + 1 for i in range(10) if i % 2 == 1])
 
+        # re-execute all
         re_result = reexecute_pipeline(
-            reconstructable(dynamic_job), parent_run_id=result.run_id, instance=instance
+            reconstructable(dynamic_with_transitive_optional_output_job),
+            parent_run_id=result.run_id,
+            instance=instance,
         )
         assert re_result.success
         assert re_result.output_for_solid("adder") == sum([i + 1 for i in range(10) if i % 2 == 0])
+
+
+def test_reexec_dynamic_with_transitive_optional_output_job_2():
+    with instance_for_test() as instance:
+        result = dynamic_with_transitive_optional_output_job().execute_in_process(instance=instance)
+
+        # re-execute the step where the source yielded an output
+        re_result = reexecute_pipeline(
+            reconstructable(dynamic_with_transitive_optional_output_job),
+            parent_run_id=result.run_id,
+            instance=instance,
+            step_selection=["echo[1]"],
+        )
+        assert re_result.success
+        assert re_result.result_for_solid("echo").output_value() == {"1": 2}
+
+
+def test_reexec_dynamic_with_transitive_optional_output_job_3():
+    with instance_for_test() as instance:
+        result = dynamic_with_transitive_optional_output_job().execute_in_process(instance=instance)
+
+        # re-execute the step where the source did not yield
+        re_result = reexecute_pipeline(
+            reconstructable(dynamic_with_transitive_optional_output_job),
+            parent_run_id=result.run_id,
+            instance=instance,
+            step_selection=["echo[0]"],
+            raise_on_error=False,
+        )
+        # when all the previous runs have skipped yielding the source,
+        # run would fail because of run_id returns None
+        # FIXME: https://github.com/dagster-io/dagster/issues/3511
+        # ideally it should skip the step because all its previous runs have skipped and finish the run successfully
+        assert not re_result.success


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
resolves https://github.com/dagster-io/dagster/issues/5668
repro: https://github.com/dagster-io/dagster/issues/5668#issuecomment-969505954
cause: we allow to continue fan in / collect when upstream skips some outputs. in re-execution, when upstream is skipped, it still tries to load input from previous runs - in the repro, when the output doesn't exist in previous runs, it results in file not found path error. 
the correct behavior is to return False in `can_load`, i.e. should not load from logs when upstream (in the same run) is skipped.


## Test Plan
- unit
- repro code re-execution worked in dagit



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.