### PR TITLE
remove asset tag stub functions

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1230,12 +1230,6 @@ records = instance.get_event_records(
         check.inst_param(asset_key, "asset_key", AssetKey)
         return self._event_storage.get_asset_run_ids(asset_key)
 
-    def all_asset_tags(self):
-        return {}
-
-    def get_asset_tags(self, asset_key):  # pylint: disable=unused-argument
-        return {}
-
     @traced
     def wipe_assets(self, asset_keys):
         check.list_param(asset_keys, "asset_keys", of_type=AssetKey)

--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -29,7 +29,6 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
         self._logs = defaultdict(list)
         self._handlers = defaultdict(set)
         self._inst_data = inst_data
-        self._asset_tags = defaultdict(dict)
         self._wiped_asset_keys = defaultdict(float)
         if preload:
             for payload in preload:
@@ -85,10 +84,6 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
         check.inst_param(event, "event", EventLogEntry)
         run_id = event.run_id
         self._logs[run_id].append(event)
-
-        if event.is_dagster_event and event.dagster_event.asset_key:
-            materialization = event.dagster_event.step_materialization_data.materialization
-            self._asset_tags[event.dagster_event.asset_key] = materialization.tags or {}
 
         # snapshot handlers
         handlers = list(self._handlers[run_id])
@@ -314,5 +309,3 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
     def wipe_asset(self, asset_key):
         check.inst_param(asset_key, "asset_key", AssetKey)
         self._wiped_asset_keys[asset_key] = time.time()
-        if asset_key in self._asset_tags:
-            del self._asset_tags[asset_key]

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -100,18 +100,6 @@ def solid_normalization(_):
     yield Output(1)
 
 
-@solid
-def solid_asset_tags(_):
-    yield AssetMaterialization(asset_key=AssetKey("asset_tags"), tags={"foo": "FOO", "bar": "BAR"})
-    yield Output(1)
-
-
-@solid
-def solid_asset_tags_overwrite(_):
-    yield AssetMaterialization(asset_key=AssetKey("asset_tags"), tags={"foo": "NOT_FOO"})
-    yield Output(1)
-
-
 @pipeline
 def pipeline_one():
     solid_one()
@@ -126,16 +114,6 @@ def pipeline_two():
 @pipeline
 def pipeline_normalization():
     solid_normalization()
-
-
-@pipeline
-def pipeline_asset_tags():
-    solid_asset_tags()
-
-
-@pipeline
-def pipeline_asset_tags_overwrite():
-    solid_asset_tags_overwrite()
 
 
 @solid(config_schema={"partition": Field(str, is_required=False)})


### PR DESCRIPTION
We removed asset tags in `0.13.12` but left the stubs so that we wouldn't break internal.  Internal is now switched to ignore asset tag calls so it should be okay to remove these stubs.

## Test Plan
BK


