### PR TITLE
RFC: op_seletion 3/ nested graphs

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -625,6 +625,27 @@ class GraphDefinition(NodeDefinition):
 
 
 class SubselectedGraphDefinition(GraphDefinition):
+    """Defines a subselected graph.
+
+    Args:
+        parent_graph_def (GraphDefinition): The parent graph that this current graph is subselected
+            from. This is used for tracking where the subselected graph originally comes from.
+            Note that we allow subselecting a subselected graph, and this field refers to the direct
+            parent graph of the current subselection, rather than the original root graph.
+        node_defs (Optional[List[NodeDefinition]]): A list of all top level nodes in the graph. A
+            node can be an op or a graph that contains other nodes.
+        dependencies (Optional[Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]]):
+            A structure that declares the dependencies of each op's inputs on the outputs of other
+            ops in the subselected graph. Keys of the top level dict are either the string names of
+            ops in the graph or, in the case of aliased solids, :py:class:`NodeInvocations <NodeInvocation>`.
+            Values of the top level dict are themselves dicts, which map input names belonging to
+            the op or aliased op to :py:class:`DependencyDefinitions <DependencyDefinition>`.
+        input_mappings (Optional[List[InputMapping]]): Define the inputs to the nested graph, and
+            how they map to the inputs of its constituent ops.
+        output_mappings (Optional[List[OutputMapping]]): Define the outputs of the nested graph, and
+            how they map from the outputs of its constituent ops.
+    """
+
     def __init__(
         self,
         parent_graph_def: GraphDefinition,
@@ -751,9 +772,10 @@ def _validate_in_mappings(
             target_type = target_input.dagster_type
             fan_in_msg = ""
 
-        if target_type != mapping.definition.dagster_type and class_name not in (
-            "GraphDefinition",
-            "SubselectedGraphDefinition",  # TODO better
+        if (
+            # no need to check mapping type for graphs because users can't specify ins/out type on graphs
+            class_name not in (GraphDefinition.__name__, SubselectedGraphDefinition.__name__)
+            and target_type != mapping.definition.dagster_type
         ):
             raise DagsterInvalidDefinitionError(
                 "In {class_name} '{name}' input "

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -624,6 +624,29 @@ class GraphDefinition(NodeDefinition):
         )
 
 
+class SubselectedGraphDefinition(GraphDefinition):
+    def __init__(
+        self,
+        parent_graph_def: GraphDefinition,
+        node_defs: Optional[List[NodeDefinition]],
+        dependencies: Optional[Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]],
+        input_mappings: Optional[List[InputMapping]],
+        output_mappings: Optional[List[OutputMapping]],
+    ):
+        self._parent_graph_def = check.inst_param(
+            parent_graph_def, "parent_graph_def", GraphDefinition
+        )
+        super(SubselectedGraphDefinition, self).__init__(
+            name=parent_graph_def.name,  # should we create special name for subselected graphs
+            node_defs=node_defs,
+            dependencies=dependencies,
+            input_mappings=input_mappings,
+            output_mappings=output_mappings,
+            config=parent_graph_def.config_mapping,
+            tags=parent_graph_def.tags,
+        )
+
+
 def _validate_in_mappings(
     input_mappings: List[InputMapping],
     solid_dict: Dict[str, Node],
@@ -728,7 +751,10 @@ def _validate_in_mappings(
             target_type = target_input.dagster_type
             fan_in_msg = ""
 
-        if target_type != mapping.definition.dagster_type and class_name != "GraphDefinition":
+        if target_type != mapping.definition.dagster_type and class_name not in (
+            "GraphDefinition",
+            "SubselectedGraphDefinition",  # TODO better
+        ):
             raise DagsterInvalidDefinitionError(
                 "In {class_name} '{name}' input "
                 "'{mapping.definition.name}' of type {mapping.definition.dagster_type.display_name} maps to "

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -17,7 +17,7 @@ from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.definitions.policy import RetryPolicy
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
 from dagster.core.selector.subset_selector import (
-    LeadNodeSelection,
+    LeafNodeSelection,
     OpSelectionData,
     parse_op_selection,
 )
@@ -319,9 +319,7 @@ def _get_graph_definition(
             continue
 
         # rebuild graph if any nodes inside the graph are selected
-        if node.is_graph and not isinstance(
-            resolved_op_selection_dict[node.name], LeadNodeSelection
-        ):
+        if node.is_graph and resolved_op_selection_dict[node.name] is not LeafNodeSelection:
             definition = _get_graph_definition(
                 node.definition,
                 resolved_op_selection_dict[node.name],

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -212,10 +212,9 @@ class JobDefinition(PipelineDefinition):
             version_strategy=self.version_strategy,
             _op_selection_data=OpSelectionData(
                 op_selection=op_selection,
-                # TODO thread nested graph selection
                 resolved_op_selection=set(
                     resolved_op_selection_dict.keys()
-                ),  # equivalent to solids_to_execute
+                ),  # equivalent to solids_to_execute. currently only gets top level nodes.
                 ignored_solids=ignored_solids,  # used by config resolution
                 parent_job_def=self,  # used by pipeline snapshot lineage
             ),
@@ -359,7 +358,6 @@ def _get_subselected_graph_definition(
                     if (
                         isinstance(output_handle, SolidOutputHandle)
                         and output_handle.solid.name in resolved_op_selection_dict
-                        # TODO: handle graph subset with dynamic outs
                     )
                 ]
                 deps[_dep_key_of(node)][input_handle.input_def.name] = MultiDependencyDefinition(

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -202,6 +202,7 @@ class JobDefinition(PipelineDefinition):
 
         sub_graph = _get_graph_definition(self.graph, resolved_op_selection)
 
+        # TODO: config mapping - ignore nested nodes
         ignored_solids = [
             solid for solid in self.graph.solids if not sub_graph.has_solid_named(solid.name)
         ]
@@ -390,7 +391,7 @@ def _get_graph_definition(
             node_defs=selected_nodes,
             input_mappings=new_input_mappings,
             output_mappings=new_output_mappings,
-            config=None,
+            config=graph.config_mapping,
             description=None,
         )
     except DagsterInvalidDefinitionError as exc:

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -874,6 +874,7 @@ class CachingRepositoryData(RepositoryData):
         solid_to_pipeline = {}
         for pipeline in self._all_pipelines:
             for solid_def in pipeline.all_node_defs + [pipeline.graph]:
+                # skip checks for subselected graphs because they don't have their own names
                 if isinstance(solid_def, SubselectedGraphDefinition):
                     break
 

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -6,7 +6,7 @@ from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantV
 from dagster.utils import merge_dicts
 
 from .events import AssetKey
-from .graph_definition import GraphDefinition
+from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .job_definition import JobDefinition
 from .partition import PartitionScheduleDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
@@ -874,6 +874,9 @@ class CachingRepositoryData(RepositoryData):
         solid_to_pipeline = {}
         for pipeline in self._all_pipelines:
             for solid_def in pipeline.all_node_defs + [pipeline.graph]:
+                if isinstance(solid_def, SubselectedGraphDefinition):
+                    break
+
                 if solid_def.name not in solid_defs:
                     solid_defs[solid_def.name] = solid_def
                     solid_to_pipeline[solid_def.name] = pipeline.name

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -197,7 +197,7 @@ def clause_to_subset(graph, clause):
     return subset_list
 
 
-class LeadNodeSelection:
+class LeafNodeSelection:
     """Marker for no further nesting selection needed."""
 
 
@@ -206,7 +206,7 @@ def convert_dot_seperated_string_to_dict(tree, splits):
     # "subgraph.subsubgraph.return_one" => {"subgraph": {"subsubgraph": {"return_one": None}}}
     key = splits[0]
     if len(splits) == 1:
-        tree[key] = LeadNodeSelection
+        tree[key] = LeafNodeSelection
     else:
         tree[key] = convert_dot_seperated_string_to_dict(
             tree[key] if key in tree else {}, splits[1:]
@@ -218,13 +218,13 @@ def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dic
     """
     Examples:
         ["subgraph.return_one", "subgraph.adder", "subgraph.add_one", "add_one"]
-        => {"subgraph": {{"return_one": LeadNodeSelection}, {"adder": LeadNodeSelection}, {"add_one": LeadNodeSelection}}, "add_one": LeadNodeSelection}
+        => {"subgraph": {{"return_one": LeafNodeSelection}, {"adder": LeafNodeSelection}, {"add_one": LeafNodeSelection}}, "add_one": LeafNodeSelection}
 
         ["subgraph.subsubgraph.return_one"]
-        => {"subgraph": {"subsubgraph": {"return_one": LeadNodeSelection}}}
+        => {"subgraph": {"subsubgraph": {"return_one": LeafNodeSelection}}}
 
         ["top_level_op_1+"]
-        => {"top_level_op_1": LeadNodeSelection, "top_level_op_2": LeadNodeSelection}
+        => {"top_level_op_1": LeafNodeSelection, "top_level_op_2": LeafNodeSelection}
     """
     # TODO: better parse so it works both for dot and none dot syntax
     if any(["." in item for item in op_selection]):
@@ -234,7 +234,7 @@ def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dic
         return resolved_op_selection_dict
 
     return {
-        top_level_op: LeadNodeSelection
+        top_level_op: LeafNodeSelection
         for top_level_op in parse_solid_selection(job_def, op_selection)
     }
 

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -226,7 +226,6 @@ def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dic
         ["top_level_op_1+"]
         => {"top_level_op_1": LeafNodeSelection, "top_level_op_2": LeafNodeSelection}
     """
-    # TODO: better parse so it works both for dot and none dot syntax
     if any(["." in item for item in op_selection]):
         resolved_op_selection_dict: Dict = {}
         for item in op_selection:

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -224,10 +224,10 @@ def parse_op_selection(job_def: "JobDefinition", op_selection: List[str]) -> Dic
     """
     # TODO: better parse so it works both for dot and none dot syntax
     if any(["." in item for item in op_selection]):
-        resolved_op_selection = {}
+        resolved_op_selection_dict: Dict[str, Dict] = {}
         for item in op_selection:
-            convert_dot_seperated_string_to_dict(resolved_op_selection, splits=item.split("."))
-        return resolved_op_selection
+            convert_dot_seperated_string_to_dict(resolved_op_selection_dict, splits=item.split("."))
+        return resolved_op_selection_dict
 
     return {top_level_op: None for top_level_op in parse_solid_selection(job_def, op_selection)}
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -429,7 +429,7 @@ def test_nested_graph_selection_unsatisfied_subgraph_inputs():
 def test_nested_graph_selection_input_mapping():
     @graph
     def _subgraph(x):
-        return add_one(adder(return_one(), x))
+        return add_one(adder.alias("aliased_adder")(return_one(), x))
 
     @job
     def _super():
@@ -437,27 +437,27 @@ def test_nested_graph_selection_input_mapping():
 
     # graph subset has input mapping
     result_sub_1 = _super.execute_in_process(
-        op_selection=["return_two", "_subgraph.return_one", "_subgraph.adder"],
+        op_selection=["return_two", "_subgraph.return_one", "_subgraph.aliased_adder"],
     )
     assert result_sub_1.success
     assert set(_success_step_keys(result_sub_1)) == {
         "return_two",
         "_subgraph.return_one",
-        "_subgraph.adder",
+        "_subgraph.aliased_adder",
     }
-    assert result_sub_1.output_for_node("_subgraph.adder") == 3
+    assert result_sub_1.output_for_node("_subgraph.aliased_adder") == 3
 
     # graph subset doesn't have input mapping
     result_sub_2 = _super.execute_in_process(
-        op_selection=["_subgraph.return_one", "_subgraph.adder"],
+        op_selection=["_subgraph.return_one", "_subgraph.aliased_adder"],
         run_config={"ops": {"_subgraph": {"inputs": {"x": {"value": 100}}}}},
     )
     assert result_sub_2.success
     assert set(_success_step_keys(result_sub_2)) == {
         "_subgraph.return_one",
-        "_subgraph.adder",
+        "_subgraph.aliased_adder",
     }
-    assert result_sub_2.output_for_node("_subgraph.adder") == 101
+    assert result_sub_2.output_for_node("_subgraph.aliased_adder") == 101
 
 
 def test_sub_sub_graph_selection():

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -270,7 +270,7 @@ def test_op_selection_on_alias():
     assert result_for_subset_def.success
     assert len(_success_step_keys(result_for_subset_def)) == 2
 
-    result_for_subset = subsetted_job.execute_in_process(op_selection=["return_one_2*"])
+    result_for_subset = subsetted_job.execute_in_process(op_selection=["*"])
     assert result_for_subset.success
     assert len(_success_step_keys(result_for_subset)) == 2
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -1,19 +1,10 @@
+from typing import List
+
 import pytest
-from dagster import (
-    ConfigMapping,
-    DynamicOut,
-    DynamicOutput,
-    In,
-    graph,
-    job,
-    op,
-    root_input_manager,
-)
+from dagster import ConfigMapping, DynamicOut, DynamicOutput, In, graph, job, op, root_input_manager
 from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.core.events import DagsterEventType
 from dagster.core.execution.execute_in_process_result import ExecuteInProcessResult
-
-from typing import List
 
 
 @op

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -1,4 +1,6 @@
+import pytest
 from dagster import ConfigMapping, DynamicOut, DynamicOutput, In, graph, job, op, root_input_manager
+from dagster.core.errors import DagsterInvalidSubsetError
 from dagster.core.events import DagsterEventType
 from dagster.core.execution.execute_in_process_result import ExecuteInProcessResult
 
@@ -322,3 +324,212 @@ def test_disconnected_selection():
     executed_step_keys = _success_step_keys(result)
     assert len(executed_step_keys) == 2
     assert set(executed_step_keys) == {"return_two", "add_one"}
+
+
+def test_nested_graph_selection_all():
+    @graph
+    def subgraph():
+        return add_one(adder(return_one(), return_two()))
+
+    @job
+    def _super():
+        add_one(subgraph())
+
+    result = _super.execute_in_process()
+    assert result.success
+    assert result.output_for_node("add_one") == 5
+
+    # select the entire subgraph
+    result_graph = _super.execute_in_process(op_selection=["subgraph"])
+    assert result_graph.success
+    assert set(_success_step_keys(result_graph)) == {
+        "subgraph.return_one",
+        "subgraph.return_two",
+        "subgraph.adder",
+        "subgraph.add_one",
+    }
+    assert result_graph.output_for_node("subgraph") == 4
+
+
+def test_nested_graph_selection_single_op():
+    @graph
+    def subgraph():
+        return add_one(adder(return_one(), return_two()))
+
+    @job
+    def _super():
+        add_one(subgraph())
+
+    # select single op inside graph
+    result_graph = _super.execute_in_process(op_selection=["subgraph.return_one"])
+    assert result_graph.success
+    assert set(_success_step_keys(result_graph)) == {
+        "subgraph.return_one",
+    }
+    assert result_graph.output_for_node("subgraph.return_one") == 1
+
+
+def test_nested_graph_selection_inside_graph():
+    @graph
+    def subgraph():
+        return add_one(adder(return_one(), return_two()))
+
+    @job
+    def _super():
+        add_one(subgraph())
+
+    # select inside subgraph
+    result_graph = _super.execute_in_process(
+        op_selection=[
+            "subgraph.return_one",
+            "subgraph.return_two",
+            "subgraph.adder",
+        ]
+    )
+    assert result_graph.success
+    assert set(_success_step_keys(result_graph)) == {
+        "subgraph.return_one",
+        "subgraph.return_two",
+        "subgraph.adder",
+    }
+    assert result_graph.output_for_node("subgraph.adder") == 3
+
+
+def test_nested_graph_selection_both_inside_and_outside_disconnected():
+    @graph
+    def subgraph():
+        return add_one(adder(return_one(), return_two()))
+
+    @job
+    def _super():
+        add_one(subgraph())
+
+    # select inside subgraph (disconnected to the outside) and outside
+    with pytest.raises(DagsterInvalidSubsetError):
+        # can't build graph bc "subgraph" won't have output mapping but "add_one" expect output
+        _super.execute_in_process(
+            op_selection=["subgraph.adder", "add_one"],
+            run_config={
+                "ops": {"subgraph": {"ops": {"adder": {"inputs": {"num1": 10, "num2": 20}}}}}
+            },
+        )
+
+
+def test_nested_graph_selection_unsatisfied_subgraph_inputs():
+    @graph
+    def subgraph():
+        return add_one(adder(return_one(), return_two()))
+
+    @job
+    def _super():
+        add_one(subgraph())
+
+    # output mapping
+    result_sub_1 = _super.execute_in_process(
+        # TODO query not working yet
+        # op_selection=["subgraph.return_one*"],
+        op_selection=["subgraph.return_one", "subgraph.adder", "subgraph.add_one", "add_one"],
+        run_config={"ops": {"subgraph": {"ops": {"adder": {"inputs": {"num2": 0}}}}}},
+    )
+    assert result_sub_1.success
+    assert set(_success_step_keys(result_sub_1)) == {
+        "subgraph.return_one",
+        "subgraph.adder",
+        "subgraph.add_one",
+        "add_one",
+    }
+    assert result_sub_1.output_for_node("add_one") == 3
+
+    # no output mapping
+    result_sub_2 = _super.execute_in_process(
+        op_selection=["subgraph.return_one", "subgraph.adder", "subgraph.add_one"],
+        run_config={"ops": {"subgraph": {"ops": {"adder": {"inputs": {"num2": 100}}}}}},
+    )
+    assert result_sub_2.success
+    assert set(_success_step_keys(result_sub_2)) == {
+        "subgraph.return_one",
+        "subgraph.adder",
+        "subgraph.add_one",
+    }
+    assert result_sub_2.output_for_node("subgraph.add_one") == 102
+
+
+def test_nested_graph_selection_input_mapping():
+    @graph
+    def subgraph(x):
+        return add_one(adder(return_one(), x))
+
+    @job
+    def _super():
+        add_one(subgraph(return_two()))
+
+    # graph subset has input mapping
+    result_sub_1 = _super.execute_in_process(
+        op_selection=["return_two", "subgraph.return_one", "subgraph.adder"],
+    )
+    assert result_sub_1.success
+    assert set(_success_step_keys(result_sub_1)) == {
+        "return_two",
+        "subgraph.return_one",
+        "subgraph.adder",
+    }
+    assert result_sub_1.output_for_node("subgraph.adder") == 3
+
+    # graph subset doesn't have input mapping
+    result_sub_2 = _super.execute_in_process(
+        op_selection=["subgraph.return_one", "subgraph.adder"],
+        run_config={"ops": {"subgraph": {"inputs": {"x": {"value": 100}}}}},
+    )
+    assert result_sub_2.success
+    assert set(_success_step_keys(result_sub_2)) == {
+        "subgraph.return_one",
+        "subgraph.adder",
+    }
+    assert result_sub_2.output_for_node("subgraph.adder") == 101
+
+
+def test_sub_sub_graph_selection():
+    @graph
+    def subsubgraph():
+        return return_one()
+
+    @graph
+    def subgraph():
+        return add_one(subsubgraph())
+
+    @job
+    def _super():
+        add_one(subgraph())
+
+    result_full = _super.execute_in_process()
+    assert set(_success_step_keys(result_full)) == {
+        "subgraph.subsubgraph.return_one",
+        "subgraph.add_one",
+        "add_one",
+    }
+    assert result_full.output_for_node("add_one") == 3
+
+    # select sub sub
+    result_sub_1 = _super.execute_in_process(op_selection=["subgraph.subsubgraph.return_one"])
+    assert set(_success_step_keys(result_sub_1)) == {
+        "subgraph.subsubgraph.return_one",
+    }
+    assert result_sub_1.output_for_node("subgraph.subsubgraph.return_one") == 1
+
+    # select sub all
+    result_sub_2 = _super.execute_in_process(op_selection=["subgraph"])
+    assert set(_success_step_keys(result_sub_2)) == {
+        "subgraph.subsubgraph.return_one",
+        "subgraph.add_one",
+    }
+    assert result_sub_2.output_for_node("subgraph") == 2
+
+    # select sub with unsatisfied input
+    result_sub_3 = _super.execute_in_process(
+        op_selection=["subgraph.add_one"],
+        run_config={"ops": {"subgraph": {"ops": {"add_one": {"inputs": {"num": 100}}}}}},
+    )
+    assert set(_success_step_keys(result_sub_3)) == {
+        "subgraph.add_one",
+    }
+    assert result_sub_3.output_for_node("subgraph.add_one") == 101


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
This PR enables selecting ops inside nested graphs with the dot syntax (`*+` query syntax doesn't work yet).

It recursively builds new `SubselectedGraphDefinition`s for graph subsets if any nodes inside a nested graph are selected, and it filters out unselected nodes and unselected input/output mappings from a nested graph. Examples:
![image](https://user-images.githubusercontent.com/4531914/146100430-62dfac45-f689-43d7-8216-b01359259246.png)


**why `SubselectedGraphDefinition`?**
The alternative is to keep using GraphDefinition, but it has the following problems:
1. We'll be building new "operating graphs" (new GraphDefinitions that respect op_selection) which contain info like tied to "original graphs" (the full original graph). It would mix the original and operating info which confuses the system. For example, Dagit can't load both my_job and my_sub_job because a repo can't have two graphs with the same name.
   * With `SubselectedGraphDefinition` we can ignore check graphs when loading repos
2. Keeping using GraphDefinition increases future maintenance cost, e.g. wrapping a new GraphDefinition in different places could lead to missing newly added property in the future.

The newly modified info we need in the operating graph are:
- node_defs
- dependencies
- input_mappings
- output_mappings
- plus, parent_graph_def for keeping track of the subselection lineage



**Next Steps in the later stack:**
1. Make nested selection work with config mapping: ignore excess run config: https://github.com/dagster-io/dagster/pull/6174
2. Dagit: 1) consolidate frontend backend selection query resolution (i.e. remove `solidSelection: string[]` and send `solidSelectionQuery: string` to the backend for query resolution) 2) external pipeline solids to execute work with nested graphs
3. Resolve queries for nested graphs (make `subgraph.my_op*` work)



## Test Plan

When both a full job and its subsetted job (w/ the same graph name) are in the same repo, Dagit can load successfully: 
![image](https://user-images.githubusercontent.com/4531914/148880855-49213272-968b-432a-853f-b0c89cc5e85d.png). But the selection input doesn't work yet - see Next Steps

It now works for various executions cases:
- graphs with input/output mapping
- graphs that have unsatisfied input after selection
- sub sub graph
- fan in

It currently doesn't work with:
- Graphs that have dynamic outs - because `GraphOut` doesn't work with DynamicOut yet, so will need to do a separate diff to enable that first so we can test the subsetting.
- Config mapping where the result includes unselected nodes - see Next Steps