### PR TITLE
[dagit] Add a Launch button to the Asset details page

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -13,6 +13,7 @@ import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
 import {Spinner} from '../ui/Spinner';
 import {useRepositoryOptions} from '../workspace/WorkspaceContext';
+import {LaunchAssetExecutionButton} from '../workspace/asset-graph/LaunchAssetExecutionButton';
 import {
   buildGraphDataFromSingleNode,
   buildLiveData,
@@ -106,9 +107,18 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
       <AssetPageHeader
         currentPath={assetKey.path}
         right={
-          <div style={{marginTop: 4}}>
-            <QueryCountdown pollInterval={5 * 1000} queryResult={queryResult} />
-          </div>
+          <Box style={{margin: '-4px 0'}} flex={{gap: 8, alignItems: 'baseline'}}>
+            <Box margin={{top: 4}}>
+              <QueryCountdown pollInterval={5 * 1000} queryResult={queryResult} />
+            </Box>
+            {definition && (
+              <LaunchAssetExecutionButton
+                assets={[definition]}
+                repoAddress={{name: repo.repository.name, location: repo.repositoryLocation.name}}
+                displayJobName
+              />
+            )}
+          </Box>
         }
       />
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -17,6 +17,7 @@ interface LaunchRootExecutionButtonProps {
   disabled: boolean;
   getVariables: () => undefined | LaunchPipelineExecutionVariables;
   pipelineName: string;
+  title?: string;
 }
 
 export const LaunchRootExecutionButton: React.FunctionComponent<LaunchRootExecutionButtonProps> = (
@@ -58,7 +59,7 @@ export const LaunchRootExecutionButton: React.FunctionComponent<LaunchRootExecut
       config={{
         icon: 'open_in_new',
         onClick: onLaunch,
-        title: 'Launch Run',
+        title: props.title || 'Launch Run',
         disabled: props.disabled || !canLaunchPipelineExecution,
         tooltip: !canLaunchPipelineExecution ? DISABLED_MESSAGE : undefined,
       }}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -50,7 +50,7 @@ export const AssetNode: React.FC<{
             onClick={() => launch(repoAddress, definition)}
             text={
               <span>
-                Launch run to build{' '}
+                Refresh{' '}
                 <span style={{fontFamily: 'monospace', fontWeight: 600}}>
                   {displayNameForAssetKey(definition.assetKey)}
                 </span>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
+import {repoAddressToSelector} from '../repoAddressToSelector';
+import {RepoAddress} from '../types';
+
+export const LaunchAssetExecutionButton: React.FC<{
+  repoAddress: RepoAddress;
+  assets: {opName: string | null; jobName: string | null}[];
+  displayJobName?: boolean;
+}> = ({repoAddress, assets, displayJobName}) => {
+  const jobName = assets[0].jobName;
+  if (!jobName || !assets.every((a) => a.jobName === jobName && a.opName)) {
+    return <span />;
+  }
+
+  return (
+    <LaunchRootExecutionButton
+      pipelineName={jobName}
+      disabled={false}
+      title={displayJobName ? `Refresh using ${jobName}` : 'Refresh'}
+      getVariables={() => ({
+        executionParams: {
+          mode: 'default',
+          executionMetadata: {},
+          runConfigData: {},
+          selector: {
+            ...repoAddressToSelector(repoAddress),
+            pipelineName: jobName,
+            solidSelection: assets.map((a) => a.opName!),
+          },
+        },
+      })}
+    />
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 import {displayNameForAssetKey} from '../../app/Util';
 import {AssetMaterializations} from '../../assets/AssetMaterializations';
-import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
 import {Description} from '../../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../../pipelines/SidebarComponents';
 import {GraphExplorerSolidHandleFragment_solid_definition} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
 import {pluginForMetadata} from '../../plugins';
 import {Box} from '../../ui/Box';
 import {ColorsWIP} from '../../ui/Colors';
-import {repoAddressToSelector} from '../repoAddressToSelector';
 import {RepoAddress} from '../types';
 
+import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {LiveDataForNode} from './Utils';
 import {AssetGraphQuery_pipelineOrError_Pipeline_assetNodes} from './types/AssetGraphQuery';
 
@@ -23,7 +22,6 @@ export const SidebarAssetInfo: React.FC<{
 }> = ({node, definition, repoAddress, liveData}) => {
   const Plugin = pluginForMetadata(definition.metadata);
   const {lastMaterialization} = liveData || {};
-  const {opName, jobName} = node;
 
   return (
     <>
@@ -34,25 +32,7 @@ export const SidebarAssetInfo: React.FC<{
             margin={{bottom: 8}}
           >
             <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
-
-            {jobName && opName && (
-              <LaunchRootExecutionButton
-                pipelineName={jobName}
-                disabled={false}
-                getVariables={() => ({
-                  executionParams: {
-                    mode: 'default',
-                    executionMetadata: {},
-                    runConfigData: {},
-                    selector: {
-                      ...repoAddressToSelector(repoAddress),
-                      pipelineName: jobName,
-                      solidSelection: [opName],
-                    },
-                  },
-                })}
-              />
-            )}
+            <LaunchAssetExecutionButton assets={[node]} repoAddress={repoAddress} />
           </Box>
           <Description description={node.description || null} />
         </Box>
@@ -81,8 +61,6 @@ export const SidebarAssetsInfo: React.FC<{
   nodes: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes[];
   repoAddress: RepoAddress;
 }> = ({nodes, repoAddress}) => {
-  const {jobName} = nodes[0];
-  const opNames = nodes.map((n) => n.opName!).filter(Boolean);
   return (
     <SidebarSection title="Definition">
       <Box padding={{vertical: 16, horizontal: 24}}>
@@ -91,24 +69,7 @@ export const SidebarAssetsInfo: React.FC<{
           margin={{bottom: 8}}
         >
           <SidebarTitle>{`${nodes.length} Assets Selected`}</SidebarTitle>
-          {jobName && (
-            <LaunchRootExecutionButton
-              pipelineName={jobName}
-              disabled={false}
-              getVariables={() => ({
-                executionParams: {
-                  mode: 'default',
-                  executionMetadata: {},
-                  runConfigData: {},
-                  selector: {
-                    ...repoAddressToSelector(repoAddress),
-                    pipelineName: jobName,
-                    solidSelection: opNames,
-                  },
-                },
-              })}
-            />
-          )}
+          <LaunchAssetExecutionButton repoAddress={repoAddress} assets={nodes} />
         </Box>
       </Box>
     </SidebarSection>


### PR DESCRIPTION


## Summary
This PR renames the asset "Launch Run" buttons to say "Refresh" and adds one to the asset details page. On the asset details page, the button specifies the name of the job it will launch. In the near future, I think we can swap this out for a dropdown.

![image](https://user-images.githubusercontent.com/1037212/146844731-8cd17f51-b476-41c6-b219-edade86ebd86.png)
![image](https://user-images.githubusercontent.com/1037212/146844715-1cfc2c98-82a3-481e-891d-44543ad73e3f.png)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.