### PR TITLE
[dagit] Remove label on outer composite op box

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/PipelineGraph.tsx
+++ b/js_modules/dagit/packages/core/src/graph/PipelineGraph.tsx
@@ -40,10 +40,6 @@ interface IPipelineContentsProps extends IPipelineGraphProps {
   bounds: {top: number; left: number; right: number; bottom: number};
 }
 
-interface IPipelineContentsState {
-  highlighted: Edge[];
-}
-
 /**
  * Identifies groups of ops that share a similar `prefix.` and returns
  * an array of bounding boxes and common prefixes. Used to render lightweight
@@ -85,136 +81,125 @@ function computeOpPrefixBoundingBoxes(layout: IFullPipelineLayout) {
   return boxes;
 }
 
-class PipelineGraphContents extends React.PureComponent<
-  IPipelineContentsProps,
-  IPipelineContentsState
-> {
-  state: IPipelineContentsState = {
-    highlighted: [],
-  };
+const PipelineGraphContents: React.FC<IPipelineContentsProps> = React.memo((props) => {
+  const [highlighted, setHighlighted] = React.useState<Edge[]>(() => []);
 
-  onHighlightEdges = (highlighted: Edge[]) => {
-    this.setState({highlighted});
-  };
+  const {
+    layout,
+    minified,
+    ops,
+    bounds,
+    focusOps,
+    parentOp,
+    parentHandleID,
+    onClickOp = NoOp,
+    onDoubleClickOp = NoOp,
+    onEnterSubgraph = NoOp,
+    highlightedOps,
+    selectedOp,
+  } = props;
 
-  render() {
-    const {
-      layout,
-      minified,
-      ops,
-      bounds,
-      focusOps,
-      parentOp,
-      parentHandleID,
-      onClickOp = NoOp,
-      onDoubleClickOp = NoOp,
-      onEnterSubgraph = NoOp,
-      highlightedOps,
-      selectedOp,
-    } = this.props;
-
-    return (
-      <>
-        {parentOp && layout.parent && layout.parent.invocationBoundingBox.width > 0 && (
-          <SVGLabeledParentRect
-            {...layout.parent.invocationBoundingBox}
-            key={`composite-rect-${parentHandleID}`}
-            label={parentOp.name}
-            fill={ColorsWIP.Gray50}
-            minified={minified}
-          />
-        )}
-        {/* {selectedOp && layout.ops[selectedOp.name] && (
-          // this rect is hidden beneath the user's selection with a React key so that
-          // when they expand the composite op React sees this component becoming
-          // the one above and re-uses the DOM node. This allows us to animate the rect's
-          // bounds from the parent layout to the inner layout with no React state.
-          <SVGLabeledParentRect
-            {...layout.ops[selectedOp.name].op}
-            key={`composite-rect-${selectedHandleID}`}
-            label={''}
-            fill={ColorsWIP.Gray50}
-            minified={true}
-          />
-        )} */}
-
-        {parentOp && (
-          <ParentOpNode
-            onClickOp={onClickOp}
-            onDoubleClick={(name) => onDoubleClickOp({name})}
-            onHighlightEdges={this.onHighlightEdges}
-            highlightedEdges={this.state.highlighted}
-            key={`composite-rect-${parentHandleID}-definition`}
-            minified={minified}
-            op={parentOp}
-            layout={layout}
-          />
-        )}
-        <OpLinks
-          ops={ops}
-          layout={layout}
-          color={ColorsWIP.KeylineGray}
-          connections={layout.connections}
-          onHighlight={this.onHighlightEdges}
+  return (
+    <>
+      {parentOp && layout.parent && layout.parent.invocationBoundingBox.width > 0 && (
+        <SVGLabeledParentRect
+          {...layout.parent.invocationBoundingBox}
+          key={`composite-rect-${parentHandleID}`}
+          label=""
+          fill={ColorsWIP.Yellow50}
+          minified={minified}
         />
-        <OpLinks
-          ops={ops}
-          layout={layout}
-          color={ColorsWIP.Gray500}
-          onHighlight={this.onHighlightEdges}
-          connections={layout.connections.filter(({from, to}) =>
-            isHighlighted(this.state.highlighted, {
-              a: from.opName,
-              b: to.opName,
-            }),
-          )}
+      )}
+      {/* {selectedOp && layout.ops[selectedOp.name] && (
+        // this rect is hidden beneath the user's selection with a React key so that
+        // when they expand the composite op React sees this component becoming
+        // the one above and re-uses the DOM node. This allows us to animate the rect's
+        // bounds from the parent layout to the inner layout with no React state.
+        <SVGLabeledParentRect
+          {...layout.ops[selectedOp.name].op}
+          key={`composite-rect-${selectedHandleID}`}
+          label={''}
+          fill={ColorsWIP.Gray50}
+          minified={true}
         />
-        {computeOpPrefixBoundingBoxes(layout).map((box, idx) => (
-          <rect
-            key={idx}
-            {...box}
-            stroke="rgb(230, 219, 238)"
-            fill="rgba(230, 219, 238, 0.2)"
-            strokeWidth={2}
-          />
-        ))}
-        <foreignObject width={layout.width} height={layout.height} style={{pointerEvents: 'none'}}>
-          {ops
-            .filter((op) => {
-              const box = layout.ops[op.name].boundingBox;
-              return (
-                box.x + box.width >= bounds.left &&
-                box.y + box.height >= bounds.top &&
-                box.x < bounds.right &&
-                box.y < bounds.bottom
-              );
-            })
-            .map((op) => (
-              <OpNode
-                key={op.name}
-                invocation={op}
-                definition={op.definition}
-                minified={minified}
-                onClick={() => onClickOp({name: op.name})}
-                onDoubleClick={() => onDoubleClickOp({name: op.name})}
-                onEnterComposite={() => onEnterSubgraph({name: op.name})}
-                onHighlightEdges={this.onHighlightEdges}
-                layout={layout.ops[op.name]}
-                selected={selectedOp === op}
-                focused={focusOps.includes(op)}
-                highlightedEdges={
-                  isOpHighlighted(this.state.highlighted, op.name)
-                    ? this.state.highlighted
-                    : EmptyHighlightedArray
-                }
-                dim={highlightedOps.length > 0 && highlightedOps.indexOf(op) === -1}
-              />
-            ))}
-        </foreignObject>
-      </>
-    );
-  }
-}
+      )} */}
+
+      {parentOp && (
+        <ParentOpNode
+          onClickOp={onClickOp}
+          onDoubleClick={(name) => onDoubleClickOp({name})}
+          onHighlightEdges={setHighlighted}
+          highlightedEdges={highlighted}
+          key={`composite-rect-${parentHandleID}-definition`}
+          minified={minified}
+          op={parentOp}
+          layout={layout}
+        />
+      )}
+      <OpLinks
+        ops={ops}
+        layout={layout}
+        color={ColorsWIP.KeylineGray}
+        connections={layout.connections}
+        onHighlight={setHighlighted}
+      />
+      <OpLinks
+        ops={ops}
+        layout={layout}
+        color={ColorsWIP.Gray500}
+        onHighlight={setHighlighted}
+        connections={layout.connections.filter(({from, to}) =>
+          isHighlighted(highlighted, {
+            a: from.opName,
+            b: to.opName,
+          }),
+        )}
+      />
+      {computeOpPrefixBoundingBoxes(layout).map((box, idx) => (
+        <rect
+          key={idx}
+          {...box}
+          stroke="rgb(230, 219, 238)"
+          fill="rgba(230, 219, 238, 0.2)"
+          strokeWidth={2}
+        />
+      ))}
+      <foreignObject width={layout.width} height={layout.height} style={{pointerEvents: 'none'}}>
+        {ops
+          .filter((op) => {
+            const box = layout.ops[op.name].boundingBox;
+            return (
+              box.x + box.width >= bounds.left &&
+              box.y + box.height >= bounds.top &&
+              box.x < bounds.right &&
+              box.y < bounds.bottom
+            );
+          })
+          .map((op) => (
+            <OpNode
+              key={op.name}
+              invocation={op}
+              definition={op.definition}
+              minified={minified}
+              onClick={() => onClickOp({name: op.name})}
+              onDoubleClick={() => onDoubleClickOp({name: op.name})}
+              onEnterComposite={() => onEnterSubgraph({name: op.name})}
+              onHighlightEdges={setHighlighted}
+              layout={layout.ops[op.name]}
+              selected={selectedOp === op}
+              focused={focusOps.includes(op)}
+              highlightedEdges={
+                isOpHighlighted(highlighted, op.name) ? highlighted : EmptyHighlightedArray
+              }
+              dim={highlightedOps.length > 0 && highlightedOps.indexOf(op) === -1}
+            />
+          ))}
+      </foreignObject>
+    </>
+  );
+});
+
+PipelineGraphContents.displayName = 'PipelineGraphContents';
 
 // This is a specific empty array we pass to represent the common / empty case
 // so that OpNode can use shallow equality comparisons in shouldComponentUpdate.


### PR DESCRIPTION
## Summary

Remove the label on the outer composite op box to try to alleviate some confusion. Also tweak the color to give it a tiny bit more contrast.

Before:

<img width="939" alt="Screen Shot 2021-11-29 at 9 57 43 AM" src="https://user-images.githubusercontent.com/2823852/143900922-cd47082b-c915-46ab-8161-8ec24ded79e6.png">

After:

<img width="942" alt="Screen Shot 2021-11-29 at 9 42 04 AM" src="https://user-images.githubusercontent.com/2823852/143900932-ee75e81c-5e80-4303-a357-ddc683728e61.png">


## Test Plan

Expand a composite solid, verify rendering above.