### PR TITLE
Fix the log handler level not effect

### DIFF
--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -249,7 +249,8 @@ class DagsterLogHandler(logging.Handler):
         dagster_record = self._convert_record(record)
         # built-in handlers
         for handler in self._handlers:
-            handler.handle(dagster_record)
+            if dagster_record.levelno >= handler.level:
+                handler.handle(dagster_record)
         # user-defined @loggers
         for logger in self._loggers:
             logger.log(

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -13,6 +13,13 @@ from dagster import (
 from dagster.core.test_utils import default_mode_def_for_test, instance_for_test
 
 
+def reset_logging():
+    # resets top level logging constructs to default value
+    logging.root = logging.RootLogger(logging.WARNING)
+    logging.Logger.root = logging.root
+    logging.Logger.manager = logging.Manager(logging.Logger.root)
+
+
 def get_log_records(pipe, managed_loggers=None, python_logging_level=None, run_config=None):
     python_logs_overrides = {}
     if managed_loggers is not None:
@@ -41,6 +48,9 @@ def get_log_records(pipe, managed_loggers=None, python_logging_level=None, run_c
     ],
 )
 def test_logging_capture_logger_defined_outside(managed_logs, expect_output):
+
+    reset_logging()
+
     logger = logging.getLogger("python_logger")
     logger.setLevel(logging.INFO)
 
@@ -76,6 +86,8 @@ def test_logging_capture_logger_defined_outside(managed_logs, expect_output):
     ],
 )
 def test_logging_capture_logger_defined_inside(managed_logs, expect_output):
+    reset_logging()
+
     @solid
     def my_solid():
         logger = logging.getLogger("python_logger")
@@ -110,6 +122,8 @@ def test_logging_capture_logger_defined_inside(managed_logs, expect_output):
     ],
 )
 def test_logging_capture_resource(managed_logs, expect_output):
+
+    reset_logging()
 
     python_log = logging.getLogger("python_logger")
     python_log.setLevel(logging.DEBUG)
@@ -216,6 +230,7 @@ def multilevel_logging_builtin_outside():
     ],
 )
 def test_logging_capture_level_defined_outside(log_level, expected_msgs):
+    reset_logging()
     log_event_records = [
         lr
         for lr in get_log_records(
@@ -241,6 +256,7 @@ def test_logging_capture_level_defined_outside(log_level, expected_msgs):
     ],
 )
 def test_logging_capture_level_defined_inside(log_level, expected_msgs):
+    reset_logging()
     log_event_records = [
         lr
         for lr in get_log_records(
@@ -265,7 +281,7 @@ def test_logging_capture_level_defined_inside(log_level, expected_msgs):
     ],
 )
 def test_logging_capture_builtin_outside(log_level, expected_msgs):
-
+    reset_logging()
     log_event_records = [
         lr
         for lr in get_log_records(
@@ -288,7 +304,7 @@ def test_logging_capture_builtin_outside(log_level, expected_msgs):
     ],
 )
 def test_logging_capture_builtin_inside(log_level, expected_msgs):
-
+    reset_logging()
     log_event_records = [
         lr
         for lr in get_log_records(
@@ -326,6 +342,7 @@ def define_logging_pipeline():
 
 @pytest.mark.parametrize("managed_loggers", [["root"], ["loggerA", "loggerB"]])
 def test_multiprocess_logging(managed_loggers):
+    reset_logging()
 
     log_records = get_log_records(
         reconstructable(define_logging_pipeline),


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
issue: https://github.com/dagster-io/dagster/issues/6075


Let log handlers emit the record by level. Following the python source code, the logger filter the record level before calling handlers.
```python
# https://github.com/python/cpython/blob/v3.7.4/Lib/logging/__init__.py#L1585
class Logger(Filterer):
    ...
    def callHandlers(self, record):
        """
        Pass a record to all relevant handlers.
        Loop through all handlers for this logger and its parents in the
        logger hierarchy. If no handler was found, output a one-off error
        message to sys.stderr. Stop searching up the hierarchy whenever a
        logger with the "propagate" attribute set to zero is found - that
        will be the last logger whose handlers are called.
        """
        c = self
        found = 0
        while c:
            for hdlr in c.handlers:
                found = found + 1
                if record.levelno >= hdlr.level:
                    hdlr.handle(record)
```
The dgaster log handler takes this power but emits everything to the handlers.
```python
# https://github.com/dagster-io/dagster/blob/88acf1c06fc69d8ff9fbe3afaee5dc749922be59/python_modules/dagster/dagster/core/log_manager.py#L247

class DagsterLogHandler(logging.Handler):
    def emit(self, record: logging.LogRecord):
        """For any received record, add Dagster metadata, and have handlers handle it"""
        dagster_record = self._convert_record(record)
        # built-in handlers
        for handler in self._handlers:
            handler.handle(dagster_record)
```


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
When the user uses the handler and sets the level config directly. 
The emitted records MUST only include the record which has an equal or higher level.



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.