### PR TITLE
Return Unstarted Runs by Step

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1221,7 +1221,8 @@ type NodeInvocationSite {
 
 type InProgressRunsByStep {
   stepKey: String!
-  runs: [Run!]!
+  unstartedRuns: [Run!]!
+  inProgressRuns: [Run!]!
 }
 
 union RepositoryOrError = PythonError | Repository | RepositoryNotFoundError

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -125,7 +125,7 @@ def get_in_progress_runs_for_job(graphene_info, job_name):
     return instance.get_runs(in_progress_runs_filter)
 
 
-def get_in_progress_runs_by_in_progress_step(graphene_info, in_progress_runs, step_keys):
+def get_in_progress_runs_by_step(graphene_info, in_progress_runs, step_keys):
     from ..schema.pipelines.pipeline import GrapheneInProgressRunsByStep, GrapheneRun
 
     in_progress_runs_by_step = {}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -8,7 +8,7 @@ from dagster.core.host_representation import (
 )
 from dagster.core.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
 from dagster_graphql.implementation.fetch_runs import (
-    get_in_progress_runs_by_in_progress_step,
+    get_in_progress_runs_by_step,
     get_in_progress_runs_for_job,
 )
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
@@ -255,7 +255,7 @@ class GrapheneRepository(graphene.ObjectType):
         asset_node_keys = [
             node.op_name for node in self._repository.get_external_asset_nodes() if node.op_name
         ]
-        return get_in_progress_runs_by_in_progress_step(
+        return get_in_progress_runs_by_step(
             _graphene_info, in_progress_runs, asset_node_keys
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -255,9 +255,7 @@ class GrapheneRepository(graphene.ObjectType):
         asset_node_keys = [
             node.op_name for node in self._repository.get_external_asset_nodes() if node.op_name
         ]
-        return get_in_progress_runs_by_step(
-            _graphene_info, in_progress_runs, asset_node_keys
-        )
+        return get_in_progress_runs_by_step(_graphene_info, in_progress_runs, asset_node_keys)
 
 
 class GrapheneRepositoryConnection(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -688,7 +688,8 @@ class GrapheneRunOrError(graphene.Union):
 
 class GrapheneInProgressRunsByStep(graphene.ObjectType):
     stepKey = graphene.NonNull(graphene.String)
-    runs = non_null_list(GrapheneRun)
+    unstartedRuns = non_null_list(GrapheneRun)
+    inProgressRuns = non_null_list(GrapheneRun)
 
     class Meta:
         name = "InProgressRunsByStep"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
@@ -24,6 +24,8 @@ from dagster import (
     Field,
     InputDefinition,
     Int,
+    IOManager,
+    IOManagerDefinition,
     Materialization,
     ModeDefinition,
     Noneable,
@@ -57,7 +59,7 @@ from dagster import (
     usable_as_dagster_type,
     weekly_schedule,
 )
-from dagster.core.asset_defs import asset, build_assets_job
+from dagster.core.asset_defs import ForeignAsset, asset, build_assets_job
 from dagster.core.definitions.decorators.sensor import sensor
 from dagster.core.definitions.reconstructable import ReconstructableRepository
 from dagster.core.definitions.sensor_definition import RunRequest, SkipReason
@@ -1256,8 +1258,24 @@ def hanging_asset_resource(context):
     return context.resource_config.get("file")
 
 
+class DummyIOManager(IOManager):
+    def handle_output(self, context, obj):
+        pass
+
+    def load_input(self, context):
+        pass
+
+
+dummy_foreign_asset = ForeignAsset(key=AssetKey("dummy_foreign_asset"))
+
+
+@asset
+def first_asset(dummy_foreign_asset):
+    return 1
+
+
 @asset(required_resource_keys={"hanging_asset_resource"})
-def hanging_asset(context):
+def hanging_asset(context, first_asset):
     """
     Asset that hangs forever, used to test in-progress ops.
     """
@@ -1268,10 +1286,19 @@ def hanging_asset(context):
         time.sleep(0.1)
 
 
+@asset
+def never_runs_asset(context, hanging_asset):
+    pass
+
+
 hanging_job = build_assets_job(
     name="hanging_job",
-    assets=[hanging_asset],
-    resource_defs={"hanging_asset_resource": hanging_asset_resource},
+    source_assets=[dummy_foreign_asset],
+    assets=[first_asset, hanging_asset, never_runs_asset],
+    resource_defs={
+        "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
+        "hanging_asset_resource": hanging_asset_resource,
+    },
 )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
@@ -22,10 +22,10 @@ from dagster import (
     EventMetadataEntry,
     ExpectationResult,
     Field,
-    InputDefinition,
-    Int,
     IOManager,
     IOManagerDefinition,
+    InputDefinition,
+    Int,
     Materialization,
     ModeDefinition,
     Noneable,
@@ -1270,12 +1270,12 @@ dummy_foreign_asset = ForeignAsset(key=AssetKey("dummy_foreign_asset"))
 
 
 @asset
-def first_asset(dummy_foreign_asset):
+def first_asset(dummy_foreign_asset):  # pylint: disable=redefined-outer-name,unused-argument
     return 1
 
 
 @asset(required_resource_keys={"hanging_asset_resource"})
-def hanging_asset(context, first_asset):
+def hanging_asset(context, first_asset):  # pylint: disable=redefined-outer-name,unused-argument
     """
     Asset that hangs forever, used to test in-progress ops.
     """
@@ -1287,7 +1287,7 @@ def hanging_asset(context, first_asset):
 
 
 @asset
-def never_runs_asset(context, hanging_asset):
+def never_runs_asset(hanging_asset):  # pylint: disable=redefined-outer-name,unused-argument
     pass
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_all_snapshot_ids 1'] = '''{

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['test_all_snapshot_ids 1'] = '''{
@@ -11286,6 +11287,50 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.2f685c21666300490477185b19cda395e65a0a99": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"inputs\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "first_asset",
+            "type_key": "Shape.ec5afc1dbe49562b0b7ea7258a9d0f15a5081f63"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "hanging_asset",
+            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "never_runs_asset",
+            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.2f685c21666300490477185b19cda395e65a0a99",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.3baab16166bacfaf4705811e64d356112fd733cb": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -11355,26 +11400,23 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.6832e3504938d23e3888cf4f419bceb0b0d3af7d": {
+      "Shape.6d54715173bb030786220dac04f632dfdbb95d11": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
+            "default_provided": false,
+            "default_value_as_json_str": null,
             "description": null,
             "is_required": false,
-            "name": "hanging_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
+            "name": "dummy_foreign_asset",
+            "type_key": "Any"
           }
         ],
         "given_name": null,
-        "key": "Shape.6832e3504938d23e3888cf4f419bceb0b0d3af7d",
+        "key": "Shape.6d54715173bb030786220dac04f632dfdbb95d11",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -11398,47 +11440,6 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         ],
         "given_name": null,
         "key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
-      "Shape.7427193b8883794428a07c9fbc2e3ddb6984ba64": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "hanging_asset_resource",
-            "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "io_manager",
-            "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "root_manager",
-            "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.7427193b8883794428a07c9fbc2e3ddb6984ba64",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -11578,22 +11579,19 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.bc7a95a67e09cd090d119fdd212ce1ed97261db5": {
+      "Shape.ce80c8878e9f80d953f9042fe3a1b65fbc57abb0": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "default_provided": false,
+            "default_value_as_json_str": null,
             "description": null,
-            "is_required": false,
-            "name": "execution",
-            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+            "is_required": true,
+            "name": "hanging_asset_resource",
+            "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -11601,30 +11599,21 @@ snapshots['test_all_snapshot_ids 25'] = '''{
             "default_value_as_json_str": "{}",
             "description": null,
             "is_required": false,
-            "name": "loggers",
-            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+            "name": "io_manager",
+            "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
           },
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{\\"hanging_asset\\": {}}",
+            "default_value_as_json_str": "{}",
             "description": null,
             "is_required": false,
-            "name": "ops",
-            "type_key": "Shape.6832e3504938d23e3888cf4f419bceb0b0d3af7d"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "resources",
-            "type_key": "Shape.7427193b8883794428a07c9fbc2e3ddb6984ba64"
+            "name": "root_manager",
+            "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
           }
         ],
         "given_name": null,
-        "key": "Shape.bc7a95a67e09cd090d119fdd212ce1ed97261db5",
+        "key": "Shape.ce80c8878e9f80d953f9042fe3a1b65fbc57abb0",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -11696,6 +11685,103 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         ],
         "given_name": null,
         "key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.ec5afc1dbe49562b0b7ea7258a9d0f15a5081f63": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "inputs",
+            "type_key": "Shape.6d54715173bb030786220dac04f632dfdbb95d11"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "outputs",
+            "type_key": "Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ec5afc1dbe49562b0b7ea7258a9d0f15a5081f63",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.f367b67267b38f41194c45fc59bc4bd8acbb45eb": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "execution",
+            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "loggers",
+            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"first_asset\\": {\\"inputs\\": {}}, \\"hanging_asset\\": {}, \\"never_runs_asset\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "ops",
+            "type_key": "Shape.2f685c21666300490477185b19cda395e65a0a99"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "resources",
+            "type_key": "Shape.ce80c8878e9f80d953f9042fe3a1b65fbc57abb0"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.f367b67267b38f41194c45fc59bc4bd8acbb45eb",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -11813,10 +11899,59 @@ snapshots['test_all_snapshot_ids 25'] = '''{
     "solid_invocation_snaps": [
       {
         "__class__": "SolidInvocationSnap",
-        "input_dep_snaps": [],
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "dummy_foreign_asset",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": []
+          }
+        ],
+        "is_dynamic_mapped": false,
+        "solid_def_name": "first_asset",
+        "solid_name": "first_asset",
+        "tags": {}
+      },
+      {
+        "__class__": "SolidInvocationSnap",
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "first_asset",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": [
+              {
+                "__class__": "OutputHandleSnap",
+                "output_name": "result",
+                "solid_name": "first_asset"
+              }
+            ]
+          }
+        ],
         "is_dynamic_mapped": false,
         "solid_def_name": "hanging_asset",
         "solid_name": "hanging_asset",
+        "tags": {}
+      },
+      {
+        "__class__": "SolidInvocationSnap",
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "hanging_asset",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": [
+              {
+                "__class__": "OutputHandleSnap",
+                "output_name": "result",
+                "solid_name": "hanging_asset"
+              }
+            ]
+          }
+        ],
+        "is_dynamic_mapped": false,
+        "solid_def_name": "never_runs_asset",
+        "solid_name": "never_runs_asset",
         "tags": {}
       }
     ]
@@ -11871,7 +12006,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
             "name": "config",
             "type_key": "Any"
           },
-          "description": "The default io manager for Jobs. Uses filesystem but switches to in-memory when invoked through execute_in_process.",
+          "description": null,
           "name": "io_manager"
         },
         {
@@ -11889,7 +12024,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
           "name": "root_manager"
         }
       ],
-      "root_config_key": "Shape.bc7a95a67e09cd090d119fdd212ce1ed97261db5"
+      "root_config_key": "Shape.f367b67267b38f41194c45fc59bc4bd8acbb45eb"
     }
   ],
   "name": "hanging_job",
@@ -11908,8 +12043,49 @@ snapshots['test_all_snapshot_ids 25'] = '''{
           "name": "config",
           "type_key": "Any"
         },
+        "description": null,
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "name": "dummy_foreign_asset"
+          }
+        ],
+        "name": "first_asset",
+        "output_def_snaps": [
+          {
+            "__class__": "OutputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "is_dynamic": false,
+            "is_required": true,
+            "name": "result"
+          }
+        ],
+        "required_resource_keys": [],
+        "tags": {}
+      },
+      {
+        "__class__": "SolidDefSnap",
+        "config_field_snap": {
+          "__class__": "ConfigFieldSnap",
+          "default_provided": false,
+          "default_value_as_json_str": null,
+          "description": null,
+          "is_required": false,
+          "name": "config",
+          "type_key": "Any"
+        },
         "description": "Asset that hangs forever, used to test in-progress ops.",
-        "input_def_snaps": [],
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "name": "first_asset"
+          }
+        ],
         "name": "hanging_asset",
         "output_def_snaps": [
           {
@@ -11925,13 +12101,47 @@ snapshots['test_all_snapshot_ids 25'] = '''{
           "hanging_asset_resource"
         ],
         "tags": {}
+      },
+      {
+        "__class__": "SolidDefSnap",
+        "config_field_snap": {
+          "__class__": "ConfigFieldSnap",
+          "default_provided": false,
+          "default_value_as_json_str": null,
+          "description": null,
+          "is_required": false,
+          "name": "config",
+          "type_key": "Any"
+        },
+        "description": null,
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "name": "hanging_asset"
+          }
+        ],
+        "name": "never_runs_asset",
+        "output_def_snaps": [
+          {
+            "__class__": "OutputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "is_dynamic": false,
+            "is_required": true,
+            "name": "result"
+          }
+        ],
+        "required_resource_keys": [],
+        "tags": {}
       }
     ]
   },
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 26'] = '30cb7f503cd8e12eef4faa75abebf4d358d6c998'
+snapshots['test_all_snapshot_ids 26'] = '98ad0b43581c28e71f5f1553a32cccf259974d25'
 
 snapshots['test_all_snapshot_ids 27'] = '''{
   "__class__": "PipelineSnapshot",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['TestAssetAwareEventLog.test_all_asset_keys[asset_aware_instance_in_process_env] 1'] = {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['TestAssetAwareEventLog.test_all_asset_keys[asset_aware_instance_in_process_env] 1'] = {
@@ -34,7 +35,28 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[asset_aware_instance_in_pr
             {
                 'key': {
                     'path': [
+                        'dummy_foreign_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
                         'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
                     ]
                 }
             }
@@ -70,7 +92,28 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_
             {
                 'key': {
                     'path': [
+                        'dummy_foreign_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
                         'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
                     ]
                 }
             }
@@ -106,357 +149,30 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_la
             {
                 'key': {
                     'path': [
+                        'dummy_foreign_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
                         'hanging_asset'
                     ]
                 }
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_asset_tags[asset_aware_instance_in_process_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
+            },
             {
-                'materializationEvent': {
-                    'assetLineage': [
-                    ],
-                    'materialization': {
-                        'label': 'a'
-                    }
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
                 }
-            }
-        ],
-        'tags': [
-            {
-                'key': 'foo',
-                'value': 'FOO'
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_asset_tags[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                    ],
-                    'materialization': {
-                        'label': 'a'
-                    }
-                }
-            }
-        ],
-        'tags': [
-            {
-                'key': 'foo',
-                'value': 'FOO'
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_asset_tags[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                    ],
-                    'materialization': {
-                        'label': 'a'
-                    }
-                }
-            }
-        ],
-        'tags': [
-            {
-                'key': 'foo',
-                'value': 'FOO'
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[asset_aware_instance_in_process_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                        {
-                            'assetKey': {
-                                'path': [
-                                    'a'
-                                ]
-                            },
-                            'partitions': [
-                            ]
-                        }
-                    ],
-                    'materialization': {
-                        'label': 'b'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                        {
-                            'assetKey': {
-                                'path': [
-                                    'a'
-                                ]
-                            },
-                            'partitions': [
-                            ]
-                        }
-                    ],
-                    'materialization': {
-                        'label': 'b'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                        {
-                            'assetKey': {
-                                'path': [
-                                    'a'
-                                ]
-                            },
-                            'partitions': [
-                            ]
-                        }
-                    ],
-                    'materialization': {
-                        'label': 'b'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[asset_aware_instance_in_process_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                    ],
-                    'materialization': {
-                        'label': 'a'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                    ],
-                    'materialization': {
-                        'label': 'a'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                    ],
-                    'materialization': {
-                        'label': 'a'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[asset_aware_instance_in_process_env] 1'] = {
-    'assetOrError': {
-        '__typename': 'AssetNotFoundError'
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        '__typename': 'AssetNotFoundError'
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        '__typename': 'AssetNotFoundError'
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_lineage[asset_aware_instance_in_process_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                        {
-                            'assetKey': {
-                                'path': [
-                                    'a'
-                                ]
-                            },
-                            'partitions': [
-                                '1'
-                            ]
-                        }
-                    ],
-                    'materialization': {
-                        'label': 'b'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_lineage[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                        {
-                            'assetKey': {
-                                'path': [
-                                    'a'
-                                ]
-                            },
-                            'partitions': [
-                                '1'
-                            ]
-                        }
-                    ],
-                    'materialization': {
-                        'label': 'b'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_lineage[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'assetLineage': [
-                        {
-                            'assetKey': {
-                                'path': [
-                                    'a'
-                                ]
-                            },
-                            'partitions': [
-                                '1'
-                            ]
-                        }
-                    ],
-                    'materialization': {
-                        'label': 'b'
-                    }
-                }
-            }
-        ],
-        'tags': [
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[asset_aware_instance_in_process_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'materialization': {
-                        'label': 'a'
-                    }
-                },
-                'partition': 'partition_1'
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'materialization': {
-                        'label': 'a'
-                    }
-                },
-                'partition': 'partition_1'
-            }
-        ]
-    }
-}
-
-snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
-    'assetOrError': {
-        'assetMaterializations': [
-            {
-                'materializationEvent': {
-                    'materialization': {
-                        'label': 'a'
-                    }
-                },
-                'partition': 'partition_1'
             }
         ]
     }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_solids.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_query_all_solids 1'] = {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_solids.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['test_query_all_solids 1'] = {
@@ -468,6 +469,22 @@ snapshots['test_query_all_solids 1'] = {
             {
                 '__typename': 'UsedSolid',
                 'definition': {
+                    'name': 'first_asset'
+                },
+                'invocations': [
+                    {
+                        'pipeline': {
+                            'name': 'hanging_job'
+                        },
+                        'solidHandle': {
+                            'handleID': 'first_asset'
+                        }
+                    }
+                ]
+            },
+            {
+                '__typename': 'UsedSolid',
+                'definition': {
                     'name': 'get_input_one'
                 },
                 'invocations': [
@@ -629,6 +646,22 @@ snapshots['test_query_all_solids 1'] = {
                         },
                         'solidHandle': {
                             'handleID': 'multiply_inputs'
+                        }
+                    }
+                ]
+            },
+            {
+                '__typename': 'UsedSolid',
+                'definition': {
+                    'name': 'never_runs_asset'
+                },
+                'invocations': [
+                    {
+                        'pipeline': {
+                            'name': 'hanging_job'
+                        },
+                        'solidHandle': {
+                            'handleID': 'never_runs_asset'
                         }
                     }
                 ]


### PR DESCRIPTION
Modifies `InProgressRunsByStep` to return unstarted runs for a step key (meaning that the step has not begun to execute, but the run is in progress). Synced with Yuhan and we can fetch the full list of step keys that will be executed via `step_keys_to_execute` in the run's `ExecutionPlan` object.
```
inProgressRunsByStep: [{
  stepKey: 'a',
  unstartedRuns: [{runId: 'aaaa'}],
  inProgressRuns: [{runId: 'cccc'}],
}]
```
Also modifies the test to contain a `ForeignAsset`. 