### PR TITLE
[dagit] Allow even split of Run panes

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Icon.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Icon.tsx
@@ -31,7 +31,7 @@ const Icons = {
   panel_show_right: require('./icon-svgs/panel_show_right.svg'),
   panel_hide_right: require('./icon-svgs/panel_hide_right.svg'),
   panel_show_bottom: require('./icon-svgs/panel_show_bottom.svg'),
-  panel_show_both_horizontal: require('./icon-svgs/panel_show_both_horizontal.svg'),
+  panel_show_both: require('./icon-svgs/panel_show_both.svg'),
   copy_to_clipboard: require('./icon-svgs/assignment.svg'),
   copy_to_clipboard_done: require('./icon-svgs/assignment_turned_in.svg'),
   open_in_new: require('./icon-svgs/open_in_new.svg'),

--- a/js_modules/dagit/packages/core/src/ui/Icon.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Icon.tsx
@@ -31,6 +31,7 @@ const Icons = {
   panel_show_right: require('./icon-svgs/panel_show_right.svg'),
   panel_hide_right: require('./icon-svgs/panel_hide_right.svg'),
   panel_show_bottom: require('./icon-svgs/panel_show_bottom.svg'),
+  panel_show_both_horizontal: require('./icon-svgs/panel_show_both_horizontal.svg'),
   copy_to_clipboard: require('./icon-svgs/assignment.svg'),
   copy_to_clipboard_done: require('./icon-svgs/assignment_turned_in.svg'),
   open_in_new: require('./icon-svgs/open_in_new.svg'),

--- a/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
@@ -137,7 +137,16 @@ interface PanelToggleProps {
 }
 
 export const FirstOrSecondPanelToggle = ({container, axis}: PanelToggleProps) => {
-  // todo dish/bengotow: Fix these icons.
+  const onClick = (id: string) => {
+    let size = 50;
+    if (id === 'first-pane') {
+      size = 100;
+    } else if (id === 'second-pane') {
+      size = 0;
+    }
+    container.current?.onChangeSize(size);
+  };
+
   return (
     <ButtonGroup
       buttons={[
@@ -147,12 +156,17 @@ export const FirstOrSecondPanelToggle = ({container, axis}: PanelToggleProps) =>
           tooltip: axis === 'vertical' ? 'Show only top pane' : 'Show only left pane',
         },
         {
+          id: 'split',
+          icon: 'panel_show_both_horizontal',
+          tooltip: 'Show both panels',
+        },
+        {
           id: 'second-pane',
           icon: axis === 'vertical' ? 'panel_show_bottom' : 'panel_show_right',
           tooltip: axis === 'vertical' ? 'Show only bottom pane' : 'Show only right pane',
         },
       ]}
-      onClick={(id) => container.current?.onChangeSize(id === 'first-pane' ? 100 : 0)}
+      onClick={onClick}
     />
   );
 };

--- a/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
@@ -157,7 +157,7 @@ export const FirstOrSecondPanelToggle = ({container, axis}: PanelToggleProps) =>
         },
         {
           id: 'split',
-          icon: 'panel_show_both_horizontal',
+          icon: 'panel_show_both',
           tooltip: 'Show both panes',
         },
         {

--- a/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SplitPanelContainer.tsx
@@ -158,7 +158,7 @@ export const FirstOrSecondPanelToggle = ({container, axis}: PanelToggleProps) =>
         {
           id: 'split',
           icon: 'panel_show_both_horizontal',
-          tooltip: 'Show both panels',
+          tooltip: 'Show both panes',
         },
         {
           id: 'second-pane',

--- a/js_modules/dagit/packages/core/src/ui/icon-svgs/panel_show_both.svg
+++ b/js_modules/dagit/packages/core/src/ui/icon-svgs/panel_show_both.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.25 6.27148H2.75V2.77148H13.25V6.27148Z" stroke="black" stroke-width="1.5"/>
+<path d="M13.25 13.5H2.75V10H13.25V13.5Z" stroke="black" stroke-width="1.5"/>
+</svg>

--- a/js_modules/dagit/packages/core/src/ui/icon-svgs/panel_show_both_horizontal.svg
+++ b/js_modules/dagit/packages/core/src/ui/icon-svgs/panel_show_both_horizontal.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>panel_show_both_horizontal</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" stroke="#000000" stroke-width="1.5" x="2.75" y="3" width="10.5" height="3.5"></rect>
+        <rect id="Rectangle" stroke="#000000" stroke-width="1.5" x="2.75" y="9.75" width="10.5" height="3.5"></rect>
+    </g>
+</svg>

--- a/js_modules/dagit/packages/core/src/ui/icon-svgs/panel_show_both_horizontal.svg
+++ b/js_modules/dagit/packages/core/src/ui/icon-svgs/panel_show_both_horizontal.svg
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>panel_show_both_horizontal</title>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect id="Rectangle" stroke="#000000" stroke-width="1.5" x="2.75" y="3" width="10.5" height="3.5"></rect>
-        <rect id="Rectangle" stroke="#000000" stroke-width="1.5" x="2.75" y="9.75" width="10.5" height="3.5"></rect>
-    </g>
-</svg>


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Resolves #5628.

Add a "split" button on the Run view to automatically adjust the panes to 50/50.

This svg is hand-rolled, lmk if you have a preference on that.

## Test Plan

View Run, verify that buttons work as expected.