### PR TITLE
add k8s labels to dagster jobs

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -369,7 +369,16 @@ def create_k8s_job_task(celery_app, **task_kwargs):
         args = execute_step_args.get_command_args()
 
         job = construct_dagster_k8s_job(
-            job_config, args, job_name, user_defined_k8s_config, pod_name, component="step_worker"
+            job_config,
+            args,
+            job_name,
+            user_defined_k8s_config,
+            pod_name,
+            component="step_worker",
+            labels={
+                "dagster/job": execute_step_args.pipeline_origin.pipeline_name,
+                "dagster/op": step_key,
+            },
         )
 
         # Running list of events generated from this task execution

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -239,6 +239,9 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
             env_vars=env_vars,
+            labels={
+                "dagster/job": pipeline_origin.pipeline_name,
+            },
         )
 
         job_namespace = exc_config.get("job_namespace")

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -186,6 +186,10 @@ class K8sStepHandler(StepHandler):
             pod_name=pod_name,
             component="step_worker",
             user_defined_k8s_config=user_defined_k8s_config,
+            k8s_labels={
+                "job": step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                "op": step_key,
+            },
         )
 
         events.append(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -186,9 +186,9 @@ class K8sStepHandler(StepHandler):
             pod_name=pod_name,
             component="step_worker",
             user_defined_k8s_config=user_defined_k8s_config,
-            k8s_labels={
-                "job": step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
-                "op": step_key,
+            labels={
+                "dagster/job": step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                "dagster/op": step_key,
             },
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -485,7 +485,7 @@ def construct_dagster_k8s_job(
     user_defined_k8s_config=None,
     pod_name=None,
     component=None,
-    k8s_labels=None,
+    labels=None,
     env_vars=None,
 ):
     """Constructs a Kubernetes Job object for a dagster-graphql invocation.
@@ -500,8 +500,8 @@ def construct_dagster_k8s_job(
             in length. Defaults to "<job_name>-pod".
         component (str, optional): The name of the component, used to provide the Job label
             app.kubernetes.io/component. Defaults to None.
-        k8s_labels(Dict[str, str]): Additional labels to be attached to k8s jobs and pod templates.
-            The resulting labels are "dagster.io/<key>: <value_possibly_truncated>".
+        labels(Dict[str, str]): Additional labels to be attached to k8s jobs and pod templates.
+            Long label values are may be truncated.
         env_vars(Dict[str, str]): Additional environment variables to add to the K8s Container.
 
     Returns:
@@ -520,7 +520,7 @@ def construct_dagster_k8s_job(
     pod_name = check.opt_str_param(pod_name, "pod_name", default=job_name + "-pod")
     check.opt_str_param(component, "component")
     check.opt_dict_param(env_vars, "env_vars", key_type=str, value_type=str)
-    check.opt_dict_param(k8s_labels, "k8s_labels", key_type=str, value_type=str)
+    check.opt_dict_param(labels, "labels", key_type=str, value_type=str)
 
     check.invariant(
         len(job_name) <= MAX_K8S_NAME_LEN,
@@ -548,8 +548,8 @@ def construct_dagster_k8s_job(
     additional_labels = {
         # Truncate too long label values to fit into 63-characters limit.
         # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
-        f"dagster.io/{k}": v[:63]
-        for k, v in (k8s_labels or {}).items()
+        k: v[:63]
+        for k, v in (labels or {}).items()
     }
     dagster_labels = merge_dicts(k8s_common_labels, additional_labels)
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -485,6 +485,7 @@ def construct_dagster_k8s_job(
     user_defined_k8s_config=None,
     pod_name=None,
     component=None,
+    k8s_labels=None,
     env_vars=None,
 ):
     """Constructs a Kubernetes Job object for a dagster-graphql invocation.
@@ -499,6 +500,8 @@ def construct_dagster_k8s_job(
             in length. Defaults to "<job_name>-pod".
         component (str, optional): The name of the component, used to provide the Job label
             app.kubernetes.io/component. Defaults to None.
+        k8s_labels(Dict[str, str]): Additional labels to be attached to k8s jobs and pod templates.
+            The resulting labels are "dagster.io/<key>: <value_possibly_truncated>".
         env_vars(Dict[str, str]): Additional environment variables to add to the K8s Container.
 
     Returns:
@@ -517,6 +520,7 @@ def construct_dagster_k8s_job(
     pod_name = check.opt_str_param(pod_name, "pod_name", default=job_name + "-pod")
     check.opt_str_param(component, "component")
     check.opt_dict_param(env_vars, "env_vars", key_type=str, value_type=str)
+    check.opt_dict_param(k8s_labels, "k8s_labels", key_type=str, value_type=str)
 
     check.invariant(
         len(job_name) <= MAX_K8S_NAME_LEN,
@@ -531,7 +535,7 @@ def construct_dagster_k8s_job(
     )
 
     # See: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-    dagster_labels = {
+    k8s_common_labels = {
         "app.kubernetes.io/name": "dagster",
         "app.kubernetes.io/instance": "dagster",
         "app.kubernetes.io/version": dagster_version,
@@ -539,7 +543,15 @@ def construct_dagster_k8s_job(
     }
 
     if component:
-        dagster_labels["app.kubernetes.io/component"] = component
+        k8s_common_labels["app.kubernetes.io/component"] = component
+
+    additional_labels = {
+        # Truncate too long label values to fit into 63-characters limit.
+        # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+        f"dagster.io/{k}": v[:63]
+        for k, v in (k8s_labels or {}).items()
+    }
+    dagster_labels = merge_dicts(k8s_common_labels, additional_labels)
 
     env = [kubernetes.client.V1EnvVar(name="DAGSTER_HOME", value=job_config.dagster_home)]
     if job_config.postgres_password_secret:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -290,6 +290,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             pod_name=pod_name,
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
+            k8s_labels={
+                "job": pipeline_origin.pipeline_name,
+            },
         )
 
         self._instance.report_engine_event(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -290,8 +290,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             pod_name=pod_name,
             component="run_worker",
             user_defined_k8s_config=user_defined_k8s_config,
-            k8s_labels={
-                "job": pipeline_origin.pipeline_name,
+            labels={
+                "dagster/job": pipeline_origin.pipeline_name,
             },
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -1,6 +1,6 @@
 import pytest
-from dagster import graph
 from dagster import __version__ as dagster_version
+from dagster import graph
 from dagster.core.test_utils import environ, remove_none_recursively
 from dagster_k8s import DagsterK8sJobConfig, construct_dagster_k8s_job
 from dagster_k8s.job import (
@@ -402,30 +402,40 @@ def test_construct_dagster_k8s_job_with_job_op_labels():
         instance_config_map="test",
     )
     job1 = construct_dagster_k8s_job(
-        cfg, [], "job123",
-        k8s_labels={
-            "job": "some_job",
-            "op": "some_op",
+        cfg,
+        [],
+        "job123",
+        labels={
+            "dagster/job": "some_job",
+            "dagster/op": "some_op",
         },
     ).to_dict()
-    expected_labels1 = dict(**common_labels, **{
-        "dagster.io/job": "some_job",
-        "dagster.io/op": "some_op",
-    })
+    expected_labels1 = dict(
+        **common_labels,
+        **{
+            "dagster/job": "some_job",
+            "dagster/op": "some_op",
+        },
+    )
     assert job1["metadata"]["labels"] == expected_labels1
     assert job1["spec"]["template"]["metadata"]["labels"] == expected_labels1
 
     job2 = construct_dagster_k8s_job(
-        cfg, [], "job456",
-        k8s_labels={
-            "job": "long_job_name_64____01234567890123456789012345678901234567890123",
-            "op": "long_op_name_64_____01234567890123456789012345678901234567890123",
+        cfg,
+        [],
+        "job456",
+        labels={
+            "dagster/job": "long_job_name_64____01234567890123456789012345678901234567890123",
+            "dagster/op": "long_op_name_64_____01234567890123456789012345678901234567890123",
         },
     ).to_dict()
-    expected_labels2 = dict(**common_labels, **{
-        # The last character should be truncated.
-        "dagster.io/job": "long_job_name_64____0123456789012345678901234567890123456789012",
-        "dagster.io/op": "long_op_name_64_____0123456789012345678901234567890123456789012",
-    })
+    expected_labels2 = dict(
+        **common_labels,
+        **{
+            # The last character should be truncated.
+            "dagster/job": "long_job_name_64____0123456789012345678901234567890123456789012",
+            "dagster/op": "long_op_name_64_____0123456789012345678901234567890123456789012",
+        },
+    )
     assert job2["metadata"]["labels"] == expected_labels2
     assert job2["spec"]["template"]["metadata"]["labels"] == expected_labels2


### PR DESCRIPTION
See https://github.com/dagster-io/dagster/pull/5619 by @skirino for the original PR, I just tweaked some names and added it to celery-k8s as well

- Add labels to both k8s jobs and pod templates so that the resulting k8s objects are properly labelled with dagster job/op names
- k8s_labels => labels, apply to celery-k8s as well

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.