### PR TITLE
Log from gRPC servers on startup and shutdown, consolidate system process logging

### DIFF
--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -258,8 +258,6 @@ def create_app_from_workspace_process_context(
 
     warn_if_compute_logs_disabled()
 
-    print("Loading repository...")  # pylint: disable=print-call
-
     log_workspace_stats(instance, workspace_process_context)
 
     schema = create_schema()

--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -15,6 +15,7 @@ from dagster.cli.workspace.cli_target import WORKSPACE_TARGET_WARNING
 from dagster.core.telemetry import START_DAGIT_WEBSERVER, log_action
 from dagster.core.workspace import WorkspaceProcessContext
 from dagster.utils import DEFAULT_WORKSPACE_YAML_FILENAME
+from dagster.utils.log import default_system_logger
 from gevent import pywsgi
 from geventwebsocket.handler import WebSocketHandler
 
@@ -189,8 +190,10 @@ def uploading_logging_thread(instance):
 def start_server(instance, host, port, path_prefix, app, port_lookup, port_lookup_attempts=0):
     server = pywsgi.WSGIServer((host, port), app, handler_class=WebSocketHandler)
 
-    click.echo(
-        "Serving on http://{host}:{port}{path_prefix} in process {pid}".format(
+    logger = default_system_logger("dagit")
+
+    logger.info(
+        "Serving dagit on http://{host}:{port}{path_prefix} in process {pid}".format(
             host=host, port=port, path_prefix=path_prefix, pid=os.getpid()
         )
     )

--- a/python_modules/dagit/dagit_tests/test_debug_cli.py
+++ b/python_modules/dagit/dagit_tests/test_debug_cli.py
@@ -19,7 +19,7 @@ def pipe_test():
     emit_one()
 
 
-def test_roundtrip(monkeypatch):
+def test_roundtrip(monkeypatch, caplog):
     runner = CliRunner()
     with instance_for_test() as instance:
         run_result = execute_pipeline(pipe_test, instance=instance)
@@ -35,4 +35,4 @@ def test_roundtrip(monkeypatch):
         debug_result = runner.invoke(dagit_debug_command, [file_path])
         assert file_path in debug_result.output
         assert "run_id: {}".format(run_result.run_id) in debug_result.output
-        assert "Serving on" in debug_result.output
+        assert caplog.text.count("Serving dagit on") == 1

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import signal
 import sys
 import tempfile
@@ -460,3 +461,18 @@ def remove_none_recursively(obj):
 
 
 default_mode_def_for_test = ModeDefinition(resource_defs={"io_manager": fs_io_manager})
+
+
+def strip_ansi(input_str):
+    ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]")
+    return ansi_escape.sub("", input_str)
+
+
+def get_logger_output_from_capfd(capfd, logger_name):
+    return "\n".join(
+        [
+            line
+            for line in strip_ansi(capfd.readouterr().out.replace("\r\n", "\n")).split("\n")
+            if logger_name in line
+        ]
+    )

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from abc import abstractclassmethod, abstractmethod
 from collections import deque
@@ -13,26 +12,11 @@ from dagster.daemon.sensor import execute_sensor_iteration_loop
 from dagster.daemon.types import DaemonHeartbeat
 from dagster.scheduler import execute_scheduler_iteration
 from dagster.utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
-from dagster.utils.log import default_format_string
-
-
-def _mockable_localtime(_):
-    now_time = pendulum.now()
-    return now_time.timetuple()
+from dagster.utils.log import default_system_logger
 
 
 def get_default_daemon_logger(daemon_name):
-    handler = logging.StreamHandler(sys.stdout)
-    logger = logging.getLogger(daemon_name)
-    logger.setLevel(logging.INFO)
-    logger.handlers = [handler]
-
-    formatter = logging.Formatter(default_format_string(), "%Y-%m-%d %H:%M:%S")
-
-    formatter.converter = _mockable_localtime
-
-    handler.setFormatter(formatter)
-    return logger
+    return default_system_logger(daemon_name)
 
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -982,6 +982,7 @@ def open_server_process(
         + (["--heartbeat-timeout", str(heartbeat_timeout)] if heartbeat_timeout else [])
         + (["--fixed-server-id", fixed_server_id] if fixed_server_id else [])
         + (["--override-system-timezone", mocked_system_timezone] if mocked_system_timezone else [])
+        + (["--log-level", "WARNING"])  # don't log INFO messages for automatically spun up servers
     )
 
     if loadable_target_origin:

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -6,6 +6,7 @@ from dagster.core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace,
     get_crash_signals,
+    get_logger_output_from_capfd,
 )
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.backfill import execute_backfill_iteration
@@ -70,12 +71,10 @@ def test_simple(external_repo_context, capfd):
         launch_process.join(timeout=60)
         backfill = instance.get_backfill("simple")
         assert backfill.status == BulkActionStatus.COMPLETED
-        captured = capfd.readouterr()
         assert (
-            captured.out.replace("\r\n", "\n")
+            get_logger_output_from_capfd(capfd, "BackfillDaemon")
             == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions
-"""
+2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
 
@@ -110,11 +109,9 @@ def test_before_submit(external_repo_context, crash_signal, capfd):
         launch_process.start()
         launch_process.join(timeout=60)
         assert launch_process.exitcode != 0
-        captured = capfd.readouterr()
         assert (
-            captured.out.replace("\r\n", "\n")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-"""
+            get_logger_output_from_capfd(capfd, "BackfillDaemon")
+            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -128,12 +125,10 @@ def test_before_submit(external_repo_context, crash_signal, capfd):
         )
         launch_process.start()
         launch_process.join(timeout=60)
-        captured = capfd.readouterr()
         assert (
-            captured.out.replace("\r\n", "\n")
+            get_logger_output_from_capfd(capfd, "BackfillDaemon")
             == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions
-"""
+2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -172,11 +167,9 @@ def test_crash_after_submit(external_repo_context, crash_signal, capfd):
         launch_process.start()
         launch_process.join(timeout=60)
         assert launch_process.exitcode != 0
-        captured = capfd.readouterr()
         assert (
-            captured.out.replace("\r\n", "\n")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-"""
+            get_logger_output_from_capfd(capfd, "BackfillDaemon")
+            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -190,13 +183,11 @@ def test_crash_after_submit(external_repo_context, crash_signal, capfd):
         )
         launch_process.start()
         launch_process.join(timeout=60)
-        captured = capfd.readouterr()
         assert (
-            captured.out.replace("\r\n", "\n")
+            get_logger_output_from_capfd(capfd, "BackfillDaemon")
             == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
 2021-02-16 18:00:00 - BackfillDaemon - INFO - Found 3 existing runs for backfill simple, skipping
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions
-"""
+2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
         backfill = instance.get_backfill("simple")

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -9,6 +9,7 @@ from dagster.core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace,
     get_crash_signals,
+    get_logger_output_from_capfd,
 )
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
@@ -66,7 +67,7 @@ def test_failure_before_run_created(external_repo_context, crash_location, crash
             ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             assert ticks[0].status == JobTickStatus.SKIPPED
-            captured = capfd.readouterr()
+            capfd.readouterr()
 
             # create a starting tick, but crash
             debug_crash_flags = {external_sensor.name: {crash_location: crash_signal}}
@@ -79,7 +80,7 @@ def test_failure_before_run_created(external_repo_context, crash_location, crash
 
             assert launch_process.exitcode != 0
 
-            captured = capfd.readouterr()
+            capfd.readouterr()
 
             ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
@@ -101,13 +102,11 @@ def test_failure_before_run_created(external_repo_context, crash_location, crash
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            captured = capfd.readouterr()
             assert (
-                captured.out.replace("\r\n", "\n")
+                get_logger_output_from_capfd(capfd, "SensorDaemon")
                 == f"""2019-02-27 18:01:03 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
 2019-02-27 18:01:03 - SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:01:03 - SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor
-"""
+2019-02-27 18:01:03 - SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
             )
 
             ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -44,7 +44,11 @@ from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobState, JobStatus, JobTickStatus
 from dagster.core.storage.event_log.base import EventRecordsFilter
 from dagster.core.storage.pipeline_run import PipelineRunStatus
-from dagster.core.test_utils import create_test_daemon_workspace, instance_for_test
+from dagster.core.test_utils import (
+    create_test_daemon_workspace,
+    get_logger_output_from_capfd,
+    instance_for_test,
+)
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.controller import (
@@ -443,12 +447,10 @@ def test_simple_sensor(external_repo_context, capfd):
                 JobTickStatus.SKIPPED,
             )
 
-            captured = capfd.readouterr()
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SensorDaemon")
                 == """2019-02-27 17:59:59 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 17:59:59 - SensorDaemon - INFO - Sensor returned false for simple_sensor, skipping
-"""
+2019-02-27 17:59:59 - SensorDaemon - INFO - Sensor returned false for simple_sensor, skipping"""
             )
 
             freeze_datetime = freeze_datetime.add(seconds=30)
@@ -473,13 +475,11 @@ def test_simple_sensor(external_repo_context, capfd):
                 [run.run_id],
             )
 
-            captured = capfd.readouterr()
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SensorDaemon")
                 == """2019-02-27 18:00:29 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
 2019-02-27 18:00:29 - SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:00:29 - SensorDaemon - INFO - Completed launch of run {run_id} for simple_sensor
-""".format(
+2019-02-27 18:00:29 - SensorDaemon - INFO - Completed launch of run {run_id} for simple_sensor""".format(
                     run_id=run.run_id
                 )
             )

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -25,7 +25,7 @@ def _get_ipc_output_file():
     )
 
 
-def test_ping():
+def test_ping(capfd):
     port = find_free_port()
     python_file = file_relative_path(__file__, "grpc_repo.py")
 
@@ -39,7 +39,7 @@ def test_ping():
         python_file,
     ]
 
-    process = subprocess.Popen(subprocess_args, stdout=subprocess.PIPE)
+    process = subprocess.Popen(subprocess_args)
 
     try:
         wait_for_grpc_server(
@@ -56,6 +56,13 @@ def test_ping():
 
     finally:
         process.terminate()
+
+    out, _err = capfd.readouterr()
+
+    assert (
+        f"Started Dagster code server for file {python_file} on port {port} in process {process.pid}"
+        in out
+    )
 
 
 def test_load_via_env_var():

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -8,6 +8,7 @@ from dagster.core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace,
     get_crash_signals,
+    get_logger_output_from_capfd,
     get_terminate_signal,
 )
 from dagster.scheduler.scheduler import launch_scheduled_runs
@@ -80,12 +81,10 @@ def test_failure_recovery_before_run_created(
 
             assert scheduler_process.exitcode != 0
 
-            captured = capfd.readouterr()
             assert (
-                captured.out.replace("\r\n", "\n")
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-26 18:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000
-"""
+2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000"""
             )
 
             ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
@@ -121,14 +120,12 @@ def test_failure_recovery_before_run_created(
                 JobTickStatus.SUCCESS,
                 [instance.get_runs()[0].run_id],
             )
-            captured = capfd.readouterr()
             assert (
-                captured.out.replace("\r\n", "\n")
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-26 18:05:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
 2019-02-26 18:05:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000
 2019-02-26 18:05:00 - SchedulerDaemon - INFO - Resuming previously interrupted schedule execution
-2019-02-26 18:05:00 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule
-""".format(
+2019-02-26 18:05:00 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -48,6 +48,7 @@ from dagster.core.storage.pipeline_run import (
 from dagster.core.storage.tags import PARTITION_NAME_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster.core.test_utils import (
     create_test_daemon_workspace,
+    get_logger_output_from_capfd,
     instance_for_test,
     mock_system_timezone,
 )
@@ -529,13 +530,10 @@ def test_simple_schedule(external_repo_context, capfd):
             ticks = instance.get_job_ticks(schedule_origin.get_id())
             assert len(ticks) == 0
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-27 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 17:59:59 - SchedulerDaemon - INFO - No new runs for simple_schedule
-"""
+2019-02-27 17:59:59 - SchedulerDaemon - INFO - No new runs for simple_schedule"""
             )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
@@ -570,14 +568,11 @@ def test_simple_schedule(external_repo_context, capfd):
                 partition_time=create_pendulum_time(2019, 2, 27),
             )
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
 2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00+0000
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule
-""".format(
+2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -635,13 +630,12 @@ def test_simple_schedule(external_repo_context, capfd):
             assert "2019-02-28" in runs_by_partition
             assert "2019-03-01" in runs_by_partition
 
-            captured = capfd.readouterr()
-
-            assert captured.out == """2019-03-01 18:00:03 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+            assert get_logger_output_from_capfd(
+                capfd, "SchedulerDaemon"
+            ) == """2019-03-01 18:00:03 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
 2019-03-01 18:00:03 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-01 00:00:00+0000, 2019-03-02 00:00:00+0000
 2019-03-01 18:00:03 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-01 18:00:03 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule
-""".format(
+2019-03-01 18:00:03 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -892,13 +886,11 @@ def test_skip(external_repo_context, capfd):
                 [run.run_id for run in instance.get_runs()],
             )
 
-            captured = capfd.readouterr()
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-26 18:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: skip_schedule
 2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `skip_schedule` at 2019-02-27 00:00:00+0000
-2019-02-26 18:00:00 - SchedulerDaemon - INFO - No run requests returned for skip_schedule, skipping
-"""
+2019-02-26 18:00:00 - SchedulerDaemon - INFO - No run requests returned for skip_schedule, skipping"""
             )
 
 
@@ -1365,14 +1357,13 @@ def test_multiple_schedules_on_different_time_ranges(external_repo_context, capf
             assert len(hourly_ticks) == 1
             assert hourly_ticks[0].status == JobTickStatus.SUCCESS
 
-            captured = capfd.readouterr()
-
-            assert captured.out == """2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
+            assert get_logger_output_from_capfd(
+                capfd, "SchedulerDaemon"
+            ) == """2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
 2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00+0000
 2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
 2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 00:00:00+0000
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule
-""".format(
+2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1391,14 +1382,12 @@ def test_multiple_schedules_on_different_time_ranges(external_repo_context, capf
             assert len(hourly_ticks) == 2
             assert len([tick for tick in hourly_ticks if tick.status == JobTickStatus.SUCCESS]) == 2
 
-            captured = capfd.readouterr()
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-27 19:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
 2019-02-27 19:00:01 - SchedulerDaemon - INFO - No new runs for simple_schedule
 2019-02-27 19:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 01:00:00+0000
-2019-02-27 19:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule
-""".format(
+2019-02-27 19:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule""".format(
                     third_run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -1449,17 +1438,18 @@ def test_launch_failure(external_repo_context, capfd):
                 [run.run_id for run in instance.get_runs()],
             )
 
-            captured = capfd.readouterr()
+            logger_output = get_logger_output_from_capfd(capfd, "SchedulerDaemon")
+
             assert (
                 """2019-02-26 18:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
 2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000
 2019-02-26 18:00:00 - SchedulerDaemon - ERROR - Run {run_id} created successfully but failed to launch:""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
-                in captured.out
+                in logger_output
             )
 
-            assert "The entire purpose of this is to throw on launch" in captured.out
+            assert "The entire purpose of this is to throw on launch" in logger_output
 
 
 def test_partitionless_schedule(capfd):
@@ -1495,15 +1485,12 @@ def test_partitionless_schedule(capfd):
                 partition_time=None,
             )
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-03-04 00:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: partitionless_schedule
 2019-03-04 00:00:00 - SchedulerDaemon - WARNING - partitionless_schedule has no partition set, so not trying to catch up
 2019-03-04 00:00:00 - SchedulerDaemon - INFO - Evaluating schedule `partitionless_schedule` at 2019-03-04 00:00:00-0600
-2019-03-04 00:00:00 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule
-""".format(
+2019-03-04 00:00:00 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -1570,13 +1557,13 @@ def test_max_catchup_runs(capfd):
                 partition_time=create_pendulum_time(2019, 3, 2),
             )
 
-            captured = capfd.readouterr()
-            assert captured.out == """2019-03-04 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+            assert get_logger_output_from_capfd(
+                capfd, "SchedulerDaemon"
+            ) == """2019-03-04 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
 2019-03-04 17:59:59 - SchedulerDaemon - WARNING - simple_schedule has fallen behind, only launching 2 runs
 2019-03-04 17:59:59 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-03 00:00:00+0000, 2019-03-04 00:00:00+0000
 2019-03-04 17:59:59 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-04 17:59:59 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule
-""".format(
+2019-03-04 17:59:59 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1616,13 +1603,10 @@ def test_multi_runs(external_repo_context, capfd):
             ticks = instance.get_job_ticks(schedule_origin.get_id())
             assert len(ticks) == 0
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-27 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 17:59:59 - SchedulerDaemon - INFO - No new runs for multi_run_schedule
-"""
+2019-02-27 17:59:59 - SchedulerDaemon - INFO - No new runs for multi_run_schedule"""
             )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
@@ -1648,15 +1632,12 @@ def test_multi_runs(external_repo_context, capfd):
             validate_run_started(runs[0], execution_time=create_pendulum_time(2019, 2, 28))
             validate_run_started(runs[1], execution_time=create_pendulum_time(2019, 2, 28))
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == f"""2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
 2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-02-28 00:00:00+0000
 2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule
-"""
+2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
             )
 
             # Verify idempotence
@@ -1678,15 +1659,12 @@ def test_multi_runs(external_repo_context, capfd):
             assert len([tick for tick in ticks if tick.status == JobTickStatus.SUCCESS]) == 2
             runs = instance.get_runs()
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == f"""2019-02-28 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
 2019-02-28 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-03-01 00:00:00+0000
 2019-02-28 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-28 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule
-"""
+2019-02-28 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
             )
 
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -1,6 +1,7 @@
 import pendulum
 import pytest
 from dagster.core.scheduler.job import JobTickStatus
+from dagster.core.test_utils import get_logger_output_from_capfd
 from dagster.scheduler.scheduler import launch_scheduled_runs
 from dagster.seven.compat.pendulum import create_pendulum_time, to_timezone
 from dagster.utils.partitions import DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE
@@ -50,13 +51,10 @@ def test_non_utc_timezone_run(external_repo_context, capfd):
             ticks = instance.get_job_ticks(schedule_origin.get_id())
             assert len(ticks) == 0
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-27 21:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 21:59:59 - SchedulerDaemon - INFO - No new runs for daily_central_time_schedule
-"""
+2019-02-27 21:59:59 - SchedulerDaemon - INFO - No new runs for daily_central_time_schedule"""
             )
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
@@ -92,14 +90,11 @@ def test_non_utc_timezone_run(external_repo_context, capfd):
                 create_pendulum_time(2019, 2, 27, tz="US/Central"),
             )
 
-            captured = capfd.readouterr()
-
             assert (
-                captured.out
+                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
                 == """2019-02-27 22:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
 2019-02-27 22:00:01 - SchedulerDaemon - INFO - Evaluating schedule `daily_central_time_schedule` at 2019-02-28 00:00:00-0600
-2019-02-27 22:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule
-""".format(
+2019-02-27 22:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )


### PR DESCRIPTION
Summary:
This adds a logger call when the gRPC server starts and when it shuts down. We don't include it when dagit or the daemon spins it up, as that could be spammy and confusing. But when you run your own gRPC server (or use the helm chart) there will be output when the server starts up.

As part of this, moved dagit and the daemon and the gRPC servers to all use the same logger class (using a pretty colored log formatter).

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.