### PR TITLE
[dagit] Fix run log data sync to Apollo

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -103,7 +103,7 @@ const useLogsProviderWithSubscription = (runId: string) => {
       const local = client.readFragment<PipelineRunLogsSubscriptionStatusFragment>({
         fragmentName: 'PipelineRunLogsSubscriptionStatusFragment',
         fragment: PIPELINE_RUN_LOGS_SUBSCRIPTION_STATUS_FRAGMENT,
-        id: `PipelineRun:${runId}`,
+        id: `Run:${runId}`,
       });
 
       if (local) {
@@ -117,10 +117,11 @@ const useLogsProviderWithSubscription = (runId: string) => {
         ) {
           toWrite.canTerminate = false;
         }
+
         client.writeFragment({
           fragmentName: 'PipelineRunLogsSubscriptionStatusFragment',
           fragment: PIPELINE_RUN_LOGS_SUBSCRIPTION_STATUS_FRAGMENT,
-          id: `PipelineRun:${runId}`,
+          id: `Run:${runId}`,
           data: toWrite,
         });
       }


### PR DESCRIPTION
## Summary

Resolves #5977.

When `PipelineRun` was changed to `Run`, we overlooked the fragment read/write for syncing run status to Apollo based on the logs subscription. The result was that the Gantt chart sometimes never came out of "Queued" state, or sometimes did so at strange later times.

## Test Plan

Start the QueuedRunCoordinator daemon. Run hammer_pipeline. Verify that the Gantt renders immediately after the run moves from `QUEUED` state, and animates as expected from that point. Use console logging to verify that the Apollo cache is being read/written properly.
