### PR TITLE
[dagit] Show warning for unloadable sensors

### DIFF
--- a/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/Unloadable.tsx
@@ -135,9 +135,17 @@ const SensorStateRow = ({sensorState}: {sensorState: InstigationStateFragment}) 
     onCompleted: displaySensorMutationErrors,
   });
   const [showRepositoryOrigin, setShowRepositoryOrigin] = React.useState(false);
+  const confirm = useConfirmation();
 
-  const onChangeSwitch = () => {
+  const onChangeSwitch = async () => {
     if (status === InstigationStatus.RUNNING) {
+      await confirm({
+        title: 'Are you sure you want to turn off this sensor?',
+        description:
+          'The definition for this sensor is not available. ' +
+          'If you turn it off, you will not be able to turn it back on from ' +
+          'the currently loaded workspace.',
+      });
       stopSensor({variables: {jobOriginId: id}});
     }
   };
@@ -205,8 +213,8 @@ const ScheduleStateRow: React.FunctionComponent<{
       await confirm({
         title: 'Are you sure you want to stop this schedule?',
         description:
-          'The schedule definition for this schedule is not available. ' +
-          'If you turn off this schedule, you will not be able to turn it back on from ' +
+          'The definition for this schedule is not available. ' +
+          'If you turn it off, you will not be able to turn it back on from ' +
           'the currently loaded workspace.',
       });
       stopSchedule({variables: {scheduleOriginId: id}});


### PR DESCRIPTION
## Summary

Resolves #4038.

When turning off an unloadable sensor, we don't currently warn you about what you're doing. Use a similar warning to the unloadable schedules warning.

## Test Plan

Remove an active sensor from my repo, reload repo. View sensors, try to turn it off. Verify that the warning appears, and that I can successfully confirm or cancel.
