### PR TITLE
remove target info from sensor details if not applicable

### DIFF
--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -144,10 +144,10 @@ export const SensorDetails: React.FC<{
               )}
             </td>
           </tr>
-          <tr>
-            <td>{pipelineOrJobLabel}</td>
-            <td>
-              {sensor.targets && sensor.targets.length ? (
+          {sensor.targets && sensor.targets.length ? (
+            <tr>
+              <td>{pipelineOrJobLabel}</td>
+              <td>
                 <Group direction="column" spacing={2}>
                   {sensor.targets.map((target) =>
                     target.pipelineName ? (
@@ -160,11 +160,9 @@ export const SensorDetails: React.FC<{
                     ) : null,
                   )}
                 </Group>
-              ) : (
-                'Sensor does not target a pipeline'
-              )}
-            </td>
-          </tr>
+              </td>
+            </tr>
+          ) : null}
           <tr>
             <td>Frequency</td>
             <td>{humanizeSensorInterval(sensor.minIntervalSeconds)}</td>


### PR DESCRIPTION
## Summary
For run status sensors, the target section doesn't quite make sense.  Also, it's not job-friendly.


## Test Plan
Created run status sensor, saw details page.
