### PR TITLE
Conditionally assign a public IP

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -114,7 +114,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             networkConfiguration={
                 "awsvpcConfiguration": {
                     "subnets": metadata.subnets,
-                    "assignPublicIp": "ENABLED",
+                    "assignPublicIp": metadata.assign_public_ip,
                     "securityGroups": metadata.security_groups,
                 }
             },

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
@@ -35,8 +35,3 @@ def subnet(vpc):
 @pytest.fixture
 def security_group(vpc):
     return vpc.create_security_group(Description="test", GroupName="test")
-
-
-@pytest.fixture
-def network_interface(subnet, security_group):
-    return subnet.create_network_interface(Groups=[security_group.id])

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -40,11 +40,17 @@ def task_definition(ecs, image, environment):
 
 
 @pytest.fixture
-def task(ecs, subnet, security_group, task_definition):
+def assign_public_ip():
+    return True
+
+
+@pytest.fixture
+def task(ecs, subnet, security_group, task_definition, assign_public_ip):
     return ecs.run_task(
         taskDefinition=task_definition["family"],
         networkConfiguration={
             "awsvpcConfiguration": {
+                "assignPublicIp": "ENABLED" if assign_public_ip else "DISABLED",
                 "subnets": [subnet.id],
                 "securityGroups": [security_group.id],
             },

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -40,12 +40,12 @@ def task_definition(ecs, image, environment):
 
 
 @pytest.fixture
-def task(ecs, network_interface, security_group, task_definition):
+def task(ecs, subnet, security_group, task_definition):
     return ecs.run_task(
         taskDefinition=task_definition["family"],
         networkConfiguration={
             "awsvpcConfiguration": {
-                "subnets": [network_interface.subnet_id],
+                "subnets": [subnet.id],
                 "securityGroups": [security_group.id],
             },
         },

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -12,7 +12,6 @@ def test_default_launcher(
     workspace,
     run,
     subnet,
-    network_interface,
     image,
     environment,
     task_long_arn_format,
@@ -48,7 +47,6 @@ def test_default_launcher(
     task_arn = list(set(tasks).difference(initial_tasks))[0]
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
     assert subnet.id in str(task)
-    assert network_interface.id in str(task)
     assert task["taskDefinitionArn"] == task_definition["taskDefinitionArn"]
 
     # The run is tagged with info about the ECS task

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         extras_require={
             "redshift": ["psycopg2-binary"],
             "pyspark": ["dagster-pyspark"],
-            "test": ["moto==1.3.16", "requests-mock"],
+            "test": ["moto>=2.2.8", "requests-mock"],
         },
         zip_safe=False,
     )


### PR DESCRIPTION
If the parent task has a public ip, assign a public ip.

Otherwise, don't.

This allows us to support a wider range of networking configurations
including launching tasks into a private subnet that use a NAT gateway
to provide a static ip address.

https://aws.amazon.com/premiumsupport/knowledge-center/ecs-fargate-static-elastic-ip-address/
https://docs.aws.amazon.com/AmazonECS/latest/userguide/fargate-task-networking.html