### PR TITLE
Enable schema to be specified when materializing data to parquet file…

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -290,6 +290,11 @@ DataFrameToTypes = {
                 False,
                 "Options to be passed in to the compute method.",
             ),
+            "schema": (
+                Any,
+                False,
+                "Global schema to use for the output dataset.",
+            ),
         },
     },
     "hdf": {


### PR DESCRIPTION
Enabling a solid that is materializing its dataframe output to a parquet file(s) to conditionally specify a schema. Values passed to this argument is passed to the schema argument of Dask's to_parquet().

This PR replaces [PR5602](https://github.com/dagster-io/dagster/pull/5602).

@sryza change has been rebased to the latest master. Apologies for not doing this sooner.