### PR TITLE
rfc: Asset definition partitions

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional
+from typing import AbstractSet, Mapping, Optional
 
 from dagster.core.definitions import OpDefinition
 from dagster.core.definitions.events import AssetKey
@@ -44,6 +44,14 @@ class AssetsDefinition:
     @property
     def partitions_def(self) -> PartitionsDefinition:
         return self._partitions_def
+
+    @property
+    def asset_keys(self) -> AbstractSet[AssetKey]:
+        return self._output_defs_by_asset_key.keys()
+
+    @property
+    def parent_asset_keys(self) -> AbstractSet[AssetKey]:
+        return self._input_defs_by_asset_key.keys()
 
     def get_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
         return self._partition_mappings.get(

--- a/python_modules/dagster/dagster/core/asset_defs/asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset.py
@@ -1,7 +1,10 @@
-from typing import Mapping
+from typing import Mapping, Optional
 
 from dagster.core.definitions import OpDefinition
 from dagster.core.definitions.events import AssetKey
+from dagster.core.definitions.partition import PartitionsDefinition
+
+from .partition_mapping import PartitionMapping
 
 
 class AssetsDefinition:
@@ -10,6 +13,8 @@ class AssetsDefinition:
         input_names_by_asset_key: Mapping[AssetKey, str],
         output_names_by_asset_key: Mapping[AssetKey, str],
         op: OpDefinition,
+        partitions_def: Optional[PartitionsDefinition] = None,
+        partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
     ):
         self._op = op
         self._input_defs_by_asset_key = {
@@ -21,6 +26,8 @@ class AssetsDefinition:
             asset_key: op.output_dict[output_name]
             for asset_key, output_name in output_names_by_asset_key.items()
         }
+        self._partitions_def = partitions_def
+        self._partition_mappings = partition_mappings or {}
 
     @property
     def op(self) -> OpDefinition:
@@ -33,3 +40,13 @@ class AssetsDefinition:
     @property
     def input_defs_by_asset_key(self):
         return self._input_defs_by_asset_key
+
+    @property
+    def partitions_def(self) -> PartitionsDefinition:
+        return self._partitions_def
+
+    def get_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
+        return self._partition_mappings.get(
+            in_asset_key,
+            self.partitions_def.get_default_partition_mapping(),
+        )

--- a/python_modules/dagster/dagster/core/asset_defs/asset_partitions.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_partitions.py
@@ -1,0 +1,39 @@
+from dagster.core.definitions.events import AssetKey
+
+from .asset import AssetsDefinition
+from .partition_key_range import PartitionKeyRange
+
+
+def get_parent_partitions(
+    child_assets_def: AssetsDefinition,
+    child_asset_key: AssetKey,
+    parent_assets_def: AssetsDefinition,
+    parent_asset_key: AssetKey,
+    child_partition_key_range: PartitionKeyRange,
+) -> PartitionKeyRange:
+    """Returns the range of partition keys in the parent asset that include data necessary
+    to compute the contents of the given partition key range in the child asset.
+    """
+
+    child_partition_mapping = child_assets_def.get_partition_mapping(parent_asset_key)
+    return child_partition_mapping.get_parent_partitions(
+        child_assets_def.partitions_def, parent_assets_def.partitions_def, child_partition_key_range
+    )
+
+
+def get_child_partitions(
+    child_assets_def: AssetsDefinition,
+    child_asset_key: AssetKey,
+    parent_assets_def: AssetsDefinition,
+    parent_asset_key: AssetKey,
+    parent_partition_key_range: PartitionKeyRange,
+) -> PartitionKeyRange:
+    """Returns the range of partition keys in the child asset that use the data in the given
+    partition key range of the child asset.
+    """
+    child_partition_mapping = child_assets_def.get_partition_mapping(parent_asset_key)
+    return child_partition_mapping.get_child_partitions(
+        child_assets_def.partitions_def,
+        parent_assets_def.partitions_def,
+        parent_partition_key_range,
+    )

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -134,8 +134,17 @@ class _Asset:
             fn, self.namespace, self.ins or {}, self.non_argument_deps
         )
 
+        partitions_fn = None
+        if self.partitions_def:
+
+            def partitions_fn(context):  # pylint: disable=function-redefined
+                return self.partitions_def.get_partition_keys_in_range(
+                    start=context.partition_key_range_start, end=context.partition_key_range_end
+                )
+
         out = Out(
             asset_key=AssetKey(list(filter(None, [self.namespace, asset_name]))),
+            asset_partitions=partitions_fn,
             metadata=self.metadata or {},
             io_manager_key=self.io_manager_key,
             dagster_type=self.dagster_type,

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -7,12 +7,14 @@ from dagster.core.definitions.decorators.op import _Op
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.input import In
 from dagster.core.definitions.output import Out
+from dagster.core.definitions.partition import PartitionsDefinition
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.types.dagster_type import DagsterType
 from dagster.utils.backcompat import experimental_decorator
 
 from .asset import AssetsDefinition
 from .asset_in import AssetIn
+from .partition_mapping import PartitionMapping
 
 
 @experimental_decorator
@@ -27,6 +29,8 @@ def asset(
     io_manager_key: Optional[str] = None,
     compute_kind: Optional[str] = None,
     dagster_type: Optional[DagsterType] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
+    partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to compute an asset.
 
@@ -55,7 +59,14 @@ def asset(
             the asset, e.g. "dbt" or "spark". It will be displayed in Dagit as a badge on the asset.
         dagster_type (Optional[DagsterType]): Allows specifying type validation functions that
             will be executed on the output of the decorated function after it runs.
-
+        partitions_def (Optional[PartitionsDefiniition]): Defines the set of partition keys that
+            compose the asset.
+        partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
+            keys for this asset to partition keys of upstream assets. Each key in the dictionary
+            correponds to one of the input assets, and each value is a PartitionMapping.
+            If no entry is provided for a particular asset dependency, the partition mapping defaults
+            to the default partition mapping for the partitions definition, which is typically maps
+            partition keys to the same partition keys in upstream assets.
 
     Examples:
 
@@ -80,6 +91,8 @@ def asset(
             io_manager_key=io_manager_key,
             compute_kind=check.opt_str_param(compute_kind, "compute_kind"),
             dagster_type=dagster_type,
+            partitions_def=partitions_def,
+            partition_mappings=partition_mappings,
         )(fn)
 
     return inner
@@ -98,6 +111,8 @@ class _Asset:
         io_manager_key: Optional[str] = None,
         compute_kind: Optional[str] = None,
         dagster_type: Optional[DagsterType] = None,
+        partitions_def: Optional[PartitionsDefinition] = None,
+        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
     ):
         self.name = name
         self.namespace = namespace
@@ -109,6 +124,8 @@ class _Asset:
         self.io_manager_key = io_manager_key
         self.compute_kind = compute_kind
         self.dagster_type = dagster_type
+        self.partitions_def = partitions_def
+        self.partition_mappings = partition_mappings
 
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
@@ -142,6 +159,13 @@ class _Asset:
             },
             output_names_by_asset_key={out_asset_key: "result"},
             op=op,
+            partitions_def=self.partitions_def,
+            partition_mappings={
+                ins_by_input_names[input_name].asset_key: partition_mapping
+                for input_name, partition_mapping in self.partition_mappings.items()
+            }
+            if self.partition_mappings
+            else None,
         )
 
 

--- a/python_modules/dagster/dagster/core/asset_defs/partition_key_range.py
+++ b/python_modules/dagster/dagster/core/asset_defs/partition_key_range.py
@@ -1,0 +1,7 @@
+from typing import NamedTuple
+
+
+class PartitionKeyRange(NamedTuple):
+    # Inclusive on both sides
+    start: str
+    end: str

--- a/python_modules/dagster/dagster/core/asset_defs/partition_mapping.py
+++ b/python_modules/dagster/dagster/core/asset_defs/partition_mapping.py
@@ -48,6 +48,10 @@ class PartitionMapping(ABC):
                 parent asset.
         """
 
+    @property
+    def is_identity() -> bool:
+        return False
+
 
 class IdentityPartitionMapping(PartitionMapping):
     def get_parent_partitions(
@@ -65,3 +69,7 @@ class IdentityPartitionMapping(PartitionMapping):
         parent_partition_key_range: PartitionKeyRange,
     ) -> PartitionKeyRange:
         return parent_partition_key_range
+
+    @property
+    def is_identity() -> bool:
+        return True

--- a/python_modules/dagster/dagster/core/asset_defs/partition_mapping.py
+++ b/python_modules/dagster/dagster/core/asset_defs/partition_mapping.py
@@ -1,0 +1,67 @@
+from abc import ABC, abstractmethod
+
+from dagster.core.definitions.partition import PartitionsDefinition
+
+from .partition_key_range import PartitionKeyRange
+
+
+class PartitionMapping(ABC):
+    """Defines a correspondence between the partitions in an asset and the partitions in an asset
+    that it depends on.
+    """
+
+    @abstractmethod
+    def get_parent_partitions(
+        self,
+        child_partitions_def: PartitionsDefinition,
+        parent_partitions_def: PartitionsDefinition,
+        child_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        """Returns the range of partition keys in the parent asset that include data necessary
+        to compute the contents of the given partition key range in the child asset.
+
+        Args:
+            child_partitions_def (PartitionsDefinition): The partitions definition for the child
+                asset.
+            parent_partitions_def (PartitionsDefinition): The partitions definition for the parent
+                asset.
+            child_partition_key_range (PartitionKeyRange): The range of partition keys in the child
+                asset.
+        """
+
+    @abstractmethod
+    def get_child_partitions(
+        self,
+        child_partitions_def: PartitionsDefinition,
+        parent_partitions_def: PartitionsDefinition,
+        parent_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        """Returns the range of partition keys in the child asset that use the data in the given
+        partition key range of the child asset.
+
+        Args:
+            child_partitions_def (PartitionsDefinition): The partitions definition for the child
+                asset.
+            parent_partitions_def (PartitionsDefinition): The partitions definition for the parent
+                asset.
+            parent_partition_key_range (PartitionKeyRange): The range of partition keys in the
+                parent asset.
+        """
+
+
+class IdentityPartitionMapping(PartitionMapping):
+    def get_parent_partitions(
+        self,
+        child_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+        parent_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+        child_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        return child_partition_key_range
+
+    def get_child_partitions(
+        self,
+        child_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+        parent_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+        parent_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        return parent_partition_key_range

--- a/python_modules/dagster/dagster/core/asset_defs/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/core/asset_defs/time_window_partition_mapping.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timedelta
+from typing import cast
+
+from dagster import check
+from dagster.core.definitions.partition import PartitionsDefinition, ScheduleType
+from dagster.core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
+from dagster.core.errors import DagsterInvalidDefinitionError
+
+from .partition_key_range import PartitionKeyRange
+from .partition_mapping import PartitionMapping
+
+
+class TimeWindowPartitionMapping(PartitionMapping):
+    """
+    The default mapping between two TimeWindowPartitionsDefinitions.
+
+    A partition in the child partitions definition is mapped to all partitions in the parent whose
+    time windows overlap it.
+
+    This means that, if the parent and child partitions definitions share the same time period, then
+    this mapping is essentially the identity partition mapping - plus conversion of datetime formats.
+
+    If the parent time period is coarser than the child time period, then each partition in the child
+    will map to a single (larger) parent partition. E.g. if the child is hourly and the parent is
+    daily, then each hourly partition in the child will map to the daily partition in the parent
+    that contains that hour.
+
+    If the parent time period is finer than the child time period, then each partition in the child
+    will map to multiple parent partitions. E.g. if the child is daily and the parent is hourly,
+    then each daily partition in the child will map to the 24 hourly partitions in the parent that
+    occur on that day.
+    """
+
+    def get_parent_partitions(
+        self,
+        child_partitions_def: PartitionsDefinition,
+        parent_partitions_def: PartitionsDefinition,
+        child_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        return self._map_partitions(
+            child_partitions_def, parent_partitions_def, child_partition_key_range
+        )
+
+    def get_child_partitions(
+        self,
+        child_partitions_def: PartitionsDefinition,
+        parent_partitions_def: PartitionsDefinition,
+        parent_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        return self._map_partitions(
+            parent_partitions_def, child_partitions_def, parent_partition_key_range
+        )
+
+    def _map_partitions(
+        self,
+        from_partitions_def: PartitionsDefinition,
+        to_partitions_def: PartitionsDefinition,
+        from_partition_key_range: PartitionKeyRange,
+    ) -> PartitionKeyRange:
+        if not isinstance(from_partitions_def, TimeWindowPartitionsDefinition) or not isinstance(
+            from_partitions_def, TimeWindowPartitionsDefinition
+        ):
+            raise DagsterInvalidDefinitionError(
+                "TimeWindowPartitionMappings can only operate on TimeWindowPartitionsDefinitions"
+            )
+        from_partitions_def = cast(TimeWindowPartitionsDefinition, from_partitions_def)
+        to_partitions_def = cast(TimeWindowPartitionsDefinition, to_partitions_def)
+
+        if to_partitions_def.timezone != from_partitions_def.timezone:
+            raise DagsterInvalidDefinitionError("Timezones don't match")
+
+        to_period = to_partitions_def.schedule_type
+        from_period = from_partitions_def.schedule_type
+
+        from_start_dt = datetime.strptime(from_partition_key_range.start, from_partitions_def.fmt)
+        from_end_dt = datetime.strptime(from_partition_key_range.end, from_partitions_def.fmt)
+
+        if to_period > from_period:
+            to_start_dt = round_datetime_to_period(from_start_dt, to_period)
+            to_end_dt = round_datetime_to_period(from_end_dt, to_period)
+        elif to_period < from_period:
+            to_start_dt = from_start_dt
+            to_end_dt = (from_end_dt + from_period.delta) - to_period.delta
+        else:
+            to_start_dt = from_start_dt
+            to_end_dt = from_end_dt
+
+        return PartitionKeyRange(
+            to_start_dt.strftime(to_partitions_def.fmt),
+            to_end_dt.strftime(to_partitions_def.fmt),
+        )
+
+
+def round_datetime_to_period(dt: datetime, period: ScheduleType) -> datetime:
+    if period == ScheduleType.MONTHLY:
+        return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    elif period == ScheduleType.WEEKLY:
+        return (dt - timedelta(days=dt.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+    elif period == ScheduleType.DAILY:
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    elif period == ScheduleType.HOURLY:
+        return dt.replace(minute=0, second=0, microsecond=0)
+    else:
+        check.failed("Unknown schedule type")

--- a/python_modules/dagster/dagster/core/asset_defs/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/core/asset_defs/time_window_partition_mapping.py
@@ -90,6 +90,10 @@ class TimeWindowPartitionMapping(PartitionMapping):
             to_end_dt.strftime(to_partitions_def.fmt),
         )
 
+    @property
+    def is_identity() -> bool:
+        return True
+
 
 def round_datetime_to_period(dt: datetime, period: ScheduleType) -> datetime:
     if period == ScheduleType.MONTHLY:

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -3,10 +3,12 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Set,
     Tuple,
@@ -406,6 +408,7 @@ class GraphDefinition(NodeDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
+        tags_for_partition_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -454,6 +457,9 @@ class GraphDefinition(NodeDefinition):
             partitions_def (Optional[PartitionsDefinition]): Defines a discrete set of partition
                 keys that can parameterize the job. If this argument is supplied, the config
                 argument can't also be supplied.
+            tags_for_partition_fn (Optional[Callable[[str], Mapping[str, Any]]]) (Experimental):
+                A function that accepts a partition key and returns a set of tags that are applied
+                to runs with that partition.
 
         Returns:
             JobDefinition
@@ -520,6 +526,7 @@ class GraphDefinition(NodeDefinition):
                 executor_defs=[executor_def],
                 _config_mapping=config_mapping,
                 _partitioned_config=partitioned_config,
+                _tags_for_partition_fn=tags_for_partition_fn,
             ),
             preset_defs=presets,
             tags=tags,

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -220,12 +220,16 @@ class JobDefinition(PipelineDefinition):
             return None
 
         if not self._cached_partition_set:
+            tags_for_partition_fn = (
+                lambda p: mode.tags_for_partition_fn(p.name) if mode.tags_for_partition_fn else None
+            )
 
             self._cached_partition_set = PartitionSetDefinition(
                 job_name=self.name,
                 name=f"{self.name}_partition_set",
                 partitions_def=mode.partitioned_config.partitions_def,
                 run_config_fn_for_partition=mode.partitioned_config.run_config_for_partition_fn,
+                tags_for_partition_fn=tags_for_partition_fn,
                 mode=mode.name,
             )
 

--- a/python_modules/dagster/dagster/core/definitions/mode.py
+++ b/python_modules/dagster/dagster/core/definitions/mode.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.definitions.executor_definition import ExecutorDefinition, default_executors
@@ -27,6 +27,7 @@ class ModeDefinition(
             ("description", Optional[str]),
             ("config_mapping", Optional[ConfigMapping]),
             ("partitioned_config", Optional["PartitionedConfig"]),
+            ("tags_for_partition_fn", Optional[Callable[[str], Mapping[str, Any]]]),
         ],
     )
 ):
@@ -49,6 +50,8 @@ class ModeDefinition(
         description (Optional[str]): A human-readable description of the mode.
         _config_mapping (Optional[ConfigMapping]): Only for internal use.
         _partitions (Optional[PartitionedConfig]): Only for internal use.
+        _tags_for_partition_fn (Optional[Callable[[str], Mapping[str, Any]]]): Only for internal
+            use.
     """
 
     def __new__(
@@ -60,6 +63,7 @@ class ModeDefinition(
         description: Optional[str] = None,
         _config_mapping: Optional[ConfigMapping] = None,
         _partitioned_config: Optional["PartitionedConfig"] = None,
+        _tags_for_partition_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
     ):
 
         from .partition import PartitionedConfig
@@ -100,6 +104,9 @@ class ModeDefinition(
             config_mapping=check.opt_inst_param(_config_mapping, "_config_mapping", ConfigMapping),
             partitioned_config=check.opt_inst_param(
                 _partitioned_config, "_partitioned_config", PartitionedConfig
+            ),
+            tags_for_partition_fn=check.opt_callable_param(
+                _tags_for_partition_fn, "_tags_for_partition_fn"
             ),
         )
 

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -1,12 +1,13 @@
 import copy
 import inspect
 from abc import ABC, abstractmethod
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from enum import Enum
 from typing import Any, Callable, Dict, Generic, List, NamedTuple, Optional, TypeVar, Union, cast
 
 import pendulum
 from dagster import check
+from dateutil.relativedelta import relativedelta
 
 from ...seven.compat.pendulum import PendulumDateTime, to_timezone
 from ...utils import frozenlist, merge_dicts
@@ -128,6 +129,29 @@ class ScheduleType(Enum):
     DAILY = "DAILY"
     WEEKLY = "WEEKLY"
     MONTHLY = "MONTHLY"
+
+    @property
+    def ordinal(self):
+        return {"HOURLY": 1, "DAILY": 2, "WEEKLY": 3, "MONTHLY": 4}[self.value]
+
+    @property
+    def delta(self):
+        if self == ScheduleType.HOURLY:
+            return timedelta(hours=1)
+        elif self == ScheduleType.DAILY:
+            return timedelta(days=1)
+        elif self == ScheduleType.WEEKLY:
+            return timedelta(weeks=1)
+        elif self == ScheduleType.MONTHLY:
+            return relativedelta(months=1)
+        else:
+            check.failed(f"Unexpected ScheduleType {self}")
+
+    def __gt__(self, other):
+        return self.ordinal > other.ordinal
+
+    def __lt__(self, other):
+        return self.ordinal < other.ordinal
 
 
 class PartitionsDefinition(ABC, Generic[T]):

--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -138,6 +138,11 @@ class PartitionsDefinition(ABC, Generic[T]):
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> List[str]:
         return [partition.name for partition in self.get_partitions(current_time)]
 
+    def get_default_partition_mapping(self):
+        from dagster.core.asset_defs.partition_mapping import IdentityPartitionMapping
+
+        return IdentityPartitionMapping()
+
 
 class StaticPartitionsDefinition(
     PartitionsDefinition[str]

--- a/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
@@ -131,6 +131,18 @@ class TimeWindowPartitionsDefinition(
 
         return TimeWindowPartitionMapping()
 
+    def __hash__(self):
+        return hash((self.timezone, self.schedule_type, self.start, self.fmt, self.end_offset))
+
+    def __eq__(self, other):
+        return (
+            self.timezone == other.timezone
+            and self.schedule_type == other.schedule_type
+            and self.start == other.start
+            and self.fmt == other.fmt
+            and self.end_offset == other.end_offset
+        )
+
 
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
     def __new__(

--- a/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
@@ -112,6 +112,11 @@ class TimeWindowPartitionsDefinition(
     def start_time_for_partition_key(self, partition_key: str) -> datetime:
         return pendulum.instance(datetime.strptime(partition_key, self.fmt), tz=self.timezone)
 
+    def get_default_partition_mapping(self):
+        from dagster.core.asset_defs.time_window_partition_mapping import TimeWindowPartitionMapping
+
+        return TimeWindowPartitionMapping()
+
 
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
     def __new__(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -1,0 +1,113 @@
+from dagster import PartitionsDefinition, StaticPartitionsDefinition
+from dagster.core.asset_defs import asset
+from dagster.core.asset_defs.asset_partitions import (
+    PartitionKeyRange,
+    get_child_partitions,
+    get_parent_partitions,
+)
+from dagster.core.asset_defs.partition_mapping import PartitionMapping
+from dagster.core.definitions.events import AssetKey
+
+
+def test_assets_with_same_partitioning():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
+
+    @asset(partitions_def=partitions_def)
+    def upstream_asset():
+        pass
+
+    @asset(partitions_def=partitions_def)
+    def downstream_asset(upstream_asset):
+        assert upstream_asset
+
+    assert (
+        get_parent_partitions(
+            downstream_asset,
+            AssetKey("downstream_asset"),
+            upstream_asset,
+            AssetKey("upstream_asset"),
+            PartitionKeyRange("a", "c"),
+        )
+        == PartitionKeyRange("a", "c")
+    )
+
+    assert (
+        get_child_partitions(
+            downstream_asset,
+            AssetKey("downstream_asset"),
+            upstream_asset,
+            AssetKey("upstream_asset"),
+            PartitionKeyRange("a", "c"),
+        )
+        == PartitionKeyRange("a", "c")
+    )
+
+
+def test_filter_mapping_partitions_dep():
+    downstream_partitions = ["john", "ringo", "paul", "george"]
+    upstream_partitions = [
+        f"{hemisphere}|{beatle}"
+        for beatle in downstream_partitions
+        for hemisphere in ["southern", "northern"]
+    ]
+    downstream_partitions_def = StaticPartitionsDefinition(downstream_partitions)
+    upstream_partitions_def = StaticPartitionsDefinition(upstream_partitions)
+
+    class HemisphereFilteringPartitionMapping(PartitionMapping):
+        def __init__(self, hemisphere: str):
+            self.hemisphere = hemisphere
+
+        def get_parent_partitions(
+            self,
+            child_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+            parent_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+            child_partition_key_range: PartitionKeyRange,
+        ) -> PartitionKeyRange:
+            return PartitionKeyRange(
+                f"{self.hemisphere}|{child_partition_key_range.start}",
+                f"{self.hemisphere}|{child_partition_key_range.end}",
+            )
+
+        def get_child_partitions(
+            self,
+            child_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+            parent_partitions_def: PartitionsDefinition,  # pylint: disable=unused-argument
+            parent_partition_key_range: PartitionKeyRange,
+        ) -> PartitionKeyRange:
+            return PartitionKeyRange(
+                parent_partition_key_range.start.split("|")[-1],
+                parent_partition_key_range.end.split("|")[-1],
+            )
+
+    @asset(partitions_def=upstream_partitions_def)
+    def upstream_asset():
+        pass
+
+    @asset(
+        partitions_def=downstream_partitions_def,
+        partition_mappings={"upstream_asset": HemisphereFilteringPartitionMapping("southern")},
+    )
+    def downstream_asset(upstream_asset):
+        assert upstream_asset
+
+    assert (
+        get_parent_partitions(
+            downstream_asset,
+            AssetKey("downstream_asset"),
+            upstream_asset,
+            AssetKey("upstream_asset"),
+            PartitionKeyRange("ringo", "paul"),
+        )
+        == PartitionKeyRange("southern|ringo", "southern|paul")
+    )
+
+    assert (
+        get_child_partitions(
+            downstream_asset,
+            AssetKey("downstream_asset"),
+            upstream_asset,
+            AssetKey("upstream_asset"),
+            PartitionKeyRange("southern|ringo", "southern|paul"),
+        )
+        == PartitionKeyRange("ringo", "paul")
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_time_window_partition_mapping.py
@@ -1,0 +1,108 @@
+import pendulum
+import pytest
+from dagster import (
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+    MonthlyPartitionsDefinition,
+)
+from dagster.core.asset_defs.asset_partitions import PartitionKeyRange
+from dagster.core.asset_defs.time_window_partition_mapping import (
+    TimeWindowPartitionMapping,
+    round_datetime_to_period,
+)
+from dagster.core.definitions.partition import ScheduleType
+
+
+def test_get_parent_partitions_same_partitioning():
+    child_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    parent_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    # single partition key
+    partition_key_range = PartitionKeyRange("2021-05-07", "2021-05-07")
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def, parent_partitions_def, partition_key_range
+    )
+    assert partition_key_range == result
+
+    # range of partition keys
+    partition_key_range = PartitionKeyRange("2021-05-07", "2021-05-09")
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def, parent_partitions_def, partition_key_range
+    )
+    assert partition_key_range == result
+
+
+def test_get_parent_partitions_same_partitioning_different_formats():
+    child_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    parent_partitions_def = DailyPartitionsDefinition(start_date="2021/05/05", fmt="%Y/%m/%d")
+
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def, parent_partitions_def, PartitionKeyRange("2021-05-07", "2021-05-09")
+    )
+    assert result == PartitionKeyRange("2021/05/07", "2021/05/09")
+
+
+def test_get_parent_partitions_hourly_child_daily_parent():
+    child_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
+    parent_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def,
+        parent_partitions_def,
+        PartitionKeyRange("2021-05-07-05:00", "2021-05-07-05:00"),
+    )
+    assert result == PartitionKeyRange("2021-05-07", "2021-05-07")
+
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def,
+        parent_partitions_def,
+        PartitionKeyRange("2021-05-07-05:00", "2021-05-09-09:00"),
+    )
+    assert result == PartitionKeyRange("2021-05-07", "2021-05-09")
+
+
+def test_get_parent_partitions_daily_child_hourly_parent():
+    child_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    parent_partitions_def = HourlyPartitionsDefinition(start_date="2021-05-05-00:00")
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def,
+        parent_partitions_def,
+        PartitionKeyRange("2021-05-07", "2021-05-07"),
+    )
+    assert result == PartitionKeyRange("2021-05-07-00:00", "2021-05-07-23:00")
+
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def,
+        parent_partitions_def,
+        PartitionKeyRange("2021-05-07", "2021-05-09"),
+    )
+    assert result == PartitionKeyRange("2021-05-07-00:00", "2021-05-09-23:00")
+
+
+def test_get_parent_partitions_monthly_child_daily_parent():
+    child_partitions_def = MonthlyPartitionsDefinition(start_date="2021-05-01")
+    parent_partitions_def = DailyPartitionsDefinition(start_date="2021-05-01")
+    result = TimeWindowPartitionMapping().get_parent_partitions(
+        child_partitions_def,
+        parent_partitions_def,
+        PartitionKeyRange("2021-05-01", "2021-07-01"),
+    )
+    assert result == PartitionKeyRange("2021-05-01", "2021-07-31")
+
+
+@pytest.mark.parametrize(
+    "dt_str, period, expected_str",
+    [
+        ("2020-01-01", ScheduleType.DAILY, "2020-01-01"),
+        ("2020-01-01 01:00:00", ScheduleType.DAILY, "2020-01-01"),
+        ("2020-01-01 01:00:00", ScheduleType.HOURLY, "2020-01-01 01:00:00"),
+        ("2020-01-01", ScheduleType.MONTHLY, "2020-01-01"),
+        ("2020-01-02", ScheduleType.MONTHLY, "2020-01-01"),
+        ("2020-01-02 01:00:00", ScheduleType.MONTHLY, "2020-01-01"),
+        ("2021-12-03", ScheduleType.WEEKLY, "2021-11-29"),
+        ("2021-12-03  01:00:00", ScheduleType.WEEKLY, "2021-11-29"),
+        ("2021-11-29", ScheduleType.WEEKLY, "2021-11-29"),
+    ],
+)
+def test_round_datetime_to_period(dt_str, period, expected_str):
+    dt = pendulum.parse(dt_str)
+    expected_dt = pendulum.parse(expected_str)
+    assert round_datetime_to_period(dt, period) == expected_dt

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
@@ -39,6 +39,12 @@ def test_daily_partitions():
         "2021-05-08", "2021-05-09"
     )
 
+    assert partitions_def.get_partition_keys_in_range("2021-05-01", "2021-05-03") == [
+        "2021-05-01",
+        "2021-05-02",
+        "2021-05-03",
+    ]
+
 
 def test_daily_partitions_with_end_offset():
     @daily_partitioned_config(start_date="2021-05-05", end_offset=2)
@@ -77,6 +83,12 @@ def test_monthly_partitions():
     assert partitions_def.time_window_for_partition_key("2021-05-01") == time_window(
         "2021-05-01", "2021-06-01"
     )
+
+    assert partitions_def.get_partition_keys_in_range("2021-05-01", "2021-07-01") == [
+        "2021-05-01",
+        "2021-06-01",
+        "2021-07-01",
+    ]
 
 
 def test_monthly_partitions_with_end_offset():
@@ -122,3 +134,9 @@ def test_hourly_partitions():
     assert partitions_def.time_window_for_partition_key("2021-05-05-01:00") == time_window(
         "2021-05-05T01:00:00", "2021-05-05T02:00:00"
     )
+
+    assert partitions_def.get_partition_keys_in_range("2021-05-05-01:00", "2021-05-05-03:00") == [
+        "2021-05-05-01:00",
+        "2021-05-05-02:00",
+        "2021-05-05-03:00",
+    ]

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -40,6 +40,11 @@ def test_static_partitions(partition_keys: List[str]):
     assert static_partitions.get_partition_keys() == partition_keys
 
 
+def test_static_partitions_partition_keys_in_range():
+    static_partitions = StaticPartitionsDefinition([str(x) for x in range(10)])
+    assert static_partitions.get_partition_keys_in_range("3", "6") == ["3", "4", "5", "6"]
+
+
 @pytest.mark.parametrize(
     argnames=["schedule_type", "start", "execution_day", "end", "error_message_regex"],
     ids=[


### PR DESCRIPTION
Built on top of https://github.com/dagster-io/dagster/pull/5764.

In present Dagster, each job can have a partitioning scheme, and each run can act on a single partition. In SDA-world, each asset can have its own partitioning scheme, and different step inputs and outputs within the same run can act on different partitions.

### Example usages:

Single partitioned asset.
```
from dagster import asset, DailyPartitionsDefinition

@asset(partitions_def=DailyPartitionsDefinition(start_date="2020-12-12"))
def my_asset():
    ...
```

Every partition in `downstream_asset` depends on the partition with the same date in `upstream_asset`:
```
from dagster import asset, DailyPartitionsDefinition

@asset(partitions_def=DailyPartitionsDefinition(start_date="2020-12-12"))
def upstream_asset():
    ...

@asset(partitions_def=DailyPartitionsDefinition(start_date="2020-12-12"))
def downstream_asset(upstream_asset):
    ...
```

User defines their own behavior for which partitions in `upstream_asset` correspond to which partitions in `downstream_asset`:
```
from dagster import asset, DailyPartitionsDefinition, PartitionMapping, PartitionsDefinition, PartitionKeyRange

class MyPartitionMapping(PartitionMapping):
    def get_parent_partitions(
        self,
        child_partitions_def: PartitionsDefinition,
        parent_partitions_def: PartitionsDefinition,
        child_partition_key_range: PartitionKeyRange,
    ) -> PartitionKeyRange:
        ...


    @abstractmethod
    def get_child_partitions(
        self,
        child_partitions_def: PartitionsDefinition,
        parent_partitions_def: PartitionsDefinition,
        parent_partition_key_range: PartitionKeyRange,
    ) -> PartitionKeyRange:
        ...
    
@asset(partitions_def=DailyPartitionsDefinition(start_date="2020-12-12"))
def upstream_asset():
    ...

@asset(
    partitions_def=DailyPartitionsDefinition(start_date="2020-12-12"),
    partition_mappings={"upstream_asset": MyPartitionMapping()},
)
def downstream_asset(upstream_asset):
    ...
```

### Some elements of this approach
* `PartitionMapping` objects define the correspondence between partitions in an asset and partitions in an asset that it depends on.
* This PR tries to build asset partitions to be performant from the start by including PartitionKeyRanges.

### This PR is split into a few commits
* The first adds generic asset-partitioning.
* The second adds a default `PartitionMapping` for `TimeWindowPartitionsDefinitions`.

We still need to figure out the best way to wire partition information through to the execution contexts. I'm imagining that whatever machinery is responsible for constructing asset-partitioned runs will supply a run tag with a dictionary value that specifies the partition key(s) for each input and output in the run. Then, the contents of that tag needs to be exposed in the contexts. 

In present Dagster, the `OpExecutionContext` has a `partition_key` property. With asset partitions, the context object provided to asset ops will need to have methods like `get_partition_key_for_output` and `get_partition_key_for_input`. What's the best way to provide these? One option would be to include these methods on regular `OpExecutionContext`s. Another would be to have a special `AssetOpExecutionContext`, which gets hairy because we'd need to wrap the compute function.