### PR TITLE
[dagit telemetry 2/2] Add telemetry to whitelisted gql queries sent by dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Telemetry.tsx
+++ b/js_modules/dagit/packages/core/src/app/Telemetry.tsx
@@ -1,4 +1,6 @@
-import {gql, useMutation, useQuery} from '@apollo/client';
+import {gql} from '@apollo/client';
+import {extractPathPrefix} from '@dagit/app/src/extractPathPrefix';
+import {print} from 'graphql';
 
 import {DagitTelemetryEnabledQuery} from './types/DagitTelemetryEnabledQuery';
 
@@ -14,6 +16,8 @@ const TELEMETRY_ENABLED_QUERY = gql`
   }
 `;
 
+const GRAPHQL_PATH = `${extractPathPrefix() || ''}/graphql`;
+
 const LOG_TELEMETRY_MUTATION = gql`
   mutation LogTelemetryMutation($action: String!, $metadata: String!, $clientTime: String!) {
     logTelemetry(action: $action, metadata: $metadata, clientTime: $clientTime) {
@@ -28,19 +32,43 @@ const LOG_TELEMETRY_MUTATION = gql`
   }
 `;
 
-export const useTelemetryAction = (action: TelemetryAction) => {
-  const [telemetryRequest] = useMutation(LOG_TELEMETRY_MUTATION);
-  const {data} = useQuery<DagitTelemetryEnabledQuery>(TELEMETRY_ENABLED_QUERY);
+let __DAGIT_TELEMETRY_FLAG: boolean | undefined = undefined;
 
-  return (metadata: {[key: string]: string | null | undefined} = {}) => {
-    if (data && data.instance.dagitTelemetryEnabled) {
-      telemetryRequest({
-        variables: {
-          action: action.toString(),
-          metadata: JSON.stringify(metadata),
-          clientTime: Date.now(),
-        },
-      });
-    }
-  };
-};
+export async function logTelemetry(
+  action: TelemetryAction,
+  metadata: {[key: string]: string | null | undefined} = {},
+) {
+  if (__DAGIT_TELEMETRY_FLAG === undefined) {
+    const enabledResponse = await fetch(GRAPHQL_PATH, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({
+        query: print(TELEMETRY_ENABLED_QUERY),
+      }),
+    });
+    const payload = (await enabledResponse.json()) as {data: DagitTelemetryEnabledQuery};
+    const data = payload.data;
+    __DAGIT_TELEMETRY_FLAG = data.instance.dagitTelemetryEnabled;
+  }
+  if (!__DAGIT_TELEMETRY_FLAG) {
+    return;
+  }
+  return fetch(GRAPHQL_PATH, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      query: print(LOG_TELEMETRY_MUTATION),
+      variables: {
+        action,
+        metadata: JSON.stringify(metadata),
+        clientTime: Date.now(),
+      },
+    }),
+  });
+}

--- a/js_modules/dagit/packages/core/src/app/Telemetry.tsx
+++ b/js_modules/dagit/packages/core/src/app/Telemetry.tsx
@@ -6,6 +6,7 @@ import {DagitTelemetryEnabledQuery} from './types/DagitTelemetryEnabledQuery';
 
 export enum TelemetryAction {
   LAUNCH_RUN = 'LAUNCH_RUN',
+  GRAPHQL_QUERY_COMPLETED = 'GRAPHQL_QUERY_COMPLETED',
 }
 
 const TELEMETRY_ENABLED_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
+++ b/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
@@ -1,7 +1,6 @@
 import {ApolloLink} from '@apollo/client';
 
-import {TelemetryAction, useTelemetryAction} from './Telemetry';
-
+import {TelemetryAction, logTelemetry} from './Telemetry';
 import {formatElapsedTime, debugLog} from './Util';
 
 const TELEMETRY_WHITELIST = new Set(['PipelineRunsRootQuery']);
@@ -10,8 +9,10 @@ export const logLink = new ApolloLink((operation, forward) =>
   forward(operation).map((data) => {
     const time = performance.now() - operation.getContext().start;
     if (TELEMETRY_WHITELIST.has(operation.operationName)) {
-      const logQueryCompletion = useTelemetryAction(TelemetryAction.GRAPHQL_QUERY_COMPLETED);
-      logQueryCompletion({operationName: operation.operationName, elapsedTime: time.toString()});
+      logTelemetry(TelemetryAction.GRAPHQL_QUERY_COMPLETED, {
+        operationName: operation.operationName,
+        elapsedTime: time.toString(),
+      });
     }
     debugLog(`${operation.operationName} took ${formatElapsedTime(time)}`, {operation, data});
     return data;

--- a/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
+++ b/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
@@ -8,12 +8,12 @@ const TELEMETRY_WHITELIST = new Set(['PipelineRunsRootQuery']);
 
 export const logLink = new ApolloLink((operation, forward) =>
   forward(operation).map((data) => {
-    const logQueryCompletion = useTelemetryAction(TelemetryAction.GRAPHQL_QUERY_COMPLETED);
     const time = performance.now() - operation.getContext().start;
-    debugLog(`${operation.operationName} took ${formatElapsedTime(time)}`, {operation, data});
     if (TELEMETRY_WHITELIST.has(operation.operationName)) {
+      const logQueryCompletion = useTelemetryAction(TelemetryAction.GRAPHQL_QUERY_COMPLETED);
       logQueryCompletion({operationName: operation.operationName, elapsedTime: time.toString()});
     }
+    debugLog(`${operation.operationName} took ${formatElapsedTime(time)}`, {operation, data});
     return data;
   }),
 );

--- a/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
+++ b/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
@@ -1,11 +1,19 @@
 import {ApolloLink} from '@apollo/client';
 
+import {TelemetryAction, useTelemetryAction} from './Telemetry';
+
 import {formatElapsedTime, debugLog} from './Util';
+
+const TELEMETRY_WHITELIST = new Set(['PipelineRunsRootQuery']);
 
 export const logLink = new ApolloLink((operation, forward) =>
   forward(operation).map((data) => {
+    const logQueryCompletion = useTelemetryAction(TelemetryAction.GRAPHQL_QUERY_COMPLETED);
     const time = performance.now() - operation.getContext().start;
     debugLog(`${operation.operationName} took ${formatElapsedTime(time)}`, {operation, data});
+    if (TELEMETRY_WHITELIST.has(operation.operationName)) {
+      logQueryCompletion({operationName: operation.operationName, elapsedTime: time.toString()});
+    }
     return data;
   }),
 );

--- a/js_modules/dagit/packages/core/src/execute/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/execute/LaunchRootExecutionButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
 import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
-import {useTelemetryAction, TelemetryAction} from '../app/Telemetry';
+import {logTelemetry, TelemetryAction} from '../app/Telemetry';
 import {LAUNCH_PIPELINE_EXECUTION_MUTATION, handleLaunchResult} from '../runs/RunUtils';
 import {
   LaunchPipelineExecution,
@@ -22,7 +22,6 @@ interface LaunchRootExecutionButtonProps {
 export const LaunchRootExecutionButton: React.FunctionComponent<LaunchRootExecutionButtonProps> = (
   props,
 ) => {
-  const logLaunch = useTelemetryAction(TelemetryAction.LAUNCH_RUN);
   const {canLaunchPipelineExecution} = usePermissions();
   const [launchPipelineExecution] = useMutation<LaunchPipelineExecution>(
     LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -45,7 +44,7 @@ export const LaunchRootExecutionButton: React.FunctionComponent<LaunchRootExecut
 
     try {
       const result = await launchPipelineExecution({variables});
-      logLaunch(metadata);
+      logTelemetry(TelemetryAction.LAUNCH_RUN, metadata);
       handleLaunchResult(basePath, props.pipelineName, result);
     } catch (error) {
       showLaunchError(error as Error);


### PR DESCRIPTION
Adds a whitelist for gql queries to log via telemetry (and then logs upon their completion).

Verified that this approach works on my local dagit server.