### PR TITLE
Simplify dagster daemon core loop logic

### DIFF
--- a/python_modules/dagster/dagster/daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -15,7 +15,7 @@ from dagster.core.storage.pipeline_run import (
 )
 from dagster.core.storage.tags import PRIORITY_TAG
 from dagster.core.workspace import IWorkspace
-from dagster.daemon.daemon import DagsterDaemon
+from dagster.daemon.daemon import IntervalDaemon
 from dagster.utils.error import serializable_error_info_from_exc_info
 
 
@@ -91,7 +91,7 @@ class _TagConcurrencyLimitsCounter:
                 self._unique_value_counts[tag_tuple] += 1
 
 
-class QueuedRunCoordinatorDaemon(DagsterDaemon):
+class QueuedRunCoordinatorDaemon(IntervalDaemon):
     """
     Used with the QueuedRunCoordinator on the instance. This process finds queued runs from the run
     store and launches them.

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon_health.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon_health.py
@@ -105,12 +105,12 @@ def test_thread_die_daemon(monkeypatch):
 
         iteration_ran = {"ran": False}
 
-        def run_iteration_error(_, _instance, _workspace):
+        def run_loop_error(_, _instance, _workspace):
             iteration_ran["ran"] = True
             raise KeyboardInterrupt
             yield  # pylint: disable=unreachable
 
-        monkeypatch.setattr(SensorDaemon, "run_iteration", run_iteration_error)
+        monkeypatch.setattr(SensorDaemon, "core_loop", run_loop_error)
 
         heartbeat_interval_seconds = 1
 
@@ -178,21 +178,25 @@ def test_error_daemon(monkeypatch):
 
         error_count = {"count": 0}
 
-        def run_iteration_error(_, _instance, _workspace):
+        def run_loop_error(_, _instance, _workspace):
             if should_raise_errors:
+                time.sleep(0.5)
                 error_count["count"] = error_count["count"] + 1
                 raise DagsterInvariantViolationError("foobar:" + str(error_count["count"]))
-            yield
+
+            while True:
+                yield
+                time.sleep(0.5)
 
         def _get_error_number(error):
             error_message = error.message.strip()
             return int(error_message.split("foobar:")[1])
 
-        monkeypatch.setattr(SensorDaemon, "run_iteration", run_iteration_error)
+        monkeypatch.setattr(SensorDaemon, "core_loop", run_loop_error)
 
         heartbeat_interval_seconds = 1
 
-        gen_daemons = lambda instance: [SensorDaemon(interval_seconds=1)]
+        gen_daemons = lambda instance: [SensorDaemon()]
 
         init_time = pendulum.now("UTC")
         with daemon_controller_from_instance(
@@ -303,12 +307,16 @@ def test_multiple_error_daemon(monkeypatch):
     with instance_for_test() as instance:
         from dagster.daemon.daemon import SensorDaemon
 
-        def run_iteration_error(_, _instance, _workspace):
+        def run_loop_error(_, _instance, _workspace):
             # ?message stack cls_name cause"
             yield SerializableErrorInfo("foobar", None, None, None)
             yield SerializableErrorInfo("bizbuz", None, None, None)
 
-        monkeypatch.setattr(SensorDaemon, "run_iteration", run_iteration_error)
+            while True:
+                yield
+                time.sleep(0.5)
+
+        monkeypatch.setattr(SensorDaemon, "core_loop", run_loop_error)
 
         init_time = pendulum.now("UTC")
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -26,11 +26,7 @@ from dagster.core.definitions.decorators.sensor import asset_sensor, sensor
 from dagster.core.definitions.reconstructable import ReconstructableRepository
 from dagster.core.definitions.run_request import InstigatorType
 from dagster.core.definitions.run_status_sensor_definition import run_status_sensor
-from dagster.core.definitions.sensor_definition import (
-    DEFAULT_SENSOR_DAEMON_INTERVAL,
-    RunRequest,
-    SkipReason,
-)
+from dagster.core.definitions.sensor_definition import RunRequest, SkipReason
 from dagster.core.events import DagsterEvent, DagsterEventType
 from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.api import execute_pipeline
@@ -986,9 +982,9 @@ def test_error_sensor_daemon(external_repo_context, monkeypatch):
                     InstigatorStatus.RUNNING,
                 )
             )
-            sensor_daemon = SensorDaemon(interval_seconds=DEFAULT_SENSOR_DAEMON_INTERVAL)
+            sensor_daemon = SensorDaemon()
             daemon_shutdown_event = threading.Event()
-            sensor_daemon.run_loop(
+            sensor_daemon.run_daemon_loop(
                 instance.get_ref(),
                 "my_uuid",
                 daemon_shutdown_event,


### PR DESCRIPTION
Summary:
The number of different loops and iterations at play in the daemon controller loop has gotten a little out of control - particularly since several daemons just spin forever in the first 'iteration' since they want more control over the exact semantives of the loop.

This PR changes the default thing you override in a daemon to be run_loop instead of run_iteration (so we no longer have this convoluted loop => iteration => back to loop flow in the scheduler and sensor daemons). For simple daemons that just want to do something every N seconds without worrying about complicated workspace refresh logic, added an IntervalDaemon subclass and made the other daemons subclass that instead.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.