### PR TITLE
Explicit Asset Dependencies

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -1,5 +1,6 @@
 from typing import Any, Mapping, NamedTuple, Optional
-from dagster import check, AssetKey
+
+from dagster import AssetKey, check
 
 
 class AssetIn(

--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -1,7 +1,34 @@
 from typing import Any, Mapping, NamedTuple, Optional
+from dagster import check
 
 
-class AssetIn(NamedTuple):
-    metadata: Optional[Mapping[str, Any]] = None
-    namespace: Optional[str] = None
-    managed: bool = True
+class AssetIn(
+    NamedTuple(
+        "_AssetIn",
+        [
+            ("asset_key", Optional[str]),
+            ("metadata", Optional[Mapping[str, Any]]),
+            ("namespace", Optional[str]),
+            ("managed", bool),
+        ],
+    )
+):
+    def __new__(
+        cls,
+        asset_key: Optional[str] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+        namespace: Optional[str] = None,
+        managed: bool = True,
+    ):
+        check.invariant(
+            not (asset_key and namespace),
+            ("Asset key and namespace cannot both be set on AssetIn"),
+        )
+
+        return super(AssetIn, cls).__new__(
+            cls,
+            asset_key=check.opt_str_param(asset_key, "asset_key"),
+            metadata=check.opt_inst_param(metadata, "metadata", Mapping),
+            namespace=check.opt_str_param(namespace, "namespace"),
+            managed=managed,
+        )

--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -10,7 +10,6 @@ class AssetIn(
             ("asset_key", Optional[AssetKey]),
             ("metadata", Optional[Mapping[str, Any]]),
             ("namespace", Optional[str]),
-            ("managed", bool),
         ],
     )
 ):
@@ -19,7 +18,6 @@ class AssetIn(
         asset_key: Optional[AssetKey] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         namespace: Optional[str] = None,
-        managed: bool = True,
     ):
         check.invariant(
             not (asset_key and namespace),
@@ -31,5 +29,4 @@ class AssetIn(
             asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             metadata=check.opt_inst_param(metadata, "metadata", Mapping),
             namespace=check.opt_str_param(namespace, "namespace"),
-            managed=managed,
         )

--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -6,7 +6,7 @@ class AssetIn(
     NamedTuple(
         "_AssetIn",
         [
-            ("asset_key", Optional[str]),
+            ("asset_key", Optional[AssetKey]),
             ("metadata", Optional[Mapping[str, Any]]),
             ("namespace", Optional[str]),
             ("managed", bool),

--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -1,5 +1,5 @@
 from typing import Any, Mapping, NamedTuple, Optional
-from dagster import check
+from dagster import check, AssetKey
 
 
 class AssetIn(
@@ -15,7 +15,7 @@ class AssetIn(
 ):
     def __new__(
         cls,
-        asset_key: Optional[str] = None,
+        asset_key: Optional[AssetKey] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         namespace: Optional[str] = None,
         managed: bool = True,
@@ -27,7 +27,7 @@ class AssetIn(
 
         return super(AssetIn, cls).__new__(
             cls,
-            asset_key=check.opt_str_param(asset_key, "asset_key"),
+            asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             metadata=check.opt_inst_param(metadata, "metadata", Mapping),
             namespace=check.opt_str_param(namespace, "namespace"),
             managed=managed,

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -218,7 +218,7 @@ def build_asset_ins(
     all_input_names = set(input_param_names) | asset_ins.keys()
 
     for in_key, asset_in in asset_ins.items():
-        if in_key not in input_param_names and asset_in.managed:
+        if in_key not in input_param_names:
             raise DagsterInvalidDefinitionError(
                 f"Key '{in_key}' in provided ins dict does not correspond to any of the names "
                 "of the arguments to the decorated function"
@@ -232,7 +232,7 @@ def build_asset_ins(
             asset_key = asset_ins[input_name].asset_key
             metadata = asset_ins[input_name].metadata or {}
             namespace = asset_ins[input_name].namespace
-            dagster_type = None if asset_ins[input_name].managed else Nothing
+            dagster_type = None
         else:
             metadata = {}
             namespace = None

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -217,7 +217,7 @@ def build_asset_ins(
 
     all_input_names = set(input_param_names) | asset_ins.keys()
 
-    for in_key, asset_in in asset_ins.items():
+    for in_key in asset_ins.keys():
         if in_key not in input_param_names:
             raise DagsterInvalidDefinitionError(
                 f"Key '{in_key}' in provided ins dict does not correspond to any of the names "

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -120,7 +120,7 @@ class _Asset:
         op = _Op(
             name=asset_name,
             description=self.description,
-            ins={input_name: in_def for input_name, in_def in ins_by_input_names.items()},
+            ins=ins_by_input_names,
             out=out,
             required_resource_keys=self.required_resource_keys,
             tags={"kind": self.compute_kind} if self.compute_kind else None,
@@ -186,7 +186,9 @@ def multi_asset(
 
 
 def build_asset_ins(
-    fn: Callable, asset_namespace: Optional[str], asset_ins: Mapping[str, AssetIn]
+    fn: Callable,
+    asset_namespace: Optional[str],
+    asset_ins: Mapping[str, AssetIn],
 ) -> Mapping[AssetKey, In]:
     params = get_function_params(fn)
     is_context_provided = len(params) > 0 and params[0].name in get_valid_name_permutations(
@@ -210,8 +212,7 @@ def build_asset_ins(
         asset_key = None
 
         if input_name in asset_ins:
-            if asset_ins[input_name].asset_key:
-                asset_key = AssetKey(asset_ins[input_name].asset_key)
+            asset_key = asset_ins[input_name].asset_key
             metadata = asset_ins[input_name].metadata or {}
             namespace = asset_ins[input_name].namespace
             dagster_type = None if asset_ins[input_name].managed else Nothing

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -250,6 +250,6 @@ def build_asset_ins(
     for asset_key in depends_on:
         stringified_asset_key = asset_key.to_string(legacy=True)
         if stringified_asset_key:
-            ins[cast(str, stringified_asset_key)] = In(dagster_type=Nothing, asset_key=asset_key)
+            ins[str(stringified_asset_key)] = In(dagster_type=Nothing, asset_key=asset_key)
 
     return ins

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -160,7 +160,9 @@ def test_asset_key_for_asset_with_namespace():
     def failing_asset(foo):
         pass
 
-    with pytest.raises(DagsterInvalidDefinitionError):
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+    ):
         build_assets_job("lol", [asset_foo, failing_asset])
 
     @asset(ins={"foo": AssetIn(asset_key=AssetKey(["hello", "asset_foo"]))})

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -1,19 +1,20 @@
 import os
+
 import pytest
 from dagster import (
     AssetKey,
+    DagsterInvalidDefinitionError,
     DependencyDefinition,
     IOManager,
     io_manager,
-    DagsterInvalidDefinitionError,
 )
-from dagster.utils import safe_tempfile_path
-from dagster.core.asset_defs import ForeignAsset, asset, build_assets_job, AssetIn
+from dagster.core.asset_defs import AssetIn, ForeignAsset, asset, build_assets_job
 from dagster.core.snap import DependencyStructureIndex
 from dagster.core.snap.dep_snapshot import (
     OutputHandleSnap,
     build_dep_structure_snapshot_from_icontains_solids,
 )
+from dagster.utils import safe_tempfile_path
 
 
 def test_single_asset_pipeline():

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -235,7 +235,7 @@ def test_source_op_asset():
     assert job.execute_in_process().success
 
 
-def test_depends_on():
+def test_non_argument_deps():
     with safe_tempfile_path() as path:
 
         @asset
@@ -243,7 +243,7 @@ def test_depends_on():
             with open(path, "w") as ff:
                 ff.write("yup")
 
-        @asset(depends_on={AssetKey("foo")})
+        @asset(non_argument_deps={AssetKey("foo")})
         def bar():
             # assert that the foo asset already executed
             assert os.path.exists(path)
@@ -252,7 +252,7 @@ def test_depends_on():
         assert job.execute_in_process().success
 
 
-def test_multiple_depends_on():
+def test_multiple_non_argument_deps():
     @asset
     def foo():
         pass
@@ -265,7 +265,7 @@ def test_multiple_depends_on():
     def baz():
         return 1
 
-    @asset(depends_on={AssetKey("foo"), AssetKey("bar")})
+    @asset(non_argument_deps={AssetKey("foo"), AssetKey("bar")})
     def qux(baz):
         return baz
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -72,7 +72,7 @@ def test_asset_with_context_arg_and_dep():
 
 
 def test_input_asset_key():
-    @asset(ins={"arg1": AssetIn(asset_key="foo")})
+    @asset(ins={"arg1": AssetIn(asset_key=AssetKey("foo"))})
     def my_asset(arg1):
         assert arg1
 
@@ -82,7 +82,7 @@ def test_input_asset_key():
 def test_input_asset_key_and_namespace():
     with pytest.raises(check.CheckError, match="key and namespace cannot both be set"):
 
-        @asset(ins={"arg1": AssetIn(asset_key="foo", namespace="bar")})
+        @asset(ins={"arg1": AssetIn(asset_key=AssetKey("foo"), namespace="bar")})
         def my_asset(arg1):
             assert arg1
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, DagsterInvalidDefinitionError, String
+from dagster import AssetKey, DagsterInvalidDefinitionError, String, check
 from dagster.core.asset_defs import AssetIn, AssetsDefinition, asset
 
 
@@ -69,6 +69,22 @@ def test_asset_with_context_arg_and_dep():
     assert isinstance(my_asset, AssetsDefinition)
     assert len(my_asset.op.input_defs) == 1
     assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey("arg1")
+
+
+def test_input_asset_key():
+    @asset(ins={"arg1": AssetIn(asset_key="foo")})
+    def my_asset(arg1):
+        assert arg1
+
+    assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey("foo")
+
+
+def test_input_asset_key_and_namespace():
+    with pytest.raises(check.CheckError, match="key and namespace cannot both be set"):
+
+        @asset(ins={"arg1": AssetIn(asset_key="foo", namespace="bar")})
+        def my_asset(arg1):
+            assert arg1
 
 
 def test_input_namespace():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -4,7 +4,7 @@ import subprocess
 import textwrap
 from typing import Any, Callable, List, Mapping, Optional
 
-from dagster import OpDefinition, Output, SolidExecutionContext, check
+from dagster import AssetKey, OpDefinition, Output, SolidExecutionContext, check
 from dagster.core.asset_defs import AssetIn, asset
 
 
@@ -55,9 +55,9 @@ def _dbt_node_to_asset(
     @asset(
         name=node_info["name"],
         description=description,
-        ins={
-            dep_name.split(".")[-1]: AssetIn(managed=False)
-            for dep_name in node_info["depends_on"]["nodes"]
+        # ins={dep_name.split(".")[-1]: AssetIn() for dep_name in node_info["depends_on"]["nodes"]},
+        non_argument_deps={
+            AssetKey(dep_name.split(".")[-1]) for dep_name in node_info["depends_on"]["nodes"]
         },
         required_resource_keys={"dbt"},
         io_manager_key=io_manager_key,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -55,7 +55,6 @@ def _dbt_node_to_asset(
     @asset(
         name=node_info["name"],
         description=description,
-        # ins={dep_name.split(".")[-1]: AssetIn() for dep_name in node_info["depends_on"]["nodes"]},
         non_argument_deps={
             AssetKey(dep_name.split(".")[-1]) for dep_name in node_info["depends_on"]["nodes"]
         },

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -5,7 +5,7 @@ import textwrap
 from typing import Any, Callable, List, Mapping, Optional
 
 from dagster import AssetKey, OpDefinition, Output, SolidExecutionContext, check
-from dagster.core.asset_defs import AssetIn, asset
+from dagster.core.asset_defs import asset
 
 
 def _load_manifest_for_project(


### PR DESCRIPTION
This PR contains two changes:
1. Enabling explicit asset dependencies
```
@asset
def asset1():
    return 1

@asset(ins={"hello": AssetIn(asset_key=AssetKey("asset1"))})
def asset2(hello):
    return hello
```
`AssetIn` now contains an asset key param to explicitly accept upstream assets as inputs.

2. Explicitly add "nothing" dependencies (e.g. Asset B is dependent on asset A but no data is passed between the assets by Dagster).
```
@asset
def foo():
    with open(path, "w") as ff:
        ff.write("yup")

@asset(depends_on={AssetKey("foo")})
def bar():
    assert os.path.exists(path)
```
How this works is every single asset key provided in `depends_on` is provided as a key in the `ins` dict for an Op with the mapped value `In(dagster_type=Nothing, asset_key=asset_key)`.