### PR TITLE
adding the request calls to the debug payload breaks subscription calls

### DIFF
--- a/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
+++ b/js_modules/dagit/packages/core/src/app/apolloLinks.tsx
@@ -2,11 +2,19 @@ import {ApolloLink} from '@apollo/client';
 
 import {formatElapsedTime, debugLog} from './Util';
 
+export const getCalls = (response: any) => {
+  try {
+    return JSON.parse(response.headers.get('x-dagster-call-counts'));
+  } catch {
+    return null;
+  }
+};
+
 export const logLink = new ApolloLink((operation, forward) =>
   forward(operation).map((data) => {
     const context = operation.getContext();
     const elapsedTime = performance.now() - context.start;
-    const calls = JSON.parse(context.response.headers.get('x-dagster-call-counts'));
+    const calls = getCalls(context.response);
     operation.setContext({elapsedTime, calls});
     debugLog(`${operation.operationName} took ${formatElapsedTime(elapsedTime)}`, {
       operation,


### PR DESCRIPTION
## Summary
https://github.com/dagster-io/dagster/pull/5902 added request call tracing and inserted them into the debug logging via an apollo link.  Turns out this broke subscriptions because not all operation contexts have responses on them.  

This diff now guards against errors in the header payload.

## Test Plan
Loaded the Run page.

