### PR TITLE
[dagit] Fix double-scrollbars, incorrect height on some graph explorer pages

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -273,15 +273,23 @@ export const GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT = gql`
   ${PIPELINE_GRAPH_OP_FRAGMENT}
 `;
 
-const RightInfoPanel = styled.div`
+export const RightInfoPanel = styled.div`
   // Fixes major perofmance hit. To reproduce, add enough content to
   // the sidebar that it scrolls (via overflow-y below) and then try
   // to pan the DAG.
   position: relative;
 
   height: 100%;
-  overflow-y: scroll;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   background: ${ColorsWIP.White};
+`;
+
+export const RightInfoPanelContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
 `;
 
 const OptionsOverlay = styled.div`

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineOrJobOverview.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarPipelineOrJobOverview.tsx
@@ -46,7 +46,7 @@ export const SidebarPipelineOrJobOverview: React.FC<{
         const modes = pipelineSnapshotOrError.modes;
 
         return (
-          <div style={{overflowY: 'scroll'}}>
+          <>
             <SidebarSection title={'Description'}>
               <Box padding={{vertical: 16, horizontal: 24}}>
                 <Description
@@ -61,7 +61,7 @@ export const SidebarPipelineOrJobOverview: React.FC<{
                 ))}
               </Box>
             </SidebarSection>
-          </div>
+          </>
         );
       }}
     </Loading>

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarTabbedContainer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarTabbedContainer.tsx
@@ -9,6 +9,7 @@ import {ColorsWIP} from '../ui/Colors';
 import {Tab, Tabs} from '../ui/Tabs';
 import {RepoAddress} from '../workspace/types';
 
+import {RightInfoPanelContent} from './GraphExplorer';
 import {GraphExplorerJobContext} from './GraphExplorerJobContext';
 import {ExplorerPath} from './PipelinePathUtils';
 import {SidebarOpContainer} from './SidebarOpContainer';
@@ -119,7 +120,9 @@ export const SidebarTabbedContainer: React.FC<ISidebarTabbedContainerProps> = (p
           ))}
         </Tabs>
       </Box>
-      {TabDefinitions.find((t) => t.key === activeTab)?.content()}
+      <RightInfoPanelContent>
+        {TabDefinitions.find((t) => t.key === activeTab)?.content()}
+      </RightInfoPanelContent>
     </>
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
@@ -49,10 +49,11 @@ export const GraphRoot: React.FC<Props> = (props) => {
           </TagWIP>
         }
       />
-      <Box border={{side: 'top', width: 1, color: ColorsWIP.KeylineGray}}>
-        <div style={{minHeight: 0, flex: 1, display: 'flex'}}>
-          <GraphExplorerRoot {...props} repoAddress={repoAddress} />
-        </div>
+      <Box
+        border={{side: 'top', width: 1, color: ColorsWIP.KeylineGray}}
+        style={{minHeight: 0, flex: 1, display: 'flex'}}
+      >
+        <GraphExplorerRoot {...props} repoAddress={repoAddress} />
       </Box>
     </div>
   );

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -9,6 +9,7 @@ import {QueryCountdown} from '../../app/QueryCountdown';
 import {LaunchRootExecutionButton} from '../../execute/LaunchRootExecutionButton';
 import {SVGViewport} from '../../graph/SVGViewport';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
+import {RightInfoPanel, RightInfoPanelContent} from '../../pipelines/GraphExplorer';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {SidebarPipelineOrJobOverview} from '../../pipelines/SidebarPipelineOrJobOverview';
 import {GraphExplorerSolidHandleFragment} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
@@ -330,16 +331,20 @@ const AssetGraphExplorerWithData: React.FC<
         </>
       }
       second={
-        selectedGraphNode && selectedDefinition ? (
-          <SidebarAssetInfo
-            node={selectedGraphNode.definition}
-            liveData={liveDataByNode[selectedGraphNode.id]}
-            definition={selectedDefinition}
-            repoAddress={repoAddress}
-          />
-        ) : (
-          <SidebarPipelineOrJobOverview repoAddress={repoAddress} explorerPath={explorerPath} />
-        )
+        <RightInfoPanel>
+          <RightInfoPanelContent>
+            {selectedGraphNode && selectedDefinition ? (
+              <SidebarAssetInfo
+                node={selectedGraphNode.definition}
+                liveData={liveDataByNode[selectedGraphNode.id]}
+                definition={selectedDefinition}
+                repoAddress={repoAddress}
+              />
+            ) : (
+              <SidebarPipelineOrJobOverview repoAddress={repoAddress} explorerPath={explorerPath} />
+            )}
+          </RightInfoPanelContent>
+        </RightInfoPanel>
       }
     />
   );

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -22,7 +22,7 @@ export const SidebarAssetInfo: React.FC<{
   const {inProgressRunIds, lastMaterialization} = liveData || {};
 
   return (
-    <div style={{overflowY: 'auto'}}>
+    <>
       <SidebarSection title="Definition">
         <Box padding={{vertical: 16, horizontal: 24}}>
           <SidebarTitle>{assetKeyToString(node.assetKey)}</SidebarTitle>
@@ -44,6 +44,6 @@ export const SidebarAssetInfo: React.FC<{
         params={{}}
         setParams={() => {}}
       />
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
## Summary
This PR just fixes several small nits:

- Graph explorer pages (eg: http://localhost:3000/workspace/software_defined_assets@repo.py/graphs/spark_weather) had incorrect vertical height so the entire viewport scrolled vertically instead of being fit to the page.

- With a mouse plugged in, `overflow: scroll` renders scrollbars at all times and surfaced a few places we had double scrollbars in the right sidebar. This has been fixed so the sidebar has one `auto` scrollbar, and it scrolls the region /below/ the "Info | Types" tabs.

- The asset graph explorer also scrolled vertically if you had long content in the sidebar because there wasn't a scroll box around the sidebar at all.

Fixed in this PR:
![image](https://user-images.githubusercontent.com/1037212/144512117-96f164aa-994c-4585-a365-8ee5d66f8141.png)
![image](https://user-images.githubusercontent.com/1037212/144512208-18c9cecc-07bc-4952-9190-a3d5fadbe349.png)
![image](https://user-images.githubusercontent.com/1037212/144512284-9338ef04-a79f-41db-be81-061d1739fd9b.png)



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.