### PR TITLE
[dagit] Don't show warning icon for certain sensor/schedule daemon states

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.test.tsx
@@ -48,4 +48,180 @@ describe('InstanceWarningIcon', () => {
       expect(screen.queryByLabelText('warning')).toBeNull();
     });
   });
+
+  describe('Schedule/sensor errors', () => {
+    describe('Schedule error', () => {
+      const scheduleErrorMocks = {
+        DaemonHealth: () => ({
+          allDaemonStatuses: () => [
+            {daemonType: () => 'SCHEDULER', healthy: () => false, required: () => true},
+            {daemonType: () => 'SENSOR', healthy: () => true, required: () => true},
+            {daemonType: () => 'OTHER', healthy: () => true, required: () => true},
+          ],
+        }),
+      };
+
+      it('does not display if there are no schedules, and only a scheduler error', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [],
+            schedules: () => [],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, scheduleErrorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeNull();
+        });
+      });
+
+      it('displays if there are schedules, and only a scheduler error', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [],
+            schedules: () => [1],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, scheduleErrorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeVisible();
+        });
+      });
+    });
+
+    describe('Sensor error', () => {
+      const sensorErrorMocks = {
+        DaemonHealth: () => ({
+          allDaemonStatuses: () => [
+            {daemonType: () => 'SCHEDULER', healthy: () => true, required: () => true},
+            {daemonType: () => 'SENSOR', healthy: () => false, required: () => true},
+            {daemonType: () => 'OTHER', healthy: () => true, required: () => true},
+          ],
+        }),
+      };
+
+      it('does not display if there are no sensors, and only a sensor error', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [],
+            schedules: () => [],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, sensorErrorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeNull();
+        });
+      });
+
+      it('displays if there are sensors, and only a sensor error', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [1],
+            schedules: () => [],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, sensorErrorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeVisible();
+        });
+      });
+    });
+
+    describe('Schedule and Sensor error', () => {
+      const errorMocks = {
+        DaemonHealth: () => ({
+          allDaemonStatuses: () => [
+            {daemonType: () => 'SCHEDULER', healthy: () => false, required: () => true},
+            {daemonType: () => 'SENSOR', healthy: () => false, required: () => true},
+            {daemonType: () => 'OTHER', healthy: () => true, required: () => true},
+          ],
+        }),
+      };
+
+      it('does not display if there are no sensors/schedules, and only (both) sensor/schedule errors', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [],
+            schedules: () => [],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, errorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeNull();
+        });
+      });
+
+      it('displays if there are sensors, and only (both) sensor/schedule errors', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [1],
+            schedules: () => [],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, errorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeVisible();
+        });
+      });
+
+      it('displays if there are schedules, and only (both) sensor/schedule errors', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [],
+            schedules: () => [1],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, errorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeVisible();
+        });
+      });
+
+      it('displays if there are schedules and sensors, and only (both) sensor/schedule errors', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [1],
+            schedules: () => [1],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, errorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeVisible();
+        });
+      });
+    });
+
+    describe('Other error', () => {
+      const otherErrorMocks = {
+        DaemonHealth: () => ({
+          allDaemonStatuses: () => [
+            {daemonType: () => 'SCHEDULER', healthy: () => true, required: () => true},
+            {daemonType: () => 'SENSOR', healthy: () => true, required: () => true},
+            {daemonType: () => 'OTHER', healthy: () => false, required: () => true},
+          ],
+        }),
+      };
+
+      it('displays even if there are no sensors or schedules', async () => {
+        const pipelineMocks = {
+          Pipeline: () => ({
+            sensors: () => [],
+            schedules: () => [],
+          }),
+        };
+
+        render(<Test mocks={[defaultMocks, otherErrorMocks, pipelineMocks]} />);
+        await waitFor(() => {
+          expect(screen.queryByLabelText('warning')).toBeNull();
+        });
+      });
+    });
+  });
 });

--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
@@ -4,27 +4,77 @@ import * as React from 'react';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {ColorsWIP} from '../ui/Colors';
 import {IconWIP} from '../ui/Icon';
+import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 
 import {WarningTooltip} from './WarningTooltip';
 import {InstanceWarningQuery} from './types/InstanceWarningQuery';
 
 export const InstanceWarningIcon = React.memo(() => {
+  const {options} = useRepositoryOptions();
   const {data: healthData} = useQuery<InstanceWarningQuery>(INSTANCE_WARNING_QUERY, {
     fetchPolicy: 'cache-and-network',
     pollInterval: 15 * 1000,
   });
 
-  const daemonErrors =
-    healthData?.instance.daemonHealth.allDaemonStatuses.filter(
-      (daemon) => !daemon.healthy && daemon.required,
-    ) || [];
+  const {anySchedules, anySensors} = React.useMemo(() => {
+    let anySchedules = false;
+    let anySensors = false;
 
-  if (daemonErrors.length) {
+    // Find any schedules or sensors in the repo list.
+    for (const repo of options) {
+      const {pipelines} = repo.repository;
+      for (const job of pipelines) {
+        const {sensors, schedules} = job;
+        if (sensors.length) {
+          anySensors = true;
+        }
+        if (schedules.length) {
+          anySchedules = true;
+        }
+      }
+      if (anySensors && anySchedules) {
+        break;
+      }
+    }
+
+    return {anySchedules, anySensors};
+  }, [options]);
+
+  const allDaemons = healthData?.instance.daemonHealth.allDaemonStatuses;
+
+  const visibleErrorCount = React.useMemo(() => {
+    if (!allDaemons) {
+      return 0;
+    }
+
+    const errors = allDaemons
+      .filter((daemon) => !daemon.healthy && daemon.required)
+      .reduce((accum, daemon) => accum.add(daemon.daemonType), new Set<string>());
+
+    const totalErrorCount = errors.size;
+    const scheduleError = anySchedules && errors.has('SCHEDULER');
+    const sensorError = anySensors && errors.has('SENSOR');
+
+    errors.delete('SCHEDULER');
+    errors.delete('SENSOR');
+
+    // If there are any errors besides scheduler/sensor, show the entire count.
+    if (errors.size) {
+      return totalErrorCount;
+    }
+
+    // Otherwise, just show the number that is relevant to the user's workspace.
+    // - If there are no schedules or sensors, this will be zero.
+    // - If there is a sensor daemon error but there are no sensors, this will be zero.
+    return Number(scheduleError) + Number(sensorError);
+  }, [anySchedules, anySensors, allDaemons]);
+
+  if (visibleErrorCount) {
     return (
       <WarningTooltip
         content={
-          <div>{`${daemonErrors.length} ${
-            daemonErrors.length === 1 ? 'daemon not running' : 'daemons not running'
+          <div>{`${visibleErrorCount} ${
+            visibleErrorCount === 1 ? 'daemon not running' : 'daemons not running'
           }`}</div>
         }
         position="bottom"


### PR DESCRIPTION
## Summary

Resolves #5644.

Refine the behavior for showing a warning icon for "Status".

- If there is a sensor daemon error, don't show the icon if that is the only daemon error and there are no sensors in the workspace.
- Same for schedules.
- Same for the sensor/schedule combination. If sensor/schedule daemon errors are the only daemon errors, but there are neither schedules nor sensors in the workspace, don't show the icon.
- If there are any sensors plus sensor errors, any schedules plus scheduler errors, or if there are any other daemon errors, show the icon.

## Test Plan

Jest.
