### PR TITLE
fixes #5739 (dagster-pandas categorical_column)

### DIFF
--- a/docs/content/integrations/pandas.mdx
+++ b/docs/content/integrations/pandas.mdx
@@ -41,6 +41,7 @@ def load_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
+        dtype={'color': 'category'},
     )
 ```
 

--- a/docs/content/integrations/pandas.mdx
+++ b/docs/content/integrations/pandas.mdx
@@ -41,7 +41,7 @@ def load_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
-        dtype={'color': 'category'},
+        dtype={"color": "category"},
     )
 ```
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
@@ -29,7 +29,7 @@ def load_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
-        dtype={'color': 'category'},
+        dtype={"color": "category"},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
@@ -29,6 +29,7 @@ def load_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
+        dtype={'color': 'category'},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
@@ -48,7 +48,7 @@ def load_custom_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
-        dtype={'color': 'category'},
+        dtype={"color": "category"},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
@@ -48,6 +48,7 @@ def load_custom_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
+        dtype={'color': 'category'},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
@@ -18,6 +18,7 @@ def load_shape_constrained_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
+        dtype={'color': 'category'},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
@@ -18,7 +18,7 @@ def load_shape_constrained_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
-        dtype={'color': 'category'},
+        dtype={"color": "category"},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
@@ -29,7 +29,7 @@ def load_summary_stats_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
-        dtype={'color': 'category'},
+        dtype={"color": "category"},
     )
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
@@ -29,6 +29,7 @@ def load_summary_stats_trip_dataframe() -> DataFrame:
         script_relative_path("./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
+        dtype={'color': 'category'},
     )
 
 

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/validation.py
@@ -338,7 +338,7 @@ class PandasColumn:
     def categorical_column(
         name,
         categories,
-        of_types="object",
+        of_types=frozenset({"category", "object"}),
         non_nullable=False,
         unique=False,
         ignore_missing_vals=False,


### PR DESCRIPTION
This is a PR with a minor change to @kdowney-cloudwalledcapital's PR #6060 to avoid breaking existing behavior, put up in interest of quick resolution. Also changes dagster-pandas guides to correctly use `category` column dtype.

On a breaking release, we should remove `object` and set the default to just `category`.

Shout-out to @kdowney-cloudwalledcapital for first pass at fix!