### PR TITLE
test blank compute logs for s3

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -154,7 +154,7 @@ class S3ComputeLogManager(ComputeLogManager, ConfigurableClass):
             self._s3_session.head_object(
                 Bucket=self._s3_bucket, Key=self._bucket_key(run_id, key, io_type)
             )
-        except ClientError as e:
+        except ClientError:
             return False
 
         return True

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -155,3 +155,17 @@ def test_compute_log_manager_skip_empty_upload(mock_s3_bucket):
                 mock_s3_bucket.Object(
                     key=f"{PREFIX}/storage/{result.run_id}/compute_logs/easy.out"
                 ).get()
+
+
+def test_blank_compute_logs(mock_s3_bucket):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = S3ComputeLogManager(
+            bucket=mock_s3_bucket.name, prefix="my_prefix", local_dir=temp_dir
+        )
+
+        # simulate subscription to an in-progress run, where there is no key in the bucket
+        stdout = manager.read_logs_file("my_run_id", "my_step_key", ComputeIOType.STDOUT)
+        stderr = manager.read_logs_file("my_run_id", "my_step_key", ComputeIOType.STDERR)
+
+        assert not stdout.data
+        assert not stderr.data


### PR DESCRIPTION
Fixes issue where error is thrown when attempting to read from non-existent S3 compute log file.  Happens when attempting to read while a step is in progress, before it has been uploaded, if the logs are being uploaded from a different machine than the one attempting to read it.

OSS equivalent of https://github.com/dagster-io/internal/pull/444


## Test Plan
BK

