### PR TITLE
[dagit] Create AnchorButton components

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Redirect, Route, RouteComponentProps, Switch} from 'react-router-dom';
 
 import {Box} from '../ui/Box';
+import {ExternalAnchorButton} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
 import {NonIdealState} from '../ui/NonIdealState';
 import {Spinner} from '../ui/Spinner';
@@ -76,13 +77,9 @@ export const FallthroughRoot = () => {
                         : 'Add a repository to get started.'
                     }
                     action={
-                      <a
-                        href="https://docs.dagster.io/getting-started"
-                        target="_blank"
-                        rel="nofollow noreferrer"
-                      >
+                      <ExternalAnchorButton href="https://docs.dagster.io/getting-started">
                         View documentation
-                      </a>
+                      </ExternalAnchorButton>
                     }
                   />
                 </Box>

--- a/js_modules/dagit/packages/core/src/ui/AnchorButton.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/AnchorButton.stories.tsx
@@ -1,0 +1,102 @@
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+
+import {AnchorButton, ExternalAnchorButton} from './Button';
+import {Group} from './Group';
+import {IconWIP as Icon} from './Icon';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'AnchorButton',
+  component: AnchorButton,
+} as Meta;
+
+export const Default = () => {
+  return (
+    <Group direction="column" spacing={8}>
+      <AnchorButton to="/">Button</AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="star" />}>
+        Button
+      </AnchorButton>
+      <AnchorButton to="/" rightIcon={<Icon name="close" />}>
+        Button
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="source" />} rightIcon={<Icon name="expand_more" />}>
+        Button
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="cached" />} />
+    </Group>
+  );
+};
+
+export const Intent = () => {
+  return (
+    <Group direction="column" spacing={8}>
+      <AnchorButton to="/" icon={<Icon name="star" />}>
+        No intent set
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="star" />} intent="primary">
+        Primary
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="done" />} intent="success">
+        Success
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="error" />} intent="danger">
+        Danger
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="warning" />} intent="warning">
+        Warning
+      </AnchorButton>
+      <AnchorButton to="/" icon={<Icon name="star" />} intent="none">
+        None
+      </AnchorButton>
+    </Group>
+  );
+};
+
+export const Outlined = () => {
+  return (
+    <Group direction="column" spacing={8}>
+      <AnchorButton to="/" outlined icon={<Icon name="star" />}>
+        No intent set
+      </AnchorButton>
+      <AnchorButton to="/" outlined icon={<Icon name="star" />} intent="primary">
+        Primary
+      </AnchorButton>
+      <AnchorButton to="/" outlined icon={<Icon name="done" />} intent="success">
+        Success
+      </AnchorButton>
+      <AnchorButton to="/" outlined icon={<Icon name="error" />} intent="danger">
+        Danger
+      </AnchorButton>
+      <AnchorButton to="/" outlined icon={<Icon name="warning" />} intent="warning">
+        Warning
+      </AnchorButton>
+      <AnchorButton to="/" outlined icon={<Icon name="star" />} intent="none">
+        None
+      </AnchorButton>
+    </Group>
+  );
+};
+
+export const ExternalButton = () => {
+  return (
+    <Group direction="column" spacing={8}>
+      <ExternalAnchorButton href="https://html5zombo.com/">Button</ExternalAnchorButton>
+      <ExternalAnchorButton href="https://html5zombo.com/" icon={<Icon name="star" />}>
+        Button
+      </ExternalAnchorButton>
+      <ExternalAnchorButton href="https://html5zombo.com/" rightIcon={<Icon name="close" />}>
+        Button
+      </ExternalAnchorButton>
+      <ExternalAnchorButton
+        href="https://html5zombo.com/"
+        icon={<Icon name="source" />}
+        rightIcon={<Icon name="expand_more" />}
+      >
+        Button
+      </ExternalAnchorButton>
+      <ExternalAnchorButton href="https://html5zombo.com/" icon={<Icon name="cached" />} />
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/BaseButton.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import styled from 'styled-components/macro';
 
 import {ColorsWIP} from './Colors';
-import {IconWrapper} from './Icon';
-import {SpinnerWrapper} from './Spinner';
-import {FontFamily} from './styles';
+import {StyledButton} from './StyledButton';
 
-interface Props extends React.ComponentPropsWithRef<'button'> {
+interface CommonButtonProps {
   icon?: React.ReactNode;
   label?: React.ReactNode;
   loading?: boolean;
@@ -16,8 +13,10 @@ interface Props extends React.ComponentPropsWithRef<'button'> {
   textColor?: string;
 }
 
+interface BaseButtonProps extends CommonButtonProps, React.ComponentPropsWithRef<'button'> {}
+
 export const BaseButton = React.forwardRef(
-  (props: Props, ref: React.ForwardedRef<HTMLButtonElement>) => {
+  (props: BaseButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
     const {
       fillColor = ColorsWIP.White,
       disabled,
@@ -33,7 +32,8 @@ export const BaseButton = React.forwardRef(
     return (
       <StyledButton
         {...rest}
-        disabled={disabled || loading}
+        as="button"
+        disabled={!!(disabled || loading)}
         $fillColor={fillColor}
         $strokeColor={strokeColor}
         $textColor={textColor}
@@ -46,86 +46,3 @@ export const BaseButton = React.forwardRef(
     );
   },
 );
-
-interface StyledButtonProps {
-  $fillColor: string;
-  $strokeColor: string;
-  $textColor: string;
-}
-
-const StyledButton = styled.button<StyledButtonProps>`
-  align-items: center;
-  background-color: ${({$fillColor}) => $fillColor || 'transparent'};
-  border: none;
-  border-radius: 8px;
-  color: ${({$textColor}) => $textColor};
-  cursor: pointer;
-  display: inline-flex;
-  flex-direction: row;
-  font-family: ${FontFamily.default};
-  font-size: 14px;
-  line-height: 20px;
-  padding: 6px 12px;
-  transition: background 100ms, box-shadow 150ms, filter 100ms, opacity 150ms;
-  user-select: none;
-  box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
-
-  :hover {
-    box-shadow: ${({$strokeColor}) =>
-      `${$strokeColor} inset 0px 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 2px 12px 0px;`};
-  }
-
-  :focus {
-    box-shadow: rgba(58, 151, 212, 0.6) 0 0 0 3px;
-    outline: none;
-  }
-
-  :focus:not(:focus-visible) {
-    box-shadow: ${({$strokeColor}) =>
-      `${$strokeColor} inset 0px 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 2px 12px 0px;`};
-  }
-
-  :active {
-    filter: brightness(0.95);
-  }
-
-  :disabled {
-    cursor: default;
-    opacity: 0.5;
-  }
-
-  :disabled:hover {
-    box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
-  }
-
-  ${SpinnerWrapper} {
-    align-self: center;
-    display: block;
-  }
-
-  ${IconWrapper} {
-    color: ${({$textColor}) => $textColor};
-    background-color: ${({$textColor}) => $textColor};
-    align-self: center;
-    display: block;
-  }
-
-  ${SpinnerWrapper}:first-child,
-  ${IconWrapper}:first-child {
-    margin-left: -4px;
-    margin-right: 4px;
-  }
-
-  ${SpinnerWrapper}:last-child,
-  ${IconWrapper}:last-child {
-    margin-right: -4px;
-    margin-left: 4px;
-  }
-
-  ${SpinnerWrapper}:first-child:last-child {
-    margin: 2px -4px;
-  }
-  ${IconWrapper}:first-child:last-child {
-    margin: 2px -4px;
-  }
-`;

--- a/js_modules/dagit/packages/core/src/ui/Button.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Button.tsx
@@ -1,10 +1,12 @@
 // eslint-disable-next-line no-restricted-imports
-import {Button as BlueprintButton} from '@blueprintjs/core';
+import {Button as BlueprintButton, AnchorButton as BlueprintAnchorButton} from '@blueprintjs/core';
 import * as React from 'react';
+import {Link, LinkProps} from 'react-router-dom';
 
 import {BaseButton} from './BaseButton';
 import {ColorsWIP} from './Colors';
 import {Spinner} from './Spinner';
+import {StyledButton} from './StyledButton';
 
 type BlueprintIntent = React.ComponentProps<typeof BlueprintButton>['intent'];
 type BlueprintOutlined = React.ComponentProps<typeof BlueprintButton>['outlined'];
@@ -93,10 +95,6 @@ export const ButtonWIP = React.forwardRef(
   ) => {
     const {children, icon, intent, loading, outlined, rightIcon, ...rest} = props;
 
-    const fillColor = intentToFillColor(intent, outlined);
-    const textColor = intentToTextColor(intent, outlined);
-    const strokeColor = intentToStrokeColor(intent, outlined);
-
     let iconOrSpinner = icon;
     let rightIconOrSpinner = rightIcon;
 
@@ -113,9 +111,9 @@ export const ButtonWIP = React.forwardRef(
         icon={iconOrSpinner}
         rightIcon={rightIconOrSpinner}
         loading={loading}
-        fillColor={fillColor}
-        textColor={textColor}
-        strokeColor={strokeColor}
+        fillColor={intentToFillColor(intent, outlined)}
+        textColor={intentToTextColor(intent, outlined)}
+        strokeColor={intentToStrokeColor(intent, outlined)}
         label={children}
         ref={ref}
       />
@@ -124,3 +122,58 @@ export const ButtonWIP = React.forwardRef(
 );
 
 ButtonWIP.displayName = 'Button';
+
+interface AnchorButtonProps
+  extends Omit<React.ComponentProps<typeof BlueprintAnchorButton>, 'loading' | 'onClick' | 'type'>,
+    LinkProps {
+  label?: React.ReactNode;
+}
+
+export const AnchorButton = React.forwardRef(
+  (props: AnchorButtonProps, ref: React.ForwardedRef<HTMLAnchorElement>) => {
+    const {children, icon, intent, outlined, rightIcon, ...rest} = props;
+    return (
+      <StyledButton
+        {...rest}
+        as={Link}
+        $fillColor={intentToFillColor(intent, outlined)}
+        $strokeColor={intentToStrokeColor(intent, outlined)}
+        $textColor={intentToTextColor(intent, outlined)}
+        ref={ref}
+      >
+        {icon || null}
+        {children ? <span>{children}</span> : null}
+        {rightIcon || null}
+      </StyledButton>
+    );
+  },
+);
+
+AnchorButton.displayName = 'AnchorButton';
+
+export const ExternalAnchorButton = React.forwardRef(
+  (
+    props: Omit<React.ComponentProps<typeof BlueprintAnchorButton>, 'loading'>,
+    ref: React.ForwardedRef<HTMLAnchorElement>,
+  ) => {
+    const {children, icon, intent, outlined, rightIcon, ...rest} = props;
+    return (
+      <StyledButton
+        {...rest}
+        as="a"
+        target="_blank"
+        rel="noreferrer nofollow"
+        $fillColor={intentToFillColor(intent, outlined)}
+        $strokeColor={intentToStrokeColor(intent, outlined)}
+        $textColor={intentToTextColor(intent, outlined)}
+        ref={ref}
+      >
+        {icon || null}
+        {children ? <span>{children}</span> : null}
+        {rightIcon || null}
+      </StyledButton>
+    );
+  },
+);
+
+ExternalAnchorButton.displayName = 'ExternalAnchorButton';

--- a/js_modules/dagit/packages/core/src/ui/NonIdealState.tsx
+++ b/js_modules/dagit/packages/core/src/ui/NonIdealState.tsx
@@ -42,6 +42,7 @@ export const NonIdealState: React.FC<NonIdealStateProps> = ({title, description,
         flex={{
           gap: 8,
           direction: 'column',
+          alignItems: 'flex-start',
         }}
       >
         {title && <Subheading style={{color: ColorsWIP.Gray900}}>{title}</Subheading>}

--- a/js_modules/dagit/packages/core/src/ui/StyledButton.tsx
+++ b/js_modules/dagit/packages/core/src/ui/StyledButton.tsx
@@ -1,0 +1,90 @@
+import styled from 'styled-components/macro';
+
+import {IconWrapper} from './Icon';
+import {SpinnerWrapper} from './Spinner';
+import {FontFamily} from './styles';
+
+interface StyledButtonProps {
+  $fillColor: string;
+  $strokeColor: string;
+  $textColor: string;
+}
+
+export const StyledButton = styled.button<StyledButtonProps>`
+  align-items: center;
+  background-color: ${({$fillColor}) => $fillColor || 'transparent'};
+  border: none;
+  border-radius: 8px;
+  color: ${({$textColor}) => $textColor};
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: row;
+  font-family: ${FontFamily.default};
+  font-size: 14px;
+  line-height: 20px;
+  padding: 6px 12px;
+  transition: background 100ms, box-shadow 150ms, filter 100ms, opacity 150ms;
+  user-select: none;
+  box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
+
+  :hover {
+    box-shadow: ${({$strokeColor}) =>
+      `${$strokeColor} inset 0px 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 2px 12px 0px;`};
+    color: ${({$textColor}) => $textColor};
+    text-decoration: none;
+  }
+
+  :focus {
+    box-shadow: rgba(58, 151, 212, 0.6) 0 0 0 3px;
+    outline: none;
+  }
+
+  :focus:not(:focus-visible) {
+    box-shadow: ${({$strokeColor}) =>
+      `${$strokeColor} inset 0px 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 2px 12px 0px;`};
+  }
+
+  :active {
+    filter: brightness(0.95);
+  }
+
+  :disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+
+  :disabled:hover {
+    box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
+  }
+
+  ${SpinnerWrapper} {
+    align-self: center;
+    display: block;
+  }
+
+  ${IconWrapper} {
+    color: ${({$textColor}) => $textColor};
+    background-color: ${({$textColor}) => $textColor};
+    align-self: center;
+    display: block;
+  }
+
+  ${SpinnerWrapper}:first-child,
+  ${IconWrapper}:first-child {
+    margin-left: -4px;
+    margin-right: 4px;
+  }
+
+  ${SpinnerWrapper}:last-child,
+  ${IconWrapper}:last-child {
+    margin-right: -4px;
+    margin-left: 4px;
+  }
+
+  ${SpinnerWrapper}:first-child:last-child {
+    margin: 2px -4px;
+  }
+  ${IconWrapper}:first-child:last-child {
+    margin: 2px -4px;
+  }
+`;


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

Create a couple of components that will be useful throughout Dagit:

- `AnchorButton`, a component that looks like our new `Button` but renders a react-router Link.
- `ExternalAnchorButton`, a component that looks like `Button` but is intended for external links.

I also put this in place on `FallthroughRoot`, where I had previously removed an invalid DOM case.

## Test Plan

Storybook examples, FallthroughRoot on empty workspace Dagit.
