### PR TITLE
[dagit] Fix Open in Playground link from schedule

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Redirect, RouteComponentProps} from 'react-router-dom';
+import {Redirect, RouteComponentProps, useLocation} from 'react-router-dom';
 
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
@@ -11,13 +11,18 @@ interface Props extends RouteComponentProps<{repoPath: string; pipelinePath: str
 }
 
 export const PipelineOrJobDisambiguationRoot: React.FC<Props> = (props) => {
+  const location = useLocation();
   const {repoAddress} = props;
   const {pipelinePath} = props.match.params;
   const {pipelineName: pipelineOrJobName} = explorerPathFromString(pipelinePath);
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, pipelineOrJobName);
+  const {search} = location;
 
-  return (
-    <Redirect to={props.match.url.replace('/pipeline_or_job/', isJob ? '/jobs/' : '/pipelines/')} />
+  const replacedPath = props.match.url.replace(
+    '/pipeline_or_job/',
+    isJob ? '/jobs/' : '/pipelines/',
   );
+
+  return <Redirect to={`${replacedPath}${search}`} />;
 };

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.tsx
@@ -33,7 +33,7 @@ export const PipelineRoot: React.FC<Props> = (props) => {
       <PipelineNav repoAddress={repoAddress} />
       <Switch>
         <Route
-          path="/workspace/:repoPath/pipeline_or_job/:pipelinePath"
+          path="/workspace/:repoPath/pipeline_or_job/:pipelinePath/(/?.*)"
           render={(props: RouteComponentProps<{repoPath: string; pipelinePath: string}>) => {
             return <PipelineOrJobDisambiguationRoot {...props} repoAddress={repoAddress} />;
           }}

--- a/js_modules/dagit/packages/core/src/ui/Menu.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Menu.tsx
@@ -62,9 +62,8 @@ interface CommonMenuItemProps {
 
 interface ItemProps
   extends CommonMenuItemProps,
-    Omit<React.ComponentProps<typeof MenuItem>, 'icon'> {}
+    Omit<React.ComponentProps<typeof MenuItem>, 'href' | 'icon'> {}
 
-// todo dish: Disallow `href` prop!
 export const MenuItemWIP: React.FC<ItemProps> = (props) => {
   const {icon, intent, ...rest} = props;
   return (


### PR DESCRIPTION
## Summary

The "Open in Playground" link on the scheduled ticks list doesn't currently work, because the pipeline-or-job disambiguation route doesn't preserve the location `search` value. Repair this.

Also add `href` to the disallowed props on `MenuItemWIP`, as all use cases should now use `MenuLink` instead.

## Test Plan

TS, lint, jest. Also run ts in Cloud to validate that there are no conflicting `MenuItemWIP` cases.

View a list of scheduled ticks in a repo. Use the "Metadat" menu to navigate to "Open in Playground", verify that the redirect occurs correctly and that the config editor is populated with the specified config.
