### PR TITLE
Add an ephemeral path for memoization integration tests, fix resolve_version test

### DIFF
--- a/integration_tests/test_suites/celery-k8s-integration-test-suite/test_integration.py
+++ b/integration_tests/test_suites/celery-k8s-integration-test-suite/test_integration.py
@@ -11,7 +11,7 @@ from dagster import DagsterEventType
 from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
 from dagster.core.test_utils import create_run_for_test
-from dagster.utils import merge_dicts
+from dagster.utils.merger import deep_merge_dicts, merge_dicts
 from dagster.utils.yaml_utils import merge_yamls
 from dagster_celery_k8s.launcher import CeleryK8sRunLauncher
 from dagster_k8s.test import wait_for_job_and_get_raw_logs
@@ -584,11 +584,14 @@ def test_memoization_on_celery_k8s(  # pylint: disable=redefined-outer-name
     dagster_docker_image, dagster_instance, helm_namespace
 ):
     ephemeral_prefix = str(uuid.uuid4())
-    run_config = merge_dicts(
+    run_config = deep_merge_dicts(
         merge_yamls([os.path.join(get_test_project_environments_path(), "env_s3.yaml")]),
         get_celery_engine_config(
             dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
         ),
+    )
+    run_config = deep_merge_dicts(
+        run_config,
         {"resources": {"io_manager": {"config": {"s3_prefix": ephemeral_prefix}}}},
     )
 

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import time
+import uuid
 
 import pytest
 from dagster import check
@@ -541,6 +542,7 @@ def test_execute_on_k8s_retry_pipeline(  # pylint: disable=redefined-outer-name
 def test_memoization_k8s_executor(
     dagster_instance_for_k8s_run_launcher, helm_namespace_for_k8s_run_launcher, dagster_docker_image
 ):
+    ephemeral_path = str(uuid.uuid4())
     run_config = merge_dicts(
         load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
         {
@@ -556,11 +558,7 @@ def test_memoization_k8s_executor(
                 }
             },
         },
-    )
-
-    # Clean up any residual outputs that may have been left by failed runs.
-    cleanup_memoized_results(
-        define_memoization_pipeline(), "k8s", dagster_instance_for_k8s_run_launcher, run_config
+        {"resources": {"io_manager": {"config": {"s3_prefix": ephemeral_path}}}},
     )
 
     # wrap in try-catch to ensure that memoized results are always cleaned from s3 bucket

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
@@ -10,6 +10,7 @@ from dagster.core.storage.pipeline_run import PipelineRunStatus
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
 from dagster.core.test_utils import create_run_for_test
 from dagster.utils import load_yaml_from_path, merge_dicts
+from dagster.utils.merger import deep_merge_dicts
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.job import get_k8s_job_name
 from dagster_k8s.launcher import K8sRunLauncher
@@ -543,7 +544,7 @@ def test_memoization_k8s_executor(
     dagster_instance_for_k8s_run_launcher, helm_namespace_for_k8s_run_launcher, dagster_docker_image
 ):
     ephemeral_path = str(uuid.uuid4())
-    run_config = merge_dicts(
+    run_config = deep_merge_dicts(
         load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
         {
             "execution": {
@@ -558,6 +559,10 @@ def test_memoization_k8s_executor(
                 }
             },
         },
+    )
+
+    run_config = deep_merge_dicts(
+        run_config,
         {"resources": {"io_manager": {"config": {"s3_prefix": ephemeral_path}}}},
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_resolve_versions.py
@@ -901,6 +901,7 @@ def test_code_versioning_strategy():
         result = call_the_op.execute_in_process(instance=instance)
         assert result.success
         memoized_plan = create_execution_plan(call_the_op, instance_ref=instance.get_ref())
+        assert len(memoized_plan.step_keys_to_execute) == 0
 
 
 def test_memoization_multiprocess_execution():


### PR DESCRIPTION
Memoization integration tests were flaky because of race conditions between test runs. Because memoized runs store along the same storage path, different test runs were going to the same path and potentially overwriting / deleting from each other.

This PR fixes by adding a randomized prefix to the storage path for each run of the test.