### PR TITLE
avoid extra run group panel fetch by fixing timestamp format

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -37,7 +37,9 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
   // it's reflected in the sidebar. Observing this single timestamp from our parent
   // allows us to refetch data immediately when the run's exitedAt / startedAt, etc. is set.
   React.useEffect(() => {
-    refetch();
+    if (runStatusLastChangedAt) {
+      refetch();
+    }
   }, [refetch, runStatusLastChangedAt]);
 
   const group = data?.runGroupOrError;

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -93,7 +93,7 @@ export const extractLogCaptureStepsFromLegacySteps = (stepKeys: string[]) => {
   return logCaptureSteps;
 };
 
-const fromTimestamp = (ts: number | null) => (ts ? ts * 1000 : undefined);
+const fromTimestamp = (ts: number | null) => (ts ? Math.floor(ts * 1000) : undefined);
 function extractMetadataFromRun(run?: RunFragment): IRunMetadataDict {
   const metadata: IRunMetadataDict = {
     firstLogAt: 0,


### PR DESCRIPTION
We render the group panel on the Run page using metadata calculated from both the fetched run query and from the streaming logs.

This diff makes sure that the format matches, since changes in the timestamps trigger extra data fetches.

## Test Plan
Loaded a terminated run, saw the fetches.
