### PR TITLE
Type annotation tweak for serdes

### DIFF
--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -138,7 +138,6 @@ def _whitelist_for_serdes(
             _check_serdes_tuple_class_invariants(klass, sig_params)
             whitelist_map.register_tuple(klass.__name__, cast(Type[NamedTuple], klass), serializer, sig_params)
         else:
-            from IPython import embed; embed()
             raise SerdesUsageError(f"Can not whitelist class {klass} for serializer {serializer}")
 
         return klass

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -131,13 +131,14 @@ def _whitelist_for_serdes(
             serializer is None or issubclass(serializer, EnumSerializer)
         ):
             whitelist_map.register_enum(klass.__name__, klass, serializer)
-        elif issubclass(klass, NamedTuple) and (
+        elif issubclass(klass, tuple) and (
             serializer is None or issubclass(serializer, NamedTupleSerializer)
         ):
             sig_params = signature(klass.__new__).parameters
             _check_serdes_tuple_class_invariants(klass, sig_params)
-            whitelist_map.register_tuple(klass.__name__, klass, serializer, sig_params)
+            whitelist_map.register_tuple(klass.__name__, cast(Type[NamedTuple], klass), serializer, sig_params)
         else:
+            from IPython import embed; embed()
             raise SerdesUsageError(f"Can not whitelist class {klass} for serializer {serializer}")
 
         return klass

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -136,7 +136,9 @@ def _whitelist_for_serdes(
         ):
             sig_params = signature(klass.__new__).parameters
             _check_serdes_tuple_class_invariants(klass, sig_params)
-            whitelist_map.register_tuple(klass.__name__, cast(Type[NamedTuple], klass), serializer, sig_params)
+            whitelist_map.register_tuple(
+                klass.__name__, cast(Type[NamedTuple], klass), serializer, sig_params
+            )
         else:
             raise SerdesUsageError(f"Can not whitelist class {klass} for serializer {serializer}")
 

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -19,6 +19,7 @@ from enum import Enum
 from inspect import Parameter, isclass, signature
 from typing import (
     Any,
+    Callable,
     Dict,
     List,
     Mapping,
@@ -28,8 +29,8 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    Union,
     cast,
+    overload,
 )
 
 from dagster import check, seven
@@ -94,8 +95,13 @@ class WhitelistMap(NamedTuple):
 
 _WHITELIST_MAP = WhitelistMap.create()
 
-
-def whitelist_for_serdes(serializer: Union[Type, Type["Serializer"]]):
+@overload
+def whitelist_for_serdes(serializer: Type) -> Type:
+    ...
+@overload
+def whitelist_for_serdes(serializer: Type["Serializer"]) -> Callable[[Type], Type]:
+    ...
+def whitelist_for_serdes(serializer):
     """
     Decorator to whitelist a named tuple or enum to be serializable.
 

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -95,12 +95,17 @@ class WhitelistMap(NamedTuple):
 
 _WHITELIST_MAP = WhitelistMap.create()
 
+
 @overload
 def whitelist_for_serdes(serializer: Type) -> Type:
     ...
+
+
 @overload
 def whitelist_for_serdes(serializer: Type["Serializer"]) -> Callable[[Type], Type]:
     ...
+
+
 def whitelist_for_serdes(serializer):
     """
     Decorator to whitelist a named tuple or enum to be serializable.
@@ -121,10 +126,14 @@ def whitelist_for_serdes(serializer):
 def _whitelist_for_serdes(
     whitelist_map: WhitelistMap, serializer: Optional[Type["Serializer"]] = None
 ):
-    def __whitelist_for_serdes(klass):
-        if issubclass(klass, Enum):
+    def __whitelist_for_serdes(klass: Type):
+        if issubclass(klass, Enum) and (
+            serializer is None or issubclass(serializer, EnumSerializer)
+        ):
             whitelist_map.register_enum(klass.__name__, klass, serializer)
-        elif issubclass(klass, tuple):
+        elif issubclass(klass, NamedTuple) and (
+            serializer is None or issubclass(serializer, NamedTupleSerializer)
+        ):
             sig_params = signature(klass.__new__).parameters
             _check_serdes_tuple_class_invariants(klass, sig_params)
             whitelist_map.register_tuple(klass.__name__, klass, serializer, sig_params)


### PR DESCRIPTION
Classes decorated with `whitelist_for_serdes` have been causing pyright/pylance (default VSCode Python language server) to cry out in pain and clutter the diagnostic list with noise. This PR tweaks the type annotations of `whitelist_for_serdes` to fix this issue. There is also a very small logic change in `whitelist_for_serdes` which makes some conditional checks for the `Serializer` consistent with the existing type annotations.