### PR TITLE
[dagit] In the Gantt chart, render step state unknown in gray w/o spinner

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -154,7 +154,7 @@ const StepItem: React.FunctionComponent<{
           position="bottom"
           content={'Unknown step state. Run completed without step execution completion.'}
         >
-          <div style={{width: 12, textAlign: 'center'}}>{'?'}</div>
+          <StepStatusDot>{'?'}</StepStatusDot>
         </Tooltip>
       ) : (
         <StepStatusDot
@@ -199,6 +199,8 @@ const StepStatusDot = styled.div`
   height: 12px;
   flex-shrink: 0;
   border-radius: 50%;
+  text-align: center;
+  line-height: 12px;
 `;
 
 const Elapsed = styled.div`

--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -154,7 +154,7 @@ const StepItem: React.FunctionComponent<{
           position="bottom"
           content={'Unknown step state. Run completed without step execution completion.'}
         >
-          {'?'}
+          <div style={{width: 12, textAlign: 'center'}}>{'?'}</div>
         </Tooltip>
       ) : (
         <StepStatusDot

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -16,10 +16,15 @@ export enum IStepState {
   SUCCEEDED = 'succeeded',
   SKIPPED = 'skipped',
   FAILED = 'failed',
-  UNKNOWN = 'unknown',
+  UNKNOWN = 'unknown', // run exited without step reaching a final state
 }
 
-const BOX_EXIT_STATES = [IStepState.RETRY_REQUESTED, IStepState.SUCCEEDED, IStepState.FAILED];
+const BOX_EXIT_STATES = [
+  IStepState.RETRY_REQUESTED,
+  IStepState.SUCCEEDED,
+  IStepState.FAILED,
+  IStepState.UNKNOWN,
+];
 
 interface IMarker {
   key: string;


### PR DESCRIPTION

## Summary
This PR addresses the issue shown in this screenshot, where the run has exited without a step finishing, leaving the step in StepState.UNKNOWN in the Gantt Chart. Dagit was already aware of this state (and the right sidebar shows a `?` in the executing list) but the rendering in the Gantt Chart was still purple+spinner because we didn't treat the state as a terminal status.

After this change the steps now render in gray and do not show a spinner.

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/1037212/144509080-d6535672-016a-4847-8c07-cb2a3da74f71.png">




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.