### PR TITLE
Add (disabled) background run worker thread which watches for termination

### DIFF
--- a/python_modules/dagster/dagster/core/execution/run_cancellation_thread.py
+++ b/python_modules/dagster/dagster/core/execution/run_cancellation_thread.py
@@ -1,0 +1,47 @@
+import threading
+from typing import Tuple, cast
+
+from dagster import check
+from dagster.core.instance import DagsterInstance, InstanceRef
+from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
+from dagster.utils import send_interrupt
+
+
+def _kill_on_cancel(instance_ref: InstanceRef, run_id, shutdown_event):
+    check.inst_param(instance_ref, "instance_ref", InstanceRef)
+    check.str_param(run_id, "run_id")
+
+    with DagsterInstance.from_ref(instance_ref) as instance:
+        while not shutdown_event.is_set():
+            shutdown_event.wait(instance.cancellation_thread_poll_interval_seconds)
+            run = cast(
+                PipelineRun,
+                check.inst(
+                    instance.get_run_by_id(run_id),
+                    PipelineRun,
+                    "Run not found for cancellation thread",
+                ),
+            )
+            if run.status in [
+                PipelineRunStatus.CANCELING,
+                PipelineRunStatus.CANCELED,
+            ]:
+                print(  # pylint: disable=print-call
+                    f"Detected run status {run.status}, sending interrupt to main thread"
+                )
+                send_interrupt()
+                return
+
+
+def start_run_cancellation_thread(
+    instance: DagsterInstance, run_id
+) -> Tuple[threading.Thread, threading.Event]:
+    print("Starting run cancellation thread")  # pylint: disable=print-call
+    shutdown_event = threading.Event()
+    thread = threading.Thread(
+        target=_kill_on_cancel,
+        args=(instance.get_ref(), run_id, shutdown_event),
+        name="kill-on-cancel",
+    )
+    thread.start()
+    return thread, shutdown_event

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -603,6 +603,12 @@ class DagsterInstance:
     def run_monitoring_poll_interval_seconds(self) -> int:
         return self.run_monitoring_settings.get("poll_interval_seconds", 120)
 
+    @property
+    def cancellation_thread_poll_interval_seconds(self) -> int:
+        return self.get_settings("run_monitoring").get(
+            "cancellation_thread_poll_interval_seconds", 10
+        )
+
     # python logs
 
     @property
@@ -1792,6 +1798,13 @@ records = instance.get_event_records(
 
     def update_backfill(self, partition_backfill):
         return self._run_storage.update_backfill(partition_backfill)
+
+    @property
+    def should_start_background_run_thread(self) -> bool:
+        """
+        Gate on an experimental feature to start a thread that monitors for if the run should be canceled.
+        """
+        return False
 
 
 def is_dagit_telemetry_enabled(instance):

--- a/python_modules/dagster/dagster/core/instance/config.py
+++ b/python_modules/dagster/dagster/core/instance/config.py
@@ -124,6 +124,7 @@ def dagster_instance_config_schema():
                 "start_timeout_seconds": Field(int, is_required=False),
                 "max_resume_run_attempts": Field(int, is_required=False),
                 "poll_interval_seconds": Field(int, is_required=False),
+                "cancellation_thread_poll_interval_seconds": Field(int, is_required=False),
             },
         ),
     }

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -204,6 +204,18 @@ def test_run_monitoring():
         assert instance.run_monitoring_max_resume_run_attempts == 5
 
 
+def test_cancellation_thread():
+    with instance_for_test(
+        overrides={
+            "run_monitoring": {"cancellation_thread_poll_interval_seconds": 300},
+        }
+    ) as instance:
+        assert instance.cancellation_thread_poll_interval_seconds == 300
+
+    with instance_for_test() as instance:
+        assert instance.cancellation_thread_poll_interval_seconds == 10
+
+
 def test_dagster_home_not_set():
     with environ({"DAGSTER_HOME": ""}):
         with pytest.raises(


### PR DESCRIPTION
Experimental disabled feature:
Change run workers to poll for run status, rather than getting interrupted to signal a cancel. 