### PR TITLE
[dagit] Tweak small checkbox

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
@@ -185,15 +185,14 @@ export const TerminationDialog = (props: Props) => {
               {showCheckbox ? (
                 <Checkbox
                   checked={state.mustForce}
+                  size="small"
                   label={
-                    <Box flex={{display: 'inline-flex'}}>
-                      <Group direction="row" spacing={8}>
-                        <IconWIP name="warning" color={ColorsWIP.Yellow500} />
-                        <div>
-                          Force termination immediately. <strong>Warning:</strong> computational
-                          resources created by runs may not be cleaned up.
-                        </div>
-                      </Group>
+                    <Box flex={{display: 'flex', direction: 'row', gap: 8}}>
+                      <IconWIP name="warning" color={ColorsWIP.Yellow500} />
+                      <div>
+                        Force termination immediately. <strong>Warning:</strong> computational
+                        resources created by runs may not be cleaned up.
+                      </div>
                     </Box>
                   }
                   onChange={onToggleForce}

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -193,17 +193,18 @@ export const Checkbox = styled(Base)`
   display: inline-flex;
   position: relative;
   user-select: none;
-  align-items: center;
+  align-items: flex-start;
   color: ${({disabled}) => (disabled ? DISABLED_COLOR : ColorsWIP.Gray900)};
   cursor: pointer;
   gap: 8px;
 
   svg {
+    flex-shrink: 0;
     ${({size}) =>
       size === 'small'
         ? css`
-            margin: -6px -12px;
-            transform: scale(0.5);
+            margin: -3px -6px;
+            transform: scale(0.75);
           `
         : css`
             margin: -3px;


### PR DESCRIPTION
## Summary

Resolves #5979.

I noticed some things about the checkbox component:

- It can get squished in flex circumstances
- The `small` version looks a little *too* small.
- `align-items: center` is probably incorrect for the adjacent text, since the top line of text should align with the checkbox.

Tweak the component to repair all of the above.

## Test Plan

Use storybook example of TerminationDialog. Verify that it renders the checkbox and its label nicely.
