### PR TITLE
EMR cluster config `Tags` is a list

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py
@@ -189,7 +189,8 @@ class EmrJobRunner:
         log.info("Created new cluster %s" % cluster_id)
 
         # set EMR tags for the cluster
-        tags = cluster_config.get("Tags", {})
+        tags_items = cluster_config.get("Tags", [])
+        tags = {k: v for k, v in tags_items}
         tags["__dagster_version"] = dagster.__version__
         self.add_tags(log, tags, cluster_id)
         return cluster_id


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
When providing `Tags` to `run_job_flow`, `Tags` is a list, not a dict. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.run_job_flow

Since `Tags` is a list, it needs to be converted to a dict before adding a new tag for the Dagster version.

See also https://github.com/dagster-io/dagster/blob/56ff12be028931ce89a422ea4b388dc0c366469f/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py#L159 which treats `Tags` as a list.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.