### PR TITLE
[dagit] Improvements to AssetGraph performance, "Launch Run" functionality

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
@@ -27,7 +27,7 @@ import {HistoricalMaterialization, useMaterializationBuckets} from './useMateria
 
 interface Props {
   assetKey: AssetKey;
-  asOf: string | null;
+  asOf?: string | null;
   asSidebarSection?: boolean;
 }
 

--- a/js_modules/dagit/packages/core/src/graph/OpLinks.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpLinks.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {weakmapMemoize} from '../app/Util';
-import {ColorsWIP} from '../ui/Colors';
 
 import {IFullPipelineLayout, IFullOpLayout, ILayoutConnection} from './getFullOpLayout';
 import {PipelineGraphOpFragment} from './types/PipelineGraphOpFragment';

--- a/js_modules/dagit/packages/core/src/graph/OpLinks.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpLinks.tsx
@@ -66,13 +66,13 @@ const inputIsDynamicCollect = (
 
 export const OpLinks = React.memo(
   (props: {
-    opacity: number;
+    color: string;
     ops: PipelineGraphOpFragment[];
     layout: IFullPipelineLayout;
     connections: ILayoutConnection[];
     onHighlight: (arr: Edge[]) => void;
   }) => (
-    <g opacity={props.opacity}>
+    <g>
       {buildSVGPaths(props.connections, props.layout.ops).map(
         ({path, from, sourceOutput, targetInput, to}, idx) => (
           <g
@@ -80,9 +80,10 @@ export const OpLinks = React.memo(
             onMouseLeave={() => props.onHighlight([])}
             onMouseEnter={() => props.onHighlight([{a: from.opName, b: to.opName}])}
           >
-            <StyledPath d={path} />
+            <StyledPath d={path} style={{stroke: props.color}} />
             {outputIsDynamic(props.ops, from) && (
               <DynamicMarker
+                color={props.color}
                 x={sourceOutput.layout.x}
                 y={sourceOutput.layout.y}
                 direction={'output'}
@@ -90,6 +91,7 @@ export const OpLinks = React.memo(
             )}
             {inputIsDynamicCollect(props.ops, to) && (
               <DynamicMarker
+                color={props.color}
                 x={targetInput.layout.x}
                 y={targetInput.layout.y}
                 direction={'collect'}
@@ -108,9 +110,10 @@ const DynamicMarker: React.FunctionComponent<{
   x: number;
   y: number;
   direction: 'output' | 'collect';
-}> = ({x, y, direction}) => (
+  color: string;
+}> = ({x, y, direction, color}) => (
   <g
-    fill={ColorsWIP.Gray700}
+    fill={color}
     transform={`translate(${x - 35}, ${y})${
       direction === 'collect' ? ',rotate(180),translate(-20, -40)' : ''
     }`}
@@ -123,6 +126,5 @@ const DynamicMarker: React.FunctionComponent<{
 
 const StyledPath = styled('path')`
   stroke-width: 4;
-  stroke: ${ColorsWIP.Gray600};
   fill: none;
 `;

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -295,6 +295,7 @@ const NodeContainer = styled.div<{
   $dim: boolean;
 }>`
   opacity: ${({$dim}) => ($dim ? 0.3 : 1)};
+  pointer-events: auto;
 
   .highlight-box {
     border: ${(p) =>

--- a/js_modules/dagit/packages/core/src/graph/PipelineGraph.tsx
+++ b/js_modules/dagit/packages/core/src/graph/PipelineGraph.tsx
@@ -353,17 +353,15 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps> {
         onDoubleClick={this.unfocus}
       >
         {({scale}, bounds) => (
-          <>
-            <SVGContainer width={layout.width} height={layout.height + 200}>
-              <PipelineGraphContents
-                {...this.props}
-                layout={layout}
-                minified={scale < DETAIL_ZOOM - 0.01}
-                onDoubleClickOp={onDoubleClickOp || this.focusOnOp}
-                bounds={bounds}
-              />
-            </SVGContainer>
-          </>
+          <SVGContainer width={layout.width} height={layout.height + 200}>
+            <PipelineGraphContents
+              {...this.props}
+              layout={layout}
+              minified={scale < DETAIL_ZOOM - 0.01}
+              onDoubleClickOp={onDoubleClickOp || this.focusOnOp}
+              bounds={bounds}
+            />
+          </SVGContainer>
         )}
       </SVGViewport>
     );

--- a/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagit/packages/core/src/graph/SVGViewport.tsx
@@ -23,7 +23,10 @@ interface SVGViewportProps {
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
   onDoubleClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
-  children: (state: SVGViewportState) => React.ReactNode;
+  children: (
+    state: SVGViewportState,
+    bounds: {top: number; left: number; bottom: number; right: number},
+  ) => React.ReactNode;
 }
 
 interface SVGViewportState {
@@ -347,6 +350,18 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
     const {children, onKeyDown, onClick, interactor, backgroundColor} = this.props;
     const {x, y, scale} = this.state;
 
+    let viewport = {top: 0, left: 0, right: 0, bottom: 0};
+    if (this.element.current) {
+      const el = this.element.current!;
+      const {width, height} = el.getBoundingClientRect();
+      viewport = {
+        left: -this.state.x / this.state.scale,
+        top: -this.state.y / this.state.scale,
+        right: (-this.state.x + width) / this.state.scale,
+        bottom: (-this.state.y + height) / this.state.scale,
+      };
+    }
+
     return (
       <div
         ref={this.element}
@@ -364,7 +379,7 @@ export class SVGViewport extends React.Component<SVGViewportProps, SVGViewportSt
             transform: `matrix(${scale}, 0, 0, ${scale}, ${x}, ${y})`,
           }}
         >
-          {children(this.state)}
+          {children(this.state, viewport)}
         </div>
         {interactor.render && interactor.render(this)}
       </div>

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -60,7 +60,7 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
     repoAddress,
     isGraph,
   } = props;
-  const [highlighted, setHighlighted] = React.useState('');
+  const [nameMatch, setNameMatch] = React.useState('');
 
   const handleQueryChange = (opsQuery: string) => {
     onChangeExplorerPath({...explorerPath, opsQuery}, 'replace');
@@ -138,8 +138,8 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
   );
 
   const {all} = queryResultOps;
-  const highlightedOps = React.useMemo(() => all.filter((s) => s.name.includes(highlighted)), [
-    highlighted,
+  const highlightedOps = React.useMemo(() => all.filter((s) => s.name.includes(nameMatch)), [
+    nameMatch,
     all,
   ]);
 
@@ -188,9 +188,9 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
             <TextInput
               name="highlighted"
               icon="search"
-              value={highlighted}
+              value={nameMatch}
               placeholder="Highlight…"
-              onChange={(e) => setHighlighted(e.target.value)}
+              onChange={(e) => setNameMatch(e.target.value)}
             />
           </SearchOverlay>
           {explodeCompositesEnabled && (
@@ -294,7 +294,7 @@ const OptionsOverlay = styled.div`
   left: 0;
 `;
 
-const SearchOverlay = styled.div`
+export const SearchOverlay = styled.div`
   z-index: 2;
   padding: 12px 12px 0 0;
   display: inline-flex;

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -138,10 +138,10 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
   );
 
   const {all} = queryResultOps;
-  const highlightedOps = React.useMemo(() => all.filter((s) => s.name.includes(nameMatch)), [
-    nameMatch,
-    all,
-  ]);
+  const highlightedOps = React.useMemo(
+    () => all.filter((s) => s.name.toLowerCase().includes(nameMatch.toLowerCase())),
+    [nameMatch, all],
+  );
 
   const backgroundColor = parentHandle ? ColorsWIP.White : ColorsWIP.White;
   const backgroundTranslucent = Color(backgroundColor).fade(0.6).toString();

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -134,9 +134,9 @@ export const PipelineExplorerContainer: React.FC<{
             <AssetGraphExplorer
               repoAddress={repoAddress!}
               handles={displayedHandles}
-              selectedHandle={selectedHandle}
               explorerPath={explorerPath}
               onChangeExplorerPath={onChangeExplorerPath}
+              selectedHandle={selectedHandle}
             />
           );
         }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -1,28 +1,31 @@
 import {gql, useQuery} from '@apollo/client';
+import {uniq, without} from 'lodash';
 import React from 'react';
 import styled from 'styled-components/macro';
 
+import {filterByQuery} from '../../app/GraphQueryImpl';
 import {LATEST_MATERIALIZATION_METADATA_FRAGMENT} from '../../assets/LastMaterializationMetadata';
+import {LaunchRootExecutionButton} from '../../execute/LaunchRootExecutionButton';
 import {SVGViewport} from '../../graph/SVGViewport';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {SidebarPipelineOrJobOverview} from '../../pipelines/SidebarPipelineOrJobOverview';
 import {GraphExplorerSolidHandleFragment} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
-import {METADATA_ENTRY_FRAGMENT} from '../../runs/MetadataEntry';
-import {ColorsWIP} from '../../ui/Colors';
+import {GraphQueryInput} from '../../ui/GraphQueryInput';
 import {Loading} from '../../ui/Loading';
 import {NonIdealState} from '../../ui/NonIdealState';
 import {SplitPanelContainer} from '../../ui/SplitPanelContainer';
 import {repoAddressToSelector} from '../repoAddressToSelector';
 import {RepoAddress} from '../types';
 
-import {AssetNode, getNodeDimensions} from './AssetNode';
+import {AssetLinks} from './AssetLinks';
+import {AssetNode, ASSET_NODE_FRAGMENT, getNodeDimensions} from './AssetNode';
 import {ForeignNode, getForeignNodeDimensions} from './ForeignNode';
 import {SidebarAssetInfo} from './SidebarAssetInfo';
 import {
   buildGraphComputeStatuses,
   buildGraphData,
-  buildSVGPath,
+  GraphData,
   graphHasCycles,
   layoutGraph,
   Node,
@@ -44,26 +47,11 @@ interface Props {
 }
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
-  const {repoAddress, handles, selectedHandle, explorerPath, onChangeExplorerPath} = props;
-  const repositorySelector = repoAddressToSelector(repoAddress);
+  const repositorySelector = repoAddressToSelector(props.repoAddress);
   const queryResult = useQuery<AssetGraphQuery, AssetGraphQueryVariables>(ASSETS_GRAPH_QUERY, {
     variables: {repositorySelector},
     notifyOnNetworkStatusChange: true,
   });
-
-  const selectNode = React.useCallback(
-    (node: Node | null) => {
-      onChangeExplorerPath(
-        {
-          ...explorerPath,
-          opNames: node ? [node.definition.opName!] : [],
-          pipelineName: node?.definition.jobName || explorerPath.pipelineName,
-        },
-        'replace',
-      );
-    },
-    [onChangeExplorerPath, explorerPath],
-  );
 
   useDocumentTitle('Assets');
 
@@ -74,10 +62,9 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
           return <NonIdealState icon="error" title="Query Error" />;
         }
 
-        const graphData = buildGraphData(repositoryOrError, explorerPath.pipelineName);
-        const hasCycles = graphHasCycles(graphData);
+        const graphData = buildGraphData(repositoryOrError, props.explorerPath.pipelineName);
 
-        if (hasCycles) {
+        if (graphHasCycles(graphData)) {
           return (
             <NonIdealState
               icon="error"
@@ -86,13 +73,6 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
             />
           );
         }
-
-        const layout = layoutGraph(graphData);
-        const computeStatuses = buildGraphComputeStatuses(graphData);
-        const selectedAsset = repositoryOrError.assetNodes.find(
-          (a) => a.opName === selectedHandle?.handleID,
-        );
-
         if (!Object.keys(graphData.nodes).length) {
           return (
             <NonIdealState
@@ -103,103 +83,200 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
           );
         }
 
-        return (
-          <SplitPanelContainer
-            identifier="explorer"
-            firstInitialPercent={70}
-            firstMinSize={600}
-            first={
-              <SVGViewport
-                interactor={SVGViewport.Interactors.PanAndZoom}
-                graphWidth={layout.width}
-                graphHeight={layout.height}
-                onKeyDown={() => {}}
-                onClick={() => selectNode(null)}
-                maxZoom={1.2}
-                maxAutocenterZoom={1.0}
-              >
-                {({scale: _scale}: any) => (
-                  <SVGContainer width={layout.width} height={layout.height}>
-                    <defs>
-                      <marker
-                        id="arrow"
-                        viewBox="0 0 10 10"
-                        refX="1"
-                        refY="5"
-                        markerUnits="strokeWidth"
-                        markerWidth="2"
-                        markerHeight="4"
-                        orient="auto"
-                      >
-                        <path d="M 0 0 L 10 5 L 0 10 z" fill={ColorsWIP.Gray200} />
-                      </marker>
-                    </defs>
-                    <g opacity={0.2}>
-                      {layout.edges.map((edge, idx) => (
-                        <StyledPath
-                          key={idx}
-                          d={buildSVGPath({source: edge.from, target: edge.to})}
-                          dashed={edge.dashed}
-                          markerEnd="url(#arrow)"
-                        />
-                      ))}
-                    </g>
-                    {layout.nodes.map((layoutNode) => {
-                      const graphNode = graphData.nodes[layoutNode.id];
-                      const {width, height} = graphNode.hidden
-                        ? getForeignNodeDimensions(layoutNode.id)
-                        : getNodeDimensions(graphNode.definition);
-                      return (
-                        <foreignObject
-                          key={layoutNode.id}
-                          x={layoutNode.x}
-                          y={layoutNode.y}
-                          width={width}
-                          height={height}
-                          onClick={(e) => {
-                            selectNode(graphNode);
-                            e.stopPropagation();
-                          }}
-                        >
-                          {graphNode.hidden ? (
-                            <ForeignNode assetKey={graphNode.assetKey} />
-                          ) : (
-                            <AssetNode
-                              definition={graphNode.definition}
-                              handle={
-                                handles.find((h) => h.handleID === graphNode.definition.opName)!
-                              }
-                              secondaryHighlight={false}
-                              selected={selectedAsset === graphNode.definition}
-                              computeStatus={computeStatuses[graphNode.id]}
-                              repoAddress={repoAddress}
-                            />
-                          )}
-                        </foreignObject>
-                      );
-                    })}
-                  </SVGContainer>
-                )}
-              </SVGViewport>
-            }
-            second={
-              selectedAsset && selectedHandle ? (
-                <SidebarAssetInfo
-                  node={selectedAsset}
-                  handle={selectedHandle}
-                  repoAddress={repoAddress}
-                />
-              ) : (
-                <SidebarPipelineOrJobOverview
-                  repoAddress={repoAddress}
-                  explorerPath={explorerPath}
-                />
-              )
-            }
-          />
-        );
+        return <AssetGraphExplorerWithData graphData={graphData} {...props} />;
       }}
     </Loading>
+  );
+};
+
+const AssetGraphExplorerWithData: React.FC<
+  {graphData: ReturnType<typeof buildGraphData>} & Props
+> = (props) => {
+  const {
+    repoAddress,
+    handles,
+    selectedHandle,
+    explorerPath,
+    onChangeExplorerPath,
+    graphData,
+  } = props;
+
+  const selectedDefinition = selectedHandle?.solid.definition;
+  const selectedGraphNode =
+    selectedDefinition &&
+    Object.values(graphData.nodes).find(
+      (node) => node.definition.opName === selectedDefinition.name,
+    );
+
+  const onSelectNode = React.useCallback(
+    (e: React.MouseEvent<any>, node: Node) => {
+      e.stopPropagation();
+
+      const {opName, jobName} = node.definition;
+      if (!opName) {
+        return;
+      }
+
+      const append = jobName === explorerPath.pipelineName && (e.shiftKey || e.metaKey);
+      const existing = explorerPath.opsQuery.split(',');
+      const added =
+        e.shiftKey && selectedGraphNode
+          ? opsInRange({graph: graphData, from: selectedGraphNode, to: node})
+          : [opName];
+
+      const next = append
+        ? (existing.includes(opName)
+            ? without(existing, opName)
+            : uniq([...existing, ...added])
+          ).join(',')
+        : `${opName}`;
+
+      onChangeExplorerPath(
+        {
+          ...explorerPath,
+          opNames: [opName],
+          opsQuery: next,
+          pipelineName: jobName || explorerPath.pipelineName,
+        },
+        'replace',
+      );
+    },
+    [onChangeExplorerPath, explorerPath],
+  );
+
+  const {all: highlighted} = React.useMemo(
+    () =>
+      filterByQuery(
+        handles.map((h) => h.solid),
+        explorerPath.opsQuery,
+      ),
+    [explorerPath.opsQuery, handles],
+  );
+
+  const layout = layoutGraph(graphData);
+  const computeStatuses = buildGraphComputeStatuses(graphData);
+
+  return (
+    <SplitPanelContainer
+      identifier="explorer"
+      firstInitialPercent={70}
+      firstMinSize={600}
+      first={
+        <>
+          <SVGViewport
+            interactor={SVGViewport.Interactors.PanAndZoom}
+            graphWidth={layout.width}
+            graphHeight={layout.height}
+            onKeyDown={() => {}}
+            onClick={() =>
+              onChangeExplorerPath(
+                {
+                  ...explorerPath,
+                  pipelineName: explorerPath.pipelineName,
+                  opsQuery: '',
+                  opNames: [],
+                },
+                'replace',
+              )
+            }
+            maxZoom={1.2}
+            maxAutocenterZoom={1.0}
+          >
+            {({scale: _scale}, bounds) => (
+              <SVGContainer width={layout.width} height={layout.height}>
+                <AssetLinks edges={layout.edges} />
+
+                {layout.nodes.map((layoutNode) => {
+                  const graphNode = graphData.nodes[layoutNode.id];
+                  const {width, height} = graphNode.hidden
+                    ? getForeignNodeDimensions(layoutNode.id)
+                    : getNodeDimensions(graphNode.definition);
+
+                  if (
+                    layoutNode.x + width < bounds.left ||
+                    layoutNode.y + height < bounds.top ||
+                    layoutNode.x > bounds.right ||
+                    layoutNode.y > bounds.bottom
+                  ) {
+                    return null;
+                  }
+
+                  return (
+                    <foreignObject
+                      key={layoutNode.id}
+                      x={layoutNode.x}
+                      y={layoutNode.y}
+                      width={width}
+                      height={height}
+                      onClick={(e) => onSelectNode(e, graphNode)}
+                      style={{overflow: 'visible'}}
+                    >
+                      {graphNode.hidden ? (
+                        <ForeignNode assetKey={graphNode.assetKey} />
+                      ) : (
+                        <AssetNode
+                          definition={graphNode.definition}
+                          metadata={
+                            handles.find((h) => h.handleID === graphNode.definition.opName)!.solid
+                              .definition.metadata
+                          }
+                          selected={selectedGraphNode === graphNode}
+                          computeStatus={computeStatuses[graphNode.id]}
+                          repoAddress={repoAddress}
+                          secondaryHighlight={
+                            explorerPath.opsQuery
+                              ? highlighted.some(
+                                  (h) => h.definition.name === graphNode.definition.opName,
+                                )
+                              : false
+                          }
+                        />
+                      )}
+                    </foreignObject>
+                  );
+                })}
+              </SVGContainer>
+            )}
+          </SVGViewport>
+
+          <AssetQueryInputContainer>
+            <GraphQueryInput
+              items={handles.map((h) => h.solid)}
+              value={explorerPath.opsQuery}
+              placeholder="Type an asset subset…"
+              onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
+            />
+            <LaunchRootExecutionButton
+              pipelineName={explorerPath.pipelineName}
+              disabled={!explorerPath.opsQuery || highlighted.length === 0}
+              getVariables={() => ({
+                executionParams: {
+                  mode: 'default',
+                  executionMetadata: {},
+                  runConfigData: {},
+                  selector: {
+                    ...repoAddressToSelector(repoAddress),
+                    pipelineName: explorerPath.pipelineName,
+                    solidSelection: highlighted.map((h) => h.name),
+                  },
+                },
+              })}
+            />
+          </AssetQueryInputContainer>
+        </>
+      }
+      second={
+        selectedGraphNode && selectedDefinition ? (
+          <SidebarAssetInfo
+            node={selectedGraphNode.definition}
+            definition={selectedDefinition}
+            repoAddress={repoAddress}
+          />
+        ) : (
+          <SidebarPipelineOrJobOverview repoAddress={repoAddress} explorerPath={explorerPath} />
+        )
+      }
+    />
   );
 };
 
@@ -214,44 +291,17 @@ const ASSETS_GRAPH_QUERY = gql`
           name
         }
         assetNodes {
+          ...AssetNodeFragment
           id
           assetKey {
             path
           }
-          opName
-          description
-          jobName
           dependencies {
             inputName
             upstreamAsset {
               id
               assetKey {
                 path
-              }
-            }
-          }
-          assetMaterializations(limit: 1) {
-            ...LatestMaterializationMetadataFragment
-
-            materializationEvent {
-              materialization {
-                metadataEntries {
-                  ...MetadataEntryFragment
-                }
-              }
-              stepStats {
-                stepKey
-                startTime
-                endTime
-              }
-            }
-            runOrError {
-              ... on PipelineRun {
-                id
-                runId
-                status
-                pipelineName
-                mode
               }
             }
           }
@@ -267,7 +317,7 @@ const ASSETS_GRAPH_QUERY = gql`
       }
     }
   }
-  ${METADATA_ENTRY_FRAGMENT}
+  ${ASSET_NODE_FRAGMENT}
   ${LATEST_MATERIALIZATION_METADATA_FRAGMENT}
 `;
 
@@ -275,9 +325,42 @@ const SVGContainer = styled.svg`
   overflow: visible;
   border-radius: 0;
 `;
-const StyledPath = styled('path')<{dashed: boolean}>`
-  stroke-width: 4;
-  stroke: ${ColorsWIP.Gray600};
-  ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
-  fill: none;
+
+const AssetQueryInputContainer = styled.div`
+  z-index: 2;
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  display: flex;
 `;
+
+const opsInRange = (
+  {graph, from, to}: {graph: GraphData; from: Node; to: Node},
+  seen: string[] = [],
+) => {
+  if (!from) {
+    return [];
+  }
+  if (from.id === to.id) {
+    return [to.definition.opName!];
+  }
+  const adjacent = [
+    ...Object.keys(graph.upstream[from.id] || {}),
+    ...Object.keys(graph.downstream[from.id] || {}),
+  ].map((n) => graph.nodes[n]);
+
+  let best: string[] = [];
+
+  for (const node of adjacent) {
+    if (seen.includes(node.id)) {
+      continue;
+    }
+    const result: string[] = opsInRange({graph, from: node, to}, [...seen, from.id]);
+    if (result.length && (best.length === 0 || result.length < best.length)) {
+      best = [from.definition.opName!, ...result];
+    }
+  }
+  return best;
+};

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -151,7 +151,7 @@ const AssetGraphExplorerWithData: React.FC<
         'replace',
       );
     },
-    [onChangeExplorerPath, explorerPath],
+    [explorerPath, selectedGraphNode, graphData, onChangeExplorerPath],
   );
 
   const {all: highlighted} = React.useMemo(

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetLinks.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetLinks.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP} from '../../ui/Colors';
+
+import {buildSVGPath, IEdge} from './Utils';
+
+export const AssetLinks: React.FC<{edges: IEdge[]}> = React.memo(({edges}) => (
+  <>
+    <defs>
+      <marker
+        id="arrow"
+        viewBox="0 0 8 10"
+        refX="1"
+        refY="5"
+        markerUnits="strokeWidth"
+        markerWidth="4"
+        orient="auto"
+      >
+        <path d="M 0 0 L 8 5 L 0 10 z" fill={ColorsWIP.KeylineGray} />
+      </marker>
+    </defs>
+    {edges.map((edge, idx) => (
+      <StyledPath
+        key={idx}
+        d={buildSVGPath({source: edge.from, target: edge.to})}
+        dashed={edge.dashed}
+        markerEnd="url(#arrow)"
+      />
+    ))}
+  </>
+));
+
+const StyledPath = styled('path')<{dashed: boolean}>`
+  stroke-width: 4;
+  stroke: ${ColorsWIP.KeylineGray};
+  ${({dashed}) => (dashed ? `stroke-dasharray: 8 2;` : '')}
+  fill: none;
+`;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -1,14 +1,16 @@
-import {useMutation} from '@apollo/client';
+import {gql, useMutation} from '@apollo/client';
 import {ContextMenu2 as ContextMenu} from '@blueprintjs/popover2';
+import {isEqual} from 'lodash';
 import qs from 'query-string';
 import React, {CSSProperties} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {AppContext} from '../../app/AppContext';
+import {LATEST_MATERIALIZATION_METADATA_FRAGMENT} from '../../assets/LastMaterializationMetadata';
 import {showLaunchError} from '../../execute/showLaunchError';
 import {OpTags} from '../../graph/OpTags';
-import {GraphExplorerSolidHandleFragment} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
+import {METADATA_ENTRY_FRAGMENT} from '../../runs/MetadataEntry';
 import {
   LAUNCH_PIPELINE_EXECUTION_MUTATION,
   handleLaunchResult,
@@ -27,168 +29,214 @@ import {RepoAddress} from '../types';
 import {workspacePath} from '../workspacePath';
 
 import {assetKeyToString, Status} from './Utils';
-import {AssetGraphQuery_repositoryOrError_Repository_assetNodes} from './types/AssetGraphQuery';
+import {AssetNodeFragment} from './types/AssetNodeFragment';
 
 export const AssetNode: React.FC<{
-  definition: AssetGraphQuery_repositoryOrError_Repository_assetNodes;
-  handle: GraphExplorerSolidHandleFragment;
+  definition: AssetNodeFragment;
+  metadata: {key: string; value: string}[];
   selected: boolean;
   computeStatus: Status;
   repoAddress: RepoAddress;
   secondaryHighlight: boolean;
-}> = ({definition, handle, selected, computeStatus, repoAddress, secondaryHighlight}) => {
-  const [launchPipelineExecution] = useMutation<LaunchPipelineExecution>(
-    LAUNCH_PIPELINE_EXECUTION_MUTATION,
-  );
-  const {basePath} = React.useContext(AppContext);
-  const {materializationEvent: event, runOrError} = definition.assetMaterializations[0] || {};
-  const kind = handle.solid.definition.metadata.find((m) => m.key === 'kind')?.value;
+}> = React.memo(
+  ({definition, metadata, selected, computeStatus, repoAddress, secondaryHighlight}) => {
+    const [launchPipelineExecution] = useMutation<LaunchPipelineExecution>(
+      LAUNCH_PIPELINE_EXECUTION_MUTATION,
+    );
+    const {basePath} = React.useContext(AppContext);
+    const {materializationEvent: event, runOrError} = definition.assetMaterializations[0] || {};
+    const kind = metadata.find((m) => m.key === 'kind')?.value;
 
-  const onLaunch = async () => {
-    if (!definition.jobName) {
-      return;
-    }
-
-    try {
-      const result = await launchPipelineExecution({
-        variables: {
-          executionParams: {
-            selector: {
-              pipelineName: definition.jobName,
-              ...repoAddressToSelector(repoAddress),
-            },
-            mode: 'default',
-            stepKeys: [definition.opName],
-          },
-        },
-      });
-      handleLaunchResult(basePath, definition.jobName, result, true);
-    } catch (error) {
-      showLaunchError(error as Error);
-    }
-  };
-
-  return (
-    <ContextMenu
-      content={
-        <MenuWIP>
-          <MenuItemWIP
-            text={
-              <span>
-                Launch run to build{' '}
-                <span style={{fontFamily: 'monospace', fontWeight: 600}}>
-                  {assetKeyToString(definition.assetKey)}
-                </span>
-              </span>
-            }
-            icon="open_in_new"
-            onClick={onLaunch}
-          />
-        </MenuWIP>
+    const onLaunch = async () => {
+      if (!definition.jobName) {
+        return;
       }
-    >
-      <AssetNodeContainer $selected={selected} $secondaryHighlight={secondaryHighlight}>
-        <AssetNodeBox>
-          <Name>
-            <IconWIP name="asset" style={{marginRight: 4}} />
-            {assetKeyToString(definition.assetKey)}
-            <div style={{flex: 1}} />
-            {computeStatus === 'old' && (
-              <UpstreamNotice>
-                upstream
-                <br />
-                changed
-              </UpstreamNotice>
-            )}
-          </Name>
-          {definition.description && (
-            <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
-          )}
-          {event ? (
-            <Stats>
-              {runOrError.__typename === 'Run' && (
-                <StatsRow>
-                  <Link
-                    data-tooltip={`${runOrError.pipelineName}${
-                      runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
-                    }`}
-                    data-tooltip-style={RunLinkTooltipStyle}
-                    style={{overflow: 'hidden', textOverflow: 'ellipsis', paddingRight: 8}}
-                    to={workspacePath(
-                      repoAddress.name,
-                      repoAddress.location,
-                      `jobs/${runOrError.pipelineName}:${runOrError.mode}`,
-                    )}
-                  >
-                    {`${runOrError.pipelineName}${
-                      runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
-                    }`}
-                  </Link>
-                  <Link
-                    style={{fontFamily: FontFamily.monospace, fontSize: 14}}
-                    to={`/instance/runs/${runOrError.runId}?${qs.stringify({
-                      timestamp: event.stepStats.endTime,
-                      selection: event.stepStats.stepKey,
-                      logs: `step:${event.stepStats.stepKey}`,
-                    })}`}
-                    target="_blank"
-                  >
-                    {titleForRun({runId: runOrError.runId})}
-                  </Link>
-                </StatsRow>
-              )}
 
-              <StatsRow>
-                {event.stepStats.endTime ? (
-                  <TimestampDisplay
-                    timestamp={event.stepStats.endTime}
-                    timeFormat={{showSeconds: false, showTimezone: false}}
-                  />
-                ) : (
-                  'Never'
-                )}
-                <TimeElapsed
-                  startUnix={event.stepStats.startTime}
-                  endUnix={event.stepStats.endTime}
-                />
-              </StatsRow>
-            </Stats>
-          ) : (
-            <Stats>
-              <StatsRow style={{opacity: 0.5}}>
-                <span>No materializations</span>
-                <span>—</span>
-              </StatsRow>
-              <StatsRow style={{opacity: 0.5}}>
-                <span>—</span>
-                <span>—</span>
-              </StatsRow>
-            </Stats>
-          )}
-          {kind && (
-            <OpTags
-              minified={false}
-              style={{right: -2, paddingTop: 5}}
-              tags={[
-                {
-                  label: kind,
-                  onClick: () => {
-                    window.requestAnimationFrame(() =>
-                      document.dispatchEvent(new Event('show-kind-info')),
-                    );
-                  },
-                },
-              ]}
+      try {
+        const result = await launchPipelineExecution({
+          variables: {
+            executionParams: {
+              selector: {
+                pipelineName: definition.jobName,
+                ...repoAddressToSelector(repoAddress),
+              },
+              mode: 'default',
+              stepKeys: [definition.opName],
+            },
+          },
+        });
+        handleLaunchResult(basePath, definition.jobName, result, true);
+      } catch (error) {
+        showLaunchError(error as Error);
+      }
+    };
+
+    return (
+      <ContextMenu
+        content={
+          <MenuWIP>
+            <MenuItemWIP
+              text={
+                <span>
+                  Launch run to build{' '}
+                  <span style={{fontFamily: 'monospace', fontWeight: 600}}>
+                    {assetKeyToString(definition.assetKey)}
+                  </span>
+                </span>
+              }
+              icon="open_in_new"
+              onClick={onLaunch}
             />
-          )}
-        </AssetNodeBox>
-      </AssetNodeContainer>
-    </ContextMenu>
-  );
-};
+          </MenuWIP>
+        }
+      >
+        <AssetNodeContainer $selected={selected} $secondaryHighlight={secondaryHighlight}>
+          <AssetNodeBox>
+            <Name>
+              <IconWIP name="asset" style={{marginRight: 4}} />
+              {assetKeyToString(definition.assetKey)}
+              <div style={{flex: 1}} />
+              {computeStatus === 'old' && (
+                <UpstreamNotice>
+                  upstream
+                  <br />
+                  changed
+                </UpstreamNotice>
+              )}
+            </Name>
+            {definition.description && (
+              <Description>
+                {markdownToPlaintext(definition.description).split('\n')[0]}
+              </Description>
+            )}
+            {event ? (
+              <Stats>
+                {runOrError.__typename === 'Run' && (
+                  <StatsRow>
+                    <Link
+                      data-tooltip={`${runOrError.pipelineName}${
+                        runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
+                      }`}
+                      data-tooltip-style={RunLinkTooltipStyle}
+                      style={{overflow: 'hidden', textOverflow: 'ellipsis', paddingRight: 8}}
+                      to={workspacePath(
+                        repoAddress.name,
+                        repoAddress.location,
+                        `jobs/${runOrError.pipelineName}:${runOrError.mode}`,
+                      )}
+                    >
+                      {`${runOrError.pipelineName}${
+                        runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
+                      }`}
+                    </Link>
+                    <Link
+                      style={{fontFamily: FontFamily.monospace, fontSize: 14}}
+                      to={`/instance/runs/${runOrError.runId}?${qs.stringify({
+                        timestamp: event.stepStats.endTime,
+                        selection: event.stepStats.stepKey,
+                        logs: `step:${event.stepStats.stepKey}`,
+                      })}`}
+                      target="_blank"
+                    >
+                      {titleForRun({runId: runOrError.runId})}
+                    </Link>
+                  </StatsRow>
+                )}
 
-export const getNodeDimensions = (def: AssetGraphQuery_repositoryOrError_Repository_assetNodes) => {
-  let height = 92 + 20;
+                <StatsRow>
+                  {event.stepStats.endTime ? (
+                    <TimestampDisplay
+                      timestamp={event.stepStats.endTime}
+                      timeFormat={{showSeconds: false, showTimezone: false}}
+                    />
+                  ) : (
+                    'Never'
+                  )}
+                  <TimeElapsed
+                    startUnix={event.stepStats.startTime}
+                    endUnix={event.stepStats.endTime}
+                  />
+                </StatsRow>
+              </Stats>
+            ) : (
+              <Stats>
+                <StatsRow style={{opacity: 0.5}}>
+                  <span>No materializations</span>
+                  <span>—</span>
+                </StatsRow>
+                <StatsRow style={{opacity: 0.5}}>
+                  <span>—</span>
+                  <span>—</span>
+                </StatsRow>
+              </Stats>
+            )}
+            {kind && (
+              <OpTags
+                minified={false}
+                style={{right: -2, paddingTop: 5}}
+                tags={[
+                  {
+                    label: kind,
+                    onClick: () => {
+                      window.requestAnimationFrame(() =>
+                        document.dispatchEvent(new Event('show-kind-info')),
+                      );
+                    },
+                  },
+                ]}
+              />
+            )}
+          </AssetNodeBox>
+        </AssetNodeContainer>
+      </ContextMenu>
+    );
+  },
+  isEqual,
+);
+
+export const ASSET_NODE_FRAGMENT = gql`
+  fragment AssetNodeFragment on AssetNode {
+    id
+    opName
+    description
+    jobName
+    assetKey {
+      path
+    }
+
+    assetMaterializations(limit: 1) {
+      ...LatestMaterializationMetadataFragment
+
+      materializationEvent {
+        materialization {
+          metadataEntries {
+            ...MetadataEntryFragment
+          }
+        }
+        stepStats {
+          stepKey
+          startTime
+          endTime
+        }
+      }
+      runOrError {
+        ... on PipelineRun {
+          id
+          runId
+          status
+          pipelineName
+          mode
+        }
+      }
+    }
+  }
+
+  ${LATEST_MATERIALIZATION_METADATA_FRAGMENT}
+  ${METADATA_ENTRY_FRAGMENT}
+`;
+
+export const getNodeDimensions = (def: AssetNodeFragment) => {
+  let height = 95;
   if (def.description) {
     height += 25;
   }
@@ -211,7 +259,7 @@ const AssetNodeContainer = styled.div<{$selected: boolean; $secondaryHighlight: 
     p.$selected
       ? `2px dashed rgba(255, 69, 0, 1)`
       : p.$secondaryHighlight
-      ? `2px solid ${ColorsWIP.Blue500}55`
+      ? `2px dashed rgba(255, 69, 0, 0.5)`
       : 'none'};
   border-radius: 6px;
   outline-offset: -1px;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
@@ -1,4 +1,3 @@
-import {isEqual} from 'lodash';
 import React from 'react';
 import styled from 'styled-components/macro';
 

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
@@ -1,3 +1,4 @@
+import {isEqual} from 'lodash';
 import React from 'react';
 import styled from 'styled-components/macro';
 
@@ -7,12 +8,12 @@ import {FontFamily} from '../../ui/styles';
 
 import {assetKeyToString} from './Utils';
 
-export const ForeignNode: React.FC<{assetKey: {path: string[]}}> = ({assetKey}) => (
+export const ForeignNode: React.FC<{assetKey: {path: string[]}}> = React.memo(({assetKey}) => (
   <ForeignNodeLink>
     <span className="label">{assetKeyToString(assetKey)}</span>
     <IconWIP name="open_in_new" color={ColorsWIP.Gray500} />
   </ForeignNodeLink>
-);
+));
 
 const ForeignNodeLink = styled.div`
   display: flex;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -6,7 +6,7 @@ import {AssetMaterializations} from '../../assets/AssetMaterializations';
 import {LatestMaterializationMetadata} from '../../assets/LastMaterializationMetadata';
 import {Description} from '../../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../../pipelines/SidebarComponents';
-import {GraphExplorerSolidHandleFragment} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
+import {GraphExplorerSolidHandleFragment_solid_definition} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
 import {pluginForMetadata} from '../../plugins';
 import {Box} from '../../ui/Box';
 import {ColorsWIP} from '../../ui/Colors';
@@ -18,10 +18,9 @@ import {AssetGraphQuery_repositoryOrError_Repository_assetNodes} from './types/A
 
 export const SidebarAssetInfo: React.FC<{
   node: AssetGraphQuery_repositoryOrError_Repository_assetNodes;
-  handle: GraphExplorerSolidHandleFragment;
+  definition: GraphExplorerSolidHandleFragment_solid_definition;
   repoAddress: RepoAddress;
-}> = ({node, handle, repoAddress}) => {
-  const definition = handle.solid.definition;
+}> = ({node, definition, repoAddress}) => {
   const Plugin = pluginForMetadata(definition.metadata);
 
   return (
@@ -39,14 +38,17 @@ export const SidebarAssetInfo: React.FC<{
       <div style={{borderBottom: `2px solid ${ColorsWIP.Gray300}`}} />
       <SidebarSection title={'Materialization in Last Run'}>
         {node.assetMaterializations.length ? (
-          <Box margin={12}>
-            <LatestMaterializationMetadata latest={node.assetMaterializations[0]} asOf={null} />
-
-            <AssetCatalogLink to={`/instance/assets/${node.assetKey.path.join('/')}`}>
-              {'View All in Asset Catalog '}
-              <IconWIP name="open_in_new" color={ColorsWIP.Blue500} />
-            </AssetCatalogLink>
-          </Box>
+          <>
+            <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
+              <LatestMaterializationMetadata latest={node.assetMaterializations[0]} asOf={null} />
+            </div>
+            <Box margin={{bottom: 12, horizontal: 12, top: 8}}>
+              <AssetCatalogLink to={`/instance/assets/${node.assetKey.path.join('/')}`}>
+                {'View All in Asset Catalog '}
+                <IconWIP name="open_in_new" color={ColorsWIP.Blue500} />
+              </AssetCatalogLink>
+            </Box>
+          </>
         ) : (
           <Box margin={12}>&mdash;</Box>
         )}
@@ -54,9 +56,7 @@ export const SidebarAssetInfo: React.FC<{
 
       {node.assetMaterializations.length ? (
         <SidebarSection title={'Materialization Plots'}>
-          <Box margin={12}>
-            <AssetMaterializations assetKey={node.assetKey} asOf={null} asSidebarSection />
-          </Box>
+          <AssetMaterializations assetKey={node.assetKey} asSidebarSection />
         </SidebarSection>
       ) : null}
     </div>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -33,7 +33,7 @@ interface IPoint {
   x: number;
   y: number;
 }
-type IEdge = {
+export type IEdge = {
   from: IPoint;
   to: IPoint;
   dashed: boolean;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -1,8 +1,7 @@
 import {pathVerticalDiagonal} from '@vx/shape';
 import * as dagre from 'dagre';
-import memoize from 'lodash/memoize';
 
-import {AssetNode, getNodeDimensions} from './AssetNode';
+import {getNodeDimensions} from './AssetNode';
 import {getForeignNodeDimensions} from './ForeignNode';
 import {
   AssetGraphQuery_repositoryOrError_Repository,
@@ -51,8 +50,8 @@ export const buildGraphData = (repository: Repository, jobName?: string) => {
 
   repository.assetNodes.forEach((definition: AssetNode) => {
     const assetKeyJson = JSON.stringify(definition.assetKey.path);
-    definition.dependencies.forEach(({asset, inputName}) => {
-      const upstreamAssetKeyJson = JSON.stringify(asset.assetKey.path);
+    definition.dependencies.forEach(({upstreamAsset, inputName}) => {
+      const upstreamAssetKeyJson = JSON.stringify(upstreamAsset.assetKey.path);
       downstream[upstreamAssetKeyJson] = {
         ...(downstream[upstreamAssetKeyJson] || {}),
         [assetKeyJson]: inputName,
@@ -94,7 +93,7 @@ export const graphHasCycles = (graphData: GraphData) => {
   return hasCycles;
 };
 
-export const _layoutGraph = (graphData: GraphData, margin = 100) => {
+export const layoutGraph = (graphData: GraphData, margin = 100) => {
   const g = new dagre.graphlib.Graph();
 
   g.setGraph({rankdir: 'TB', marginx: margin, marginy: margin});
@@ -204,12 +203,6 @@ export function buildGraphComputeStatuses(graphData: GraphData) {
   }
   return statuses;
 }
-
-const _layoutCacheKey = (data: GraphData) => {
-  return Object.keys(data.nodes).join('|');
-};
-
-export const layoutGraph = memoize(_layoutGraph, _layoutCacheKey);
 
 export type Status = 'good' | 'old' | 'none';
 

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
@@ -24,23 +24,6 @@ export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetKe
   path: string[];
 }
 
-export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset {
-  __typename: "AssetNode";
-  id: string;
-  assetKey: AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset_assetKey;
-}
-
-export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies {
-  __typename: "AssetDependency";
-  inputName: string;
-  upstreamAsset: AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset;
-}
-
 export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetMaterializations_runOrError_RunNotFoundError {
   __typename: "RunNotFoundError" | "PythonError";
 }
@@ -184,15 +167,32 @@ export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetMa
   materializationEvent: AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetMaterializations_materializationEvent;
 }
 
+export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset {
+  __typename: "AssetNode";
+  id: string;
+  assetKey: AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset_assetKey;
+}
+
+export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies {
+  __typename: "AssetDependency";
+  inputName: string;
+  upstreamAsset: AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies_upstreamAsset;
+}
+
 export interface AssetGraphQuery_repositoryOrError_Repository_assetNodes {
   __typename: "AssetNode";
   id: string;
-  assetKey: AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetKey;
   opName: string | null;
   description: string | null;
   jobName: string | null;
-  dependencies: AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies[];
+  assetKey: AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetKey;
   assetMaterializations: AssetGraphQuery_repositoryOrError_Repository_assetNodes_assetMaterializations[];
+  dependencies: AssetGraphQuery_repositoryOrError_Repository_assetNodes_dependencies[];
 }
 
 export interface AssetGraphQuery_repositoryOrError_Repository_pipelines_modes {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetNodeFragment.ts
@@ -1,0 +1,168 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus } from "./../../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: AssetNodeFragment
+// ====================================================
+
+export interface AssetNodeFragment_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetNodeFragment_assetMaterializations_runOrError_RunNotFoundError {
+  __typename: "RunNotFoundError" | "PythonError";
+}
+
+export interface AssetNodeFragment_assetMaterializations_runOrError_Run_repositoryOrigin {
+  __typename: "RepositoryOrigin";
+  id: string;
+  repositoryName: string;
+  repositoryLocationName: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_runOrError_Run {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  mode: string;
+  pipelineName: string;
+  pipelineSnapshotId: string | null;
+  repositoryOrigin: AssetNodeFragment_assetMaterializations_runOrError_Run_repositoryOrigin | null;
+  status: RunStatus;
+}
+
+export type AssetNodeFragment_assetMaterializations_runOrError = AssetNodeFragment_assetMaterializations_runOrError_RunNotFoundError | AssetNodeFragment_assetMaterializations_runOrError_Run;
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_stepStats {
+  __typename: "RunStepStats";
+  endTime: number | null;
+  startTime: number | null;
+  stepKey: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventPathMetadataEntry {
+  __typename: "EventPathMetadataEntry";
+  label: string;
+  description: string | null;
+  path: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventJsonMetadataEntry {
+  __typename: "EventJsonMetadataEntry";
+  label: string;
+  description: string | null;
+  jsonString: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventUrlMetadataEntry {
+  __typename: "EventUrlMetadataEntry";
+  label: string;
+  description: string | null;
+  url: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventTextMetadataEntry {
+  __typename: "EventTextMetadataEntry";
+  label: string;
+  description: string | null;
+  text: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventMarkdownMetadataEntry {
+  __typename: "EventMarkdownMetadataEntry";
+  label: string;
+  description: string | null;
+  mdStr: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventPythonArtifactMetadataEntry {
+  __typename: "EventPythonArtifactMetadataEntry";
+  label: string;
+  description: string | null;
+  module: string;
+  name: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventFloatMetadataEntry {
+  __typename: "EventFloatMetadataEntry";
+  label: string;
+  description: string | null;
+  floatValue: number | null;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventIntMetadataEntry {
+  __typename: "EventIntMetadataEntry";
+  label: string;
+  description: string | null;
+  intValue: number | null;
+  intRepr: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventPipelineRunMetadataEntry {
+  __typename: "EventPipelineRunMetadataEntry";
+  label: string;
+  description: string | null;
+  runId: string;
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventAssetMetadataEntry_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventAssetMetadataEntry {
+  __typename: "EventAssetMetadataEntry";
+  label: string;
+  description: string | null;
+  assetKey: AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventAssetMetadataEntry_assetKey;
+}
+
+export type AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries = AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventPathMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventJsonMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventUrlMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventTextMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventMarkdownMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventPythonArtifactMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventFloatMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventIntMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventPipelineRunMetadataEntry | AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries_EventAssetMetadataEntry;
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_materialization {
+  __typename: "Materialization";
+  metadataEntries: AssetNodeFragment_assetMaterializations_materializationEvent_materialization_metadataEntries[];
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_assetLineage_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent_assetLineage {
+  __typename: "AssetLineageInfo";
+  assetKey: AssetNodeFragment_assetMaterializations_materializationEvent_assetLineage_assetKey;
+  partitions: string[];
+}
+
+export interface AssetNodeFragment_assetMaterializations_materializationEvent {
+  __typename: "StepMaterializationEvent";
+  runId: string;
+  timestamp: string;
+  stepKey: string | null;
+  stepStats: AssetNodeFragment_assetMaterializations_materializationEvent_stepStats;
+  materialization: AssetNodeFragment_assetMaterializations_materializationEvent_materialization;
+  assetLineage: AssetNodeFragment_assetMaterializations_materializationEvent_assetLineage[];
+}
+
+export interface AssetNodeFragment_assetMaterializations {
+  __typename: "AssetMaterialization";
+  partition: string | null;
+  runOrError: AssetNodeFragment_assetMaterializations_runOrError;
+  materializationEvent: AssetNodeFragment_assetMaterializations_materializationEvent;
+}
+
+export interface AssetNodeFragment {
+  __typename: "AssetNode";
+  id: string;
+  opName: string | null;
+  description: string | null;
+  jobName: string | null;
+  assetKey: AssetNodeFragment_assetKey;
+  assetMaterializations: AssetNodeFragment_assetMaterializations[];
+}


### PR DESCRIPTION
## Summary
This PR implements the select+launch functionality in the asset graph view.

I also made several small improvements to the rendering of the Asset and Op graphs:

-    The SVGViewport vends the current viewport to it's contents so we can clip the rendered ops / assets to only the ones onscreen. Now that we render complex HTML inside the ops this is a pretty nice performance win.

  -  The op / asset lines are no longer drawn into a layer and then composited at 0.2 opacity. Instead we just render them light gray.

   - There are memo calls in more places.




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.