### PR TITLE
update external step launchers to work with dynamic execution

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/step_launcher.py
+++ b/python_modules/dagster/dagster/core/definitions/step_launcher.py
@@ -10,7 +10,7 @@ from dagster.core.storage.pipeline_run import PipelineRun
 class StepRunRef(
     namedtuple(
         "_StepRunRef",
-        "run_config pipeline_run run_id retry_mode step_key recon_pipeline prior_attempts_count",
+        "run_config pipeline_run run_id retry_mode step_key recon_pipeline prior_attempts_count known_state",
     )
 ):
     """
@@ -27,7 +27,10 @@ class StepRunRef(
         step_key,
         recon_pipeline,
         prior_attempts_count,
+        known_state,
     ):
+        from dagster.core.execution.plan.state import KnownExecutionState
+
         return super(StepRunRef, cls).__new__(
             cls,
             check.dict_param(run_config, "run_config", key_type=str),
@@ -37,6 +40,7 @@ class StepRunRef(
             check.str_param(step_key, "step_key"),
             check.inst_param(recon_pipeline, "recon_pipeline", ReconstructablePipeline),
             check.int_param(prior_attempts_count, "prior_attempts_count"),
+            check.opt_inst_param(known_state, "known_state", KnownExecutionState),
         )
 
 

--- a/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
+++ b/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
@@ -17,7 +17,7 @@ def main(step_run_ref_path: str) -> None:
 
     try:
         with DagsterInstance.ephemeral() as instance:
-            instance.add_event_listener(step_run_ref.run_id, lambda event: all_events.append(event))
+            instance.add_event_listener(step_run_ref.run_id, all_events.append)
             # consume entire step iterator
             list(run_step_from_ref(step_run_ref, instance))
     finally:

--- a/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
+++ b/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
@@ -15,14 +15,9 @@ def main(step_run_ref_path: str) -> None:
 
     all_events = []
 
-    def events_callback(event):
-        # each new event will get added to this list so we can send them back to the parent
-        # process (which will add them to that instance)
-        all_events.append(event)
-
     try:
         with DagsterInstance.ephemeral() as instance:
-            instance.add_event_listener(step_run_ref.run_id, events_callback)
+            instance.add_event_listener(step_run_ref.run_id, lambda event: all_events.append(event))
             # consume entire step iterator
             list(run_step_from_ref(step_run_ref, instance))
     finally:

--- a/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
+++ b/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
@@ -1,7 +1,9 @@
 import os
 import pickle
 import sys
+from typing import List
 
+from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.plan.external_step import PICKLED_EVENTS_FILE_NAME, run_step_from_ref
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.file_manager import LocalFileHandle, LocalFileManager
@@ -13,7 +15,7 @@ def main(step_run_ref_path: str) -> None:
     file_handle = LocalFileHandle(step_run_ref_path)
     step_run_ref = pickle.loads(file_manager.read_data(file_handle))
 
-    all_events = []
+    all_events: List[EventLogEntry] = []
 
     try:
         with DagsterInstance.ephemeral() as instance:

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
@@ -17,11 +17,17 @@ from dagster import (
     reconstructable,
     resource,
     solid,
+    job,
+    graph,
+    op,
+    DynamicOut,
+    DynamicOutput,
 )
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster.core.events import DagsterEventType
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.execution.context_creation_pipeline import PlanExecutionContextManager
+from dagster.core.test_utils import instance_for_test
 from dagster.core.execution.plan.external_step import (
     LocalExternalStepLauncher,
     local_external_step_launcher,
@@ -69,6 +75,36 @@ class RequestRetryLocalExternalStepLauncher(LocalExternalStepLauncher):
 @resource(config_schema=local_external_step_launcher.config_schema)
 def request_retry_local_external_step_launcher(context):
     return RequestRetryLocalExternalStepLauncher(**context.resource_config)
+
+
+def define_dynamic_job():
+    from typing import List
+
+    @op(required_resource_keys={"first_step_launcher"}, out=DynamicOut(int))
+    def dynamic_outs():
+        for i in range(0, 3):
+            yield DynamicOutput(value=i, mapping_key=f"num_{i}")
+
+    @op(required_resource_keys={"second_step_launcher"})
+    def increment(i):
+        return i + 1
+
+    @op
+    def total(ins: List[int]):
+        return sum(ins)
+
+    @job(
+        resource_defs={
+            "first_step_launcher": local_external_step_launcher,
+            "second_step_launcher": local_external_step_launcher,
+            "io_manager": fs_io_manager,
+        }
+    )
+    def my_job():
+        all_incs = dynamic_outs().map(increment)
+        total(all_incs.collect())
+
+    return my_job
 
 
 def define_basic_pipeline():
@@ -215,6 +251,27 @@ def test_pipeline(mode):
         )
         assert result.result_for_solid("return_two").output_value() == 2
         assert result.result_for_solid("add_one").output_value() == 3
+
+
+def test_dynamic_job():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with instance_for_test() as instance:
+            result = execute_pipeline(
+                pipeline=reconstructable(define_dynamic_job),
+                run_config={
+                    "resources": {
+                        "first_step_launcher": {
+                            "config": {"scratch_dir": tmpdir},
+                        },
+                        "second_step_launcher": {
+                            "config": {"scratch_dir": tmpdir},
+                        },
+                        "io_manager": {"config": {"base_dir": tmpdir}},
+                    }
+                },
+                instance=instance,
+            )
+            assert result.result_for_solid("total").output_value() == 6
 
 
 def test_launcher_requests_retry():

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
@@ -6,6 +6,8 @@ from threading import Thread
 
 import pytest
 from dagster import (
+    DynamicOut,
+    DynamicOutput,
     Field,
     ModeDefinition,
     RetryRequested,
@@ -13,21 +15,17 @@ from dagster import (
     execute_pipeline,
     execute_pipeline_iterator,
     fs_io_manager,
+    job,
+    op,
     pipeline,
     reconstructable,
     resource,
     solid,
-    job,
-    graph,
-    op,
-    DynamicOut,
-    DynamicOutput,
 )
 from dagster.core.definitions.no_step_launcher import no_step_launcher
 from dagster.core.events import DagsterEventType
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.execution.context_creation_pipeline import PlanExecutionContextManager
-from dagster.core.test_utils import instance_for_test
 from dagster.core.execution.plan.external_step import (
     LocalExternalStepLauncher,
     local_external_step_launcher,
@@ -37,6 +35,7 @@ from dagster.core.execution.plan.external_step import (
 from dagster.core.execution.retries import RetryMode
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import PipelineRun
+from dagster.core.test_utils import instance_for_test
 from dagster.utils import safe_tempfile_path, send_interrupt
 from dagster.utils.merger import deep_merge_dicts, merge_dicts
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -169,8 +169,10 @@ class DatabricksJobRunner:
         # since they're imported by our scripts.
         # Add them if they're not already added by users in config.
         libraries = list(run_config.get("libraries", []))
-        python_libraries = {x["pypi"]["package"].split("==")[0] for x in libraries if "pypi" in x}
-        for library in ["dagster", "dagster_databricks", "dagster_pyspark"]:
+        python_libraries = {
+            x["pypi"]["package"].split("==")[0].replace("_", "-") for x in libraries if "pypi" in x
+        }
+        for library in ["dagster", "dagster-databricks", "dagster-pyspark"]:
             if library not in python_libraries:
                 libraries.append(
                     {"pypi": {"package": "{}=={}".format(library, dagster.__version__)}}

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -6,7 +6,6 @@ import tempfile
 from dagster import Bool, Field, IntSource, StringSource, check, resource
 from dagster.core.definitions.step_launcher import StepLauncher
 from dagster.core.errors import raise_execution_interrupts
-from dagster.core.events import log_step_event
 from dagster.core.execution.plan.external_step import (
     PICKLED_EVENTS_FILE_NAME,
     PICKLED_STEP_RUN_REF_FILE_NAME,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -167,8 +167,10 @@ class DatabricksPySparkStepLauncher(StepLauncher):
                 self._log_logs_from_cluster(log, databricks_run_id)
 
         for event in self.get_step_events(run_id, step_key):
-            log_step_event(step_context, event)
-            yield event
+            # write each pickled event from the DataBricks instance to the local instance
+            step_context.instance.handle_new_event(event)
+            if event.is_dagster_event:
+                yield event.dagster_event
 
     def get_step_events(self, run_id, step_key):
         path = self._dbfs_path(run_id, step_key, PICKLED_EVENTS_FILE_NAME)
@@ -252,13 +254,31 @@ class DatabricksPySparkStepLauncher(StepLauncher):
     def _main_file_local_path(self):
         return databricks_step_main.__file__
 
+    def _sanitize_step_key(self, step_key: str) -> str:
+        # step_keys of dynamic steps contain brackets, which are invalid characters
+        return step_key.replace("[", "__").replace("]", "__")
+
     def _dbfs_path(self, run_id, step_key, filename):
-        path = "/".join([self.staging_prefix, run_id, step_key, os.path.basename(filename)])
+        path = "/".join(
+            [
+                self.staging_prefix,
+                run_id,
+                self._sanitize_step_key(step_key),
+                os.path.basename(filename),
+            ]
+        )
         return "dbfs://{}".format(path)
 
     def _internal_dbfs_path(self, run_id, step_key, filename):
         """Scripts running on Databricks should access DBFS at /dbfs/."""
-        path = "/".join([self.staging_prefix, run_id, step_key, os.path.basename(filename)])
+        path = "/".join(
+            [
+                self.staging_prefix,
+                run_id,
+                self._sanitize_step_key(step_key),
+                os.path.basename(filename),
+            ]
+        )
         return "/dbfs/{}".format(path)
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -56,9 +56,7 @@ def main(
 
         try:
             with DagsterInstance.ephemeral() as instance:
-                instance.add_event_listener(
-                    step_run_ref.run_id, lambda event: all_events.append(event)
-                )
+                instance.add_event_listener(step_run_ref.run_id, all_events.append)
                 list(run_step_from_ref(step_run_ref, instance))
         finally:
             events_filepath = (

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -54,12 +54,11 @@ def main(
 
         all_events = []
 
-        def events_callback(event):
-            all_events.append(event)
-
         try:
             with DagsterInstance.ephemeral() as instance:
-                instance.add_event_listener(step_run_ref.run_id, events_callback)
+                instance.add_event_listener(
+                    step_run_ref.run_id, lambda event: all_events.append(event)
+                )
                 list(run_step_from_ref(step_run_ref, instance))
         finally:
             events_filepath = (

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -14,7 +14,9 @@ import site
 import sys
 import tempfile
 import zipfile
+from typing import List
 
+from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.plan.external_step import PICKLED_EVENTS_FILE_NAME, run_step_from_ref
 from dagster.core.instance import DagsterInstance
 from dagster.serdes import serialize_value
@@ -52,7 +54,7 @@ def main(
             step_run_ref = pickle.load(handle)
         print("Running dagster job")  # noqa pylint: disable=print-call
 
-        all_events = []
+        all_events: List[EventLogEntry] = []
 
         try:
             with DagsterInstance.ephemeral() as instance:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -24,8 +24,8 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
         spark_jar_task=task["spark_jar_task"],
         libraries=[
             {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_databricks=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_pyspark=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
     )
 
@@ -57,8 +57,8 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
         spark_jar_task=task["spark_jar_task"],
         libraries=[
             {"pypi": {"package": "dagster=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_databricks=={}".format(dagster.__version__)}},
-            {"pypi": {"package": "dagster_pyspark=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-databricks=={}".format(dagster.__version__)}},
+            {"pypi": {"package": "dagster-pyspark=={}".format(dagster.__version__)}},
         ],
     )
 


### PR DESCRIPTION
Updates both LocalExternalStepLauncher and DatabricksPysparkStepLauncher to play nicely with the external state created by running stuff externally.

This basically just reworks the expectations for how step launchers work, and has them send back all the event records created on their local instance and directly write them back to the local instance. This also fixes a ton of subtle bugs that existed in the previous DagsterEvent-only implementation:

- Timestamps will now be accurate to the time the event was actually produced in the timeline view, rather than representing the time at which the local process received the remote event
- Messages logged with context.log() will be retrieved from the remote instance
- Not all events received from the instance are step events (for example, resource events), but all of the received events were logged with log_step_event(). this caused some weird graphical issues.
- Probably a ton of other things related to state being slightly misrepresented.

