### PR TITLE
Handle native list and dict types in k8s model parsing

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_models.py
@@ -1,3 +1,5 @@
+import re
+
 import kubernetes
 import pytest
 from dagster_k8s.models import k8s_model_from_dict
@@ -36,3 +38,48 @@ def test_extra_key():
     }
     with pytest.raises(Exception, match="Unexpected keys in model class V1Volume: {'extraKey'}"):
         k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)
+
+
+def test_list_type():
+    volume_dict = {
+        "name": "my_volume",
+        "cephfs": {
+            "monitors": [
+                "ip1",
+                "ip2",
+            ],
+            "path": "my_path",
+            "secretRef": {"name": "my_secret"},
+            "user": "my_user",
+        },
+    }
+    model = k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)
+    assert model.cephfs.monitors == ["ip1", "ip2"]
+
+
+def test_incorrect_list_value_type():
+    volume_dict = {
+        "name": "my_volume",
+        "configMap": {
+            "items": [{"key": "my_key", "path": "my_path"}, "foobar"],
+        },
+    }
+    with pytest.raises(
+        Exception,
+        match=re.escape(
+            "Attribute items[1] of type V1KeyToPath must be a dict, received foobar instead"
+        ),
+    ):
+        k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)
+
+
+def test_dict_type():
+    volume_dict = {
+        "name": "my_volume",
+        "csi": {
+            "driver": "my_driver",
+            "volumeAttributes": {"foo_key": "foo_val", "bar_key": "bar_val"},
+        },
+    }
+    model = k8s_model_from_dict(kubernetes.client.V1Volume, volume_dict)
+    assert model.csi.volume_attributes == {"foo_key": "foo_val", "bar_key": "bar_val"}


### PR DESCRIPTION
Summary:
We were missing a decoding path for certain volume types that have lists or dicts (as opposed to named model types).

Test Plan: New test cases

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.