### PR TITLE
disallow non-standard cron strings for schedules

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -38,7 +38,7 @@ You define a schedule by constructing a <PyObject object="ScheduleDefinition" />
 
 ### A basic schedule
 
-Here's a simple schedule that runs a job every day, at midnight. The `cron_schedule` accepts standard [cron expressions](https://en.wikipedia.org/wiki/Cron). It also accepts `"@hourly"`, `"@daily"`, `"@weekly"`, and "@monthly" if your croniter dependency's version is >= 1.0.12.
+Here's a simple schedule that runs a job every day, at midnight. The `cron_schedule` accepts standard [cron expressions](https://en.wikipedia.org/wiki/Cron).
 
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_basic_schedule endbefore=end_basic_schedule
 @job

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -10,6 +10,7 @@ from dagster.seven import funcsigs
 
 from ...serdes import whitelist_for_serdes
 from ...utils import ensure_gen, merge_dicts
+from ...utils.schedules import is_valid_cron_string
 from ..decorator_utils import get_function_params
 from ..errors import (
     DagsterInvalidDefinitionError,
@@ -197,13 +198,10 @@ class ScheduleDefinition:
 
         self._cron_schedule = check.str_param(cron_schedule, "cron_schedule")
 
-        if not croniter.is_valid(self._cron_schedule):
+        if not is_valid_cron_string(self._cron_schedule):
             raise DagsterInvalidDefinitionError(
-                f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''."
-            )
-        if len(self._cron_schedule.split(" ")) != 5:
-            raise DagsterInvalidDefinitionError(
-                f"Found non-standard cron schedule '{self._cron_schedule}' for schedule '{name}''."
+                f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''.  "
+                "Dagster recognizes cron expressions consisting of 5 space-separated fields."
             )
 
         if job is not None:

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -201,6 +201,10 @@ class ScheduleDefinition:
             raise DagsterInvalidDefinitionError(
                 f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''."
             )
+        if len(self._cron_schedule.split(" ")) != 5:
+            raise DagsterInvalidDefinitionError(
+                f"Found non-standard cron schedule '{self._cron_schedule}' for schedule '{name}''."
+            )
 
         if job is not None:
             self._target: Union[DirectTarget, RepoRelativeTarget] = DirectTarget(job)

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Union, cast
 
 import pendulum
-from croniter import croniter
 from dagster import check
 from dagster.seven import funcsigs
 

--- a/python_modules/dagster/dagster/utils/schedules.py
+++ b/python_modules/dagster/dagster/utils/schedules.py
@@ -8,6 +8,11 @@ from dagster import check
 from dagster.seven.compat.pendulum import to_timezone
 
 
+def is_valid_cron_string(cron_string: str) -> bool:
+    # dagster only recognizes standard cron strings that contains 5 parts
+    return croniter.is_valid(cron_string) and len(cron_string.split(" ")) == 5
+
+
 def schedule_execution_time_iterator(
     start_timestamp: float, cron_schedule: str, execution_timezone: Optional[str]
 ) -> Iterator[datetime.datetime]:
@@ -24,7 +29,7 @@ def schedule_execution_time_iterator(
 
     cron_parts = cron_schedule.split(" ")
 
-    check.invariant(len(cron_parts) == 5)
+    check.invariant(is_valid_cron_string(cron_schedule))
 
     is_numeric = [part.isnumeric() for part in cron_parts]
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -732,6 +732,12 @@ def test_schedule_decorators_bad():
         def bad_cron_string_two(context):
             return {}
 
+    with pytest.raises(DagsterInvalidDefinitionError, match="non-standard cron schedule"):
+
+        @schedule(cron_schedule="@daily", pipeline_name="foo_pipeline")
+        def bad_cron_string_three(context):
+            return {}
+
 
 def test_scheduled_jobs():
     from dagster import Field, String

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -732,7 +732,7 @@ def test_schedule_decorators_bad():
         def bad_cron_string_two(context):
             return {}
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="non-standard cron schedule"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="invalid cron schedule"):
 
         @schedule(cron_schedule="@daily", pipeline_name="foo_pipeline")
         def bad_cron_string_three(context):


### PR DESCRIPTION
## Summary
This causes invariant errors while calculating future ticks.


## Test Plan
BK

