### PR TITLE
chore(logging): configure daemon/grpc loggers on initialization

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import threading
@@ -15,7 +16,7 @@ from dagster.cli.workspace.cli_target import WORKSPACE_TARGET_WARNING
 from dagster.core.telemetry import START_DAGIT_WEBSERVER, log_action
 from dagster.core.workspace import WorkspaceProcessContext
 from dagster.utils import DEFAULT_WORKSPACE_YAML_FILENAME
-from dagster.utils.log import default_system_logger
+from dagster.utils.log import configure_loggers
 from gevent import pywsgi
 from geventwebsocket.handler import WebSocketHandler
 
@@ -186,7 +187,8 @@ def uploading_logging_thread():
 def start_server(instance, host, port, path_prefix, app, port_lookup, port_lookup_attempts=0):
     server = pywsgi.WSGIServer((host, port), app, handler_class=WebSocketHandler)
 
-    logger = default_system_logger("dagit")
+    configure_loggers()
+    logger = logging.getLogger("dagit")
 
     logger.info(
         "Serving dagit on http://{host}:{port}{path_prefix} in process {pid}".format(

--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -22,7 +23,7 @@ from dagster.serdes import deserialize_as, serialize_dagster_namedtuple
 from dagster.seven import nullcontext
 from dagster.utils.hosted_user_process import recon_pipeline_from_origin
 from dagster.utils.interrupts import capture_interrupts
-from dagster.utils.log import default_system_logger
+from dagster.utils.log import configure_loggers
 
 
 @click.group(name="api")
@@ -406,7 +407,8 @@ def grpc_command(
     if not (port or socket and not (port and socket)):
         raise click.UsageError("You must pass one and only one of --port/-p or --socket/-s.")
 
-    logger = default_system_logger("dagster-code-server", coerce_valid_log_level(log_level))
+    configure_loggers(log_level=coerce_valid_log_level(log_level))
+    logger = logging.getLogger("dagster.code_server")
 
     loadable_target_origin = None
     if any(

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -28,6 +28,7 @@ from dagster.serdes import ConfigurableClass
 from dagster.seven.compat.pendulum import create_pendulum_time, mock_pendulum_timezone
 from dagster.utils import Counter, merge_dicts, traced, traced_counter
 from dagster.utils.error import serializable_error_info_from_exc_info
+from dagster.utils.log import configure_loggers
 
 
 def step_output_event_filter(pipe_iterator):
@@ -439,6 +440,7 @@ def in_process_test_workspace(instance, recon_repo):
 @contextmanager
 def create_test_daemon_workspace():
     """Creates a DynamicWorkspace suitable for passing into a DagsterDaemon loop when running tests."""
+    configure_loggers()
     with create_daemon_grpc_server_registry() as grpc_server_registry:
         with DynamicWorkspace(grpc_server_registry) as workspace:
             yield workspace

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 from abc import abstractclassmethod, abstractmethod
@@ -14,11 +15,10 @@ from dagster.daemon.sensor import execute_sensor_iteration_loop
 from dagster.daemon.types import DaemonHeartbeat
 from dagster.scheduler.scheduler import execute_scheduler_iteration_loop
 from dagster.utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
-from dagster.utils.log import default_system_logger
 
 
 def get_default_daemon_logger(daemon_name):
-    return default_system_logger(daemon_name)
+    return logging.getLogger(f"dagster.daemon.{daemon_name}")
 
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -72,9 +72,9 @@ def test_simple(external_repo_context, capfd):
         backfill = instance.get_backfill("simple")
         assert backfill.status == BulkActionStatus.COMPLETED
         assert (
-            get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
+            get_logger_output_from_capfd(capfd, "dagster.daemon.BackfillDaemon")
+            == """2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Starting backfill for simple
+2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
 
@@ -110,8 +110,8 @@ def test_before_submit(external_repo_context, crash_signal, capfd):
         launch_process.join(timeout=60)
         assert launch_process.exitcode != 0
         assert (
-            get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple"""
+            get_logger_output_from_capfd(capfd, "dagster.daemon.BackfillDaemon")
+            == """2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Starting backfill for simple"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -126,9 +126,9 @@ def test_before_submit(external_repo_context, crash_signal, capfd):
         launch_process.start()
         launch_process.join(timeout=60)
         assert (
-            get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
+            get_logger_output_from_capfd(capfd, "dagster.daemon.BackfillDaemon")
+            == """2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Starting backfill for simple
+2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -168,8 +168,8 @@ def test_crash_after_submit(external_repo_context, crash_signal, capfd):
         launch_process.join(timeout=60)
         assert launch_process.exitcode != 0
         assert (
-            get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple"""
+            get_logger_output_from_capfd(capfd, "dagster.daemon.BackfillDaemon")
+            == """2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Starting backfill for simple"""
         )
 
         backfill = instance.get_backfill("simple")
@@ -184,10 +184,10 @@ def test_crash_after_submit(external_repo_context, crash_signal, capfd):
         launch_process.start()
         launch_process.join(timeout=60)
         assert (
-            get_logger_output_from_capfd(capfd, "BackfillDaemon")
-            == """2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Starting backfill for simple
-2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Found 3 existing runs for backfill simple, skipping
-2021-02-16 18:00:00 -0600 - BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
+            get_logger_output_from_capfd(capfd, "dagster.daemon.BackfillDaemon")
+            == """2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Starting backfill for simple
+2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Found 3 existing runs for backfill simple, skipping
+2021-02-16 18:00:00 -0600 - dagster.daemon.BackfillDaemon - INFO - Backfill completed for simple for 3 partitions"""
         )
 
         backfill = instance.get_backfill("simple")

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
@@ -49,7 +49,7 @@ def _scheduler_ran(caplog):
         logger_name, _level, text = log_tuple
 
         if (
-            logger_name == "SchedulerDaemon"
+            logger_name == "dagster.daemon.SchedulerDaemon"
             and "Not checking for any runs since no schedules have been started." in text
         ):
             count = count + 1
@@ -62,7 +62,10 @@ def _run_coordinator_ran(caplog):
     for log_tuple in caplog.record_tuples:
         logger_name, _level, text = log_tuple
 
-        if logger_name == "QueuedRunCoordinatorDaemon" and "Poll returned no queued runs." in text:
+        if (
+            logger_name == "dagster.daemon.QueuedRunCoordinatorDaemon"
+            and "Poll returned no queued runs." in text
+        ):
             count = count + 1
 
     return count
@@ -74,7 +77,7 @@ def _sensor_ran(caplog):
         logger_name, _level, text = log_tuple
 
         if (
-            logger_name == "SensorDaemon"
+            logger_name == "dagster.daemon.SensorDaemon"
             and "Not checking for any runs since no sensors have been started." in text
         ):
             count = count + 1

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -107,10 +107,10 @@ def test_failure_before_run_created(external_repo_context, crash_location, crash
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
             assert (
-                get_logger_output_from_capfd(capfd, "SensorDaemon")
-                == f"""2019-02-27 18:01:03 -0600 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 18:01:03 -0600 - SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:01:03 -0600 - SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SensorDaemon")
+                == f"""2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
+2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Launching run for simple_sensor
+2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
             )
 
             ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -448,9 +448,9 @@ def test_simple_sensor(external_repo_context, capfd):
             )
 
             assert (
-                get_logger_output_from_capfd(capfd, "SensorDaemon")
-                == """2019-02-27 17:59:59 -0600 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 17:59:59 -0600 - SensorDaemon - INFO - No run requests returned for simple_sensor, skipping"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SensorDaemon")
+                == """2019-02-27 17:59:59 -0600 - dagster.daemon.SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
+2019-02-27 17:59:59 -0600 - dagster.daemon.SensorDaemon - INFO - No run requests returned for simple_sensor, skipping"""
             )
 
             freeze_datetime = freeze_datetime.add(seconds=30)
@@ -476,10 +476,10 @@ def test_simple_sensor(external_repo_context, capfd):
             )
 
             assert (
-                get_logger_output_from_capfd(capfd, "SensorDaemon")
-                == """2019-02-27 18:00:29 -0600 - SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
-2019-02-27 18:00:29 -0600 - SensorDaemon - INFO - Launching run for simple_sensor
-2019-02-27 18:00:29 -0600 - SensorDaemon - INFO - Completed launch of run {run_id} for simple_sensor""".format(
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SensorDaemon")
+                == """2019-02-27 18:00:29 -0600 - dagster.daemon.SensorDaemon - INFO - Checking for new runs for sensor: simple_sensor
+2019-02-27 18:00:29 -0600 - dagster.daemon.SensorDaemon - INFO - Launching run for simple_sensor
+2019-02-27 18:00:29 -0600 - dagster.daemon.SensorDaemon - INFO - Completed launch of run {run_id} for simple_sensor""".format(
                     run_id=run.run_id
                 )
             )
@@ -927,7 +927,7 @@ def test_custom_interval_sensor_with_offset(external_repo_context, monkeypatch):
                 execute_sensor_iteration_loop(
                     instance,
                     workspace,
-                    get_default_daemon_logger("SensorDaemon"),
+                    get_default_daemon_logger("dagster.daemon.SensorDaemon"),
                     until=freeze_datetime.add(seconds=65).timestamp(),
                 )
             )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -82,9 +82,9 @@ def test_failure_recovery_before_run_created(
             assert scheduler_process.exitcode != 0
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000"""
             )
 
             ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
@@ -121,11 +121,11 @@ def test_failure_recovery_before_run_created(
                 [instance.get_runs()[0].run_id],
             )
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
-2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Resuming previously interrupted schedule execution at 2019-02-27 00:00:00 +0000
-2019-02-26 18:05:00 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
+2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Resuming previously interrupted schedule execution at 2019-02-27 00:00:00 +0000
+2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -567,9 +567,9 @@ def test_simple_schedule(external_repo_context, capfd):
             assert len(ticks) == 0
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - No new runs for simple_schedule"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - No new runs for simple_schedule"""
             )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
@@ -605,10 +605,10 @@ def test_simple_schedule(external_repo_context, capfd):
             )
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -667,11 +667,11 @@ def test_simple_schedule(external_repo_context, capfd):
             assert "2019-03-01" in runs_by_partition
 
             assert get_logger_output_from_capfd(
-                capfd, "SchedulerDaemon"
-            ) == """2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-01 00:00:00 +0000, 2019-03-02 00:00:00 +0000
-2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-01 18:00:03 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
+                capfd, "dagster.daemon.SchedulerDaemon"
+            ) == """2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-01 00:00:00 +0000, 2019-03-02 00:00:00 +0000
+2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
+2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1141,10 +1141,10 @@ def test_skip(external_repo_context, capfd):
             )
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: skip_schedule
-2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `skip_schedule` at 2019-02-27 00:00:00 +0000
-2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Schedule skip_schedule skipped: should_execute function for skip_schedule returned false."""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: skip_schedule
+2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `skip_schedule` at 2019-02-27 00:00:00 +0000
+2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Schedule skip_schedule skipped: should_execute function for skip_schedule returned false."""
             )
 
 
@@ -1580,12 +1580,12 @@ def test_multiple_schedules_on_different_time_ranges(external_repo_context, capf
             assert hourly_ticks[0].status == TickStatus.SUCCESS
 
             assert get_logger_output_from_capfd(
-                capfd, "SchedulerDaemon"
-            ) == """2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule""".format(
+                capfd, "dagster.daemon.SchedulerDaemon"
+            ) == """2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1605,11 +1605,11 @@ def test_multiple_schedules_on_different_time_ranges(external_repo_context, capf
             assert len([tick for tick in hourly_ticks if tick.status == TickStatus.SUCCESS]) == 2
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
-2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - No new runs for simple_schedule
-2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 01:00:00 +0000
-2019-02-27 19:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule""".format(
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
+2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - No new runs for simple_schedule
+2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 01:00:00 +0000
+2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule""".format(
                     third_run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -1660,12 +1660,12 @@ def test_launch_failure(external_repo_context, capfd):
                 [run.run_id for run in instance.get_runs()],
             )
 
-            logger_output = get_logger_output_from_capfd(capfd, "SchedulerDaemon")
+            logger_output = get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
 
             assert (
-                """2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
-2019-02-26 18:00:00 -0600 - SchedulerDaemon - ERROR - Run {run_id} created successfully but failed to launch:""".format(
+                """2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
+2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - ERROR - Run {run_id} created successfully but failed to launch:""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
                 in logger_output
@@ -1708,11 +1708,11 @@ def test_partitionless_schedule(capfd):
             )
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-03-04 00:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: partitionless_schedule
-2019-03-04 00:00:00 -0600 - SchedulerDaemon - WARNING - partitionless_schedule has no partition set, so not trying to catch up
-2019-03-04 00:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `partitionless_schedule` at 2019-03-04 00:00:00 -0600
-2019-03-04 00:00:00 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule""".format(
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: partitionless_schedule
+2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - WARNING - partitionless_schedule has no partition set, so not trying to catch up
+2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `partitionless_schedule` at 2019-03-04 00:00:00 -0600
+2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )
@@ -1780,12 +1780,12 @@ def test_max_catchup_runs(capfd):
             )
 
             assert get_logger_output_from_capfd(
-                capfd, "SchedulerDaemon"
-            ) == """2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-03-04 17:59:59 -0600 - SchedulerDaemon - WARNING - simple_schedule has fallen behind, only launching 2 runs
-2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-03 00:00:00 +0000, 2019-03-04 00:00:00 +0000
-2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-04 17:59:59 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
+                capfd, "dagster.daemon.SchedulerDaemon"
+            ) == """2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
+2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - WARNING - simple_schedule has fallen behind, only launching 2 runs
+2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-03 00:00:00 +0000, 2019-03-04 00:00:00 +0000
+2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
+2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
                 first_run_id=instance.get_runs()[1].run_id,
                 second_run_id=instance.get_runs()[0].run_id,
             )
@@ -1826,9 +1826,9 @@ def test_multi_runs(external_repo_context, capfd):
             assert len(ticks) == 0
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 17:59:59 -0600 - SchedulerDaemon - INFO - No new runs for multi_run_schedule"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
+2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - No new runs for multi_run_schedule"""
             )
 
         freeze_datetime = freeze_datetime.add(seconds=2)
@@ -1855,11 +1855,11 @@ def test_multi_runs(external_repo_context, capfd):
             validate_run_started(runs[1], execution_time=create_pendulum_time(2019, 2, 28))
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == f"""2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-27 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == f"""2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
+2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
             )
 
             # Verify idempotence
@@ -1882,11 +1882,11 @@ def test_multi_runs(external_repo_context, capfd):
             runs = instance.get_runs()
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == f"""2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-03-01 00:00:00 +0000
-2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-28 18:00:01 -0600 - SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == f"""2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
+2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-03-01 00:00:00 +0000
+2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
+2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
             )
 
 
@@ -2066,10 +2066,10 @@ def test_skip_reason_schedule(external_repo_context, capfd):
             assert len(ticks) == 1
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 18:00:00 -0600 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: empty_schedule
-2019-02-27 18:00:00 -0600 - SchedulerDaemon - INFO - Evaluating schedule `empty_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:00 -0600 - SchedulerDaemon - INFO - Schedule empty_schedule skipped: Schedule function returned an empty result"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: empty_schedule
+2019-02-27 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `empty_schedule` at 2019-02-28 00:00:00 +0000
+2019-02-27 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Schedule empty_schedule skipped: Schedule function returned an empty result"""
             )
 
             expected_datetime = create_pendulum_time(year=2019, month=2, day=28, tz="UTC")

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -52,9 +52,9 @@ def test_non_utc_timezone_run(external_repo_context, capfd):
             assert len(ticks) == 0
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 21:59:59 -0800 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 21:59:59 -0800 - SchedulerDaemon - INFO - No new runs for daily_central_time_schedule"""
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 21:59:59 -0800 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
+2019-02-27 21:59:59 -0800 - dagster.daemon.SchedulerDaemon - INFO - No new runs for daily_central_time_schedule"""
             )
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
@@ -91,10 +91,10 @@ def test_non_utc_timezone_run(external_repo_context, capfd):
             )
 
             assert (
-                get_logger_output_from_capfd(capfd, "SchedulerDaemon")
-                == """2019-02-27 22:00:01 -0800 - SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 22:00:01 -0800 - SchedulerDaemon - INFO - Evaluating schedule `daily_central_time_schedule` at 2019-02-28 00:00:00 -0600
-2019-02-27 22:00:01 -0800 - SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule""".format(
+                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
+                == """2019-02-27 22:00:01 -0800 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
+2019-02-27 22:00:01 -0800 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `daily_central_time_schedule` at 2019-02-28 00:00:00 -0600
+2019-02-27 22:00:01 -0800 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule""".format(
                     run_id=instance.get_runs()[0].run_id
                 )
             )


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Because we configure loggers just in time instead of on application initialization, libraries that import 
system level components from Dagster (e.g. the daemon) cannot override the logging format. If one attempts
to override the logging format by introducing a new handler on the root logger, the result is that you get
double logs.

To follow best practices around logging (see https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library), 
we configure the logger on application initialization. Also, we allow overrides to the logging scheme by configuring a 
null handler to allow the user to use their own logging configuration. 


## Test Plan
run locally, see logs are still formatted properly. 
Allow overrides, and see log formatting is dictated by the application code logic, rather than the library code.
pytest

<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
