### PR TITLE
Allow json serialized strings to be passed in as run config to graphql calls

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -41,7 +41,11 @@ from ..errors import (
 from ..external import GrapheneWorkspace, GrapheneWorkspaceLocationEntry
 from ..inputs import GrapheneAssetKeyInput, GrapheneExecutionParams, GrapheneLaunchBackfillParams
 from ..pipelines.pipeline import GrapheneRun
-from ..runs import GrapheneLaunchRunReexecutionResult, GrapheneLaunchRunResult
+from ..runs import (
+    GrapheneLaunchRunReexecutionResult,
+    GrapheneLaunchRunResult,
+    parse_run_config_input,
+)
 from ..schedules import GrapheneStartScheduleMutation, GrapheneStopRunningScheduleMutation
 from ..sensors import GrapheneStartSensorMutation, GrapheneStopSensorMutation
 from ..util import non_null_list
@@ -93,7 +97,7 @@ def create_execution_params(graphene_info, graphql_execution_params):
 def execution_params_from_graphql(graphql_execution_params):
     return ExecutionParams(
         selector=pipeline_selector_from_graphql(graphql_execution_params.get("selector")),
-        run_config=graphql_execution_params.get("runConfigData") or {},
+        run_config=parse_run_config_input(graphql_execution_params.get("runConfigData") or {}),
         mode=graphql_execution_params.get("mode"),
         execution_metadata=create_execution_metadata(
             graphql_execution_params.get("executionMetadata")

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -71,6 +71,7 @@ from ..runs import (
     GrapheneRunGroupsOrError,
     GrapheneRuns,
     GrapheneRunsOrError,
+    parse_run_config_input,
 )
 from ..schedules import GrapheneScheduleOrError, GrapheneSchedulerOrError, GrapheneSchedulesOrError
 from ..sensors import GrapheneSensorOrError, GrapheneSensorsOrError
@@ -387,7 +388,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         return validate_pipeline_config(
             graphene_info,
             pipeline_selector_from_graphql(pipeline),
-            kwargs.get("runConfigData"),
+            parse_run_config_input(kwargs.get("runConfigData", {})),
             kwargs.get("mode"),
         )
 
@@ -395,7 +396,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         return get_execution_plan(
             graphene_info,
             pipeline_selector_from_graphql(pipeline),
-            kwargs.get("runConfigData"),
+            parse_run_config_input(kwargs.get("runConfigData", {})),
             kwargs.get("mode"),
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -6,7 +6,7 @@ from ..implementation.run_config_schema import resolve_is_run_config_valid
 from .config_types import GrapheneConfigType, to_config_type
 from .errors import GrapheneModeNotFoundError, GraphenePipelineNotFoundError, GraphenePythonError
 from .pipelines.config_result import GraphenePipelineConfigValidationResult
-from .runs import GrapheneRunConfigData
+from .runs import GrapheneRunConfigData, parse_run_config_input
 from .util import non_null_list
 
 
@@ -74,7 +74,7 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
             graphene_info,
             self._represented_pipeline,
             self._mode,
-            kwargs.get("runConfigData", {}),
+            parse_run_config_input(kwargs.get("runConfigData", {})),
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -1,3 +1,5 @@
+import json
+
 import graphene
 from dagster import check
 from graphene.types.generic import GenericScalar
@@ -133,9 +135,15 @@ class GrapheneRunGroupsOrError(graphene.ObjectType):
 class GrapheneRunConfigData(GenericScalar, graphene.Scalar):
     class Meta:
         description = """This type is used when passing in a configuration object
-        for pipeline configuration. This is any-typed in the GraphQL type system,
-        but must conform to the constraints of the dagster config type system"""
+        for pipeline configuration. Can either be passed in as a string (the
+        JSON-serialized configuration object) or as the configuration object itself. In
+        either case, the object must conform to the constraints of the dagster config type system.
+        """
         name = "RunConfigData"
+
+
+def parse_run_config_input(run_config):
+    return json.loads(run_config) if isinstance(run_config, str) else run_config
 
 
 types = [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_types.py
@@ -1,3 +1,5 @@
+import json
+
 from dagster import check
 from dagster.config.config_type import ALL_CONFIG_BUILTINS
 from dagster.utils import file_relative_path
@@ -125,6 +127,19 @@ class TestConfigTypes(NonLaunchableGraphQLContextTestMatrix):
             graphql_context,
             pipeline_name="csv_hello_world",
             run_config=csv_hello_world_solids_config(),
+            mode="default",
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["isPipelineConfigValid"]["__typename"] == "PipelineConfigValidationValid"
+        assert result.data["isPipelineConfigValid"]["pipelineName"] == "csv_hello_world"
+
+    def test_basic_valid_config_serialized_config(self, graphql_context):
+        result = execute_config_graphql(
+            graphql_context,
+            pipeline_name="csv_hello_world",
+            run_config=json.dumps(csv_hello_world_solids_config()),
             mode="default",
         )
 


### PR DESCRIPTION
Summary:
In some languages / graphql clients it is a pain to set up a scalar that is a JSON object, and it's easier for clients to serialize up the run config as a string and upload that (even if it ends up double-encoded since the transport is also JSON-encoded).

This PR adds that as an option.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.