### PR TITLE
[dagit] Query for config tab availability

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -1,19 +1,23 @@
-import {QueryResult} from '@apollo/client';
+import {gql, QueryResult, useQuery} from '@apollo/client';
 import * as React from 'react';
 
 import {QueryCountdown} from '../app/QueryCountdown';
 import {Box} from '../ui/Box';
 import {Tab, Tabs} from '../ui/Tabs';
 
+import {InstanceConfigHasInfo} from './types/InstanceConfigHasInfo';
+
 const POLL_INTERVAL = 15000;
 
-interface Props {
-  queryData?: QueryResult;
+interface Props<TData> {
+  queryData?: QueryResult<TData, any>;
   tab: string;
 }
 
-export const InstanceTabs: React.FC<Props> = (props) => {
+export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {queryData, tab} = props;
+  const {data} = useQuery<InstanceConfigHasInfo>(INSTANCE_CONFIG_HAS_INFO);
+
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
       <Tabs selectedTabId={tab}>
@@ -21,7 +25,7 @@ export const InstanceTabs: React.FC<Props> = (props) => {
         <Tab id="schedules" title="Schedules" to="/instance/schedules" />
         <Tab id="sensors" title="Sensors" to="/instance/sensors" />
         <Tab id="backfills" title="Backfills" to="/instance/backfills" />
-        {queryData?.data?.instance.hasInfo ? (
+        {data?.instance.hasInfo ? (
           <Tab id="config" title="Configuration" to="/instance/config" />
         ) : null}
       </Tabs>
@@ -33,3 +37,11 @@ export const InstanceTabs: React.FC<Props> = (props) => {
     </Box>
   );
 };
+
+const INSTANCE_CONFIG_HAS_INFO = gql`
+  query InstanceConfigHasInfo {
+    instance {
+      hasInfo
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceConfigHasInfo.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceConfigHasInfo.ts
@@ -1,0 +1,17 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: InstanceConfigHasInfo
+// ====================================================
+
+export interface InstanceConfigHasInfo_instance {
+  __typename: "Instance";
+  hasInfo: boolean;
+}
+
+export interface InstanceConfigHasInfo {
+  instance: InstanceConfigHasInfo_instance;
+}


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Resolves #5869.

Repair `Configuration` tab in Instance view.

## Test Plan

Set `hasInfo` resolver to `false`, verify that the tab doesn't appear. Allow it to be true, verify that it does appear.