### PR TITLE
[dagit] Support for adding headers to GraphQL requests, code preview refactoring

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppContext.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppContext.tsx
@@ -4,10 +4,12 @@ export type AppContextValue = {
   basePath: string;
   rootServerURI: string;
   telemetryEnabled: boolean;
+  setTemporaryHeader: (key: string, value: string | undefined) => void;
 };
 
 export const AppContext = React.createContext<AppContextValue>({
   basePath: '',
   rootServerURI: '',
   telemetryEnabled: false,
+  setTemporaryHeader: () => {},
 });

--- a/js_modules/dagit/packages/core/src/app/AppContext.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppContext.tsx
@@ -4,12 +4,10 @@ export type AppContextValue = {
   basePath: string;
   rootServerURI: string;
   telemetryEnabled: boolean;
-  setTemporaryHeader: (key: string, value: string | undefined) => void;
 };
 
 export const AppContext = React.createContext<AppContextValue>({
   basePath: '',
   rootServerURI: '',
   telemetryEnabled: false,
-  setTemporaryHeader: () => {},
 });

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -127,10 +127,7 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
   const websocketURI = `${rootServerURI.replace(/^http/, 'ws')}/graphql`;
 
   // Ensure that we use the same `headers` value.
-  const [temporaryHeaders, setTemporaryHeaders] = React.useState<{
-    [key: string]: string | undefined;
-  }>({});
-  const headersAsString = JSON.stringify({...headers, ...temporaryHeaders});
+  const headersAsString = JSON.stringify(headers);
   const headerObject = React.useMemo(() => JSON.parse(headersAsString), [headersAsString]);
 
   const websocketClient = React.useMemo(
@@ -159,23 +156,13 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     });
   }, [apolloLinks, appCache, graphqlPath, headerObject, websocketClient]);
 
-  const setTemporaryHeader = React.useMemo(() => {
-    return (key: string, value: string | undefined) => {
-      if (temporaryHeaders[key] !== value) {
-        setTemporaryHeaders({...temporaryHeaders, [key]: value});
-        apolloClient.resetStore();
-      }
-    };
-  }, [apolloClient, temporaryHeaders]);
-
   const appContextValue = React.useMemo(
     () => ({
       basePath,
       rootServerURI,
       telemetryEnabled,
-      setTemporaryHeader,
     }),
-    [basePath, rootServerURI, telemetryEnabled, setTemporaryHeader],
+    [basePath, rootServerURI, telemetryEnabled],
   );
 
   return (

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -21,6 +21,61 @@ interface Props {
 
 export const AppTopNav: React.FC<Props> = ({children, searchPlaceholder}) => {
   const history = useHistory();
+
+  return (
+    <AppTopNavContainer>
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+        <AppTopNavLogo />
+        <SearchDialog searchPlaceholder={searchPlaceholder} />
+      </Box>
+      <Box flex={{direction: 'row', alignItems: 'center'}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+          <ShortcutHandler
+            onShortcut={() => history.push('/instance/runs')}
+            shortcutLabel={`⌥1`}
+            shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
+          >
+            <TopNavLink to="/instance/runs">Runs</TopNavLink>
+          </ShortcutHandler>
+          <ShortcutHandler
+            onShortcut={() => history.push('/instance/assets')}
+            shortcutLabel={`⌥2`}
+            shortcutFilter={(e) => e.code === 'Digit2' && e.altKey}
+          >
+            <TopNavLink to="/instance/assets">Assets</TopNavLink>
+          </ShortcutHandler>
+          <ShortcutHandler
+            onShortcut={() => history.push('/instance')}
+            shortcutLabel={`⌥3`}
+            shortcutFilter={(e) => e.code === 'Digit3' && e.altKey}
+          >
+            <TopNavLink to="/instance">
+              <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+                Status
+                <InstanceWarningIcon />
+              </Box>
+            </TopNavLink>
+          </ShortcutHandler>
+          <ShortcutHandler
+            onShortcut={() => history.push('/workspace')}
+            shortcutLabel={`⌥4`}
+            shortcutFilter={(e) => e.code === 'Digit4' && e.altKey}
+          >
+            <TopNavLink to="/workspace">
+              <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+                Workspace
+                <WorkspaceWarningIcon />
+              </Box>
+            </TopNavLink>
+          </ShortcutHandler>
+        </Box>
+        {children}
+      </Box>
+    </AppTopNavContainer>
+  );
+};
+
+export const AppTopNavLogo: React.FC = () => {
   const {nav} = React.useContext(LayoutContext);
   const navButton = React.useRef<null | HTMLButtonElement>(null);
 
@@ -39,81 +94,33 @@ export const AppTopNav: React.FC<Props> = ({children, searchPlaceholder}) => {
   );
 
   return (
-    <AppTopNavContainer>
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
-        <LogoContainer>
-          <ShortcutHandler
-            onShortcut={() => onToggle()}
-            shortcutLabel="."
-            shortcutFilter={(e) => e.key === '.'}
-          >
-            <NavButton onClick={onToggle} onKeyDown={onKeyDown} ref={navButton}>
-              <IconWIP name="menu" color={ColorsWIP.White} size={24} />
-            </NavButton>
-          </ShortcutHandler>
-          <Box flex={{display: 'inline-flex'}} margin={{left: 8}}>
-            <DaggyTooltip
-              content={
-                <Box flex={{direction: 'row', gap: 4}}>
-                  <WebSocketStatus />
-                  <VersionNumber />
-                </Box>
-              }
-              placement="bottom"
-              modifiers={{offset: {enabled: true, options: {offset: [0, 18]}}}}
-            >
-              <Link to="/workspace" style={{outline: 0, display: 'flex'}}>
-                <GhostDaggy />
-              </Link>
-            </DaggyTooltip>
-          </Box>
-        </LogoContainer>
-        <SearchDialog searchPlaceholder={searchPlaceholder} />
+    <LogoContainer>
+      <ShortcutHandler
+        onShortcut={() => onToggle()}
+        shortcutLabel="."
+        shortcutFilter={(e) => e.key === '.'}
+      >
+        <NavButton onClick={onToggle} onKeyDown={onKeyDown} ref={navButton}>
+          <IconWIP name="menu" color={ColorsWIP.White} size={24} />
+        </NavButton>
+      </ShortcutHandler>
+      <Box flex={{display: 'inline-flex'}} margin={{left: 8}}>
+        <DaggyTooltip
+          content={
+            <Box flex={{direction: 'row', gap: 4}}>
+              <WebSocketStatus />
+              <VersionNumber />
+            </Box>
+          }
+          placement="bottom"
+          modifiers={{offset: {enabled: true, options: {offset: [0, 18]}}}}
+        >
+          <Link to="/workspace" style={{outline: 0, display: 'flex'}}>
+            <GhostDaggy />
+          </Link>
+        </DaggyTooltip>
       </Box>
-      <Box flex={{direction: 'row', alignItems: 'center'}}>
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
-          <ShortcutHandler
-            onShortcut={() => history.push('/instance/runs')}
-            shortcutLabel={`⌥1`}
-            shortcutFilter={(e) => e.code === 'Digit1' && e.altKey}
-          >
-            <NavLink to="/instance/runs">Runs</NavLink>
-          </ShortcutHandler>
-          <ShortcutHandler
-            onShortcut={() => history.push('/instance/assets')}
-            shortcutLabel={`⌥2`}
-            shortcutFilter={(e) => e.code === 'Digit2' && e.altKey}
-          >
-            <NavLink to="/instance/assets">Assets</NavLink>
-          </ShortcutHandler>
-          <ShortcutHandler
-            onShortcut={() => history.push('/instance')}
-            shortcutLabel={`⌥3`}
-            shortcutFilter={(e) => e.code === 'Digit3' && e.altKey}
-          >
-            <NavLink to="/instance">
-              <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                Status
-                <InstanceWarningIcon />
-              </Box>
-            </NavLink>
-          </ShortcutHandler>
-          <ShortcutHandler
-            onShortcut={() => history.push('/workspace')}
-            shortcutLabel={`⌥4`}
-            shortcutFilter={(e) => e.code === 'Digit4' && e.altKey}
-          >
-            <NavLink to="/workspace">
-              <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-                Workspace
-                <WorkspaceWarningIcon />
-              </Box>
-            </NavLink>
-          </ShortcutHandler>
-        </Box>
-        {children}
-      </Box>
-    </AppTopNavContainer>
+    </LogoContainer>
   );
 };
 
@@ -164,7 +171,7 @@ const DaggyTooltip = styled(Tooltip)`
   }
 `;
 
-const NavLink = styled(Link)`
+export const TopNavLink = styled(Link)`
   color: ${ColorsWIP.Gray200};
   font-weight: 600;
   transition: color 50ms linear;
@@ -177,7 +184,7 @@ const NavLink = styled(Link)`
   }
 `;
 
-const AppTopNavContainer = styled.div`
+export const AppTopNavContainer = styled.div`
   background: ${ColorsWIP.Gray900};
   display: flex;
   flex-direction: row;

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -1,6 +1,6 @@
 import memoize from 'lodash/memoize';
 import * as React from 'react';
-import {useRouteMatch} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {ColorsWIP} from '../ui/Colors';
@@ -107,18 +107,12 @@ const useNavVisibleRepos = (
 };
 
 const LoadedRepositorySection: React.FC<{allRepos: DagsterRepoOption[]}> = ({allRepos}) => {
-  const match = useRouteMatch<
-    | {repoPath: string; selector: string; tab: string; rootTab: undefined}
-    | {selector: undefined; tab: undefined; rootTab: string}
-  >([
-    '/workspace/:repoPath/pipelines/:selector/:tab?',
-    '/workspace/:repoPath/jobs/:selector/:tab?',
-    '/workspace/:repoPath/solids/:selector',
-    '/workspace/:repoPath/ops/:selector',
-    '/workspace/:repoPath/schedules/:selector',
-    '/workspace/:repoPath/sensors/:selector',
-    '/:rootTab?',
-  ]);
+  const location = useLocation();
+  const workspacePath = location.pathname.split('/workspace/').pop();
+  const [, repoPath, , selector, tab] =
+    workspacePath?.match(
+      /([^\/]+)\/(pipelines|jobs|solids|ops|sensors|schedules)\/([^\/]+)\/?([^\/]+)?/,
+    ) || [];
 
   const [visibleRepos, toggleRepo] = useNavVisibleRepos(allRepos);
 
@@ -138,7 +132,12 @@ const LoadedRepositorySection: React.FC<{allRepos: DagsterRepoOption[]}> = ({all
     <Container>
       <ListContainer>
         {visibleRepos.size ? (
-          <FlatContentList {...match?.params} repos={visibleOptions} />
+          <FlatContentList
+            repoPath={repoPath}
+            selector={selector}
+            repos={visibleOptions}
+            tab={tab}
+          />
         ) : allRepos.length > 0 ? (
           <EmptyState>Select a repository to see a list of jobs and pipelines.</EmptyState>
         ) : (

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -32,7 +32,6 @@ const testValue: AppContextValue = {
   basePath: '',
   rootServerURI: '',
   telemetryEnabled: false,
-  setTemporaryHeader: () => {},
 };
 
 const websocketValue: WebSocketContextType = {

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -28,10 +28,11 @@ export const PERMISSIONS_ALLOW_ALL: PermissionsFromJSON = {
   cancel_partition_backfill: true,
 };
 
-const testValue = {
+const testValue: AppContextValue = {
   basePath: '',
   rootServerURI: '',
   telemetryEnabled: false,
+  setTemporaryHeader: () => {},
 };
 
 const websocketValue: WebSocketContextType = {

--- a/js_modules/dagit/packages/core/src/ui/Text.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Text.tsx
@@ -8,6 +8,7 @@ interface TextProps {
 }
 
 export const Heading = styled.span<TextProps>`
+  ${({color}) => (color ? `color: ${color};` : null)}
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
@@ -15,6 +16,7 @@ export const Heading = styled.span<TextProps>`
 `;
 
 export const Subheading = styled.span<TextProps>`
+  ${({color}) => (color ? `color: ${color};` : null)}
   font-size: 14px;
   font-weight: 600;
   line-height: 20px;


### PR DESCRIPTION
## Summary
This PR adds a small feature to AppContext that allows headers to be added to requests at runtime. This supports the new implementation of workspace snapshots / code previews, where the CODE_PREVIEW_UUID is passed as a header to avoid needing to add a param to a large number of GraphQL requests in cloud only.

This PR also exports a few things from the AppNav so that code previews can have a slightly different top nav bar.

## Test Plan
No new tests on this side yet



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.