### PR TITLE
improve scheduler error recovery when the user code is unreachable

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
@@ -1,6 +1,6 @@
 import time
 
-import grpc
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster_graphql import ShutdownRepositoryLocationStatus
 
 from ..graphql.graphql_context_test_suite import (
@@ -28,7 +28,7 @@ class TestShutdownRepositoryLocation(
         while time.time() - start_time < 15:
             try:
                 origin.create_client().heartbeat()
-            except grpc._channel._InactiveRpcError:  # pylint:disable=protected-access
+            except DagsterUserCodeUnreachableError:
                 # Shutdown succeeded
                 return
             time.sleep(1)

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -370,7 +370,7 @@ class SensorDefinition:
         target_names = [target.pipeline_name for target in self._targets]
 
         if run_requests and not self._targets:
-            raise DagsterInvariantViolationError(
+            raise Exception(
                 f"Error in sensor {self._name}: Sensor evaluation function returned a RunRequest "
                 "for a sensor without a specified target. Targets can be specified by providing "
                 "a job or pipeline_name."
@@ -378,12 +378,12 @@ class SensorDefinition:
 
         for run_request in run_requests:
             if run_request.job_name is None and has_multiple_targets:
-                raise DagsterInvariantViolationError(
+                raise Exception(
                     f"Error in sensor {self._name}: Sensor returned a RunRequest that did not "
                     f"specify job_name for the requested run. Expected one of: {target_names}"
                 )
             elif run_request.job_name and run_request.job_name not in target_names:
-                raise DagsterInvariantViolationError(
+                raise Exception(
                     f"Error in sensor {self._name}: Sensor returned a RunRequest with job_name "
                     f"{run_request.job_name}. Expected one of: {target_names}"
                 )
@@ -457,7 +457,7 @@ def wrap_sensor_evaluation(
             yield result
 
         elif result is not None:
-            raise DagsterInvariantViolationError(
+            raise Exception(
                 (
                     "Error in sensor {sensor_name}: Sensor unexpectedly returned output "
                     "{result} of type {type_}.  Should only return SkipReason or "

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -362,6 +362,10 @@ class DagsterSubprocessError(DagsterError):
         super(DagsterSubprocessError, self).__init__(*args, **kwargs)
 
 
+class DagsterUserCodeUnreachableError(DagsterError):
+    """Dagster was unable to reach a user code server to fetch information about user code."""
+
+
 class DagsterUserCodeProcessError(DagsterError):
     """An exception has occurred in a user code process that the host process raising this error
     was communicating with."""

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -5,10 +5,9 @@ from collections import namedtuple
 from contextlib import contextmanager
 from typing import Set
 
-import grpc
 from dagster import check
 from dagster.core.definitions.reconstructable import ReconstructableRepository
-from dagster.core.errors import DagsterInvariantViolationError
+from dagster.core.errors import DagsterInvariantViolationError, DagsterUserCodeUnreachableError
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.serdes import DefaultNamedTupleSerializer, create_snapshot_id, whitelist_for_serdes
 
@@ -291,7 +290,7 @@ class GrpcServerRepositoryLocationOrigin(
     def shutdown_server(self):
         try:
             self.create_client().shutdown_server()
-        except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+        except DagsterUserCodeUnreachableError:
             # Server already shutdown
             pass
 

--- a/python_modules/dagster/dagster/core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/core/launcher/default_run_launcher.py
@@ -1,8 +1,11 @@
 import time
 
-import grpc
 from dagster import Bool, Field, check, seven
-from dagster.core.errors import DagsterInvariantViolationError, DagsterLaunchFailedError
+from dagster.core.errors import (
+    DagsterInvariantViolationError,
+    DagsterLaunchFailedError,
+    DagsterUserCodeUnreachableError,
+)
 from dagster.core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
 from dagster.core.host_representation.repository_location import GrpcServerRepositoryLocation
 from dagster.core.storage.pipeline_run import PipelineRun
@@ -144,7 +147,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
             res = deserialize_json_to_dagster_namedtuple(
                 client.can_cancel_execution(CanCancelExecutionRequest(run_id=run_id), timeout=5)
             )
-        except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+        except DagsterUserCodeUnreachableError:
             # Server that created the run may no longer exist
             return False
 

--- a/python_modules/dagster/dagster/core/scheduler/__init__.py
+++ b/python_modules/dagster/dagster/core/scheduler/__init__.py
@@ -7,7 +7,6 @@ from .execution import (
 from .scheduler import (
     DagsterDaemonScheduler,
     DagsterScheduleDoesNotExist,
-    DagsterScheduleReconciliationError,
     DagsterSchedulerError,
     Scheduler,
     SchedulerDebugInfo,

--- a/python_modules/dagster/dagster/core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/core/scheduler/scheduler.py
@@ -19,28 +19,6 @@ class DagsterSchedulerError(DagsterError):
     """Base class for all Dagster Scheduler errors"""
 
 
-class DagsterScheduleReconciliationError(DagsterError):
-    """Error raised during schedule state reconcilation. During reconcilation, exceptions that are
-    raised when trying to start or stop a schedule are collected and passed to this wrapper exception.
-    The individual exceptions can be accessed by the `errors` property."""
-
-    def __init__(self, preamble, errors, *args, **kwargs):
-        self.errors = errors
-
-        error_msg = preamble
-        error_messages = []
-        for i_error, error in enumerate(self.errors):
-            error_messages.append(str(error))
-            error_msg += "\n    Error {i_error}: {error_message}".format(
-                i_error=i_error + 1, error_message=str(error)
-            )
-
-        self.message = error_msg
-        self.error_messages = error_messages
-
-        super(DagsterScheduleReconciliationError, self).__init__(error_msg, *args, **kwargs)
-
-
 class DagsterScheduleDoesNotExist(DagsterSchedulerError):
     """Errors raised when ending a job for a schedule."""
 

--- a/python_modules/dagster/dagster/grpc/client.py
+++ b/python_modules/dagster/dagster/grpc/client.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import grpc
 from dagster import check, seven
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.core.events import EngineEventData
 from dagster.core.host_representation.origin import ExternalRepositoryOrigin
 from dagster.core.instance import DagsterInstance
@@ -44,7 +45,7 @@ def client_heartbeat_thread(client, shutdown_event):
 
         try:
             client.heartbeat("ping")
-        except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+        except DagsterUserCodeUnreachableError:
             continue
 
 
@@ -98,17 +99,22 @@ class DagsterGrpcClient:
             yield channel
 
     def _query(self, method, request_type, timeout=DEFAULT_GRPC_TIMEOUT, **kwargs):
-        with self._channel() as channel:
-            stub = DagsterApiStub(channel)
-            response = getattr(stub, method)(request_type(**kwargs), timeout=timeout)
-        # TODO need error handling here
-        return response
+        try:
+            with self._channel() as channel:
+                stub = DagsterApiStub(channel)
+                response = getattr(stub, method)(request_type(**kwargs), timeout=timeout)
+            return response
+        except Exception as e:
+            raise DagsterUserCodeUnreachableError("Could not reach user code server") from e
 
     def _streaming_query(self, method, request_type, timeout=DEFAULT_GRPC_TIMEOUT, **kwargs):
-        with self._channel() as channel:
-            stub = DagsterApiStub(channel)
-            response_stream = getattr(stub, method)(request_type(**kwargs), timeout=timeout)
-            yield from response_stream
+        try:
+            with self._channel() as channel:
+                stub = DagsterApiStub(channel)
+                response_stream = getattr(stub, method)(request_type(**kwargs), timeout=timeout)
+                yield from response_stream
+        except Exception as e:
+            raise DagsterUserCodeUnreachableError("Could not reach user code server") from e
 
     def ping(self, echo):
         check.str_param(echo, "echo")
@@ -401,7 +407,7 @@ class EphemeralDagsterGrpcClient(DagsterGrpcClient):
             if self._server_process.poll() is None:
                 try:
                     self.shutdown_server()
-                except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+                except DagsterUserCodeUnreachableError:
                     pass
             self._server_process = None
 

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -17,6 +17,7 @@ from dagster.core.definitions.reconstructable import (
     ReconstructableRepository,
     repository_def_from_target_def,
 )
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.core.host_representation.external_data import external_repository_data_from_def
 from dagster.core.host_representation.origin import ExternalPipelineOrigin, ExternalRepositoryOrigin
 from dagster.core.instance import DagsterInstance
@@ -936,7 +937,7 @@ def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60):
         try:
             client.ping("")
             return
-        except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+        except DagsterUserCodeUnreachableError:
             last_error = serializable_error_info_from_exc_info(sys.exc_info())
 
         if time.time() - start_time > timeout:

--- a/python_modules/dagster/dagster/grpc/server_watcher.py
+++ b/python_modules/dagster/dagster/grpc/server_watcher.py
@@ -1,7 +1,7 @@
 import threading
 
-import grpc
 from dagster import check
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.grpc.client import DagsterGrpcClient
 
 WATCH_INTERVAL = 1
@@ -108,7 +108,7 @@ def watch_grpc_server_thread(
                     on_updated(location_name, new_server_id)
                     set_server_id(new_server_id)
                     return
-            except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+            except DagsterUserCodeUnreachableError:
                 attempts += 1
 
             if attempts >= max_reconnect_attempts and not has_error():
@@ -120,7 +120,7 @@ def watch_grpc_server_thread(
             break
         try:
             watch_for_changes()
-        except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+        except DagsterUserCodeUnreachableError:
             on_disconnect(location_name)
             reconnect_loop()
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -1,10 +1,10 @@
 from contextlib import ExitStack
 
-import grpc
 import pytest
 import yaml
 from dagster import seven
 from dagster.check import CheckError
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.core.host_representation import GrpcServerRepositoryLocationOrigin
 from dagster.core.test_utils import environ
 from dagster.core.workspace.load import location_origins_from_config
@@ -137,7 +137,7 @@ def test_ssl_grpc_server_workspace():
             try:
                 with origin.create_location():
                     assert False
-            except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+            except DagsterUserCodeUnreachableError:
                 pass
 
     finally:

--- a/python_modules/dagster/dagster_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/conftest.py
@@ -5,9 +5,9 @@ import time
 from contextlib import contextmanager
 
 import docker
-import grpc
 import pytest
 from dagster import check, seven
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.grpc.client import DagsterGrpcClient
 from dagster.seven import nullcontext
 from dagster.utils import file_relative_path
@@ -61,7 +61,7 @@ def wait_for_connection(host, port):
         try:
             if DagsterGrpcClient(host=host, port=port).ping("ready") == "ready":
                 return True
-        except grpc.RpcError:
+        except DagsterUserCodeUnreachableError:
             pass
 
         time.sleep(0.2)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -366,7 +366,7 @@ def validate_tick(
     if expected_run_ids is not None:
         assert set(tick_data.run_ids) == set(expected_run_ids)
     if expected_error:
-        assert expected_error in tick_data.error.message
+        assert expected_error in str(tick_data.error)
 
 
 def validate_run_started(run, expected_success=True):

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -5,6 +5,7 @@ import uuid
 
 import pytest
 from dagster import seven
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.core.host_representation.origin import (
     ExternalRepositoryOrigin,
     GrpcServerRepositoryLocationOrigin,
@@ -442,7 +443,7 @@ def test_sensor_timeout():
                 ),
                 repository_name="bar_repo",
             )
-            with pytest.raises(Exception, match="Deadline Exceeded"):
+            with pytest.raises(DagsterUserCodeUnreachableError) as exc_info:
                 client.external_sensor_execution(
                     sensor_execution_args=SensorExecutionArgs(
                         repository_origin=repo_origin,
@@ -454,6 +455,8 @@ def test_sensor_timeout():
                     ),
                     timeout=2,
                 )
+
+            assert "Deadline Exceeded" in str(exc_info.getrepr())
 
             # Call succeeds without the timeout
             client.external_sensor_execution(

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_server.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_server.py
@@ -1,7 +1,7 @@
 import threading
 import time
 
-import grpc
+from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.grpc.client import ephemeral_grpc_api_client
 
 
@@ -28,7 +28,7 @@ def test_streaming_terminate():
 
         try:
             api_client.shutdown_server()
-        except grpc._channel._InactiveRpcError:  # pylint: disable=protected-access
+        except DagsterUserCodeUnreachableError:
             # shutting down sometimes happens so fast that it terminates the calling RPC
             pass
 


### PR DESCRIPTION
Raises a new exception when the gRPC server (or more abstractly the 'user code') is inaccessible. When a scheduler tick fails due to such an error, it patiently waits for the user code to be accessible again, rather than always failing the tick and moving on.