### PR TITLE
Instrument telemetry for daemon heartbeats

### DIFF
--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -40,7 +40,7 @@ DAGSTER_HOME_FALLBACK = "~/.dagster"
 MAX_BYTES = 10485760  # 10 MB = 10 * 1024 * 1024 bytes
 UPDATE_REPO_STATS = "update_repo_stats"
 START_DAGIT_WEBSERVER = "start_dagit_webserver"
-DAEMON_HEARTBEAT = "daemon_heartbeat"
+DAEMON_ALIVE = "daemon_alive"
 TELEMETRY_VERSION = "0.2"
 
 TELEMETRY_WHITELISTED_FUNCTIONS = {

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -40,6 +40,7 @@ DAGSTER_HOME_FALLBACK = "~/.dagster"
 MAX_BYTES = 10485760  # 10 MB = 10 * 1024 * 1024 bytes
 UPDATE_REPO_STATS = "update_repo_stats"
 START_DAGIT_WEBSERVER = "start_dagit_webserver"
+DAEMON_HEARTBEAT = "daemon_heartbeat"
 TELEMETRY_VERSION = "0.2"
 
 TELEMETRY_WHITELISTED_FUNCTIONS = {

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -142,8 +142,6 @@ def cleanup_test_instance(instance):
     # that might be accessing the run history DB.
     instance.run_launcher.join()
 
-    cleanup_telemetry_logger()
-
 
 def create_run_for_test(
     instance,

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -20,7 +20,6 @@ from dagster.core.instance import DagsterInstance
 from dagster.core.launcher import RunLauncher
 from dagster.core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, PipelineRunsFilter
-from dagster.core.telemetry import cleanup_telemetry_logger
 from dagster.core.workspace.context import WorkspaceProcessContext
 from dagster.core.workspace.dynamic_workspace import DynamicWorkspace
 from dagster.core.workspace.load_target import WorkspaceLoadTarget

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -4,8 +4,8 @@ from collections import deque
 from contextlib import AbstractContextManager
 
 import pendulum
-from dagster.core.telemetry import log_action, DAEMON_HEARTBEAT
 from dagster import DagsterInstance, check
+from dagster.core.telemetry import DAEMON_ALIVE, log_action
 from dagster.core.workspace import IWorkspace
 from dagster.daemon.backfill import execute_backfill_iteration
 from dagster.daemon.monitoring import execute_monitoring_iteration
@@ -21,7 +21,7 @@ def get_default_daemon_logger(daemon_name):
 
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors
-LOG_FREQUENCY = 20  # Frequency at which to log daemon heartbeats
+TELEMETRY_LOGGING_INTERVAL = 3600  # Interval (in seconds) at which to log that daemon is alive
 
 
 class DagsterDaemon(AbstractContextManager):
@@ -31,7 +31,7 @@ class DagsterDaemon(AbstractContextManager):
 
         self._last_iteration_time = None
         self._last_heartbeat_time = None
-        self._num_heartbeats_since_log = 0
+        self._last_log_time = None
         self._errors = deque(
             maxlen=DAEMON_HEARTBEAT_ERROR_LIMIT
         )  # (SerializableErrorInfo, timestamp) tuples
@@ -194,10 +194,12 @@ class DagsterDaemon(AbstractContextManager):
                 errors=[error for (error, timestamp) in self._errors],
             )
         )
-        self._num_heartbeats_since_log += 1
-        if self._num_heartbeats_since_log >= LOG_FREQUENCY:
-            log_action(instance, DAEMON_HEARTBEAT)
-            self._num_heartbeats_since_log = 0
+        if (
+            not self._last_log_time
+            or (curr_time - self._last_log_time).total_seconds() >= TELEMETRY_LOGGING_INTERVAL
+        ):
+            log_action(instance, DAEMON_ALIVE)
+            self._last_log_time = curr_time
 
     @abstractmethod
     def run_iteration(self, instance, workspace):

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -4,6 +4,7 @@ from collections import deque
 from contextlib import AbstractContextManager
 
 import pendulum
+from dagster.core.telemetry import log_action, DAEMON_HEARTBEAT
 from dagster import DagsterInstance, check
 from dagster.core.workspace import IWorkspace
 from dagster.daemon.backfill import execute_backfill_iteration
@@ -20,6 +21,7 @@ def get_default_daemon_logger(daemon_name):
 
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors
+LOG_FREQUENCY = 20  # Frequency at which to log daemon heartbeats
 
 
 class DagsterDaemon(AbstractContextManager):
@@ -29,6 +31,7 @@ class DagsterDaemon(AbstractContextManager):
 
         self._last_iteration_time = None
         self._last_heartbeat_time = None
+        self._num_heartbeats_since_log = 0
         self._errors = deque(
             maxlen=DAEMON_HEARTBEAT_ERROR_LIMIT
         )  # (SerializableErrorInfo, timestamp) tuples
@@ -191,6 +194,10 @@ class DagsterDaemon(AbstractContextManager):
                 errors=[error for (error, timestamp) in self._errors],
             )
         )
+        self._num_heartbeats_since_log += 1
+        if self._num_heartbeats_since_log >= LOG_FREQUENCY:
+            log_action(instance, DAEMON_HEARTBEAT)
+            self._num_heartbeats_since_log = 0
 
     @abstractmethod
     def run_iteration(self, instance, workspace):


### PR DESCRIPTION
Add telemetry to daemon heartbeats. Because heartbeats happen with great frequency, so as to not flood the system with events, we can just log after some fixed number of heartbeats.

We should probably additionally log when the daemon goes unhealthy.