### PR TITLE
Change dask executor config depending on if using job

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -246,7 +246,13 @@ class DaskExecutor(Executor):
                         for key in step_input.dependency_keys:
                             dependencies.append(execution_futures_dict[key])
 
-                    run_config = dict(plan_context.run_config, execution={"in_process": {}})
+                    # If the mode name is the default mode name for a job, then we can be
+                    # reasonably confident that we are executing a job, in which case it doesn't
+                    # make sense to be able to switch on in_process execution.
+                    if plan_context.pipeline_run.mode == "default":
+                        run_config = plan_context.run_config
+                    else:
+                        run_config = dict(plan_context.run_config, execution={"in_process": {}})
 
                     dask_task_name = "%s.%s" % (pipeline_name, step.key)
 

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -246,10 +246,7 @@ class DaskExecutor(Executor):
                         for key in step_input.dependency_keys:
                             dependencies.append(execution_futures_dict[key])
 
-                    # If the mode name is the default mode name for a job, then we can be
-                    # reasonably confident that we are executing a job, in which case it doesn't
-                    # make sense to be able to switch on in_process execution.
-                    if plan_context.pipeline_run.mode == "default":
+                    if plan_context.pipeline.get_definition().is_job:
                         run_config = plan_context.run_config
                     else:
                         run_config = dict(plan_context.run_config, execution={"in_process": {}})

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
@@ -14,6 +14,8 @@ from dagster import (
     execute_pipeline_iterator,
     file_relative_path,
     fs_io_manager,
+    job,
+    op,
     pipeline,
     reconstructable,
     solid,
@@ -308,3 +310,24 @@ def test_dask_executor_memoization():
         )
         assert result.success
         assert len(result.step_event_list) == 0
+
+
+@op
+def the_op():
+    return 5
+
+
+@job(executor_def=dask_executor)
+def the_job():
+    the_op()
+
+
+def test_dask_executor_job():
+    with instance_for_test() as instance:
+        result = execute_pipeline(
+            reconstructable(the_job),
+            instance=instance,
+            run_config={"execution": {"config": {"cluster": {"local": {"timeout": 30}}}}},
+        )
+        assert result.success
+        assert result.output_for_solid("the_op") == 5


### PR DESCRIPTION
The check that I chose here is maybe not the correct one. If someone has a pipeline with a mode default, and put the dask executor on it, then we might run into a problem.