### PR TITLE
add flag to configure asset_sensor to fire for every materialization

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/sensor.py
@@ -110,6 +110,7 @@ def asset_sensor(
     description: Optional[str] = None,
     job: Optional[Union[GraphDefinition, JobDefinition]] = None,
     jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
+    last_event_only: bool = True,
 ) -> Callable[
     [
         Callable[
@@ -197,6 +198,7 @@ def asset_sensor(
             description=description,
             job=job,
             jobs=jobs,
+            last_event_only=last_event_only,
         )
 
     return inner

--- a/python_modules/dagster/dagster/core/definitions/decorators/sensor.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/sensor.py
@@ -110,7 +110,7 @@ def asset_sensor(
     description: Optional[str] = None,
     job: Optional[Union[GraphDefinition, JobDefinition]] = None,
     jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
-    last_event_only: bool = True,
+    on_every_event: bool = False,
 ) -> Callable[
     [
         Callable[
@@ -153,6 +153,10 @@ def asset_sensor(
         description (Optional[str]): A human-readable description of the sensor.
         job (Optional[Union[GraphDefinition, JobDefinition]]): The job to be executed when the sensor fires.
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition]]]): (experimental) A list of jobs to be executed when the sensor fires.
+        on_every_event (bool): If True, the decorated function will be evaluated for every
+            materialization event since the last sensor tick.  The default value is False, where the
+            decorated function is evaluated at most once, for the most recent materialization event,
+            if one has been recorded since the last sensor tick.
     """
 
     check.opt_str_param(name, "name")
@@ -198,7 +202,7 @@ def asset_sensor(
             description=description,
             job=job,
             jobs=jobs,
-            last_event_only=last_event_only,
+            on_every_event=on_every_event,
         )
 
     return inner

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -533,6 +533,10 @@ class AssetSensorDefinition(SensorDefinition):
         description (Optional[str]): A human-readable description of the sensor.
         job (Optional[Union[GraphDefinition, JobDefinition]]): The job object to target with this sensor.
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition]]]): (experimental) A list of jobs to be executed when the sensor fires.
+        on_every_event (bool): If True, the evaluation function will be evaluated for
+            every materialization event since the last sensor tick.  The default value is False,
+            where the decorated function is evaluated at most once, for the most recent
+            materialization event, if one has been recorded since the last sensor tick.
 
     """
 
@@ -551,7 +555,7 @@ class AssetSensorDefinition(SensorDefinition):
         description: Optional[str] = None,
         job: Optional[Union[GraphDefinition, JobDefinition]] = None,
         jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
-        last_event_only: bool = True,
+        on_every_event: bool = False,
     ):
         self._asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
 
@@ -574,7 +578,7 @@ class AssetSensorDefinition(SensorDefinition):
                         after_cursor=after_cursor,
                     ),
                     ascending=False,
-                    limit=1 if last_event_only else None,
+                    limit=None if on_every_event else 1,
                 )
 
                 if not event_records:


### PR DESCRIPTION
The existing implementation gets the most recent materialization for each sensor interval.  This change allows the materialization function to get called for every materialization, regardless of distribution across intervals.

Addresses: https://github.com/dagster-io/dagster/issues/5699

## Test Plan
BK


