### PR TITLE
Error when a solid/op is invoked within another solid/op

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
 
 _composition_stack: List["InProgressCompositionContext"] = []
-_invalid_composition_stack: List[Tuple[str, str]] = []
+_op_execution_context: List[Tuple[str, str]] = []
 
 
 class MappedInputPlaceholder:
@@ -95,9 +95,9 @@ def enter_composition(name: str, source: str) -> None:
     _composition_stack.append(InProgressCompositionContext(name, source))
 
 
-def enter_invalid_composition_context(name: str, source: str) -> None:
+def enter_op_execution_context(name: str, source: str) -> None:
     """For use when within the body of an op/non-composite solid, where it should not be possible to directly invoke another op."""
-    _invalid_composition_stack.append((name, source))
+    _op_execution_context.append((name, source))
 
 
 def exit_composition(
@@ -106,8 +106,8 @@ def exit_composition(
     return _composition_stack.pop().complete(output)
 
 
-def exit_invalid_composition_context() -> None:
-    _invalid_composition_stack.pop()
+def exit_op_execution_context() -> None:
+    _op_execution_context.pop()
 
 
 def current_context() -> "InProgressCompositionContext":
@@ -118,13 +118,13 @@ def is_in_composition() -> bool:
     return bool(_composition_stack)
 
 
-def is_in_invalid_invocation_context() -> bool:
-    return bool(_invalid_composition_stack)
+def is_in_op_execution_context() -> bool:
+    return bool(_op_execution_context)
 
 
-def current_invalid_invocation_node() -> Tuple[str, str]:
+def current_op_execution_context() -> Tuple[str, str]:
     """Get the name and source of the node which is preventing the invocation."""
-    return _invalid_composition_stack[-1]
+    return _op_execution_context[-1]
 
 
 def assert_in_composition(name: str, node_def: NodeDefinition) -> None:

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -160,7 +160,8 @@ class SolidDefinition(NodeDefinition):
             try:
                 result = self.invoke(*args, **kwargs)
             finally:
-                exit_invalid_composition_context()
+                if is_in_invalid_invocation_context():
+                    exit_invalid_composition_context()
 
             return result
 

--- a/python_modules/dagster/dagster/core/definitions/solid_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_definition.py
@@ -140,39 +140,30 @@ class SolidDefinition(NodeDefinition):
     def __call__(self, *args, **kwargs) -> Any:
         from .composition import (
             is_in_composition,
-            enter_invalid_composition_context,
-            is_in_invalid_invocation_context,
-            current_invalid_invocation_node,
-            exit_invalid_composition_context,
+            enter_op_execution_context,
+            is_in_op_execution_context,
+            current_op_execution_context,
+            exit_op_execution_context,
         )
-        from .decorators.solid import DecoratedSolidFunction
-        from ..execution.context.invocation import UnboundSolidExecutionContext
 
         if is_in_composition():
             return super(SolidDefinition, self).__call__(*args, **kwargs)
-        elif is_in_invalid_invocation_context():
-            name, source = current_invalid_invocation_node()
+        elif is_in_op_execution_context():
+            name, source = current_op_execution_context()
             raise DagsterInvalidInvocationError(
                 f"Attempted to invoke @{self.node_type_str} '{self.name}' within {source} '{name}', which is undefined behavior. In order to compose invocations, check out the graph API: https://docs.dagster.io/concepts/ops-jobs-graphs/nesting-graphs#nesting-graphs"
             )
         else:
-            enter_invalid_composition_context(self.name, f"@{self.node_type_str}")
+            enter_op_execution_context(self.name, f"@{self.node_type_str}")
             try:
                 result = self.invoke(*args, **kwargs)
             finally:
-                if is_in_invalid_invocation_context():
-                    exit_invalid_composition_context()
+                if is_in_op_execution_context():
+                    exit_op_execution_context()
 
             return result
 
     def invoke(self, *args, **kwargs) -> Any:
-        from .composition import (
-            is_in_composition,
-            enter_invalid_composition_context,
-            is_in_invalid_invocation_context,
-            current_invalid_invocation_node,
-            exit_invalid_composition_context,
-        )
         from .decorators.solid import DecoratedSolidFunction
         from ..execution.context.invocation import UnboundSolidExecutionContext
 

--- a/python_modules/dagster/dagster/core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_invocation.py
@@ -234,7 +234,12 @@ def _type_check_output_wrapper(
     elif inspect.iscoroutine(result):
 
         async def type_check_coroutine(coro):
-            out = await coro
+            enter_invalid_composition_context(solid_def.name, solid_def.node_type_str)
+            try:
+                out = await coro
+            finally:
+                if is_in_invalid_invocation_context():
+                    exit_invalid_composition_context()
             return _type_check_function_output(solid_def, out, context)
 
         return type_check_coroutine(result)

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -63,31 +63,31 @@ async def _coerce_async_solid_to_async_gen(awaitable, context, output_defs):
 
 def _coerce_solid_compute_fn_to_iterator(fn, output_defs, context, context_arg_provided, kwargs):
     from ...definitions.composition import (
-        enter_invalid_composition_context,
-        exit_invalid_composition_context,
-        is_in_invalid_invocation_context,
+        enter_op_execution_context,
+        exit_op_execution_context,
+        is_in_op_execution_context,
     )
 
-    enter_invalid_composition_context(context.solid_def.name, f"@{context.solid_def.node_type_str}")
+    enter_op_execution_context(context.solid_def.name, f"@{context.solid_def.node_type_str}")
     try:
         result = fn(context, **kwargs) if context_arg_provided else fn(**kwargs)
     finally:
-        exit_invalid_composition_context()
+        exit_op_execution_context()
 
     event_iter = _validate_and_coerce_solid_result_to_iterator(result, context, output_defs)
     try:
         while True:
-            enter_invalid_composition_context(
+            enter_op_execution_context(
                 context.solid_def.name, f"@{context.solid_def.node_type_str}"
             )
             event = next(event_iter)
-            exit_invalid_composition_context()
+            exit_op_execution_context()
             yield event
     except StopIteration:
         pass
     finally:
-        if is_in_invalid_invocation_context():
-            exit_invalid_composition_context()
+        if is_in_op_execution_context():
+            exit_op_execution_context()
 
 
 def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -454,7 +454,7 @@ def test_multiple_outputs_iterator():
 
 def test_wrong_output():
     from dagster.core.definitions.composition import (  # pylint: disable=unused-import
-        current_invalid_invocation_node,
+        current_op_execution_context,
     )
 
     @solid

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -453,6 +453,10 @@ def test_multiple_outputs_iterator():
 
 
 def test_wrong_output():
+    from dagster.core.definitions.composition import (  # pylint: disable=unused-import
+        current_invalid_invocation_node,
+    )
+
     @solid
     def solid_wrong_output():
         return Output(5, output_name="wrong_name")

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -931,3 +931,20 @@ def test_build_context_with_resources_config(context_builder):
             resources={"my_resource": my_resource},
             resources_config={"bad_resource": {"config": "foo"}},
         )
+
+
+def test_nested_invocation_with_yield():
+    @solid
+    def basic():
+        pass
+
+    @solid
+    def should_not_work():
+        basic()
+        yield Output("foo")
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match="Attempted to invoke @solid 'basic' within solid 'should_not_work'",
+    ):
+        list(should_not_work())


### PR DESCRIPTION
Relevant issue: https://github.com/dagster-io/dagster/issues/5542

Right now, we kind of let people blindly invoke ops/solids within other ops/solids. This leads to misunderstandings with our composition DSL, and hinders ramp-up with dagster. 

This PR hard-errors when performing this type of invocation, and points people to the relevant documentation. Technically, this is a breaking change, but it's a breaking change for undefined behavior.