### PR TITLE
[dagit] Support + require subset rendering of large asset graphs

### DIFF
--- a/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
@@ -78,11 +78,12 @@ function expansionDepthForClause(clause: string) {
 
 export function filterByQuery<T extends GraphQueryItem>(items: T[], query: string) {
   if (query === '*') {
-    return {all: items, focus: []};
+    return {all: items, applyingEmptyDefault: false, focus: []};
   }
   if (query === '') {
     return {
-      all: items.length < MAX_RENDERED_FOR_EMPTY_QUERY ? items : [],
+      all: items.length >= MAX_RENDERED_FOR_EMPTY_QUERY ? [] : items,
+      applyingEmptyDefault: items.length >= MAX_RENDERED_FOR_EMPTY_QUERY,
       focus: [],
     };
   }
@@ -114,5 +115,6 @@ export function filterByQuery<T extends GraphQueryItem>(items: T[], query: strin
   return {
     all: Array.from(results),
     focus: Array.from(focus),
+    applyingEmptyDefault: false,
   };
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
@@ -20,7 +20,7 @@ const buildGraphFromSingleNode = (assetNode: AssetNodeDefinitionFragment) => {
       [assetNode.id]: {
         id: assetNode.id,
         assetKey: assetNode.assetKey,
-        definition: {...assetNode, dependencies: [], dependedBy: []},
+        definition: {...assetNode, dependencies: []},
         hidden: false,
       },
     },
@@ -31,21 +31,21 @@ const buildGraphFromSingleNode = (assetNode: AssetNodeDefinitionFragment) => {
 
   for (const {asset} of assetNode.dependencies) {
     graphData.upstream[assetNode.id][asset.id] = true;
-    graphData.downstream[asset.id] = {...graphData.downstream[asset.id], [assetNode.id]: 'a'};
+    graphData.downstream[asset.id] = {...graphData.downstream[asset.id], [assetNode.id]: true};
     graphData.nodes[asset.id] = {
       id: asset.id,
       assetKey: asset.assetKey,
-      definition: {...asset, dependencies: [], dependedBy: []},
+      definition: {...asset, dependencies: []},
       hidden: false,
     };
   }
   for (const {asset} of assetNode.dependedBy) {
     graphData.upstream[asset.id] = {...graphData.upstream[asset.id], [assetNode.id]: true};
-    graphData.downstream[assetNode.id][asset.id] = 'a';
+    graphData.downstream[assetNode.id][asset.id] = true;
     graphData.nodes[asset.id] = {
       id: asset.id,
       assetKey: asset.assetKey,
-      definition: {...asset, dependencies: [], dependedBy: []},
+      definition: {...asset, dependencies: []},
       hidden: false,
     };
   }

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -13,13 +13,12 @@ import {OpNameOrPath} from '../ops/OpNameOrPath';
 import {Checkbox} from '../ui/Checkbox';
 import {ColorsWIP} from '../ui/Colors';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
-import {IconWIP} from '../ui/Icon';
-import {NonIdealState} from '../ui/NonIdealState';
 import {SplitPanelContainer} from '../ui/SplitPanelContainer';
 import {TextInput} from '../ui/TextInput';
 import {RepoAddress} from '../workspace/types';
 
-import {OpJumpBar} from './PipelineJumpComponents';
+import {EmptyDAGNotice, LargeDAGNotice} from './GraphNotices';
+import {NodeJumpBar} from './NodeJumpBar';
 import {ExplorerPath} from './PipelinePathUtils';
 import {
   SidebarTabbedContainer,
@@ -133,14 +132,16 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
       solids.some((f) => f.definition.__typename === 'CompositeSolidDefinition'));
 
   const queryResultOps = React.useMemo(
-    () => (solidsQueryEnabled ? filterByQuery(solids, opsQuery) : {all: solids, focus: []}),
+    () =>
+      solidsQueryEnabled
+        ? filterByQuery(solids, opsQuery)
+        : {all: solids, focus: [], applyingEmptyDefault: false},
     [opsQuery, solids, solidsQueryEnabled],
   );
 
-  const {all} = queryResultOps;
   const highlightedOps = React.useMemo(
-    () => all.filter((s) => s.name.toLowerCase().includes(nameMatch.toLowerCase())),
-    [nameMatch, all],
+    () => queryResultOps.all.filter((s) => s.name.toLowerCase().includes(nameMatch.toLowerCase())),
+    [nameMatch, queryResultOps.all],
   );
 
   const backgroundColor = parentHandle ? ColorsWIP.White : ColorsWIP.White;
@@ -154,25 +155,25 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
         <>
           <PathOverlay style={{background: backgroundTranslucent}}>
             <Breadcrumbs
-              items={explorerPath.opNames.map((name, idx) => {
-                return {
-                  text: name,
-                  onClick: () =>
-                    onChangeExplorerPath(
-                      {...explorerPath, opNames: explorerPath.opNames.slice(0, idx + 1)},
-                      'push',
-                    ),
-                };
-              })}
+              items={explorerPath.opNames.map((name, idx) => ({
+                text: name,
+                onClick: () =>
+                  onChangeExplorerPath(
+                    {...explorerPath, opNames: explorerPath.opNames.slice(0, idx + 1)},
+                    'push',
+                  ),
+              }))}
               currentBreadcrumbRenderer={() => (
-                <OpJumpBar
-                  ops={queryResultOps.all}
-                  selectedOp={selectedHandle && selectedHandle.solid}
-                  onChange={(solid) => handleClickOp({name: solid.name})}
+                <NodeJumpBar
+                  nodes={queryResultOps.all}
+                  nodeType="op"
+                  selectedNode={selectedHandle && selectedHandle.solid}
+                  onChange={handleClickOp}
                 />
               )}
             />
           </PathOverlay>
+
           {solidsQueryEnabled && (
             <PipelineGraphQueryInputContainer>
               <GraphQueryInput
@@ -208,10 +209,11 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
               />
             </OptionsOverlay>
           )}
-          {solids.length === 0 ? <EmptyDAGNotice isGraph={isGraph} /> : null}
-          {solids.length > 0 &&
-            queryResultOps.all.length === 0 &&
-            !explorerPath.opsQuery.length && <LargeDAGNotice />}
+          {solids.length === 0 ? (
+            <EmptyDAGNotice nodeType="op" isGraph={isGraph} />
+          ) : queryResultOps.applyingEmptyDefault ? (
+            <LargeDAGNotice nodeType="op" />
+          ) : undefined}
           <PipelineGraphContainer
             pipelineName={pipelineOrGraph.name}
             backgroundColor={backgroundColor}
@@ -320,74 +322,6 @@ const PathOverlay = styled.div`
   align-items: center;
   position: absolute;
   left: 0;
-`;
-
-const LargeDAGNotice = () => (
-  <LargeDAGContainer>
-    <LargeDAGInstructionBox>
-      <p>
-        This is a large DAG that may be difficult to visualize. Type <code>*</code> in the subset
-        box below to render the entire thing, or type a solid name and use:
-      </p>
-      <ul style={{marginBottom: 0}}>
-        <li>
-          <code>+</code> to expand a single layer before or after the solid.
-        </li>
-        <li>
-          <code>*</code> to expand recursively before or after the solid.
-        </li>
-        <li>
-          <code>AND</code> to render another disconnected fragment.
-        </li>
-      </ul>
-    </LargeDAGInstructionBox>
-    <IconWIP name="arrow_downward" size={24} />
-  </LargeDAGContainer>
-);
-
-const EmptyDAGNotice: React.FC<{isGraph: boolean}> = ({isGraph}) => {
-  return (
-    <NonIdealState
-      icon="no-results"
-      title={isGraph ? 'Empty graph' : 'Empty pipeline'}
-      description={
-        <>
-          <div>This {isGraph ? 'graph' : 'pipeline'} is empty.</div>
-          <div>Solids will appear here when you add them.</div>
-        </>
-      }
-    />
-  );
-};
-
-const LargeDAGContainer = styled.div`
-  width: 50vw;
-  position: absolute;
-  transform: translateX(-50%);
-  left: 50%;
-  bottom: 60px;
-  z-index: 2;
-  max-width: 600px;
-  text-align: center;
-  .bp3-icon {
-    color: ${ColorsWIP.Gray200};
-  }
-`;
-
-const LargeDAGInstructionBox = styled.div`
-  padding: 15px 20px;
-  border: 1px solid #fff5c3;
-  margin-bottom: 20px;
-  color: ${ColorsWIP.Gray800};
-  background: #fffbe5;
-  text-align: left;
-  line-height: 1.4rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  code {
-    background: #f8ebad;
-    font-weight: 500;
-    padding: 0 4px;
-  }
 `;
 
 const PipelineGraphQueryInputContainer = styled.div`

--- a/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphNotices.tsx
@@ -1,0 +1,80 @@
+import {capitalize} from 'lodash';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP} from '../ui/Colors';
+import {IconWIP} from '../ui/Icon';
+import {NonIdealState} from '../ui/NonIdealState';
+
+export const LargeDAGNotice = ({nodeType}: {nodeType: 'op' | 'asset'}) => (
+  <LargeDAGContainer>
+    <LargeDAGInstructionBox>
+      <p>
+        This is a large DAG that may be difficult to visualize. Type <code>*</code> in the subset
+        box below to render the entire thing, or type a {nodeType} name and use:
+      </p>
+      <ul style={{marginBottom: 0}}>
+        <li>
+          <code>+</code> to expand a single layer before or after the {nodeType}.
+        </li>
+        <li>
+          <code>*</code> to expand recursively before or after the {nodeType}.
+        </li>
+        <li>
+          <code>AND</code> to render another disconnected fragment.
+        </li>
+      </ul>
+    </LargeDAGInstructionBox>
+    <IconWIP name="arrow_downward" size={24} />
+  </LargeDAGContainer>
+);
+
+export const EmptyDAGNotice: React.FC<{isGraph: boolean; nodeType: 'asset' | 'op'}> = ({
+  isGraph,
+  nodeType,
+}) => {
+  return (
+    <NonIdealState
+      icon="no-results"
+      title={isGraph ? 'Empty graph' : 'Empty pipeline'}
+      description={
+        <>
+          <div>This {isGraph ? 'graph' : 'pipeline'} is empty.</div>
+          <div>{capitalize(nodeType)} will appear here when you add them.</div>
+        </>
+      }
+    />
+  );
+};
+
+const LargeDAGContainer = styled.div`
+  width: 50vw;
+  position: absolute;
+  transform: translateX(-50%);
+  left: 50%;
+  bottom: 60px;
+  z-index: 2;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  .bp3-icon {
+    color: ${ColorsWIP.Gray200};
+  }
+`;
+
+const LargeDAGInstructionBox = styled.div`
+  padding: 15px 20px;
+  border: 1px solid #fff5c3;
+  margin-bottom: 20px;
+  color: ${ColorsWIP.Gray800};
+  background: #fffbe5;
+  text-align: left;
+  line-height: 1.4rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  code {
+    background: #f8ebad;
+    font-weight: 500;
+    padding: 0 4px;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/pipelines/NodeJumpBar.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/NodeJumpBar.tsx
@@ -7,16 +7,15 @@ import {IconWIP} from '../ui/Icon';
 import {MenuItemWIP} from '../ui/Menu';
 import {SelectWIP} from '../ui/Select';
 
-import {GraphExplorerSolidHandleFragment_solid} from './types/GraphExplorerSolidHandleFragment';
-
-interface OpJumpBarProps {
-  ops: Array<GraphExplorerSolidHandleFragment_solid>;
-  selectedOp: GraphExplorerSolidHandleFragment_solid | undefined;
-  onChange: (op: GraphExplorerSolidHandleFragment_solid) => void;
+interface NodeJumpBarProps<T extends {name: string}> {
+  nodes: T[];
+  nodeType: 'asset' | 'op';
+  selectedNode: T | undefined;
+  onChange: (node: T) => void;
 }
 
-export const OpJumpBar: React.FC<OpJumpBarProps> = (props) => {
-  const {ops, selectedOp, onChange} = props;
+export function NodeJumpBar<T extends {name: string}>(props: NodeJumpBarProps<T>) {
+  const {nodes, nodeType, selectedNode, onChange} = props;
   const button = React.useRef<HTMLButtonElement | null>(null);
 
   return (
@@ -26,19 +25,19 @@ export const OpJumpBar: React.FC<OpJumpBarProps> = (props) => {
       shortcutFilter={(e) => e.code === 'KeyS' && e.altKey}
     >
       <SelectWIP
-        items={ops.map((s) => s.name)}
+        items={nodes.map((s) => s.name)}
         itemRenderer={BasicStringRenderer}
         itemListPredicate={BasicStringPredicate}
         noResults={<MenuItemWIP disabled text="No results." />}
-        onItemSelect={(name) => onChange(ops.find((s) => s.name === name)!)}
+        onItemSelect={(name) => onChange(nodes.find((s) => s.name === name)!)}
       >
         <SelectButton ref={button} rightIcon={<IconWIP name="unfold_more" />}>
-          {selectedOp ? selectedOp.name : 'Select an op…'}
+          {selectedNode ? selectedNode.name : `Select an ${nodeType}…`}
         </SelectButton>
       </SelectWIP>
     </ShortcutHandler>
   );
-};
+}
 
 // By default, Blueprint's Select component has an intrinsic size determined by the length of
 // it's content, which in our case can be wildly long and unruly. Giving the Select a min-width

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -80,13 +80,15 @@ export const PipelineExplorerContainer: React.FC<{
           ? explodeCompositesInHandleGraph(result.solidHandles)
           : result.solidHandles;
 
-        const selectedHandle = displayedHandles.find((h) => h.solid.name === selectedName);
+        const selectedHandles = displayedHandles.filter((h) =>
+          selectedName.split(',').includes(h.solid.name),
+        );
 
         // Run a few assertions on the state of the world and redirect the user
         // back to safety if they've landed in an invalid place. Note that we can
         // pop one layer at a time and this renders recursively until we reach a
         // valid parent.
-        const invalidSelection = selectedName && !selectedHandle;
+        const invalidSelection = selectedName && !selectedHandles;
         const invalidParent =
           parentHandle && parentHandle.solid.definition.__typename !== 'CompositeSolidDefinition';
 
@@ -120,7 +122,7 @@ export const PipelineExplorerContainer: React.FC<{
               handles={displayedHandles}
               explorerPath={explorerPath}
               onChangeExplorerPath={onChangeExplorerPath}
-              selectedHandle={selectedHandle}
+              selectedHandles={selectedHandles}
             />
           );
         }
@@ -134,7 +136,7 @@ export const PipelineExplorerContainer: React.FC<{
             repoAddress={repoAddress}
             handles={displayedHandles}
             parentHandle={parentHandle ? parentHandle : undefined}
-            selectedHandle={selectedHandle}
+            selectedHandle={selectedHandles[0]}
             isGraph={isGraph}
             getInvocations={(definitionName) =>
               displayedHandles

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -1,5 +1,5 @@
 import {gql, QueryResult, useQuery} from '@apollo/client';
-import {uniq, without} from 'lodash';
+import _, {uniq, without} from 'lodash';
 import React from 'react';
 import styled from 'styled-components/macro';
 
@@ -7,8 +7,8 @@ import {filterByQuery} from '../../app/GraphQueryImpl';
 import {QueryCountdown} from '../../app/QueryCountdown';
 import {SVGViewport} from '../../graph/SVGViewport';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
-import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
 import {RightInfoPanel, RightInfoPanelContent} from '../../pipelines/GraphExplorer';
+import {EmptyDAGNotice, LargeDAGNotice} from '../../pipelines/GraphNotices';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {SidebarPipelineOrJobOverview} from '../../pipelines/SidebarPipelineOrJobOverview';
 import {GraphExplorerSolidHandleFragment} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
@@ -18,13 +18,12 @@ import {Loading} from '../../ui/Loading';
 import {NonIdealState} from '../../ui/NonIdealState';
 import {SplitPanelContainer} from '../../ui/SplitPanelContainer';
 import {buildPipelineSelector} from '../WorkspaceContext';
-import {repoAddressToSelector} from '../repoAddressToSelector';
 import {RepoAddress} from '../types';
 
 import {AssetLinks} from './AssetLinks';
 import {AssetNode, ASSET_NODE_FRAGMENT, ASSET_NODE_LIVE_FRAGMENT} from './AssetNode';
 import {ForeignNode} from './ForeignNode';
-import {SidebarAssetInfo} from './SidebarAssetInfo';
+import {SidebarAssetInfo, SidebarAssetsInfo} from './SidebarAssetInfo';
 import {
   buildGraphData,
   buildLiveData,
@@ -49,12 +48,12 @@ interface Props {
   repoAddress: RepoAddress;
   explorerPath: ExplorerPath;
   handles: GraphExplorerSolidHandleFragment[];
-  selectedHandle?: GraphExplorerSolidHandleFragment;
+  selectedHandles: GraphExplorerSolidHandleFragment[];
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
 }
 
 export const AssetGraphExplorer: React.FC<Props> = (props) => {
-  const {repoAddress, explorerPath} = props;
+  const {repoAddress, explorerPath, handles} = props;
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
   const repositorySelector = {
     repositoryLocationName: repoAddress.location,
@@ -82,8 +81,17 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     if (queryResult.data?.pipelineOrError.__typename !== 'Pipeline') {
       return null;
     }
-    return buildGraphData(queryResult.data.pipelineOrError.assetNodes, explorerPath.pipelineName);
-  }, [queryResult, explorerPath.pipelineName]);
+    const assetNodes = queryResult.data.pipelineOrError.assetNodes;
+    const queryOps = filterByQuery(
+      handles.map((h) => h.solid),
+      explorerPath.opsQuery,
+    );
+    const queryAssetNodes = assetNodes.filter((a) =>
+      queryOps.all.some((op) => op.name === a.opName),
+    );
+
+    return buildGraphData(queryAssetNodes, explorerPath.pipelineName);
+  }, [queryResult, handles, explorerPath.pipelineName, explorerPath.opsQuery]);
 
   const liveDataByNode = React.useMemo(() => {
     if (!liveResult.data || !graphData) {
@@ -91,11 +99,12 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     }
 
     const {repositoryOrError, pipelineOrError} = liveResult.data;
-    const assetNodes = pipelineOrError.__typename === 'Pipeline' ? pipelineOrError.assetNodes : [];
+    const liveAssetNodes =
+      pipelineOrError.__typename === 'Pipeline' ? pipelineOrError.assetNodes : [];
     const inProgressRunsByStep =
       repositoryOrError.__typename === 'Repository' ? repositoryOrError.inProgressRunsByStep : [];
 
-    return buildLiveData(graphData, assetNodes, inProgressRunsByStep);
+    return buildLiveData(graphData, liveAssetNodes, inProgressRunsByStep);
   }, [graphData, liveResult]);
 
   return (
@@ -116,15 +125,6 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
             />
           );
         }
-        if (!Object.keys(graphData.nodes).length) {
-          return (
-            <NonIdealState
-              icon="no-results"
-              title="No assets defined"
-              description="No assets defined using the @asset definition"
-            />
-          );
-        }
 
         return (
           <AssetGraphExplorerWithData
@@ -142,7 +142,7 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
 
 const AssetGraphExplorerWithData: React.FC<
   {
-    graphData: ReturnType<typeof buildGraphData>;
+    graphData: GraphData;
     liveDataByNode: LiveData;
     liveDataQueryResult: QueryResult<any>;
   } & Props
@@ -150,7 +150,7 @@ const AssetGraphExplorerWithData: React.FC<
   const {
     repoAddress,
     handles,
-    selectedHandle,
+    selectedHandles,
     explorerPath,
     onChangeExplorerPath,
     liveDataQueryResult,
@@ -159,12 +159,11 @@ const AssetGraphExplorerWithData: React.FC<
   } = props;
 
   const fetchAssetDefinitionLocation = useFetchAssetDefinitionLocation();
-  const selectedDefinition = selectedHandle?.solid.definition;
-  const selectedGraphNode =
-    selectedDefinition &&
-    Object.values(graphData.nodes).find(
-      (node) => node.definition.opName === selectedDefinition.name,
-    );
+  const selectedDefinitions = selectedHandles.map((h) => h.solid.definition);
+  const selectedGraphNodes = selectedDefinitions.map(
+    (def) => Object.values(graphData.nodes).find((node) => node.definition.opName === def.name)!,
+  );
+  const focusedGraphNode = selectedGraphNodes[selectedGraphNodes.length - 1];
 
   const onSelectNode = React.useCallback(
     async (e: React.MouseEvent<any>, assetKey: {path: string[]}, node: Node) => {
@@ -176,16 +175,19 @@ const AssetGraphExplorerWithData: React.FC<
       }
 
       const {opName, jobName} = def;
-      let nextOpsQuery = `${opName}`;
+      let nextOpsQuery = explorerPath.opsQuery;
+      let nextOpsNameSelection = opName;
 
-      if (jobName === explorerPath.pipelineName && (e.shiftKey || e.metaKey)) {
-        const existing = explorerPath.opsQuery.split(',');
+      if (jobName !== explorerPath.pipelineName) {
+        nextOpsQuery = '';
+      } else if (e.shiftKey || e.metaKey) {
+        const existing = explorerPath.opNames[0].split(',');
         const added =
-          e.shiftKey && selectedGraphNode
-            ? opsInRange({graph: graphData, from: selectedGraphNode, to: node})
+          e.shiftKey && focusedGraphNode
+            ? opsInRange({graph: graphData, from: focusedGraphNode, to: node})
             : [opName];
 
-        nextOpsQuery = (existing.includes(opName)
+        nextOpsNameSelection = (existing.includes(opName)
           ? without(existing, opName)
           : uniq([...existing, ...added])
         ).join(',');
@@ -194,23 +196,17 @@ const AssetGraphExplorerWithData: React.FC<
       onChangeExplorerPath(
         {
           ...explorerPath,
-          opNames: [opName],
+          opNames: [nextOpsNameSelection],
           opsQuery: nextOpsQuery,
           pipelineName: jobName || explorerPath.pipelineName,
         },
         'replace',
       );
     },
-    [
-      fetchAssetDefinitionLocation,
-      explorerPath,
-      onChangeExplorerPath,
-      selectedGraphNode,
-      graphData,
-    ],
+    [fetchAssetDefinitionLocation, explorerPath, onChangeExplorerPath, focusedGraphNode, graphData],
   );
 
-  const {all: highlighted} = React.useMemo(
+  const queryResultAssets = React.useMemo(
     () =>
       filterByQuery(
         handles.map((h) => h.solid),
@@ -235,12 +231,7 @@ const AssetGraphExplorerWithData: React.FC<
             onKeyDown={() => {}}
             onClick={() =>
               onChangeExplorerPath(
-                {
-                  ...explorerPath,
-                  pipelineName: explorerPath.pipelineName,
-                  opsQuery: '',
-                  opNames: [],
-                },
+                {...explorerPath, pipelineName: explorerPath.pipelineName, opNames: []},
                 'replace',
               )
             }
@@ -280,15 +271,9 @@ const AssetGraphExplorerWithData: React.FC<
                             handles.find((h) => h.handleID === graphNode.definition.opName)!.solid
                               .definition.metadata
                           }
-                          selected={selectedGraphNode === graphNode}
+                          selected={focusedGraphNode === graphNode}
                           repoAddress={repoAddress}
-                          secondaryHighlight={
-                            explorerPath.opsQuery
-                              ? highlighted.some(
-                                  (h) => h.definition.name === graphNode.definition.opName,
-                                )
-                              : false
-                          }
+                          secondaryHighlight={selectedGraphNodes.includes(graphNode)}
                         />
                       )}
                     </foreignObject>
@@ -297,6 +282,12 @@ const AssetGraphExplorerWithData: React.FC<
               </SVGContainer>
             )}
           </SVGViewport>
+
+          {handles.length === 0 ? (
+            <EmptyDAGNotice nodeType="asset" isGraph />
+          ) : queryResultAssets.applyingEmptyDefault ? (
+            <LargeDAGNotice nodeType="asset" />
+          ) : undefined}
 
           <div style={{position: 'absolute', right: 8, top: 6}}>
             <QueryCountdown pollInterval={5 * 1000} queryResult={liveDataQueryResult} />
@@ -308,33 +299,22 @@ const AssetGraphExplorerWithData: React.FC<
               placeholder="Type an asset subset…"
               onChange={(opsQuery) => onChangeExplorerPath({...explorerPath, opsQuery}, 'replace')}
             />
-            <LaunchRootExecutionButton
-              pipelineName={explorerPath.pipelineName}
-              disabled={!explorerPath.opsQuery || highlighted.length === 0}
-              getVariables={() => ({
-                executionParams: {
-                  mode: 'default',
-                  executionMetadata: {},
-                  runConfigData: {},
-                  selector: {
-                    ...repoAddressToSelector(repoAddress),
-                    pipelineName: explorerPath.pipelineName,
-                    solidSelection: highlighted.map((h) => h.name),
-                  },
-                },
-              })}
-            />
           </AssetQueryInputContainer>
         </>
       }
       second={
         <RightInfoPanel>
           <RightInfoPanelContent>
-            {selectedGraphNode && selectedDefinition ? (
+            {selectedGraphNodes.length > 1 ? (
+              <SidebarAssetsInfo
+                nodes={selectedGraphNodes.map((n) => n.definition)}
+                repoAddress={repoAddress}
+              />
+            ) : selectedGraphNodes.length === 1 && selectedGraphNodes[0] ? (
               <SidebarAssetInfo
-                node={selectedGraphNode.definition}
-                liveData={liveDataByNode[selectedGraphNode.id]}
-                definition={selectedDefinition}
+                node={selectedGraphNodes[0].definition}
+                liveData={liveDataByNode[selectedGraphNodes[0].id]}
+                definition={selectedDefinitions[0]}
                 repoAddress={repoAddress}
               />
             ) : (
@@ -384,27 +364,7 @@ const ASSETS_GRAPH_QUERY = gql`
         assetNodes {
           id
           ...AssetNodeFragment
-
-          dependedBy {
-            inputName
-            asset {
-              id
-              assetKey {
-                path
-              }
-            }
-          }
-          dependedBy {
-            inputName
-            asset {
-              id
-              assetKey {
-                path
-              }
-            }
-          }
           dependencies {
-            inputName
             asset {
               id
               assetKey {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 
 import {displayNameForAssetKey} from '../../app/Util';
 import {AssetMaterializations} from '../../assets/AssetMaterializations';
+import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
 import {Description} from '../../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../../pipelines/SidebarComponents';
 import {GraphExplorerSolidHandleFragment_solid_definition} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
 import {pluginForMetadata} from '../../plugins';
 import {Box} from '../../ui/Box';
 import {ColorsWIP} from '../../ui/Colors';
+import {repoAddressToSelector} from '../repoAddressToSelector';
 import {RepoAddress} from '../types';
 
 import {LiveDataForNode} from './Utils';
@@ -21,14 +23,40 @@ export const SidebarAssetInfo: React.FC<{
 }> = ({node, definition, repoAddress, liveData}) => {
   const Plugin = pluginForMetadata(definition.metadata);
   const {lastMaterialization} = liveData || {};
+  const {opName, jobName} = node;
 
   return (
     <>
       <SidebarSection title="Definition">
         <Box padding={{vertical: 16, horizontal: 24}}>
-          <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
+          <Box
+            flex={{gap: 8, justifyContent: 'space-between', alignItems: 'baseline'}}
+            margin={{bottom: 8}}
+          >
+            <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
+
+            {jobName && opName && (
+              <LaunchRootExecutionButton
+                pipelineName={jobName}
+                disabled={false}
+                getVariables={() => ({
+                  executionParams: {
+                    mode: 'default',
+                    executionMetadata: {},
+                    runConfigData: {},
+                    selector: {
+                      ...repoAddressToSelector(repoAddress),
+                      pipelineName: jobName,
+                      solidSelection: [opName],
+                    },
+                  },
+                })}
+              />
+            )}
+          </Box>
           <Description description={node.description || null} />
         </Box>
+
         {definition.metadata && Plugin && Plugin.SidebarComponent && (
           <Plugin.SidebarComponent definition={definition} repoAddress={repoAddress} />
         )}
@@ -46,5 +74,43 @@ export const SidebarAssetInfo: React.FC<{
         setParams={() => {}}
       />
     </>
+  );
+};
+
+export const SidebarAssetsInfo: React.FC<{
+  nodes: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes[];
+  repoAddress: RepoAddress;
+}> = ({nodes, repoAddress}) => {
+  const {jobName} = nodes[0];
+  const opNames = nodes.map((n) => n.opName!).filter(Boolean);
+  return (
+    <SidebarSection title="Definition">
+      <Box padding={{vertical: 16, horizontal: 24}}>
+        <Box
+          flex={{gap: 8, justifyContent: 'space-between', alignItems: 'baseline'}}
+          margin={{bottom: 8}}
+        >
+          <SidebarTitle>{`${nodes.length} Assets Selected`}</SidebarTitle>
+          {jobName && (
+            <LaunchRootExecutionButton
+              pipelineName={jobName}
+              disabled={false}
+              getVariables={() => ({
+                executionParams: {
+                  mode: 'default',
+                  executionMetadata: {},
+                  runConfigData: {},
+                  selector: {
+                    ...repoAddressToSelector(repoAddress),
+                    pipelineName: jobName,
+                    solidSelection: opNames,
+                  },
+                },
+              })}
+            />
+          )}
+        </Box>
+      </Box>
+    </SidebarSection>
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
@@ -18,23 +18,6 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_assetKey {
   path: string[];
 }
 
-export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedBy_asset_assetKey {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedBy_asset {
-  __typename: "AssetNode";
-  id: string;
-  assetKey: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedBy_asset_assetKey;
-}
-
-export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedBy {
-  __typename: "AssetDependency";
-  inputName: string;
-  asset: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedBy_asset;
-}
-
 export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies_asset_assetKey {
   __typename: "AssetKey";
   path: string[];
@@ -48,7 +31,6 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencie
 
 export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies {
   __typename: "AssetDependency";
-  inputName: string;
   asset: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies_asset;
 }
 
@@ -59,7 +41,6 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes {
   description: string | null;
   jobName: string | null;
   assetKey: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_assetKey;
-  dependedBy: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedBy[];
   dependencies: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies[];
 }
 


### PR DESCRIPTION


## Summary
This PR moves the DAG "selection" state out of the bottom op selection bar, freeing it up to operate the same way it does in the op graph explorer. If you open a DAG with more than 100 nodes, we prompt you to type a query to select a subset of the nodes or "*" to render them all.

The "Launch Run" button has moved to the right sidebar. You can still shift-select or command-select multiple nodes, but there is no freeform input for launching multiple assets in a single run anymore. I think this may be fine, since that feature was largely experimental. We could potentially add a "Select All" button so you could filter the displayed nodes using the bottom bar and launch them all.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1037212/145238393-6b0d3b85-95cd-41f2-b2fe-3dc3dee0b2c1.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1037212/145238417-f4df0c5f-9d82-4969-8e77-75312644fefb.png">
<img width="810" alt="image" src="https://user-images.githubusercontent.com/1037212/145238470-f8e06a08-6672-453a-baa4-dc508d3e0c8b.png">



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.