### PR TITLE
add software-defined assets toy

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
@@ -21,6 +21,7 @@ from dagster_test.graph_job_op_toys.many_events import many_events, many_events_
 from dagster_test.graph_job_op_toys.notebooks import hello_world_notebook_pipeline
 from dagster_test.graph_job_op_toys.retries import retry_job
 from dagster_test.graph_job_op_toys.sleepy import sleepy_job
+from dagster_test.graph_job_op_toys.software_defined_assets import software_defined_assets_job
 from dagster_test.graph_job_op_toys.unreliable import unreliable_job
 
 from .schedules import get_toys_schedules
@@ -67,6 +68,7 @@ def toys_repository():
             asset_lineage_partition_set,
             model_job,
             hello_world_notebook_pipeline,
+            software_defined_assets_job,
         ]
         + get_toys_schedules()
         + get_toys_sensors()

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/software_defined_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/software_defined_assets.py
@@ -1,0 +1,45 @@
+# pylint: disable=redefined-outer-name
+import time
+
+from dagster import AssetKey, IOManager, IOManagerDefinition
+from dagster.core.asset_defs import ForeignAsset, asset, build_assets_job
+
+sfo_q2_weather_sample = ForeignAsset(key=AssetKey("sfo_q2_weather_sample"))
+
+
+class DataFrame:
+    pass
+
+
+class DummyIOManager(IOManager):
+    def handle_output(self, context, obj: DataFrame):
+        assert context
+        assert obj
+
+    def load_input(self, context):
+        assert context
+        return DataFrame()
+
+
+@asset
+def daily_temperature_highs(sfo_q2_weather_sample: DataFrame) -> DataFrame:
+    """Computes the temperature high for each day"""
+    assert sfo_q2_weather_sample
+    time.sleep(3)
+    return DataFrame()
+
+
+@asset
+def hottest_dates(daily_temperature_highs: DataFrame) -> DataFrame:
+    """Computes the 10 hottest dates"""
+    assert daily_temperature_highs
+    time.sleep(3)
+    return DataFrame()
+
+
+software_defined_assets_job = build_assets_job(
+    "weather",
+    assets=[daily_temperature_highs, hottest_dates],
+    source_assets=[sfo_q2_weather_sample],
+    resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager())},
+)

--- a/python_modules/dagster-test/dagster_test_tests/test_graph_job_op_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_graph_job_op_toys.py
@@ -26,6 +26,7 @@ from dagster_test.graph_job_op_toys.resources import lots_of_resources, resource
 from dagster_test.graph_job_op_toys.retries import retry
 from dagster_test.graph_job_op_toys.schedules import longitudinal_schedule
 from dagster_test.graph_job_op_toys.sleepy import sleepy
+from dagster_test.graph_job_op_toys.software_defined_assets import software_defined_assets_job
 from dagster_tests.execution_tests.engine_tests.test_step_delegating_executor import (
     test_step_delegating_executor,
 )
@@ -293,3 +294,7 @@ def test_retry_job(executor_def):
         .execute_in_process()
         .success
     )
+
+
+def test_software_defined_assets_job():
+    assert software_defined_assets_job.execute_in_process().success


### PR DESCRIPTION
To make it easier to play around with the SDA UI.

Test plan: `dagit -f`, and ran the job manually.