### PR TITLE
lazily migrate the asset index table

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -608,6 +608,13 @@ def test_asset_lazy_migration():
             # still should not be migrated (on write)
             assert not storage.has_secondary_index(ASSET_KEY_INDEX_COLS)
 
+            # fetching partial results should not trigger migration
+            instance.get_asset_keys(prefix=["b"])
+            instance.get_asset_keys(cursor=str(AssetKey("b")))
+            instance.get_latest_materialization_events(asset_keys=[AssetKey("b")])
+
+            assert not storage.has_secondary_index(ASSET_KEY_INDEX_COLS)
+
             # on read, we should see that all the data has already been migrated and we can now mark
             # the asset key index as migrated
             instance.all_asset_keys()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -27,7 +27,7 @@ from dagster.core.storage.event_log import (
     InMemoryEventLogStorage,
     SqliteEventLogStorage,
 )
-from dagster.core.storage.event_log.migration import migrate_asset_key_data
+from dagster.core.storage.event_log.migration import ASSET_KEY_INDEX_COLS, migrate_asset_key_data
 from dagster.core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster.core.storage.root import LocalArtifactStorage
 from dagster.core.storage.runs import InMemoryRunStorage
@@ -562,3 +562,53 @@ def test_backcompat_asset_materializations():
             assert mat_by_key.get(a) is None
             _validate_materialization(b, mat_by_key.get(b), expected_tags={})
             _validate_materialization(c, c_mat, expected_tags={"foo": "bar"})
+
+
+def test_asset_lazy_migration():
+    src_dir = file_relative_path(__file__, "compat_tests/snapshot_0_11_0_asset_materialization")
+    # should contain materialization events for asset keys a, b, c, d, e, f
+    # events a and b have been wiped, but b has been rematerialized
+
+    @op
+    def materialize():
+        yield AssetMaterialization(AssetKey("a"))
+        yield AssetMaterialization(AssetKey("b"))
+        yield AssetMaterialization(AssetKey("c"))
+        yield AssetMaterialization(AssetKey("d"))
+        yield AssetMaterialization(AssetKey("e"))
+        yield AssetMaterialization(AssetKey("f"))
+        yield Output(None)
+
+    @job
+    def my_job():
+        materialize()
+
+    with copy_directory(src_dir) as test_dir:
+        with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
+            storage = instance.event_log_storage
+            assert not storage.has_asset_key_index_cols()
+            assert not storage.has_secondary_index(ASSET_KEY_INDEX_COLS)
+
+            # run the schema migration without reindexing the asset keys
+            storage.upgrade()
+            assert storage.has_asset_key_index_cols()
+            assert not storage.has_secondary_index(ASSET_KEY_INDEX_COLS)
+
+            # fetch all asset keys
+            instance.all_asset_keys()
+            assert not storage.has_secondary_index(ASSET_KEY_INDEX_COLS)
+
+            # wipe a, b in order to populate wipe_timestamp
+            storage.wipe_asset(AssetKey("a"))
+            storage.wipe_asset(AssetKey("b"))
+
+            # materialize all the assets to populate materialization_timestamp
+            my_job.execute_in_process(instance=instance)
+
+            # still should not be migrated (on write)
+            assert not storage.has_secondary_index(ASSET_KEY_INDEX_COLS)
+
+            # on read, we should see that all the data has already been migrated and we can now mark
+            # the asset key index as migrated
+            instance.all_asset_keys()
+            assert storage.has_secondary_index(ASSET_KEY_INDEX_COLS)


### PR DESCRIPTION
## Summary
Lazily migrate to the reindexed asset key structure.  We currently decouple the schema migration with the data migration.  While users running `dagster instance migrate` get reindexed and the new faster queries, new users who got their schema stamped never got the data migration flag marked.  This diff makes sure that the data will eventually get migrated without expensive operations, as long as every asset gets materialized in the new format.


## Test Plan
BK
