### PR TITLE
Don't check the brokerUrl field when determining the backendUrl value

### DIFF
--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -167,7 +167,7 @@ rpc://
 {{- else if .Values.redis.enabled -}}
 {{- $password := ternary (printf ":%s@" .Values.redis.password) "" .Values.redis.usePassword -}}
 {{- $connectionUrl := printf "redis://%s%s:%g/%g" $password .Values.redis.host .Values.redis.port (.Values.redis.backendDbNumber | default (float64 0)) -}}
-{{- ternary .Values.redis.backendUrl $connectionUrl (not (empty .Values.redis.brokerUrl)) }}
+{{- ternary .Values.redis.backendUrl $connectionUrl (not (empty .Values.redis.backendUrl)) }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Summary:
Maybe we should raise an error if one of these is set but the other isn't, but today if you set brokerUrl but don't set backendUrl, confusing things happen where it is always set to "".

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.