### PR TITLE
Take pipeline out of run fragment, use fields on run directly

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -70,7 +70,7 @@ export const Run: React.FC<RunProps> = (props) => {
 
   useFavicon(run ? runStatusFavicon(run.status) : '/favicon.svg');
   useDocumentTitle(
-    run ? `${run.pipeline.name} ${runId.slice(0, 8)} [${run.status}]` : `Run: ${runId}`,
+    run ? `${run.pipelineName} ${runId.slice(0, 8)} [${run.status}]` : `Run: ${runId}`,
   );
 
   const onShowStateDetails = (stepKey: string, logs: RunDagsterRunEventFragment[]) => {
@@ -231,7 +231,7 @@ const RunWithData: React.FunctionComponent<RunWithDataProps> = ({
     : [];
 
   const onLaunch = async (style: ReExecutionStyle) => {
-    if (!run || run.pipeline.__typename === 'UnknownPipeline' || !repoMatch) {
+    if (!run || !run.pipelineSnapshotId || !repoMatch) {
       return;
     }
 
@@ -244,7 +244,7 @@ const RunWithData: React.FunctionComponent<RunWithDataProps> = ({
 
     try {
       const result = await launchPipelineReexecution({variables});
-      handleLaunchResult(basePath, run.pipeline.name, result);
+      handleLaunchResult(basePath, run.pipelineName, result);
     } catch (error) {
       showLaunchError(error as Error);
     }

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -251,10 +251,10 @@ function usePipelineAvailabilityErrorForRun(
     return null;
   }
 
-  if (run?.pipeline.__typename === 'UnknownPipeline') {
+  if (!run.pipelineSnapshotId) {
     return {
       icon: 'error',
-      tooltip: `"${run.pipeline.name}" could not be found.`,
+      tooltip: `"${run.pipelineName}" could not be found.`,
       disabled: true,
     };
   }
@@ -275,7 +275,7 @@ function usePipelineAvailabilityErrorForRun(
       // Only the repo is a match.
       return {
         icon: 'warning',
-        tooltip: `The workspace version of "${run.pipeline.name}" may be different than the one used for the original run.`,
+        tooltip: `The workspace version of "${run.pipelineName}" may be different than the one used for the original run.`,
         disabled: false,
       };
     }
@@ -286,7 +286,7 @@ function usePipelineAvailabilityErrorForRun(
         icon: 'warning',
         tooltip: (
           <Group direction="column" spacing={4}>
-            <div>{`The original run loaded "${run.pipeline.name}" from a different repository.`}</div>
+            <div>{`The original run loaded "${run.pipelineName}" from a different repository.`}</div>
             {run.repositoryOrigin ? (
               <div>
                 Original repository:{' '}
@@ -305,7 +305,7 @@ function usePipelineAvailabilityErrorForRun(
     // Only the pipeline name matched. This could be from any repo in the workspace.
     return {
       icon: 'warning',
-      tooltip: `The pipeline "${run.pipeline.name}" may be a different version from the original pipeline run.`,
+      tooltip: `The pipeline "${run.pipelineName}" may be a different version from the original pipeline run.`,
       disabled: false,
     };
   }
@@ -317,7 +317,7 @@ function usePipelineAvailabilityErrorForRun(
 
   const tooltip = (
     <Group direction="column" spacing={8}>
-      <div>{`"${run.pipeline.name}" is not available in the current workspace.`}</div>
+      <div>{`"${run.pipelineName}" is not available in the current workspace.`}</div>
       {repoForRun && repoLocationForRun ? (
         <div>{`Load repository ${buildRepoPath(
           repoForRun,

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -36,13 +36,7 @@ export const RunFragments = {
       rootRunId
       parentRunId
       pipelineName
-      pipeline {
-        __typename
-        ... on PipelineReference {
-          name
-          solidSelection
-        }
-      }
+      solidSelection
       pipelineSnapshotId
       executionPlan {
         artifactsPersisted

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -38,7 +38,7 @@ export const RunRoot = () => {
     : null;
 
   const isJob = React.useMemo(
-    () => !!(run && repoMatch && isThisThingAJob(repoMatch.match, run.pipeline.name)),
+    () => !!(run && repoMatch && isThisThingAJob(repoMatch.match, run.pipelineName)),
     [run, repoMatch],
   );
 
@@ -83,7 +83,7 @@ export const RunRoot = () => {
                 <TagWIP icon="run">
                   Run of{' '}
                   <PipelineReference
-                    pipelineName={run?.pipeline.name}
+                    pipelineName={run?.pipelineName}
                     pipelineHrefContext={repoAddress || 'repo-unknown'}
                     snapshotId={snapshotID}
                     size="small"
@@ -130,13 +130,6 @@ const RUN_ROOT_QUERY = gql`
       __typename
       ... on Run {
         id
-        pipeline {
-          __typename
-          ... on PipelineReference {
-            name
-            solidSelection
-          }
-        }
         ...RunFragment
       }
     }

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -122,7 +122,7 @@ export function getReexecutionVariables(input: {
 }) {
   const {run, style, repositoryLocationName, repositoryName} = input;
 
-  if (!run || ('pipeline' in run && run.pipeline.__typename === 'UnknownPipeline')) {
+  if (!run || !run.pipelineSnapshotId) {
     return undefined;
   }
 
@@ -134,7 +134,7 @@ export function getReexecutionVariables(input: {
       repositoryLocationName,
       repositoryName,
       pipelineName: run.pipelineName,
-      solidSelection: 'solidSelection' in run ? run.solidSelection : run.pipeline.solidSelection,
+      solidSelection: run.solidSelection,
     },
   };
 

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragment.ts
@@ -15,12 +15,6 @@ export interface RunFragment_tags {
   value: string;
 }
 
-export interface RunFragment_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-  solidSelection: string[] | null;
-}
-
 export interface RunFragment_executionPlan_steps_inputs_dependsOn {
   __typename: "ExecutionStep";
   key: string;
@@ -99,7 +93,7 @@ export interface RunFragment {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineName: string;
-  pipeline: RunFragment_pipeline;
+  solidSelection: string[] | null;
   pipelineSnapshotId: string | null;
   executionPlan: RunFragment_executionPlan | null;
   stepKeysToExecute: string[] | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRootQuery.ts
@@ -13,12 +13,6 @@ export interface RunRootQuery_pipelineRunOrError_RunNotFoundError {
   __typename: "RunNotFoundError" | "PythonError";
 }
 
-export interface RunRootQuery_pipelineRunOrError_Run_pipeline {
-  __typename: "PipelineSnapshot" | "UnknownPipeline";
-  name: string;
-  solidSelection: string[] | null;
-}
-
 export interface RunRootQuery_pipelineRunOrError_Run_tags {
   __typename: "PipelineTag";
   key: string;
@@ -94,7 +88,6 @@ export interface RunRootQuery_pipelineRunOrError_Run_stepStats {
 export interface RunRootQuery_pipelineRunOrError_Run {
   __typename: "Run";
   id: string;
-  pipeline: RunRootQuery_pipelineRunOrError_Run_pipeline;
   runConfig: any;
   runId: string;
   canTerminate: boolean;
@@ -104,6 +97,7 @@ export interface RunRootQuery_pipelineRunOrError_Run {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineName: string;
+  solidSelection: string[] | null;
   pipelineSnapshotId: string | null;
   executionPlan: RunRootQuery_pipelineRunOrError_Run_executionPlan | null;
   stepKeysToExecute: string[] | null;


### PR DESCRIPTION
Don't query pipeline snapshot at all when rendering the runs page / gantt chart