### PR TITLE
[dagit] Fix asset links from DAG to details pages

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -20,6 +20,10 @@ export const formatElapsedTime = (msec: number) => {
   return `${hours}:${twoDigit(min)}:${twoDigit(sec)}`;
 };
 
+export function displayNameForAssetKey(key: {path: string[]}) {
+  return key.path.join(' > ');
+}
+
 export function breakOnUnderscores(str: string) {
   return str.replace(/_/g, '_\u200b');
 }

--- a/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
@@ -6,7 +6,12 @@ import {SVGViewport} from '../graph/SVGViewport';
 import {AssetLinks} from '../workspace/asset-graph/AssetLinks';
 import {AssetNode} from '../workspace/asset-graph/AssetNode';
 import {ForeignNode} from '../workspace/asset-graph/ForeignNode';
-import {layoutGraph, GraphData, assetKeyToString, LiveData} from '../workspace/asset-graph/Utils';
+import {
+  layoutGraph,
+  GraphData,
+  displayNameForAssetKey,
+  LiveData,
+} from '../workspace/asset-graph/Utils';
 import {RepoAddress} from '../workspace/types';
 
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';

--- a/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
@@ -6,12 +6,7 @@ import {SVGViewport} from '../graph/SVGViewport';
 import {AssetLinks} from '../workspace/asset-graph/AssetLinks';
 import {AssetNode} from '../workspace/asset-graph/AssetNode';
 import {ForeignNode} from '../workspace/asset-graph/ForeignNode';
-import {
-  layoutGraph,
-  GraphData,
-  displayNameForAssetKey,
-  LiveData,
-} from '../workspace/asset-graph/Utils';
+import {layoutGraph, GraphData, LiveData} from '../workspace/asset-graph/Utils';
 import {RepoAddress} from '../workspace/types';
 
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';

--- a/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
@@ -85,7 +85,7 @@ export const AssetNeighborsGraph: React.FC<{
                 onClick={(e) => {
                   e.stopPropagation();
                   if (graphNode.definition.opName) {
-                    history.push(`/instance/assets/${assetKeyToString(graphNode.assetKey)}`);
+                    history.push(`/instance/assets/${graphNode.assetKey.path.join('/')}`);
                   }
                 }}
               >

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -13,7 +13,7 @@ import {ColorsWIP} from '../ui/Colors';
 import {Spinner} from '../ui/Spinner';
 import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 import {
-  assetKeyToString,
+  displayNameForAssetKey,
   buildGraphDataFromSingleNode,
   buildLiveData,
   IN_PROGRESS_RUNS_FRAGMENT,
@@ -41,7 +41,7 @@ export interface AssetViewParams {
 }
 
 export const AssetView: React.FC<Props> = ({assetKey}) => {
-  useDocumentTitle(`Asset: ${assetKeyToString(assetKey)}`);
+  useDocumentTitle(`Asset: ${displayNameForAssetKey(assetKey)}`);
 
   const [params, setParams] = useQueryPersistedState<AssetViewParams>({});
   const [navigatedDirectlyToTime, setNavigatedDirectlyToTime] = React.useState(() =>

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -2,6 +2,7 @@ import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
 
 import {QueryCountdown} from '../app/QueryCountdown';
+import {displayNameForAssetKey} from '../app/Util';
 import {Timestamp} from '../app/time/Timestamp';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -13,7 +14,6 @@ import {ColorsWIP} from '../ui/Colors';
 import {Spinner} from '../ui/Spinner';
 import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 import {
-  displayNameForAssetKey,
   buildGraphDataFromSingleNode,
   buildLiveData,
   IN_PROGRESS_RUNS_FRAGMENT,

--- a/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
@@ -1,10 +1,10 @@
 import {gql, RefetchQueriesFunction, useMutation} from '@apollo/client';
 import * as React from 'react';
 
+import {displayNameForAssetKey} from '../app/Util';
 import {ButtonWIP} from '../ui/Button';
 import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
-import {displayNameForAssetKey} from '../workspace/asset-graph/Utils';
 
 interface AssetKey {
   path: string[];

--- a/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetWipeDialog.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {ButtonWIP} from '../ui/Button';
 import {DialogBody, DialogFooter, DialogWIP} from '../ui/Dialog';
 import {Group} from '../ui/Group';
-import {assetKeyToString} from '../workspace/asset-graph/Utils';
+import {displayNameForAssetKey} from '../workspace/asset-graph/Utils';
 
 interface AssetKey {
   path: string[];
@@ -34,7 +34,7 @@ export const AssetWipeDialog: React.FC<{
     <DialogWIP
       isOpen={isOpen}
       title={`Wipe materializations of ${
-        assetKeys.length === 1 ? assetKeyToString(assetKeys[0]) : 'selected assets'
+        assetKeys.length === 1 ? displayNameForAssetKey(assetKeys[0]) : 'selected assets'
       }?`}
       onClose={onClose}
       style={{width: 400}}

--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -10,7 +10,7 @@ import {ErrorSource} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {TagWIP} from '../ui/TagWIP';
-import {assetKeyToString} from '../workspace/asset-graph/Utils';
+import {displayNameForAssetKey} from '../workspace/asset-graph/Utils';
 
 import {EventTypeColumn} from './LogsRowComponents';
 import {LogRowStructuredContentTable, MetadataEntries, MetadataEntryLink} from './MetadataEntry';
@@ -375,7 +375,7 @@ const MaterializationContent: React.FC<{
               label: 'asset_key',
               item: (
                 <>
-                  {assetKeyToString(materialization.assetKey)}
+                  {displayNameForAssetKey(materialization.assetKey)}
                   {assetDashboardLink}
                 </>
               ),

--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -10,6 +10,7 @@ import {ErrorSource} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {TagWIP} from '../ui/TagWIP';
+import {assetKeyToString} from '../workspace/asset-graph/Utils';
 
 import {EventTypeColumn} from './LogsRowComponents';
 import {LogRowStructuredContentTable, MetadataEntries, MetadataEntryLink} from './MetadataEntry';
@@ -374,7 +375,7 @@ const MaterializationContent: React.FC<{
               label: 'asset_key',
               item: (
                 <>
-                  {materialization.assetKey.path.join(' > ')}
+                  {assetKeyToString(materialization.assetKey)}
                   {assetDashboardLink}
                 </>
               ),

--- a/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowStructuredContent.tsx
@@ -4,13 +4,12 @@ import querystring from 'query-string';
 import * as React from 'react';
 import {Link, useLocation} from 'react-router-dom';
 
-import {assertUnreachable} from '../app/Util';
+import {assertUnreachable, displayNameForAssetKey} from '../app/Util';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
 import {ErrorSource} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {TagWIP} from '../ui/TagWIP';
-import {displayNameForAssetKey} from '../workspace/asset-graph/Utils';
 
 import {EventTypeColumn} from './LogsRowComponents';
 import {LogRowStructuredContentTable, MetadataEntries, MetadataEntryLink} from './MetadataEntry';

--- a/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
@@ -14,6 +14,7 @@ import {IconWIP} from '../ui/Icon';
 import {Markdown} from '../ui/Markdown';
 import {Tooltip} from '../ui/Tooltip';
 import {FontFamily} from '../ui/styles';
+import {assetKeyToString} from '../workspace/asset-graph/Utils';
 
 import {MetadataEntryFragment} from './types/MetadataEntryFragment';
 
@@ -153,7 +154,7 @@ export const MetadataEntry: React.FC<{
         <MetadataEntryLink
           to={`/instance/assets/${entry.assetKey.path.map(encodeURIComponent).join('/')}`}
         >
-          {entry.assetKey.path.join(' > ')}
+          {assetKeyToString(entry.assetKey)}
         </MetadataEntryLink>
       );
     default:

--- a/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
@@ -14,7 +14,7 @@ import {IconWIP} from '../ui/Icon';
 import {Markdown} from '../ui/Markdown';
 import {Tooltip} from '../ui/Tooltip';
 import {FontFamily} from '../ui/styles';
-import {assetKeyToString} from '../workspace/asset-graph/Utils';
+import {displayNameForAssetKey} from '../workspace/asset-graph/Utils';
 
 import {MetadataEntryFragment} from './types/MetadataEntryFragment';
 
@@ -154,7 +154,7 @@ export const MetadataEntry: React.FC<{
         <MetadataEntryLink
           to={`/instance/assets/${entry.assetKey.path.map(encodeURIComponent).join('/')}`}
         >
-          {assetKeyToString(entry.assetKey)}
+          {displayNameForAssetKey(entry.assetKey)}
         </MetadataEntryLink>
       );
     default:

--- a/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/runs/MetadataEntry.tsx
@@ -4,7 +4,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {copyValue} from '../app/DomUtils';
-import {assertUnreachable} from '../app/Util';
+import {assertUnreachable, displayNameForAssetKey} from '../app/Util';
 import {Box} from '../ui/Box';
 import {ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
@@ -14,7 +14,6 @@ import {IconWIP} from '../ui/Icon';
 import {Markdown} from '../ui/Markdown';
 import {Tooltip} from '../ui/Tooltip';
 import {FontFamily} from '../ui/styles';
-import {displayNameForAssetKey} from '../workspace/asset-graph/Utils';
 
 import {MetadataEntryFragment} from './types/MetadataEntryFragment';
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {displayNameForAssetKey} from '../app/Util';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {Group} from '../ui/Group';
 import {NonIdealState} from '../ui/NonIdealState';
 import {Table} from '../ui/Table';
 
-import {displayNameForAssetKey} from './asset-graph/Utils';
 import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -9,6 +9,7 @@ import {Group} from '../ui/Group';
 import {NonIdealState} from '../ui/NonIdealState';
 import {Table} from '../ui/Table';
 
+import {assetKeyToString} from './asset-graph/Utils';
 import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
@@ -57,7 +58,7 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
       return null;
     }
     const items = repo.assetNodes.map((asset) => ({
-      name: asset.assetKey.path.join(' > '),
+      name: assetKeyToString(asset.assetKey),
       path: `/jobs/${asset.jobName}:default/${asset.assetKey.path
         .map(encodeURIComponent)
         .join('/')}`,

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -9,7 +9,7 @@ import {Group} from '../ui/Group';
 import {NonIdealState} from '../ui/NonIdealState';
 import {Table} from '../ui/Table';
 
-import {assetKeyToString} from './asset-graph/Utils';
+import {displayNameForAssetKey} from './asset-graph/Utils';
 import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
@@ -58,7 +58,7 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
       return null;
     }
     const items = repo.assetNodes.map((asset) => ({
-      name: assetKeyToString(asset.assetKey),
+      name: displayNameForAssetKey(asset.assetKey),
       path: `/jobs/${asset.jobName}:default/${asset.assetKey.path
         .map(encodeURIComponent)
         .join('/')}`,

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -6,6 +6,7 @@ import React, {CSSProperties} from 'react';
 import {Link, useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {displayNameForAssetKey} from '../../app/Util';
 import {LATEST_MATERIALIZATION_METADATA_FRAGMENT} from '../../assets/LastMaterializationMetadata';
 import {OpTags} from '../../graph/OpTags';
 import {METADATA_ENTRY_FRAGMENT} from '../../runs/MetadataEntry';
@@ -22,7 +23,7 @@ import {FontFamily} from '../../ui/styles';
 import {RepoAddress} from '../types';
 import {workspacePath, workspacePipelinePathGuessRepo} from '../workspacePath';
 
-import {displayNameForAssetKey, LiveDataForNode} from './Utils';
+import {LiveDataForNode} from './Utils';
 import {AssetNodeFragment} from './types/AssetNodeFragment';
 import {useLaunchSingleAssetJob} from './useLaunchSingleAssetJob';
 

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -22,7 +22,7 @@ import {FontFamily} from '../../ui/styles';
 import {RepoAddress} from '../types';
 import {workspacePath, workspacePipelinePathGuessRepo} from '../workspacePath';
 
-import {assetKeyToString, LiveDataForNode} from './Utils';
+import {displayNameForAssetKey, LiveDataForNode} from './Utils';
 import {AssetNodeFragment} from './types/AssetNodeFragment';
 import {useLaunchSingleAssetJob} from './useLaunchSingleAssetJob';
 
@@ -51,7 +51,7 @@ export const AssetNode: React.FC<{
               <span>
                 Launch run to build{' '}
                 <span style={{fontFamily: 'monospace', fontWeight: 600}}>
-                  {assetKeyToString(definition.assetKey)}
+                  {displayNameForAssetKey(definition.assetKey)}
                 </span>
               </span>
             }
@@ -72,7 +72,7 @@ export const AssetNode: React.FC<{
           <Name>
             <IconWIP name="asset" />
             <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
-              {assetKeyToString(definition.assetKey)}
+              {displayNameForAssetKey(definition.assetKey)}
             </div>
             <div style={{flex: 1}} />
             {liveData && liveData.inProgressRunIds.length > 0 ? (
@@ -243,7 +243,7 @@ export const getNodeDimensions = (def: {
   if (def.description) {
     height += 25;
   }
-  return {width: Math.max(250, assetKeyToString(def.assetKey).length * 9.5) + 25, height};
+  return {width: Math.max(250, displayNameForAssetKey(def.assetKey).length * 9.5) + 25, height};
 };
 
 const RunLinkTooltipStyle = JSON.stringify({

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
@@ -5,11 +5,11 @@ import {ColorsWIP} from '../../ui/Colors';
 import {IconWIP} from '../../ui/Icon';
 import {FontFamily} from '../../ui/styles';
 
-import {assetKeyToString} from './Utils';
+import {displayNameForAssetKey} from './Utils';
 
 export const ForeignNode: React.FC<{assetKey: {path: string[]}}> = React.memo(({assetKey}) => (
   <ForeignNodeLink>
-    <span className="label">{assetKeyToString(assetKey)}</span>
+    <span className="label">{displayNameForAssetKey(assetKey)}</span>
     <IconWIP name="open_in_new" color={ColorsWIP.Gray500} />
   </ForeignNodeLink>
 ));
@@ -30,5 +30,5 @@ const ForeignNodeLink = styled.div`
 `;
 export const getForeignNodeDimensions = (id: string) => {
   const path = JSON.parse(id);
-  return {width: assetKeyToString({path}).length * 7 + 30, height: 30};
+  return {width: displayNameForAssetKey({path}).length * 7 + 30, height: 30};
 };

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
+import {displayNameForAssetKey} from '../../app/Util';
 import {ColorsWIP} from '../../ui/Colors';
 import {IconWIP} from '../../ui/Icon';
 import {FontFamily} from '../../ui/styles';
-
-import {displayNameForAssetKey} from './Utils';
 
 export const ForeignNode: React.FC<{assetKey: {path: string[]}}> = React.memo(({assetKey}) => (
   <ForeignNodeLink>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -9,7 +9,7 @@ import {Box} from '../../ui/Box';
 import {ColorsWIP} from '../../ui/Colors';
 import {RepoAddress} from '../types';
 
-import {assetKeyToString, LiveDataForNode} from './Utils';
+import {displayNameForAssetKey, LiveDataForNode} from './Utils';
 import {AssetGraphQuery_pipelineOrError_Pipeline_assetNodes} from './types/AssetGraphQuery';
 
 export const SidebarAssetInfo: React.FC<{
@@ -25,7 +25,7 @@ export const SidebarAssetInfo: React.FC<{
     <>
       <SidebarSection title="Definition">
         <Box padding={{vertical: 16, horizontal: 24}}>
-          <SidebarTitle>{assetKeyToString(node.assetKey)}</SidebarTitle>
+          <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
           <Description description={node.description || null} />
         </Box>
         {definition.metadata && Plugin && Plugin.SidebarComponent && (

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {displayNameForAssetKey} from '../../app/Util';
 import {AssetMaterializations} from '../../assets/AssetMaterializations';
 import {Description} from '../../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../../pipelines/SidebarComponents';
@@ -9,7 +10,7 @@ import {Box} from '../../ui/Box';
 import {ColorsWIP} from '../../ui/Colors';
 import {RepoAddress} from '../types';
 
-import {displayNameForAssetKey, LiveDataForNode} from './Utils';
+import {LiveDataForNode} from './Utils';
 import {AssetGraphQuery_pipelineOrError_Pipeline_assetNodes} from './types/AssetGraphQuery';
 
 export const SidebarAssetInfo: React.FC<{

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -46,7 +46,7 @@ export type IEdge = {
 };
 
 export function assetKeyToString(key: {path: string[]}) {
-  return key.path.join('>');
+  return key.path.join(' > ');
 }
 
 export const buildGraphData = (assetNodes: AssetNode[], jobName?: string) => {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -1,6 +1,6 @@
+import {gql} from '@apollo/client';
 import {pathVerticalDiagonal} from '@vx/shape';
 import * as dagre from 'dagre';
-import {gql} from 'graphql.macro';
 
 import {AssetNodeDefinitionFragment} from '../../assets/types/AssetNodeDefinitionFragment';
 
@@ -44,10 +44,6 @@ export type IEdge = {
   to: IPoint;
   dashed: boolean;
 };
-
-export function displayNameForAssetKey(key: {path: string[]}) {
-  return key.path.join(' > ');
-}
 
 export const buildGraphData = (assetNodes: AssetNode[], jobName?: string) => {
   const data: GraphData = {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -45,7 +45,7 @@ export type IEdge = {
   dashed: boolean;
 };
 
-export function assetKeyToString(key: {path: string[]}) {
+export function displayNameForAssetKey(key: {path: string[]}) {
   return key.path.join(' > ');
 }
 


### PR DESCRIPTION


## Summary
This PR fixes a place I used `assetPathToString` in a URL, putting `>` joiners in the URL instead of `/`. This is tricky to spot because the SDA demo we use for development doesn't use asset paths with more than one component.

To prevent this from happening again, I also renamed the `assetKeyToString` helper to `displayNameForAssetKey`.



## Test Plan
You can now click from the SDA DAG to asset details pages.



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.