### PR TITLE
change dagsterbot gh issue template formatting

### DIFF
--- a/docs/next/util/github/docs-issue-template.md
+++ b/docs/next/util/github/docs-issue-template.md
@@ -1,14 +1,10 @@
 ### Dagster Documentation Gap
 
-{{ message }}
-
 This issue was generated from the slack conversation at: {{ permalink }}
 
-Conversation excerpt:
+### Conversation excerpt
 
-```
 {{ replies }}
-```
 
 ---
 

--- a/docs/next/util/github/issue-template.md
+++ b/docs/next/util/github/issue-template.md
@@ -1,17 +1,15 @@
 ### Issue from the [Dagster Slack](https://join.slack.com/t/dagster/shared_invite/enQtNjEyNjkzNTA2OTkzLTI0MzdlNjU0ODVhZjQyOTMyMGM1ZDUwZDQ1YjJmYjI3YzExZGViMDI1ZDlkNTY5OThmYWVlOWM1MWVjN2I3NjU)
 
-{{ message }}
-
 This issue was generated from the slack conversation at: {{ permalink }}
 
-Conversation excerpt:
+---
 
-```
+### Conversation excerpt
+
 {{ replies }}
-```
 
 ---
 
 #### Message from the maintainers:
 
-Are you looking for the same documentation content? Give it a :thumbsup:. We factor engagement into prioritization.
+Do you care about this too? Give it a :thumbsup:. We factor engagement into prioritization.


### PR DESCRIPTION
I have found GH issues filed by dagsterbot difficult to read, because they put the entire conversation inside a code block.