### PR TITLE
custom location name support in Helm chart when setting your own gRPC servers

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
@@ -7,7 +7,7 @@ from ...utils.utils import BaseModel
 class Server(BaseModel):
     host: str
     port: int
-    name: str
+    name: Optional[str]
 
 
 class Workspace(BaseModel):

--- a/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
@@ -7,6 +7,7 @@ from ...utils.utils import BaseModel
 class Server(BaseModel):
     host: str
     port: int
+    name: str
 
 
 class Workspace(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_workspace.py
+++ b/helm/dagster/schema/schema_tests/test_workspace.py
@@ -151,7 +151,7 @@ def test_workspace_server_location_name_renders_from_helm_dagit(template: HelmTe
     assert len(grpc_servers) == len(servers)
 
     for grpc_server, server in zip(grpc_servers, servers):
-        assert grpc_servers["grpc_server"]["host"] == server.host
+        assert grpc_server["grpc_server"]["host"] == server.host
         assert grpc_server["grpc_server"]["port"] == server.port
 
     assert grpc_servers[0]["grpc_server"]["location_name"] == servers[0].host

--- a/helm/dagster/schema/schema_tests/test_workspace.py
+++ b/helm/dagster/schema/schema_tests/test_workspace.py
@@ -122,6 +122,42 @@ def test_workspace_renders_from_helm_dagit(template: HelmTemplate):
         assert grpc_server["grpc_server"]["location_name"] == server.name
 
 
+def test_workspace_server_location_name_renders_from_helm_dagit(template: HelmTemplate):
+    servers = [
+        Server(host="another-deployment-one", port=4000),
+        Server(host="another-deployment-two", port=4001, name="deployment two"),
+    ]
+    helm_values = DagsterHelmValues.construct(
+        dagit=Dagit.construct(workspace=Workspace(enabled=True, servers=servers)),
+        dagsterUserDeployments=UserDeployments(
+            enabled=True,
+            enableSubchart=True,
+            deployments=[
+                create_simple_user_deployment("deployment-one"),
+                create_simple_user_deployment("deployment-two"),
+            ],
+        ),
+    )
+
+    workspace_templates = template.render(helm_values)
+
+    assert len(workspace_templates) == 1
+
+    workspace_template = workspace_templates[0]
+
+    workspace = yaml.full_load(workspace_template.data["workspace.yaml"])
+    grpc_servers = workspace["load_from"]
+
+    assert len(grpc_servers) == len(servers)
+
+    for grpc_server, server in zip(grpc_servers, servers):
+        assert grpc_servers["grpc_server"]["host"] == server.host
+        assert grpc_server["grpc_server"]["port"] == server.port
+
+    assert grpc_servers[0]["grpc_server"]["location_name"] == servers[0].host
+    assert grpc_servers[1]["grpc_server"]["location_name"] == servers[1].name
+
+
 def test_workspace_renders_empty(template: HelmTemplate):
     servers: List[Server] = []
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/schema/schema_tests/test_workspace.py
+++ b/helm/dagster/schema/schema_tests/test_workspace.py
@@ -89,9 +89,9 @@ def test_workspace_renders_from_helm_user_deployments(template: HelmTemplate):
 
 def test_workspace_renders_from_helm_dagit(template: HelmTemplate):
     servers = [
-        Server(host="another-deployment-one", port=4000),
-        Server(host="another-deployment-two", port=4001),
-        Server(host="another-deployment-three", port=4002),
+        Server(host="another-deployment-one", port=4000, name="deployment one"),
+        Server(host="another-deployment-two", port=4001, name="deployment two"),
+        Server(host="another-deployment-three", port=4002, name="deployment three"),
     ]
     helm_values = DagsterHelmValues.construct(
         dagit=Dagit.construct(workspace=Workspace(enabled=True, servers=servers)),
@@ -119,7 +119,7 @@ def test_workspace_renders_from_helm_dagit(template: HelmTemplate):
     for grpc_server, server in zip(grpc_servers, servers):
         assert grpc_server["grpc_server"]["host"] == server.host
         assert grpc_server["grpc_server"]["port"] == server.port
-        assert grpc_server["grpc_server"]["location_name"] == server.host
+        assert grpc_server["grpc_server"]["location_name"] == server.name
 
 
 def test_workspace_renders_empty(template: HelmTemplate):

--- a/helm/dagster/templates/configmap-workspace.yaml
+++ b/helm/dagster/templates/configmap-workspace.yaml
@@ -25,7 +25,7 @@ data:
       - grpc_server:
           host: {{ $deploymentHost }}
           port: {{ $deployment.port }}
-          location_name: {{ $deploymentHost }}
+          location_name: {{ $deployment.name }}
       {{- end }}
     {{- else }}
     load_from: []

--- a/helm/dagster/templates/configmap-workspace.yaml
+++ b/helm/dagster/templates/configmap-workspace.yaml
@@ -25,7 +25,11 @@ data:
       - grpc_server:
           host: {{ $deploymentHost }}
           port: {{ $deployment.port }}
+          {{- if $deployment.name }}
           location_name: {{ $deployment.name }}
+          {{else}}
+          location_name: {{ $deploymentHost }}
+          {{end}}
       {{- end }}
     {{- else }}
     load_from: []

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -168,6 +168,10 @@
                 "port": {
                     "title": "Port",
                     "type": "integer"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
                 }
             },
             "required": [

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -171,7 +171,14 @@
                 },
                 "name": {
                     "title": "Name",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -53,6 +53,7 @@ dagit:
     servers:
       - host: "k8s-example-user-code-1"
         port: 3030
+        name: "user-code-example"
 
   # Deploy a separate instance of Dagit in --read-only mode (can't launch runs, disable schedules, etc.)
   enableReadOnly: false


### PR DESCRIPTION
Original PR from @pcherednichenko: https://github.com/dagster-io/dagster/pull/5796

- support location name in chart
- backwards compatible localion_name
- Make server name optional, fixup test

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.