### PR TITLE
[python telemetry 1/ ] Refactor telemetry_wrapper to account for class methods and context managers

### DIFF
--- a/docs/content/getting-started/telemetry.mdx
+++ b/docs/content/getting-started/telemetry.mdx
@@ -8,16 +8,6 @@ As an open source project, we collect usage statistics to better understand how 
 
 We will not see or store any data that is processed within ops and graphs. We will not see or store op definitions (including generated context) or graph definitions (including resources).
 
-The telemetry-instrumented functions are:
-
-```python file=../../../python_modules/dagster/dagster/core/telemetry.py startafter=start_TELEMETRY_WHITELISTED_FUNCTIONS endbefore=end_TELEMETRY_WHITELISTED_FUNCTIONS
-TELEMETRY_WHITELISTED_FUNCTIONS = {
-    "_logged_execute_pipeline",
-    "execute_execute_command",
-    "execute_launch_command",
-}
-```
-
 To see the logs we send, open `$DAGSTER_HOME/logs/` if `$DAGSTER_HOME` is set or `~/.dagster/logs/` if not set (after calling the instrumented functions).
 
 If you'd like to opt-out, you can add the following to `$DAGSTER_HOME/dagster.yaml` (creating that file if necessary):

--- a/python_modules/dagster/dagster_tests/core_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_telemetry.py
@@ -1,25 +1,14 @@
 import json
 import logging
 
-import pytest
-from dagster.core.errors import DagsterInvariantViolationError
-from dagster.core.telemetry import telemetry_wrapper
+from dagster.core.telemetry import TelemetryRegistry, telemetry_wrapper
 from dagster.core.test_utils import instance_for_test
 
 
-def test_telemetry_on_function_not_in_whitelist():
-    with pytest.raises(
-        DagsterInvariantViolationError,
-        match="Attempted to log telemetry for function _my_func that is not in telemetry whitelisted functions list: {'foo'}",
-    ):
-
-        @telemetry_wrapper(whitelist={"foo"})
-        def _my_func(instance):  # pylint: disable=unused-argument
-            pass
-
-
 def test_telemetry_instance_logger():
-    @telemetry_wrapper(whitelist={"my_func"})
+    registry = TelemetryRegistry()
+
+    @telemetry_wrapper(registry=registry)
     def my_func(instance):  # pylint: disable=unused-argument
         pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_telemetry.py
@@ -1,16 +1,20 @@
 import json
 import logging
+import time
+from contextlib import contextmanager
 
 from dagster.core.telemetry import TelemetryRegistry, telemetry_wrapper
 from dagster.core.test_utils import instance_for_test
 
+registry_for_test = TelemetryRegistry()
+
+
+@telemetry_wrapper(registry=registry_for_test)
+def my_func(instance):  # pylint: disable=unused-argument
+    pass
+
 
 def test_telemetry_instance_logger():
-    registry = TelemetryRegistry()
-
-    @telemetry_wrapper(registry=registry)
-    def my_func(instance):  # pylint: disable=unused-argument
-        pass
 
     with instance_for_test() as instance:
         my_func(instance)
@@ -25,3 +29,57 @@ def test_telemetry_instance_logger():
         assert started["action"] == "my_func_started"
         ended = log_entries[1]
         assert ended["action"] == "my_func_ended"
+
+
+class RecordMethodTelemetry:
+    @telemetry_wrapper(registry=registry_for_test)
+    def my_meth(self, instance):  # pylint: disable=unused-argument
+        pass
+
+
+def test_telemetry_on_class_method():
+    assert "RecordMethodTelemetry.my_meth" in list(registry_for_test.registry.keys())
+
+    with instance_for_test() as instance:
+        RecordMethodTelemetry().my_meth(instance)
+        telemetry_logger = logging.getLogger("dagster_telemetry_logger")
+        path_to_logs = telemetry_logger.handlers[0].baseFilename
+        with open(path_to_logs) as f:
+            log_string = f.read()
+            log_entries = [json.loads(log) for log in log_string.split("\n") if len(log) > 0]
+
+        assert len(log_entries) == 2
+        started = log_entries[0]
+        assert started["action"] == "RecordMethodTelemetry.my_meth_started"
+        ended = log_entries[1]
+        assert ended["action"] == "RecordMethodTelemetry.my_meth_ended"
+
+
+@contextmanager
+@telemetry_wrapper(registry=registry_for_test)
+def dummy_cm(instance):  # pylint: disable=unused-argument
+    time.sleep(1)
+    yield "foo"
+
+
+def test_telemetry_on_contextmanager():
+    assert "dummy_cm" in list(registry_for_test.registry.keys())
+
+    with instance_for_test() as instance:
+        with dummy_cm(instance):
+            pass
+        telemetry_logger = logging.getLogger("dagster_telemetry_logger")
+        path_to_logs = telemetry_logger.handlers[0].baseFilename
+        with open(path_to_logs) as f:
+            log_string = f.read()
+            log_entries = [json.loads(log) for log in log_string.split("\n") if len(log) > 0]
+
+        assert len(log_entries) == 2
+        started = log_entries[0]
+        assert started["action"] == "dummy_cm_started"
+        ended = log_entries[1]
+        assert ended["action"] == "dummy_cm_ended"
+
+        # Ensure that the sleep is accounted for in the last time and we track how long the
+        # generator takes to yield all results.
+        assert ended["elapsed_time"] > "0:00:01"

--- a/python_modules/dagster/dagster_tests/core_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_telemetry.py
@@ -1,0 +1,38 @@
+import json
+import logging
+
+import pytest
+from dagster.core.errors import DagsterInvariantViolationError
+from dagster.core.telemetry import telemetry_wrapper
+from dagster.core.test_utils import instance_for_test
+
+
+def test_telemetry_on_function_not_in_whitelist():
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Attempted to log telemetry for function _my_func that is not in telemetry whitelisted functions list: {'foo'}",
+    ):
+
+        @telemetry_wrapper(whitelist={"foo"})
+        def _my_func(instance):  # pylint: disable=unused-argument
+            pass
+
+
+def test_telemetry_instance_logger():
+    @telemetry_wrapper(whitelist={"my_func"})
+    def my_func(instance):  # pylint: disable=unused-argument
+        pass
+
+    with instance_for_test() as instance:
+        my_func(instance)
+        telemetry_logger = logging.getLogger("dagster_telemetry_logger")
+        path_to_logs = telemetry_logger.handlers[0].baseFilename
+        with open(path_to_logs) as f:
+            log_string = f.read()
+            log_entries = [json.loads(log) for log in log_string.split("\n") if len(log) > 0]
+
+        assert len(log_entries) == 2
+        started = log_entries[0]
+        assert started["action"] == "my_func_started"
+        ended = log_entries[1]
+        assert ended["action"] == "my_func_ended"


### PR DESCRIPTION
This PR does a few things:
- allows class methods to be telemetry-wrapped by figuring out the class name when a method is wrapped
- allows wrapped context managers to be wrapped more usefully by tracking opening to closing time instead of the time it takes to create the actual context manager.
- gets rid of the telemetry whitelist. Using the decorator should be enough to whitelist for telemetry, the only thing the whitelist was adding was a human readable representation of the methods registered for telemetry. I think we can do better by computing the registry and pasting to file when `make snapshot` is called.