### PR TITLE
[dagit] Static status tags on Runs page

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -15,6 +15,7 @@ import {NonIdealState} from '../ui/NonIdealState';
 import {Page} from '../ui/Page';
 import {PageHeader} from '../ui/PageHeader';
 import {Tab, Tabs} from '../ui/Tabs';
+import {TagWIP} from '../ui/TagWIP';
 import {Heading} from '../ui/Text';
 import {TokenizingFieldValue} from '../ui/TokenizingField';
 
@@ -81,6 +82,9 @@ export const RunsRoot: React.FC<RouteComponentProps> = () => {
     pageSize: PAGE_SIZE,
   });
 
+  const selectedTab = showScheduled ? 'scheduled' : selectedTabId(filterTokens);
+  const staticStatusTags = selectedTab !== 'all';
+
   const setStatusFilter = (statuses: RunStatus[]) => {
     const tokensMinusStatus = filterTokens.filter((token) => token.token !== 'status');
     const statusTokens = statuses.map((status) => ({token: 'status', value: status}));
@@ -88,15 +92,34 @@ export const RunsRoot: React.FC<RouteComponentProps> = () => {
     setShowScheduled(false);
   };
 
-  const selectedTab = showScheduled ? 'scheduled' : selectedTabId(filterTokens);
-  const enabledFilters: RunFilterTokenType[] = [
-    'status',
-    'tag',
-    'snapshotId',
-    'id',
-    'job',
-    'pipeline',
-  ];
+  const setFilterTokensWithStatus = React.useCallback(
+    (tokens) => {
+      if (staticStatusTags) {
+        const statusTokens = filterTokens.filter((token) => token.token === 'status');
+        setFilterTokens([...statusTokens, ...tokens]);
+      } else {
+        setFilterTokens(tokens);
+      }
+    },
+    [filterTokens, setFilterTokens, staticStatusTags],
+  );
+
+  const enabledFilters = React.useMemo(() => {
+    const filters: RunFilterTokenType[] = ['tag', 'snapshotId', 'id', 'job', 'pipeline'];
+
+    if (!staticStatusTags) {
+      filters.push('status');
+    }
+
+    return filters;
+  }, [staticStatusTags]);
+
+  const mutableTokens = React.useMemo(() => {
+    if (staticStatusTags) {
+      return filterTokens.filter((token) => token.token !== 'status');
+    }
+    return filterTokens;
+  }, [filterTokens, staticStatusTags]);
 
   return (
     <Page>
@@ -175,15 +198,26 @@ export const RunsRoot: React.FC<RouteComponentProps> = () => {
               <>
                 <RunTable
                   runs={pipelineRunsOrError.results.slice(0, PAGE_SIZE)}
-                  onSetFilter={setFilterTokens}
+                  onSetFilter={setFilterTokensWithStatus}
                   actionBarComponents={
                     showScheduled ? null : (
-                      <RunsFilterInput
-                        tokens={filterTokens}
-                        onChange={setFilterTokens}
-                        loading={queryResult.loading}
-                        enabledFilters={enabledFilters}
-                      />
+                      <Box flex={{direction: 'column', gap: 8}}>
+                        {selectedTab !== 'all' ? (
+                          <Box flex={{direction: 'row', gap: 8}}>
+                            {filterTokens
+                              .filter((token) => token.token === 'status')
+                              .map(({token, value}) => (
+                                <TagWIP key={token}>{`${token}:${value}`}</TagWIP>
+                              ))}
+                          </Box>
+                        ) : null}
+                        <RunsFilterInput
+                          tokens={mutableTokens}
+                          onChange={setFilterTokensWithStatus}
+                          loading={queryResult.loading}
+                          enabledFilters={enabledFilters}
+                        />
+                      </Box>
                     )
                   }
                 />


### PR DESCRIPTION
## Summary

Relates to https://github.com/dagster-io/dagster/issues/5704.

Use static tags for `status` on the Runs page. This is a step toward making the input a free text filter input like the logs filter input, instead of a tokenized field.

![image](https://user-images.githubusercontent.com/2823852/146032699-38486f4f-c545-423b-ad4c-40d466a8cd3c.png)

## Test Plan

View Runs page. Click on tabs, verify that the status tags render properly above the filter input, and that filtering occurs properly.

Add more filters with typing or tag clicks, verify that the page updates and queries properly. Remove tags, verify same.
