### PR TITLE
Include timezone info in all dagster console log timestamps

### DIFF
--- a/python_modules/dagster/dagster/loggers/__init__.py
+++ b/python_modules/dagster/dagster/loggers/__init__.py
@@ -5,7 +5,7 @@ from dagster import seven
 from dagster.config import Field
 from dagster.core.definitions.logger_definition import logger
 from dagster.core.utils import coerce_valid_log_level
-from dagster.utils.log import default_format_string
+from dagster.utils.log import default_date_format_string, default_format_string
 
 
 @logger(
@@ -28,6 +28,7 @@ def colored_console_logger(init_context):
         logger=logger_,
         level=level,
         fmt=default_format_string(),
+        datefmt=default_date_format_string(),
         field_styles={"levelname": {"color": "blue"}, "asctime": {"color": "green"}},
         level_styles={"debug": {}, "error": {"color": "red"}},
     )

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -16,6 +16,7 @@ from dagster.core.workspace import IWorkspace
 from dagster.seven.compat.pendulum import to_timezone
 from dagster.utils import merge_dicts
 from dagster.utils.error import serializable_error_info_from_exc_info
+from dagster.utils.log import default_date_format_string
 
 
 class _ScheduleLaunchContext:
@@ -43,9 +44,6 @@ class _ScheduleLaunchContext:
             self.update_state(JobTickStatus.FAILURE, error=error_data)
 
         self._write()
-
-
-_SCHEDULER_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"
 
 
 def execute_scheduler_iteration(instance, workspace, logger, max_catchup_runs):
@@ -176,10 +174,10 @@ def launch_scheduled_runs_for_schedule(
         tick_times = tick_times[-max_catchup_runs:]
 
     if len(tick_times) == 1:
-        tick_time = tick_times[0].strftime(_SCHEDULER_DATETIME_FORMAT)
+        tick_time = tick_times[0].strftime(default_date_format_string())
         logger.info(f"Evaluating schedule `{schedule_name}` at {tick_time}")
     else:
-        times = ", ".join([time.strftime(_SCHEDULER_DATETIME_FORMAT) for time in tick_times])
+        times = ", ".join([time.strftime(default_date_format_string()) for time in tick_times])
         logger.info(f"Evaluating schedule `{schedule_name}` at the following times: {times}")
 
     for schedule_time in tick_times:

--- a/python_modules/dagster/dagster/utils/log.py
+++ b/python_modules/dagster/dagster/utils/log.py
@@ -191,11 +191,10 @@ def get_stack_trace_array(exception):
     return traceback.format_tb(tb)
 
 
-def _mockable_localtime(_):
+def _mockable_formatTime(record, datefmt=None):  # pylint: disable=unused-argument
     """Uses pendulum.now to determine the logging time, causing pendulum
     mocking to affect the logger timestamp in tests."""
-    now_time = pendulum.now()
-    return now_time.timetuple()
+    return pendulum.now().strftime(datefmt if datefmt else default_date_format_string())
 
 
 def default_system_logger(logger_name: str, level: str = "INFO"):
@@ -206,12 +205,13 @@ def default_system_logger(logger_name: str, level: str = "INFO"):
     system_logger.handlers = [handler]
 
     formatter = coloredlogs.ColoredFormatter(
-        default_format_string(),
+        fmt=default_format_string(),
+        datefmt=default_date_format_string(),
         field_styles={"levelname": {"color": "blue"}, "asctime": {"color": "green"}},
         level_styles={"debug": {}, "error": {"color": "red"}},
     )
 
-    formatter.converter = _mockable_localtime
+    formatter.formatTime = _mockable_formatTime
 
     handler.setFormatter(formatter)
 
@@ -222,8 +222,12 @@ def default_format_string():
     return "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 
+def default_date_format_string():
+    return "%Y-%m-%d %H:%M:%S %z"
+
+
 def define_default_formatter():
-    return logging.Formatter(default_format_string())
+    return logging.Formatter(default_format_string(), default_date_format_string())
 
 
 @contextmanager

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -73,8 +73,8 @@ def test_simple(external_repo_context, capfd):
         assert backfill.status == BulkActionStatus.COMPLETED
         assert (
             get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
+            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple
+2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
 
@@ -111,7 +111,7 @@ def test_before_submit(external_repo_context, crash_signal, capfd):
         assert launch_process.exitcode != 0
         assert (
             get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple"""
+            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -127,8 +127,8 @@ def test_before_submit(external_repo_context, crash_signal, capfd):
         launch_process.join(timeout=60)
         assert (
             get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
+            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple
+2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -169,7 +169,7 @@ def test_crash_after_submit(external_repo_context, crash_signal, capfd):
         assert launch_process.exitcode != 0
         assert (
             get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple"""
+            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -185,9 +185,9 @@ def test_crash_after_submit(external_repo_context, crash_signal, capfd):
         launch_process.join(timeout=60)
         assert (
             get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Found 3 existing runs for backfill simple, skipping
-2021-02-16 18:00:00 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
+            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple
+2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Found 3 existing runs for backfill simple, skipping
+2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
         backfill = instance.get_backfill("simple")

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -104,9 +104,9 @@ def test_failure_before_run_created(external_repo_context, crash_location, crash
             run = instance.get_runs()[0]
             assert (
                 get_logger_output_from_capfd(capfd, "SensorDaemon")
-                == f"""2019-02-27 18:01:03 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 18:01:03 - SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:01:03 - SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
+                == f"""2019-02-27 18:01:03 -0600 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
+2019-02-27 18:01:03 -0600 - SensorDaemon - INFO - Launching run for simple_sensor
+2019-02-27 18:01:03 -0600 - SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
             )
 
             ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -449,8 +449,8 @@ def test_simple_sensor(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SensorDaemon")
-                == """2019-02-27 17:59:59 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 17:59:59 - SensorDaemon - INFO - Sensor returned false for simple_sensor, skipping"""
+                == """2019-02-27 17:59:59 -0600 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
+2019-02-27 17:59:59 -0600 - SensorDaemon - INFO - Sensor returned false for simple_sensor, skipping"""
             )
 
             freeze_datetime = freeze_datetime.add(seconds=30)
@@ -477,9 +477,9 @@ def test_simple_sensor(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SensorDaemon")
-                == """2019-02-27 18:00:29 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 18:00:29 - SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:00:29 - SensorDaemon - INFO - Completed launch of run {run_id} for simple_sensor""".format(
+                == """2019-02-27 18:00:29 -0600 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
+2019-02-27 18:00:29 -0600 - SensorDaemon - INFO - Launching run for simple_sensor
+2019-02-27 18:00:29 -0600 - SensorDaemon - INFO - Completed launch of run {run_id} for simple_sensor""".format(
                     run_id=run.run_id
                 )
             )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -83,8 +83,8 @@ def test_failure_recovery_before_run_created(
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-26 18:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000"""
+                == """2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000"""
             )
 
             ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
@@ -122,10 +122,10 @@ def test_failure_recovery_before_run_created(
             )
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-26 18:05:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:05:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000
-2019-02-26 18:05:00 - SchedulerDaemon - INFO - Resuming previously interrupted schedule execution
-2019-02-26 18:05:00 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
+                == """2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
+2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Resuming previously interrupted schedule execution
+2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -532,8 +532,8 @@ def test_simple_schedule(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 17:59:59 - SchedulerDaemon - INFO - No new runs for simple_schedule"""
+                == """2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - No new runs for simple_schedule"""
             )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
@@ -570,9 +570,9 @@ def test_simple_schedule(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00+0000
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
+                == """2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -632,10 +632,10 @@ def test_simple_schedule(external_repo_context, capfd):
 
             assert get_logger_output_from_capfd(
                 capfd, "SchedulerDaemon"
-            ) == """2019-03-01 18:00:03 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-03-01 18:00:03 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-01 00:00:00+0000, 2019-03-02 00:00:00+0000
-2019-03-01 18:00:03 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-01 18:00:03 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
+            ) == """2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-01 00:00:00 +0000, 2019-03-02 00:00:00 +0000
+2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
+2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -888,9 +888,9 @@ def test_skip(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-26 18:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: skip_schedule
-2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `skip_schedule` at 2019-02-27 00:00:00+0000
-2019-02-26 18:00:00 - SchedulerDaemon - INFO - No run requests returned for skip_schedule, skipping"""
+                == """2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: skip_schedule
+2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `skip_schedule` at 2019-02-27 00:00:00 +0000
+2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - No run requests returned for skip_schedule, skipping"""
             )
 
 
@@ -1359,11 +1359,11 @@ def test_multiple_schedules_on_different_time_ranges(external_repo_context, capf
 
             assert get_logger_output_from_capfd(
                 capfd, "SchedulerDaemon"
-            ) == """2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00+0000
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 00:00:00+0000
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule""".format(
+            ) == """2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1384,10 +1384,10 @@ def test_multiple_schedules_on_different_time_ranges(external_repo_context, capf
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 19:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
-2019-02-27 19:00:01 - SchedulerDaemon - INFO - No new runs for simple_schedule
-2019-02-27 19:00:01 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 01:00:00+0000
-2019-02-27 19:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule""".format(
+                == """2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
+2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - No new runs for simple_schedule
+2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 01:00:00 +0000
+2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule""".format(
                     third_run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -1441,9 +1441,9 @@ def test_launch_failure(external_repo_context, capfd):
             logger_output = get_logger_output_from_capfd(capfd, "SchedulerDaemon")
 
             assert (
-                """2019-02-26 18:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00+0000
-2019-02-26 18:00:00 - SchedulerDaemon - ERROR - Run {run_id} created successfully but failed to launch:""".format(
+                """2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
+2019-02-26 18:00:00 -0600 - SchedulerDaemon - ERROR - Run {run_id} created successfully but failed to launch:""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
                 in logger_output
@@ -1487,10 +1487,10 @@ def test_partitionless_schedule(capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-03-04 00:00:00 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: partitionless_schedule
-2019-03-04 00:00:00 - SchedulerDaemon - WARNING - partitionless_schedule has no partition set, so not trying to catch up
-2019-03-04 00:00:00 - SchedulerDaemon - INFO - Evaluating schedule `partitionless_schedule` at 2019-03-04 00:00:00-0600
-2019-03-04 00:00:00 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule""".format(
+                == """2019-03-04 00:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: partitionless_schedule
+2019-03-04 00:00:00 -0600 - SchedulerDaemon - WARNING - partitionless_schedule has no partition set, so not trying to catch up
+2019-03-04 00:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `partitionless_schedule` at 2019-03-04 00:00:00 -0600
+2019-03-04 00:00:00 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -1559,11 +1559,11 @@ def test_max_catchup_runs(capfd):
 
             assert get_logger_output_from_capfd(
                 capfd, "SchedulerDaemon"
-            ) == """2019-03-04 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-03-04 17:59:59 - SchedulerDaemon - WARNING - simple_schedule has fallen behind, only launching 2 runs
-2019-03-04 17:59:59 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-03 00:00:00+0000, 2019-03-04 00:00:00+0000
-2019-03-04 17:59:59 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-04 17:59:59 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
+            ) == """2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-03-04 17:59:59 -0600 - SchedulerDaemon - WARNING - simple_schedule has fallen behind, only launching 2 runs
+2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-03 00:00:00 +0000, 2019-03-04 00:00:00 +0000
+2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
+2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1605,8 +1605,8 @@ def test_multi_runs(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 17:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 17:59:59 - SchedulerDaemon - INFO - No new runs for multi_run_schedule"""
+                == """2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
+2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - No new runs for multi_run_schedule"""
             )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
@@ -1634,10 +1634,10 @@ def test_multi_runs(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == f"""2019-02-27 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-02-28 00:00:00+0000
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-27 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
+                == f"""2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
+2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
             )
 
             # Verify idempotence
@@ -1661,10 +1661,10 @@ def test_multi_runs(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == f"""2019-02-28 18:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-28 18:00:01 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-03-01 00:00:00+0000
-2019-02-28 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-28 18:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
+                == f"""2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
+2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-03-01 00:00:00 +0000
+2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
+2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
             )
 
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -53,8 +53,8 @@ def test_non_utc_timezone_run(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 21:59:59 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 21:59:59 - SchedulerDaemon - INFO - No new runs for daily_central_time_schedule"""
+                == """2019-02-27 21:59:59 -0800 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
+2019-02-27 21:59:59 -0800 - SchedulerDaemon - INFO - No new runs for daily_central_time_schedule"""
             )
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
@@ -92,9 +92,9 @@ def test_non_utc_timezone_run(external_repo_context, capfd):
 
             assert (
                 get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 22:00:01 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 22:00:01 - SchedulerDaemon - INFO - Evaluating schedule `daily_central_time_schedule` at 2019-02-28 00:00:00-0600
-2019-02-27 22:00:01 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule""".format(
+                == """2019-02-27 22:00:01 -0800 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
+2019-02-27 22:00:01 -0800 - SchedulerDaemon - INFO - Evaluating schedule `daily_central_time_schedule` at 2019-02-28 00:00:00 -0600
+2019-02-27 22:00:01 -0800 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )


### PR DESCRIPTION
Summary:
Before I go in and fix the large number of tests this is likely to break, I wanted to see if this is something we even want to do. Adding timezone info to logs (both the dagit/daemon logs, but also run logs that are logged oto console)seems like a useful thing to me.

Concretely, before this change console output during a run might look something like:

`
2021-12-07 23:22:17 - dagster - DEBUG - asset_lineage_pipeline - 8b862d6a-4a75-424e-a52f-08455e7f5b37 - 6145 - daily_top_action - STEP_SUCCESS - Finished execution of step "daily_top_action" in 104ms.
`

Now, it will look like:
`
2021-12-07 23:22:17-0600 - dagster - DEBUG - asset_lineage_pipeline - 8b862d6a-4a75-424e-a52f-08455e7f5b37 - 6145 - daily_top_action - STEP_SUCCESS - Finished execution of step "daily_top_action" in 104ms.
`