### PR TITLE
Fix failing test on windows

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_local_instance.py
@@ -53,6 +53,7 @@ def test_fs_stores():
                 run_coordinator=DefaultRunCoordinator(),
                 run_launcher=DefaultRunLauncher(),
                 ref=InstanceRef.from_dir(temp_dir),
+                settings={"telemetry": {"enabled": False}},
             )
 
             result = execute_pipeline(simple, instance=instance)


### PR DESCRIPTION
Added dagster_home to a few tests, which ended up enabling telemetry accidentally. As a result, some threads were hanging during cleanup on a windows test. Added a flag disabling telemetry to the dagster instance, which should fix the cleanup issue.