### PR TITLE
Move make_email_on_run_failure_sensor out of the import dagster.utils path

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -421,7 +421,7 @@ slack_on_run_failure = make_slack_on_run_failure_sensor("#my_channel", os.getenv
 you create a job failure sensor that will send emails via the SMTP protocol:
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensor_alert.py startafter=start_email_marker endbefore=end_email_marker
-from dagster.utils import make_email_on_run_failure_sensor
+from dagster import make_email_on_run_failure_sensor
 
 
 email_on_run_failure = make_email_on_run_failure_sensor(

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -30,7 +30,7 @@ slack_on_run_failure = make_slack_on_run_failure_sensor("#my_channel", os.getenv
 
 
 # start_email_marker
-from dagster.utils import make_email_on_run_failure_sensor
+from dagster import make_email_on_run_failure_sensor
 
 
 email_on_run_failure = make_email_on_run_failure_sensor(

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -207,6 +207,7 @@ from dagster.core.types.python_dict import Dict
 from dagster.core.types.python_set import Set
 from dagster.core.types.python_tuple import Tuple
 from dagster.utils import file_relative_path
+from dagster.utils.alert import make_email_on_run_failure_sensor
 from dagster.utils.backcompat import ExperimentalWarning
 from dagster.utils.log import get_dagster_logger
 from dagster.utils.partitions import (
@@ -461,6 +462,7 @@ __all__ = [
     "create_offset_partition_selector",
     "date_partition_range",
     "identity_partition_selector",
+    "make_email_on_run_failure_sensor",
     # IO managers
     "IOManager",
     "IOManagerDefinition",

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -27,7 +27,6 @@ from dagster.core.errors import DagsterExecutionInterruptedError, DagsterInvaria
 from dagster.seven import IS_WINDOWS, multiprocessing
 from dagster.seven.abc import Mapping
 
-from .alert import make_email_on_pipeline_failure_sensor, make_email_on_run_failure_sensor
 from .merger import merge_dicts
 from .yaml_utils import load_yaml_from_glob_list, load_yaml_from_globs, load_yaml_from_path
 
@@ -46,6 +45,20 @@ PICKLE_PROTOCOL = 4
 
 
 DEFAULT_WORKSPACE_YAML_FILENAME = "workspace.yaml"
+
+
+# Back-compat after make_email_on_pipeline_failure_sensor and make_email_on_run_failure_sensor
+# were moved to avoid circular-dependency issues
+def make_email_on_pipeline_failure_sensor(*args, **kwargs):
+    from .alert import make_email_on_pipeline_failure_sensor  # pylint: disable=redefined-outer-name
+
+    return make_email_on_pipeline_failure_sensor(*args, **kwargs)
+
+
+def make_email_on_run_failure_sensor(*args, **kwargs):
+    from .alert import make_email_on_run_failure_sensor  # pylint: disable=redefined-outer-name
+
+    return make_email_on_run_failure_sensor(*args, **kwargs)
 
 
 def file_relative_path(dunderfile: str, relative_path: str) -> str:


### PR DESCRIPTION
Summary:
Lots of things import from dagster.utils so let's not include the alert sensor stuff whenever somebody imports dagster.utils, or we are very likely to get circular dependencies - let's treat it more like date_partition_range where you can get it right from dagster itself.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.