### PR TITLE
[dagit] Disable Search shortcut if modified key event

### DIFF
--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -133,7 +133,9 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
       <ShortcutHandler
         onShortcut={() => dispatch({type: 'show-dialog'})}
         shortcutLabel="/"
-        shortcutFilter={(e) => e.key === '/'}
+        shortcutFilter={(e) =>
+          e.key === '/' && !e.altKey && !e.metaKey && !e.shiftKey && !e.ctrlKey
+        }
       >
         <SearchTrigger onClick={openSearch}>
           <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Resolves #3811.

Disable search shortcut if the key event has a modifier key. This repairs <kbd>Cmd</kbd>+<kbd>/</kbd> for comment/uncomment in the config editor.

## Test Plan

Open Launchpad, focus editor. Use <kbd>Cmd</kbd>+<kbd>/</kbd> to comment and uncomment yaml, verify success without opening search dialog. Unfocus code editor, press <kbd>/</kbd>, verify that search overlay opens.