### PR TITLE
[dagit] Move asset refresh button to allow "Refresh All"

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -14,7 +14,10 @@ import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {SidebarPipelineOrJobOverview} from '../../pipelines/SidebarPipelineOrJobOverview';
 import {GraphExplorerSolidHandleFragment} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
 import {useDidLaunchEvent} from '../../runs/RunUtils';
+import {Box} from '../../ui/Box';
+import {ColorsWIP} from '../../ui/Colors';
 import {GraphQueryInput} from '../../ui/GraphQueryInput';
+import {IconWIP} from '../../ui/Icon';
 import {Loading} from '../../ui/Loading';
 import {NonIdealState} from '../../ui/NonIdealState';
 import {SplitPanelContainer} from '../../ui/SplitPanelContainer';
@@ -24,7 +27,8 @@ import {RepoAddress} from '../types';
 import {AssetLinks} from './AssetLinks';
 import {AssetNode, ASSET_NODE_FRAGMENT, ASSET_NODE_LIVE_FRAGMENT} from './AssetNode';
 import {ForeignNode} from './ForeignNode';
-import {SidebarAssetInfo, SidebarAssetsInfo} from './SidebarAssetInfo';
+import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+import {SidebarAssetInfo} from './SidebarAssetInfo';
 import {
   buildGraphData,
   buildLiveData,
@@ -321,7 +325,24 @@ const AssetGraphExplorerWithData: React.FC<
             <LargeDAGNotice nodeType="asset" />
           ) : undefined}
 
-          <div style={{position: 'absolute', right: 8, top: 6}}>
+          <div style={{position: 'absolute', right: 12, top: 12}}>
+            <LaunchAssetExecutionButton
+              title={
+                selectedGraphNodes.length === 0
+                  ? 'Refresh All'
+                  : selectedGraphNodes.length === 1
+                  ? 'Refresh Selected'
+                  : `Refresh Selected (${selectedGraphNodes.length})`
+              }
+              repoAddress={repoAddress}
+              assetJobName={explorerPath.pipelineName}
+              assets={(selectedGraphNodes.length
+                ? selectedGraphNodes
+                : Object.values(graphData.nodes)
+              ).map((n) => n.definition)}
+            />
+          </div>
+          <div style={{position: 'absolute', left: 24, top: 16}}>
             <QueryCountdown pollInterval={5 * 1000} queryResult={liveDataQueryResult} />
           </div>
           <AssetQueryInputContainer>
@@ -338,14 +359,15 @@ const AssetGraphExplorerWithData: React.FC<
         <RightInfoPanel>
           <RightInfoPanelContent>
             {selectedGraphNodes.length > 1 ? (
-              <SidebarAssetsInfo
-                jobName={explorerPath.pipelineName}
-                nodes={selectedGraphNodes.map((n) => n.definition)}
-                repoAddress={repoAddress}
-              />
+              <Box
+                style={{height: '70%', color: ColorsWIP.Gray400}}
+                flex={{justifyContent: 'center', alignItems: 'center', gap: 4, direction: 'column'}}
+              >
+                <IconWIP size={48} name="asset" color={ColorsWIP.Gray400} />
+                {`${selectedGraphNodes.length} Assets Selected`}
+              </Box>
             ) : selectedGraphNodes.length === 1 && selectedGraphNodes[0] ? (
               <SidebarAssetInfo
-                jobName={explorerPath.pipelineName}
                 node={selectedGraphNodes[0].definition}
                 liveData={liveDataByNode[selectedGraphNodes[0].id]}
                 definition={selectedDefinitions[0]}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -7,7 +7,8 @@ export const LaunchAssetExecutionButton: React.FC<{
   repoAddress: RepoAddress;
   assetJobName: string;
   assets: {opName: string | null}[];
-}> = ({repoAddress, assets, assetJobName}) => {
+  title?: string;
+}> = ({repoAddress, assets, assetJobName, title}) => {
   if (!assets.every((a) => a.opName)) {
     return <span />;
   }
@@ -15,7 +16,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     <LaunchRootExecutionButton
       pipelineName={assetJobName}
       disabled={false}
-      title={'Refresh'}
+      title={title || 'Refresh'}
       getVariables={() => ({
         executionParams: {
           mode: 'default',

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -10,17 +10,15 @@ import {Box} from '../../ui/Box';
 import {ColorsWIP} from '../../ui/Colors';
 import {RepoAddress} from '../types';
 
-import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {LiveDataForNode} from './Utils';
 import {AssetGraphQuery_pipelineOrError_Pipeline_assetNodes} from './types/AssetGraphQuery';
 
 export const SidebarAssetInfo: React.FC<{
-  jobName: string;
   definition: GraphExplorerSolidHandleFragment_solid_definition;
   node: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes;
   liveData: LiveDataForNode;
   repoAddress: RepoAddress;
-}> = ({jobName, node, definition, repoAddress, liveData}) => {
+}> = ({node, definition, repoAddress, liveData}) => {
   const Plugin = pluginForMetadata(definition.metadata);
   const {lastMaterialization} = liveData || {};
 
@@ -33,11 +31,6 @@ export const SidebarAssetInfo: React.FC<{
             margin={{bottom: 8}}
           >
             <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
-            <LaunchAssetExecutionButton
-              assets={[node]}
-              assetJobName={jobName}
-              repoAddress={repoAddress}
-            />
           </Box>
           <Description description={node.description || null} />
         </Box>
@@ -59,29 +52,5 @@ export const SidebarAssetInfo: React.FC<{
         setParams={() => {}}
       />
     </>
-  );
-};
-
-export const SidebarAssetsInfo: React.FC<{
-  jobName: string;
-  nodes: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes[];
-  repoAddress: RepoAddress;
-}> = ({nodes, jobName, repoAddress}) => {
-  return (
-    <SidebarSection title="Definition">
-      <Box padding={{vertical: 16, horizontal: 24}}>
-        <Box
-          flex={{gap: 8, justifyContent: 'space-between', alignItems: 'baseline'}}
-          margin={{bottom: 8}}
-        >
-          <SidebarTitle>{`${nodes.length} Assets Selected`}</SidebarTitle>
-          <LaunchAssetExecutionButton
-            repoAddress={repoAddress}
-            assets={nodes}
-            assetJobName={jobName}
-          />
-        </Box>
-      </Box>
-    </SidebarSection>
   );
 };


### PR DESCRIPTION
This PR moves the "Refresh" button out of the asset sidebar. When viewing the asset graph, the refresh button now appears overlaid in the top right of the graph. It's present when nothing is selected and allows you to launch the entire graph.

We could put the button in the graph sidebar (shown when nothing is selected) as well as the asset sidebar and achieve the same thing, but I'm not sure putting it in the "Definition" section of the sidebar made sense? 

## Summary
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/1037212/147265532-d24bcf5f-22b9-4005-a100-bcf6739458a8.png">
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/1037212/147265558-0a7a6c0a-f567-4ead-b537-ef1aae7676aa.png">



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.