### PR TITLE
[dagit] Scope the asset graph query for materializations to displayed nodes

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -65,21 +65,9 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     notifyOnNetworkStatusChange: true,
   });
 
-  const liveResult = useQuery<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>(
-    ASSETS_GRAPH_LIVE_QUERY,
-    {
-      variables: {pipelineSelector, repositorySelector},
-      notifyOnNetworkStatusChange: true,
-      pollInterval: 5 * 1000,
-    },
-  );
-
-  useDocumentTitle('Assets');
-  useDidLaunchEvent(liveResult.refetch);
-
-  const graphData = React.useMemo(() => {
+  const {graphData, graphAssetKeys} = React.useMemo(() => {
     if (queryResult.data?.pipelineOrError.__typename !== 'Pipeline') {
-      return null;
+      return {graphAssetKeys: [], graphData: null};
     }
     const assetNodes = queryResult.data.pipelineOrError.assetNodes;
     const queryOps = filterByQuery(
@@ -89,9 +77,22 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     const queryAssetNodes = assetNodes.filter((a) =>
       queryOps.all.some((op) => op.name === a.opName),
     );
+    const graphData = buildGraphData(queryAssetNodes, explorerPath.pipelineName);
+    return {
+      graphAssetKeys: queryAssetNodes.map((n) => ({path: n.assetKey.path})),
+      graphData: graphData,
+    };
+  }, [queryResult.data, handles, explorerPath.pipelineName, explorerPath.opsQuery]);
 
-    return buildGraphData(queryAssetNodes, explorerPath.pipelineName);
-  }, [queryResult, handles, explorerPath.pipelineName, explorerPath.opsQuery]);
+  const liveResult = useQuery<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>(
+    ASSETS_GRAPH_LIVE_QUERY,
+    {
+      skip: graphAssetKeys.length === 0,
+      variables: {pipelineSelector, repositorySelector, assetKeys: graphAssetKeys},
+      notifyOnNetworkStatusChange: true,
+      pollInterval: 5 * 1000,
+    },
+  );
 
   const liveDataByNode = React.useMemo(() => {
     if (!liveResult.data || !graphData) {
@@ -107,10 +108,13 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     return buildLiveData(graphData, liveAssetNodes, inProgressRunsByStep);
   }, [graphData, liveResult]);
 
+  useDocumentTitle('Assets');
+  useDidLaunchEvent(liveResult.refetch);
+
   return (
     <Loading allowStaleData queryResult={queryResult}>
-      {({pipelineOrError}) => {
-        if (pipelineOrError.__typename !== 'Pipeline' || !graphData) {
+      {() => {
+        if (!graphData) {
           return <NonIdealState icon="error" title="Query Error" />;
         }
 
@@ -331,6 +335,7 @@ const ASSETS_GRAPH_LIVE_QUERY = gql`
   query AssetGraphLiveQuery(
     $pipelineSelector: PipelineSelector!
     $repositorySelector: RepositorySelector!
+    $assetKeys: [AssetKeyInput!]
   ) {
     repositoryOrError(repositorySelector: $repositorySelector) {
       __typename
@@ -345,7 +350,7 @@ const ASSETS_GRAPH_LIVE_QUERY = gql`
     pipelineOrError(params: $pipelineSelector) {
       ... on Pipeline {
         id
-        assetNodes {
+        assetNodes(assetKeys: $assetKeys) {
           id
           ...AssetNodeLiveFragment
         }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphLiveQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphLiveQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PipelineSelector, RepositorySelector, RunStatus } from "./../../../types/globalTypes";
+import { PipelineSelector, RepositorySelector, AssetKeyInput, RunStatus } from "./../../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: AssetGraphLiveQuery
@@ -209,4 +209,5 @@ export interface AssetGraphLiveQuery {
 export interface AssetGraphLiveQueryVariables {
   pipelineSelector: PipelineSelector;
   repositorySelector: RepositorySelector;
+  assetKeys?: AssetKeyInput[] | null;
 }


### PR DESCRIPTION
## Summary
This PR leverages @clairelin135's new `assetNodes(assetKeys:)` parameter to fetch "live" data for only the subset of asset nodes actually displayed using the new subset picker on the asset graph.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.