### PR TITLE
Mypy fixes for the @job decorator

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/job.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job.py
@@ -110,6 +110,7 @@ def job(
     logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
     hooks: Optional[AbstractSet[HookDefinition]] = None,
+    op_retry_policy: Optional[RetryPolicy] = None,
     version_strategy: Optional[VersionStrategy] = None,
 ) -> _Job:
     ...

--- a/python_modules/dagster/dagster/core/definitions/decorators/job.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Dict, Optional, Union, overload
 
 from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -93,6 +93,26 @@ class _Job:
         )
         update_wrapper(job_def, fn)
         return job_def
+
+
+@overload
+def job(name: Callable[..., Any]) -> JobDefinition:
+    ...
+
+
+@overload
+def job(
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    resource_defs: Optional[Dict[str, ResourceDefinition]] = None,
+    config: Union[ConfigMapping, Dict[str, Any], "PartitionedConfig"] = None,
+    tags: Optional[Dict[str, Any]] = None,
+    logger_defs: Optional[Dict[str, LoggerDefinition]] = None,
+    executor_def: Optional["ExecutorDefinition"] = None,
+    hooks: Optional[AbstractSet[HookDefinition]] = None,
+    version_strategy: Optional[VersionStrategy] = None,
+) -> _Job:
+    ...
 
 
 def job(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_typechecks.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_typechecks.py
@@ -1,0 +1,20 @@
+from dagster import job, op, sensor
+
+
+@op
+def foo_op(_):
+    return
+
+
+@job
+def foo_job():
+    foo_op()
+
+
+@sensor(job=foo_job)
+def foo_sensor(_context):
+    return
+
+
+def test_sensor_typechecks_when_defined_on_job_decorated_function():
+    assert foo_sensor is not None


### PR DESCRIPTION
This is required in order for the sensor APIs (etc.?) to type check correctly with jobs constructed using `@job` rather than `GraphDefinition.to_job()`.