### PR TITLE
[dagit] Hide queue alert for users who can't see config

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceTabs.tsx
@@ -1,11 +1,11 @@
-import {gql, QueryResult, useQuery} from '@apollo/client';
+import {QueryResult} from '@apollo/client';
 import * as React from 'react';
 
 import {QueryCountdown} from '../app/QueryCountdown';
 import {Box} from '../ui/Box';
 import {Tab, Tabs} from '../ui/Tabs';
 
-import {InstanceConfigHasInfo} from './types/InstanceConfigHasInfo';
+import {useCanSeeConfig} from './useCanSeeConfig';
 
 const POLL_INTERVAL = 15000;
 
@@ -16,7 +16,7 @@ interface Props<TData> {
 
 export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {queryData, tab} = props;
-  const {data} = useQuery<InstanceConfigHasInfo>(INSTANCE_CONFIG_HAS_INFO);
+  const canSeeConfig = useCanSeeConfig();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -25,9 +25,7 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
         <Tab id="schedules" title="Schedules" to="/instance/schedules" />
         <Tab id="sensors" title="Sensors" to="/instance/sensors" />
         <Tab id="backfills" title="Backfills" to="/instance/backfills" />
-        {data?.instance.hasInfo ? (
-          <Tab id="config" title="Configuration" to="/instance/config" />
-        ) : null}
+        {canSeeConfig ? <Tab id="config" title="Configuration" to="/instance/config" /> : null}
       </Tabs>
       {queryData ? (
         <Box padding={{bottom: 8}}>
@@ -37,11 +35,3 @@ export const InstanceTabs = <TData extends Record<string, any>>(props: Props<TDa
     </Box>
   );
 };
-
-const INSTANCE_CONFIG_HAS_INFO = gql`
-  query InstanceConfigHasInfo {
-    instance {
-      hasInfo
-    }
-  }
-`;

--- a/js_modules/dagit/packages/core/src/instance/useCanSeeConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useCanSeeConfig.tsx
@@ -1,0 +1,16 @@
+import {gql, useQuery} from '@apollo/client';
+
+import {InstanceConfigHasInfo} from './types/InstanceConfigHasInfo';
+
+export const useCanSeeConfig = () => {
+  const {data} = useQuery<InstanceConfigHasInfo>(INSTANCE_CONFIG_HAS_INFO);
+  return !!data?.instance.hasInfo;
+};
+
+const INSTANCE_CONFIG_HAS_INFO = gql`
+  query InstanceConfigHasInfo {
+    instance {
+      hasInfo
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -5,6 +5,7 @@ import {Link, RouteComponentProps} from 'react-router-dom';
 
 import {QueryCountdown} from '../app/QueryCountdown';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useCanSeeConfig} from '../instance/useCanSeeConfig';
 import {RunStatus} from '../types/globalTypes';
 import {Alert} from '../ui/Alert';
 import {Box} from '../ui/Box';
@@ -55,6 +56,7 @@ export const RunsRoot: React.FC<RouteComponentProps> = () => {
   const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
   const filter = runsFilterForSearchTokens(filterTokens);
   const [showScheduled, setShowScheduled] = React.useState(false);
+  const canSeeConfig = useCanSeeConfig();
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     RunsRootQuery,
@@ -139,7 +141,7 @@ export const RunsRoot: React.FC<RouteComponentProps> = () => {
           </Box>
         }
       />
-      {selectedTab === 'queued' ? (
+      {selectedTab === 'queued' && canSeeConfig ? (
         <Box
           flex={{direction: 'column', gap: 8}}
           padding={{horizontal: 24, vertical: 16}}


### PR DESCRIPTION
## Summary

Queue coordination alerts don't need to be visible in cloud, so hide them based on the `Instance.hasInfo` field.

## Test Plan

Verify that queue alerts show up when `hasInfo` is true and there are alerts to show.

Force `hasInfo` to be false, verify that the queue alerts are not shown on the Runs > Queued page.
