### PR TITLE
Update RepositoryData docs to reflect what method you actually need to override when building one

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository.py
@@ -211,7 +211,7 @@ def repository(
             def __init__(self, yaml_directory):
                 self._yaml_directory = yaml_directory
 
-            def get_all_jobs(self):
+            def get_all_pipelines(self):
                 return [
                     self._construct_job_def_from_yaml_file(
                       self._yaml_file_for_job_name(file_name)


### PR DESCRIPTION
Summary:
Currently RepositoryData has two methods, get_all_pipelines and get_all_jobs, and (presumably for back-compat reasons), get_all_pipelines returns both pipelines and jobs. The doc incorrectly implies that you only need to override get_all_jobs.

We may want to change this in the future as CRAG rolls out more, but for now update the docs to reflect reality.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.