### PR TITLE
[dagit] Repair empty state for Jobs list on repo

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
@@ -77,5 +77,23 @@ export const RepositoryPipelinesList: React.FC<Props> = (props) => {
     );
   }
 
+  if (!pipelinesForTable.length) {
+    return (
+      <Box padding={64}>
+        <NonIdealState
+          icon="job"
+          title={display === 'jobs' ? 'No jobs found' : 'No pipelines found'}
+          description={
+            <div>
+              {display === 'jobs'
+                ? 'This repository does not have any jobs defined.'
+                : 'This repository does not have any pipelines defined.'}
+            </div>
+          }
+        />
+      </Box>
+    );
+  }
+
   return <PipelineTable pipelinesOrJobs={pipelinesForTable} showRepo={false} />;
 };


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

I noticed that repositories that contain no jobs are missing an empty state. Add one. This also applies to repos that have no pipelines, though in that circumstance we just don't show the Pipelines tab on the repo page.

## Test Plan

View `/workspace/graph_job_dev_repo@dagster_test.toys.graph_job_repos/pipelines`. Verify that the empty state appears.