### PR TITLE
Fix issue with testing in dagster new-project

### DIFF
--- a/python_modules/dagster/dagster/generate/new_project/new_project_tests/test_graphs/test_say_hello.py.tmpl
+++ b/python_modules/dagster/dagster/generate/new_project/new_project_tests/test_graphs/test_say_hello.py.tmpl
@@ -11,4 +11,4 @@ def test_say_hello():
     result = say_hello.execute_in_process()
 
     assert result.success
-    assert result.result_for_node("hello").output_values == {"result": "Hello, Dagster!"}
+    assert result.output_for_node("hello") == "Hello, Dagster!"


### PR DESCRIPTION
We were using the wrong testing API in dagster new-project. This fixes. Assuming that I'm actually editing this in the right place.