### PR TITLE
[dagit] Tweak fuse threshold

### DIFF
--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -16,7 +16,7 @@ import {SearchSecondaryQuery} from './types/SearchSecondaryQuery';
 const fuseOptions = {
   keys: ['label', 'tags', 'type'],
   limit: 10,
-  threshold: 0.3,
+  threshold: 0.5,
   useExtendedSearch: true,
 };
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

May resolve #5655.

Bump the Fuse threshold to try to get more distant text matches.

## Test Plan

Tested some strings on https://fusejs.io/demo.html with this threshold value.