### PR TITLE
defer pipeline snapshot id calculation for historical pipelines

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/historical.py
+++ b/python_modules/dagster/dagster/core/host_representation/historical.py
@@ -24,7 +24,9 @@ class HistoricalPipeline(RepresentedPipeline):
             identifying_pipeline_snapshot_id, "identifying_pipeline_snapshot_id"
         )
         super(HistoricalPipeline, self).__init__(
-            pipeline_index=PipelineIndex(pipeline_snapshot, parent_pipeline_snapshot)
+            pipeline_index=PipelineIndex(
+                pipeline_snapshot, parent_pipeline_snapshot, is_historical=True
+            ),
         )
 
     @property

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
@@ -26,7 +26,12 @@ def test_run_created_in_0_7_9_snapshot_id_change():
 
         # It is the pipeline snapshot that changed
         # Verify that snapshot ids are not equal. This changed in 0.7.10
-        assert create_pipeline_snapshot_id(pipeline_snapshot) != old_pipeline_snapshot_id
+        created_snapshot_id = create_pipeline_snapshot_id(pipeline_snapshot)
+        assert created_snapshot_id != old_pipeline_snapshot_id
+
+        # verify that both are accessible off of the historical pipeline
+        assert historical_pipeline.computed_pipeline_snapshot_id == created_snapshot_id
+        assert historical_pipeline.identifying_pipeline_snapshot_id == old_pipeline_snapshot_id
 
         # We also changed execution plan schema in 0.7.11.post1
         assert create_execution_plan_snapshot_id(ep_snapshot) != old_execution_plan_snapshot_id


### PR DESCRIPTION
## Summary
For a benchmark run, 20% of the RunRootQuery (i.e. Run view) time is spent calculating the snapshot id for a historical pipeline.  This is unnecessary because it is calculating a *new* snapshot id for a snapshot that we have retrieved using the persisted snapshot id.  The new snapshot id might be different, or may be identical to the persisted id, but it doesn't matter because nothing reads this new snapshot id.

This PR adds a flag to the `PipelineIndex` constructor that allows for lazy construction of the `pipeline_snapshot_id` property for historical pipelines.



## Test Plan
grepped for `computed_pipeline_snapshot_id`, saw nothing.
