### PR TITLE
Add additional parameters to `build_hook_context`

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/hook_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/hook_invocation.py
@@ -14,7 +14,9 @@ def hook_invocation_result(
     event_list: Optional[List["DagsterEvent"]] = None,
 ):
     if not hook_context:
-        hook_context = UnboundHookContext(resources={}, mode_def=None, solid=None)
+        hook_context = UnboundHookContext(
+            resources={}, mode_def=None, op=None, run_id=None, job_name=None, op_exception=None
+        )
 
     # Validate that all required resources are provided in the context
     for key in hook_def.required_resource_keys:
@@ -25,12 +27,17 @@ def hook_invocation_result(
                 "the context."
             )
 
+    # pylint: disable=protected-access
+
     bound_context = BoundHookContext(
         hook_def=hook_def,
         resources=hook_context.resources,
         mode_def=hook_context.mode_def,
         log_manager=hook_context.log,
-        solid=hook_context._solid,  # pylint: disable=protected-access
+        op=hook_context._op,
+        run_id=hook_context._run_id,
+        job_name=hook_context._job_name,
+        op_exception=hook_context._op_exception,
     )
 
     return (

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -77,11 +77,11 @@ class HookContext:
 
     @property
     def pipeline_name(self) -> str:
-        return self._step_execution_context.pipeline_name
+        return self.job_name
 
     @property
     def job_name(self) -> str:
-        return self.pipeline_name
+        return self._step_execution_context.job_name
 
     @property
     def run_id(self) -> str:
@@ -93,11 +93,11 @@ class HookContext:
 
     @property
     def solid(self) -> Node:
-        return self._step_execution_context.solid
+        return self.op
 
     @property
     def op(self) -> Node:
-        return self.solid
+        return self._step_execution_context.solid
 
     @property
     def step(self) -> ExecutionStep:
@@ -148,12 +148,11 @@ class HookContext:
         Returns:
             Optional[BaseException]: the exception object, None if the solid execution succeeds.
         """
-
-        return self._step_execution_context.step_exception
+        return self.op_exception
 
     @property
     def op_exception(self):
-        return self.solid_exception
+        return self._step_execution_context.step_exception
 
     @property
     def solid_output_values(self) -> Dict[str, Union[Any, Dict[str, Any]]]:
@@ -233,10 +232,6 @@ class UnboundHookContext(HookContext):
             self._resources_cm.__exit__(None, None, None)  # pylint: disable=no-member
 
     @property
-    def pipeline_name(self) -> str:
-        return self.job_name
-
-    @property
     def job_name(self) -> str:
         return self.pipeline_name
 
@@ -249,12 +244,6 @@ class UnboundHookContext(HookContext):
     @property
     def hook_def(self) -> HookDefinition:
         raise DagsterInvalidPropertyError(_property_msg("hook_def", "property"))
-
-    @property
-    def solid(self) -> Node:
-        return _check_property_on_test_context(
-            self, attr_str="_op", user_facing_name="solid", param_on_builder="solid"
-        )
 
     @property
     def op(self) -> Node:
@@ -297,16 +286,6 @@ class UnboundHookContext(HookContext):
         return self._log
 
     @property
-    def solid_exception(self) -> Optional[BaseException]:
-        """The thrown exception in a failed solid.
-
-        Returns:
-            Optional[BaseException]: the exception object, None if the solid execution succeeds.
-        """
-
-        return self.op_exception
-
-    @property
     def op_exception(self) -> Optional[BaseException]:
         return self._op_exception
 
@@ -343,10 +322,6 @@ class BoundHookContext(HookContext):
         self._op_exception = op_exception
 
     @property
-    def pipeline_name(self) -> str:
-        return self.job_name
-
-    @property
     def job_name(self) -> str:
         return _check_property_on_test_context(
             self, attr_str="_job_name", user_facing_name="job_name", param_on_builder="job_name"
@@ -361,12 +336,6 @@ class BoundHookContext(HookContext):
     @property
     def hook_def(self) -> HookDefinition:
         return self._hook_def
-
-    @property
-    def solid(self) -> Node:
-        return _check_property_on_test_context(
-            self, attr_str="_op", user_facing_name="solid", param_on_builder="solid"
-        )
 
     @property
     def op(self) -> Node:
@@ -401,16 +370,6 @@ class BoundHookContext(HookContext):
     @property
     def log(self) -> DagsterLogManager:
         return self._log_manager
-
-    @property
-    def solid_exception(self) -> Optional[BaseException]:
-        """The thrown exception in a failed solid.
-
-        Returns:
-            Optional[BaseException]: the exception object, None if the solid execution succeeds.
-        """
-
-        return self.op_exception
 
     @property
     def op_exception(self):

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, Optional, Set, Union, cast
+from typing import Any, Dict, Optional, Set, Union
 
 from dagster import check
 
@@ -22,6 +22,24 @@ def _property_msg(prop_name: str, method_name: str) -> str:
         f"The {prop_name} {method_name} is not set when a `HookContext` is constructed from "
         "`build_hook_context`."
     )
+
+
+def _check_property_on_test_context(
+    context: "HookContext", attr_str: str, user_facing_name: str, param_on_builder: str
+):
+    """Check if attribute is not None on context. If none, error, and point user in direction of
+    how to specify the parameter on the context object."""
+
+    value = getattr(context, attr_str)
+    if value is None:
+        raise DagsterInvalidPropertyError(
+            f"Attribute {user_facing_name} was not provided when "
+            f"constructing context. Provide a value for the '{param_on_builder}' parameter on "
+            "'build_hook_context'. To learn more, check out the testing hooks section of Dagster's "
+            "concepts docs: https://docs.dagster.io/concepts/ops-jobs-graphs/op-hooks#testing-hooks"
+        )
+    else:
+        return value
 
 
 class HookContext:
@@ -171,26 +189,33 @@ class UnboundHookContext(HookContext):
         self,
         resources: Dict[str, Any],
         mode_def: Optional[ModeDefinition],
-        solid: Optional[Union[SolidDefinition, PendingNodeInvocation]],
+        op: Optional[Union[SolidDefinition, PendingNodeInvocation]],
+        run_id: Optional[str],
+        job_name: Optional[str],
+        op_exception: Optional[Exception],
     ):  # pylint: disable=super-init-not-called
         from ..context_creation_pipeline import initialize_console_manager
         from ..build_resources import build_resources
 
         self._mode_def = mode_def
 
-        self._solid = None
-        if solid is not None:
+        self._op = None
+        if op is not None:
 
             @graph(name="hook_context_container")
             def temp_graph():
-                solid()
+                op()
 
-            self._solid = temp_graph.solids[0]
+            self._op = temp_graph.solids[0]
 
         # Open resource context manager
         self._resources_cm = build_resources(resources)
         self._resources = self._resources_cm.__enter__()  # pylint: disable=no-member
         self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
+
+        self._run_id = run_id
+        self._job_name = job_name
+        self._op_exception = op_exception
 
         self._log = initialize_console_manager(None)
 
@@ -209,11 +234,17 @@ class UnboundHookContext(HookContext):
 
     @property
     def pipeline_name(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("pipeline_name", "property"))
+        return self.job_name
+
+    @property
+    def job_name(self) -> str:
+        return self.pipeline_name
 
     @property
     def run_id(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("run_id", "property"))
+        return _check_property_on_test_context(
+            self, attr_str="_run_id", user_facing_name="run_id", param_on_builder="run_id"
+        )
 
     @property
     def hook_def(self) -> HookDefinition:
@@ -221,11 +252,15 @@ class UnboundHookContext(HookContext):
 
     @property
     def solid(self) -> Node:
-        check.invariant(
-            self._solid is not None,
-            "solid property was not provided when constructing the context.",
+        return _check_property_on_test_context(
+            self, attr_str="_op", user_facing_name="solid", param_on_builder="solid"
         )
-        return cast(Node, self._solid)
+
+    @property
+    def op(self) -> Node:
+        return _check_property_on_test_context(
+            self, attr_str="_op", user_facing_name="op", param_on_builder="op"
+        )
 
     @property
     def step(self) -> ExecutionStep:
@@ -269,7 +304,11 @@ class UnboundHookContext(HookContext):
             Optional[BaseException]: the exception object, None if the solid execution succeeds.
         """
 
-        raise DagsterInvalidPropertyError(_property_msg("solid_exception", "property"))
+        return self.op_exception
+
+    @property
+    def op_exception(self) -> Optional[BaseException]:
+        return self._op_exception
 
     @property
     def solid_output_values(self) -> Dict[str, Union[Any, Dict[str, Any]]]:
@@ -287,23 +326,37 @@ class BoundHookContext(HookContext):
         self,
         hook_def: HookDefinition,
         resources: Resources,
-        solid: Optional[Node],
+        op: Optional[Node],
         mode_def: Optional[ModeDefinition],
         log_manager: DagsterLogManager,
+        run_id: Optional[str],
+        job_name: Optional[str],
+        op_exception: Optional[Exception],
     ):  # pylint: disable=super-init-not-called
         self._hook_def = hook_def
         self._resources = resources
-        self._solid = solid
+        self._op = op
         self._mode_def = mode_def
         self._log_manager = log_manager
+        self._run_id = run_id
+        self._job_name = job_name
+        self._op_exception = op_exception
 
     @property
     def pipeline_name(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("pipeline_name", "property"))
+        return self.job_name
+
+    @property
+    def job_name(self) -> str:
+        return _check_property_on_test_context(
+            self, attr_str="_job_name", user_facing_name="job_name", param_on_builder="job_name"
+        )
 
     @property
     def run_id(self) -> str:
-        raise DagsterInvalidPropertyError(_property_msg("run_id", "property"))
+        return _check_property_on_test_context(
+            self, attr_str="_run_id", user_facing_name="run_id", param_on_builder="run_id"
+        )
 
     @property
     def hook_def(self) -> HookDefinition:
@@ -311,11 +364,15 @@ class BoundHookContext(HookContext):
 
     @property
     def solid(self) -> Node:
-        check.invariant(
-            self._solid is not None,
-            "solid property was not provided when constructing the context.",
+        return _check_property_on_test_context(
+            self, attr_str="_op", user_facing_name="solid", param_on_builder="solid"
         )
-        return cast(Node, self._solid)
+
+    @property
+    def op(self) -> Node:
+        return _check_property_on_test_context(
+            self, attr_str="_op", user_facing_name="op", param_on_builder="op"
+        )
 
     @property
     def step(self) -> ExecutionStep:
@@ -353,7 +410,11 @@ class BoundHookContext(HookContext):
             Optional[BaseException]: the exception object, None if the solid execution succeeds.
         """
 
-        raise DagsterInvalidPropertyError(_property_msg("solid_exception", "property"))
+        return self.op_exception
+
+    @property
+    def op_exception(self):
+        return self._op_exception
 
     @property
     def solid_output_values(self) -> Dict[str, Union[Any, Dict[str, Any]]]:
@@ -371,6 +432,9 @@ def build_hook_context(
     mode_def: Optional[ModeDefinition] = None,
     solid: Optional[Union[SolidDefinition, PendingNodeInvocation]] = None,
     op: Optional[Union[OpDefinition, PendingNodeInvocation]] = None,
+    run_id: Optional[str] = None,
+    job_name: Optional[str] = None,
+    op_exception: Optional[Exception] = None,
 ) -> UnboundHookContext:
     """Builds hook context from provided parameters.
 
@@ -387,6 +451,9 @@ def build_hook_context(
             hook may be associated with.
         solid (Optional[SolidDefinition, PendingNodeInvocation]): (legacy) The solid definition which the
             hook may be associated with.
+        run_id (Optional[str]): The id of the run in which the hook is invoked (provided for mocking purposes).
+        job_name (Optional[str]): The name of the job in which the hook is used (provided for mocking purposes).
+        op_exception (Optional[Exception]): The exception that caused the hook to be triggered.
 
     Examples:
         .. code-block:: python
@@ -398,14 +465,16 @@ def build_hook_context(
                 hook_to_invoke(context)
     """
     check.invariant(not (solid and op), "cannot set both `solid` and `op` on `build_hook_context`.")
-    if op:
-        return UnboundHookContext(
-            resources=check.opt_dict_param(resources, "resources", key_type=str),
-            mode_def=None,
-            solid=check.opt_inst_param(op, "op", (OpDefinition, PendingNodeInvocation)),
-        )
+
+    op = check.opt_inst_param(op, "op", (OpDefinition, PendingNodeInvocation))
+    solid = check.opt_inst_param(solid, "solid", (SolidDefinition, PendingNodeInvocation))
+    op = op or solid
+
     return UnboundHookContext(
         resources=check.opt_dict_param(resources, "resources", key_type=str),
         mode_def=check.opt_inst_param(mode_def, "mode_def", ModeDefinition),
-        solid=check.opt_inst_param(solid, "solid", (SolidDefinition, PendingNodeInvocation)),
+        op=op,
+        run_id=check.opt_str_param(run_id, "run_id"),
+        job_name=check.opt_str_param(job_name, "job_name"),
+        op_exception=check.opt_inst_param(op_exception, "op_exception", Exception),
     )

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -33,7 +33,7 @@ def _check_property_on_test_context(
     value = getattr(context, attr_str)
     if value is None:
         raise DagsterInvalidPropertyError(
-            f"Attribute {user_facing_name} was not provided when "
+            f"Attribute '{user_facing_name}' was not provided when "
             f"constructing context. Provide a value for the '{param_on_builder}' parameter on "
             "'build_hook_context'. To learn more, check out the testing hooks section of Dagster's "
             "concepts docs: https://docs.dagster.io/concepts/ops-jobs-graphs/op-hooks#testing-hooks"

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
@@ -212,3 +212,14 @@ def test_hook_invocation_with_solid():
 
     basic_hook(build_hook_context(solid=foo))
     basic_hook(build_hook_context(solid=not_foo.alias("foo")))
+
+
+def test_properties_on_hook_context():
+    @success_hook
+    def basic_hook(context):
+        assert isinstance(context.job_name, str)
+        assert isinstance(context.run_id, str)
+        assert isinstance(context.op_exception, BaseException)
+
+    error = DagsterInvariantViolationError("blah")
+    basic_hook(build_hook_context(run_id="blah", job_name="blah", op_exception=error))


### PR DESCRIPTION
As requested in https://github.com/dagster-io/dagster/issues/4350#issuecomment-974195028. Also performs some general cleanup of backcompat parameters so that we don't have so much code duplication.