### PR TITLE
[dagster-databricks] make storage configuration optional for dagster-databricks

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/configs.py
@@ -600,12 +600,10 @@ def define_databricks_storage_config():
         Selector(
             {"s3": _define_s3_storage_credentials(), "adls2": _define_adls2_storage_credentials()}
         ),
-        description="Databricks storage configuration. Solids using the "
-        "DatabricksPySparkStepLauncher to execute dagster job steps in Databricks MUST configure "
-        "storage using this config (either S3 or ADLS2 can be used). Access credentials for the "
-        "storage must be stored in Databricks secrets; this config indicates the secret scope "
-        "and the secret keys used to access either S3 or ADLS2.",
-        is_required=True,
+        description="Databricks storage configuration for either S3 or ADLS2. If access credentials "
+        "for your Databricks storage are stored in Databricks secrets, this config indicates the "
+        "secret scope and the secret keys used to access either S3 or ADLS2.",
+        is_required=False,
     )
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -321,8 +321,6 @@ class DatabricksConfig:
             self.setup_s3_storage(self.storage["s3"], dbutils, sc)
         elif "adls2" in self.storage:
             self.setup_adls2_storage(self.storage["adls2"], dbutils, sc)
-        else:
-            raise Exception("No valid storage found in Databricks configuration!")
 
     def setup_s3_storage(self, s3_storage, dbutils, sc):
         """Obtain AWS credentials from Databricks secrets and export so both Spark and boto can use them."""


### PR DESCRIPTION
The current implementation assumes that the only way to configure Databricks storage is through Databricks secrets, which is not the case (https://github.com/dagster-io/dagster/issues/5836#issuecomment-983199145).

