### PR TITLE
[dagit] Allow multiple run IDs in the runs filter bar

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -83,11 +83,10 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
     if (item.token === 'pipeline' || item.token === 'job') {
       obj.pipelineName = item.value;
     } else if (item.token === 'id') {
-      obj.runIds = [item.value];
+      obj.runIds = obj.runIds || [];
+      obj.runIds.push(item.value);
     } else if (item.token === 'status') {
-      if (!obj.statuses) {
-        obj.statuses = [];
-      }
+      obj.statuses = obj.statuses || [];
       obj.statuses.push(item.value as RunStatus);
     } else if (item.token === 'snapshotId') {
       obj.snapshotId = item.value;


### PR DESCRIPTION

## Summary
It turns out our backend filtering logic supports putting multiple runIds into the run filter bar (and treats them as an OR, the same way multiple statuses / tags are OR'd), but the UI was ignoring all but the last tag.

I discovered this because I wanted to make a link that took you to a set of 5 specific failed runs in the run list. This is now possible by constructing a URL with the five `id:abcdefg` search tokens.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.