### PR TITLE
[round trips 2/n] add startTime and endTime to Run graphql schema

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -387,6 +387,8 @@ type Run implements PipelineRun {
   assets: [Asset!]!
   events(after: Cursor): [DagsterRunEvent!]!
   resolvedOpSelection: [String!]
+  startTime: Float
+  endTime: Float
 }
 
 interface PipelineRun {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -235,6 +235,7 @@ class GrapheneRun(graphene.ObjectType):
         )
         self._pipeline_run = check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
         self._run_record = run if isinstance(run, RunRecord) else None
+        self._run_stats = None
 
     def resolve_id(self, _graphene_info):
         return self._pipeline_run.run_id
@@ -343,14 +344,19 @@ class GrapheneRun(graphene.ObjectType):
 
     def resolve_startTime(self, graphene_info):
         run_record = self._get_run_record(graphene_info.context.instance)
+        # If a user has not migrated in 0.13.15, then run_record will not have start_time and end_time. So it will be necessary to fill this data using the run_stats. Since we potentially make this call multiple times, we cache the result.
         if run_record.start_time is None and self._pipeline_run.status in STARTED_STATUSES:
-            return graphene_info.context.instance.get_run_stats(self.runId).start_time
+            if self._run_stats is None or self._run_stats.start_time is None:
+                self._run_stats = graphene_info.context.instance.get_run_stats(self.runId)
+            return self._run_stats.start_time
         return run_record.start_time
 
     def resolve_endTime(self, graphene_info):
         run_record = self._get_run_record(graphene_info.context.instance)
         if run_record.end_time is None and self._pipeline_run.status in COMPLETED_STATUSES:
-            return graphene_info.context.instance.get_run_stats(self.runId).end_time
+            if self._run_stats is None or self._run_stats.end_time is None:
+                self._run_stats = graphene_info.context.instance.get_run_stats(self.runId)
+            return self._run_stats.end_time
         return run_record.end_time
 
 


### PR DESCRIPTION
Graphql layer for reducing number of round trips. The implementation here is a bit tricky, because currently the GrapheneRun takes in a PipelineRun, not a RunRecord.