### PR TITLE
[dagit] Remove confusing keymapping from Launchpad editor

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
@@ -270,10 +270,6 @@ export class ConfigEditor extends React.Component<ConfigEditorProps> {
               keyMap: 'sublime',
               extraKeys: {
                 'Cmd-Space': (editor: any) => editor.showHint({completeSingle: true}),
-                'Ctrl-A': (editor: any) => {
-                  editor.execCommand('goLineStartSmart');
-                },
-                'Ctrl-E': (editor: any) => editor.execCommand('goLineEnd'),
                 'Ctrl-Space': (editor: any) => editor.showHint({completeSingle: true}),
                 'Alt-Space': (editor: any) => editor.showHint({completeSingle: true}),
                 'Shift-Tab': (editor: any) => editor.execCommand('indentLess'),
@@ -281,8 +277,6 @@ export class ConfigEditor extends React.Component<ConfigEditorProps> {
                 // Persistent search box in Query Editor
                 'Cmd-F': 'findPersistent',
                 'Ctrl-F': 'findPersistent',
-                'Cmd-Z': (editor: any) => editor.undo(),
-                'Cmd-Y': (editor: any) => editor.redo(),
               },
               gutters: [
                 'CodeMirror-foldgutter',


### PR DESCRIPTION
## Summary

Resolves #6099.

The Launchpad editor is currently configured to override <kbd>Ctrl</kbd>+<kbd>A</kbd> to do a smart line-start jump, but this overrides default Windows select-all behavior. Since Mac users will already get line-start jumping by default from this key binding, and imo we shouldn't override important default Windows key bindings for this, I'm going to go ahead and remove the override.

For "smart" line-start jumping, if necessary, Mac users can use <kbd>Home</kbd> instead.

We also define <kbd>Ctrl</kbd>+<kbd>E</kbd> as jumping to the end of the line, which it should already do by default. There is also an undo/redo mapping that is present by default. I've removed all of these.

## Test Plan

Testing on MacOS and I don't have a quick way to test on Windows, so I don't know for sure that this repairs the issue in Windows. :|

View Launchpad, test that all keybindings work as expected, including the ones that I removed.
