### PR TITLE
Owen/databricks testing

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/step_launcher.py
+++ b/python_modules/dagster/dagster/core/definitions/step_launcher.py
@@ -10,7 +10,7 @@ from dagster.core.storage.pipeline_run import PipelineRun
 class StepRunRef(
     namedtuple(
         "_StepRunRef",
-        "run_config pipeline_run run_id retry_mode step_key recon_pipeline prior_attempts_count",
+        "run_config pipeline_run run_id retry_mode step_key recon_pipeline prior_attempts_count known_state",
     )
 ):
     """
@@ -27,6 +27,7 @@ class StepRunRef(
         step_key,
         recon_pipeline,
         prior_attempts_count,
+        known_state=None,
     ):
         return super(StepRunRef, cls).__new__(
             cls,
@@ -37,6 +38,7 @@ class StepRunRef(
             check.str_param(step_key, "step_key"),
             check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline),
             check.int_param(prior_attempts_count, "prior_attempts_count"),
+            known_state,
         )
 
 

--- a/python_modules/dagster/dagster/core/definitions/step_launcher.py
+++ b/python_modules/dagster/dagster/core/definitions/step_launcher.py
@@ -10,7 +10,7 @@ from dagster.core.storage.pipeline_run import PipelineRun
 class StepRunRef(
     namedtuple(
         "_StepRunRef",
-        "run_config pipeline_run run_id retry_mode step_key recon_pipeline prior_attempts_count known_state",
+        "run_config pipeline_run run_id retry_mode step_key recon_pipeline prior_attempts_count known_state parent_run",
     )
 ):
     """
@@ -28,6 +28,7 @@ class StepRunRef(
         recon_pipeline,
         prior_attempts_count,
         known_state=None,
+        parent_run=None,
     ):
         return super(StepRunRef, cls).__new__(
             cls,
@@ -39,6 +40,7 @@ class StepRunRef(
             check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline),
             check.int_param(prior_attempts_count, "prior_attempts_count"),
             known_state,
+            check.opt_inst_param(parent_run, "parent_run", PipelineRun),
         )
 
 

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -150,6 +150,7 @@ def step_context_to_step_run_ref(
         retry_mode=retry_mode,
         recon_pipeline=recon_pipeline,
         prior_attempts_count=prior_attempts_count,
+        known_state=step_context.execution_plan.known_state,
     )
 
 
@@ -166,6 +167,7 @@ def step_run_ref_to_step_context(
         step_run_ref.run_config,
         mode=step_run_ref.pipeline_run.mode,
         step_keys_to_execute=[step_run_ref.step_key],
+        known_state=step_run_ref.known_state,
     )
 
     initialization_manager = PlanExecutionContextManager(
@@ -197,4 +199,4 @@ def run_step_from_ref(
 ) -> Iterator[DagsterEvent]:
     check.inst_param(instance, "instance", DagsterInstance)
     step_context = step_run_ref_to_step_context(step_run_ref, instance)
-    return core_dagster_event_sequence_for_step(step_context)
+    yield from core_dagster_event_sequence_for_step(step_context)

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -24,7 +24,7 @@ from dagster.core.instance import DagsterInstance
 from dagster.core.storage.file_manager import LocalFileHandle, LocalFileManager
 from dagster.serdes import serialize_value, deserialize_value
 
-PICKLED_EVENTS_FILE_NAME = "events.pkl"
+COMPUTE_LOGS_FILE_NAME = "logs.txt"
 PICKLED_RECORDS_FILE_NAME = "records.pkl"
 PICKLED_STEP_RUN_REF_FILE_NAME = "step_run_ref.pkl"
 
@@ -208,27 +208,3 @@ def run_step_from_ref(
     check.inst_param(instance, "instance", DagsterInstance)
     step_context = step_run_ref_to_step_context(step_run_ref, instance)
     return core_dagster_event_sequence_for_step(step_context)
-
-
-def _pack_dagster_log_record(record: logging.LogRecord) -> logging.LogRecord:
-    packed_record = copy.deepcopy(record)
-    packed_record.__dict__[DAGSTER_META_KEY] = serialize_value(record.__dict__[DAGSTER_META_KEY])
-    return packed_record
-
-
-def serialize_dagster_log_records(records: List[logging.LogRecord]) -> bytes:
-    """Serialize a list of Dagster-produced log records"""
-    return pickle.dumps([_pack_dagster_log_record(r) for r in records])
-
-
-def _unpack_dagster_log_record(record: logging.LogRecord) -> logging.LogRecord:
-    unpacked_record = copy.deepcopy(record)
-    unpacked_record.__dict__[DAGSTER_META_KEY] = deserialize_value(
-        record.__dict__[DAGSTER_META_KEY]
-    )
-    return unpacked_record
-
-
-def deserialize_dagster_log_records(data: bytes) -> List[logging.LogRecord]:
-    """Deserialize a list of Dagster-produced log records"""
-    return [_unpack_dagster_log_record(r) for r in pickle.loads(data)]

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -199,4 +199,4 @@ def run_step_from_ref(
 ) -> Iterator[DagsterEvent]:
     check.inst_param(instance, "instance", DagsterInstance)
     step_context = step_run_ref_to_step_context(step_run_ref, instance)
-    yield from core_dagster_event_sequence_for_step(step_context)
+    return core_dagster_event_sequence_for_step(step_context)

--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from dagster.core.events import DagsterEvent
 
 DAGSTER_META_KEY = "dagster_meta"
+DAGSTER_META_DAGSTER_EVENT_KEY = "dagster_event"
 
 
 class DagsterMessageProps(

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -17,6 +17,8 @@ Why not pickle?
 from abc import ABC, abstractmethod
 from enum import Enum
 from inspect import Parameter, isclass, signature
+import logging
+import pickle
 from typing import (
     Any,
     Dict,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -600,7 +600,7 @@ def define_databricks_storage_config():
         Selector(
             {"s3": _define_s3_storage_credentials(), "adls2": _define_adls2_storage_credentials()}
         ),
-        description="Databricks storage configuration. Solids using the "
+        description="Databricks storage configuration. Ops using the "
         "DatabricksPySparkStepLauncher to execute dagster job steps in Databricks MUST configure "
         "storage using this config (either S3 or ADLS2 can be used). Access credentials for the "
         "storage must be stored in Databricks secrets; this config indicates the secret scope "

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -111,7 +111,7 @@ class DatabricksJobRunner:
     """Submits jobs created using Dagster config to Databricks, and monitors their progress."""
 
     def __init__(
-        self, host, token, poll_interval_sec=10, max_wait_time_sec=DEFAULT_RUN_MAX_WAIT_TIME_SEC
+        self, host, token, poll_interval_sec=2.5, max_wait_time_sec=DEFAULT_RUN_MAX_WAIT_TIME_SEC
     ):
         """Args:
         host (str): Databricks host, e.g. https://uksouth.azuredatabricks.net

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -165,11 +165,13 @@ class DatabricksJobRunner:
             "Invalid value for run_config.cluster",
         )
 
-        # We'll always need some libraries, namely dagster/dagster_databricks/dagster_pyspark,
+        # We'll always need some libraries, namely dagster/dagster-databricks/dagster-pyspark,
         # since they're imported by our scripts.
         # Add them if they're not already added by users in config.
         libraries = list(run_config.get("libraries", []))
-        python_libraries = {x["pypi"]["package"].split("==")[0] for x in libraries if "pypi" in x}
+        python_libraries = {
+            x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
+        }
         for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
             if library not in python_libraries:
                 libraries.append(
@@ -241,10 +243,10 @@ class DatabricksJobRunner:
                 time.sleep(waiter_delay)
         log.warn("Could not retrieve cluster logs!")
 
-    def wait_for_run_to_complete(self, databricks_run_id):
+    def wait_for_run_to_complete(self, log, databricks_run_id):
         return wait_for_run_to_complete(
             self.client,
-            get_dagster_logger(),
+            log,
             databricks_run_id,
             self.poll_interval_sec,
             self.max_wait_time_sec,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -212,9 +212,8 @@ class DatabricksPySparkStepLauncher(StepLauncher):
                     # we get all available records on each poll, but we only want to process the
                     # ones we haven't seen before
                     for record in all_records[processed_records:]:
-                        dagster_event = getattr(record, DAGSTER_META_KEY)[
-                            DAGSTER_META_DAGSTER_EVENT_KEY
-                        ]
+                        dagster_meta = getattr(record, DAGSTER_META_KEY)
+                        dagster_event = dagster_meta.get("dagster_event")
                         if dagster_event:
                             yield dagster_event
                         log.dagster_handler.emit_dagster_record(record)
@@ -241,7 +240,6 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         # if you poll before the Databricks process has had a chance to create the file,
         # we expect to get this error
         except HTTPError as e:
-            print("HAD ERROR")
             if e.response.json().get("error_code") == "RESOURCE_DOES_NOT_EXIST":
                 return []
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -18,6 +18,7 @@ from dagster_databricks import databricks_step_main
 from dagster_databricks.databricks import (
     DEFAULT_RUN_MAX_WAIT_TIME_SEC,
     DatabricksJobRunner,
+    DatabricksError,
     poll_run_state,
 )
 from dagster_pyspark.utils import build_pyspark_zip
@@ -165,10 +166,11 @@ class DatabricksPySparkStepLauncher(StepLauncher):
 
         try:
             for event in self.step_events_iterator(log, step_key, run_id, databricks_run_id):
-                log_step_event(step_context, event)
-                yield event
+                if not (isinstance(event, databricks_step_main.LogsCompleteSentinal)):
+                    log_step_event(step_context, event)
+                    yield event
         finally:
-            if True:  # self.wait_for_logs:
+            if self.wait_for_logs:
                 self._log_logs_from_cluster(log, databricks_run_id)
 
     def step_events_iterator(self, log, step_key: str, dagster_run_id: str, databricks_run_id: int):
@@ -177,16 +179,18 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         previous poll. This allows events to be "streamed" back to the parent process rather than
         requiring that we wait until it has fully completed."""
         all_events = []
+        all_events_new = []
         start = time.time()
-        poll_interval_sec = 1  # self.databricks_runner.poll_interval_sec
+        done = False
+        poll_interval_sec = 2.5  # self.databricks_runner.poll_interval_sec
         check.int_param(databricks_run_id, "databricks_run_id")
         log.info("Waiting for Databricks run %s to complete..." % databricks_run_id)
-        while True:
+        while not done:
             with raise_execution_interrupts():
                 log.debug("Waiting %.1f seconds..." % poll_interval_sec)
                 time.sleep(poll_interval_sec)
                 try:
-                    is_finished = poll_run_state(
+                    done = poll_run_state(
                         self.databricks_runner.client,
                         log,
                         start,
@@ -195,21 +199,43 @@ class DatabricksPySparkStepLauncher(StepLauncher):
                     )
                 finally:
                     all_events_new = self.get_step_events(dagster_run_id, step_key)
+                    if all_events_new:
+                        for i in range(len(all_events), len(all_events_new)):
+                            yield all_events_new[i]
+                        all_events = all_events_new
+        # if run completed without error, we want to wait until all the logs are available on dbfs.
+        log.info(f"Databricks run {databricks_run_id} completed.")
+        while not isinstance(all_events[-1], databricks_step_main.LogsCompleteSentinal):
+            with raise_execution_interrupts():
+                if time.time() - start > self.databricks_runner.max_wait_time_sec:
+                    raise DatabricksError("Timed out while waiting for logs to become available.")
+                log.info(
+                    f"Waiting for Dagster logs to become available for Databricks run {databricks_run_id}."
+                )
+                all_events_new = self.get_step_events(dagster_run_id, step_key)
+                if all_events_new:
                     for i in range(len(all_events), len(all_events_new)):
                         yield all_events_new[i]
                     all_events = all_events_new
-            if is_finished:
-                break
+                time.sleep(poll_interval_sec)
 
     def get_step_events(self, run_id, step_key):
+        err = None
+        cur_retries = 0
         path = self._dbfs_path(run_id, step_key, PICKLED_EVENTS_FILE_NAME)
-        try:
-            events_data = self.databricks_runner.client.read_file(path)
-        except HTTPError as ex:
-            if ex.response.json().get("error_code") == "RESOURCE_DOES_NOT_EXIST":
-                return []
-            raise ex
-        return deserialize_value(pickle.loads(events_data))
+        while True:
+            try:
+                events_data = self.databricks_runner.client.read_file(path)
+                return deserialize_value(pickle.loads(events_data))
+            except HTTPError as e:
+                err = e
+                if e.response.json().get("error_code") == "RESOURCE_DOES_NOT_EXIST":
+                    return []
+            except Exception as e:
+                err = e
+            cur_retries += 1
+            if cur_retries == 3:
+                raise err
 
     def _get_databricks_task(self, run_id, step_key):
         """Construct the 'task' parameter to  be submitted to the Databricks API.

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -14,11 +14,12 @@ import site
 import sys
 import tempfile
 import zipfile
-from typing import NamedTuple
+import logging
 
 from dagster.core.execution.plan.external_step import PICKLED_EVENTS_FILE_NAME, run_step_from_ref
 from dagster.core.instance import DagsterInstance
-from dagster.serdes import serialize_value, whitelist_for_serdes
+from dagster.core.log_manager import DAGSTER_META_KEY
+from dagster.serdes import serialize_value
 
 
 # This won't be set in Databricks but is needed to be non-None for the
@@ -27,13 +28,29 @@ if "DATABRICKS_TOKEN" not in os.environ:
     os.environ["DATABRICKS_TOKEN"] = ""
 
 
-@whitelist_for_serdes
-class LogsCompleteSentinal(NamedTuple):
-    """Written to the events file after run has completed to allow processes to determine that
-    all available data has been written.
+LOGS_COMPLETE = "__DONE__"
 
-    This subclasses dict to make it natively serializable
-    """
+
+class MyHandler(logging.Handler):
+    def __init__(self, events_filepath: str):
+        super().__init__()
+        self._all_events = []
+        self._events_filepath = events_filepath
+
+    def _write_obj(self, obj):
+        with open(self._events_filepath, "wb") as handle:
+            pickle.dump(obj, handle)
+
+    def emit(self, record):
+        # can't directly serialize DagsterEvents
+        record.__dict__[DAGSTER_META_KEY]["dagster_event"] = serialize_value(
+            record.__dict__[DAGSTER_META_KEY]["dagster_event"]
+        )
+        self._all_events.append(record)
+        self._write_obj(self._all_events)
+
+    def mark_complete(self):
+        self._write_obj(self._all_events + [LOGS_COMPLETE])
 
 
 def main(
@@ -60,24 +77,19 @@ def main(
         databricks_config.setup(dbutils, sc)  # noqa pylint: disable=undefined-variable
 
         with open(step_run_ref_filepath, "rb") as handle:
-            print("y" * 100)
             step_run_ref = pickle.load(handle)
         print("Running dagster job")  # noqa pylint: disable=print-call
         events_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
-        with DagsterInstance.ephemeral() as instance:
-            events = []
-            for event in run_step_from_ref(step_run_ref, instance):
-                events.append(event)
-                print("*" * 100)
-                print("--events: ", events)
-                with open(events_filepath, "wb") as handle:
-                    pickle.dump(serialize_value(events), handle)
 
-        print("FINAL EVENTS")
-        events.append(LogsCompleteSentinal())
-        print(events)
-        with open(events_filepath, "wb") as handle:
-            pickle.dump(serialize_value(events), handle)
+        events_handler = MyHandler(events_filepath=events_filepath)
+
+        with DagsterInstance.ephemeral() as instance:
+            # hack to send all events to a specific filepath
+            instance.get_handlers = lambda: [events_handler]
+            # run the step
+            list(run_step_from_ref(step_run_ref, instance))
+
+        events_handler.mark_complete()
 
 
 if __name__ == "__main__":

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -38,12 +38,13 @@ class DBFSHandler(logging.Handler):
         self._records_filepath = records_filepath
 
     def emit(self, record):
-        print("--------------")
-        print(self._all_records)
-        print(self._records_filepath)
+        import time
+
+        start = time.time()
         self._all_records.append(record)
         with open(self._records_filepath, "wb") as handle:
             handle.write(serialize_dagster_log_records(self._all_records))
+        print("TIME: ", time.time() - start)
 
 
 def main(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -14,15 +14,26 @@ import site
 import sys
 import tempfile
 import zipfile
+from typing import NamedTuple
 
 from dagster.core.execution.plan.external_step import PICKLED_EVENTS_FILE_NAME, run_step_from_ref
 from dagster.core.instance import DagsterInstance
-from dagster.serdes import serialize_value
+from dagster.serdes import serialize_value, whitelist_for_serdes
+
 
 # This won't be set in Databricks but is needed to be non-None for the
 # Dagster step to run.
 if "DATABRICKS_TOKEN" not in os.environ:
     os.environ["DATABRICKS_TOKEN"] = ""
+
+
+@whitelist_for_serdes
+class LogsCompleteSentinal(NamedTuple):
+    """Written to the events file after run has completed to allow processes to determine that
+    all available data has been written.
+
+    This subclasses dict to make it natively serializable
+    """
 
 
 def main(
@@ -52,15 +63,21 @@ def main(
             print("y" * 100)
             step_run_ref = pickle.load(handle)
         print("Running dagster job")  # noqa pylint: disable=print-call
+        events_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
         with DagsterInstance.ephemeral() as instance:
-            events_filepath = (
-                os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
-            )
             events = []
-            with open(events_filepath, "wb") as handle:
-                for event in run_step_from_ref(step_run_ref, instance):
-                    events.append(event)
+            for event in run_step_from_ref(step_run_ref, instance):
+                events.append(event)
+                print("*" * 100)
+                print("--events: ", events)
+                with open(events_filepath, "wb") as handle:
                     pickle.dump(serialize_value(events), handle)
+
+        print("FINAL EVENTS")
+        events.append(LogsCompleteSentinal())
+        print(events)
+        with open(events_filepath, "wb") as handle:
+            pickle.dump(serialize_value(events), handle)
 
 
 if __name__ == "__main__":

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -49,14 +49,18 @@ def main(
         databricks_config.setup(dbutils, sc)  # noqa pylint: disable=undefined-variable
 
         with open(step_run_ref_filepath, "rb") as handle:
+            print("y" * 100)
             step_run_ref = pickle.load(handle)
         print("Running dagster job")  # noqa pylint: disable=print-call
         with DagsterInstance.ephemeral() as instance:
-            events = list(run_step_from_ref(step_run_ref, instance))
-
-    events_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
-    with open(events_filepath, "wb") as handle:
-        pickle.dump(serialize_value(events), handle)
+            events_filepath = (
+                os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
+            )
+            events = []
+            with open(events_filepath, "wb") as handle:
+                for event in run_step_from_ref(step_run_ref, instance):
+                    events.append(event)
+                    pickle.dump(serialize_value(events), handle)
 
 
 if __name__ == "__main__":

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -16,10 +16,13 @@ import tempfile
 import zipfile
 import logging
 
-from dagster.core.execution.plan.external_step import PICKLED_EVENTS_FILE_NAME, run_step_from_ref
+from dagster.core.execution.plan.external_step import (
+    PICKLED_RECORDS_FILE_NAME,
+    run_step_from_ref,
+    serialize_dagster_log_records,
+)
 from dagster.core.instance import DagsterInstance
 from dagster.core.log_manager import DAGSTER_META_KEY
-from dagster.serdes import serialize_value
 
 
 # This won't be set in Databricks but is needed to be non-None for the
@@ -28,29 +31,19 @@ if "DATABRICKS_TOKEN" not in os.environ:
     os.environ["DATABRICKS_TOKEN"] = ""
 
 
-LOGS_COMPLETE = "__DONE__"
-
-
-class MyHandler(logging.Handler):
-    def __init__(self, events_filepath: str):
+class DBFSHandler(logging.Handler):
+    def __init__(self, records_filepath: str):
         super().__init__()
-        self._all_events = []
-        self._events_filepath = events_filepath
-
-    def _write_obj(self, obj):
-        with open(self._events_filepath, "wb") as handle:
-            pickle.dump(obj, handle)
+        self._all_records = []
+        self._records_filepath = records_filepath
 
     def emit(self, record):
-        # can't directly serialize DagsterEvents
-        record.__dict__[DAGSTER_META_KEY]["dagster_event"] = serialize_value(
-            record.__dict__[DAGSTER_META_KEY]["dagster_event"]
-        )
-        self._all_events.append(record)
-        self._write_obj(self._all_events)
-
-    def mark_complete(self):
-        self._write_obj(self._all_events + [LOGS_COMPLETE])
+        print("--------------")
+        print(self._all_records)
+        print(self._records_filepath)
+        self._all_records.append(record)
+        with open(self._records_filepath, "wb") as handle:
+            handle.write(serialize_dagster_log_records(self._all_records))
 
 
 def main(
@@ -78,18 +71,18 @@ def main(
 
         with open(step_run_ref_filepath, "rb") as handle:
             step_run_ref = pickle.load(handle)
-        print("Running dagster job")  # noqa pylint: disable=print-call
-        events_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
 
-        events_handler = MyHandler(events_filepath=events_filepath)
-
+        records_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_RECORDS_FILE_NAME
         with DagsterInstance.ephemeral() as instance:
+            # enable re-execution
+            if step_run_ref.parent_run:
+                instance.add_run(step_run_ref.parent_run._replace(pipeline_snapshot_id=None))
+            instance.add_run(step_run_ref.pipeline_run._replace(pipeline_snapshot_id=None))
             # hack to send all events to a specific filepath
-            instance.get_handlers = lambda: [events_handler]
+            instance.get_handlers = lambda: [DBFSHandler(records_filepath)]
             # run the step
+            print("Running dagster job")  # noqa pylint: disable=print-call
             list(run_step_from_ref(step_run_ref, instance))
-
-        events_handler.mark_complete()
 
 
 if __name__ == "__main__":

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -24,8 +24,8 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
         spark_jar_task=task["spark_jar_task"],
         libraries=[
             {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_databricks=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_pyspark=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
     )
 
@@ -57,8 +57,8 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
         spark_jar_task=task["spark_jar_task"],
         libraries=[
             {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_databricks=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_pyspark=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
     )
 


### PR DESCRIPTION
Lots of fixes / improvements to the databricks step launcher. Still a WIP, and there are some known issues that this does not yet address. However, these changes make the step launcher significantly easier to reason about, and overall reduces the jank level a fair bit.

What this fixes/changes:

- Events:
    - Previously, the only events that were serialized and sent back from Databricks to the launching process were events yielded during execution. This means that context.log calls would vanish into the void, as they do not yield events.
    - Previously, all events would be collected into a single list after the Databricks process completed, then written to dbfs. This means that all events for the step would arrive simultaneously, rather than showing up as the step executes.
    - Previously, all events would be logged with log_step_event(). Not all events created during a step are step_events (for example, there are resource_events created when you initialize resources). This would cause issue in the timeline view, except the next issue prevent that from being noticeable...
    - Previously, all events would be logged with timestamps generated from the local launching process. This means that they would all have nearly-identical timestamps, resulting in a very misleading gantt chart.
    - Now, all of these issues have been fixed by doing away with the event-based scheme, and replacing it with a log-record based implementation. In this world, we create a log handler that will capture every single log event created during a run (this includes dagster events as well as context.log stuff), and serialize this to a file instead. This means that all sorts of useful metadata is preserved, including the remote timestamp. This fixes nearly all of the bugs described above
    - We also now use a polling implementation to read from this file as the run progresses. This allows users to see progress as the step executes (although the gantt chart will have proper timestamps regardless of when you read the remote file)
    - TODO: Writing to dbfs in the log handler should actually happen in a separate thread, as it can take up to a few tenths of a second per write.
- Execution
    - Re-execution was broken because Dagster expects the previous run to be available in the instance storage. Because we create an ephemeral instance on Databricks to run this step in, it has no knowledge of the true run history. We fix this by adding information to the StepRunRef, and populating the ephemeral instance with this info (this is admittedly a hack)
    - Dynamic execution was broken because we did not include the known_state on the step run ref. This can be fixed very easily just by adding that back on.

There are some outstanding issues with getting stdout/stderr logs off of the instance, and I believe that we can implement this in a way that eliminates the need to wait_for_logs in most scenarios. Right now, we have to rely on the databricks-backed log storage, which has up to a 5 minute latency for updating. People want to grab stdout/stderr off of the cluster either just for general information, or to debug what happened if a step fails. I believe that as long as the databricks job itself doesn't fail (meaning it's an error within the user's python code), we should be able to ship the compute logs out to a dbfs file and read it back locally. There will still be some logs we can't capture, but this will be much rarer scenarios.

There are also some configuration issues that are a bit annoying (some things are required when I think they can be made optional), which this does not yet address.