### PR TITLE
[dagit] Highlight op links with blue

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
@@ -88,7 +88,7 @@ const OpIOContainer = styled.div<{$colorKey: string; $highlighted: boolean}>`
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: ${(p) => (p.$highlighted ? ColorsWIP.Gray700 : ColorsWIP.Gray500)};
+    background: ${(p) => (p.$highlighted ? ColorsWIP.Blue500 : ColorsWIP.Gray500)};
     display: inline-block;
     margin: 6px;
   }

--- a/js_modules/dagit/packages/core/src/graph/PipelineGraph.tsx
+++ b/js_modules/dagit/packages/core/src/graph/PipelineGraph.tsx
@@ -146,7 +146,7 @@ const PipelineGraphContents: React.FC<IPipelineContentsProps> = React.memo((prop
       <OpLinks
         ops={ops}
         layout={layout}
-        color={ColorsWIP.Gray500}
+        color={ColorsWIP.Blue500}
         onHighlight={setHighlighted}
         connections={layout.connections.filter(({from, to}) =>
           isHighlighted(highlighted, {


### PR DESCRIPTION
## Summary

Resolves #5640.

Make the highlighted input/output connections on DAGs a little more obvious, using blue instead of gray.

## Test Plan

View a job DAG. Highlight some inputs, outputs, connections. Verify that it's blue!
