### PR TITLE
[dagit] Display a notice when multiple repos in the workspace define the same asset

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -1,10 +1,12 @@
 import {gql, useQuery} from '@apollo/client';
 import React from 'react';
+
 import {Alert} from '../ui/Alert';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
+
 import {AssetIdScanQuery} from './types/AssetIdScanQuery';
 
 export const AssetDefinedInMultipleReposNotice: React.FC<{
@@ -27,17 +29,17 @@ export const AssetDefinedInMultipleReposNotice: React.FC<{
 
   return (
     <Box
-      padding={{vertical: 16, horizontal: 24}}
+      padding={{vertical: 16, left: 24, right: 12}}
       border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
     >
       <Alert
         intent="info"
-        title={`Multiple assets with this name are loaded in your workspace. Showing the definition from ${buildRepoPath(
+        title={`Multiple repositories in your workspace include assets with this name. Showing the definition from ${buildRepoPath(
           loadedFromRepo.name,
           loadedFromRepo.location,
         )} below. (Also found in ${otherRepos
           .map((o) => buildRepoPath(o.name, o.location.name))
-          .join(', ')}). You may want to consider renaming an asset if they are separate entities.`}
+          .join(', ')}). You may want to consider renaming to avoid collisions.`}
       />
     </Box>
   );
@@ -49,8 +51,10 @@ const ASSET_ID_SCAN_QUERY = gql`
       __typename
       ... on RepositoryConnection {
         nodes {
+          id
           name
           location {
+            id
             name
           }
           assetNodes {

--- a/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetDefinedInMultipleReposNotice.tsx
@@ -1,0 +1,63 @@
+import {gql, useQuery} from '@apollo/client';
+import React from 'react';
+import {Alert} from '../ui/Alert';
+import {Box} from '../ui/Box';
+import {ColorsWIP} from '../ui/Colors';
+import {buildRepoPath} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
+import {AssetIdScanQuery} from './types/AssetIdScanQuery';
+
+export const AssetDefinedInMultipleReposNotice: React.FC<{
+  assetId: string;
+  loadedFromRepo: RepoAddress;
+}> = ({assetId, loadedFromRepo}) => {
+  const {data} = useQuery<AssetIdScanQuery>(ASSET_ID_SCAN_QUERY);
+  const otherRepos =
+    data?.repositoriesOrError.__typename === 'RepositoryConnection'
+      ? data.repositoriesOrError.nodes.filter(
+          (n) =>
+            (n.name !== loadedFromRepo.name || n.location.name !== loadedFromRepo.location) &&
+            n.assetNodes.some((n) => n.id === assetId),
+        )
+      : [];
+
+  if (otherRepos.length === 0) {
+    return <span />;
+  }
+
+  return (
+    <Box
+      padding={{vertical: 16, horizontal: 24}}
+      border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
+    >
+      <Alert
+        intent="info"
+        title={`Multiple assets with this name are loaded in your workspace. Showing the definition from ${buildRepoPath(
+          loadedFromRepo.name,
+          loadedFromRepo.location,
+        )} below. (Also found in ${otherRepos
+          .map((o) => buildRepoPath(o.name, o.location.name))
+          .join(', ')}). You may want to consider renaming an asset if they are separate entities.`}
+      />
+    </Box>
+  );
+};
+
+const ASSET_ID_SCAN_QUERY = gql`
+  query AssetIdScanQuery {
+    repositoriesOrError {
+      __typename
+      ... on RepositoryConnection {
+        nodes {
+          name
+          location {
+            name
+          }
+          assetNodes {
+            id
+          }
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -17,9 +17,9 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
+import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNotice';
 import {AssetNodeList} from './AssetNodeList';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
-import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNotice';
 
 export const AssetNodeDefinition: React.FC<{
   repo: DagsterRepoOption | null;

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -19,6 +19,7 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {AssetNodeList} from './AssetNodeList';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
+import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNotice';
 
 export const AssetNodeDefinition: React.FC<{
   repo: DagsterRepoOption | null;
@@ -42,66 +43,70 @@ export const AssetNodeDefinition: React.FC<{
   }
 
   return (
-    <Box
-      flex={{direction: 'row'}}
-      border={{side: 'bottom', width: 4, color: ColorsWIP.KeylineGray}}
-    >
-      <Box style={{flex: 1}}>
-        <Box
-          padding={{vertical: 16, horizontal: 24}}
-          border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
-          flex={{justifyContent: 'space-between'}}
-        >
-          <Subheading>Definition in Repository</Subheading>
-          {assetNode.jobName && (
-            <PipelineReference
-              showIcon
-              pipelineName={assetNode.jobName}
-              pipelineHrefContext={'repo-unknown'}
-              isJob
+    <>
+      <AssetDefinedInMultipleReposNotice assetId={assetNode.id} loadedFromRepo={repoAddress} />
+
+      <Box
+        flex={{direction: 'row'}}
+        border={{side: 'bottom', width: 4, color: ColorsWIP.KeylineGray}}
+      >
+        <Box style={{flex: 1}}>
+          <Box
+            padding={{vertical: 16, horizontal: 24}}
+            border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
+            flex={{justifyContent: 'space-between'}}
+          >
+            <Subheading>Definition in Repository</Subheading>
+            {assetNode.jobName && (
+              <PipelineReference
+                showIcon
+                pipelineName={assetNode.jobName}
+                pipelineHrefContext={'repo-unknown'}
+                isJob
+              />
+            )}
+          </Box>
+          <Box padding={{top: 16, horizontal: 24, bottom: 4}}>
+            <Description
+              description={assetNode.description || 'No description provided.'}
+              maxHeight={260}
             />
-          )}
+          </Box>
         </Box>
-        <Box padding={{top: 16, horizontal: 24, bottom: 4}}>
-          <Description
-            description={assetNode.description || 'No description provided.'}
-            maxHeight={318}
+        <Box
+          border={{side: 'left', width: 1, color: ColorsWIP.KeylineGray}}
+          style={{width: '40%', height: 330}}
+          flex={{direction: 'column'}}
+        >
+          <Box
+            padding={{vertical: 16, left: 24, right: 12}}
+            flex={{justifyContent: 'space-between'}}
+            border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
+          >
+            <Subheading>Upstream Assets ({assetNode.dependencies.length})</Subheading>
+            <JobGraphLink repoAddress={repoAddress} assetNode={assetNode} direction="upstream" />
+          </Box>
+          <AssetNodeList
+            items={assetNode.dependencies}
+            liveDataByNode={liveDataByNode}
+            repoAddress={repoAddress}
+          />
+          <Box
+            padding={{vertical: 16, left: 24, right: 12}}
+            flex={{justifyContent: 'space-between'}}
+            border={{side: 'horizontal', width: 1, color: ColorsWIP.KeylineGray}}
+          >
+            <Subheading>Downstream Assets ({assetNode.dependedBy.length})</Subheading>
+            <JobGraphLink repoAddress={repoAddress} assetNode={assetNode} direction="downstream" />
+          </Box>
+          <AssetNodeList
+            items={assetNode.dependedBy}
+            liveDataByNode={liveDataByNode}
+            repoAddress={repoAddress}
           />
         </Box>
       </Box>
-      <Box
-        border={{side: 'left', width: 1, color: ColorsWIP.KeylineGray}}
-        style={{width: '40%', height: 330}}
-        flex={{direction: 'column'}}
-      >
-        <Box
-          padding={{vertical: 16, left: 24, right: 12}}
-          flex={{justifyContent: 'space-between'}}
-          border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
-        >
-          <Subheading>Upstream Assets ({assetNode.dependencies.length})</Subheading>
-          <JobGraphLink repoAddress={repoAddress} assetNode={assetNode} direction="upstream" />
-        </Box>
-        <AssetNodeList
-          items={assetNode.dependencies}
-          liveDataByNode={liveDataByNode}
-          repoAddress={repoAddress}
-        />
-        <Box
-          padding={{vertical: 16, left: 24, right: 12}}
-          flex={{justifyContent: 'space-between'}}
-          border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
-        >
-          <Subheading>Downstream Assets ({assetNode.dependedBy.length})</Subheading>
-          <JobGraphLink repoAddress={repoAddress} assetNode={assetNode} direction="downstream" />
-        </Box>
-        <AssetNodeList
-          items={assetNode.dependedBy}
-          liveDataByNode={liveDataByNode}
-          repoAddress={repoAddress}
-        />
-      </Box>
-    </Box>
+    </>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -20,7 +20,7 @@ export const AssetNodeList: React.FC<{
       flex={{gap: 5}}
       padding={{horizontal: 12}}
       style={{
-        height: 110,
+        height: 112,
         overflowX: 'auto',
         width: '100%',
         whiteSpace: 'nowrap',

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -115,7 +115,6 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
               <LaunchAssetExecutionButton
                 assets={[definition]}
                 repoAddress={{name: repo.repository.name, location: repo.repositoryLocation.name}}
-                displayJobName
               />
             )}
           </Box>
@@ -135,27 +134,10 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
             padding={{vertical: 16, horizontal: 24}}
             border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
           >
-            <Alert
-              intent="info"
-              title={
-                <span>
-                  This is a historical view of materializations as of{' '}
-                  <span style={{fontWeight: 600}}>
-                    <Timestamp
-                      timestamp={{ms: Number(params.asOf)}}
-                      timeFormat={{showSeconds: true, showTimezone: true}}
-                    />
-                  </span>
-                  .
-                </span>
-              }
-              description={
-                <ButtonLink onClick={() => setNavigatedDirectlyToTime(false)} underline="always">
-                  {definition
-                    ? 'Show definition and latest materializations'
-                    : 'Show latest materializations'}
-                </ButtonLink>
-              }
+            <HistoricalViewAlert
+              asOf={params.asOf}
+              onClick={() => setNavigatedDirectlyToTime(false)}
+              hasDefinition={!!definition}
             />
           </Box>
         ) : definition ? (
@@ -218,3 +200,32 @@ const ASSET_NODE_DEFINITION_RUNS_QUERY = gql`
   }
   ${IN_PROGRESS_RUNS_FRAGMENT}
 `;
+
+const HistoricalViewAlert: React.FC<{
+  asOf: string | undefined;
+  onClick: () => void;
+  hasDefinition: boolean;
+}> = ({asOf, onClick, hasDefinition}) => (
+  <Alert
+    intent="info"
+    title={
+      <span>
+        This is a historical view of materializations as of{' '}
+        <span style={{fontWeight: 600}}>
+          <Timestamp
+            timestamp={{ms: Number(asOf)}}
+            timeFormat={{showSeconds: true, showTimezone: true}}
+          />
+        </span>
+        .
+      </span>
+    }
+    description={
+      <ButtonLink onClick={onClick} underline="always">
+        {hasDefinition
+          ? 'Show definition and latest materializations'
+          : 'Show latest materializations'}
+      </ButtonLink>
+    }
+  />
+);

--- a/js_modules/dagit/packages/core/src/assets/types/AssetIdScanQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetIdScanQuery.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: AssetIdScanQuery
+// ====================================================
+
+export interface AssetIdScanQuery_repositoriesOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_location {
+  __typename: "RepositoryLocation";
+  name: string;
+}
+
+export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+}
+
+export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes {
+  __typename: "Repository";
+  name: string;
+  location: AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_location;
+  assetNodes: AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_assetNodes[];
+}
+
+export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection {
+  __typename: "RepositoryConnection";
+  nodes: AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes[];
+}
+
+export type AssetIdScanQuery_repositoriesOrError = AssetIdScanQuery_repositoriesOrError_PythonError | AssetIdScanQuery_repositoriesOrError_RepositoryConnection;
+
+export interface AssetIdScanQuery {
+  repositoriesOrError: AssetIdScanQuery_repositoriesOrError;
+}

--- a/js_modules/dagit/packages/core/src/assets/types/AssetIdScanQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetIdScanQuery.ts
@@ -13,6 +13,7 @@ export interface AssetIdScanQuery_repositoriesOrError_PythonError {
 
 export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_location {
   __typename: "RepositoryLocation";
+  id: string;
   name: string;
 }
 
@@ -23,6 +24,7 @@ export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes
 
 export interface AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes {
   __typename: "Repository";
+  id: string;
   name: string;
   location: AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_location;
   assetNodes: AssetIdScanQuery_repositoriesOrError_RepositoryConnection_nodes_assetNodes[];

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -7,8 +7,7 @@ import {RepoAddress} from '../types';
 export const LaunchAssetExecutionButton: React.FC<{
   repoAddress: RepoAddress;
   assets: {opName: string | null; jobName: string | null}[];
-  displayJobName?: boolean;
-}> = ({repoAddress, assets, displayJobName}) => {
+}> = ({repoAddress, assets}) => {
   const jobName = assets[0].jobName;
   if (!jobName || !assets.every((a) => a.jobName === jobName && a.opName)) {
     return <span />;
@@ -18,7 +17,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     <LaunchRootExecutionButton
       pipelineName={jobName}
       disabled={false}
-      title={displayJobName ? `Refresh using ${jobName}` : 'Refresh'}
+      title={'Refresh'}
       getVariables={() => ({
         executionParams: {
           mode: 'default',


### PR DESCRIPTION
## Summary
This is a small PR that adds a new lazy-loaded notice to the asset details page, warning you if two repos define the same asset ID. I think it's important to actively catch and discourage this case because it breaks some assumptions in Dagit and things behave oddly if two meaningfully different assets have the same name.


I also adjusted the height of a few things and fixed a border that was missing.

![image](https://user-images.githubusercontent.com/1037212/146980511-8b0e781b-d3f6-4de9-a974-d019837a4b8b.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.