### PR TITLE
support future ticks $until argument to be used instead of a hard limit

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1010,7 +1010,7 @@ type Schedule {
   description: String
   scheduleState: InstigationState!
   partitionSet: PartitionSet
-  futureTicks(cursor: Float, limit: Int): FutureInstigationTicks!
+  futureTicks(cursor: Float, limit: Int, until: Float): FutureInstigationTicks!
   futureTick(tickTimestamp: Int!): FutureInstigationTick!
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -155,6 +155,27 @@ mutation(
 }
 """
 
+GET_SCHEDULE_FUTURE_TICKS_UNTIL = """
+query getSchedule($scheduleSelector: ScheduleSelector!, $ticksAfter: Float, $ticksUntil: Float) {
+  scheduleOrError(scheduleSelector: $scheduleSelector) {
+    __typename
+    ... on PythonError {
+      message
+      stack
+    }
+    ... on Schedule {
+      name
+      futureTicks(cursor: $ticksAfter, until: $ticksUntil) {
+        results {
+          timestamp
+        }
+        cursor
+      }
+    }
+  }
+}
+"""
+
 
 def default_execution_params():
     return {
@@ -404,3 +425,46 @@ def test_get_unloadable_job(graphql_context):
         result.data["unloadableInstigationStatesOrError"]["results"][0]["name"]
         == "unloadable_running"
     )
+
+
+def test_future_ticks_until(graphql_context):
+    schedule_selector = infer_schedule_selector(graphql_context, "timezone_schedule")
+
+    future_ticks_start_time = create_pendulum_time(2019, 2, 27, tz="US/Central").timestamp()
+
+    # Start a single schedule, future tick run requests only available for running schedules
+    start_result = execute_dagster_graphql(
+        graphql_context,
+        START_SCHEDULES_QUERY,
+        variables={"scheduleSelector": schedule_selector},
+    )
+    assert (
+        start_result.data["startSchedule"]["scheduleState"]["status"]
+        == InstigatorStatus.RUNNING.value
+    )
+
+    future_ticks_start_time = create_pendulum_time(2019, 2, 27, tz="US/Central").timestamp()
+    future_ticks_end_time = create_pendulum_time(2019, 3, 2, tz="US/Central").timestamp()
+
+    result = execute_dagster_graphql(
+        graphql_context,
+        GET_SCHEDULE_FUTURE_TICKS_UNTIL,
+        variables={
+            "scheduleSelector": schedule_selector,
+            "ticksAfter": future_ticks_start_time,
+            "ticksUntil": future_ticks_end_time,
+        },
+    )
+
+    future_ticks = result.data["scheduleOrError"]["futureTicks"]
+
+    assert future_ticks
+    assert len(future_ticks["results"]) == 3
+
+    timestamps = [future_tick["timestamp"] for future_tick in future_ticks["results"]]
+
+    assert timestamps == [
+        create_pendulum_time(2019, 2, 27, tz="US/Central").timestamp(),
+        create_pendulum_time(2019, 2, 28, tz="US/Central").timestamp(),
+        create_pendulum_time(2019, 3, 1, tz="US/Central").timestamp(),
+    ]


### PR DESCRIPTION
## Summary
For time-window based queries, it's useful to render future ticks up until a future timestamp.  This will be used to render the instance overview timeline.


## Test Plan
BK