### PR TITLE
[dagit] Adjust column widths on tables

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -91,7 +91,7 @@ export const AssetTable = ({
             <th>Asset Key</th>
             {flagAssetGraph ? <th>Description</th> : null}
             {flagAssetGraph ? <th style={{maxWidth: 250}}>Defined In</th> : null}
-            {canWipeAssets ? <th>Actions</th> : null}
+            {canWipeAssets ? <th style={{width: 80}}>Actions</th> : null}
           </tr>
         </thead>
         <tbody>

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -231,12 +231,12 @@ const BackfillTable = ({backfills, refetch}: {backfills: Backfill[]; refetch: ()
       <Table>
         <thead>
           <tr>
-            <th style={{width: '120px'}}>Backfill Id</th>
+            <th style={{width: 120}}>Backfill Id</th>
             <th>Partition Set</th>
             <th style={{textAlign: 'right'}}>Progress</th>
             <th>Status</th>
             <th>Created</th>
-            <th></th>
+            <th style={{width: 80}} />
           </tr>
         </thead>
         <tbody>
@@ -348,7 +348,7 @@ const BackfillRow = ({
         <BackfillStatusTable backfill={backfill} />
       </td>
       <td>{backfill.timestamp ? <TimestampDisplay timestamp={backfill.timestamp} /> : '-'}</td>
-      <td style={{width: '100px'}}>
+      <td>
         <Popover
           content={
             <MenuWIP>

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -104,7 +104,7 @@ export const RunTable = (props: RunTableProps) => {
       <Table>
         <thead>
           <tr>
-            <th style={{paddingTop: 0, paddingBottom: 0}}>
+            <th style={{width: 42, paddingTop: 0, paddingBottom: 0}}>
               {canTerminateOrDelete ? (
                 <Checkbox
                   indeterminate={checkedIds.size > 0 && checkedIds.size !== runs.length}
@@ -117,10 +117,10 @@ export const RunTable = (props: RunTableProps) => {
                 />
               ) : null}
             </th>
-            <th>Status</th>
-            <th>Run ID</th>
+            <th style={{width: 120}}>Status</th>
+            <th style={{width: 90}}>Run ID</th>
             <th>{anyPipelines ? 'Job / Pipeline' : 'Job'}</th>
-            <th style={{width: 120, minWidth: 120}}>Snapshot ID</th>
+            <th style={{width: 90}}>Snapshot ID</th>
             <th style={{width: 180}}>Timing</th>
             {props.additionalColumnHeaders}
             <th style={{width: 52}} />

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
@@ -46,10 +46,10 @@ export const SchedulesTable: React.FC<{
       <thead>
         <tr>
           <th style={{width: '60px'}}></th>
-          <th style={{minWidth: '300px'}}>Schedule name</th>
-          <th style={{minWidth: '150px'}}>Schedule</th>
-          <th style={{minWidth: '170px'}}>Next tick</th>
-          <th style={{width: '120px'}}>
+          <th>Schedule name</th>
+          <th style={{width: '15%'}}>Schedule</th>
+          <th style={{width: '10%'}}>Next tick</th>
+          <th style={{width: '10%'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Last tick
               <Tooltip position="top" content={lastTick}>
@@ -57,7 +57,7 @@ export const SchedulesTable: React.FC<{
               </Tooltip>
             </Box>
           </th>
-          <th>
+          <th style={{width: 130}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Last run
               <Tooltip position="top" content={lastRun}>
@@ -65,7 +65,7 @@ export const SchedulesTable: React.FC<{
               </Tooltip>
             </Box>
           </th>
-          <th>
+          <th style={{width: '30%'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Partition Set
               <Tooltip position="top" content={partitionStatus}>
@@ -73,7 +73,7 @@ export const SchedulesTable: React.FC<{
               </Tooltip>
             </Box>
           </th>
-          <th />
+          <th style={{width: 80}} />
         </tr>
       </thead>
       <tbody>

--- a/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsTable.tsx
@@ -32,8 +32,8 @@ export const SensorsTable: React.FC<{
         <tr>
           <th style={{width: '60px'}}></th>
           <th>Sensor Name</th>
-          <th style={{width: '150px'}}>Frequency</th>
-          <th style={{width: '120px'}}>
+          <th style={{width: '15%'}}>Frequency</th>
+          <th style={{width: '15%'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Last tick
               <Tooltip position="top" content={lastTick}>
@@ -41,7 +41,7 @@ export const SensorsTable: React.FC<{
               </Tooltip>
             </Box>
           </th>
-          <th>
+          <th style={{width: '20%'}}>
             <Box flex={{gap: 8, alignItems: 'end'}}>
               Last Run
               <Tooltip position="top" content={lastRun}>


### PR DESCRIPTION
## Summary
This PR adjusts column widths on tables in Dagit to avoid columns with fixed content length (eg: Run ID) from becoming too long on large screens or when job names are short. It also makes the widths consistent so that pages that show multiple tables (eg: sensors for each repo) are aligned as often as possible.

I think each table should have only one column with no width. All the others should have a either a fixed width or a % width.

Before:
![Screen Shot 2021-12-22 at 12 13 04 PM](https://user-images.githubusercontent.com/1037212/147137782-fd262e1f-5b07-4837-b4d4-50720fd80af4.png)

After:
![Screen Shot 2021-12-22 at 12 13 42 PM](https://user-images.githubusercontent.com/1037212/147137806-3bb84f35-5f9c-499d-b826-d1d10d94484b.png)

Before:
![Screen Shot 2021-12-22 at 12 20 56 PM](https://user-images.githubusercontent.com/1037212/147137921-e7ad658b-de10-4cf0-af3d-b5c5462c9099.png)

After:
![Screen Shot 2021-12-22 at 12 21 04 PM](https://user-images.githubusercontent.com/1037212/147137915-9684df17-bbfb-4a48-81e7-e731d5ee81b2.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.