### PR TITLE
Add a get_run_queue_config method to DagsterInstance

### DIFF
--- a/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from dagster import DagsterEvent, DagsterEventType, IntSource, String, check
 from dagster.builtins import Bool
@@ -11,6 +12,15 @@ from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster.serdes import ConfigurableClass, ConfigurableClassData
 
 from .base import RunCoordinator, SubmitRunContext
+
+
+class RunQueueConfig(
+    NamedTuple(
+        "_RunQueueConfig",
+        [("max_concurrent_runs", int), ("tag_concurrency_limits", Optional[List[Dict[str, Any]]])],
+    )
+):
+    pass
 
 
 class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
@@ -44,13 +54,11 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
     def inst_data(self):
         return self._inst_data
 
-    @property
-    def max_concurrent_runs(self):
-        return self._max_concurrent_runs
-
-    @property
-    def tag_concurrency_limits(self):
-        return self._tag_concurrency_limits
+    def get_run_queue_config(self):
+        return RunQueueConfig(
+            max_concurrent_runs=self._max_concurrent_runs,
+            tag_concurrency_limits=self._tag_concurrency_limits,
+        )
 
     @property
     def dequeue_interval_seconds(self):

--- a/python_modules/dagster/dagster/daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -105,8 +105,10 @@ class QueuedRunCoordinatorDaemon(DagsterDaemon):
         check.inst_param(instance, "instance", DagsterInstance)
         check.inst_param(workspace, "workspace", IWorkspace)
 
-        max_concurrent_runs = instance.run_coordinator.max_concurrent_runs
-        tag_concurrency_limits = instance.run_coordinator.tag_concurrency_limits
+        run_queue_config = instance.run_coordinator.get_run_queue_config()
+
+        max_concurrent_runs = run_queue_config.max_concurrent_runs
+        tag_concurrency_limits = run_queue_config.tag_concurrency_limits
 
         in_progress_runs = self._get_in_progress_runs(instance)
         max_runs_to_launch = max_concurrent_runs - len(in_progress_runs)


### PR DESCRIPTION
Summary:
Thisc could let us support more configurable run config sources in the future (e.g. editting the config in a UI)

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.