### PR TITLE
allow importing of downloaded debug files into an existing run storage

### DIFF
--- a/python_modules/dagster/dagster/cli/debug.py
+++ b/python_modules/dagster/dagster/cli/debug.py
@@ -4,7 +4,6 @@ import click
 from dagster import DagsterInstance, check
 from dagster.core.debug import DebugRunPayload
 from dagster.core.storage.pipeline_run import PipelineRunStatus, PipelineRunsFilter
-from dagster.core.storage.runs.sql_run_storage import SnapshotType
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 from tqdm import tqdm
 

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -662,6 +662,9 @@ class DagsterInstance:
     def has_pipeline_snapshot(self, snapshot_id: str) -> bool:
         return self._run_storage.has_pipeline_snapshot(snapshot_id)
 
+    def has_snapshot(self, snapshot_id: str) -> bool:
+        return self._run_storage.has_snapshot(snapshot_id)
+
     def get_historical_pipeline(self, snapshot_id: str) -> "HistoricalPipeline":
         from dagster.core.host_representation import HistoricalPipeline
 
@@ -1017,6 +1020,9 @@ class DagsterInstance:
     def add_run(self, pipeline_run: PipelineRun):
         return self._run_storage.add_run(pipeline_run)
 
+    def add_snapshot(self, snapshot, snapshot_id=None):
+        return self._run_storage.add_snapshot(snapshot, snapshot_id)
+
     def handle_run_event(self, run_id: str, event: "DagsterEvent"):
         return self._run_storage.handle_run_event(run_id, event)
 
@@ -1221,6 +1227,9 @@ records = instance.get_event_records(
         handlers = [self._get_event_log_handler()]
         handlers.extend(self._get_yaml_python_handlers())
         return handlers
+
+    def store_event(self, event):
+        self._event_storage.store_event(event)
 
     def handle_new_event(self, event):
         run_id = event.run_id

--- a/python_modules/dagster/dagster/core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/execution_plan_snapshot.py
@@ -27,7 +27,7 @@ from dagster.utils.error import SerializableErrorInfo
 CURRENT_SNAPSHOT_VERSION = 1
 
 
-def create_execution_plan_snapshot_id(execution_plan_snapshot):
+def create_execution_plan_snapshot_id(execution_plan_snapshot) -> str:
     check.inst_param(execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot)
     return create_snapshot_id(execution_plan_snapshot)
 

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -183,6 +183,30 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
             bool
         """
 
+    def add_snapshot(
+        self,
+        snapshot: Union[PipelineSnapshot, ExecutionPlanSnapshot],
+        snapshot_id: Optional[str] = None,
+    ):
+        """Add a snapshot to the storage.
+
+        Args:
+            snapshot (Union[PipelineSnapshot, ExecutionPlanSnapshot])
+            snapshot_id (Optional[str]): [Internal] The id of the snapshot. If not provided, the
+                snapshot id will be generated from a hash of the snapshot. This should only be used
+                in debugging, where we might want to import a historical run whose snapshots were
+                calculated using a different hash function than the current code.
+        """
+        if isinstance(snapshot, PipelineSnapshot):
+            self.add_pipeline_snapshot(snapshot, snapshot_id)
+        else:
+            self.add_execution_plan_snapshot(snapshot, snapshot_id)
+
+    def has_snapshot(self, snapshot_id: str):
+        return self.has_pipeline_snapshot(snapshot_id) or self.has_execution_plan_snapshot(
+            snapshot_id
+        )
+
     @abstractmethod
     def has_pipeline_snapshot(self, pipeline_snapshot_id: str) -> bool:
         """Check to see if storage contains a pipeline snapshot.
@@ -195,7 +219,9 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def add_pipeline_snapshot(self, pipeline_snapshot: PipelineSnapshot) -> str:
+    def add_pipeline_snapshot(
+        self, pipeline_snapshot: PipelineSnapshot, snapshot_id: Optional[str] = None
+    ) -> str:
         """Add a pipeline snapshot to the run store.
 
         Pipeline snapshots are content-addressable, meaning
@@ -205,6 +231,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
 
         Args:
             pipeline_snapshot (PipelineSnapshot)
+            snapshot_id (Optional[str]): [Internal] The id of the snapshot. If not provided, the
+                snapshot id will be generated from a hash of the snapshot. This should only be used
+                in debugging, where we might want to import a historical run whose snapshots were
+                calculated using a different hash function than the current code.
 
         Return:
             str: The pipeline_snapshot_id
@@ -233,7 +263,9 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def add_execution_plan_snapshot(self, execution_plan_snapshot: ExecutionPlanSnapshot) -> str:
+    def add_execution_plan_snapshot(
+        self, execution_plan_snapshot: ExecutionPlanSnapshot, snapshot_id: Optional[str] = None
+    ) -> str:
         """Add an execution plan snapshot to the run store.
 
         Execution plan snapshots are content-addressable, meaning
@@ -243,6 +275,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
 
         Args:
             execution_plan_snapshot (ExecutionPlanSnapshot)
+            snapshot_id (Optional[str]): [Internal] The id of the snapshot. If not provided, the
+                snapshot id will be generated from a hash of the snapshot. This should only be used
+                in debugging, where we might want to import a historical run whose snapshots were
+                calculated using a different hash function than the current code.
 
         Return:
             str: The execution_plan_snapshot_id

--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -189,11 +189,15 @@ class InMemoryRunStorage(RunStorage):
         check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id")
         return pipeline_snapshot_id in self._pipeline_snapshots
 
-    def add_pipeline_snapshot(self, pipeline_snapshot: PipelineSnapshot) -> str:
+    def add_pipeline_snapshot(
+        self, pipeline_snapshot: PipelineSnapshot, snapshot_id: Optional[str] = None
+    ) -> str:
         check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
-        pipeline_snapshot_id = create_pipeline_snapshot_id(pipeline_snapshot)
-        self._pipeline_snapshots[pipeline_snapshot_id] = pipeline_snapshot
-        return pipeline_snapshot_id
+        check.opt_str_param(snapshot_id, "snapshot_id")
+        if not snapshot_id:
+            snapshot_id = create_pipeline_snapshot_id(pipeline_snapshot)
+        self._pipeline_snapshots[snapshot_id] = pipeline_snapshot
+        return snapshot_id
 
     def get_pipeline_snapshot(self, pipeline_snapshot_id: str) -> PipelineSnapshot:
         check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id")
@@ -203,11 +207,15 @@ class InMemoryRunStorage(RunStorage):
         check.str_param(execution_plan_snapshot_id, "execution_plan_snapshot_id")
         return execution_plan_snapshot_id in self._ep_snapshots
 
-    def add_execution_plan_snapshot(self, execution_plan_snapshot: ExecutionPlanSnapshot) -> str:
+    def add_execution_plan_snapshot(
+        self, execution_plan_snapshot: ExecutionPlanSnapshot, snapshot_id: Optional[str] = None
+    ) -> str:
         check.inst_param(execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot)
-        execution_plan_snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)
-        self._ep_snapshots[execution_plan_snapshot_id] = execution_plan_snapshot
-        return execution_plan_snapshot_id
+        check.opt_str_param(snapshot_id, "snapshot_id")
+        if not snapshot_id:
+            snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)
+        self._ep_snapshots[snapshot_id] = execution_plan_snapshot
+        return snapshot_id
 
     def get_execution_plan_snapshot(self, execution_plan_snapshot_id: str) -> ExecutionPlanSnapshot:
         check.str_param(execution_plan_snapshot_id, "execution_plan_snapshot_id")

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -580,10 +580,17 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id")
         return self._has_snapshot_id(pipeline_snapshot_id)
 
-    def add_pipeline_snapshot(self, pipeline_snapshot: PipelineSnapshot) -> str:
+    def add_pipeline_snapshot(
+        self, pipeline_snapshot: PipelineSnapshot, snapshot_id: Optional[str] = None
+    ) -> str:
         check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
+        check.opt_str_param(snapshot_id, "snapshot_id")
+
+        if not snapshot_id:
+            snapshot_id = create_pipeline_snapshot_id(pipeline_snapshot)
+
         return self._add_snapshot(
-            snapshot_id=create_pipeline_snapshot_id(pipeline_snapshot),
+            snapshot_id=snapshot_id,
             snapshot_obj=pipeline_snapshot,
             snapshot_type=SnapshotType.PIPELINE,
         )
@@ -596,11 +603,17 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         check.str_param(execution_plan_snapshot_id, "execution_plan_snapshot_id")
         return bool(self.get_execution_plan_snapshot(execution_plan_snapshot_id))
 
-    def add_execution_plan_snapshot(self, execution_plan_snapshot: ExecutionPlanSnapshot) -> str:
+    def add_execution_plan_snapshot(
+        self, execution_plan_snapshot: ExecutionPlanSnapshot, snapshot_id: Optional[str] = None
+    ) -> str:
         check.inst_param(execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot)
-        execution_plan_snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)
+        check.opt_str_param(snapshot_id, "snapshot_id")
+
+        if not snapshot_id:
+            snapshot_id = create_execution_plan_snapshot_id(execution_plan_snapshot)
+
         return self._add_snapshot(
-            snapshot_id=execution_plan_snapshot_id,
+            snapshot_id=snapshot_id,
             snapshot_obj=execution_plan_snapshot,
             snapshot_type=SnapshotType.EXECUTION_PLAN,
         )


### PR DESCRIPTION
For investigating perf issues, it's sometimes helpful to view downloaded debug files from users into a sql-based storage (rather than an in-memory storage).

This diff changes the run storage API slightly to expose the ability to store a snapshot with an existing snapshot id.

