### PR TITLE
Working directory python file load tweaks

### DIFF
--- a/python_modules/dagster/dagster/core/code_pointer.py
+++ b/python_modules/dagster/dagster/core/code_pointer.py
@@ -101,7 +101,7 @@ def load_python_file(python_file, working_directory):
                 raise DagsterImportError(
                     f"Encountered ImportError: `{msg}` while importing module {module_name} from "
                     f"file {python_file}. Consider using the module-based options `-m` for "
-                    "CLI-based targets or the `python_package` workspace.yaml target."
+                    "CLI-based targets or the `python_package` workspace target."
                 ) from ie
 
             working_directory = os.path.abspath(os.path.expanduser(working_directory))
@@ -112,7 +112,7 @@ def load_python_file(python_file, working_directory):
                 f"directory `{working_directory}`. If another working directory should be "
                 "used, please explicitly specify the appropriate path using the `-d` or "
                 "`--working-directory` for CLI based targets or the `working_directory` "
-                "configuration option for `python_file`-based workspace.yaml targets. "
+                "configuration option for `python_file`-based workspace targets. "
             ) from ie
 
     error = None
@@ -146,13 +146,13 @@ def load_python_file(python_file, working_directory):
             f"Module `{module_name}` was resolved using the working directory. The ability to "
             "implicitly load modules from the working directory is deprecated and "
             "will be removed in a future release. Please explicitly specify the "
-            "`working_directory` config option in your workspace.yaml or install "
+            "`working_directory` config option in your workspace or install "
             f"`{module_name}` to your python environment."
         )
         return module
-    except RuntimeError:
-        # We might be here because numpy throws run time errors at import time when being imported
-        # multiple times... we should also use the original import error as the root
+    except (RuntimeError, ImportError):
+        # RuntimeError is because numpy throws run time errors at import time when being imported
+        # multiple times
         python_file = os.path.abspath(os.path.expanduser(python_file))
 
         raise DagsterImportError(
@@ -160,11 +160,8 @@ def load_python_file(python_file, working_directory):
             f" {python_file}. If relying on the working directory to resolve modules, please "
             "explicitly specify the appropriate path using the `-d` or "
             "`--working-directory` for CLI based targets or the `working_directory` "
-            "configuration option for `python_file`-based workspace.yaml targets. " + error.msg
+            "configuration option for `python_file`-based workspace targets. " + error.msg
         ) from error
-    except ImportError:
-        # raise the original import error
-        raise error
 
 
 def load_python_module(module_name, warn_only=False, remove_from_path_fn=None):

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -6,6 +6,7 @@ import pytest
 from dagster import DagsterInvariantViolationError, RepositoryDefinition
 from dagster.core.code_pointer import CodePointer
 from dagster.core.definitions.reconstructable import repository_def_from_pointer
+from dagster.core.errors import DagsterImportError
 from dagster.core.workspace.autodiscovery import (
     loadable_targets_from_python_file,
     loadable_targets_from_python_module,
@@ -203,10 +204,10 @@ def test_local_directory_file():
     path = file_relative_path(__file__, "autodiscover_file_in_directory/repository.py")
 
     with restore_sys_modules():
-        with pytest.raises(ImportError) as exc_info:
+        with pytest.raises(DagsterImportError) as exc_info:
             loadable_targets_from_python_file(path)
 
-        assert str(exc_info.value) == "No module named 'autodiscover_src'"
+        assert "No module named 'autodiscover_src'" in str(exc_info.value)
 
     with pytest.warns(
         UserWarning,
@@ -215,7 +216,7 @@ def test_local_directory_file():
                 "Module `{module}` was resolved using the working directory. The ability to "
                 "implicitly load modules from the working directory is deprecated and will be removed "
                 "in a future release. Please explicitly specify the `working_directory` config option "
-                "in your workspace.yaml or install `{module}` to your python environment."
+                "in your workspace or install `{module}` to your python environment."
             ).format(module="autodiscover_src")
         ),
     ):


### PR DESCRIPTION
Summary:
- Fix issue where we weren't showing a helpful error message when you have no working directory set and can't import a module
- Calculate the cwd using the designated method for that in os (it's not always the same as sys.path[0])
- Genericize the error messages a bit to account for workspaces not necc. loaded from a workspace.yaml fiel

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.