### PR TITLE
[dagit] Show execution timezone in Schedules table

### DIFF
--- a/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
@@ -46,12 +46,12 @@ export const SchedulesTable: React.FC<{
       <thead>
         <tr>
           <th style={{width: '60px'}}></th>
-          <th style={{minWidth: '300px'}}>Schedule Name</th>
+          <th style={{minWidth: '300px'}}>Schedule name</th>
           <th style={{minWidth: '150px'}}>Schedule</th>
-          <th style={{minWidth: '170px'}}>Next Tick</th>
+          <th style={{minWidth: '170px'}}>Next tick</th>
           <th style={{width: '120px'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
-              Last Tick
+              Last tick
               <Tooltip position="top" content={lastTick}>
                 <IconWIP name="info" color={ColorsWIP.Gray400} />
               </Tooltip>
@@ -59,7 +59,7 @@ export const SchedulesTable: React.FC<{
           </th>
           <th>
             <Box flex={{gap: 8, alignItems: 'end'}}>
-              Last Run
+              Last run
               <Tooltip position="top" content={lastRun}>
                 <IconWIP name="info" color={ColorsWIP.Gray400} />
               </Tooltip>
@@ -185,6 +185,7 @@ const ScheduleRow: React.FC<{
           <TimestampDisplay
             timestamp={futureTicks.results[0].timestamp}
             timezone={executionTimezone}
+            timeFormat={{showSeconds: false, showTimezone: true}}
           />
         ) : (
           <span style={{color: ColorsWIP.Gray300}}>None</span>


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Resolves #4217.

Surface execution timezone alongside timestamps in the Schedules table. The timestamps are currently confusing because they are correct for the execution timezone...but we don't show that information.

The tooltip will continue to show local time, if the execution time differs from the user's timezone. If they're the same timezone, we just won't show the tooltip. (Same as current.)

<img width="231" alt="Screen Shot 2021-11-18 at 3 03 13 PM" src="https://user-images.githubusercontent.com/2823852/142496477-957c76b9-19e4-487a-bcbf-222af5bb9e9b.png">

## Test Plan

Turn on a schedule with a PST execution timezone, verify that the timezone appears in the Schedules table.