### PR TITLE
[dagit] Repair Launchpad panel op selection

### DIFF
--- a/js_modules/dagit/packages/core/src/execute/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/execute/RunPreview.tsx
@@ -266,7 +266,8 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
     });
   }
 
-  const {resources, solids, ...rest} = rootCompositeChildren;
+  const {resources, ops, solids, ...rest} = rootCompositeChildren;
+  const hasOps = !!ops?.fields;
 
   const itemsIn = (parents: string[], items: {name: string; isRequired: boolean}[]) => {
     const boxes = items
@@ -290,9 +291,11 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
         const isMissing = path.some((_, idx) =>
           missingNodes.includes(path.slice(0, idx + 1).join('.')),
         );
+
         if (errorsOnly && !isInvalid) {
           return false;
         }
+
         const state =
           isMissing && item.isRequired
             ? 'missing'
@@ -388,7 +391,12 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
             </RuntimeAndResourcesSection>
             <Section>
               <SectionTitle>Ops</SectionTitle>
-              <ItemSet>{itemsIn(['solids'], solids?.fields || [])}</ItemSet>
+              <ItemSet>
+                {itemsIn(
+                  [hasOps ? 'ops' : 'solids'],
+                  (hasOps ? ops?.fields : solids?.fields) || [],
+                )}
+              </ItemSet>
             </Section>
             <div style={{height: 50}} />
           </div>


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

In the Run preview panel on the lower right of the Launchpad page, we aren't showing ops. This appears to be because we're still looking for `solids` in the configuration, which may not exist.

Instead, look for `ops` *or* `solids`, and use whichever is there.

## Test Plan

View jobs and pipelines in Dagit. Verify that the panel reflects the solid selection accurately.