### PR TITLE
[dagit] Repair hidden repo keys for single repo

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.test.tsx
@@ -128,6 +128,23 @@ describe('Repository options', () => {
       });
     });
 
+    it(`initializes with one repo if it's the only one, even though it's hidden`, async () => {
+      window.localStorage.setItem(HIDDEN_REPO_KEYS, `["${repoOne}:${locationOne}"]`);
+      render(
+        <TestProvider
+          apolloProps={{mocks: [defaultMocks, mocksWithOne]}}
+          routerProps={{initialEntries: ['/instance/runs']}}
+        >
+          <LeftNavRepositorySection />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        // Three links. One for repo, two for pipelines.
+        expect(screen.getAllByRole('link')).toHaveLength(3);
+      });
+    });
+
     it('initializes empty, if multiple options and no localStorage', async () => {
       render(
         <TestProvider

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -53,6 +53,11 @@ const useNavVisibleRepos = (
   // Collect hidden keys from localStorage and remove them from the visible repo key list.
   React.useEffect(() => {
     setVisibleKeys(() => {
+      // If there's only one key, skip the local storage check -- we have to show this one.
+      if (allKeys.length === 1) {
+        return new Set(allKeys);
+      }
+
       const hiddenKeys = hiddenKeysFromLocalStorage();
       const visible = allKeys.filter((key) => !hiddenKeys.has(key));
 


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

There is an edge case with the left nav where one might hide a repo key when multiple repos are loaded into the workspace, but if subsequently only that repo is loaded in the workspace, it remains hidden and inaccessible. The only recourse in that case is to load the multi-repo workspace again or clear one's localStorage for that value.

To fix this, if there's only one repo in the workspace, make sure we always show it. This has the added effect of removing the repo key from the hidden keys list in localStorage, which I think is fine.

## Test Plan

Jest. Load workspace with many repos, hide one. Reload workspace with only the newly-hidden repo, verify that it appears in the left nav and has been removed from the hidden keys list in localStorage.