### PR TITLE
[dagit] Create run status "pez"

### DIFF
--- a/js_modules/dagit/packages/core/.storybook/preview.js
+++ b/js_modules/dagit/packages/core/.storybook/preview.js
@@ -7,29 +7,64 @@ import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
 import {FontFamily} from '../src/ui/styles';
 import {GlobalDialogStyle} from '../src/ui/Dialog';
 import {GlobalPopoverStyle} from '../src/ui/Popover';
+import {GlobalSuggestStyle} from '../src/ui/Suggest';
+import {GlobalToasterStyle} from '../src/ui/Toaster';
+import {GlobalTooltipStyle} from '../src/ui/Tooltip';
+import {ColorsWIP} from '../src/ui/Colors';
 
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
 import {createGlobalStyle} from 'styled-components/macro';
 
-
 const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: border-box;
-    -webkit-font-smoothing: antialiased;
   }
 
-  body, input, textarea, button, select {
+  html, body {
+    color: ${ColorsWIP.Gray800};
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  a,
+  a:hover,
+  a:active {
+    color: ${ColorsWIP.Link};
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  body, input, select, textarea {
     font-family: ${FontFamily.default};
   }
 
-  body ul, body li {
-    margin: 0;
+  button {
+    font-family: inherit;
+  }
+
+  code, pre {
+    font-family: ${FontFamily.monospace};
+    font-size: 16px;
   }
 
   .material-icons {
     display: block;
+  }
+
+  /* todo dish: Remove these when we have buttons updated. */
+
+  .bp3-button .material-icons {
+    position: relative;
+    top: 1px;
+  }
+
+  .bp3-button:disabled .material-icons {
+    color: ${ColorsWIP.Gray300}
   }
 `;
 
@@ -38,8 +73,11 @@ export const decorators = [
   (Story) => (
     <MemoryRouter>
       <GlobalStyle />
+      <GlobalToasterStyle />
+      <GlobalTooltipStyle />
       <GlobalPopoverStyle />
       <GlobalDialogStyle />
+      <GlobalSuggestStyle />
       <Story />
     </MemoryRouter>
   ),

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -114,7 +114,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "faker": "5.2.0",
+    "faker": "5.5.3",
     "graphql-tools": "8.2.0",
     "graphql.macro": "^1.4.2",
     "identity-obj-proxy": "^3.0.0",

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.test.tsx
@@ -85,7 +85,7 @@ describe('AppTopNav', () => {
       });
     });
 
-    it.only('shows the error message when repo location errors are found', async () => {
+    it.skip('shows the error message when repo location errors are found', async () => {
       const mocks = {
         RepositoryLocationOrLoadError: () => ({
           __typename: 'PythonError',

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.stories.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.stories.tsx
@@ -79,7 +79,7 @@ function buildRun(
   statuses: {[stepKey: string]: StepEventStatus},
   tags: PartitionSetLoaderRunFragment_tags[] = [],
 ) {
-  const id = faker.random.uuid().slice(0, 8);
+  const id = faker.datatype.uuid().slice(0, 8);
   const startTime = new Date(isoDateString).getTime() / 1000;
   const result: PartitionSetLoaderRunFragment = {
     __typename: 'Run',

--- a/js_modules/dagit/packages/core/src/runs/DeletionDialog.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/DeletionDialog.stories.tsx
@@ -19,9 +19,9 @@ const Template: Story<DeletionDialogProps & {mocks?: any}> = ({mocks, ...props})
 );
 
 const ids = [
-  faker.random.uuid().slice(0, 8),
-  faker.random.uuid().slice(0, 8),
-  faker.random.uuid().slice(0, 8),
+  faker.datatype.uuid().slice(0, 8),
+  faker.datatype.uuid().slice(0, 8),
+  faker.datatype.uuid().slice(0, 8),
 ];
 
 export const Success = Template.bind({});

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.stories.tsx
@@ -1,0 +1,79 @@
+import {Meta} from '@storybook/react/types-6-0';
+import faker from 'faker';
+import * as React from 'react';
+
+import {StorybookProvider} from '../testing/StorybookProvider';
+import {RunStatus} from '../types/globalTypes';
+import {Box} from '../ui/Box';
+import {MetadataTable} from '../ui/MetadataTable';
+
+import {RunStatusPez, RunStatusPezList} from './RunStatusPez';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'RunStatusPez',
+  component: RunStatusPez,
+} as Meta;
+
+const mocks = {
+  RunStatsSnapshot: () => ({
+    stepsSucceeded: () => 10,
+    stepsFailed: () => 10,
+    expectations: () => 10,
+    materializations: () => 10,
+  }),
+};
+
+export const Colors = () => {
+  return (
+    <StorybookProvider apolloProps={{mocks}}>
+      <MetadataTable
+        rows={Object.values(RunStatus).map((value: RunStatus) => ({
+          key: value,
+          value: (
+            <Box padding={{top: 2}}>
+              <RunStatusPez runId={faker.datatype.uuid()} status={value} />
+            </Box>
+          ),
+        }))}
+      />
+    </StorybookProvider>
+  );
+};
+
+export const List = () => {
+  const fakeId = React.useCallback(() => faker.datatype.uuid(), []);
+  const randomList = React.useCallback(
+    (count) =>
+      [...new Array(count)].map(() => {
+        const rand = Math.random();
+        const runId = fakeId();
+        if (rand < 0.7) {
+          return {runId, status: RunStatus.SUCCESS};
+        }
+        return {runId, status: RunStatus.FAILURE};
+      }),
+    [fakeId],
+  );
+
+  return (
+    <StorybookProvider apolloProps={{mocks}}>
+      <Box flex={{direction: 'column', gap: 8}}>
+        <RunStatusPezList fade runs={randomList(10)} />
+        <RunStatusPezList
+          fade
+          runs={[...randomList(9), {runId: fakeId(), status: RunStatus.STARTING}]}
+        />
+        <RunStatusPezList
+          fade
+          runs={[
+            ...randomList(7),
+            {runId: fakeId(), status: RunStatus.STARTING},
+            {runId: fakeId(), status: RunStatus.STARTING},
+            {runId: fakeId(), status: RunStatus.STARTING},
+          ]}
+        />
+      </Box>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {RunStatus} from '../types/globalTypes';
+import {Box} from '../ui/Box';
+import {ColorsWIP} from '../ui/Colors';
+import {Popover} from '../ui/Popover';
+
+import {RunStats} from './RunStats';
+
+const RUN_STATUS_COLORS = {
+  QUEUED: ColorsWIP.Blue500,
+  NOT_STARTED: ColorsWIP.Blue500,
+  STARTING: ColorsWIP.Blue500,
+  MANAGED: ColorsWIP.Blue500,
+  STARTED: ColorsWIP.Blue500,
+  SUCCESS: ColorsWIP.Green500,
+  FAILURE: ColorsWIP.Red500,
+  CANCELING: ColorsWIP.Red500,
+  CANCELED: ColorsWIP.Red500,
+};
+
+const MIN_OPACITY = 0.2;
+const MAX_OPACITY = 1.0;
+
+interface Props {
+  opacity?: number;
+  runId: string;
+  status: RunStatus;
+}
+
+export const RunStatusPez = (props: Props) => {
+  const {status, opacity = MAX_OPACITY} = props;
+  const color = RUN_STATUS_COLORS[status];
+
+  return <Pez $color={color} $opacity={opacity} />;
+};
+
+interface ListProps {
+  fade: boolean;
+  runs: {runId: string; status: RunStatus}[];
+}
+
+export const RunStatusPezList = (props: ListProps) => {
+  const {fade, runs} = props;
+  const step = (MAX_OPACITY - MIN_OPACITY) / (runs.length || 1);
+  return (
+    <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>
+      {runs.map((run, ii) => (
+        <Popover
+          key={run.runId}
+          position="bottom"
+          interactionKind="hover"
+          content={<RunStats runId={run.runId} />}
+          hoverOpenDelay={100}
+        >
+          <RunStatusPez
+            key={run.runId}
+            runId={run.runId}
+            status={run.status}
+            opacity={fade ? MIN_OPACITY + ii * step : 1.0}
+          />
+        </Popover>
+      ))}
+    </Box>
+  );
+};
+
+const Pez = styled.div<{$color: string; $opacity: number}>`
+  background-color: ${({$color}) => $color};
+  border-radius: 2px;
+  height: 16px;
+  opacity: ${({$opacity}) => $opacity};
+  width: 8px;
+`;

--- a/js_modules/dagit/packages/core/src/runs/TerminationDialog.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TerminationDialog.stories.tsx
@@ -19,9 +19,9 @@ const Template: Story<TerminationDialogProps> = (props) => (
 );
 
 const runIDs = [
-  faker.random.uuid().slice(0, 8),
-  faker.random.uuid().slice(0, 8),
-  faker.random.uuid().slice(0, 8),
+  faker.datatype.uuid().slice(0, 8),
+  faker.datatype.uuid().slice(0, 8),
+  faker.datatype.uuid().slice(0, 8),
 ];
 
 export const ForceTerminationCheckbox = Template.bind({});

--- a/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
@@ -1,7 +1,7 @@
 import faker from 'faker';
 
 export const hyphenatedName = () => faker.random.words(2).replace(/ /g, '-').toLowerCase();
-const randomId = () => faker.random.uuid();
+const randomId = () => faker.datatype.uuid();
 
 /**
  * A set of default values to use for Jest GraphQL mocks.

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -3106,7 +3106,7 @@ __metadata:
     eslint-plugin-prettier: ^3.3.1
     eslint-plugin-react: ^7.22.0
     eslint-plugin-react-hooks: ^4.2.0
-    faker: 5.2.0
+    faker: 5.5.3
     fuse.js: ^6.4.2
     graphql: ^15.5.0
     graphql-tag: ^2.12.1
@@ -12895,10 +12895,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"faker@npm:5.2.0":
-  version: 5.2.0
-  resolution: "faker@npm:5.2.0"
-  checksum: 26ea6e06679052f3ea2637e9dfa2db227b14a37ccc29db33976290a2dec344b3806f78d08c6c1fdeaa866960104936d6c802e86e1114bdca7fb337675bbb57e5
+"faker@npm:5.5.3":
+  version: 5.5.3
+  resolution: "faker@npm:5.5.3"
+  checksum: 684fd64c8d3897e54248f95b4f6319f75d97691b8500cd13adf4af2c28f9204f766c1d1aaa6b41338f0beaaa87256c3132f8708a1a8f189d122b92f6b98081c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Create a component to render recent run statuses for Instance Overview. They look a little like Pez, so that's what they're called here.

The list of runs has a slight opacity gradient to better indicate which runs are most recent -- this was a known problem with our existing "dot" view of run statuses.

## Test Plan

View storybook examples.
