### PR TITLE
[dagit] More Checkbox adjustments

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Checkbox.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.stories.tsx
@@ -76,3 +76,74 @@ export const Default = () => {
     </Group>
   );
 };
+
+export const Small = () => {
+  const [state, setState] = useState<'true' | 'false' | 'indeterminate'>('false');
+  const onChange = () =>
+    setState(({true: 'indeterminate', indeterminate: 'false', false: 'true'} as const)[state]);
+
+  return (
+    <Group spacing={8} direction="column">
+      {[ColorsWIP.Blue500, ColorsWIP.ForestGreen, ColorsWIP.Gray800].map((fillColor) => (
+        <Group spacing={24} direction="row" key={fillColor}>
+          <Checkbox
+            size="small"
+            label="Hello world"
+            checked={state === 'false' ? false : true}
+            indeterminate={state === 'indeterminate'}
+            fillColor={fillColor}
+            onChange={onChange}
+            format="check"
+          />
+          <Checkbox
+            size="small"
+            label="Hello world"
+            checked={state === 'false' ? false : true}
+            indeterminate={state === 'indeterminate'}
+            fillColor={fillColor}
+            onChange={onChange}
+            format="star"
+          />
+          <Checkbox
+            size="small"
+            label="Hello world"
+            checked={state === 'false' ? false : true}
+            indeterminate={state === 'indeterminate'}
+            fillColor={fillColor}
+            onChange={onChange}
+            format="switch"
+          />
+        </Group>
+      ))}
+      <Group spacing={24} direction="row">
+        <Checkbox
+          disabled
+          size="small"
+          label="Hello world"
+          checked={state === 'false' ? false : true}
+          indeterminate={state === 'indeterminate'}
+          onChange={onChange}
+          format="check"
+        />
+        <Checkbox
+          disabled
+          size="small"
+          label="Hello world"
+          checked={state === 'false' ? false : true}
+          indeterminate={state === 'indeterminate'}
+          onChange={onChange}
+          format="star"
+        />
+        <Checkbox
+          disabled
+          size="small"
+          label="Hello world"
+          checked={state === 'false' ? false : true}
+          indeterminate={state === 'indeterminate'}
+          onChange={onChange}
+          format="switch"
+        />
+      </Group>
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -7,6 +7,9 @@ import {ColorsWIP} from './Colors';
 
 const DISABLED_COLOR = ColorsWIP.Gray300;
 
+type Format = 'check' | 'star' | 'switch';
+type Size = 'small' | 'large';
+
 type Props = Omit<
   React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
   'size'
@@ -15,9 +18,9 @@ type Props = Omit<
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   label?: React.ReactNode;
   indeterminate?: boolean;
-  format?: 'check' | 'star' | 'switch';
+  format?: Format;
   fillColor?: string;
-  size?: 'small' | 'large';
+  size?: Size;
 };
 
 interface IconProps {
@@ -60,7 +63,7 @@ const StarIcon: React.FC<IconProps> = ({checked, indeterminate, fillColor}) => (
 );
 
 const SwitchIcon: React.FC<IconProps> = ({checked, indeterminate, disabled, fillColor}) => (
-  <svg width="42px" height="28px" viewBox="-3 -3 42 28">
+  <svg width="36px" height="24px" viewBox="-3 -3 42 28">
     <defs>
       <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="innerShadow">
         <stop stopColor="#000" stopOpacity="0.2" offset="0%" />
@@ -189,6 +192,28 @@ const Base = ({
   );
 };
 
+const svgStyle = (values: {size?: Size; format?: Format}) => {
+  const {size = 'large', format = 'check'} = values;
+
+  if (size === 'large') {
+    return css`
+      margin: -3px;
+    `;
+  }
+
+  if (format === 'switch') {
+    return css`
+      margin: -3px -9px;
+      transform: scale(0.5);
+    `;
+  }
+
+  return css`
+    margin: -3px -6px;
+    transform: scale(0.75);
+  `;
+};
+
 export const Checkbox = styled(Base)`
   display: inline-flex;
   position: relative;
@@ -200,15 +225,7 @@ export const Checkbox = styled(Base)`
 
   svg {
     flex-shrink: 0;
-    ${({size}) =>
-      size === 'small'
-        ? css`
-            margin: -3px -6px;
-            transform: scale(0.75);
-          `
-        : css`
-            margin: -3px;
-          `}
+    ${svgStyle}
   }
 
   input[type='checkbox'] {


### PR DESCRIPTION
## Summary

Make some more changes to `Checkbox`.

- Make `Switch` smaller by default. It's 28px high, which doesn't match `check` or `star`. Make it 24px high to match.
- Adjust the `small` versions of all formats.
- Add a storybook example for all `small` sizes.

## Test Plan

View storybook examples, verify rendering and behavior. Load Dagit, verify same to sanity check.
