### PR TITLE
unbreak foreign assets in dagit

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -494,7 +494,8 @@ def external_asset_graph_from_defs(
 
     source_asset_keys = all_upstream_asset_keys.difference(node_defs_by_asset_key.keys())
     asset_nodes = [
-        ExternalAssetNode(asset_key=asset_key, dependencies=[]) for asset_key in source_asset_keys
+        ExternalAssetNode(asset_key=asset_key, dependencies=[], job_names=[])
+        for asset_key in source_asset_keys
     ]
 
     for asset_key, node_tuple_list in node_defs_by_asset_key.items():


### PR DESCRIPTION
Before this change, I was running into this error when trying to load up a repository with a `ForeignAsset`:

```
TypeError: 'NoneType' object is not iterable
  File "/Users/sryza/dagster/python_modules/dagster/dagster/core/workspace/context.py", line 535, in _load_location
    location = self._create_location_from_origin(origin)
  File "/Users/sryza/dagster/python_modules/dagster/dagster/core/workspace/context.py", line 462, in _create_location_from_origin
    return GrpcServerRepositoryLocation(
  File "/Users/sryza/dagster/python_modules/dagster/dagster/core/host_representation/repository_location.py", line 528, in __init__
    self.external_repositories = {
  File "/Users/sryza/dagster/python_modules/dagster/dagster/core/host_representation/repository_location.py", line 529, in <dictcomp>
    repo_name: ExternalRepository(
  File "/Users/sryza/dagster/python_modules/dagster/dagster/core/host_representation/external.py", line 77, in __init__
    for job_name in asset_node.job_names:
```