### PR TITLE
Enable batch fetching of job state for schedule / sensors

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -1,4 +1,5 @@
 from dagster import check
+from dagster.core.definitions.run_request import InstigatorType
 from dagster.core.host_representation import PipelineSelector, RepositorySelector, ScheduleSelector
 from dagster.core.scheduler.instigation import InstigatorStatus
 from dagster.seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
@@ -57,9 +58,21 @@ def get_schedules_or_error(graphene_info, repository_selector):
     location = graphene_info.context.get_repository_location(repository_selector.location_name)
     repository = location.get_repository(repository_selector.repository_name)
     external_schedules = repository.get_external_schedules()
+    schedule_states_by_name = {
+        state.name: state
+        for state in graphene_info.context.instance.all_stored_job_state(
+            repository_origin_id=repository.get_external_origin_id(),
+            job_type=InstigatorType.SCHEDULE,
+        )
+    }
 
     results = [
-        GrapheneSchedule(graphene_info, external_schedule=external_schedule)
+        GrapheneSchedule(
+            graphene_info,
+            external_schedule=external_schedule,
+            schedule_state=schedule_states_by_name.get(external_schedule.name),
+            fetched_state=True,
+        )
         for external_schedule in external_schedules
     ]
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -67,8 +67,7 @@ def get_schedules_or_error(graphene_info, repository_selector):
     }
 
     results = [
-        GrapheneSchedule.with_default_state(
-            graphene_info.context.instance,
+        GrapheneSchedule(
             external_schedule,
             schedule_states_by_name.get(external_schedule.name),
         )
@@ -96,11 +95,7 @@ def get_schedules_for_pipeline(graphene_info, pipeline_selector):
         schedule_state = graphene_info.context.instance.get_job_state(
             external_schedule.get_external_origin_id()
         )
-        results.append(
-            GrapheneSchedule.with_default_state(
-                graphene_info.context.instance, external_schedule, schedule_state
-            )
-        )
+        results.append(GrapheneSchedule(external_schedule, schedule_state))
 
     return results
 
@@ -124,9 +119,7 @@ def get_schedule_or_error(graphene_info, schedule_selector):
     schedule_state = graphene_info.context.instance.get_job_state(
         external_schedule.get_external_origin_id()
     )
-    return GrapheneSchedule.with_default_state(
-        graphene_info.context.instance, external_schedule, schedule_state
-    )
+    return GrapheneSchedule(external_schedule, schedule_state)
 
 
 def get_schedule_next_tick(graphene_info, schedule_state):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -28,10 +28,8 @@ def get_sensors_or_error(graphene_info, repository_selector):
     return GrapheneSensors(
         results=[
             GrapheneSensor(
-                graphene_info,
                 sensor,
                 sensor_states_by_name.get(sensor.name),
-                fetched_state=True,
             )
             for sensor in sensors
         ]
@@ -51,8 +49,11 @@ def get_sensor_or_error(graphene_info, selector):
     if not repository.has_external_sensor(selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
     external_sensor = repository.get_external_sensor(selector.sensor_name)
+    sensor_state = graphene_info.context.instance.get_job_state(
+        external_sensor.get_external_origin_id()
+    )
 
-    return GrapheneSensor(graphene_info, external_sensor)
+    return GrapheneSensor(external_sensor, sensor_state)
 
 
 @capture_error
@@ -69,7 +70,10 @@ def start_sensor(graphene_info, sensor_selector):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(sensor_selector.sensor_name))
     external_sensor = repository.get_external_sensor(sensor_selector.sensor_name)
     graphene_info.context.instance.start_sensor(external_sensor)
-    return GrapheneSensor(graphene_info, external_sensor)
+    sensor_state = graphene_info.context.instance.get_job_state(
+        external_sensor.get_external_origin_id()
+    )
+    return GrapheneSensor(external_sensor, sensor_state)
 
 
 @capture_error
@@ -128,12 +132,19 @@ def get_sensors_for_pipeline(graphene_info, pipeline_selector):
     repository = location.get_repository(pipeline_selector.repository_name)
     external_sensors = repository.get_external_sensors()
 
-    return [
-        GrapheneSensor(graphene_info, external_sensor)
-        for external_sensor in external_sensors
-        if pipeline_selector.pipeline_name
-        in [target.pipeline_name for target in external_sensor.get_external_targets()]
-    ]
+    results = []
+    for external_sensor in external_sensors:
+        if pipeline_selector.pipeline_name not in [
+            target.pipeline_name for target in external_sensor.get_external_targets()
+        ]:
+            continue
+
+        sensor_state = graphene_info.context.instance.get_job_state(
+            external_sensor.get_external_origin_id()
+        )
+        results.append(GrapheneSensor(external_sensor, sensor_state))
+
+    return results
 
 
 def get_sensor_next_tick(graphene_info, sensor_state):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -17,10 +17,23 @@ def get_sensors_or_error(graphene_info, repository_selector):
 
     location = graphene_info.context.get_repository_location(repository_selector.location_name)
     repository = location.get_repository(repository_selector.repository_name)
-
+    sensors = repository.get_external_sensors()
+    sensor_states_by_name = {
+        state.name: state
+        for state in graphene_info.context.instance.all_stored_job_state(
+            repository_origin_id=repository.get_external_origin_id(),
+            job_type=InstigatorType.SENSOR,
+        )
+    }
     return GrapheneSensors(
         results=[
-            GrapheneSensor(graphene_info, sensor) for sensor in repository.get_external_sensors()
+            GrapheneSensor(
+                graphene_info,
+                sensor,
+                sensor_states_by_name.get(sensor.name),
+                fetched_state=True,
+            )
+            for sensor in sensors
         ]
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -196,8 +196,7 @@ class GrapheneRepository(graphene.ObjectType):
 
         return sorted(
             [
-                GrapheneSchedule.with_default_state(
-                    graphene_info.context.instance,
+                GrapheneSchedule(
                     schedule,
                     schedule_states_by_name.get(schedule.name),
                 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -209,8 +209,23 @@ class GrapheneRepository(graphene.ObjectType):
 
     def resolve_sensors(self, graphene_info):
         sensors = self._repository.get_external_sensors()
+        sensor_states_by_name = {
+            state.name: state
+            for state in graphene_info.context.instance.all_stored_job_state(
+                repository_origin_id=self._repository.get_external_origin_id(),
+                job_type=InstigatorType.SENSOR,
+            )
+        }
         return sorted(
-            [GrapheneSensor(graphene_info, sensor) for sensor in sensors],
+            [
+                GrapheneSensor(
+                    graphene_info,
+                    sensor,
+                    sensor_states_by_name.get(sensor.name),
+                    fetched_state=True,
+                )
+                for sensor in sensors
+            ],
             key=lambda sensor: sensor.name,
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -196,11 +196,10 @@ class GrapheneRepository(graphene.ObjectType):
 
         return sorted(
             [
-                GrapheneSchedule(
-                    graphene_info,
+                GrapheneSchedule.with_default_state(
+                    graphene_info.context.instance,
                     schedule,
                     schedule_states_by_name.get(schedule.name),
-                    fetched_state=True,
                 )
                 for schedule in schedules
             ],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -6,13 +6,13 @@ from dagster.core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
     RepositoryLocation,
 )
+from dagster.core.scheduler.instigation import InstigatorType
 from dagster.core.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
 from dagster_graphql.implementation.fetch_runs import (
     get_in_progress_runs_by_step,
     get_in_progress_runs_for_job,
 )
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
-from dagster.core.scheduler.instigation import InstigatorType
 
 from .asset_graph import GrapheneAssetNode
 from .errors import GraphenePythonError, GrapheneRepositoryNotFoundError

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -217,10 +217,8 @@ class GrapheneRepository(graphene.ObjectType):
         return sorted(
             [
                 GrapheneSensor(
-                    graphene_info,
                     sensor,
                     sensor_states_by_name.get(sensor.name),
-                    fetched_state=True,
                 )
                 for sensor in sensors
             ],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -348,7 +348,7 @@ class GrapheneInstigationState(graphene.ObjectType):
         else:
             return get_schedule_next_tick(graphene_info, self._job_state)
 
-    def resolve_runningCount(self, graphene_info):
+    def resolve_runningCount(self, _graphene_info):
         return 1 if self._job_state.status == InstigatorStatus.RUNNING else 0
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -349,12 +349,7 @@ class GrapheneInstigationState(graphene.ObjectType):
             return get_schedule_next_tick(graphene_info, self._job_state)
 
     def resolve_runningCount(self, graphene_info):
-        if self._job_state.job_type == InstigatorType.SENSOR:
-            return 1 if self._job_state.status == InstigatorStatus.RUNNING else 0
-        else:
-            return graphene_info.context.instance.running_schedule_count(
-                self._job_state.job_origin_id
-            )
+        return 1 if self._job_state.status == InstigatorStatus.RUNNING else 0
 
 
 class GrapheneInstigationStates(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -38,18 +38,13 @@ class GrapheneSchedule(graphene.ObjectType):
     class Meta:
         name = "Schedule"
 
-    def __init__(self, graphene_info, external_schedule, schedule_state=None, fetched_state=False):
+    def __init__(self, external_schedule, schedule_state):
         self._external_schedule = check.inst_param(
             external_schedule, "external_schedule", ExternalSchedule
         )
-        if not fetched_state:
-            self._schedule_state = graphene_info.context.instance.get_job_state(
-                self._external_schedule.get_external_origin_id()
-            )
-        else:
-            self._schedule_state = check.opt_inst_param(
-                schedule_state, "schedule_state", InstigatorState
-            )
+        self._schedule_state = check.opt_inst_param(
+            schedule_state, "schedule_state", InstigatorState
+        )
 
         if not self._schedule_state:
             # Also include a ScheduleState for a stopped schedule that may not
@@ -113,6 +108,19 @@ class GrapheneSchedule(graphene.ObjectType):
 
     def resolve_futureTick(self, _graphene_info, tick_timestamp):
         return GrapheneFutureInstigationTick(self._schedule_state, float(tick_timestamp))
+
+    @staticmethod
+    def with_default_state(instance, external_schedule, stored_state):
+        """Helper function to populate the GrapheneSchedule with the default state if no stored
+        state could be found"""
+        check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
+        check.opt_inst_param(stored_state, "stored_state", InstigatorState)
+        return GrapheneSchedule(
+            external_schedule,
+            stored_state
+            if stored_state
+            else external_schedule.get_default_instigation_state(instance),
+        )
 
 
 class GrapheneScheduleOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -2,6 +2,7 @@ import graphene
 from dagster import check
 from dagster.core.host_representation import ExternalSchedule
 from dagster.seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
+from dagster.core.scheduler.instigation import InstigatorState
 
 from ..errors import (
     GraphenePythonError,
@@ -37,13 +38,18 @@ class GrapheneSchedule(graphene.ObjectType):
     class Meta:
         name = "Schedule"
 
-    def __init__(self, graphene_info, external_schedule):
+    def __init__(self, graphene_info, external_schedule, schedule_state=None, fetched_state=False):
         self._external_schedule = check.inst_param(
             external_schedule, "external_schedule", ExternalSchedule
         )
-        self._schedule_state = graphene_info.context.instance.get_job_state(
-            self._external_schedule.get_external_origin_id()
-        )
+        if not fetched_state:
+            self._schedule_state = graphene_info.context.instance.get_job_state(
+                self._external_schedule.get_external_origin_id()
+            )
+        else:
+            self._schedule_state = check.opt_inst_param(
+                schedule_state, "schedule_state", InstigatorState
+            )
 
         if not self._schedule_state:
             # Also include a ScheduleState for a stopped schedule that may not

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -45,11 +45,8 @@ class GrapheneSchedule(graphene.ObjectType):
         self._schedule_state = check.opt_inst_param(
             schedule_state, "schedule_state", InstigatorState
         )
-
         if not self._schedule_state:
-            # Also include a ScheduleState for a stopped schedule that may not
-            # have a stored database row yet
-            self._schedule_state = self._external_schedule.get_default_instigation_state()
+            self._schedule_state = external_schedule.get_default_instigation_state()
 
         super().__init__(
             name=external_schedule.name,
@@ -108,19 +105,6 @@ class GrapheneSchedule(graphene.ObjectType):
 
     def resolve_futureTick(self, _graphene_info, tick_timestamp):
         return GrapheneFutureInstigationTick(self._schedule_state, float(tick_timestamp))
-
-    @staticmethod
-    def with_default_state(instance, external_schedule, stored_state):
-        """Helper function to populate the GrapheneSchedule with the default state if no stored
-        state could be found"""
-        check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
-        check.opt_inst_param(stored_state, "stored_state", InstigatorState)
-        return GrapheneSchedule(
-            external_schedule,
-            stored_state
-            if stored_state
-            else external_schedule.get_default_instigation_state(instance),
-        )
 
 
 class GrapheneScheduleOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -1,8 +1,8 @@
 import graphene
 from dagster import check
 from dagster.core.host_representation import ExternalSchedule
-from dagster.seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 from dagster.core.scheduler.instigation import InstigatorState
+from dagster.seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 
 from ..errors import (
     GraphenePythonError,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -58,18 +58,11 @@ class GrapheneSensor(graphene.ObjectType):
     class Meta:
         name = "Sensor"
 
-    def __init__(self, graphene_info, external_sensor, sensor_state=None, fetched_state=False):
+    def __init__(self, external_sensor, sensor_state):
         self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
-        if not fetched_state:
-            self._sensor_state = graphene_info.context.instance.get_job_state(
-                self._external_sensor.get_external_origin_id()
-            )
-        else:
-            self._sensor_state = check.opt_inst_param(sensor_state, "sensor_state", InstigatorState)
+        self._sensor_state = check.opt_inst_param(sensor_state, "sensor_state", InstigatorState)
 
         if not self._sensor_state:
-            # Also include a SensorState for a stopped sensor that may not
-            # have a stored database row yet
             self._sensor_state = self._external_sensor.get_default_instigation_state()
 
         super().__init__(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -58,11 +58,14 @@ class GrapheneSensor(graphene.ObjectType):
     class Meta:
         name = "Sensor"
 
-    def __init__(self, graphene_info, external_sensor):
+    def __init__(self, graphene_info, external_sensor, sensor_state=None, fetched_state=False):
         self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
-        self._sensor_state = graphene_info.context.instance.get_job_state(
-            self._external_sensor.get_external_origin_id()
-        )
+        if not fetched_state:
+            self._sensor_state = graphene_info.context.instance.get_job_state(
+                self._external_sensor.get_external_origin_id()
+            )
+        else:
+            self._sensor_state = check.opt_inst_param(sensor_state, "sensor_state", InstigatorState)
 
         if not self._sensor_state:
             # Also include a SensorState for a stopped sensor that may not


### PR DESCRIPTION
Instead of serially fetching from the schedule storage for instigator state, batch fetch for all the instigator states in the repository.

Also, removed extra calls to fetch state for schedules, which is an old artifact from when scheduler status could be different than stored status.

## Test Plan
BK, graphql tests
