### PR TITLE
dagit changes to enable/disable schedule/status checkboxes if the status is set in code

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
@@ -70,6 +70,7 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules {
@@ -91,6 +92,7 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors {

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
@@ -129,6 +129,7 @@ export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection
   runs: InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_runs[];
   ticks: InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_futureTicks_results {
@@ -252,6 +253,7 @@ export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_Insti
   runs: InstanceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
   ticks: InstanceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates {

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
@@ -128,6 +128,7 @@ export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_n
   runs: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_sensorState_runs[];
   ticks: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_sensorState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_targets {
@@ -256,6 +257,7 @@ export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_Instiga
   runs: InstanceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
   ticks: InstanceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates {

--- a/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
@@ -64,6 +64,7 @@ export interface OverviewJobFragment_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface OverviewJobFragment_schedules {
@@ -85,6 +86,7 @@ export interface OverviewJobFragment_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface OverviewJobFragment_sensors {

--- a/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
@@ -60,6 +60,7 @@ export const INSTIGATION_STATE_FRAGMENT = gql`
       ...TickTagFragment
     }
     runningCount
+    canChangeStatus
   }
   ${REPOSITORY_ORIGIN_FRAGMENT}
   ${PYTHON_ERROR_FRAGMENT}

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
@@ -76,4 +76,5 @@ export interface InstigationStateFragment {
   runs: InstigationStateFragment_runs[];
   ticks: InstigationStateFragment_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataQuery.ts
@@ -17,6 +17,7 @@ export interface JobMetadataQuery_pipelineOrError_Pipeline_schedules_scheduleSta
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface JobMetadataQuery_pipelineOrError_Pipeline_schedules {
@@ -38,6 +39,7 @@ export interface JobMetadataQuery_pipelineOrError_Pipeline_sensors_sensorState {
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface JobMetadataQuery_pipelineOrError_Pipeline_sensors {

--- a/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
@@ -123,6 +123,7 @@ export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nod
   runs: SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_runs[];
   ticks: SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_futureTicks_results {

--- a/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
@@ -88,6 +88,7 @@ export interface RepositorySchedulesFragment_schedules_scheduleState {
   runs: RepositorySchedulesFragment_schedules_scheduleState_runs[];
   ticks: RepositorySchedulesFragment_schedules_scheduleState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface RepositorySchedulesFragment_schedules_futureTicks_results {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
@@ -82,6 +82,7 @@ export interface ScheduleFragment_scheduleState {
   runs: ScheduleFragment_scheduleState_runs[];
   ticks: ScheduleFragment_scheduleState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface ScheduleFragment_futureTicks_results {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
@@ -82,6 +82,7 @@ export interface ScheduleRootQuery_scheduleOrError_Schedule_scheduleState {
   runs: ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_runs[];
   ticks: ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface ScheduleRootQuery_scheduleOrError_Schedule_futureTicks_results {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleSwitchFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleSwitchFragment.ts
@@ -13,6 +13,7 @@ export interface ScheduleSwitchFragment_scheduleState {
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface ScheduleSwitchFragment {

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
@@ -92,6 +92,7 @@ export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_sched
   runs: SchedulesRootQuery_repositoryOrError_Repository_schedules_scheduleState_runs[];
   ticks: SchedulesRootQuery_repositoryOrError_Repository_schedules_scheduleState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_futureTicks_results {
@@ -216,6 +217,7 @@ export interface SchedulesRootQuery_unloadableInstigationStatesOrError_Instigati
   runs: SchedulesRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
   ticks: SchedulesRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SchedulesRootQuery_unloadableInstigationStatesOrError_InstigationStates {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
@@ -81,6 +81,7 @@ export interface SensorFragment_sensorState {
   runs: SensorFragment_sensorState_runs[];
   ticks: SensorFragment_sensorState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SensorFragment_targets {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
@@ -85,6 +85,7 @@ export interface SensorRootQuery_sensorOrError_Sensor_sensorState {
   runs: SensorRootQuery_sensorOrError_Sensor_sensorState_runs[];
   ticks: SensorRootQuery_sensorOrError_Sensor_sensorState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SensorRootQuery_sensorOrError_Sensor_targets {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorSwitchFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorSwitchFragment.ts
@@ -13,6 +13,7 @@ export interface SensorSwitchFragment_sensorState {
   __typename: "InstigationState";
   id: string;
   status: InstigationStatus;
+  canChangeStatus: boolean;
 }
 
 export interface SensorSwitchFragment {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
@@ -98,6 +98,7 @@ export interface SensorsRootQuery_sensorsOrError_Sensors_results_sensorState {
   runs: SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_runs[];
   ticks: SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SensorsRootQuery_sensorsOrError_Sensors_results_targets {
@@ -204,6 +205,7 @@ export interface SensorsRootQuery_unloadableInstigationStatesOrError_Instigation
   runs: SensorsRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_runs[];
   ticks: SensorsRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks[];
   runningCount: number;
+  canChangeStatus: boolean;
 }
 
 export interface SensorsRootQuery_unloadableInstigationStatesOrError_InstigationStates {

--- a/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Checkbox.tsx
@@ -7,6 +7,8 @@ import {ColorsWIP} from './Colors';
 
 const DISABLED_COLOR = ColorsWIP.Gray300;
 
+const DISABLED_CHECKED_COLOR = ColorsWIP.Blue200;
+
 type Format = 'check' | 'star' | 'switch';
 type Size = 'small' | 'large';
 
@@ -185,7 +187,7 @@ const Base = ({
         disabled={disabled}
         checked={checked}
         indeterminate={indeterminate}
-        fillColor={disabled ? DISABLED_COLOR : fillColor}
+        fillColor={disabled ? (checked ? DISABLED_CHECKED_COLOR : DISABLED_COLOR) : fillColor}
       />
       {label}
     </label>


### PR DESCRIPTION
https://user-images.githubusercontent.com/8451211/147960635-df417723-59b0-4dd4-87bc-a8df76e994a3.mov

The UI for a new feature to let you set whether a schedule/sensor is running purely in code (as a solution for https://github.com/dagster-io/dagster/issues/4103). Will send out a separate doc to hash out whether this is the experience we want (specifically, no way to stop a schedule/sensor that is set to RUNNING in code) - but this is an implementation assuming that we end up going in that direction