### PR TITLE
refactor: separate resume_run method on launchers

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1538,7 +1538,7 @@ records = instance.get_event_records(
         Args:
             run_id (str): The id of the run the launch.
         """
-        from dagster.core.launcher import LaunchRunContext
+        from dagster.core.launcher import ResumeRunContext
         from dagster.core.events import EngineEventData
         from dagster.daemon.monitoring import RESUME_RUN_LOG_MESSAGE
 
@@ -1558,11 +1558,10 @@ records = instance.get_event_records(
         )
 
         try:
-            self._run_launcher.launch_run(
-                LaunchRunContext(
+            self._run_launcher.resume_run(
+                ResumeRunContext(
                     pipeline_run=run,
                     workspace=workspace,
-                    resume_from_failure=True,
                     resume_attempt_number=attempt_number,
                 )
             )

--- a/python_modules/dagster/dagster/core/launcher/__init__.py
+++ b/python_modules/dagster/dagster/core/launcher/__init__.py
@@ -1,2 +1,8 @@
-from .base import CheckRunHealthResult, LaunchRunContext, RunLauncher, WorkerStatus
+from .base import (
+    CheckRunHealthResult,
+    LaunchRunContext,
+    ResumeRunContext,
+    RunLauncher,
+    WorkerStatus,
+)
 from .default_run_launcher import DefaultRunLauncher

--- a/python_modules/dagster/dagster/core/launcher/base.py
+++ b/python_modules/dagster/dagster/core/launcher/base.py
@@ -15,7 +15,19 @@ class LaunchRunContext(NamedTuple):
 
     pipeline_run: PipelineRun
     workspace: Optional[IWorkspace]
-    resume_from_failure: bool = False
+
+    @property
+    def pipeline_code_origin(self) -> Optional[PipelinePythonOrigin]:
+        return self.pipeline_run.pipeline_code_origin
+
+
+class ResumeRunContext(NamedTuple):
+    """
+    Context available within a run launcher's resume_run call.
+    """
+
+    pipeline_run: PipelineRun
+    workspace: Optional[IWorkspace]
     resume_attempt_number: Optional[int] = None
 
     @property
@@ -92,4 +104,12 @@ class RunLauncher(ABC, MayHaveInstanceWeakref):
         return False
 
     def check_run_worker_health(self, run: PipelineRun) -> CheckRunHealthResult:
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "This run launcher does not support run monitoring. Please disable it on your instance."
+        )
+
+    def resume_run(self, context: ResumeRunContext) -> None:
+        raise NotImplementedError(
+            "This run launcher does not support resuming runs. If using "
+            "run monitoring, set max_resume_run_attempts to 0."
+        )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -24,6 +24,7 @@ class TestRunLauncher(RunLauncher, ConfigurableClass):
     def __init__(self, inst_data=None):
         self._inst_data = inst_data
         self.launch_run_calls = 0
+        self.resume_run_calls = 0
         super().__init__()
 
     @property
@@ -40,6 +41,9 @@ class TestRunLauncher(RunLauncher, ConfigurableClass):
 
     def launch_run(self, context):
         self.launch_run_calls += 1
+
+    def resume_run(self, context):
+        self.resume_run_calls += 1
 
     def join(self, timeout=30):
         pass
@@ -138,20 +142,25 @@ def test_monitor_started(instance, workspace, logger):
         monitor_started_run(instance, workspace, run, logger)
         assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
         assert instance.run_launcher.launch_run_calls == 0
+        assert instance.run_launcher.resume_run_calls == 0
 
     monitor_started_run(instance, workspace, run, logger)
     assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
-    assert instance.run_launcher.launch_run_calls == 1
+    assert instance.run_launcher.launch_run_calls == 0
+    assert instance.run_launcher.resume_run_calls == 1
 
     monitor_started_run(instance, workspace, run, logger)
     assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
-    assert instance.run_launcher.launch_run_calls == 2
+    assert instance.run_launcher.launch_run_calls == 0
+    assert instance.run_launcher.resume_run_calls == 2
 
     monitor_started_run(instance, workspace, run, logger)
     assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.STARTED
-    assert instance.run_launcher.launch_run_calls == 3
+    assert instance.run_launcher.launch_run_calls == 0
+    assert instance.run_launcher.resume_run_calls == 3
 
     # exausted the 3 attempts
     monitor_started_run(instance, workspace, run, logger)
     assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.FAILURE
-    assert instance.run_launcher.launch_run_calls == 3
+    assert instance.run_launcher.launch_run_calls == 0
+    assert instance.run_launcher.resume_run_calls == 3

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -4,7 +4,7 @@ import kubernetes
 from dagster import EventMetadataEntry, Field, Noneable, StringSource, check
 from dagster.cli.api import ExecuteRunArgs
 from dagster.core.events import EngineEventData
-from dagster.core.launcher import LaunchRunContext, RunLauncher
+from dagster.core.launcher import LaunchRunContext, ResumeRunContext, RunLauncher
 from dagster.core.launcher.base import CheckRunHealthResult, WorkerStatus
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
@@ -266,17 +266,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             volumes=self._volumes,
         )
 
-    def launch_run(self, context: LaunchRunContext) -> None:
-        run = context.pipeline_run
-
-        job_name = get_job_name_from_run_id(
-            run.run_id, resume_attempt_number=context.resume_attempt_number
-        )
+    def _launch_k8s_job_with_args(self, job_name, args, run, pipeline_origin):
         pod_name = job_name
 
         user_defined_k8s_config = get_user_defined_k8s_config(frozentags(run.tags))
-
-        pipeline_origin = context.pipeline_code_origin
         repository_origin = pipeline_origin.repository_origin
 
         job_config = (
@@ -290,22 +283,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             {DOCKER_IMAGE_TAG: job_config.job_image},
         )
 
-        if not context.resume_from_failure:
-            run_args = ExecuteRunArgs(
-                pipeline_origin=pipeline_origin,
-                pipeline_run_id=run.run_id,
-                instance_ref=self._instance.get_ref(),
-            ).get_command_args()
-        else:
-            run_args = ResumeRunArgs(
-                pipeline_origin=pipeline_origin,
-                pipeline_run_id=run.run_id,
-                instance_ref=self._instance.get_ref(),
-            ).get_command_args()
-
         job = construct_dagster_k8s_job(
             job_config=job_config,
-            args=run_args,
+            args=args,
             job_name=job_name,
             pod_name=pod_name,
             component="run_worker",
@@ -338,6 +318,34 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             ),
             cls=self.__class__,
         )
+
+    def launch_run(self, context: LaunchRunContext) -> None:
+        run = context.pipeline_run
+        job_name = get_job_name_from_run_id(run.run_id)
+        pipeline_origin = context.pipeline_code_origin
+
+        args = ExecuteRunArgs(
+            pipeline_origin=pipeline_origin,
+            pipeline_run_id=run.run_id,
+            instance_ref=self._instance.get_ref(),
+        ).get_command_args()
+
+        self._launch_k8s_job_with_args(job_name, args, run, pipeline_origin)
+
+    def resume_run(self, context: ResumeRunContext) -> None:
+        run = context.pipeline_run
+        job_name = get_job_name_from_run_id(
+            run.run_id, resume_attempt_number=context.resume_attempt_number
+        )
+        pipeline_origin = context.pipeline_code_origin
+
+        args = ResumeRunArgs(
+            pipeline_origin=pipeline_origin,
+            pipeline_run_id=run.run_id,
+            instance_ref=self._instance.get_ref(),
+        ).get_command_args()
+
+        self._launch_k8s_job_with_args(job_name, args, run, pipeline_origin)
 
     # https://github.com/dagster-io/dagster/issues/2741
     def can_terminate(self, run_id):


### PR DESCRIPTION
Probably should have done this from the start. Creates a better separation between launchers which support resuming and those that currently don't