### PR TITLE
add descriptions to foreign assets, and include them in repositories

### DIFF
--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -31,7 +31,10 @@ from dagster import AssetKey
 from dagster.core.asset_defs import ForeignAsset, asset
 from pandas import DataFrame
 
-sfo_q2_weather_sample = ForeignAsset(key=AssetKey("sfo_q2_weather_sample"))
+sfo_q2_weather_sample = ForeignAsset(
+    key=AssetKey("sfo_q2_weather_sample"),
+    description="Weather samples, taken every five minutes at SFO",
+)
 
 
 @asset

--- a/examples/software_defined_assets/software_defined_assets/assets.py
+++ b/examples/software_defined_assets/software_defined_assets/assets.py
@@ -6,7 +6,10 @@ from dagster import AssetKey
 from dagster.core.asset_defs import ForeignAsset, asset
 from pandas import DataFrame
 
-sfo_q2_weather_sample = ForeignAsset(key=AssetKey("sfo_q2_weather_sample"))
+sfo_q2_weather_sample = ForeignAsset(
+    key=AssetKey("sfo_q2_weather_sample"),
+    description="Weather samples, taken every five minutes at SFO",
+)
 
 
 @asset

--- a/python_modules/dagster/dagster/core/asset_defs/foreign_asset.py
+++ b/python_modules/dagster/dagster/core/asset_defs/foreign_asset.py
@@ -12,8 +12,10 @@ class ForeignAsset(NamedTuple):
         metadata (Optional[Any]): Metadata associated with the asset.
         io_manager_key (str): The key for the IOManager that will be used to load the contents of
             the asset when it's used as an input to other assets inside a job.
+        description (Optional[str]): The description of the asset.
     """
 
     key: AssetKey
     metadata: Optional[Any] = None
     io_manager_key: str = "io_manager"
+    description: Optional[str] = None

--- a/python_modules/dagster/dagster/core/definitions/decorators/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository.py
@@ -23,6 +23,8 @@ class _Repository:
         self.description = check.opt_str_param(description, "description")
 
     def __call__(self, fn: Callable[[], Any]) -> RepositoryDefinition:
+        from dagster.core.asset_defs import ForeignAsset
+
         check.callable_param(fn, "fn")
 
         if not self.name:
@@ -50,6 +52,7 @@ class _Repository:
                     or isinstance(definition, ScheduleDefinition)
                     or isinstance(definition, SensorDefinition)
                     or isinstance(definition, GraphDefinition)
+                    or isinstance(definition, ForeignAsset)
                 ):
                     bad_definitions.append((i, type(definition)))
             if bad_definitions:
@@ -62,7 +65,7 @@ class _Repository:
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
                     "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
-                    "PartitionSetDefinition, ScheduleDefinition, or SensorDefinition. "
+                    "PartitionSetDefinition, ScheduleDefinition, SensorDefinition, or ForeignAsset. "
                     f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 import pytest
 from dagster import (
+    AssetKey,
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     PipelineDefinition,
@@ -21,6 +22,7 @@ from dagster import (
     sensor,
     solid,
 )
+from dagster.core.asset_defs import ForeignAsset
 from dagster.core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 
 
@@ -558,3 +560,14 @@ def test_bad_coerce():
             return {
                 "jobs": {"bar": bar},
             }
+
+
+def test_foreign_assets():
+    foo = ForeignAsset(key=AssetKey("foo"))
+    bar = ForeignAsset(key=AssetKey("bar"))
+
+    @repository
+    def my_repo():
+        return [foo, bar]
+
+    assert my_repo.foreign_assets_by_key == {AssetKey("foo"): foo, AssetKey("bar"): bar}


### PR DESCRIPTION
Foreign assets (does the name feel a little xenophobic? maybe we need a different one?) are assets that Dagster knows about, but whose contents are not produced by Dagster ops.

This PR paves the way for surfacing definition-level metadata about foreign assets in Dagit, by including `ForeignAssets` as top-level objects on `RepositoryDefinitions`. For example, this is useful for documenting the set of columns you expect to exist in one of the tables that you derived tables depend on.

I went as far as writing tests to verify that descriptions appear on `ExternalAssetNode`s. However, these descriptions aren't actually appearing in Dagit yet. I'm hoping that someone else can take that on in a followup.