### PR TITLE
[dagit] Don't show timezone on daemon status

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/DaemonList.tsx
+++ b/js_modules/dagit/packages/core/src/instance/DaemonList.tsx
@@ -38,7 +38,7 @@ interface Props {
   daemonStatuses: DaemonStatus[] | undefined;
 }
 
-const TIME_FORMAT = {showSeconds: true, showTimezone: true};
+const TIME_FORMAT = {showSeconds: true, showTimezone: false};
 
 export const DaemonList = (props: Props) => {
   const {daemonStatuses} = props;
@@ -75,7 +75,7 @@ export const DaemonList = (props: Props) => {
                         timestamp={{unix: daemon.lastHeartbeatTime}}
                         timeFormat={TIME_FORMAT}
                       />
-                      <span>({`${moment.unix(daemon.lastHeartbeatTime).fromNow()}`})</span>
+                      <span>&nbsp;({`${moment.unix(daemon.lastHeartbeatTime).fromNow()}`})</span>
                     </Group>
                   ) : (
                     'Never'


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Relates to #5626.

Don't show the timezone on daemon status, as this may be confusing. The time rendered here uses the user's timezone setting, so it should appear to be the local time.

Also fixed some spacing.

## Test Plan

View `/instance/health`, verify that the timezone is no longer shown.