### PR TITLE
Disable telemetry on instance_for_test via config

### DIFF
--- a/python_modules/dagit/dagit_tests/test_telemetry.py
+++ b/python_modules/dagit/dagit_tests/test_telemetry.py
@@ -30,7 +30,7 @@ def test_dagster_telemetry_upload(env):
 
     responses.add(responses.POST, DAGSTER_TELEMETRY_URL)
 
-    with instance_for_test():
+    with instance_for_test(overrides={"telemetry": {"enabled": True}}):
         with environ(env):
             runner = CliRunner()
             with pushd(path_to_file("")):

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -107,7 +107,8 @@ def instance_for_test(overrides=None, set_dagster_home=True, temp_dir=None):
                     "config": {
                         "wait_for_processes": True,
                     },
-                }
+                },
+                "telemetry": {"enabled": False},
             },
             (overrides if overrides else {}),
         )


### PR DESCRIPTION
The original PR that I put up to disable telemetry on test did so by setting an environment variable. This didn't account for tests that might be launching off other threads, which may not always have that environment variable. This led to failures on our azure tests. 

The fix is to explicitly disable telemetry via config when testing, such that it is still disabled cross process.