### PR TITLE
Enable dagit telemetry to upload logs

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -169,22 +169,18 @@ def host_dagit_ui_with_workspace_process_context(
 
 
 @contextmanager
-def uploading_logging_thread(instance):
-    from dagster.core.instance import is_dagit_telemetry_enabled
+def uploading_logging_thread():
 
     stop_event = threading.Event()
     logging_thread = threading.Thread(
         target=upload_logs, args=([stop_event]), name="telemetry-upload"
     )
     try:
-        # Telemetry data is still experimental, so don't upload if telemetry flags are enabled.
-        if not is_dagit_telemetry_enabled(instance):
-            logging_thread.start()
+        logging_thread.start()
         yield
     finally:
-        if not is_dagit_telemetry_enabled(instance):
-            stop_event.set()
-            logging_thread.join()
+        stop_event.set()
+        logging_thread.join()
 
 
 def start_server(instance, host, port, path_prefix, app, port_lookup, port_lookup_attempts=0):
@@ -199,7 +195,7 @@ def start_server(instance, host, port, path_prefix, app, port_lookup, port_looku
     )
 
     log_action(instance, START_DAGIT_WEBSERVER)
-    with uploading_logging_thread(instance):
+    with uploading_logging_thread():
         try:
             server.serve_forever()
         except OSError as os_error:


### PR DESCRIPTION
Now, when the experimental_dagit telemetry is enabled, logs will actually be uploaded to mixpanel.