### PR TITLE
Removed "managed" from Toy Asset

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/big_honkin_asset_graph.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/big_honkin_asset_graph.py
@@ -2,7 +2,7 @@ import random
 from typing import Sequence
 
 from dagster import AssetKey
-from dagster.core.asset_defs import AssetIn, asset, build_assets_job
+from dagster.core.asset_defs import asset, build_assets_job
 
 N_ASSETS = 1000
 

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/big_honkin_asset_graph.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/big_honkin_asset_graph.py
@@ -1,6 +1,7 @@
 import random
 from typing import Sequence
 
+from dagster import AssetKey
 from dagster.core.asset_defs import AssetIn, asset, build_assets_job
 
 N_ASSETS = 1000
@@ -11,12 +12,11 @@ def generate_big_honkin_assets() -> Sequence:
     assets = []
 
     for i in range(N_ASSETS):
-        ins = {
-            f"asset_{j}": AssetIn(managed=False)
-            for j in random.sample(range(i), min(i, random.randint(0, 3)))
+        non_argument_deps = {
+            AssetKey(f"asset_{j}") for j in random.sample(range(i), min(i, random.randint(0, 3)))
         }
 
-        @asset(name=f"asset_{i}", ins=ins)
+        @asset(name=f"asset_{i}", non_argument_deps=non_argument_deps)
         def some_asset():
             pass
 


### PR DESCRIPTION
Unblocks master by removing param that is no longer used on toy.