### PR TITLE
[PipelineRun] only make new run id when needed

### DIFF
--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -319,10 +319,13 @@ class PipelineRun(
                 "external_pipeline_origin is required for queued runs",
             )
 
+        if run_id is None:
+            run_id = make_new_run_id()
+
         return super(PipelineRun, cls).__new__(
             cls,
             pipeline_name=check.opt_str_param(pipeline_name, "pipeline_name"),
-            run_id=check.opt_str_param(run_id, "run_id", default=make_new_run_id()),
+            run_id=check.str_param(run_id, "run_id"),
             run_config=check.opt_dict_param(run_config, "run_config", key_type=str),
             mode=check.opt_str_param(mode, "mode"),
             solid_selection=solid_selection,


### PR DESCRIPTION
it is suprisingly expensive to generate uuids so only do it when we need them 

## Test Plan

existing bk  coverage