### PR TITLE
Add volumes and volumeMounts to celery k8s run launcher

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -111,7 +111,7 @@ spec:
         {{- if $deployment.volumeMounts }}
           volumeMounts:
           {{- range $volumeMount := $deployment.volumeMounts }}
-            - {{ $volumeMount | toYaml | nindent 16 }}
+            - {{- $volumeMount | toYaml | nindent 14 }}
           {{- end }}
         {{- end }}
       nodeSelector: {{ $deployment.nodeSelector | toYaml | nindent 8 }}
@@ -120,7 +120,7 @@ spec:
       {{- if $deployment.volumes }}
       volumes:
         {{- range $volume := $deployment.volumes }}
-        - {{ $volume | toYaml | nindent 12 }}
+        - {{- $volume | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 ---

--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -41,6 +41,8 @@ class CeleryK8sRunLauncherConfig(BaseModel):
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
     livenessProbe: kubernetes.LivenessProbe
+    volumeMounts: List[kubernetes.VolumeMount]
+    volumes: List[kubernetes.Volume]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/schema_tests/test_celery_queues.py
+++ b/helm/dagster/schema/schema_tests/test_celery_queues.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+from dagster.core.test_utils import remove_none_recursively
 from kubernetes.client import models
 from schema.charts.dagster.subschema.run_launcher import (
     CeleryK8sRunLauncherConfig,
@@ -65,11 +66,11 @@ def test_celery_queue_image(deployment_template: HelmTemplate):
         )
     )
 
-    dagit_deployments = deployment_template.render(helm_values)
+    celery_queue_deployments = deployment_template.render(helm_values)
 
-    assert len(dagit_deployments) == 1
+    assert len(celery_queue_deployments) == 1
 
-    image = dagit_deployments[0].spec.template.spec.containers[0].image
+    image = celery_queue_deployments[0].spec.template.spec.containers[0].image
     image_name, image_tag = image.split(":")
 
     assert image_name == repository
@@ -215,3 +216,70 @@ def test_celery_queue_empty_run_launcher_config_source(
         extra_queue_celery["execution"]["celery"]["config_source"]
         == workerQueues[1]["configSource"]
     )
+
+
+def test_celery_queue_volumes(deployment_template: HelmTemplate):
+    volume_mounts = [
+        {
+            "name": "test-volume",
+            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+            "subPath": "volume_mounted_file.yaml",
+        },
+    ]
+
+    volumes = [
+        {"name": "test-volume", "configMap": {"name": "test-volume-configmap"}},
+        {"name": "test-pvc", "persistentVolumeClaim": {"claimName": "my_claim", "readOnly": False}},
+    ]
+
+    repository = "repository"
+    tag = "tag"
+
+    helm_values = DagsterHelmValues.construct(
+        runLauncher=RunLauncher(
+            type=RunLauncherType.CELERY,
+            config=RunLauncherConfig(
+                celeryK8sRunLauncher=CeleryK8sRunLauncherConfig.construct(
+                    image=kubernetes.Image.construct(repository=repository, tag=tag),
+                    volumeMounts=volume_mounts,
+                    volumes=volumes,
+                )
+            ),
+        )
+    )
+
+    celery_queue_deployments = deployment_template.render(helm_values)
+
+    assert len(celery_queue_deployments) == 1
+
+    mounts = celery_queue_deployments[0].spec.template.spec.containers[0].volume_mounts
+
+    assert [remove_none_recursively(mount.to_dict()) for mount in mounts] == [
+        {
+            "mount_path": "/opt/dagster/dagster_home/dagster.yaml",
+            "name": "dagster-instance",
+            "sub_path": "dagster.yaml",
+        },
+        {
+            "mount_path": "/opt/dagster/dagster_home/celery-config.yaml",
+            "name": "dagster-celery",
+            "sub_path": "celery.yaml",
+        },
+        {
+            "mount_path": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+            "name": "test-volume",
+            "sub_path": "volume_mounted_file.yaml",
+        },
+    ]
+
+    rendered_volumes = celery_queue_deployments[0].spec.template.spec.volumes
+
+    assert [remove_none_recursively(volume.to_dict()) for volume in rendered_volumes] == [
+        {"config_map": {"name": "RELEASE-NAME-dagster-instance"}, "name": "dagster-instance"},
+        {"config_map": {"name": "RELEASE-NAME-dagster-celery-dagster"}, "name": "dagster-celery"},
+        {"name": "test-volume", "config_map": {"name": "test-volume-configmap"}},
+        {
+            "name": "test-pvc",
+            "persistent_volume_claim": {"claim_name": "my_claim", "read_only": False},
+        },
+    ]

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -171,6 +171,24 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
         {"name": "extra-queue-1", "replicaCount": 1},
     ]
 
+    volume_mounts = [
+        {
+            "mountPath": "/opt/dagster/dagster_home/dagster.yaml",
+            "name": "dagster-instance",
+            "subPath": "dagster.yaml",
+        },
+        {
+            "name": "test-volume",
+            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+            "subPath": "volume_mounted_file.yaml",
+        },
+    ]
+
+    volumes = [
+        {"name": "test-volume", "configMap": {"name": "test-volume-configmap"}},
+        {"name": "test-pvc", "persistentVolumeClaim": {"claimName": "my_claim", "readOnly": False}},
+    ]
+
     helm_values = DagsterHelmValues.construct(
         runLauncher=RunLauncher.construct(
             type=RunLauncherType.CELERY,
@@ -179,6 +197,8 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
                     image=image,
                     configSource=configSource,
                     workerQueues=workerQueues,
+                    volumeMounts=volume_mounts,
+                    volumes=volumes,
                 )
             ),
         )
@@ -196,6 +216,9 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
     assert run_launcher_config["config"]["broker"] == {"env": "DAGSTER_CELERY_BROKER_URL"}
 
     assert run_launcher_config["config"]["backend"] == {"env": "DAGSTER_CELERY_BACKEND_URL"}
+
+    assert run_launcher_config["config"]["volume_mounts"] == volume_mounts
+    assert run_launcher_config["config"]["volumes"] == volumes
 
 
 @pytest.mark.parametrize("enabled", [True, False])

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -85,6 +85,9 @@ spec:
             - name: dagster-celery
               mountPath: "{{ $.Values.global.dagsterHome }}/celery-config.yaml"
               subPath: celery.yaml
+            {{- range $volumeMount := $celeryK8sRunLauncherConfig.volumeMounts }}
+            - {{- $volumeMount | toYaml | nindent 14 }}
+            {{- end }}
           resources:
             {{- toYaml $celeryK8sRunLauncherConfig.resources | nindent 12 }}
       {{- if $celeryK8sRunLauncherConfig.livenessProbe }}
@@ -128,6 +131,9 @@ spec:
         - name: dagster-celery
           configMap:
             name: {{ template "dagster.fullname" $ }}-celery-{{- $queue.name }}
+        {{- range $volume := $celeryK8sRunLauncherConfig.volumes }}
+        - {{- $volume | toYaml | nindent 10 }}
+        {{- end }}
     {{- with $celeryK8sRunLauncherConfig.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -32,6 +32,13 @@ config:
     {{- end }}
     - {{ .Values.global.celeryConfigSecretName }}
   {{- end }}
+  {{- if $celeryK8sRunLauncherConfig.volumeMounts }}
+  volume_mounts: {{- $celeryK8sRunLauncherConfig.volumeMounts | toYaml | nindent 4 }}
+  {{- end }}
+
+  {{- if $celeryK8sRunLauncherConfig.volumes }}
+  volumes: {{- $celeryK8sRunLauncherConfig.volumes | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 
 {{- define "dagsterYaml.runLauncher.k8s" }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1593,6 +1593,20 @@
                 },
                 "livenessProbe": {
                     "$ref": "#/definitions/LivenessProbe"
+                },
+                "volumeMounts": {
+                    "title": "Volumemounts",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VolumeMount"
+                    }
+                },
+                "volumes": {
+                    "title": "Volumes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Volume"
+                    }
                 }
             },
             "required": [
@@ -1610,7 +1624,9 @@
                 "podSecurityContext",
                 "securityContext",
                 "resources",
-                "livenessProbe"
+                "livenessProbe",
+                "volumeMounts",
+                "volumes"
             ],
             "additionalProperties": false
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -537,6 +537,27 @@ runLauncher:
         successThreshold: 1
         failureThreshold: 3
 
+      # Additional volumes that should be included in the Job's Pod. See:
+      # https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
+      #
+      # Example:
+      #
+      # volumes:
+      #   - name: my-volume
+      #     configMap: my-config-map
+      volumes: []
+
+      # Additional volume mounts that should be included in the container in the Job's Pod. See:
+      # See: https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+      #
+      # Example:
+      #
+      # volumeMounts:
+      #   - name: test-volume
+      #     mountPath: /opt/dagster/test_folder
+      #     subPath: test_file.yaml
+      volumeMounts: []
+
     ## Uncomment this configuration will only be used if the CustomRunLauncher is selected.
     ## Using this setting requires a custom Dagit image that defines the user specified
     ## run launcher in an installed python module.

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -821,6 +821,19 @@ def _base_helm_config(docker_image):
                     ),
                     "env": {"TEST_SET_ENV_VAR": "test_celery_env_var"},
                     "envSecrets": [{"name": TEST_SECRET_NAME}],
+                    "volumeMounts": [
+                        {
+                            "name": "test-volume",
+                            "mountPath": "/opt/dagster/test_mount_path/volume_mounted_file.yaml",
+                            "subPath": "volume_mounted_file.yaml",
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "test-volume",
+                            "configMap": {"name": TEST_VOLUME_CONFIGMAP_NAME},
+                        }
+                    ],
                 },
             },
         },

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
@@ -103,6 +103,7 @@ def test_k8s_run_launcher_volume_mounts(
         helm_namespace_for_k8s_run_launcher,
         pipeline_name="volume_mount_pipeline",
         num_steps=1,
+        mode="k8s",
     )
 
 
@@ -212,8 +213,11 @@ def _launch_executor_run(
     helm_namespace_for_k8s_run_launcher,
     pipeline_name="demo_k8s_executor_pipeline",
     num_steps=2,
+    mode="default",
 ):
-    run_id = launch_run_over_graphql(dagit_url, run_config=run_config, pipeline_name=pipeline_name)
+    run_id = launch_run_over_graphql(
+        dagit_url, run_config=run_config, pipeline_name=pipeline_name, mode=mode
+    )
 
     result = wait_for_job_and_get_raw_logs(
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace_for_k8s_run_launcher

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -631,7 +631,7 @@ def check_volume_mount(context):
 
 def define_volume_mount_pipeline():
     @pipeline(
-        mode_defs=k8s_mode_defs(),
+        mode_defs=k8s_mode_defs(name="k8s") + celery_mode_defs(name="celery"),
     )
     def volume_mount_pipeline():
         check_volume_mount()

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -83,6 +83,11 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         env_secrets (Optional[List[str]]): A list of custom Secret names from which to
             draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
             https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+        volume_mounts (Optional[List[Permissive]]): A list of volume mounts to include in the job's
+            container. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+        volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
+            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
     """
 
     def __init__(
@@ -101,6 +106,8 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         k8s_client_batch_api=None,
         env_config_maps=None,
         env_secrets=None,
+        volume_mounts=None,
+        volumes=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
@@ -133,6 +140,9 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             env_config_maps, "env_config_maps", of_type=str
         )
         self._env_secrets = check.opt_list_param(env_secrets, "env_secrets", of_type=str)
+
+        self._volume_mounts = check.opt_list_param(volume_mounts, "volume_mounts")
+        self._volumes = check.opt_list_param(volumes, "volumes")
 
         super().__init__()
 
@@ -271,8 +281,8 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             service_account_name=exc_config.get("service_account_name"),
             env_config_maps=exc_config.get("env_config_maps", []) + self._env_config_maps,
             env_secrets=exc_config.get("env_secrets", []) + self._env_secrets,
-            volume_mounts=exc_config.get("volume_mounts"),
-            volumes=exc_config.get("volumes"),
+            volume_mounts=exc_config.get("volume_mounts", []) + self._volume_mounts,
+            volumes=exc_config.get("volumes", []) + self._volumes,
         )
 
     # https://github.com/dagster-io/dagster/issues/2741

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -316,6 +316,38 @@ class DagsterK8sJobConfig(
                 "variables (using ``envFrom``) for the Job. Default: ``[]``. See:"
                 "https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables",
             ),
+            "volume_mounts": Field(
+                Array(
+                    Shape(
+                        {
+                            "name": StringSource,
+                            "mountPath": StringSource,
+                            "mountPropagation": Field(StringSource, is_required=False),
+                            "readOnly": Field(BoolSource, is_required=False),
+                            "subPath": Field(StringSource, is_required=False),
+                            "subPathExpr": Field(StringSource, is_required=False),
+                        }
+                    )
+                ),
+                is_required=False,
+                default_value=[],
+                description="A list of volume mounts to include in the job's container. Default: ``[]``. See: "
+                "https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core",
+            ),
+            "volumes": Field(
+                Array(
+                    Permissive(
+                        {
+                            "name": str,
+                        }
+                    )
+                ),
+                is_required=False,
+                default_value=[],
+                description="A list of volumes to include in the Job's Pod. Default: ``[]``. For the many "
+                "possible volume source types that can be included, see: "
+                "https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core",
+            ),
         }
 
     @classmethod


### PR DESCRIPTION
Summary:
This way you can switch from K8sRunLauncher to CeleryK8sRunLauncher without having to totally revamp your config.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.