### PR TITLE
[dagit] Properly handle 1:N mapping from asset to job

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEntryRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEntryRoot.tsx
@@ -23,12 +23,12 @@ export const AssetEntryRoot = () => {
 
   return queryResult.loading ? (
     <Page>
-      <AssetPageHeader currentPath={currentPath} />
+      <AssetPageHeader assetKey={{path: currentPath}} repoAddress={null} />
       <Loading queryResult={queryResult}>{() => null}</Loading>
     </Page>
   ) : queryResult.data?.assetOrError.__typename === 'AssetNotFoundError' ? (
     <Page>
-      <AssetPageHeader currentPath={currentPath} />
+      <AssetPageHeader assetKey={{path: currentPath}} repoAddress={null} />
       <AssetsCatalogTable prefixPath={currentPath} />
     </Page>
   ) : (

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
@@ -176,7 +176,10 @@ export const AssetMaterializations: React.FC<Props> = ({
             }
           />
         ) : (
-          <Box padding={{vertical: 20}}>
+          <Box
+            padding={{vertical: 20}}
+            border={{side: 'top', color: ColorsWIP.KeylineGray, width: 1}}
+          >
             <NonIdealState
               icon="asset"
               title="No materializations"

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -138,6 +138,18 @@ const JobGraphLink: React.FC<{
 export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
   fragment AssetNodeDefinitionFragment on AssetNode {
     id
+    description
+    opName
+    jobs {
+      name
+      repository {
+        name
+        location {
+          name
+        }
+      }
+    }
+
     ...AssetNodeFragment
     ...AssetNodeLiveFragment
 

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -8,12 +8,9 @@ import {PipelineReference} from '../pipelines/PipelineReference';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {IconWIP} from '../ui/Icon';
-import {NonIdealState} from '../ui/NonIdealState';
-import {Subheading} from '../ui/Text';
-import {DagsterRepoOption} from '../workspace/WorkspaceContext';
+import {Caption, Subheading} from '../ui/Text';
 import {ASSET_NODE_FRAGMENT, ASSET_NODE_LIVE_FRAGMENT} from '../workspace/asset-graph/AssetNode';
 import {LiveData} from '../workspace/asset-graph/Utils';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -22,30 +19,13 @@ import {AssetNodeList} from './AssetNodeList';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
 
 export const AssetNodeDefinition: React.FC<{
-  repo: DagsterRepoOption | null;
+  repoAddress: RepoAddress;
   assetNode: AssetNodeDefinitionFragment;
   liveDataByNode: LiveData;
-}> = ({repo, assetNode, liveDataByNode}) => {
-  const repoAddress = repo
-    ? buildRepoAddress(repo.repository.name, repo.repositoryLocation.name)
-    : undefined;
-
-  if (!repoAddress) {
-    return (
-      <Box padding={{vertical: 20}}>
-        <NonIdealState
-          icon="asset"
-          title="No software-defined metadata"
-          description="The definition of this asset could not be found in a repository."
-        />
-      </Box>
-    );
-  }
-
+}> = ({repoAddress, assetNode, liveDataByNode}) => {
   return (
     <>
       <AssetDefinedInMultipleReposNotice assetId={assetNode.id} loadedFromRepo={repoAddress} />
-
       <Box
         flex={{direction: 'row'}}
         border={{side: 'bottom', width: 4, color: ColorsWIP.KeylineGray}}
@@ -54,17 +34,23 @@ export const AssetNodeDefinition: React.FC<{
           <Box
             padding={{vertical: 16, horizontal: 24}}
             border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
-            flex={{justifyContent: 'space-between'}}
+            flex={{justifyContent: 'space-between', gap: 8}}
           >
             <Subheading>Definition in Repository</Subheading>
-            {assetNode.jobName && (
-              <PipelineReference
-                showIcon
-                pipelineName={assetNode.jobName}
-                pipelineHrefContext={'repo-unknown'}
-                isJob
-              />
-            )}
+            <Box flex={{alignItems: 'baseline', gap: 8, wrap: 'wrap'}}>
+              {assetNode.jobs.map((job) => (
+                <PipelineReference
+                  key={job.id}
+                  isJob
+                  showIcon
+                  pipelineName={job.name}
+                  pipelineHrefContext={repoAddress}
+                />
+              ))}
+              {assetNode.jobs.length === 0 && !assetNode.opName && (
+                <Caption style={{marginTop: 2}}>Foreign Asset</Caption>
+              )}
+            </Box>
           </Box>
           <Box padding={{top: 16, horizontal: 24, bottom: 4}}>
             <Description
@@ -115,14 +101,14 @@ const JobGraphLink: React.FC<{
   assetNode: AssetNodeDefinitionFragment;
   direction: 'upstream' | 'downstream';
 }> = ({direction, assetNode, repoAddress}) =>
-  assetNode.jobName &&
+  assetNode.jobs.length > 0 &&
   assetNode.opName &&
   (direction === 'upstream' ? assetNode.dependencies : assetNode.dependedBy).length > 0 ? (
     <Link
       to={workspacePathFromAddress(
         repoAddress,
         `/jobs/${explorerPathToString({
-          pipelineName: assetNode.jobName,
+          pipelineName: assetNode.jobs[0].name,
           opNames: [assetNode.opName],
           opsQuery: direction === 'upstream' ? `*${assetNode.opName}` : `${assetNode.opName}*`,
         })}`,
@@ -141,13 +127,8 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
     description
     opName
     jobs {
+      id
       name
-      repository {
-        name
-        location {
-          name
-        }
-      }
     }
 
     ...AssetNodeFragment
@@ -157,6 +138,10 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
       asset {
         id
         opName
+        jobs {
+          id
+          name
+        }
         ...AssetNodeFragment
         ...AssetNodeLiveFragment
       }
@@ -165,6 +150,10 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
       asset {
         id
         opName
+        jobs {
+          id
+          name
+        }
         ...AssetNodeFragment
         ...AssetNodeLiveFragment
       }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -3,6 +3,7 @@ import {useHistory} from 'react-router-dom';
 
 import {Box} from '../ui/Box';
 import {AssetNode} from '../workspace/asset-graph/AssetNode';
+import {ForeignNode} from '../workspace/asset-graph/ForeignNode';
 import {LiveData} from '../workspace/asset-graph/Utils';
 import {RepoAddress} from '../workspace/types';
 
@@ -33,19 +34,22 @@ export const AssetNodeList: React.FC<{
             style={{position: 'relative', flexShrink: 0, width: 240, height: 90}}
             onClick={(e) => {
               e.stopPropagation();
-              if (asset.opName) {
-                history.push(`/instance/assets/${asset.assetKey.path.join('/')}`);
-              }
+              history.push(`/instance/assets/${asset.assetKey.path.join('/')}`);
             }}
           >
-            <AssetNode
-              definition={{...asset, description: null}}
-              metadata={[]}
-              selected={false}
-              liveData={liveDataByNode[asset.id]}
-              secondaryHighlight={false}
-              repoAddress={repoAddress}
-            />
+            {asset.jobs.length ? (
+              <AssetNode
+                definition={{...asset, description: null}}
+                metadata={[]}
+                jobName={asset.jobs[0].name}
+                selected={false}
+                liveData={liveDataByNode[asset.id]}
+                secondaryHighlight={false}
+                repoAddress={repoAddress}
+              />
+            ) : (
+              <ForeignNode assetKey={asset.assetKey} />
+            )}
           </div>
         );
       })}

--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -3,39 +3,43 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {RepositoryLink} from '../nav/RepositoryLink';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
 import {PageHeader} from '../ui/PageHeader';
 import {TagWIP} from '../ui/TagWIP';
 import {Heading} from '../ui/Text';
+import {RepoAddress} from '../workspace/types';
 
 import {useAssetView} from './useAssetView';
 
-export const AssetPageHeader: React.FC<
-  {currentPath: string[]} & Partial<React.ComponentProps<typeof PageHeader>>
-> = ({currentPath, ...extra}) => {
+type Props = {assetKey: {path: string[]}; repoAddress: RepoAddress | null} & Partial<
+  React.ComponentProps<typeof PageHeader>
+>;
+
+export const AssetPageHeader: React.FC<Props> = ({assetKey, repoAddress, ...extra}) => {
   const [view] = useAssetView();
 
   const breadcrumbs = React.useMemo(() => {
-    if (currentPath.length === 1 || view !== 'directory') {
+    if (assetKey.path.length === 1 || view !== 'directory') {
       return null;
     }
 
     const list: BreadcrumbProps[] = [];
-    currentPath.reduce((accum: string, elem: string) => {
+    assetKey.path.reduce((accum: string, elem: string) => {
       const href = `${accum}/${encodeURIComponent(elem)}`;
       list.push({text: elem, href});
       return href;
     }, '/instance/assets');
 
     return list;
-  }, [currentPath, view]);
+  }, [assetKey.path, view]);
 
   return (
     <PageHeader
       title={
         view !== 'directory' || !breadcrumbs ? (
-          <Heading>{currentPath[currentPath.length - 1]}</Heading>
+          <Heading>{assetKey.path[assetKey.path.length - 1]}</Heading>
         ) : (
           <Box
             flex={{alignItems: 'center', gap: 4}}
@@ -53,7 +57,15 @@ export const AssetPageHeader: React.FC<
           </Box>
         )
       }
-      tags={<TagWIP icon="asset">Asset</TagWIP>}
+      tags={
+        repoAddress ? (
+          <TagWIP icon="asset">
+            Asset in <RepositoryLink repoAddress={repoAddress} />
+          </TagWIP>
+        ) : (
+          <TagWIP icon="asset">Asset</TagWIP>
+        )
+      }
       {...extra}
     />
   );

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -176,14 +176,18 @@ const AssetEntryRow: React.FC<{
         ) : null}
         {shouldShowAssetGraphColumns ? (
           <td>
-            {first.definition && first.definition.jobName && (
+            {(first.definition?.jobs || []).map((job) => (
               <PipelineReference
+                key={job.id}
                 showIcon
-                pipelineName={first.definition.jobName}
-                pipelineHrefContext="repo-unknown"
+                pipelineName={job.name}
+                pipelineHrefContext={{
+                  name: job.repository.name,
+                  location: job.repository.location.name,
+                }}
                 isJob
               />
-            )}
+            ))}
           </td>
         ) : null}
         {canWipe ? (
@@ -267,8 +271,19 @@ export const ASSET_TABLE_FRAGMENT = gql`
     definition {
       id
       opName
-      jobName
       description
+      jobs {
+        id
+        name
+        repository {
+          id
+          name
+          location {
+            id
+            name
+          }
+        }
+      }
     }
   }
 `;

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -176,18 +176,20 @@ const AssetEntryRow: React.FC<{
         ) : null}
         {shouldShowAssetGraphColumns ? (
           <td>
-            {(first.definition?.jobs || []).map((job) => (
-              <PipelineReference
-                key={job.id}
-                showIcon
-                pipelineName={job.name}
-                pipelineHrefContext={{
-                  name: job.repository.name,
-                  location: job.repository.location.name,
-                }}
-                isJob
-              />
-            ))}
+            <Box flex={{direction: 'column', gap: 2}}>
+              {(first.definition?.jobs || []).map((job) => (
+                <PipelineReference
+                  key={job.id}
+                  isJob
+                  showIcon
+                  pipelineName={job.name}
+                  pipelineHrefContext={{
+                    name: job.repository.name,
+                    location: job.repository.location.name,
+                  }}
+                />
+              ))}
+            </Box>
           </td>
         ) : null}
         {canWipe ? (

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -172,11 +172,6 @@ const ASSET_QUERY = gql`
         }
 
         definition {
-          id
-          description
-          opName
-          jobName
-
           ...AssetNodeDefinitionFragment
         }
       }

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -12,7 +12,6 @@ import {Box} from '../ui/Box';
 import {ButtonLink} from '../ui/ButtonLink';
 import {ColorsWIP} from '../ui/Colors';
 import {Spinner} from '../ui/Spinner';
-import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 import {LaunchAssetExecutionButton} from '../workspace/asset-graph/LaunchAssetExecutionButton';
 import {
   buildGraphDataFromSingleNode,
@@ -20,7 +19,7 @@ import {
   IN_PROGRESS_RUNS_FRAGMENT,
   LiveData,
 } from '../workspace/asset-graph/Utils';
-import {findRepoContainingPipeline} from '../workspace/findRepoContainingPipeline';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetMaterializations} from './AssetMaterializations';
 import {AssetNodeDefinition, ASSET_NODE_DEFINITION_FRAGMENT} from './AssetNodeDefinition';
@@ -62,19 +61,18 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
   const asset = assetOrError && assetOrError.__typename === 'Asset' ? assetOrError : null;
   const definition = asset?.definition;
   const lastMaterializedAt = asset?.assetMaterializations[0]?.materializationEvent.timestamp;
-
-  // Note: Todo create a better way to link an Asset to a Repo
-  const {options} = useRepositoryOptions();
-  const [repo] = definition?.jobName ? findRepoContainingPipeline(options, definition.jobName) : [];
+  const repoAddress = definition
+    ? buildRepoAddress(definition.repository.name, definition.repository.location.name)
+    : null;
 
   const bonusResult = useQuery<AssetNodeDefinitionRunsQuery, AssetNodeDefinitionRunsQueryVariables>(
     ASSET_NODE_DEFINITION_RUNS_QUERY,
     {
-      skip: !definition?.jobName,
+      skip: !repoAddress,
       variables: {
         repositorySelector: {
-          repositoryLocationName: repo?.repositoryLocation.name || '',
-          repositoryName: repo?.repository.name || '',
+          repositoryLocationName: repoAddress ? repoAddress.location : '',
+          repositoryName: repoAddress ? repoAddress.name : '',
         },
       },
       notifyOnNetworkStatusChange: true,
@@ -105,16 +103,18 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
   return (
     <div>
       <AssetPageHeader
-        currentPath={assetKey.path}
+        assetKey={assetKey}
+        repoAddress={repoAddress}
         right={
           <Box style={{margin: '-4px 0'}} flex={{gap: 8, alignItems: 'baseline'}}>
             <Box margin={{top: 4}}>
               <QueryCountdown pollInterval={5 * 1000} queryResult={queryResult} />
             </Box>
-            {definition && (
+            {definition && definition.jobs.length > 0 && repoAddress && (
               <LaunchAssetExecutionButton
                 assets={[definition]}
-                repoAddress={{name: repo.repository.name, location: repo.repositoryLocation.name}}
+                assetJobName={definition.jobs[0].name}
+                repoAddress={repoAddress}
               />
             )}
           </Box>
@@ -140,8 +140,12 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
               hasDefinition={!!definition}
             />
           </Box>
-        ) : definition ? (
-          <AssetNodeDefinition repo={repo} assetNode={definition} liveDataByNode={liveDataByNode} />
+        ) : definition && repoAddress ? (
+          <AssetNodeDefinition
+            repoAddress={repoAddress}
+            assetNode={definition}
+            liveDataByNode={liveDataByNode}
+          />
         ) : undefined}
       </div>
       <AssetMaterializations
@@ -172,6 +176,15 @@ const ASSET_QUERY = gql`
         }
 
         definition {
+          id
+          repository {
+            id
+            name
+            location {
+              id
+              name
+            }
+          }
           ...AssetNodeDefinitionFragment
         }
       }

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNamespaceTableQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNamespaceTableQuery.ts
@@ -12,12 +12,32 @@ export interface AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_ke
   path: string[];
 }
 
+export interface AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository_location;
+}
+
+export interface AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  repository: AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository;
+}
+
 export interface AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
-  jobName: string | null;
   description: string | null;
+  jobs: AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes_definition_jobs[];
 }
 
 export interface AssetNamespaceTableQuery_assetsOrError_AssetConnection_nodes {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -9,21 +9,10 @@ import { RunStatus } from "./../../types/globalTypes";
 // GraphQL fragment: AssetNodeDefinitionFragment
 // ====================================================
 
-export interface AssetNodeDefinitionFragment_jobs_repository_location {
-  __typename: "RepositoryLocation";
-  name: string;
-}
-
-export interface AssetNodeDefinitionFragment_jobs_repository {
-  __typename: "Repository";
-  name: string;
-  location: AssetNodeDefinitionFragment_jobs_repository_location;
-}
-
 export interface AssetNodeDefinitionFragment_jobs {
   __typename: "Pipeline";
+  id: string;
   name: string;
-  repository: AssetNodeDefinitionFragment_jobs_repository;
 }
 
 export interface AssetNodeDefinitionFragment_assetKey {
@@ -172,6 +161,12 @@ export interface AssetNodeDefinitionFragment_assetMaterializations {
   partition: string | null;
   runOrError: AssetNodeDefinitionFragment_assetMaterializations_runOrError;
   materializationEvent: AssetNodeDefinitionFragment_assetMaterializations_materializationEvent;
+}
+
+export interface AssetNodeDefinitionFragment_dependencies_asset_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
 }
 
 export interface AssetNodeDefinitionFragment_dependencies_asset_assetKey {
@@ -326,8 +321,8 @@ export interface AssetNodeDefinitionFragment_dependencies_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  jobs: AssetNodeDefinitionFragment_dependencies_asset_jobs[];
   description: string | null;
-  jobName: string | null;
   assetKey: AssetNodeDefinitionFragment_dependencies_asset_assetKey;
   assetMaterializations: AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations[];
 }
@@ -335,6 +330,12 @@ export interface AssetNodeDefinitionFragment_dependencies_asset {
 export interface AssetNodeDefinitionFragment_dependencies {
   __typename: "AssetDependency";
   asset: AssetNodeDefinitionFragment_dependencies_asset;
+}
+
+export interface AssetNodeDefinitionFragment_dependedBy_asset_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
 }
 
 export interface AssetNodeDefinitionFragment_dependedBy_asset_assetKey {
@@ -489,8 +490,8 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  jobs: AssetNodeDefinitionFragment_dependedBy_asset_jobs[];
   description: string | null;
-  jobName: string | null;
   assetKey: AssetNodeDefinitionFragment_dependedBy_asset_assetKey;
   assetMaterializations: AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations[];
 }
@@ -506,7 +507,6 @@ export interface AssetNodeDefinitionFragment {
   description: string | null;
   opName: string | null;
   jobs: AssetNodeDefinitionFragment_jobs[];
-  jobName: string | null;
   assetKey: AssetNodeDefinitionFragment_assetKey;
   assetMaterializations: AssetNodeDefinitionFragment_assetMaterializations[];
   dependencies: AssetNodeDefinitionFragment_dependencies[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -9,6 +9,23 @@ import { RunStatus } from "./../../types/globalTypes";
 // GraphQL fragment: AssetNodeDefinitionFragment
 // ====================================================
 
+export interface AssetNodeDefinitionFragment_jobs_repository_location {
+  __typename: "RepositoryLocation";
+  name: string;
+}
+
+export interface AssetNodeDefinitionFragment_jobs_repository {
+  __typename: "Repository";
+  name: string;
+  location: AssetNodeDefinitionFragment_jobs_repository_location;
+}
+
+export interface AssetNodeDefinitionFragment_jobs {
+  __typename: "Pipeline";
+  name: string;
+  repository: AssetNodeDefinitionFragment_jobs_repository;
+}
+
 export interface AssetNodeDefinitionFragment_assetKey {
   __typename: "AssetKey";
   path: string[];
@@ -486,8 +503,9 @@ export interface AssetNodeDefinitionFragment_dependedBy {
 export interface AssetNodeDefinitionFragment {
   __typename: "AssetNode";
   id: string;
-  opName: string | null;
   description: string | null;
+  opName: string | null;
+  jobs: AssetNodeDefinitionFragment_jobs[];
   jobName: string | null;
   assetKey: AssetNodeDefinitionFragment_assetKey;
   assetMaterializations: AssetNodeDefinitionFragment_assetMaterializations[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -28,6 +28,23 @@ export interface AssetQuery_assetOrError_Asset_assetMaterializations {
   materializationEvent: AssetQuery_assetOrError_Asset_assetMaterializations_materializationEvent;
 }
 
+export interface AssetQuery_assetOrError_Asset_definition_jobs_repository_location {
+  __typename: "RepositoryLocation";
+  name: string;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs_repository {
+  __typename: "Repository";
+  name: string;
+  location: AssetQuery_assetOrError_Asset_definition_jobs_repository_location;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs {
+  __typename: "Pipeline";
+  name: string;
+  repository: AssetQuery_assetOrError_Asset_definition_jobs_repository;
+}
+
 export interface AssetQuery_assetOrError_Asset_definition_assetKey {
   __typename: "AssetKey";
   path: string[];
@@ -507,6 +524,7 @@ export interface AssetQuery_assetOrError_Asset_definition {
   id: string;
   description: string | null;
   opName: string | null;
+  jobs: AssetQuery_assetOrError_Asset_definition_jobs[];
   jobName: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_assetMaterializations[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -28,21 +28,23 @@ export interface AssetQuery_assetOrError_Asset_assetMaterializations {
   materializationEvent: AssetQuery_assetOrError_Asset_assetMaterializations_materializationEvent;
 }
 
-export interface AssetQuery_assetOrError_Asset_definition_jobs_repository_location {
+export interface AssetQuery_assetOrError_Asset_definition_repository_location {
   __typename: "RepositoryLocation";
+  id: string;
   name: string;
 }
 
-export interface AssetQuery_assetOrError_Asset_definition_jobs_repository {
+export interface AssetQuery_assetOrError_Asset_definition_repository {
   __typename: "Repository";
+  id: string;
   name: string;
-  location: AssetQuery_assetOrError_Asset_definition_jobs_repository_location;
+  location: AssetQuery_assetOrError_Asset_definition_repository_location;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_jobs {
   __typename: "Pipeline";
+  id: string;
   name: string;
-  repository: AssetQuery_assetOrError_Asset_definition_jobs_repository;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_assetKey {
@@ -191,6 +193,12 @@ export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations 
   partition: string | null;
   runOrError: AssetQuery_assetOrError_Asset_definition_assetMaterializations_runOrError;
   materializationEvent: AssetQuery_assetOrError_Asset_definition_assetMaterializations_materializationEvent;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetKey {
@@ -345,8 +353,8 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  jobs: AssetQuery_assetOrError_Asset_definition_dependencies_asset_jobs[];
   description: string | null;
-  jobName: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations[];
 }
@@ -354,6 +362,12 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset {
 export interface AssetQuery_assetOrError_Asset_definition_dependencies {
   __typename: "AssetDependency";
   asset: AssetQuery_assetOrError_Asset_definition_dependencies_asset;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetKey {
@@ -508,8 +522,8 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
+  jobs: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_jobs[];
   description: string | null;
-  jobName: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations[];
 }
@@ -522,10 +536,10 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy {
 export interface AssetQuery_assetOrError_Asset_definition {
   __typename: "AssetNode";
   id: string;
+  repository: AssetQuery_assetOrError_Asset_definition_repository;
   description: string | null;
   opName: string | null;
   jobs: AssetQuery_assetOrError_Asset_definition_jobs[];
-  jobName: string | null;
   assetKey: AssetQuery_assetOrError_Asset_definition_assetKey;
   assetMaterializations: AssetQuery_assetOrError_Asset_definition_assetMaterializations[];
   dependencies: AssetQuery_assetOrError_Asset_definition_dependencies[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.ts
@@ -12,12 +12,32 @@ export interface AssetTableFragment_key {
   path: string[];
 }
 
+export interface AssetTableFragment_definition_jobs_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface AssetTableFragment_definition_jobs_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: AssetTableFragment_definition_jobs_repository_location;
+}
+
+export interface AssetTableFragment_definition_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  repository: AssetTableFragment_definition_jobs_repository;
+}
+
 export interface AssetTableFragment_definition {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
-  jobName: string | null;
   description: string | null;
+  jobs: AssetTableFragment_definition_jobs[];
 }
 
 export interface AssetTableFragment {

--- a/js_modules/dagit/packages/core/src/assets/types/PaginatedAssetKeysQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/PaginatedAssetKeysQuery.ts
@@ -12,12 +12,32 @@ export interface PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_key
   path: string[];
 }
 
+export interface PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository_location;
+}
+
+export interface PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  repository: PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition_jobs_repository;
+}
+
 export interface PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
-  jobName: string | null;
   description: string | null;
+  jobs: PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes_definition_jobs[];
 }
 
 export interface PaginatedAssetKeysQuery_assetsOrError_AssetConnection_nodes {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -620,8 +620,8 @@ type AssetNode {
   assetKey: AssetKey!
   description: String
   opName: String
-  jobName: String
   jobs: [Pipeline!]!
+  repository: Repository!
   dependencies: [AssetDependency!]!
   dependedBy: [AssetDependency!]!
   dependencyKeys: [AssetKey!]!

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -7,7 +7,6 @@ import {displayNameForAssetKey} from '../app/Util';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {Box} from '../ui/Box';
 import {ColorsWIP} from '../ui/Colors';
-import {Group} from '../ui/Group';
 import {NonIdealState} from '../ui/NonIdealState';
 import {Table} from '../ui/Table';
 
@@ -15,7 +14,6 @@ import {repoAddressAsString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
 import {RepoAddress} from './types';
 import {RepositoryAssetsListQuery} from './types/RepositoryAssetsListQuery';
-import {workspacePath} from './workspacePath';
 
 const REPOSITORY_ASSETS_LIST_QUERY = gql`
   query RepositoryAssetsListQuery($repositorySelector: RepositorySelector!) {
@@ -105,15 +103,15 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
         {assetsForTable.map((asset) => (
           <tr key={asset.id}>
             <td>
-              <Group direction="column" spacing={4}>
+              <Box flex={{direction: 'column', gap: 4}}>
                 <Link to={`/instance/assets/${asset.assetKey.path.join('/')}`}>
                   {displayNameForAssetKey(asset.assetKey)}
                 </Link>
                 <Description>{asset.description}</Description>
-              </Group>
+              </Box>
             </td>
             <td>
-              <Group direction="column" spacing={4}>
+              <Box flex={{direction: 'column', gap: 2}}>
                 {asset.jobs.map(({name}) => (
                   <PipelineReference
                     showIcon
@@ -123,7 +121,7 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
                     pipelineHrefContext={repoAddress}
                   />
                 ))}
-              </Group>
+              </Box>
             </td>
           </tr>
         ))}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -77,12 +77,12 @@ export const AssetGraphExplorer: React.FC<Props> = (props) => {
     const queryAssetNodes = assetNodes.filter((a) =>
       queryOps.all.some((op) => op.name === a.opName),
     );
-    const graphData = buildGraphData(queryAssetNodes, explorerPath.pipelineName);
+    const graphData = buildGraphData(queryAssetNodes);
     return {
       graphAssetKeys: queryAssetNodes.map((n) => ({path: n.assetKey.path})),
       graphData: graphData,
     };
-  }, [queryResult.data, handles, explorerPath.pipelineName, explorerPath.opsQuery]);
+  }, [queryResult.data, handles, explorerPath.opsQuery]);
 
   const liveResult = useQuery<AssetGraphLiveQuery, AssetGraphLiveQueryVariables>(
     ASSETS_GRAPH_LIVE_QUERY,
@@ -221,6 +221,11 @@ const AssetGraphExplorerWithData: React.FC<
 
   const layout = React.useMemo(() => layoutGraph(graphData), [graphData]);
 
+  const viewportEl = React.useRef<SVGViewport>();
+  React.useEffect(() => {
+    viewportEl.current?.autocenter();
+  }, [layout, viewportEl]);
+
   return (
     <SplitPanelContainer
       identifier="explorer"
@@ -229,6 +234,7 @@ const AssetGraphExplorerWithData: React.FC<
       first={
         <>
           <SVGViewport
+            ref={(r) => (viewportEl.current = r || undefined)}
             interactor={SVGViewport.Interactors.PanAndZoom}
             graphWidth={layout.width}
             graphHeight={layout.height}
@@ -265,7 +271,7 @@ const AssetGraphExplorerWithData: React.FC<
                       onClick={(e) => onSelectNode(e, {path}, graphNode)}
                       style={{overflow: 'visible'}}
                     >
-                      {!graphNode || graphNode.hidden ? (
+                      {!graphNode || !graphNode.definition.opName ? (
                         <ForeignNode assetKey={{path}} />
                       ) : (
                         <AssetNode

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -32,161 +32,170 @@ export const AssetNode: React.FC<{
   liveData?: LiveDataForNode;
   metadata: {key: string; value: string}[];
   selected: boolean;
+  jobName: string;
   repoAddress: RepoAddress;
   secondaryHighlight: boolean;
-}> = React.memo(({definition, metadata, selected, liveData, repoAddress, secondaryHighlight}) => {
-  const launch = useLaunchSingleAssetJob();
-  const history = useHistory();
+}> = React.memo(
+  ({definition, metadata, selected, liveData, repoAddress, jobName, secondaryHighlight}) => {
+    const launch = useLaunchSingleAssetJob();
+    const history = useHistory();
 
-  const {materializationEvent: event, runOrError} = liveData?.lastMaterialization || {};
-  const kind = metadata.find((m) => m.key === 'kind')?.value;
+    const {materializationEvent: event, runOrError} = liveData?.lastMaterialization || {};
+    const kind = metadata.find((m) => m.key === 'kind')?.value;
 
-  return (
-    <ContextMenu
-      content={
-        <MenuWIP>
-          <MenuItemWIP
-            icon="open_in_new"
-            onClick={() => launch(repoAddress, definition)}
-            text={
-              <span>
-                Refresh{' '}
-                <span style={{fontFamily: 'monospace', fontWeight: 600}}>
-                  {displayNameForAssetKey(definition.assetKey)}
+    return (
+      <ContextMenu
+        content={
+          <MenuWIP>
+            <MenuItemWIP
+              icon="open_in_new"
+              onClick={(e) => {
+                launch(repoAddress, jobName, definition.opName);
+                e.stopPropagation();
+              }}
+              text={
+                <span>
+                  Refresh{' '}
+                  <span style={{fontFamily: 'monospace', fontWeight: 600}}>
+                    {displayNameForAssetKey(definition.assetKey)}
+                  </span>
                 </span>
-              </span>
-            }
-          />
-          <MenuItemWIP
-            icon="link"
-            onClick={(e) => {
-              e.stopPropagation();
-              history.push(`/instance/assets/${definition.assetKey.path.join('/')}`);
-            }}
-            text="View in Asset Catalog"
-          />
-        </MenuWIP>
-      }
-    >
-      <AssetNodeContainer $selected={selected} $secondaryHighlight={secondaryHighlight}>
-        <AssetNodeBox>
-          <Name>
-            <IconWIP name="asset" />
-            <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
-              {displayNameForAssetKey(definition.assetKey)}
-            </div>
-            <div style={{flex: 1}} />
-            {liveData && liveData.inProgressRunIds.length > 0 ? (
-              <Tooltip content={'A run is currently refreshing this asset.'}>
-                <Spinner purpose="body-text" />
-              </Tooltip>
-            ) : liveData && liveData.unstartedRunIds.length > 0 ? (
-              <Tooltip content={'A run has started that will refresh this asset soon.'}>
-                <Spinner purpose="body-text" stopped />
-              </Tooltip>
-            ) : undefined}
-
-            {liveData?.computeStatus === 'old' && (
-              <UpstreamNotice>
-                upstream
-                <br />
-                changed
-              </UpstreamNotice>
-            )}
-          </Name>
-          {definition.description && (
-            <Description>{markdownToPlaintext(definition.description).split('\n')[0]}</Description>
-          )}
-          {event ? (
-            <Stats>
-              {runOrError?.__typename === 'Run' && (
-                <StatsRow>
-                  <Link
-                    data-tooltip={`${runOrError.pipelineName}${
-                      runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
-                    }`}
-                    data-tooltip-style={RunLinkTooltipStyle}
-                    style={{overflow: 'hidden', textOverflow: 'ellipsis', paddingRight: 8}}
-                    to={
-                      repoAddress.name
-                        ? workspacePath(
-                            repoAddress.name,
-                            repoAddress.location,
-                            `jobs/${runOrError.pipelineName}:${runOrError.mode}`,
-                          )
-                        : workspacePipelinePathGuessRepo(
-                            `${runOrError.pipelineName}:${runOrError.mode}`,
-                            true,
-                            '',
-                          )
-                    }
-                  >
-                    {`${runOrError.pipelineName}${
-                      runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
-                    }`}
-                  </Link>
-                  <Link
-                    style={{fontFamily: FontFamily.monospace, fontSize: 14}}
-                    to={`/instance/runs/${runOrError.runId}?${qs.stringify({
-                      timestamp: event.stepStats.endTime,
-                      selection: event.stepStats.stepKey,
-                      logs: `step:${event.stepStats.stepKey}`,
-                    })}`}
-                    target="_blank"
-                  >
-                    {titleForRun({runId: runOrError.runId})}
-                  </Link>
-                </StatsRow>
-              )}
-
-              <StatsRow>
-                {event.stepStats.endTime ? (
-                  <TimestampDisplay
-                    timestamp={event.stepStats.endTime}
-                    timeFormat={{showSeconds: false, showTimezone: false}}
-                  />
-                ) : (
-                  'Never'
-                )}
-                <TimeElapsed
-                  startUnix={event.stepStats.startTime}
-                  endUnix={event.stepStats.endTime}
-                />
-              </StatsRow>
-            </Stats>
-          ) : (
-            <Stats>
-              <StatsRow style={{opacity: 0.5}}>
-                <span>No materializations</span>
-                <span>—</span>
-              </StatsRow>
-              <StatsRow style={{opacity: 0.5}}>
-                <span>—</span>
-                <span>—</span>
-              </StatsRow>
-            </Stats>
-          )}
-          {kind && (
-            <OpTags
-              minified={false}
-              style={{right: -2, paddingTop: 5}}
-              tags={[
-                {
-                  label: kind,
-                  onClick: () => {
-                    window.requestAnimationFrame(() =>
-                      document.dispatchEvent(new Event('show-kind-info')),
-                    );
-                  },
-                },
-              ]}
+              }
             />
-          )}
-        </AssetNodeBox>
-      </AssetNodeContainer>
-    </ContextMenu>
-  );
-}, isEqual);
+            <MenuItemWIP
+              icon="link"
+              onClick={(e) => {
+                e.stopPropagation();
+                history.push(`/instance/assets/${definition.assetKey.path.join('/')}`);
+              }}
+              text="View in Asset Catalog"
+            />
+          </MenuWIP>
+        }
+      >
+        <AssetNodeContainer $selected={selected} $secondaryHighlight={secondaryHighlight}>
+          <AssetNodeBox>
+            <Name>
+              <IconWIP name="asset" />
+              <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
+                {displayNameForAssetKey(definition.assetKey)}
+              </div>
+              <div style={{flex: 1}} />
+              {liveData && liveData.inProgressRunIds.length > 0 ? (
+                <Tooltip content={'A run is currently refreshing this asset.'}>
+                  <Spinner purpose="body-text" />
+                </Tooltip>
+              ) : liveData && liveData.unstartedRunIds.length > 0 ? (
+                <Tooltip content={'A run has started that will refresh this asset soon.'}>
+                  <Spinner purpose="body-text" stopped />
+                </Tooltip>
+              ) : undefined}
+
+              {liveData?.computeStatus === 'old' && (
+                <UpstreamNotice>
+                  upstream
+                  <br />
+                  changed
+                </UpstreamNotice>
+              )}
+            </Name>
+            {definition.description && (
+              <Description>
+                {markdownToPlaintext(definition.description).split('\n')[0]}
+              </Description>
+            )}
+            {event ? (
+              <Stats>
+                {runOrError?.__typename === 'Run' && (
+                  <StatsRow>
+                    <Link
+                      data-tooltip={`${runOrError.pipelineName}${
+                        runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
+                      }`}
+                      data-tooltip-style={RunLinkTooltipStyle}
+                      style={{overflow: 'hidden', textOverflow: 'ellipsis', paddingRight: 8}}
+                      to={
+                        repoAddress.name
+                          ? workspacePath(
+                              repoAddress.name,
+                              repoAddress.location,
+                              `jobs/${runOrError.pipelineName}:${runOrError.mode}`,
+                            )
+                          : workspacePipelinePathGuessRepo(
+                              `${runOrError.pipelineName}:${runOrError.mode}`,
+                              true,
+                              '',
+                            )
+                      }
+                    >
+                      {`${runOrError.pipelineName}${
+                        runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
+                      }`}
+                    </Link>
+                    <Link
+                      style={{fontFamily: FontFamily.monospace, fontSize: 14}}
+                      to={`/instance/runs/${runOrError.runId}?${qs.stringify({
+                        timestamp: event.stepStats.endTime,
+                        selection: event.stepStats.stepKey,
+                        logs: `step:${event.stepStats.stepKey}`,
+                      })}`}
+                      target="_blank"
+                    >
+                      {titleForRun({runId: runOrError.runId})}
+                    </Link>
+                  </StatsRow>
+                )}
+
+                <StatsRow>
+                  {event.stepStats.endTime ? (
+                    <TimestampDisplay
+                      timestamp={event.stepStats.endTime}
+                      timeFormat={{showSeconds: false, showTimezone: false}}
+                    />
+                  ) : (
+                    'Never'
+                  )}
+                  <TimeElapsed
+                    startUnix={event.stepStats.startTime}
+                    endUnix={event.stepStats.endTime}
+                  />
+                </StatsRow>
+              </Stats>
+            ) : (
+              <Stats>
+                <StatsRow style={{opacity: 0.5}}>
+                  <span>No materializations</span>
+                  <span>—</span>
+                </StatsRow>
+                <StatsRow style={{opacity: 0.5}}>
+                  <span>—</span>
+                  <span>—</span>
+                </StatsRow>
+              </Stats>
+            )}
+            {kind && (
+              <OpTags
+                minified={false}
+                style={{right: -2, paddingTop: 5}}
+                tags={[
+                  {
+                    label: kind,
+                    onClick: () => {
+                      window.requestAnimationFrame(() =>
+                        document.dispatchEvent(new Event('show-kind-info')),
+                      );
+                    },
+                  },
+                ]}
+              />
+            )}
+          </AssetNodeBox>
+        </AssetNodeContainer>
+      </ContextMenu>
+    );
+  },
+  isEqual,
+);
 
 export const ASSET_NODE_LIVE_FRAGMENT = gql`
   fragment AssetNodeLiveFragment on AssetNode {
@@ -229,7 +238,6 @@ export const ASSET_NODE_FRAGMENT = gql`
     id
     opName
     description
-    jobName
     assetKey {
       path
     }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
 
 import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
-import {repoAddressToSelector} from '../repoAddressToSelector';
 import {RepoAddress} from '../types';
 
 export const LaunchAssetExecutionButton: React.FC<{
   repoAddress: RepoAddress;
-  assets: {opName: string | null; jobName: string | null}[];
-}> = ({repoAddress, assets}) => {
-  const jobName = assets[0].jobName;
-  if (!jobName || !assets.every((a) => a.jobName === jobName && a.opName)) {
+  assetJobName: string;
+  assets: {opName: string | null}[];
+}> = ({repoAddress, assets, assetJobName}) => {
+  if (!assets.every((a) => a.opName)) {
     return <span />;
   }
-
   return (
     <LaunchRootExecutionButton
-      pipelineName={jobName}
+      pipelineName={assetJobName}
       disabled={false}
       title={'Refresh'}
       getVariables={() => ({
@@ -24,9 +22,10 @@ export const LaunchAssetExecutionButton: React.FC<{
           executionMetadata: {},
           runConfigData: {},
           selector: {
-            ...repoAddressToSelector(repoAddress),
-            pipelineName: jobName,
-            solidSelection: assets.map((a) => a.opName!),
+            repositoryLocationName: repoAddress.location,
+            repositoryName: repoAddress.name,
+            pipelineName: assetJobName,
+            solidSelection: assets.map((o) => o.opName!),
           },
         },
       })}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -15,11 +15,12 @@ import {LiveDataForNode} from './Utils';
 import {AssetGraphQuery_pipelineOrError_Pipeline_assetNodes} from './types/AssetGraphQuery';
 
 export const SidebarAssetInfo: React.FC<{
+  jobName: string;
   definition: GraphExplorerSolidHandleFragment_solid_definition;
   node: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes;
   liveData: LiveDataForNode;
   repoAddress: RepoAddress;
-}> = ({node, definition, repoAddress, liveData}) => {
+}> = ({jobName, node, definition, repoAddress, liveData}) => {
   const Plugin = pluginForMetadata(definition.metadata);
   const {lastMaterialization} = liveData || {};
 
@@ -32,7 +33,11 @@ export const SidebarAssetInfo: React.FC<{
             margin={{bottom: 8}}
           >
             <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
-            <LaunchAssetExecutionButton assets={[node]} repoAddress={repoAddress} />
+            <LaunchAssetExecutionButton
+              assets={[node]}
+              assetJobName={jobName}
+              repoAddress={repoAddress}
+            />
           </Box>
           <Description description={node.description || null} />
         </Box>
@@ -58,9 +63,10 @@ export const SidebarAssetInfo: React.FC<{
 };
 
 export const SidebarAssetsInfo: React.FC<{
+  jobName: string;
   nodes: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes[];
   repoAddress: RepoAddress;
-}> = ({nodes, repoAddress}) => {
+}> = ({nodes, jobName, repoAddress}) => {
   return (
     <SidebarSection title="Definition">
       <Box padding={{vertical: 16, horizontal: 24}}>
@@ -69,7 +75,11 @@ export const SidebarAssetsInfo: React.FC<{
           margin={{bottom: 8}}
         >
           <SidebarTitle>{`${nodes.length} Assets Selected`}</SidebarTitle>
-          <LaunchAssetExecutionButton repoAddress={repoAddress} assets={nodes} />
+          <LaunchAssetExecutionButton
+            repoAddress={repoAddress}
+            assets={nodes}
+            assetJobName={jobName}
+          />
         </Box>
       </Box>
     </SidebarSection>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -21,7 +21,6 @@ export interface Node {
   id: string;
   assetKey: AssetKey;
   definition: AssetNode;
-  hidden: boolean;
 }
 interface LayoutNode {
   id: string;
@@ -45,7 +44,7 @@ export type IEdge = {
   dashed: boolean;
 };
 
-export const buildGraphData = (assetNodes: AssetNode[], jobName?: string) => {
+export const buildGraphData = (assetNodes: AssetNode[]) => {
   const data: GraphData = {
     nodes: {},
     downstream: {},
@@ -68,7 +67,6 @@ export const buildGraphData = (assetNodes: AssetNode[], jobName?: string) => {
     data.nodes[assetKeyJson] = {
       id: assetKeyJson,
       assetKey: definition.assetKey,
-      hidden: !!jobName && definition.jobName !== jobName,
       definition,
     };
   });
@@ -86,7 +84,6 @@ export const buildGraphDataFromSingleNode = (assetNode: AssetNodeDefinitionFragm
         id: assetNode.id,
         assetKey: assetNode.assetKey,
         definition: {...assetNode, dependencyKeys: []},
-        hidden: false,
       },
     },
     upstream: {
@@ -101,7 +98,6 @@ export const buildGraphDataFromSingleNode = (assetNode: AssetNodeDefinitionFragm
       id: asset.id,
       assetKey: asset.assetKey,
       definition: {...asset, dependencyKeys: []},
-      hidden: false,
     };
   }
   for (const {asset} of assetNode.dependedBy) {
@@ -111,7 +107,6 @@ export const buildGraphDataFromSingleNode = (assetNode: AssetNodeDefinitionFragm
       id: asset.id,
       assetKey: asset.assetKey,
       definition: {...asset, dependencyKeys: []},
-      hidden: false,
     };
   }
   return graphData;
@@ -157,7 +152,7 @@ export const layoutGraph = (
   });
   g.setDefaultEdgeLabel(() => ({}));
 
-  const shouldRender = (node?: Node) => node && !node.hidden && node.definition.opName;
+  const shouldRender = (node?: Node) => node && node.definition.opName;
 
   Object.values(graphData.nodes)
     .filter(shouldRender)

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetForNavigationQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetForNavigationQuery.ts
@@ -13,11 +13,17 @@ export interface AssetForNavigationQuery_assetOrError_AssetNotFoundError {
   __typename: "AssetNotFoundError";
 }
 
+export interface AssetForNavigationQuery_assetOrError_Asset_definition_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+}
+
 export interface AssetForNavigationQuery_assetOrError_Asset_definition {
   __typename: "AssetNode";
   id: string;
   opName: string | null;
-  jobName: string | null;
+  jobs: AssetForNavigationQuery_assetOrError_Asset_definition_jobs[];
 }
 
 export interface AssetForNavigationQuery_assetOrError_Asset {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
@@ -28,7 +28,6 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes {
   id: string;
   opName: string | null;
   description: string | null;
-  jobName: string | null;
   assetKey: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_assetKey;
   dependencyKeys: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencyKeys[];
 }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetNodeFragment.ts
@@ -17,6 +17,5 @@ export interface AssetNodeFragment {
   id: string;
   opName: string | null;
   description: string | null;
-  jobName: string | null;
   assetKey: AssetNodeFragment_assetKey;
 }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/useFindAssetInWorkspace.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/useFindAssetInWorkspace.tsx
@@ -8,22 +8,18 @@ import {
   AssetForNavigationQueryVariables,
 } from './types/AssetForNavigationQuery';
 
-export function useFetchAssetDefinitionLocation() {
+export function useFindAssetInWorkspace() {
   const apollo = useApolloClient();
 
   return React.useCallback(
-    async (
-      key: AssetKeyInput,
-    ): Promise<{
-      opName: string | null;
-      jobName: string | null;
-    }> => {
+    async (key: AssetKeyInput): Promise<{opName: string | null; jobName: string | null}> => {
       const {data} = await apollo.query<AssetForNavigationQuery, AssetForNavigationQueryVariables>({
         query: ASSET_FOR_NAVIGATION_QUERY,
         variables: {key},
       });
       if (data?.assetOrError.__typename === 'Asset' && data?.assetOrError.definition) {
-        return data?.assetOrError.definition;
+        const def = data.assetOrError.definition;
+        return {opName: def.opName, jobName: def.jobs[0]?.name || null};
       }
       return {opName: null, jobName: null};
     },
@@ -40,7 +36,10 @@ const ASSET_FOR_NAVIGATION_QUERY = gql`
         definition {
           id
           opName
-          jobName
+          jobs {
+            id
+            name
+          }
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/useLaunchSingleAssetJob.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/useLaunchSingleAssetJob.tsx
@@ -15,11 +15,8 @@ export const useLaunchSingleAssetJob = () => {
   );
 
   return React.useCallback(
-    async (
-      repoAddress: RepoAddress,
-      definition: {jobName: string | null; opName: string | null},
-    ) => {
-      if (!definition.jobName) {
+    async (repoAddress: RepoAddress, jobName: string | null, opName: string | null) => {
+      if (!jobName || !opName) {
         return;
       }
 
@@ -27,16 +24,13 @@ export const useLaunchSingleAssetJob = () => {
         const result = await launchPipelineExecution({
           variables: {
             executionParams: {
-              selector: {
-                pipelineName: definition.jobName,
-                ...repoAddressToSelector(repoAddress),
-              },
               mode: 'default',
-              stepKeys: [definition.opName],
+              selector: {pipelineName: jobName, ...repoAddressToSelector(repoAddress)},
+              stepKeys: [opName],
             },
           },
         });
-        handleLaunchResult(basePath, definition.jobName, result, true);
+        handleLaunchResult(basePath, jobName, result, true);
       } catch (error) {
         showLaunchError(error as Error);
       }

--- a/js_modules/dagit/packages/core/src/workspace/types/RepositoryAssetsListQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RepositoryAssetsListQuery.ts
@@ -18,13 +18,19 @@ export interface RepositoryAssetsListQuery_repositoryOrError_Repository_assetNod
   path: string[];
 }
 
+export interface RepositoryAssetsListQuery_repositoryOrError_Repository_assetNodes_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+}
+
 export interface RepositoryAssetsListQuery_repositoryOrError_Repository_assetNodes {
   __typename: "AssetNode";
   id: string;
   assetKey: RepositoryAssetsListQuery_repositoryOrError_Repository_assetNodes_assetKey;
   opName: string | null;
   description: string | null;
-  jobName: string | null;
+  jobs: RepositoryAssetsListQuery_repositoryOrError_Repository_assetNodes_jobs[];
 }
 
 export interface RepositoryAssetsListQuery_repositoryOrError_Repository {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -8,6 +8,7 @@ from dagster.core.host_representation.external_data import (
     ExternalTimeWindowPartitionsDefinitionData,
 )
 
+from . import external
 from .asset_key import GrapheneAssetKey
 from .errors import GrapheneAssetNotFoundError
 from .pipelines.pipeline import GrapheneAssetMaterialization, GraphenePipeline
@@ -40,8 +41,8 @@ class GrapheneAssetNode(graphene.ObjectType):
     assetKey = graphene.NonNull(GrapheneAssetKey)
     description = graphene.String()
     opName = graphene.String()
-    jobName = graphene.String()
     jobs = non_null_list(GraphenePipeline)
+    repository = graphene.NonNull(lambda: external.GrapheneRepository)
     dependencies = non_null_list(GrapheneAssetDependency)
     dependedBy = non_null_list(GrapheneAssetDependency)
     dependencyKeys = non_null_list(GrapheneAssetKey)
@@ -84,8 +85,14 @@ class GrapheneAssetNode(graphene.ObjectType):
             assetKey=external_asset_node.asset_key,
             opName=external_asset_node.op_name,
             description=external_asset_node.op_description,
-            jobName=external_asset_node.job_names[0] if external_asset_node.job_names else None,
         )
+
+    def resolve_repository(self, _graphene_info):
+        loc = None
+        for location in _graphene_info.context.repository_locations:
+            if self._external_repository in location.get_repositories().values():
+                loc = location
+        return external.GrapheneRepository(self._external_repository, loc)
 
     def resolve_dependencies(self, _graphene_info):
         return [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -99,7 +99,10 @@ GET_ASSET_IN_PROGRESS_RUNS = """
                 assetNodes {
                     opName
                     description
-                    jobName
+                    jobs {
+                        id
+                        name
+                    }
                 }
                 inProgressRunsByStep {
                     stepKey


### PR DESCRIPTION
## Summary
This PR upgrades Dagit to use the new and more correct `assetNode.jobs` instead of `assetNode.jobName`. This reflects the fact that an asset can be used in more than one job within a repository.

Given a repo with the same asset in two jobs:
- From the asset catalog, "Defined in" now shows both jobs
- From the asset details page, the "Definition in Repository" header shows both jobs
- From the asset explorer, you can explore the asset in both jobs and clicking "Refresh" launches the job you're currently viewing, not one of them at random.
- From the asset explorer, you can click around assets that are in your current job and also in another job and it'll stay on the current job. Clicking a foreign link to an asset in a different job still takes you there.

I also fixed support for viewing the definition of ForeginAssets, which can have a description and belong to a repo but have no `jobs`. I added a `assetNode.repository` resolver to the GraphQL schema so that we can tell where foreign assets are defined without relying on `jobs[0].repository`.

After updating Dagit I removed `assetNode.jobName` from the GraphQL schema.

## Test Plan

Run through impacted screens and verify everything looks correct.



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.