### PR TITLE
Disable telemetry in test contexts

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -3,13 +3,13 @@ import logging
 import logging.config
 import os
 import sys
-import tempfile
 import time
 import warnings
 import weakref
 from collections import defaultdict
 from contextlib import ExitStack
 from enum import Enum
+from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -234,7 +234,7 @@ class DagsterInstance:
             boundaries.
     """
 
-    _PROCESS_TEMPDIR = None
+    _PROCESS_TEMPDIR: Optional[TemporaryDirectory] = None
     _EXIT_STACK = None
 
     def __init__(
@@ -470,8 +470,8 @@ class DagsterInstance:
             DagsterInstance._EXIT_STACK.enter_context(
                 environ({"DAGSTER_TELEMETRY_DISABLED": "yes"})
             )
-            DagsterInstance._PROCESS_TEMPDIR = tempfile.TemporaryDirectory()
-        return DagsterInstance._PROCESS_TEMPDIR.name
+            DagsterInstance._PROCESS_TEMPDIR = TemporaryDirectory()
+        return cast(TemporaryDirectory, DagsterInstance._PROCESS_TEMPDIR).name
 
     def _info(self, component):
         # ConfigurableClass may not have inst_data if it's a direct instantiation

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -114,7 +114,7 @@ def instance_for_test(overrides=None, set_dagster_home=True, temp_dir=None):
 
         if set_dagster_home:
             stack.enter_context(
-                environ({"DAGSTER_HOME": temp_dir, "DAGSTER_DISABLE_TELEMETRY": True})
+                environ({"DAGSTER_HOME": temp_dir, "DAGSTER_DISABLE_TELEMETRY": "yes"})
             )
 
         with open(os.path.join(temp_dir, "dagster.yaml"), "w") as fd:

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -113,7 +113,9 @@ def instance_for_test(overrides=None, set_dagster_home=True, temp_dir=None):
         )
 
         if set_dagster_home:
-            stack.enter_context(environ({"DAGSTER_HOME": temp_dir}))
+            stack.enter_context(
+                environ({"DAGSTER_HOME": temp_dir, "DAGSTER_DISABLE_TELEMETRY": True})
+            )
 
         with open(os.path.join(temp_dir, "dagster.yaml"), "w") as fd:
             yaml.dump(instance_overrides, fd, default_flow_style=False)


### PR DESCRIPTION
When creating a persistent test instance, using `instance_for_test`, `DagsterInstance.local_temp(), or `DagsterInstance.temp_storage()`, we log telemetry data to the temporary directory. Since we only upload these telemetry logs when Dagit loads, this data is likely discarded, but it is theoretically possible for this data to be uploaded if Dagit were somehow launched from a test context. By adding a certain environment variable, we can ensure that does not happen.