### PR TITLE
[dagit] Simplify DaemonList prop

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/DaemonList.tsx
+++ b/js_modules/dagit/packages/core/src/instance/DaemonList.tsx
@@ -8,10 +8,7 @@ import {Group} from '../ui/Group';
 import {Table} from '../ui/Table';
 
 import {DaemonHealth} from './DaemonHealth';
-import {
-  DaemonHealthFragment,
-  DaemonHealthFragment_allDaemonStatuses as DaemonStatus,
-} from './types/DaemonHealthFragment';
+import {DaemonHealthFragment_allDaemonStatuses as DaemonStatus} from './types/DaemonHealthFragment';
 
 interface DaemonLabelProps {
   daemon: DaemonStatus;
@@ -38,15 +35,15 @@ const DaemonLabel = (props: DaemonLabelProps) => {
 };
 
 interface Props {
-  daemonHealth: DaemonHealthFragment | undefined;
+  daemonStatuses: DaemonStatus[] | undefined;
 }
 
 const TIME_FORMAT = {showSeconds: true, showTimezone: true};
 
 export const DaemonList = (props: Props) => {
-  const {daemonHealth} = props;
+  const {daemonStatuses} = props;
 
-  if (!daemonHealth) {
+  if (!daemonStatuses?.length) {
     return null;
   }
 
@@ -60,7 +57,7 @@ export const DaemonList = (props: Props) => {
         </tr>
       </thead>
       <tbody>
-        {daemonHealth.allDaemonStatuses
+        {daemonStatuses
           .filter((daemon) => daemon.required)
           .map((daemon) => {
             return (

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -26,7 +26,9 @@ export const InstanceHealthPage = () => {
     if (loading && !data?.instance) {
       return <div style={{color: ColorsWIP.Gray400}}>Loading…</div>;
     }
-    return data?.instance ? <DaemonList daemonHealth={data.instance.daemonHealth} /> : null;
+    return data?.instance ? (
+      <DaemonList daemonStatuses={data.instance.daemonHealth.allDaemonStatuses} />
+    ) : null;
   };
 
   return (


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Change `DaemonList` to require only the list of daemon statuses, not the entire fragment. This makes it easier to render separate daemon list tables for Cloud.

## Test Plan

Load Dagit, view Status page.