### PR TITLE
Don't call out to gRPC to load an external pipeline unless a solid selection is set

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -55,10 +55,9 @@ def get_subset_external_pipeline(context, selector):
     check.inst_param(selector, "selector", PipelineSelector)
 
     repository_location = context.get_repository_location(selector.location_name)
-    external_repository = repository_location.get_repository(selector.repository_name)
 
     try:
-        subset_result = repository_location.get_subset_external_pipeline_result(selector)
+        external_pipeline = repository_location.get_external_pipeline(selector)
     except Exception:
         error_info = serializable_error_info_from_exc_info(sys.exc_info())
         raise UserFacingGraphQLError(
@@ -73,10 +72,7 @@ def get_subset_external_pipeline(context, selector):
             )
         )
 
-    return ExternalPipeline(
-        subset_result.external_pipeline_data,
-        repository_handle=external_repository.handle,
-    )
+    return external_pipeline
 
 
 def ensure_valid_config(external_pipeline, mode, run_config):

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -510,17 +510,12 @@ def _create_external_pipeline_run(
         solid_selection=solid_selection,
     )
 
-    subset_pipeline_result = repo_location.get_subset_external_pipeline_result(pipeline_selector)
+    external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
 
-    external_pipeline_subset = ExternalPipeline(
-        subset_pipeline_result.external_pipeline_data,
-        external_repo.handle,
-    )
-
-    pipeline_mode = mode or external_pipeline_subset.get_default_mode_name()
+    pipeline_mode = mode or external_pipeline.get_default_mode_name()
 
     external_execution_plan = repo_location.get_external_execution_plan(
-        external_pipeline_subset,
+        external_pipeline,
         run_config,
         pipeline_mode,
         step_keys_to_execute=None,
@@ -534,17 +529,17 @@ def _create_external_pipeline_run(
         run_id=run_id,
         run_config=run_config,
         mode=pipeline_mode,
-        solids_to_execute=external_pipeline_subset.solids_to_execute,
+        solids_to_execute=external_pipeline.solids_to_execute,
         step_keys_to_execute=execution_plan_snapshot.step_keys_to_execute,
         solid_selection=solid_selection,
         status=None,
         root_run_id=None,
         parent_run_id=None,
         tags=tags,
-        pipeline_snapshot=external_pipeline_subset.pipeline_snapshot,
+        pipeline_snapshot=external_pipeline.pipeline_snapshot,
         execution_plan_snapshot=execution_plan_snapshot,
-        parent_pipeline_snapshot=external_pipeline_subset.parent_pipeline_snapshot,
-        external_pipeline_origin=external_pipeline_subset.get_external_origin(),
+        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
     )
 

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -128,11 +128,29 @@ class RepositoryLocation(AbstractContextManager):
     ) -> ExternalExecutionPlan:
         pass
 
+    def get_external_pipeline(self, selector: PipelineSelector) -> ExternalPipeline:
+        """Return the ExternalPipeline for a specific pipeline. Subclasses only
+        need to implement get_subset_external_pipeline_result to handle the case where
+        a solid selection is specified, which requires access to the underlying PipelineDefinition
+        to generate the subsetted pipeline snapshot."""
+        if not selector.solid_selection:
+            return self.get_repository(selector.repository_name).get_full_external_pipeline(
+                selector.pipeline_name
+            )
+
+        repo_handle = self.get_repository(selector.repository_name).handle
+
+        return ExternalPipeline(
+            self.get_subset_external_pipeline_result(selector).external_pipeline_data, repo_handle
+        )
+
     @abstractmethod
     def get_subset_external_pipeline_result(
         self, selector: PipelineSelector
     ) -> ExternalPipelineSubsetResult:
-        pass
+        """Returns a snapshot about an ExternalPipeline with a solid selection, which requires
+        access to the underlying PipelineDefinition. Callsites should likely use
+        `get_external_pipeline` instead."""
 
     @abstractmethod
     def get_external_partition_config(

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -8,7 +8,7 @@ from dagster import check, seven
 from dagster.core.definitions.run_request import JobType
 from dagster.core.definitions.sensor_definition import SensorExecutionData
 from dagster.core.errors import DagsterError
-from dagster.core.host_representation import ExternalPipeline, PipelineSelector
+from dagster.core.host_representation import PipelineSelector
 from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobStatus, JobTickData, JobTickStatus, SensorJobData
 from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus, PipelineRunsFilter
@@ -330,13 +330,7 @@ def _evaluate_sensor(
             pipeline_name=target_data.pipeline_name,
             solid_selection=target_data.solid_selection,
         )
-        subset_pipeline_result = repo_location.get_subset_external_pipeline_result(
-            pipeline_selector
-        )
-        external_pipeline = ExternalPipeline(
-            subset_pipeline_result.external_pipeline_data,
-            external_repo.handle,
-        )
+        external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
         run = _get_or_create_sensor_run(
             context,
             instance,

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -6,7 +6,7 @@ import time
 import pendulum
 from dagster import check
 from dagster.core.errors import DagsterUserCodeUnreachableError
-from dagster.core.host_representation import ExternalPipeline, PipelineSelector, RepositoryLocation
+from dagster.core.host_representation import PipelineSelector, RepositoryLocation
 from dagster.core.instance import DagsterInstance
 from dagster.core.scheduler.job import JobState, JobStatus, JobTickData, JobTickStatus, JobType
 from dagster.core.scheduler.scheduler import DEFAULT_MAX_CATCHUP_RUNS, DagsterSchedulerError
@@ -324,11 +324,7 @@ def _schedule_runs_at_time(
         solid_selection=external_schedule.solid_selection,
     )
 
-    subset_pipeline_result = repo_location.get_subset_external_pipeline_result(pipeline_selector)
-    external_pipeline = ExternalPipeline(
-        subset_pipeline_result.external_pipeline_data,
-        external_repo.handle,
-    )
+    external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
 
     schedule_execution_data = repo_location.get_external_schedule_execution_data(
         instance=instance,

--- a/python_modules/dagster/dagster/utils/external.py
+++ b/python_modules/dagster/dagster/utils/external.py
@@ -1,5 +1,5 @@
 from dagster import check
-from dagster.core.host_representation import ExternalPipeline, RepositoryLocation
+from dagster.core.host_representation import RepositoryLocation
 from dagster.core.host_representation.origin import ExternalPipelineOrigin
 from dagster.core.host_representation.selector import PipelineSelector
 
@@ -26,9 +26,4 @@ def external_pipeline_from_location(repo_location, external_pipeline_origin, sol
         solid_selection=solid_selection,
     )
 
-    subset_pipeline_result = repo_location.get_subset_external_pipeline_result(pipeline_selector)
-    external_pipeline = ExternalPipeline(
-        subset_pipeline_result.external_pipeline_data,
-        external_repo.handle,
-    )
-    return external_pipeline
+    return repo_location.get_external_pipeline(pipeline_selector)


### PR DESCRIPTION
Summary:
This adds a new repo location method that, in the common case where there is no solid selection, uses the already loaded full external pipeline rather than calling out to gRPC.

Test Plan: BK