### PR TITLE
[dagit] Use array for run filtering

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -7,8 +7,8 @@ import {
   SuggestionProvider,
   TokenizingField,
   TokenizingFieldValue,
-  stringFromValue,
-  tokenizedValuesFromString,
+  tokensAsStringArray,
+  tokenizedValuesFromStringArray,
 } from '../ui/TokenizingField';
 import {DagsterRepoOption, useRepositoryOptions} from '../workspace/WorkspaceContext';
 
@@ -60,9 +60,9 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
   return useQueryPersistedState<TokenizingFieldValue[]>(
     React.useMemo(
       () => ({
-        encode: (tokens) => ({q: stringFromValue(tokens), cursor: undefined}),
-        decode: ({q = ''}) =>
-          tokenizedValuesFromString(q, RUN_PROVIDERS_EMPTY).filter(
+        encode: (tokens) => ({q: tokensAsStringArray(tokens), cursor: undefined}),
+        decode: ({q = []}) =>
+          tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY).filter(
             (t) =>
               !t.token || !enabledFilters || enabledFilters.includes(t.token as RunFilterTokenType),
           ),
@@ -183,7 +183,7 @@ export const RunsFilterInput: React.FC<RunsFilterInputProps> = ({
 
   const suggestions = searchSuggestionsForRuns(options, data?.pipelineRunTags, enabledFilters);
 
-  const search = tokenizedValuesFromString(stringFromValue(tokens), suggestions);
+  const search = tokenizedValuesFromStringArray(tokensAsStringArray(tokens), suggestions);
 
   const suggestionProvidersFilter = (
     suggestionProviders: SuggestionProvider[],

--- a/js_modules/dagit/packages/core/src/ui/TokenizingField.tsx
+++ b/js_modules/dagit/packages/core/src/ui/TokenizingField.tsx
@@ -54,13 +54,16 @@ function findProviderByToken(token: string, providers: SuggestionProvider[]) {
   return providers.find((p) => p.token.toLowerCase() === token.toLowerCase());
 }
 
-export function tokenizedValuesFromString(str: string, providers: SuggestionProvider[]) {
+export const tokenizedValuesFromString = (str: string, providers: SuggestionProvider[]) => {
   if (str === '') {
     return [];
   }
   const tokens = str.split(',');
-  return tokens.map((token) => tokenizedValueFromString(token, providers));
-}
+  return tokenizedValuesFromStringArray(tokens, providers);
+};
+
+export const tokenizedValuesFromStringArray = (tokens: string[], providers: SuggestionProvider[]) =>
+  tokens.map((token) => tokenizedValueFromString(token, providers));
 
 export function tokenizedValueFromString(
   str: string,
@@ -80,12 +83,11 @@ export function tokenizedValueFromString(
   return {value: str};
 }
 
-export function stringFromValue(value: TokenizingFieldValue[]) {
-  return value
-    .filter((v) => v.value !== '')
-    .map((v) => (v.token ? `${v.token}:${v.value}` : v.value))
-    .join(',');
-}
+export const tokensAsStringArray = (value: TokenizingFieldValue[]) =>
+  value.filter((v) => v.value !== '').map((v) => (v.token ? `${v.token}:${v.value}` : v.value));
+
+export const stringFromValue = (value: TokenizingFieldValue[]) =>
+  tokensAsStringArray(value).join(',');
 
 /** Provides a text field with typeahead autocompletion for key value pairs,
 where the key is one of a known set of "suggestion provider tokens". Provide


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Resolves #5839.

Depends on #5880.

Use an array for tracking run filters to avoid the issue where run tags with commas break the filter input.

## Test Plan


Launch a run with a tag that contains commas. View Runs page, click on that tag. Verify that the filter input is populated correctly, the URL query is correct, and that filtering behavior is correct.