### PR TITLE
[dagit] Prefer "Rematerialize" to "Refresh" for assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -114,6 +114,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
               <LaunchAssetExecutionButton
                 assets={[definition]}
                 assetJobName={definition.jobs[0].name}
+                title={lastMaterializedAt ? 'Rematerialize' : 'Materialize'}
                 repoAddress={repoAddress}
               />
             )}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -329,10 +329,10 @@ const AssetGraphExplorerWithData: React.FC<
             <LaunchAssetExecutionButton
               title={
                 selectedGraphNodes.length === 0
-                  ? 'Refresh All'
+                  ? 'Rematerialize All'
                   : selectedGraphNodes.length === 1
-                  ? 'Refresh Selected'
-                  : `Refresh Selected (${selectedGraphNodes.length})`
+                  ? 'Rematerialize Selected'
+                  : `Rematerialize Selected (${selectedGraphNodes.length})`
               }
               repoAddress={repoAddress}
               assetJobName={explorerPath.pipelineName}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -327,13 +327,7 @@ const AssetGraphExplorerWithData: React.FC<
 
           <div style={{position: 'absolute', right: 12, top: 12}}>
             <LaunchAssetExecutionButton
-              title={
-                selectedGraphNodes.length === 0
-                  ? 'Rematerialize All'
-                  : selectedGraphNodes.length === 1
-                  ? 'Rematerialize Selected'
-                  : `Rematerialize Selected (${selectedGraphNodes.length})`
-              }
+              title={titleForLaunch(selectedGraphNodes, liveDataByNode)}
               repoAddress={repoAddress}
               assetJobName={explorerPath.pipelineName}
               assets={(selectedGraphNodes.length
@@ -493,4 +487,15 @@ const opsInRange = (
     }
   }
   return uniq(ledToTarget);
+};
+
+const titleForLaunch = (nodes: Node[], liveDataByNode: LiveData) => {
+  const isRematerializeForAll = (nodes.length
+    ? nodes.map((n) => liveDataByNode[n.id])
+    : Object.values(liveDataByNode)
+  ).every((e) => !!e?.lastMaterialization);
+
+  return `${isRematerializeForAll ? 'Rematerialize' : 'Materialize'} ${
+    nodes.length === 0 ? `All` : nodes.length === 1 ? `Selected` : `Selected (${nodes.length})`
+  }`;
 };

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -55,7 +55,7 @@ export const AssetNode: React.FC<{
               }}
               text={
                 <span>
-                  Rematerialize{' '}
+                  {event ? 'Rematerialize ' : 'Materialize '}
                   <span style={{fontFamily: 'monospace', fontWeight: 600}}>
                     {displayNameForAssetKey(definition.assetKey)}
                   </span>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -55,7 +55,7 @@ export const AssetNode: React.FC<{
               }}
               text={
                 <span>
-                  Refresh{' '}
+                  Rematerialize{' '}
                   <span style={{fontFamily: 'monospace', fontWeight: 600}}>
                     {displayNameForAssetKey(definition.assetKey)}
                   </span>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -16,7 +16,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     <LaunchRootExecutionButton
       pipelineName={assetJobName}
       disabled={false}
-      title={title || 'Refresh'}
+      title={title || 'Rematerialize'}
       getVariables={() => ({
         executionParams: {
           mode: 'default',

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -7,7 +7,7 @@ export const LaunchAssetExecutionButton: React.FC<{
   repoAddress: RepoAddress;
   assetJobName: string;
   assets: {opName: string | null}[];
-  title?: string;
+  title: string;
 }> = ({repoAddress, assets, assetJobName, title}) => {
   if (!assets.every((a) => a.opName)) {
     return <span />;
@@ -16,7 +16,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     <LaunchRootExecutionButton
       pipelineName={assetJobName}
       disabled={false}
-      title={title || 'Rematerialize'}
+      title={title}
       getVariables={() => ({
         executionParams: {
           mode: 'default',


### PR DESCRIPTION

## Summary
This is a simple PR that replaces references to "Refresh AssetName" with "Rematerialize AssetName". This language is more clear and is also preferable because it disambiguates asset refresh from "auto-refresh" countdowns, etc. 



## Test Plan


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.