### PR TITLE
[dagit] Add step information to Instance Overview

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -20,7 +20,7 @@ import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {RunStatus} from '../types/globalTypes';
 import {Box} from '../ui/Box';
-import {ButtonWIP} from '../ui/Button';
+import {AnchorButton, ButtonWIP} from '../ui/Button';
 import {ColorsWIP} from '../ui/Colors';
 import {IconWIP} from '../ui/Icon';
 import {MenuItemWIP, MenuWIP} from '../ui/Menu';
@@ -40,6 +40,7 @@ import {RepoAddress} from '../workspace/types';
 
 import {InstanceTabs} from './InstanceTabs';
 import {NextTick, SCHEDULE_FUTURE_TICKS_FRAGMENT} from './NextTick';
+import {StepSummaryForRun} from './StepSummaryForRun';
 import {InstanceOverviewInitialQuery} from './types/InstanceOverviewInitialQuery';
 import {LastTenRunsPerJobQuery} from './types/LastTenRunsPerJobQuery';
 import {OverviewJobFragment} from './types/OverviewJobFragment';
@@ -405,8 +406,8 @@ const JobSection = (props: JobSectionProps) => {
         <thead>
           <tr>
             <th style={{width: '40%'}}>Job</th>
-            <th style={{width: '30%'}}>Trigger</th>
-            <th style={{width: '30%'}}>Latest run</th>
+            <th style={{width: '25%'}}>Trigger</th>
+            <th style={{width: '35%'}}>Latest run</th>
             <th />
           </tr>
         </thead>
@@ -454,14 +455,29 @@ const JobSection = (props: JobSectionProps) => {
                   )}
                 </td>
                 <td>
-                  <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                    <TagWIP intent={intent(job.runs[0].status)}>
-                      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                        <RunStatusIndicator status={job.runs[0].status} size={10} />
-                        <RunTime run={job.runs[0]} />
-                      </Box>
-                    </TagWIP>
-                    <RunElapsed run={job.runs[0]} />
+                  <Box
+                    flex={{
+                      direction: 'row',
+                      justifyContent: 'space-between',
+                      alignItems: 'flex-start',
+                    }}
+                  >
+                    <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
+                      <TagWIP intent={intent(job.runs[0].status)}>
+                        <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                          <RunStatusIndicator status={job.runs[0].status} size={10} />
+                          <RunTime run={job.runs[0]} />
+                        </Box>
+                      </TagWIP>
+                      {failedStatuses.has(job.runs[0].status) ||
+                      inProgressStatuses.has(job.runs[0].status) ? (
+                        <StepSummaryForRun runId={job.runs[0].id} />
+                      ) : null}
+                    </Box>
+                    <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                      <RunElapsed run={job.runs[0]} />
+                      <AnchorButton to={`/instance/runs/${job.runs[0].id}`}>View run</AnchorButton>
+                    </Box>
                   </Box>
                 </td>
                 <td>

--- a/js_modules/dagit/packages/core/src/instance/NextTick.tsx
+++ b/js_modules/dagit/packages/core/src/instance/NextTick.tsx
@@ -67,7 +67,7 @@ export const SCHEDULE_FUTURE_TICKS_FRAGMENT = gql`
       id
       status
     }
-    futureTicks(limit: 30) {
+    futureTicks(limit: 1) {
       results {
         timestamp
       }

--- a/js_modules/dagit/packages/core/src/instance/StepSummaryForRun.tsx
+++ b/js_modules/dagit/packages/core/src/instance/StepSummaryForRun.tsx
@@ -1,0 +1,102 @@
+import {gql, useQuery} from '@apollo/client';
+import qs from 'qs';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {failedStatuses, inProgressStatuses} from '../runs/RunStatuses';
+import {StepEventStatus} from '../types/globalTypes';
+import {ColorsWIP} from '../ui/Colors';
+import {CaptionMono} from '../ui/Text';
+
+import {StepSummaryForRunQuery} from './types/StepSummaryForRunQuery';
+
+interface Props {
+  runId: string;
+}
+
+export const StepSummaryForRun = (props: Props) => {
+  const {runId} = props;
+  const {data} = useQuery<StepSummaryForRunQuery>(STEP_SUMMARY_FOR_RUN_QUERY, {variables: {runId}});
+
+  const run = data?.pipelineRunOrError;
+  const status = run?.__typename === 'Run' ? run.status : null;
+
+  const relevantSteps = React.useMemo(() => {
+    if (run?.__typename !== 'Run') {
+      return [];
+    }
+
+    const {status} = run;
+    if (failedStatuses.has(status)) {
+      return run.stepStats.filter((step) => step.status === StepEventStatus.FAILURE);
+    }
+
+    if (inProgressStatuses.has(status)) {
+      return run.stepStats.filter((step) => step.status === StepEventStatus.IN_PROGRESS);
+    }
+
+    return [];
+  }, [run]);
+
+  const stepCount = relevantSteps.length;
+
+  if (!stepCount || !status) {
+    return null;
+  }
+
+  if (failedStatuses.has(status)) {
+    if (stepCount === 1) {
+      const step = relevantSteps[0];
+      const query = step.endTime
+        ? qs.stringify({focusedTime: Math.floor(step.endTime * 1000)}, {addQueryPrefix: true})
+        : '';
+      return (
+        <CaptionMono color={ColorsWIP.Gray500}>
+          Failed at <Link to={`/instance/runs/${runId}${query}`}>{step.stepKey}</Link>
+        </CaptionMono>
+      );
+    }
+    return (
+      <CaptionMono color={ColorsWIP.Gray500}>
+        Failed at <Link to={`/instance/runs/${runId}`}>{stepCount} steps</Link>
+      </CaptionMono>
+    );
+  }
+
+  if (inProgressStatuses.has(status)) {
+    if (stepCount === 1) {
+      const step = relevantSteps[0];
+      const query = step.endTime
+        ? qs.stringify({focusedTime: Math.floor(step.endTime * 1000)}, {addQueryPrefix: true})
+        : '';
+      return (
+        <CaptionMono color={ColorsWIP.Gray500}>
+          In progress at <Link to={`/instance/runs/${runId}${query}`}>{step.stepKey}</Link>
+        </CaptionMono>
+      );
+    }
+    return (
+      <CaptionMono color={ColorsWIP.Gray500}>
+        In progress at <Link to={`/instance/runs/${runId}`}>{stepCount} steps</Link>
+      </CaptionMono>
+    );
+  }
+
+  return null;
+};
+
+const STEP_SUMMARY_FOR_RUN_QUERY = gql`
+  query StepSummaryForRunQuery($runId: ID!) {
+    pipelineRunOrError(runId: $runId) {
+      ... on Run {
+        id
+        status
+        stepStats {
+          endTime
+          stepKey
+          status
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/instance/types/StepSummaryForRunQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/StepSummaryForRunQuery.ts
@@ -1,0 +1,38 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus, StepEventStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: StepSummaryForRunQuery
+// ====================================================
+
+export interface StepSummaryForRunQuery_pipelineRunOrError_RunNotFoundError {
+  __typename: "RunNotFoundError" | "PythonError";
+}
+
+export interface StepSummaryForRunQuery_pipelineRunOrError_Run_stepStats {
+  __typename: "RunStepStats";
+  endTime: number | null;
+  stepKey: string;
+  status: StepEventStatus | null;
+}
+
+export interface StepSummaryForRunQuery_pipelineRunOrError_Run {
+  __typename: "Run";
+  id: string;
+  status: RunStatus;
+  stepStats: StepSummaryForRunQuery_pipelineRunOrError_Run_stepStats[];
+}
+
+export type StepSummaryForRunQuery_pipelineRunOrError = StepSummaryForRunQuery_pipelineRunOrError_RunNotFoundError | StepSummaryForRunQuery_pipelineRunOrError_Run;
+
+export interface StepSummaryForRunQuery {
+  pipelineRunOrError: StepSummaryForRunQuery_pipelineRunOrError;
+}
+
+export interface StepSummaryForRunQueryVariables {
+  runId: string;
+}


### PR DESCRIPTION
## Summary

Add step-level information to the Instance Overview, to indicate the step keys where a job has failed or is currently in progress.

If there is a single step key, link to it directly.

Also add a "View run" button to link to the run.

## Test Plan

View Instance Overview, verify the details above for a handful of failed runs.
