### PR TITLE
[RFC] execute_in_process input values

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -603,6 +603,7 @@ class PendingNodeInvocation:
         instance: Optional["DagsterInstance"] = None,
         resources: Optional[Dict[str, Any]] = None,
         raise_on_error: bool = True,
+        input_values: Optional[Dict[str, Any]] = None,
     ) -> "ExecuteInProcessResult":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -75,6 +75,7 @@ class JobDefinition(PipelineDefinition):
         partition_key: Optional[str] = None,
         raise_on_error: bool = True,
         op_selection: Optional[List[str]] = None,
+        input_values: Optional[Dict[str, Any]] = None,
     ) -> "ExecuteInProcessResult":
         """
         Execute the Job in-process, gathering results in-memory.


### PR DESCRIPTION
Add input values to execute_in_process. If the top level graph/job has inputs, previously, you would provide them by using config, which is cumbersome in most scenarios. This adds an argument which allows them to be added more conveniently. 

It does have weird collisions with config unfortunately, which are mapped out in the errors. If you provide input config, or any config mapping, then providing input values becomes difficult.