### PR TITLE
[dagit] Clean up AppCache

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppCache.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppCache.tsx
@@ -7,25 +7,6 @@ export const createAppCache = () =>
   new InMemoryCache({
     addTypename: true,
     possibleTypes,
-    typePolicies: {
-      Query: {
-        fields: {
-          pipeline: (_, {args, toReference}) => {
-            return toReference({__typename: 'Pipeline', name: args?.name});
-          },
-          type: (_, {args}) => {
-            // That's "IdValue" from '@apollo/client/utilities'.
-            // Magical thing to make it work with interfaces, getCacheKey gets
-            // incorrect typename and breaks
-            return {
-              type: 'id',
-              generated: true,
-              id: `Type.${args?.typeName}`,
-            };
-          },
-        },
-      },
-    },
     dataIdFromObject: (object: any) => {
       if (
         object.name &&


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

I'm pretty sure we don't need these type policies in the app cache initialization anymore, since these fields don't exist on `Query`.

## Test Plan

Buildkite. Run dagit, verify that the Apollo cache looks fine.