### PR TITLE
remove scheduler class from stored schedule specific data

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_jobs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_jobs.py
@@ -47,18 +47,14 @@ def get_job_state_or_error(graphene_info, selector):
             external_sensor.get_external_origin_id()
         )
         if not job_state:
-            job_state = external_sensor.get_default_instigation_state(
-                graphene_info.context.instance
-            )
+            job_state = external_sensor.get_default_instigation_state()
     elif repository.has_external_schedule(selector.name):
         external_schedule = repository.get_external_schedule(selector.name)
         job_state = graphene_info.context.instance.get_job_state(
             external_schedule.get_external_origin_id()
         )
         if not job_state:
-            job_state = external_schedule.get_default_instigation_state(
-                graphene_info.context.instance
-            )
+            job_state = external_schedule.get_default_instigation_state()
     else:
         check.failed(f"Could not find a definition for {selector.name}")
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -48,9 +48,7 @@ class GrapheneSchedule(graphene.ObjectType):
         if not self._schedule_state:
             # Also include a ScheduleState for a stopped schedule that may not
             # have a stored database row yet
-            self._schedule_state = self._external_schedule.get_default_instigation_state(
-                graphene_info.context.instance
-            )
+            self._schedule_state = self._external_schedule.get_default_instigation_state()
 
         super().__init__(
             name=external_schedule.name,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -67,9 +67,7 @@ class GrapheneSensor(graphene.ObjectType):
         if not self._sensor_state:
             # Also include a SensorState for a stopped sensor that may not
             # have a stored database row yet
-            self._sensor_state = self._external_sensor.get_default_instigation_state(
-                graphene_info.context.instance
-            )
+            self._sensor_state = self._external_sensor.get_default_instigation_state()
 
         super().__init__(
             name=external_sensor.name,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -382,7 +382,6 @@ def test_get_unloadable_job(graphql_context):
                 ScheduleInstigatorData(
                     "0 0 * * *",
                     pendulum.now("UTC").timestamp(),
-                    graphql_context.instance.scheduler.__class__.__name__,
                 ),
             )
         )
@@ -395,7 +394,6 @@ def test_get_unloadable_job(graphql_context):
                 ScheduleInstigatorData(
                     "0 0 * * *",
                     pendulum.now("UTC").timestamp(),
-                    graphql_context.instance.scheduler.__class__.__name__,
                 ),
             )
         )

--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -489,7 +489,7 @@ class ExternalSchedule:
     # ScheduleState that represents the state of the schedule
     # when there is no row in the schedule DB (for example, when
     # the schedule is first created in code)
-    def get_default_instigation_state(self, instance):
+    def get_default_instigation_state(self):
         from dagster.core.scheduler.instigation import (
             InstigatorState,
             InstigatorStatus,
@@ -500,9 +500,7 @@ class ExternalSchedule:
             self.get_external_origin(),
             InstigatorType.SCHEDULE,
             InstigatorStatus.STOPPED,
-            ScheduleInstigatorData(
-                self.cron_schedule, start_timestamp=None, scheduler=instance.scheduler_class
-            ),
+            ScheduleInstigatorData(self.cron_schedule, start_timestamp=None),
         )
 
     def execution_time_iterator(self, start_timestamp):
@@ -573,7 +571,7 @@ class ExternalSensor:
     def get_external_origin_id(self):
         return self.get_external_origin().get_id()
 
-    def get_default_instigation_state(self, _instance):
+    def get_default_instigation_state(self):
         from dagster.core.scheduler.instigation import (
             InstigatorState,
             InstigatorStatus,

--- a/python_modules/dagster/dagster/core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/core/scheduler/instigation.py
@@ -55,6 +55,7 @@ class ScheduleInstigatorData(
             # `start_date` on partition-based schedules, which is used to define
             # the range of partitions)
             check.opt_float_param(start_timestamp, "start_timestamp"),
+            # this is a vestigial parameter that is not used and will be removed in the future
             check.opt_str_param(scheduler, "scheduler"),
         )
 

--- a/python_modules/dagster/dagster/core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/core/scheduler/instigation.py
@@ -45,9 +45,10 @@ SensorJobData = SensorInstigatorData
 
 @whitelist_for_serdes
 class ScheduleInstigatorData(
-    namedtuple("_ScheduleInstigatorData", "cron_schedule start_timestamp scheduler")
+    namedtuple("_ScheduleInstigatorData", "cron_schedule start_timestamp")
 ):
-    def __new__(cls, cron_schedule, start_timestamp=None, scheduler=None):
+    # removed scheduler, 1/5/2022 (0.13.13)
+    def __new__(cls, cron_schedule, start_timestamp=None):
         return super(ScheduleInstigatorData, cls).__new__(
             cls,
             check.str_param(cron_schedule, "cron_schedule"),
@@ -55,8 +56,6 @@ class ScheduleInstigatorData(
             # `start_date` on partition-based schedules, which is used to define
             # the range of partitions)
             check.opt_float_param(start_timestamp, "start_timestamp"),
-            # this is a vestigial parameter that is not used and will be removed in the future
-            check.opt_str_param(scheduler, "scheduler"),
         )
 
 

--- a/python_modules/dagster/dagster/core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/core/scheduler/scheduler.py
@@ -61,9 +61,7 @@ class Scheduler(abc.ABC):
             external_schedule.get_external_origin(),
             InstigatorType.SCHEDULE,
             InstigatorStatus.STOPPED,
-            ScheduleInstigatorData(
-                external_schedule.cron_schedule, scheduler=self.__class__.__name__
-            ),
+            ScheduleInstigatorData(external_schedule.cron_schedule),
         )
 
         instance.add_job_state(schedule_state)
@@ -102,7 +100,6 @@ class Scheduler(abc.ABC):
             ScheduleInstigatorData(
                 external_schedule.cron_schedule,
                 get_current_datetime_in_utc().timestamp(),
-                scheduler=self.__class__.__name__,
             )
         )
         instance.update_job_state(started_schedule)
@@ -127,7 +124,6 @@ class Scheduler(abc.ABC):
         stopped_schedule = schedule_state.with_status(InstigatorStatus.STOPPED).with_data(
             ScheduleInstigatorData(
                 cron_schedule=schedule_state.job_specific_data.cron_schedule,
-                scheduler=self.__class__.__name__,
             )
         )
         instance.update_job_state(stopped_schedule)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1262,9 +1262,7 @@ def test_bad_schedules_mixed_with_good_schedule(external_repo_context, capfd):
                 unloadable_origin,
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.RUNNING,
-                ScheduleInstigatorData(
-                    "0 0 * * *", pendulum.now("UTC").timestamp(), "DagsterDaemonScheduler"
-                ),
+                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
             )
             instance.add_job_state(unloadable_schedule_state)
 
@@ -1419,9 +1417,7 @@ def test_bad_load_repository(external_repo_context, capfd):
                 invalid_repo_origin,
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.RUNNING,
-                ScheduleInstigatorData(
-                    "0 0 * * *", pendulum.now("UTC").timestamp(), "DagsterDaemonScheduler"
-                ),
+                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
             )
             instance.add_job_state(schedule_state)
 
@@ -1468,9 +1464,7 @@ def test_bad_load_schedule(external_repo_context, capfd):
                 invalid_repo_origin,
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.RUNNING,
-                ScheduleInstigatorData(
-                    "0 0 * * *", pendulum.now("UTC").timestamp(), "DagsterDaemonScheduler"
-                ),
+                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
             )
             instance.add_job_state(schedule_state)
 
@@ -1507,9 +1501,7 @@ def test_bad_load_repository_location(capfd):
                 fake_origin,
                 InstigatorType.SCHEDULE,
                 InstigatorStatus.RUNNING,
-                ScheduleInstigatorData(
-                    "0 0 * * *", pendulum.now("UTC").timestamp(), "DagsterDaemonScheduler"
-                ),
+                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
             )
             instance.add_job_state(schedule_state)
 


### PR DESCRIPTION
## Summary

We don't expose the scheduler class anywhere via GraphQL.  I'm not 100% sure what the purpose of this is.

This diff removes it from the instigator storage, which should simplify construction of schedule state by not requiring instance information


## Test Plan
BK

