### PR TITLE
Make @asset and @multi_asset return asset definitions instead of ops

### DIFF
--- a/examples/hacker_news_assets/hacker_news_assets_tests/test_solids/test_comment_stories.py
+++ b/examples/hacker_news_assets/hacker_news_assets_tests/test_solids/test_comment_stories.py
@@ -13,7 +13,7 @@ from pandas import DataFrame
 def test_comment_stories(comments, stories, expected):
     comments = DataFrame(comments, columns=["id", "parent", "by"])
     stories = DataFrame(stories, columns=["id"])
-    result = comment_stories(stories=stories, comments=comments)
+    result = comment_stories.op(stories=stories, comments=comments)
     expected = DataFrame(expected, columns=["comment_id", "story_id", "commenter_id"]).set_index(
         "comment_id"
     )

--- a/examples/hacker_news_assets/hacker_news_assets_tests/test_solids/test_user_story_matrix.py
+++ b/examples/hacker_news_assets/hacker_news_assets_tests/test_solids/test_user_story_matrix.py
@@ -24,6 +24,6 @@ def test_user_story_matrix(comment_stories, expected):
     comment_stories_df = DataFrame(
         comment_stories, columns=["comment_id", "story_id", "commenter_id"]
     )
-    indexed_matrix = user_story_matrix(comment_stories=comment_stories_df)
+    indexed_matrix = user_story_matrix.op(comment_stories=comment_stories_df)
 
     assert indexed_matrix.matrix.toarray().tolist() == expected

--- a/examples/hacker_news_assets/hacker_news_assets_tests/test_solids/test_user_top_recommended_stories.py
+++ b/examples/hacker_news_assets/hacker_news_assets_tests/test_solids/test_user_top_recommended_stories.py
@@ -13,7 +13,7 @@ def test_user_top_recommended_stories():
     row_users = Series(["abc"])
     col_stories = Series([35, 38, 40])
 
-    result = user_top_recommended_stories(
+    result = user_top_recommended_stories.op(
         None,
         recommender_model=model,
         user_story_matrix=IndexedCooMatrix(user_story_matrix, row_users, col_stories),

--- a/python_modules/dagster/dagster/core/asset_defs/__init__.py
+++ b/python_modules/dagster/dagster/core/asset_defs/__init__.py
@@ -1,3 +1,4 @@
+from .asset import AssetsDefinition
 from .asset_in import AssetIn
 from .assets_job import build_assets_job
 from .decorators import asset, multi_asset

--- a/python_modules/dagster/dagster/core/asset_defs/asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset.py
@@ -1,0 +1,35 @@
+from typing import Mapping
+
+from dagster.core.definitions import OpDefinition
+from dagster.core.definitions.events import AssetKey
+
+
+class AssetsDefinition:
+    def __init__(
+        self,
+        input_names_by_asset_key: Mapping[AssetKey, str],
+        output_names_by_asset_key: Mapping[AssetKey, str],
+        op: OpDefinition,
+    ):
+        self._op = op
+        self._input_defs_by_asset_key = {
+            asset_key: op.input_dict[input_name]
+            for asset_key, input_name in input_names_by_asset_key.items()
+        }
+
+        self._output_defs_by_asset_key = {
+            asset_key: op.output_dict[output_name]
+            for asset_key, output_name in output_names_by_asset_key.items()
+        }
+
+    @property
+    def op(self) -> OpDefinition:
+        return self._op
+
+    @property
+    def output_defs_by_asset_key(self):
+        return self._output_defs_by_asset_key
+
+    @property
+    def input_defs_by_asset_key(self):
+        return self._input_defs_by_asset_key

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -11,9 +11,7 @@ from dagster.core.definitions.dependency import (
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.executor_definition import ExecutorDefinition
 from dagster.core.definitions.graph_definition import GraphDefinition
-from dagster.core.definitions.input import InputDefinition
 from dagster.core.definitions.job_definition import JobDefinition
-from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.definitions.output import Out, OutputDefinition
 from dagster.core.definitions.partition import PartitionedConfig
@@ -25,14 +23,15 @@ from dagster.core.storage.root_input_manager import RootInputManagerDefinition, 
 from dagster.utils.backcompat import experimental
 from dagster.utils.merger import merge_dicts
 
+from .asset import AssetsDefinition
 from .foreign_asset import ForeignAsset
 
 
 @experimental
 def build_assets_job(
     name: str,
-    assets: List[OpDefinition],
-    source_assets: Optional[Sequence[Union[ForeignAsset, OpDefinition]]] = None,
+    assets: List[AssetsDefinition],
+    source_assets: Optional[Sequence[Union[ForeignAsset, AssetsDefinition]]] = None,
     resource_defs: Optional[Dict[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
     config: Union[ConfigMapping, Dict[str, Any], PartitionedConfig] = None,
@@ -46,10 +45,11 @@ def build_assets_job(
 
     Args:
         name (str): The name of the job.
-        assets (List[OpDefinition]): A list of assets or multi-assets - usually constructed using
-            the :py:func:`@asset` or :py:func:`@multi_asset` decorator.
-        source_assets (Optional[Sequence[Union[ForeignAsset, OpDefinition]]]): A list of assets
-            that are not materialized by this job, but that assets in this job depend on.
+        assets (List[AssetsDefinition]): A list of assets or
+            multi-assets - usually constructed using the :py:func:`@asset` or :py:func:`@multi_asset`
+            decorator.
+        source_assets (Optional[Sequence[Union[ForeignAsset, AssetsDefinition]]]): A list of
+            assets that are not materialized by this job, but that assets in this job depend on.
         resource_defs (Optional[Dict[str, ResourceDefinition]]): Resource defs to be included in
             this job.
         description (Optional[str]): A description of the job.
@@ -72,8 +72,8 @@ def build_assets_job(
         JobDefinition: A job that materializes the given assets.
     """
     check.str_param(name, "name")
-    check.list_param(assets, "assets", of_type=OpDefinition)
-    check.opt_list_param(source_assets, "source_assets", of_type=(ForeignAsset, OpDefinition))
+    check.list_param(assets, "assets", of_type=AssetsDefinition)
+    check.opt_list_param(source_assets, "source_assets", of_type=(ForeignAsset, AssetsDefinition))
     check.opt_str_param(description, "description")
     source_assets_by_key = build_source_assets_by_key(source_assets)
 
@@ -82,7 +82,7 @@ def build_assets_job(
 
     return GraphDefinition(
         name=name,
-        node_defs=cast(List[NodeDefinition], assets),
+        node_defs=[asset.op for asset in assets],
         dependencies=op_defs,
         description=description,
         input_mappings=None,
@@ -97,57 +97,49 @@ def build_assets_job(
 
 
 def build_source_assets_by_key(
-    source_assets: Optional[Sequence[Union[ForeignAsset, OpDefinition]]]
+    source_assets: Optional[Sequence[Union[ForeignAsset, AssetsDefinition]]]
 ) -> Mapping[AssetKey, Union[ForeignAsset, OutputDefinition]]:
     source_assets_by_key: Dict[AssetKey, Union[ForeignAsset, OutputDefinition]] = {}
     for asset_source in source_assets or []:
         if isinstance(asset_source, ForeignAsset):
             source_assets_by_key[asset_source.key] = asset_source
-        elif isinstance(asset_source, OpDefinition):
-            for output_def in asset_source.output_defs:
-                if output_def.get_asset_key(None):
-                    source_assets_by_key[output_def.get_asset_key(None)] = output_def
+        elif isinstance(asset_source, AssetsDefinition):
+            for asset_key, output_def in asset_source.output_defs_by_asset_key.items():
+                if asset_key:
+                    source_assets_by_key[asset_key] = output_def
 
     return source_assets_by_key
 
 
 def build_op_deps(
-    assets: List[OpDefinition], source_paths: AbstractSet[AssetKey]
+    multi_asset_defs: List[AssetsDefinition], source_paths: AbstractSet[AssetKey]
 ) -> Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]:
     op_outputs_by_asset: Dict[AssetKey, Tuple[OpDefinition, str]] = {}
-    for asset_op in assets:
-        for output_def in asset_op.output_defs:
-            logical_asset = get_asset_key(output_def, f"Output of asset '{asset_op.name}'")
-
-            if logical_asset in op_outputs_by_asset:
-                prev_op = op_outputs_by_asset[logical_asset][0].name
+    for multi_asset_def in multi_asset_defs:
+        for asset_key, output_def in multi_asset_def.output_defs_by_asset_key.items():
+            if asset_key in op_outputs_by_asset:
                 raise DagsterInvalidDefinitionError(
-                    f"Two ops produce the same logical asset: '{asset_op.name}' and '{prev_op.name}"
+                    f"The same asset key was included for two definitions: '{asset_key.to_string()}'"
                 )
 
-            op_outputs_by_asset[logical_asset] = (asset_op, output_def.name)
+            op_outputs_by_asset[asset_key] = (multi_asset_def.op, output_def.name)
 
-    op_defs: Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]] = {}
-    for asset_op in assets:
-        op_defs[asset_op.name] = {}
-        for input_def in asset_op.input_defs:
-            logical_asset = get_asset_key(
-                input_def, f"Input '{input_def.name}' of asset '{asset_op.name}'"
-            )
-
-            if logical_asset in op_outputs_by_asset:
-                op_def, output_name = op_outputs_by_asset[logical_asset]
-                op_defs[asset_op.name][input_def.name] = DependencyDefinition(
-                    op_def.name, output_name
-                )
-            elif logical_asset not in source_paths and not input_def.dagster_type.is_nothing:
+    op_deps: Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]] = {}
+    for multi_asset_def in multi_asset_defs:
+        op_name = multi_asset_def.op.name
+        op_deps[op_name] = {}
+        for asset_key, input_def in multi_asset_def.input_defs_by_asset_key.items():
+            if asset_key in op_outputs_by_asset:
+                op_def, output_name = op_outputs_by_asset[asset_key]
+                op_deps[op_name][input_def.name] = DependencyDefinition(op_def.name, output_name)
+            elif asset_key not in source_paths and not input_def.dagster_type.is_nothing:
                 raise DagsterInvalidDefinitionError(
-                    f"Input asset '{logical_asset.to_string()}' for asset '{asset_op.name}' is not "
+                    f"Input asset '{asset_key.to_string()}' for asset '{op_name}' is not "
                     "produced by any of the provided asset ops and is not one of the provided "
                     "sources"
                 )
 
-    return op_defs
+    return op_deps
 
 
 def build_root_manager(
@@ -187,13 +179,3 @@ def build_root_manager(
         return io_manager.load_input(input_context_with_upstream)
 
     return _root_manager
-
-
-def get_asset_key(
-    input_or_output: Union[InputDefinition, OutputDefinition], error_prefix: str
-) -> AssetKey:
-    asset_key = input_or_output.get_asset_key(None)
-    if asset_key is None:
-        raise DagsterInvalidDefinitionError(f"{error_prefix}' is missing asset_key")
-    else:
-        return asset_key

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -6,12 +6,12 @@ from dagster.core.decorator_utils import get_function_params, get_valid_name_per
 from dagster.core.definitions.decorators.op import _Op
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.input import In
-from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.definitions.output import Out
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.types.dagster_type import DagsterType
 from dagster.utils.backcompat import experimental_decorator
 
+from .asset import AssetsDefinition
 from .asset_in import AssetIn
 
 
@@ -26,7 +26,7 @@ def asset(
     io_manager_key: Optional[str] = None,
     compute_kind: Optional[str] = None,
     dagster_type: Optional[DagsterType] = None,
-) -> Callable[[Callable[..., Any]], OpDefinition]:
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to compute an asset.
 
     A software-defined asset is the combination of:
@@ -67,7 +67,7 @@ def asset(
     if callable(name):
         return _Asset()(name)
 
-    def inner(fn: Callable[..., Any]) -> OpDefinition:
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         return _Asset(
             name=name,
             namespace=namespace,
@@ -106,8 +106,12 @@ class _Asset:
         self.compute_kind = compute_kind
         self.dagster_type = dagster_type
 
-    def __call__(self, fn: Callable):
+    def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
+
+        ins_by_asset_key: Mapping[AssetKey, In] = build_asset_ins(
+            fn, self.namespace, self.ins or {}
+        )
 
         out = Out(
             asset_key=AssetKey(list(filter(None, [self.namespace, asset_name]))),
@@ -115,25 +119,35 @@ class _Asset:
             io_manager_key=self.io_manager_key,
             dagster_type=self.dagster_type,
         )
-        return _Op(
+        op = _Op(
             name=asset_name,
             description=self.description,
-            ins=build_asset_ins(fn, self.namespace, self.ins),
+            ins={asset_key.path[-1]: in_def for asset_key, in_def in ins_by_asset_key.items()},
             out=out,
             required_resource_keys=self.required_resource_keys,
             tags={"kind": self.compute_kind} if self.compute_kind else None,
         )(fn)
 
+        out_asset_key = AssetKey(list(filter(None, [self.namespace, asset_name])))
+        return AssetsDefinition(
+            input_names_by_asset_key={
+                in_asset_key: in_asset_key.path[-1] for in_asset_key in ins_by_asset_key.keys()
+            },
+            output_names_by_asset_key={out_asset_key: "result"},
+            op=op,
+        )
+
 
 @experimental_decorator
 def multi_asset(
+    outs: Dict[str, Out],
     name: Optional[str] = None,
-    outs: Optional[Dict[str, Out]] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
     description: Optional[str] = None,
     required_resource_keys: Optional[Set[str]] = None,
-) -> Callable[[Callable[..., Any]], OpDefinition]:
-    """Create an op that computes multiple assets.
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    """Create a combined definition of multiple assets that are computed using the same op and same
+    upstream assets.
 
     Each argument to the decorated function references an upstream asset that this asset depends on.
     The name of the argument designates the name of the upstream asset.
@@ -149,53 +163,32 @@ def multi_asset(
             (default: "io_manager").
     """
 
-    if callable(name):
-        return _Asset()(name)
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
+        asset_name = name or fn.__name__
+        ins_by_asset_key: Mapping[AssetKey, In] = build_asset_ins(fn, None, ins or {})
 
-    def inner(fn: Callable[..., Any]) -> OpDefinition:
-        return _MultiAsset(
-            name=name,
-            outs=outs,
-            ins=ins,
+        op = _Op(
+            name=asset_name,
             description=description,
+            ins={asset_key.path[-1]: in_def for asset_key, in_def in ins_by_asset_key.items()},
+            out=outs,
             required_resource_keys=required_resource_keys,
         )(fn)
+
+        return AssetsDefinition(
+            input_names_by_asset_key={
+                in_asset_key: in_asset_key.path[-1] for in_asset_key in ins_by_asset_key.keys()
+            },
+            output_names_by_asset_key={AssetKey([name]): name for name in outs.keys()},
+            op=op,
+        )
 
     return inner
 
 
-class _MultiAsset:
-    def __init__(
-        self,
-        name: Optional[str] = None,
-        outs: Optional[Dict[str, Out]] = None,
-        ins: Optional[Mapping[str, AssetIn]] = None,
-        description: Optional[str] = None,
-        required_resource_keys: Optional[Set[str]] = None,
-        io_manager_key: Optional[str] = None,
-    ):
-        self.name = name
-        self.ins = ins or {}
-        self.outs = outs
-        self.description = description
-        self.required_resource_keys = required_resource_keys
-        self.io_manager_key = io_manager_key
-
-    def __call__(self, fn: Callable):
-        asset_name = self.name or fn.__name__
-
-        return _Op(
-            name=asset_name,
-            description=self.description,
-            ins=build_asset_ins(fn, None, self.ins),
-            out=self.outs,
-            required_resource_keys=self.required_resource_keys,
-        )(fn)
-
-
 def build_asset_ins(
     fn: Callable, asset_namespace: Optional[str], asset_ins: Mapping[str, AssetIn]
-) -> Dict[str, In]:
+) -> Mapping[AssetKey, In]:
     params = get_function_params(fn)
     is_context_provided = len(params) > 0 and params[0].name in get_valid_name_permutations(
         "context"
@@ -213,7 +206,7 @@ def build_asset_ins(
                 "of the arguments to the decorated function"
             )
 
-    ins: Dict[str, In] = {}
+    ins: Dict[AssetKey, In] = {}
     for input_name in all_input_names:
         if input_name in asset_ins:
             metadata = asset_ins[input_name].metadata or {}
@@ -226,7 +219,7 @@ def build_asset_ins(
 
         asset_key = AssetKey(list(filter(None, [namespace or asset_namespace, input_name])))
 
-        ins[input_name] = In(
+        ins[asset_key] = In(
             metadata=metadata,
             root_manager_key="root_manager",
             asset_key=asset_key,

--- a/python_modules/dagster/dagster/core/definitions/decorators/op.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Union
 
 from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -16,6 +16,9 @@ from .solid import (
     NoContextDecoratedSolidFunction,
     resolve_checked_solid_fn_inputs,
 )
+
+if TYPE_CHECKING:
+    from ..op_definition import OpDefinition
 
 
 class _Op:
@@ -57,7 +60,7 @@ class _Op:
         self.ins = check.opt_nullable_dict_param(ins, "ins", key_type=str, value_type=In)
         self.out = out
 
-    def __call__(self, fn: Callable[..., Any]) -> SolidDefinition:
+    def __call__(self, fn: Callable[..., Any]) -> "OpDefinition":
         from ..op_definition import OpDefinition
 
         if self.input_defs is not None and self.ins is not None:

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, abstractproperty
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 from dagster import check
 from dagster.core.definitions.configurable import NamedConfigurableDefinition
@@ -11,6 +11,8 @@ from .utils import check_valid_name, validate_tags
 
 if TYPE_CHECKING:
     from .graph_definition import GraphDefinition
+    from .input import InputDefinition
+    from .output import OutputDefinition
     from .solid_definition import SolidDefinition
 
 # base class for SolidDefinition and GraphDefinition
@@ -71,11 +73,11 @@ class NodeDefinition(NamedConfigurableDefinition):
         return self._positional_inputs
 
     @property
-    def input_defs(self):
+    def input_defs(self) -> Sequence["InputDefinition"]:
         return self._input_defs
 
     @property
-    def input_dict(self):
+    def input_dict(self) -> Mapping[str, "InputDefinition"]:
         return self._input_dict
 
     def resolve_input_name_at_position(self, idx):
@@ -96,11 +98,11 @@ class NodeDefinition(NamedConfigurableDefinition):
         return self._positional_inputs[idx]
 
     @property
-    def output_defs(self):
+    def output_defs(self) -> Sequence["OutputDefinition"]:
         return self._output_defs
 
     @property
-    def output_dict(self):
+    def output_dict(self) -> Mapping[str, "OutputDefinition"]:
         return self._output_dict
 
     def has_input(self, name):

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -8,7 +8,7 @@ def test_single_asset_pipeline():
         return 1
 
     job = build_assets_job("a", [asset1])
-    assert job.graph.node_defs == [asset1]
+    assert job.graph.node_defs == [asset1.op]
     assert job.execute_in_process().success
 
 
@@ -22,7 +22,7 @@ def test_two_asset_pipeline():
         assert asset1 == 1
 
     job = build_assets_job("a", [asset1, asset2])
-    assert job.graph.node_defs == [asset1, asset2]
+    assert job.graph.node_defs == [asset1.op, asset2.op]
     assert job.dependencies == {
         "asset1": {},
         "asset2": {"asset1": DependencyDefinition("asset1", "result")},
@@ -44,7 +44,7 @@ def test_fork():
         assert asset1 == 1
 
     job = build_assets_job("a", [asset1, asset2, asset3])
-    assert job.graph.node_defs == [asset1, asset2, asset3]
+    assert job.graph.node_defs == [asset1.op, asset2.op, asset3.op]
     assert job.dependencies == {
         "asset1": {},
         "asset2": {"asset1": DependencyDefinition("asset1", "result")},
@@ -68,7 +68,7 @@ def test_join():
         assert asset2 == 2
 
     job = build_assets_job("a", [asset1, asset2, asset3])
-    assert job.graph.node_defs == [asset1, asset2, asset3]
+    assert job.graph.node_defs == [asset1.op, asset2.op, asset3.op]
     assert job.dependencies == {
         "asset1": {},
         "asset2": {},
@@ -103,7 +103,7 @@ def test_foreign_asset():
         source_assets=[ForeignAsset(AssetKey("source1"), io_manager_key="special_io_manager")],
         resource_defs={"special_io_manager": my_io_manager},
     )
-    assert job.graph.node_defs == [asset1]
+    assert job.graph.node_defs == [asset1.op]
     assert job.execute_in_process().success
 
 
@@ -134,5 +134,5 @@ def test_source_op_asset():
         source_assets=[source1],
         resource_defs={"special_io_manager": my_io_manager},
     )
-    assert job.graph.node_defs == [asset1]
+    assert job.graph.node_defs == [asset1.op]
     assert job.execute_in_process().success

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -1,6 +1,6 @@
 import pytest
-from dagster import AssetKey, DagsterInvalidDefinitionError, SolidDefinition, String
-from dagster.core.asset_defs import AssetIn, asset
+from dagster import AssetKey, DagsterInvalidDefinitionError, String
+from dagster.core.asset_defs import AssetIn, AssetsDefinition, asset
 
 
 def test_asset_no_decorator_args():
@@ -8,9 +8,9 @@ def test_asset_no_decorator_args():
     def my_asset():
         return 1
 
-    assert isinstance(my_asset, SolidDefinition)
-    assert len(my_asset.output_defs) == 1
-    assert len(my_asset.input_defs) == 0
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 0
 
 
 def test_asset_with_inputs():
@@ -18,10 +18,10 @@ def test_asset_with_inputs():
     def my_asset(arg1):
         return arg1
 
-    assert isinstance(my_asset, SolidDefinition)
-    assert len(my_asset.output_defs) == 1
-    assert len(my_asset.input_defs) == 1
-    assert my_asset.input_defs[0].get_asset_key(None) == AssetKey("arg1")
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 1
+    assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey("arg1")
 
 
 def test_asset_with_compute_kind():
@@ -29,7 +29,7 @@ def test_asset_with_compute_kind():
     def my_asset(arg1):
         return arg1
 
-    assert my_asset.tags == {"kind": "sql"}
+    assert my_asset.op.tags == {"kind": "sql"}
 
 
 def test_asset_with_dagster_type():
@@ -37,7 +37,7 @@ def test_asset_with_dagster_type():
     def my_asset(arg1):
         return arg1
 
-    assert my_asset.output_defs[0].dagster_type.display_name == "String"
+    assert my_asset.op.output_defs[0].dagster_type.display_name == "String"
 
 
 def test_asset_with_inputs_and_namespace():
@@ -45,10 +45,10 @@ def test_asset_with_inputs_and_namespace():
     def my_asset(arg1):
         return arg1
 
-    assert isinstance(my_asset, SolidDefinition)
-    assert len(my_asset.output_defs) == 1
-    assert len(my_asset.input_defs) == 1
-    assert my_asset.input_defs[0].get_asset_key(None) == AssetKey(["my_namespace", "arg1"])
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 1
+    assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey(["my_namespace", "arg1"])
 
 
 def test_asset_with_context_arg():
@@ -56,8 +56,8 @@ def test_asset_with_context_arg():
     def my_asset(context):
         context.log("hello")
 
-    assert isinstance(my_asset, SolidDefinition)
-    assert len(my_asset.input_defs) == 0
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.input_defs) == 0
 
 
 def test_asset_with_context_arg_and_dep():
@@ -66,9 +66,9 @@ def test_asset_with_context_arg_and_dep():
         context.log("hello")
         assert arg1
 
-    assert isinstance(my_asset, SolidDefinition)
-    assert len(my_asset.input_defs) == 1
-    assert my_asset.input_defs[0].get_asset_key(None) == AssetKey("arg1")
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.input_defs) == 1
+    assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey("arg1")
 
 
 def test_input_namespace():
@@ -76,7 +76,7 @@ def test_input_namespace():
     def my_asset(arg1):
         assert arg1
 
-    assert my_asset.input_defs[0].get_asset_key(None) == AssetKey(["abc", "arg1"])
+    assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey(["abc", "arg1"])
 
 
 def test_input_metadata():
@@ -84,7 +84,7 @@ def test_input_metadata():
     def my_asset(arg1):
         assert arg1
 
-    assert my_asset.input_defs[0].metadata == {"abc": 123}
+    assert my_asset.op.input_defs[0].metadata == {"abc": 123}
 
 
 def test_unknown_in():
@@ -105,10 +105,10 @@ def test_all_fields():
     def my_asset():
         pass
 
-    assert my_asset.required_resource_keys == {"abc", "123"}
-    assert my_asset.description == "some description"
-    assert len(my_asset.output_defs) == 1
-    output_def = my_asset.output_defs[0]
+    assert my_asset.op.required_resource_keys == {"abc", "123"}
+    assert my_asset.op.description == "some description"
+    assert len(my_asset.op.output_defs) == 1
+    output_def = my_asset.op.output_defs[0]
     assert output_def.io_manager_key == "my_io_key"
     assert output_def.metadata["metakey"] == "metaval"
 
@@ -118,4 +118,4 @@ def test_infer_input_dagster_type():
     def my_asset(_input1: str):
         pass
 
-    assert my_asset.input_defs[0].dagster_type.display_name == "String"
+    assert my_asset.op.input_defs[0].dagster_type.display_name == "String"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -45,19 +45,19 @@ def test_runtime_metadata_fn():
     for asset in assets:
         materializations = [
             event.event_specific_data.materialization
-            for event in result.events_for_node(asset.name)
+            for event in result.events_for_node(asset.op.name)
             if event.event_type_value == "ASSET_MATERIALIZATION"
         ]
         assert len(materializations) == 1
         assert materializations[0].metadata_entries == [
-            EventMetadataEntry.text(asset.name, label="op_name"),
-            EventMetadataEntry.text(asset.name, label="dbt_model"),
+            EventMetadataEntry.text(asset.op.name, label="op_name"),
+            EventMetadataEntry.text(asset.op.name, label="dbt_model"),
         ]
 
 
 def assert_assets_match_project(assets):
     assert len(assets) == 4
-    assets_by_name = {asset.name: asset for asset in assets}
+    assets_by_name = {asset.op.name: asset for asset in assets}
     assert assets_by_name.keys() == {
         "sort_hot_cereals_by_calories",
         "sort_by_calories",
@@ -65,10 +65,10 @@ def assert_assets_match_project(assets):
         "sort_cold_cereals_by_calories",
     }
     for name, asset in assets_by_name.items():
-        assert name == asset.name
-        assert len(asset.output_defs) == 1
-        assert f'["{name}"]' == asset.output_defs[0].hardcoded_asset_key.to_string()
-        assert asset.tags == {"kind": "dbt"}
+        assert name == asset.op.name
+        assert len(asset.op.output_defs) == 1
+        assert f'["{name}"]' == asset.op.output_defs[0].hardcoded_asset_key.to_string()
+        assert asset.op.tags == {"kind": "dbt"}
 
     job = build_assets_job(
         "jarb", assets, resource_defs={"dbt": ResourceDefinition.none_resource()}


### PR DESCRIPTION
This should not affect behavior.

A couple consequences:
* Users can no longer take the definitions produced by `@asset` and `@multi_asset` and build jobs out of them using `@graph` / `@job`.  This is a good thing, because in theory they could wire up the graph dependencies in a way that contradicts the asset dependencies, which would cause all kinds of zaniness.
* We'll have a place for the asset partition definitions to live.