### PR TITLE
[dagit] Allow for React prod profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ sanity_check:
 	@! (pip list --exclude-editable | grep -e dagster -e dagit)
 
 rebuild_dagit: sanity_check
-	cd js_modules/dagit/; yarn install && yarn build-for-python
+	cd js_modules/dagit/; yarn install && yarn build
+
+rebuild_dagit_with_profiling: sanity_check
+	cd js_modules/dagit/; yarn install && yarn build-with-profiling
 
 dev_install: install_dev_python_modules_verbose rebuild_dagit
 

--- a/js_modules/dagit/package.json
+++ b/js_modules/dagit/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build-for-python": "yarn workspace @dagit/app build && cd ../../python_modules/dagit/dagit && rm -rf webapp && mkdir -p webapp && cp -r ../../../js_modules/dagit/packages/app/build ./webapp/ && mkdir -p webapp/build/vendor && cp -r graphql-playground ./webapp/build/vendor",
+    "build": "yarn workspace @dagit/app build && yarn post-build",
+    "build-with-profiling": "yarn workspace @dagit/app build --profile && yarn post-build",
+    "post-build": "cd ../../python_modules/dagit/dagit && rm -rf webapp && mkdir -p webapp && cp -r ../../../js_modules/dagit/packages/app/build ./webapp/ && mkdir -p webapp/build/vendor && cp -r graphql-playground ./webapp/build/vendor",
     "lint": "yarn workspace @dagit/app lint && yarn workspace @dagit/core lint",
     "start": "yarn workspace @dagit/app start",
     "ts": "yarn workspace @dagit/app ts"


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Add yarn and make commands for building Dagit JS with prod profiling. As we're hunting down perf problems, the prod build will give us more accurate data than the dev build.

`yarn build-for-python` is now `yarn build`.

## Test Plan

Run `yarn build-with-profiling`, then run Dagit. Verify that the prod-profiling build is in use.