### PR TITLE
[dagit] Add next tick to Instance Overview

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -39,6 +39,7 @@ import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
 import {InstanceTabs} from './InstanceTabs';
+import {NextTick, SCHEDULE_FUTURE_TICKS_FRAGMENT} from './NextTick';
 import {InstanceOverviewInitialQuery} from './types/InstanceOverviewInitialQuery';
 import {LastTenRunsPerJobQuery} from './types/LastTenRunsPerJobQuery';
 import {OverviewJobFragment} from './types/OverviewJobFragment';
@@ -444,7 +445,10 @@ const JobSection = (props: JobSectionProps) => {
                 </td>
                 <td>
                   {job.schedules.length || job.sensors.length ? (
-                    <ScheduleOrSensorTag job={job} repoAddress={repoAddress} />
+                    <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
+                      <ScheduleOrSensorTag job={job} repoAddress={repoAddress} />
+                      {job.schedules.length ? <NextTick schedules={job.schedules} /> : null}
+                    </Box>
                   ) : (
                     <div style={{color: ColorsWIP.Gray500}}>None</div>
                   )}
@@ -497,6 +501,7 @@ const OVERVIEW_JOB_FRAGMENT = gql`
         id
         status
       }
+      ...ScheduleFutureTicksFragment
       ...ScheduleSwitchFragment
     }
     sensors {
@@ -515,6 +520,7 @@ const OVERVIEW_JOB_FRAGMENT = gql`
   }
 
   ${SCHEDULE_SWITCH_FRAGMENT}
+  ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
   ${SENSOR_SWITCH_FRAGMENT}
   ${RUN_METADATA_FRAGMENT}
   ${RUN_TIME_FRAGMENT}

--- a/js_modules/dagit/packages/core/src/instance/NextTick.tsx
+++ b/js_modules/dagit/packages/core/src/instance/NextTick.tsx
@@ -1,0 +1,76 @@
+import {gql} from '@apollo/client';
+import * as React from 'react';
+
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {InstigationStatus} from '../types/globalTypes';
+import {ColorsWIP} from '../ui/Colors';
+import {CaptionMono} from '../ui/Text';
+
+import {ScheduleFutureTicksFragment} from './types/ScheduleFutureTicksFragment';
+
+const TIME_FORMAT = {
+  showTimezone: true,
+  showSeconds: true,
+};
+
+interface Props {
+  schedules: ScheduleFutureTicksFragment[];
+}
+
+export const NextTick = (props: Props) => {
+  const {schedules} = props;
+
+  const nextTick = React.useMemo(() => {
+    const timestamps = schedules.map((schedule) => {
+      const {executionTimezone, futureTicks, scheduleState} = schedule;
+      if (scheduleState.status === InstigationStatus.RUNNING) {
+        return {
+          executionTimezone,
+          earliest: Math.min(...futureTicks.results.map(({timestamp}) => timestamp)),
+        };
+      }
+      return null;
+    });
+
+    return timestamps.reduce((earliestOverall, timestamp) => {
+      if (
+        !earliestOverall ||
+        (timestamp?.earliest && timestamp.earliest < earliestOverall?.earliest)
+      ) {
+        return timestamp;
+      }
+      return earliestOverall;
+    }, null);
+  }, [schedules]);
+
+  if (nextTick) {
+    return (
+      <CaptionMono color={ColorsWIP.Gray500}>
+        Next tick:{' '}
+        <TimestampDisplay
+          timestamp={nextTick.earliest}
+          timezone={nextTick.executionTimezone}
+          timeFormat={TIME_FORMAT}
+        />
+      </CaptionMono>
+    );
+  }
+
+  return null;
+};
+
+export const SCHEDULE_FUTURE_TICKS_FRAGMENT = gql`
+  fragment ScheduleFutureTicksFragment on Schedule {
+    id
+    executionTimezone
+    scheduleState {
+      id
+      status
+    }
+    futureTicks(limit: 30) {
+      results {
+        timestamp
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
@@ -72,12 +72,24 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   status: InstigationStatus;
 }
 
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks_results {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks {
+  __typename: "FutureInstigationTicks";
+  results: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks_results[];
+}
+
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules {
   __typename: "Schedule";
   id: string;
   mode: string;
   name: string;
   scheduleState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState;
+  executionTimezone: string | null;
+  futureTicks: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks;
   cronSchedule: string;
 }
 

--- a/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
@@ -66,12 +66,24 @@ export interface OverviewJobFragment_schedules_scheduleState {
   status: InstigationStatus;
 }
 
+export interface OverviewJobFragment_schedules_futureTicks_results {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface OverviewJobFragment_schedules_futureTicks {
+  __typename: "FutureInstigationTicks";
+  results: OverviewJobFragment_schedules_futureTicks_results[];
+}
+
 export interface OverviewJobFragment_schedules {
   __typename: "Schedule";
   id: string;
   mode: string;
   name: string;
   scheduleState: OverviewJobFragment_schedules_scheduleState;
+  executionTimezone: string | null;
+  futureTicks: OverviewJobFragment_schedules_futureTicks;
   cronSchedule: string;
 }
 

--- a/js_modules/dagit/packages/core/src/instance/types/ScheduleFutureTicksFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/ScheduleFutureTicksFragment.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: ScheduleFutureTicksFragment
+// ====================================================
+
+export interface ScheduleFutureTicksFragment_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface ScheduleFutureTicksFragment_futureTicks_results {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface ScheduleFutureTicksFragment_futureTicks {
+  __typename: "FutureInstigationTicks";
+  results: ScheduleFutureTicksFragment_futureTicks_results[];
+}
+
+export interface ScheduleFutureTicksFragment {
+  __typename: "Schedule";
+  id: string;
+  executionTimezone: string | null;
+  scheduleState: ScheduleFutureTicksFragment_scheduleState;
+  futureTicks: ScheduleFutureTicksFragment_futureTicks;
+}

--- a/js_modules/dagit/packages/core/src/ui/Text.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Text.tsx
@@ -47,3 +47,9 @@ export const Mono = styled.span`
   font-family: ${FontFamily.monospace};
   font-size: 16px;
 `;
+
+export const CaptionMono = styled.span<TextProps>`
+  ${({color}) => (color ? `color: ${color};` : null)}
+  font-family: ${FontFamily.monospace};
+  font-size: 14px;
+`;


### PR DESCRIPTION
## Summary

On Instance Overview, add "Next tick" information for jobs that have running schedules.

I'm fetching the next 30 ticks (arbitrary limit) because the plan will be to use these in the run timeline view as well.

## Test Plan

View Instance Overview, verify that the next tick shows up and renders correctly for running schedules.

For a job with multiple schedules, verify that turning on multiple schedules results in the correct "next" tick showing up in the table.
