### PR TITLE
[dagit] Use run status pez in Instance Overview

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/types/LastTenRunsPerJobQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/LastTenRunsPerJobQuery.ts
@@ -1,0 +1,84 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: LastTenRunsPerJobQuery
+// ====================================================
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  isJob: boolean;
+  runs: LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs[];
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  pipelines: LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+  repositories: LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories[];
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError_cause | null;
+}
+
+export type LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation | LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError;
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries {
+  __typename: "WorkspaceLocationEntry";
+  id: string;
+  locationOrLoadError: LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_Workspace {
+  __typename: "Workspace";
+  locationEntries: LastTenRunsPerJobQuery_workspaceOrError_Workspace_locationEntries[];
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface LastTenRunsPerJobQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: LastTenRunsPerJobQuery_workspaceOrError_PythonError_cause | null;
+}
+
+export type LastTenRunsPerJobQuery_workspaceOrError = LastTenRunsPerJobQuery_workspaceOrError_Workspace | LastTenRunsPerJobQuery_workspaceOrError_PythonError;
+
+export interface LastTenRunsPerJobQuery {
+  workspaceOrError: LastTenRunsPerJobQuery_workspaceOrError;
+}

--- a/js_modules/dagit/packages/core/src/instance/types/RunStatusFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/RunStatusFragment.ts
@@ -1,0 +1,17 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: RunStatusFragment
+// ====================================================
+
+export interface RunStatusFragment {
+  __typename: "Run";
+  id: string;
+  runId: string;
+  status: RunStatus;
+}


### PR DESCRIPTION
## Summary

Show ten most recent runs for each job in Instance Overview. Renders the pez component with opacity gradient.

This change also involves performing a lazy query to retrieve these `limit: 10` sets of runs. My understanding is that we probably shouldn't block the main query on this, but we can always refactor as needed.

## Test Plan

View Instance Overview page in Dagit. Verify rendering of run status Pez.
