### PR TITLE
rm unused ephemeral check in daemon entrypoint

### DIFF
--- a/python_modules/dagster/dagster/daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/daemon/cli/__init__.py
@@ -35,13 +35,6 @@ def _get_heartbeat_tolerance():
 def run_command():
     with capture_interrupts():
         with DagsterInstance.get() as instance:
-            if instance.is_ephemeral:
-                raise Exception(
-                    "dagster-daemon can't run using an in-memory instance. Make sure "
-                    "the DAGSTER_HOME environment variable has been set correctly and that "
-                    "you have created a dagster.yaml file there."
-                )
-
             with daemon_controller_from_instance(
                 instance, heartbeat_tolerance_seconds=_get_heartbeat_tolerance()
             ) as controller:


### PR DESCRIPTION
Summary:
This can't happen anymore in DagsterInstance.get() - unclear if it ever could happen.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.