### PR TITLE
use the right instance in the download debug log endpoint

### DIFF
--- a/python_modules/dagit/dagit/starlette.py
+++ b/python_modules/dagit/dagit/starlette.py
@@ -70,7 +70,7 @@ class DagitWebserver(GraphQLServer):
         context = self.make_request_context(request)
 
         run = context.instance.get_run_by_id(run_id)
-        debug_payload = DebugRunPayload.build(self._process_context.instance, run)
+        debug_payload = DebugRunPayload.build(context.instance, run)
 
         result = io.BytesIO()
         with gzip.GzipFile(fileobj=result, mode="wb") as file:


### PR DESCRIPTION
Summary:

In some situations the request context uses a different instance than the process context.

Test Plan:
Load debug endpoint for a run

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.