### PR TITLE
add queries to telemetry whitelist

### DIFF
--- a/js_modules/dagit/packages/app/src/telemetryLink.tsx
+++ b/js_modules/dagit/packages/app/src/telemetryLink.tsx
@@ -2,7 +2,9 @@ import {ApolloLink} from '@apollo/client';
 import {TelemetryAction, logTelemetry} from '@dagit/core/app/Telemetry';
 
 const TELEMETRY_WHITELIST = new Set([
+  'PipelineExplorerRootQuery',
   'PipelineRunsRootQuery',
+  'RunRootQuery',
   'RunsRootQuery',
   'ScheduleRootQuery',
   'SensorRootQuery',


### PR DESCRIPTION
Want to add telemetry to the run page and the job explorer page


## Test Plan
BK
