### PR TITLE
[dagit] Use timer icon for elapsed times

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunDetails.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.test.tsx
@@ -120,7 +120,7 @@ describe('RunDetails', () => {
     await waitFor(() => {
       expect(screen.getByRole('row', {name: /started feb 17, 6:24:30 am/i})).toBeVisible();
       expect(screen.getByRole('row', {name: /ended feb 17, 6:25:16 am/i})).toBeVisible();
-      expect(screen.getByRole('row', {name: /duration schedule 0:00:46/i})).toBeVisible();
+      expect(screen.getByRole('row', {name: /duration timer 0:00:46/i})).toBeVisible();
     });
   });
 
@@ -149,7 +149,7 @@ describe('RunDetails', () => {
       jest.runTimersToTime(5000);
       expect(screen.getByRole('row', {name: /started feb 17, 6:24:30 am/i})).toBeVisible();
       expect(screen.getByRole('row', {name: /ended canceling/i})).toBeVisible();
-      expect(screen.getByRole('row', {name: /duration schedule 0:01:01/i})).toBeVisible();
+      expect(screen.getByRole('row', {name: /duration timer 0:01:01/i})).toBeVisible();
     });
   });
 
@@ -163,7 +163,7 @@ describe('RunDetails', () => {
     await waitFor(() => {
       expect(screen.getByRole('row', {name: /started feb 17, 6:24:30 am/i})).toBeVisible();
       expect(screen.getByRole('row', {name: /ended feb 17, 6:25:16 am/i})).toBeVisible();
-      expect(screen.getByRole('row', {name: /duration schedule 0:00:46/i})).toBeVisible();
+      expect(screen.getByRole('row', {name: /duration timer 0:00:46/i})).toBeVisible();
     });
   });
 
@@ -205,7 +205,7 @@ describe('RunDetails', () => {
     await waitFor(() => {
       expect(screen.getByRole('row', {name: /started feb 17, 6:24:30 am/i})).toBeVisible();
       expect(screen.getByRole('row', {name: /ended started…/i})).toBeVisible();
-      expect(screen.getByRole('row', {name: /duration schedule 0:01:01/i})).toBeVisible();
+      expect(screen.getByRole('row', {name: /duration timer 0:01:01/i})).toBeVisible();
     });
   });
 
@@ -219,7 +219,7 @@ describe('RunDetails', () => {
     await waitFor(() => {
       expect(screen.getByRole('row', {name: /started feb 17, 6:24:30 am/i})).toBeVisible();
       expect(screen.getByRole('row', {name: /ended starting…/i})).toBeVisible();
-      expect(screen.getByRole('row', {name: /duration schedule 0:01:01/i})).toBeVisible();
+      expect(screen.getByRole('row', {name: /duration timer 0:01:01/i})).toBeVisible();
     });
   });
 
@@ -247,7 +247,7 @@ describe('RunDetails', () => {
     await waitFor(() => {
       expect(screen.getByRole('row', {name: /started feb 17, 6:24:30 am/i})).toBeVisible();
       expect(screen.getByRole('row', {name: /ended feb 17, 6:25:16 am/i})).toBeVisible();
-      expect(screen.getByRole('row', {name: /duration schedule 0:00:46/i})).toBeVisible();
+      expect(screen.getByRole('row', {name: /duration timer 0:00:46/i})).toBeVisible();
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/runs/TimeElapsed.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TimeElapsed.tsx
@@ -44,7 +44,7 @@ export const TimeElapsed = (props: Props) => {
 
   return (
     <Group direction="row" spacing={4} alignItems="center">
-      <IconWIP name="schedule" color={ColorsWIP.Gray400} />
+      <IconWIP name="timer" color={ColorsWIP.Gray400} />
       <span style={{fontVariantNumeric: 'tabular-nums'}}>
         {startTime ? formatElapsedTime((endTime || Date.now()) - startTime) : ''}
       </span>


### PR DESCRIPTION
## Summary

Use `timer` instead of `schedule` to better disambiguate what these values mean.

## Test Plan

View Instance Overview and Runs page.
