### PR TITLE
Permit deploy_ecs example to set ECS secrets

### DIFF
--- a/examples/deploy_ecs/docker-compose.yml
+++ b/examples/deploy_ecs/docker-compose.yml
@@ -72,6 +72,8 @@ services:
             - "ecs:RegisterTaskDefinition"
             - "ecs:RunTask"
             - "ecs:TagResource"
+            - "secretsmanager:ListSecrets"
+            - "secretsManager:GetSecretValue"
           Resource:
             - "*"
         - Effect: "Allow"


### PR DESCRIPTION
I forgot to do this in https://github.com/dagster-io/dagster/pull/5614