### PR TITLE
Lazily load the pipeline snapshot within ExternalExecutionPlan

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -492,13 +492,11 @@ type ExecutionStep {
 
 type ExecutionStepInput {
   name: String!
-  type: DagsterType!
   dependsOn: [ExecutionStep!]!
 }
 
 type ExecutionStepOutput {
   name: String!
-  type: DagsterType!
 }
 
 enum StepKind {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -253,20 +253,15 @@ class GrapheneRun(graphene.ObjectType):
             return None
 
         instance = graphene_info.context.instance
-        historical_pipeline = instance.get_historical_pipeline(
-            self._pipeline_run.pipeline_snapshot_id
-        )
+
         execution_plan_snapshot = instance.get_execution_plan_snapshot(
             self._pipeline_run.execution_plan_snapshot_id
         )
         return (
             GrapheneExecutionPlan(
-                ExternalExecutionPlan(
-                    execution_plan_snapshot=execution_plan_snapshot,
-                    represented_pipeline=historical_pipeline,
-                )
+                ExternalExecutionPlan(execution_plan_snapshot=execution_plan_snapshot)
             )
-            if execution_plan_snapshot and historical_pipeline
+            if execution_plan_snapshot
             else None
         )
 

--- a/python_modules/dagster/dagster/core/execution/plan/resume_retry.py
+++ b/python_modules/dagster/dagster/core/execution/plan/resume_retry.py
@@ -47,11 +47,7 @@ def get_retry_steps_from_parent_run(
             f"Could not load execution plan snapshot for run {parent_run_id}"
         )
 
-    historical_pipeline = instance.get_historical_pipeline(parent_run.pipeline_snapshot_id)
-
-    execution_plan = ExternalExecutionPlan(
-        execution_plan_snapshot=execution_plan_snapshot, represented_pipeline=historical_pipeline
-    )
+    execution_plan = ExternalExecutionPlan(execution_plan_snapshot=execution_plan_snapshot)
 
     # keep track of steps with dicts that point:
     # * step_key -> set(step_handle) in the normal case

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -6,7 +6,6 @@ from dagster import check
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.run_request import InstigatorType
 from dagster.core.definitions.sensor_definition import DEFAULT_SENSOR_DAEMON_INTERVAL
-from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
 from dagster.core.origin import PipelinePythonOrigin
 from dagster.core.snap import ExecutionPlanSnapshot
@@ -352,24 +351,12 @@ class ExternalExecutionPlan:
     was compiled in another process or persisted in an instance.
     """
 
-    def __init__(self, execution_plan_snapshot, represented_pipeline):
+    def __init__(self, execution_plan_snapshot):
         self.execution_plan_snapshot = check.inst_param(
             execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot
         )
-        self.represented_pipeline = check.inst_param(
-            represented_pipeline, "represented_pipeline", RepresentedPipeline
-        )
 
         self._step_index = {step.key: step for step in self.execution_plan_snapshot.steps}
-
-        if (
-            execution_plan_snapshot.pipeline_snapshot_id
-            != represented_pipeline.identifying_pipeline_snapshot_id
-        ):
-            raise DagsterInvariantViolationError(
-                "The target snapshot ID from the execution plan snapshot does not match the "
-                "passed in target snapshot. "
-            )
 
         self._step_keys_in_plan = (
             set(execution_plan_snapshot.step_keys_to_execute)

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -357,8 +357,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             execution_plan_snapshot=snapshot_from_execution_plan(
                 execution_plan,
                 external_pipeline.identifying_pipeline_snapshot_id,
-            ),
-            represented_pipeline=external_pipeline,
+            )
         )
 
     def get_external_partition_config(
@@ -654,10 +653,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             instance=instance,
         )
 
-        return ExternalExecutionPlan(
-            execution_plan_snapshot=execution_plan_snapshot_or_error,
-            represented_pipeline=external_pipeline,
-        )
+        return ExternalExecutionPlan(execution_plan_snapshot=execution_plan_snapshot_or_error)
 
     def get_subset_external_pipeline_result(
         self, selector: PipelineSelector

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
@@ -1,6 +1,3 @@
-import re
-
-import pytest
 from dagster.core.host_representation import ExternalExecutionPlan
 from dagster.core.instance import DagsterInstance, InstanceRef
 from dagster.core.snap import create_execution_plan_snapshot_id, create_pipeline_snapshot_id
@@ -37,7 +34,7 @@ def test_run_created_in_0_7_9_snapshot_id_change():
         assert create_execution_plan_snapshot_id(ep_snapshot) != old_execution_plan_snapshot_id
 
         # This previously failed with a check error
-        assert ExternalExecutionPlan(ep_snapshot, historical_pipeline)
+        assert ExternalExecutionPlan(ep_snapshot)
 
 
 # Scripts to create this (run against 0.7.9)


### PR DESCRIPTION
Summary:
We only actually need to load this within one specific field in the execution plan object, which the gantt chart doesn't actually use. Add a method that that specific field can use when it needs access to the snapshot.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.