### PR TITLE
Batch calls to fetch workspace sensors/schedules in RootWorkspaceQuery

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
+++ b/js_modules/dagit/packages/core/src/nav/FlatContentList.tsx
@@ -10,8 +10,8 @@ import {IconWIP} from '../ui/Icon';
 import {Tooltip} from '../ui/Tooltip';
 import {
   DagsterRepoOption,
-  WorkspaceJobSchedule,
-  WorkspaceJobSensor,
+  WorkspaceRepositorySchedule,
+  WorkspaceRepositorySensor,
 } from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
@@ -32,8 +32,8 @@ type JobItem = {
   isJob: boolean;
   label: React.ReactNode;
   repoAddress: RepoAddress;
-  schedule: WorkspaceJobSchedule | null;
-  sensor: WorkspaceJobSensor | null;
+  schedule: WorkspaceRepositorySchedule | null;
+  sensor: WorkspaceRepositorySensor | null;
 };
 
 export const FlatContentList: React.FC<Props> = (props) => {
@@ -55,10 +55,14 @@ export const FlatContentList: React.FC<Props> = (props) => {
         continue;
       }
 
+      const {schedules, sensors} = repository;
       for (const pipeline of repository.pipelines) {
-        const {isJob, name, schedules, sensors} = pipeline;
-        const schedule = schedules[0] || null;
-        const sensor = sensors[0] || null;
+        const {isJob, name} = pipeline;
+        const schedule = schedules.find((schedule) => schedule.pipelineName === name) || null;
+        const sensor =
+          sensors.find((sensor) =>
+            sensor.targets?.map((target) => target.pipelineName).includes(name),
+          ) || null;
         items.push({
           name,
           isJob,

--- a/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
+++ b/js_modules/dagit/packages/core/src/nav/InstanceWarningIcon.tsx
@@ -22,15 +22,12 @@ export const InstanceWarningIcon = React.memo(() => {
 
     // Find any schedules or sensors in the repo list.
     for (const repo of options) {
-      const {pipelines} = repo.repository;
-      for (const job of pipelines) {
-        const {sensors, schedules} = job;
-        if (sensors.length) {
-          anySensors = true;
-        }
-        if (schedules.length) {
-          anySchedules = true;
-        }
+      const {schedules, sensors} = repo.repository;
+      if (sensors.length) {
+        anySensors = true;
+      }
+      if (schedules.length) {
+        anySchedules = true;
       }
       if (anySensors && anySchedules) {
         break;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -14,16 +14,16 @@ import {
   RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries,
   RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation,
   RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories,
-  RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors,
-  RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules,
+  RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors,
+  RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules,
 } from './types/RootWorkspaceQuery';
 
 type Repository = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories;
 type RepositoryLocation = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation;
 type RepositoryError = RootWorkspaceQuery_workspaceOrError_PythonError;
 
-export type WorkspaceJobSensor = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors;
-export type WorkspaceJobSchedule = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules;
+export type WorkspaceRepositorySensor = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors;
+export type WorkspaceRepositorySchedule = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules;
 export type WorkspaceRepositoryLocationNode = RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries;
 
 export interface DagsterRepoOption {
@@ -77,26 +77,27 @@ const ROOT_WORKSPACE_QUERY = gql`
                     id
                     name
                   }
-                  schedules {
+                }
+                schedules {
+                  id
+                  mode
+                  name
+                  pipelineName
+                  scheduleState {
                     id
-                    mode
-                    name
-                    scheduleState {
-                      id
-                      status
-                    }
+                    status
                   }
-                  sensors {
+                }
+                sensors {
+                  id
+                  name
+                  targets {
+                    mode
+                    pipelineName
+                  }
+                  sensorState {
                     id
-                    name
-                    targets {
-                      mode
-                      pipelineName
-                    }
-                    sensorState {
-                      id
-                      status
-                    }
+                    status
                   }
                 }
                 partitionSets {

--- a/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/RootWorkspaceQuery.ts
@@ -21,40 +21,6 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
   name: string;
 }
 
-export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState {
-  __typename: "InstigationState";
-  id: string;
-  status: InstigationStatus;
-}
-
-export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules {
-  __typename: "Schedule";
-  id: string;
-  mode: string;
-  name: string;
-  scheduleState: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState;
-}
-
-export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_targets {
-  __typename: "Target";
-  mode: string;
-  pipelineName: string;
-}
-
-export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState {
-  __typename: "InstigationState";
-  id: string;
-  status: InstigationStatus;
-}
-
-export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors {
-  __typename: "Sensor";
-  id: string;
-  name: string;
-  targets: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_targets[] | null;
-  sensorState: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState;
-}
-
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
   __typename: "Pipeline";
   id: string;
@@ -63,8 +29,41 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
   graphName: string;
   pipelineSnapshotId: string;
   modes: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];
-  schedules: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules[];
-  sensors: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors[];
+}
+
+export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules {
+  __typename: "Schedule";
+  id: string;
+  mode: string;
+  name: string;
+  pipelineName: string;
+  scheduleState: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState;
+}
+
+export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets {
+  __typename: "Target";
+  mode: string;
+  pipelineName: string;
+}
+
+export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors {
+  __typename: "Sensor";
+  id: string;
+  name: string;
+  targets: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets[] | null;
+  sensorState: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState;
 }
 
 export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_partitionSets {
@@ -91,6 +90,8 @@ export interface RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_l
   id: string;
   name: string;
   pipelines: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
+  schedules: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules[];
+  sensors: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors[];
   partitionSets: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_partitionSets[];
   location: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_location;
   displayMetadata: RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_displayMetadata[];


### PR DESCRIPTION
## Summary
We're fetching all sensors/schedules by pipeline for each pipeline in the repo instead of batch fetching all sensors/schedules in the repo and then splitting them up by pipeline.



## Test Plan
Rendered the flat nav list, BK

