### PR TITLE
Celery-k8s run monitoring

### DIFF
--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -111,6 +111,8 @@ data:
     run_monitoring:
       enabled: {{ $runMonitoring.enabled }}
       start_timeout_seconds:  {{ $runMonitoring.startTimeoutSeconds }}
+      {{- if $runMonitoring.maxResumeRunAttempts }}
       max_resume_run_attempts: {{ $runMonitoring.maxResumeRunAttempts }}
+      {{- end }}
       poll_interval_seconds: {{ $runMonitoring.pollIntervalSeconds }}
     {{- end }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -939,10 +939,11 @@ dagsterDaemon:
     enabled: false
     # Timeout for runs to start (avoids runs hanging in STARTED)
     startTimeoutSeconds: 180
-    # Max number of times to attempt to resume a run with a new run worker
-    maxResumeRunAttempts: 3
     # How often to check on in progress runs
     pollIntervalSeconds: 120
+    # Max number of times to attempt to resume a run with a new run worker. Defaults to 3 if the the
+    # run launcher supports resuming runs, otherwise defaults to 0.
+    maxResumeRunAttempts: ~
 
   # Additional environment variables to set.
   # A Kubernetes ConfigMap will be created with these environment variables. See:

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -870,6 +870,10 @@ def _base_helm_config(docker_image):
                 "failureThreshold": 12,
                 "timeoutSeconds": 12,
             },
+            "runMonitoring": {
+                "enabled": True,
+                "pollIntervalSeconds": 5,
+            },
         },
         # Used to set the environment variables in dagster.shared_env that determine the run config
         "pipelineRun": {"image": {"repository": repository, "tag": tag, "pullPolicy": pull_policy}},

--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/test_monitoring.py
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/test_monitoring.py
@@ -1,0 +1,134 @@
+# pylint doesn't know about pytest fixtures
+# pylint: disable=unused-argument
+
+import os
+import time
+
+from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.test_utils import poll_for_finished_run
+from dagster.utils import merge_dicts
+from dagster.utils.yaml_utils import merge_yamls
+from dagster_k8s.job import get_job_name_from_run_id
+from dagster_k8s.utils import delete_job
+from dagster_k8s_test_infra.integration_utils import image_pull_policy, launch_run_over_graphql
+from dagster_test.test_project import get_test_project_environments_path
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+
+
+def log_run_events(instance, run_id):
+    for log in instance.all_logs(run_id):
+        print(str(log) + "\n")  # pylint: disable=print-call
+
+
+def get_celery_job_engine_config(dagster_docker_image, job_namespace):
+    return {
+        "execution": {
+            "config": merge_dicts(
+                (
+                    {
+                        "job_image": dagster_docker_image,
+                    }
+                    if dagster_docker_image
+                    else {}
+                ),
+                {
+                    "job_namespace": job_namespace,
+                    "image_pull_policy": image_pull_policy(),
+                },
+            )
+        },
+    }
+
+
+def get_failing_celery_job_engine_config(dagster_docker_image, job_namespace):
+    return {
+        "execution": {
+            "config": merge_dicts(
+                (
+                    {
+                        "job_image": dagster_docker_image,
+                    }
+                    if dagster_docker_image
+                    else {}
+                ),
+                {
+                    "job_namespace": job_namespace,
+                    "image_pull_policy": image_pull_policy(),
+                    "env_config_maps": ["non-existent-config-map"],
+                },
+            )
+        },
+    }
+
+
+def test_run_monitoring_fails_on_interrupt(  # pylint: disable=redefined-outer-name
+    dagster_docker_image, dagster_instance, helm_namespace, dagit_url
+):
+    run_config = merge_dicts(
+        merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
+        get_celery_job_engine_config(
+            dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
+        ),
+    )
+
+    pipeline_name = "demo_job_celery"
+
+    try:
+        run_id = launch_run_over_graphql(
+            dagit_url, run_config=run_config, pipeline_name=pipeline_name
+        )
+        start_time = time.time()
+        while time.time() - start_time < 60:
+            run = dagster_instance.get_run_by_id(run_id)
+            if run.status == PipelineRunStatus.STARTED:
+                break
+            assert run.status == PipelineRunStatus.STARTING
+            time.sleep(1)
+
+        assert delete_job(get_job_name_from_run_id(run_id), helm_namespace)
+        poll_for_finished_run(dagster_instance, run.run_id, timeout=120)
+        assert dagster_instance.get_run_by_id(run_id).status == PipelineRunStatus.FAILURE
+    finally:
+        log_run_events(dagster_instance, run_id)
+
+
+def test_run_monitoring_startup_fail(  # pylint: disable=redefined-outer-name
+    dagster_docker_image, dagster_instance, helm_namespace, dagit_url
+):
+    run_config = merge_dicts(
+        merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
+        get_failing_celery_job_engine_config(
+            dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
+        ),
+    )
+
+    pipeline_name = "demo_job_celery"
+
+    try:
+        run_id = launch_run_over_graphql(
+            dagit_url, run_config=run_config, pipeline_name=pipeline_name
+        )
+        start_time = time.time()
+        while time.time() - start_time < 60:
+            run = dagster_instance.get_run_by_id(run_id)
+            if run.status == PipelineRunStatus.STARTED:
+                break
+            assert run.status == PipelineRunStatus.STARTING
+            time.sleep(1)
+
+        assert delete_job(get_job_name_from_run_id(run_id), helm_namespace)
+        poll_for_finished_run(dagster_instance, run.run_id, timeout=120)
+        assert dagster_instance.get_run_by_id(run_id).status == PipelineRunStatus.FAILURE
+    finally:
+        log_run_events(dagster_instance, run_id)

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -96,7 +96,7 @@ def test_docker_monitoring():
             "solids": {
                 "multiply_the_word_slow": {
                     "inputs": {"word": "bar"},
-                    "config": {"factor": 2, "sleep_time": 10},
+                    "config": {"factor": 2, "sleep_time": 20},
                 }
             },
             "execution": {"docker": {"config": {}}},
@@ -181,7 +181,7 @@ def test_docker_monitoring_run_out_of_attempts():
             "solids": {
                 "multiply_the_word_slow": {
                     "inputs": {"word": "bar"},
-                    "config": {"factor": 2, "sleep_time": 10},
+                    "config": {"factor": 2, "sleep_time": 20},
                 }
             },
             "execution": {"docker": {"config": {}}},

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -324,8 +324,14 @@ class DagsterInstance:
         if self.run_monitoring_enabled:
             check.invariant(
                 self.run_launcher.supports_check_run_worker_health,
-                "Run monitoring only supports select RunLaunchers",
+                "The configured run launcher does not support run monitoring.",
             )
+
+            if self.run_monitoring_max_resume_run_attempts:
+                check.invariant(
+                    self.run_launcher.supports_resume_run,
+                    "The configured run launcher does not support resuming runs. Set max_resume_run_attempts to 0.",
+                )
 
     # ctors
 
@@ -611,7 +617,10 @@ class DagsterInstance:
 
     @property
     def run_monitoring_max_resume_run_attempts(self) -> int:
-        return self.run_monitoring_settings.get("max_resume_run_attempts", 3)
+        default_max_resume_run_attempts = 3 if self.run_launcher.supports_resume_run else 0
+        return self.run_monitoring_settings.get(
+            "max_resume_run_attempts", default_max_resume_run_attempts
+        )
 
     @property
     def run_monitoring_poll_interval_seconds(self) -> int:

--- a/python_modules/dagster/dagster/core/launcher/base.py
+++ b/python_modules/dagster/dagster/core/launcher/base.py
@@ -108,6 +108,13 @@ class RunLauncher(ABC, MayHaveInstanceWeakref):
             "This run launcher does not support run monitoring. Please disable it on your instance."
         )
 
+    @property
+    def supports_resume_run(self):
+        """
+        Whether the run launcher supports resume_run.
+        """
+        return False
+
     def resume_run(self, context: ResumeRunContext) -> None:
         raise NotImplementedError(
             "This run launcher does not support resuming runs. If using "

--- a/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
+++ b/python_modules/dagster/dagster/daemon/monitoring/monitoring_daemon.py
@@ -57,10 +57,16 @@ def monitor_started_run(instance: DagsterInstance, workspace, run, logger):
                 attempt_number,
             )
         else:
-            msg = (
-                f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
-                "failed, because it has surpassed the configured maximum attempts to resume the run: {max_resume_run_attempts}."
-            )
+            if instance.run_launcher.supports_resume_run:
+                msg = (
+                    f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
+                    "failed, because it has surpassed the configured maximum attempts to resume the run: {max_resume_run_attempts}."
+                )
+            else:
+                msg = (
+                    f"Detected run worker status {check_health_result}. Marking run {run.run_id} as "
+                    "failed."
+                )
             logger.info(msg)
             instance.report_run_failed(run, msg)
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -55,6 +55,10 @@ class TestRunLauncher(RunLauncher, ConfigurableClass):
         raise NotImplementedError()
 
     @property
+    def supports_resume_run(self):
+        return True
+
+    @property
     def supports_check_run_worker_health(self):
         return True
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -162,6 +162,10 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
 
         self._launch_container_with_command(run, docker_image, command)
 
+    @property
+    def supports_resume_run(self):
+        return True
+
     def resume_run(self, context: ResumeRunContext) -> None:
         run = context.pipeline_run
         pipeline_code_origin = context.pipeline_code_origin

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -343,6 +343,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
         self._launch_k8s_job_with_args(job_name, args, run, pipeline_origin)
 
+    @property
+    def supports_resume_run(self):
+        return True
+
     def resume_run(self, context: ResumeRunContext) -> None:
         run = context.pipeline_run
         job_name = get_job_name_from_run_id(


### PR DESCRIPTION
With this change, Celery-k8s users can take advantage of run monitoring features (timeouts and health checks). They don't get access to resuming a failed run, because rediscovering in progress Celery steps has proved to be a bit difficult.

Currently a user will have to enable run monitoring, but disable retries. That's a bit janky, and there's ways we can improve it in the future: if we move executors to job defs, we could have a property on them for if resuming the run is supported