### PR TITLE
Use the `dagster` CLI entry point by default when launching dagster runs and steps via CLI, instead of <python_path> -m dagster api grpc

### DIFF
--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -358,6 +358,16 @@ def execute_step_command(input_json):
     "directory as a default",
 )
 @click.option(
+    "--use-system-executable-path",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Inform clients of this server to use the value of `sys.executable` as the Python "
+    "environment when launching runs using this code, instead of running `dagster`. Useful when "
+    "running code in environments that contain multiple Python environments, where a single "
+    "`dagster` command-line entry point is not enough to identify the correct Python environment.",
+)
+@click.option(
     "--ipc-output-file",
     type=click.Path(),
     help="[INTERNAL] This option should generally not be used by users. Internal param used by "
@@ -393,6 +403,7 @@ def grpc_command(
     heartbeat=False,
     heartbeat_timeout=30,
     lazy_load_user_code=False,
+    use_system_executable_path=False,
     ipc_output_file=None,
     fixed_server_id=None,
     override_system_timezone=None,
@@ -421,7 +432,7 @@ def grpc_command(
         ]
     ):
         loadable_target_origin = LoadableTargetOrigin(
-            executable_path=sys.executable,
+            executable_path=sys.executable if use_system_executable_path else "",
             attribute=kwargs["attribute"],
             working_directory=(
                 None

--- a/python_modules/dagster/dagster/cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/cli/workspace/cli_target.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from contextlib import contextmanager
 
 import click
@@ -545,7 +544,7 @@ def get_repository_python_origin_from_kwargs(kwargs):
             )
         else:
             check.failed("Must specify a Python file or module name")
-        return RepositoryPythonOrigin(executable_path=sys.executable, code_pointer=code_pointer)
+        return RepositoryPythonOrigin(executable_path="", code_pointer=code_pointer)
 
     code_pointer_dict = _get_code_pointer_dict_from_kwargs(kwargs)
     if provided_repo_name is None and len(code_pointer_dict) == 1:
@@ -567,7 +566,7 @@ def get_repository_python_origin_from_kwargs(kwargs):
     else:
         code_pointer = code_pointer_dict[provided_repo_name]
 
-    return RepositoryPythonOrigin(executable_path=sys.executable, code_pointer=code_pointer)
+    return RepositoryPythonOrigin(executable_path="", code_pointer=code_pointer)
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/core/definitions/reconstructable.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstructable.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import sys
 from collections import namedtuple
 from functools import lru_cache
 
@@ -65,7 +64,7 @@ class ReconstructableRepository(
 
     def get_python_origin(self):
         return RepositoryPythonOrigin(
-            executable_path=self.executable_path if self.executable_path else sys.executable,
+            executable_path=self.executable_path if self.executable_path else "",
             code_pointer=self.pointer,
             container_image=self.container_image,
         )

--- a/python_modules/dagster/dagster/core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/core/host_representation/origin.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from abc import ABC, abstractmethod, abstractproperty
 from collections import namedtuple
 from contextlib import contextmanager
@@ -175,7 +174,7 @@ class ManagedGrpcPythonEnvRepositoryLocationOrigin(
             "package_name": self.loadable_target_origin.package_name,
             "executable_path": (
                 self.loadable_target_origin.executable_path
-                if self.loadable_target_origin.executable_path != sys.executable
+                if self.loadable_target_origin.executable_path
                 else None
             ),
         }

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -1,5 +1,4 @@
 import datetime
-import sys
 import threading
 from abc import abstractmethod, abstractproperty
 from contextlib import AbstractContextManager
@@ -283,9 +282,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
 
     @property
     def executable_path(self) -> Optional[str]:
-        return (
-            self._recon_repo.executable_path if self._recon_repo.executable_path else sys.executable
-        )
+        return self._recon_repo.executable_path
 
     @property
     def container_image(self) -> str:

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -301,7 +301,7 @@ class DagsterApiServer(DagsterApiServicer):
                 external_repository_origin.repository_name
             ],
             self._get_current_image(),
-            sys.executable,
+            self._loadable_target_origin.executable_path,
         )
 
     def _recon_pipeline_from_origin(self, external_pipeline_origin):
@@ -974,13 +974,11 @@ def open_server_process(
     mocked_system_timezone = get_mocked_system_timezone()
 
     subprocess_args = (
-        [
-            loadable_target_origin.executable_path
-            if loadable_target_origin and loadable_target_origin.executable_path
-            else sys.executable,
-            "-m",
-            "dagster.grpc",
-        ]
+        (
+            [loadable_target_origin.executable_path, "-m", "dagster.grpc"]
+            if (loadable_target_origin and loadable_target_origin.executable_path)
+            else ["dagster", "api", "grpc"]
+        )
         + ["--lazy-load-user-code"]
         + (["--port", str(port)] if port else [])
         + (["--socket", socket] if socket else [])

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -67,9 +67,14 @@ class ExecuteRunArgs(namedtuple("_ExecuteRunArgs", "pipeline_origin pipeline_run
         )
 
     def get_command_args(self) -> List[str]:
-        return [
-            self.pipeline_origin.executable_path,
-            "-m",
+        return (
+            [
+                self.pipeline_origin.executable_path,
+                "-m",
+            ]
+            if self.pipeline_origin.executable_path
+            else []
+        ) + [
             "dagster",
             "api",
             "execute_run",
@@ -92,9 +97,14 @@ class ResumeRunArgs(namedtuple("_ResumeRunArgs", "pipeline_origin pipeline_run_i
         )
 
     def get_command_args(self) -> List[str]:
-        return [
-            self.pipeline_origin.executable_path,
-            "-m",
+        return (
+            [
+                self.pipeline_origin.executable_path,
+                "-m",
+            ]
+            if self.pipeline_origin.executable_path
+            else []
+        ) + [
             "dagster",
             "api",
             "resume_run",
@@ -155,9 +165,14 @@ class ExecuteStepArgs(
         )
 
     def get_command_args(self) -> List[str]:
-        return [
-            self.pipeline_origin.executable_path,
-            "-m",
+        return (
+            [
+                self.pipeline_origin.executable_path,
+                "-m",
+            ]
+            if self.pipeline_origin.executable_path
+            else []
+        ) + [
             "dagster",
             "api",
             "execute_step",
@@ -195,8 +210,6 @@ class ListRepositoriesResponse(
             repository_symbols=check.list_param(
                 repository_symbols, "repository_symbols", of_type=LoadableRepositorySymbol
             ),
-            # These are currently only used by the GRPC Repository Location, but
-            # we will need to migrate the rest of the repository locations to use this.
             executable_path=check.opt_str_param(executable_path, "executable_path"),
             repository_code_pointer_dict=check.opt_dict_param(
                 repository_code_pointer_dict,

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from dagster import check
 from dagster.core.code_pointer import ModuleCodePointer
@@ -31,7 +29,7 @@ def test_queued_pipeline_origin_check():
     fake_code_origin = PipelinePythonOrigin(
         pipeline_name="foo",
         repository_origin=RepositoryPythonOrigin(
-            sys.executable,
+            "",
             code_pointer,
         ),
     )


### PR DESCRIPTION
Summary:
In https://github.com/dagster-io/dagster/pull/5415 we started using the executable_path much more frequently when running commands - it basically became the default in all environments to pull sys.executable from the gRPC server and then use that to determine the entry point, even in environemnts like Docker/K8s/etc. where using `dagster` as the entry point was working fine. That change was to support a couple of different users who reported running mutliple venvs in a single Docker image, and having no way to tell Dagster to use that venv on run launch.

However, that change seems to have, perhaps predictably in hindsight, affected another class of users, who run a single Dagster executable/entrypoint and want to route all dagster commands through that (i.e assuming that sys.executable points at a Python runtime specifically that can be called with -m is not a valid assumption in general). Moreover, you can imagine people doing things like running dagster in custom images not neccesarily having the exact same python entry point. So making the change above in a blanket fashion may not have been the best move.

To support both use cases, this is a partial revert of #5415 - instead of being the default behavior, it's now something you can explicitly enable with a flag on the gRPC server - this will then make the executable_path non-null, which will ensure that that executable path. In the common case though, we switch back to the deafutl

This will be a bit of a breaking change for those couple of users who reported the multiple venv behavior originally, but I'll make sure they are aware of that before this goes out, assuming this seems like a good idea..