### PR TITLE
Remove telemetry whitelist from docs

### DIFF
--- a/docs/content/getting-started/telemetry.mdx
+++ b/docs/content/getting-started/telemetry.mdx
@@ -8,16 +8,6 @@ As an open source project, we collect usage statistics to better understand how 
 
 We will not see or store any data that is processed within ops and graphs. We will not see or store op definitions (including generated context) or graph definitions (including resources).
 
-The telemetry-instrumented functions are:
-
-```python file=../../../python_modules/dagster/dagster/core/telemetry.py startafter=start_TELEMETRY_WHITELISTED_FUNCTIONS endbefore=end_TELEMETRY_WHITELISTED_FUNCTIONS
-TELEMETRY_WHITELISTED_FUNCTIONS = {
-    "_logged_execute_pipeline",
-    "execute_execute_command",
-    "execute_launch_command",
-}
-```
-
 To see the logs we send, open `$DAGSTER_HOME/logs/` if `$DAGSTER_HOME` is set or `~/.dagster/logs/` if not set (after calling the instrumented functions).
 
 If you'd like to opt-out, you can add the following to `$DAGSTER_HOME/dagster.yaml` (creating that file if necessary):

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -42,13 +42,11 @@ UPDATE_REPO_STATS = "update_repo_stats"
 START_DAGIT_WEBSERVER = "start_dagit_webserver"
 TELEMETRY_VERSION = "0.2"
 
-# start_TELEMETRY_WHITELISTED_FUNCTIONS
 TELEMETRY_WHITELISTED_FUNCTIONS = {
     "_logged_execute_pipeline",
     "execute_execute_command",
     "execute_launch_command",
 }
-# end_TELEMETRY_WHITELISTED_FUNCTIONS
 
 
 def telemetry_wrapper(f):


### PR DESCRIPTION
List is not super well formatted, and potentially misleading (names a bunch of internal functions instead of the user-facing functions which may call them).