### PR TITLE
Use the output_for_node method in the tests of the generated project

### DIFF
--- a/python_modules/dagster/dagster/generate/new_project/new_project_tests/test_graphs/test_say_hello.py.tmpl
+++ b/python_modules/dagster/dagster/generate/new_project/new_project_tests/test_graphs/test_say_hello.py.tmpl
@@ -11,4 +11,4 @@ def test_say_hello():
     result = say_hello.execute_in_process()
 
     assert result.success
-    assert result.output_for_node("hello") == {"result": "Hello, Dagster!"}
+    assert result.output_for_node("hello") == "Hello, Dagster!"

--- a/python_modules/dagster/dagster/generate/new_project/new_project_tests/test_graphs/test_say_hello.py.tmpl
+++ b/python_modules/dagster/dagster/generate/new_project/new_project_tests/test_graphs/test_say_hello.py.tmpl
@@ -11,4 +11,4 @@ def test_say_hello():
     result = say_hello.execute_in_process()
 
     assert result.success
-    assert result.result_for_node("hello").output_values == {"result": "Hello, Dagster!"}
+    assert result.output_for_node("hello") == {"result": "Hello, Dagster!"}


### PR DESCRIPTION
## Summary

I generated a new project (version `0.13.8`) with the command: `dagster new-project myworkflow`.

Then I ran unittests: `pytest myworkflow_tests`.  The tests immediately failed:

```
        assert result.success
>       assert result.result_for_node("hello").output_values == {"result": "Hello, Dagster!"}
E       AttributeError: 'ExecuteInProcessResult' object has no attribute 'result_for_node'
```

The API for the results has been changed in this pull request: https://github.com/dagster-io/dagster/pull/4794. The template for the new project should use the new method `output_for_node( ... )`. (https://docs.dagster.io/_apidocs/execution#dagster.ExecuteInProcessResult.output_for_node)

## Test Plan

N/A

## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.