### PR TITLE
Make celery broker / backend url always sourced from an env var in the helm chart

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -25,11 +25,11 @@ class BuildkiteQueue(Enum):
 
 
 class StepBuilder:
-    def __init__(self, label, key=None):
+    def __init__(self, label, key=None, timeout_in_minutes=None):
         self._step = {
             "agents": {"queue": BuildkiteQueue.MEDIUM.value},
             "label": label,
-            "timeout_in_minutes": TIMEOUT_IN_MIN,
+            "timeout_in_minutes": timeout_in_minutes or TIMEOUT_IN_MIN,
             "retry": {
                 "automatic": [
                     {"exit_status": -1, "limit": 2},  # agent lost

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -169,6 +169,7 @@ def build_steps_integration_suite(
         depends_on_fn=test_image_depends_fn,
         tox_env_suffixes=tox_env_suffixes,
         retries=2,
+        timeout_in_minutes=30,
     ).get_tox_build_steps()
 
 

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -193,6 +193,10 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
 
     assert run_launcher_config["config"]["config_source"] == configSource
 
+    assert run_launcher_config["config"]["broker"] == {"env": "DAGSTER_K8S_CELERY_BROKER"}
+
+    assert run_launcher_config["config"]["backend"] == {"env": "DAGSTER_K8S_CELERY_BACKEND"}
+
 
 @pytest.mark.parametrize("enabled", [True, False])
 def test_queued_run_coordinator_config(template: HelmTemplate, enabled: bool):

--- a/helm/dagster/templates/configmap-celery.yaml
+++ b/helm/dagster/templates/configmap-celery.yaml
@@ -17,8 +17,10 @@ data:
   celery.yaml: |
     execution:
       celery:
-        broker: {{ include "dagster.celery.broker_url" $ | quote }}
-        backend: {{ include "dagster.celery.backend_url" $ | quote }}
+        broker:
+          env: DAGSTER_K8S_CELERY_BROKER
+        backend:
+          env: DAGSTER_K8S_CELERY_BACKEND
         config_source: {{ merge $individualConfig $sharedConfig | toYaml | nindent 10 }}
 ---
 {{- end }}

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -92,7 +92,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - celery -A dagster_celery_k8s.app -b {{ include "dagster.celery.broker_url" $ }} status | grep "${HOSTNAME}:.*OK"
+                - dagster-celery status -A dagster_celery_k8s.app -y {{ $.Values.global.dagsterHome }}/celery-config.yaml | grep "${HOSTNAME}:.*OK"
             {{- if hasKey $celeryK8sRunLauncherConfig.livenessProbe "initialDelaySeconds" }}
             initialDelaySeconds:
               {{- toYaml $celeryK8sRunLauncherConfig.livenessProbe.initialDelaySeconds | nindent 14 }}

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -53,9 +53,15 @@ spec:
                 name: {{ template "dagster.fullname" . }}-flower-env
           env:
             - name: CELERY_BROKER_URL
-              value: "{{ include "dagster.celery.broker_url" . }}"
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "dagster.fullname" . }}-flower-env
+                  key: DAGSTER_K8S_CELERY_BROKER
             - name: CELERY_RESULT_BACKEND
-              value: "{{ include "dagster.celery.backend_url" . }}"
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "dagster.fullname" . }}-flower-env
+                  key: DAGSTER_K8S_CELERY_BACKEND
           volumeMounts: []
           ports:
             - name: flower

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -178,7 +178,7 @@ until wget http://{{ .Values.rabbitmq.rabbitmq.username }}:{{ .Values.rabbitmq.r
 {{/*
 This environment shared across all containers.
 
-This includes Dagit, Celery Workers, Run Master, and Step Execution containers.
+This includes Dagit, Celery Workers, Run Worker, and Step Worker containers.
 */}}
 {{- define "dagster.shared_env" -}}
 DAGSTER_HOME: {{ .Values.global.dagsterHome | quote }}

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -9,9 +9,10 @@ config:
     env: DAGSTER_K8S_INSTANCE_CONFIG_MAP
   postgres_password_secret:
     env: DAGSTER_K8S_PG_PASSWORD_SECRET
-  broker: {{ include "dagster.celery.broker_url" . | quote }}
-  backend: {{ include "dagster.celery.backend_url" . | quote}}
-
+  broker:
+    env: DAGSTER_K8S_CELERY_BROKER
+  backend:
+    env: DAGSTER_K8S_CELERY_BACKEND
   {{- if $celeryK8sRunLauncherConfig.configSource }}
   config_source: {{- $celeryK8sRunLauncherConfig.configSource | toYaml | nindent 4 }}
   {{- end }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 # README:
 # - If using a fixed tag for images, changing the image pull policy to anything other than "Always"
 #   will use a cached/stale image.
@@ -522,7 +523,7 @@ runLauncher:
       #   command:
       #     - /bin/sh
       #     - -c
-      #     - celery status -A dagster_celery_k8s.app -b {{ include "dagster.celery.broker_url" . }} | grep "${HOSTNAME}:.*OK"
+      #     - dagster-celery status -A dagster_celery_k8s.app -y {{ $.Values.global.dagsterHome }}/celery-config.yaml | grep "${HOSTNAME}:.*OK"
       livenessProbe:
         initialDelaySeconds: 15
         periodSeconds: 10


### PR DESCRIPTION
A prerequisite for putting celery URLs in a secret that can be externally managed is to not hardcode the broker URL and backend URL. This diff does that.

Also bumped the timeout on the celery k8s integration tests since they were timing out regularly (we should speed the m up, but until then slow is better than timing out), and fixed an issue where the debug payloads weren't writing.