### PR TITLE
[assets] Precalculate dependedBy for better perf, fix foreign asset deps

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -75,18 +75,14 @@ class GrapheneAssetNode(graphene.ObjectType):
         ]
 
     def resolve_dependedBy(self, _graphene_info):
-        results = []
-        for item in self._external_repository.get_external_asset_nodes():
-            for dep in item.dependencies:
-                if dep.upstream_asset_key == self._external_asset_node.asset_key:
-                    results.append(
-                        GrapheneAssetDependency(
-                            external_repository=self._external_repository,
-                            input_name=dep.input_name,
-                            asset_key=item.asset_key,
-                        )
-                    )
-        return results
+        return [
+            GrapheneAssetDependency(
+                external_repository=self._external_repository,
+                input_name=dep.input_name,
+                asset_key=dep.downstream_asset_key,
+            )
+            for dep in self._external_asset_node.depended_by
+        ]
 
     def resolve_assetMaterializations(self, graphene_info, **kwargs):
         from ..implementation.fetch_assets import get_asset_events

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -530,8 +530,8 @@ def external_asset_graph_from_defs(
     asset_nodes = [
         ExternalAssetNode(
             asset_key=asset_key,
-            dependencies=[],
-            depended_by=[],
+            dependencies=list(deps[asset_key].values()),
+            depended_by=list(dep_by[asset_key].values()),
             job_names=[],
         )
         for asset_key in asset_keys_without_definitions
@@ -544,21 +544,11 @@ def external_asset_graph_from_defs(
                 " and as a non-foreign asset"
             )
 
-        foreign_depended_by = []
-        for node_asset_key, node_deps in deps.items():
-            for dep in node_deps.values():
-                if dep.upstream_asset_key == foreign_asset.key:
-                    foreign_depended_by.append(
-                        ExternalAssetDependedBy(
-                            downstream_asset_key=node_asset_key, input_name=dep.input_name
-                        )
-                    )
-
         asset_nodes.append(
             ExternalAssetNode(
                 asset_key=foreign_asset.key,
-                dependencies=[],
-                depended_by=foreign_depended_by,
+                dependencies=list(deps[foreign_asset.key].values()),
+                depended_by=list(dep_by[foreign_asset.key].values()),
                 job_names=[],
                 op_description=foreign_asset.description,
             )

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -411,8 +411,28 @@ class ExternalAssetDependency(
 
 
 @whitelist_for_serdes
+class ExternalAssetDependedBy(
+    namedtuple("_ExternalAssetDependedBy", "downstream_asset_key input_name")
+):
+    """A definition of a directed edge in the logical asset graph.
+
+    An downstream asset that's depended by, and the corresponding input name in the upstream
+    asset that it depends on.
+    """
+
+    def __new__(cls, downstream_asset_key: AssetKey, input_name: str):
+        return super(ExternalAssetDependedBy, cls).__new__(
+            cls,
+            downstream_asset_key=downstream_asset_key,
+            input_name=input_name,
+        )
+
+
+@whitelist_for_serdes
 class ExternalAssetNode(
-    namedtuple("_ExternalAssetNode", "asset_key dependencies op_name op_description job_names")
+    namedtuple(
+        "_ExternalAssetNode", "asset_key dependencies depended_by op_name op_description job_names"
+    )
 ):
     """A definition of a node in the logical asset graph.
 
@@ -423,6 +443,7 @@ class ExternalAssetNode(
         cls,
         asset_key: AssetKey,
         dependencies: List[ExternalAssetDependency],
+        depended_by: List[ExternalAssetDependedBy],
         op_name: Optional[str] = None,
         op_description: Optional[str] = None,
         job_names: Optional[List[str]] = None,
@@ -431,6 +452,7 @@ class ExternalAssetNode(
             cls,
             asset_key=asset_key,
             dependencies=dependencies,
+            depended_by=depended_by,
             op_name=op_name,
             op_description=op_description,
             job_names=job_names,
@@ -471,9 +493,11 @@ def external_asset_graph_from_defs(
     node_defs_by_asset_key: Dict[
         AssetKey, List[Tuple[NodeDefinition, PipelineDefinition]]
     ] = defaultdict(list)
-    deps: Dict[AssetKey, Dict[str, ExternalAssetDependency]] = defaultdict(dict)
 
+    deps: Dict[AssetKey, Dict[str, ExternalAssetDependency]] = defaultdict(dict)
+    dep_by: Dict[AssetKey, Dict[str, ExternalAssetDependedBy]] = defaultdict(dict)
     all_upstream_asset_keys = set()
+
     for pipeline in pipelines:
         for node_def in pipeline.all_node_defs:
             node_asset_keys: Set[AssetKey] = set()
@@ -488,12 +512,16 @@ def external_asset_graph_from_defs(
                 upstream_asset_key = input_def.hardcoded_asset_key
 
                 if upstream_asset_key:
+                    all_upstream_asset_keys.add(upstream_asset_key)
                     for node_asset_key in node_asset_keys:
                         deps[node_asset_key][input_def.name] = ExternalAssetDependency(
                             upstream_asset_key=upstream_asset_key,
                             input_name=input_def.name,
                         )
-                        all_upstream_asset_keys.add(upstream_asset_key)
+                        dep_by[upstream_asset_key][input_def.name] = ExternalAssetDependedBy(
+                            downstream_asset_key=node_asset_key,
+                            input_name=input_def.name,
+                        )
 
     asset_keys_without_definitions = all_upstream_asset_keys.difference(
         node_defs_by_asset_key.keys()
@@ -503,6 +531,7 @@ def external_asset_graph_from_defs(
         ExternalAssetNode(
             asset_key=asset_key,
             dependencies=[],
+            depended_by=[],
             job_names=[],
         )
         for asset_key in asset_keys_without_definitions
@@ -515,10 +544,21 @@ def external_asset_graph_from_defs(
                 " and as a non-foreign asset"
             )
 
+        foreign_depended_by = []
+        for node_asset_key, node_deps in deps.items():
+            for dep in node_deps.values():
+                if dep.upstream_asset_key == foreign_asset.key:
+                    foreign_depended_by.append(
+                        ExternalAssetDependedBy(
+                            downstream_asset_key=node_asset_key, input_name=dep.input_name
+                        )
+                    )
+
         asset_nodes.append(
             ExternalAssetNode(
                 asset_key=foreign_asset.key,
                 dependencies=[],
+                depended_by=foreign_depended_by,
                 job_names=[],
                 op_description=foreign_asset.description,
             )
@@ -531,6 +571,7 @@ def external_asset_graph_from_defs(
             ExternalAssetNode(
                 asset_key=asset_key,
                 dependencies=list(deps[asset_key].values()),
+                depended_by=list(dep_by[asset_key].values()),
                 op_name=node_def.name,
                 op_description=node_def.description,
                 job_names=job_names,


### PR DESCRIPTION
## Summary

I originally hacked a `dependedBy` resolver into AssetNode because Dagit needed to be able to fetch bidirectionally from a single asset node for the new asset details view. It turns out scanning dependencies to build the reverse relations was pretty slow and pre-computing on ExternalAssetNode is a 50%+ performance win on the mega asset DAG.

The only reason we were fetching `dependedBy` when rendering the Asset DAG explorer (eg: requesting it for EVERY asset node) was because it was the only way to show arrows going in to downstream foreign assets and assets without definitions.  It turns out we were just leaving the `dependencies` field blank when constructing the ExternalAssetNodes, so I fixed that in this PR and removed the overfetching in Dagit in #5904.  (I think this makes sense?)

This makes the performance improvements less necessary so I'd be happy to revert to the scan approach if that's easier to maintain.


## Test Plan
Edited the tests to check the depended_by relations


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.