### PR TITLE
Specifically disable telemetry on test instance

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -279,7 +279,7 @@ def test_dagit_logs(
     caplog,
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
-        with instance_for_test(temp_dir=temp_dir):
+        with instance_for_test(temp_dir=temp_dir, overrides={"telemetry": {"enabled": True}}):
             runner = CliRunner(env={"DAGSTER_HOME": temp_dir})
             workspace_path = file_relative_path(__file__, "telemetry_repository.yaml")
             result = runner.invoke(

--- a/python_modules/dagit/dagit_tests/test_telemetry.py
+++ b/python_modules/dagit/dagit_tests/test_telemetry.py
@@ -30,7 +30,7 @@ def test_dagster_telemetry_upload(env):
 
     responses.add(responses.POST, DAGSTER_TELEMETRY_URL)
 
-    with instance_for_test():
+    with instance_for_test(overrides={"telemetry": {"enabled": True}}):
         with environ(env):
             runner = CliRunner()
             with pushd(path_to_file("")):

--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -107,7 +107,8 @@ def instance_for_test(overrides=None, set_dagster_home=True, temp_dir=None):
                     "config": {
                         "wait_for_processes": True,
                     },
-                }
+                },
+                "telemetry": {"enabled": False},
             },
             (overrides if overrides else {}),
         )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -88,7 +88,7 @@ def test_dagster_telemetry_disabled(caplog):
 
 def test_dagster_telemetry_unset(caplog):
     with tempfile.TemporaryDirectory() as temp_dir:
-        with instance_for_test(temp_dir=temp_dir):
+        with instance_for_test(temp_dir=temp_dir, overrides={"telemetry": {"enabled": True}}):
             runner = CliRunner(env={"DAGSTER_HOME": temp_dir})
             with pushd(path_to_file("")):
                 pipeline_attribute = "foo_pipeline"
@@ -114,7 +114,7 @@ def test_dagster_telemetry_unset(caplog):
 
 def test_repo_stats(caplog):
     with tempfile.TemporaryDirectory() as temp_dir:
-        with instance_for_test(temp_dir=temp_dir):
+        with instance_for_test(temp_dir=temp_dir, overrides={"telemetry": {"enabled": True}}):
             runner = CliRunner(env={"DAGSTER_HOME": temp_dir})
             with pushd(path_to_file("")):
                 pipeline_name = "multi_mode_with_resources"
@@ -149,7 +149,7 @@ def test_repo_stats(caplog):
 
 
 def test_log_workspace_stats(caplog):
-    with instance_for_test() as instance:
+    with instance_for_test(overrides={"telemetry": {"enabled": True}}) as instance:
         with load_workspace_process_context_from_yaml_paths(
             instance, [file_relative_path(__file__, "./multi_env_telemetry_workspace.yaml")]
         ) as context:


### PR DESCRIPTION
The original PR that I put up to disable telemetry on test did so by setting an environment variable. This didn't account for tests that might be launching off other threads, which may not always have that environment variable. This led to failures on our azure tests.

The fix is to explicitly disable telemetry via config when testing, such that it is still disabled cross process.