### PR TITLE
remove builtin types from types concepts page

### DIFF
--- a/docs/content/concepts/types.mdx
+++ b/docs/content/concepts/types.mdx
@@ -82,35 +82,9 @@ def my_op() -> MyClass:
 
 If the op in the above example returned an object that was not an instance of MyClass, Dagster would raise an error after executing the op.
 
-## Built-in Types
+## The Nothing Type
 
-Here is a list of Dagster's built-in Dagster types. You can find code examples of each type's usage in its API Reference:
-
-- <PyObject module="dagster" object="Any" />: Use this type for any input,
-  output, or config field whose type is unconstrained.
-- <PyObject module="dagster" object="Bool" />: Use this type for any boolean
-  input, output, or config_field.
-- <PyObject module="dagster" object="Int" />: Use this type for any integer
-  input or output.
-- <PyObject module="dagster" object="Float" />: Use this type for any float
-  input, output, or config value.
-- <PyObject module="dagster" object="String" />: Use this type for any string
-  input, output, or config value.
-- <PyObject module="dagster" object="Optional" />: Use this type only for inputs
-  and outputs, if the value can also be None.
-- <PyObject module="dagster" object="List" />: Use this type for inputs, or
-  outputs.
-- <PyObject module="dagster" object="Dict" />: Use this type for inputs, or
-  outputs that are dicts.
-- <PyObject module="dagster" object="Set" />: Use this type for inputs, or
-  outputs that are sets.
-- <PyObject module="dagster" object="Tuple" />: Use this type for inputs or
-  outputs that are tuples.
-- <PyObject module="dagster" object="Nothing" />: Use this type only for inputs
-  and outputs, in order to establish an execution dependency without
-  communicating a value.
-
-  See details in the [Nothing dependencies](/concepts/ops-jobs-graphs/jobs-graphs#order-based-dependencies-nothing-dependencies) example.
+Dagster offers a special type called <PyObject object="Nothing" />, which is used when you need to model a dependency between ops where Dagster is passing no data along the edge. See details in the [Nothing dependencies](/concepts/ops-jobs-graphs/jobs-graphs#order-based-dependencies-nothing-dependencies) example.
 
 ## Testing a Dagster Type
 


### PR DESCRIPTION
Very possible I'm missing some important cases with fan-in or something, but I'm not aware of good reasons to use the built-in Dagster types, vs. just using regular Python type.

I think that including them on the concepts page makes the distinction between Dagster types and regular Python types more difficult to understand. 