### PR TITLE
Fix bug in assetNode.dependedBy caused by inputName collisions, add test

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -562,7 +562,7 @@ def external_asset_graph_from_defs(
     ] = defaultdict(list)
 
     deps: Dict[AssetKey, Dict[str, ExternalAssetDependency]] = defaultdict(dict)
-    dep_by: Dict[AssetKey, Dict[str, ExternalAssetDependedBy]] = defaultdict(dict)
+    dep_by: Dict[AssetKey, List[ExternalAssetDependedBy]] = defaultdict(list)
     all_upstream_asset_keys = set()
 
     for pipeline in pipelines:
@@ -585,9 +585,11 @@ def external_asset_graph_from_defs(
                             upstream_asset_key=upstream_asset_key,
                             input_name=input_def.name,
                         )
-                        dep_by[upstream_asset_key][input_def.name] = ExternalAssetDependedBy(
-                            downstream_asset_key=node_asset_key,
-                            input_name=input_def.name,
+                        dep_by[upstream_asset_key].append(
+                            ExternalAssetDependedBy(
+                                downstream_asset_key=node_asset_key,
+                                input_name=input_def.name,
+                            )
                         )
 
     asset_keys_without_definitions = all_upstream_asset_keys.difference(
@@ -598,7 +600,7 @@ def external_asset_graph_from_defs(
         ExternalAssetNode(
             asset_key=asset_key,
             dependencies=list(deps[asset_key].values()),
-            depended_by=list(dep_by[asset_key].values()),
+            depended_by=dep_by[asset_key],
             job_names=[],
         )
         for asset_key in asset_keys_without_definitions
@@ -615,7 +617,7 @@ def external_asset_graph_from_defs(
             ExternalAssetNode(
                 asset_key=foreign_asset.key,
                 dependencies=list(deps[foreign_asset.key].values()),
-                depended_by=list(dep_by[foreign_asset.key].values()),
+                depended_by=dep_by[foreign_asset.key],
                 job_names=[],
                 op_description=foreign_asset.description,
             )
@@ -649,7 +651,7 @@ def external_asset_graph_from_defs(
             ExternalAssetNode(
                 asset_key=asset_key,
                 dependencies=list(deps[asset_key].values()),
-                depended_by=list(dep_by[asset_key].values()),
+                depended_by=dep_by[asset_key],
                 op_name=node_def.name,
                 op_description=node_def.description,
                 job_names=job_names,


### PR DESCRIPTION
## Summary
This one was my fault - when I optimized the performance of the `dependedBy` resolver, I copied the code for the `dependencies` pre-calculation but it was uniqued on inputName. Uniquing downstream assets on `inputName` causes 1:N relationships between assets to be de-duped. 

I added a failing test case and a fix - this is only noticeable on the Asset Neighbors graph but causes only a single downstream node to appear when many should.


## Test Plan
New test case!




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.