### PR TITLE
fetch dependency asset keys only for asset node graph

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNeighborsGraph.tsx
@@ -20,7 +20,7 @@ const buildGraphFromSingleNode = (assetNode: AssetNodeDefinitionFragment) => {
       [assetNode.id]: {
         id: assetNode.id,
         assetKey: assetNode.assetKey,
-        definition: {...assetNode, dependencies: []},
+        definition: {...assetNode, dependencyKeys: []},
         hidden: false,
       },
     },
@@ -35,7 +35,7 @@ const buildGraphFromSingleNode = (assetNode: AssetNodeDefinitionFragment) => {
     graphData.nodes[asset.id] = {
       id: asset.id,
       assetKey: asset.assetKey,
-      definition: {...asset, dependencies: []},
+      definition: {...asset, dependencyKeys: []},
       hidden: false,
     };
   }
@@ -45,7 +45,7 @@ const buildGraphFromSingleNode = (assetNode: AssetNodeDefinitionFragment) => {
     graphData.nodes[asset.id] = {
       id: asset.id,
       assetKey: asset.assetKey,
-      definition: {...asset, dependencies: []},
+      definition: {...asset, dependencyKeys: []},
       hidden: false,
     };
   }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -624,6 +624,8 @@ type AssetNode {
   jobs: [Pipeline!]!
   dependencies: [AssetDependency!]!
   dependedBy: [AssetDependency!]!
+  dependencyKeys: [AssetKey!]!
+  dependedByKeys: [AssetKey!]!
   assetMaterializations(partitions: [String], beforeTimestampMillis: String, limit: Int): [AssetMaterialization!]!
 }
 

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -364,13 +364,8 @@ const ASSETS_GRAPH_QUERY = gql`
         assetNodes {
           id
           ...AssetNodeFragment
-          dependencies {
-            asset {
-              id
-              assetKey {
-                path
-              }
-            }
+          dependencyKeys {
+            path
           }
         }
       }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -54,8 +54,8 @@ export const buildGraphData = (assetNodes: AssetNode[], jobName?: string) => {
 
   assetNodes.forEach((definition: AssetNode) => {
     const assetKeyJson = JSON.stringify(definition.assetKey.path);
-    definition.dependencies.forEach(({asset}) => {
-      const upstreamAssetKeyJson = JSON.stringify(asset.assetKey.path);
+    definition.dependencyKeys.forEach(({path}) => {
+      const upstreamAssetKeyJson = JSON.stringify(path);
       data.downstream[upstreamAssetKeyJson] = {
         ...(data.downstream[upstreamAssetKeyJson] || {}),
         [assetKeyJson]: true,
@@ -85,7 +85,7 @@ export const buildGraphDataFromSingleNode = (assetNode: AssetNodeDefinitionFragm
       [assetNode.id]: {
         id: assetNode.id,
         assetKey: assetNode.assetKey,
-        definition: {...assetNode, dependencies: []},
+        definition: {...assetNode, dependencyKeys: []},
         hidden: false,
       },
     },
@@ -100,7 +100,7 @@ export const buildGraphDataFromSingleNode = (assetNode: AssetNodeDefinitionFragm
     graphData.nodes[asset.id] = {
       id: asset.id,
       assetKey: asset.assetKey,
-      definition: {...asset, dependencies: []},
+      definition: {...asset, dependencyKeys: []},
       hidden: false,
     };
   }
@@ -110,7 +110,7 @@ export const buildGraphDataFromSingleNode = (assetNode: AssetNodeDefinitionFragm
     graphData.nodes[asset.id] = {
       id: asset.id,
       assetKey: asset.assetKey,
-      definition: {...asset, dependencies: []},
+      definition: {...asset, dependencyKeys: []},
       hidden: false,
     };
   }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
@@ -18,20 +18,9 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_assetKey {
   path: string[];
 }
 
-export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies_asset_assetKey {
+export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencyKeys {
   __typename: "AssetKey";
   path: string[];
-}
-
-export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies_asset {
-  __typename: "AssetNode";
-  id: string;
-  assetKey: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies_asset_assetKey;
-}
-
-export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies {
-  __typename: "AssetDependency";
-  asset: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies_asset;
 }
 
 export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes {
@@ -41,7 +30,7 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes {
   description: string | null;
   jobName: string | null;
   assetKey: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_assetKey;
-  dependencies: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencies[];
+  dependencyKeys: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencyKeys[];
 }
 
 export interface AssetGraphQuery_pipelineOrError_Pipeline {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -86,13 +86,13 @@ class GrapheneAssetNode(graphene.ObjectType):
             for dep in self._external_asset_node.depended_by
         ]
 
-    def resolve_dependencyKeys(self, graphene_info):
+    def resolve_dependencyKeys(self, _graphene_info):
         return [
             GrapheneAssetKey(path=dep.upstream_asset_key.path)
             for dep in self._external_asset_node.dependencies
         ]
 
-    def resolve_dependencyByKeys(self, graphene_info):
+    def resolve_dependencyByKeys(self, _graphene_info):
         return [
             GrapheneAssetKey(path=dep.downstream_asset_key.path)
             for dep in self._external_asset_node.depended_by

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -39,6 +39,8 @@ class GrapheneAssetNode(graphene.ObjectType):
     jobs = non_null_list(GraphenePipeline)
     dependencies = non_null_list(GrapheneAssetDependency)
     dependedBy = non_null_list(GrapheneAssetDependency)
+    dependencyKeys = non_null_list(GrapheneAssetKey)
+    dependedByKeys = non_null_list(GrapheneAssetKey)
     assetMaterializations = graphene.Field(
         non_null_list(GrapheneAssetMaterialization),
         partitions=graphene.List(graphene.String),
@@ -81,6 +83,18 @@ class GrapheneAssetNode(graphene.ObjectType):
                 input_name=dep.input_name,
                 asset_key=dep.downstream_asset_key,
             )
+            for dep in self._external_asset_node.depended_by
+        ]
+
+    def resolve_dependencyKeys(self, graphene_info):
+        return [
+            GrapheneAssetKey(path=dep.upstream_asset_key.path)
+            for dep in self._external_asset_node.dependencies
+        ]
+
+    def resolve_dependencyByKeys(self, graphene_info):
+        return [
+            GrapheneAssetKey(path=dep.downstream_asset_key.path)
             for dep in self._external_asset_node.depended_by
         ]
 


### PR DESCRIPTION
## Summary
Most of the clock time is spent fetching/building up the node objects instead of just rendering the key, which is the only thing we use to build the graph client side.


## Test Plan
BK


