### PR TITLE
[dagit] When relaunching a run, preserve log / step filters on the page

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -47,7 +47,7 @@ export const LaunchRootExecutionButton: React.FunctionComponent<LaunchRootExecut
     try {
       const result = await launchPipelineExecution({variables});
       logTelemetry(TelemetryAction.LAUNCH_RUN, metadata);
-      handleLaunchResult(basePath, props.pipelineName, result);
+      handleLaunchResult(basePath, props.pipelineName, result, {});
     } catch (error) {
       showLaunchError(error as Error);
     }

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -81,14 +81,14 @@ export const SidebarOpExecutionGraphs: React.FC<{
 
   return (
     <>
-      <SidebarSection title={'Execution Time'}>
+      <SidebarSection title="Execution Time">
         <Box flex={{alignItems: 'center', justifyContent: 'center'}} style={{height: 170}}>
           {result.loading ? (
             <Spinner purpose="section" />
           ) : (
             <AssetValueGraph
-              label={'Step Execution Time'}
-              width={'100%'}
+              label="Step Execution Time"
+              width="100%"
               data={executionTime}
               xHover={highlightedStartTime}
               onHoverX={(v) => setHighlightedStartTime(v ? Number(v) : null)}
@@ -96,7 +96,7 @@ export const SidebarOpExecutionGraphs: React.FC<{
           )}
         </Box>
       </SidebarSection>
-      <SidebarSection title={'Execution Status'}>
+      <SidebarSection title="Execution Status">
         <Box padding={{left: 24, right: 16, vertical: 12}}>
           <Box flex={{gap: 16}} style={{fontSize: '0.8rem'}}>
             <div style={{flex: 1}}>{`Last ${displayed.length} Run${

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -138,7 +138,7 @@ export const RunActionsMenu: React.FC<{
                           repositoryName: repoMatch.match.repository.name,
                         }),
                       });
-                      handleLaunchResult(basePath, run.pipelineName, result);
+                      handleLaunchResult(basePath, run.pipelineName, result, {});
                     }
                   }}
                 />

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -40,7 +40,7 @@ export function handleLaunchResult(
   basePath: string,
   pipelineName: string,
   result: void | {data?: LaunchPipelineExecution | LaunchPipelineReexecution | null},
-  openInTab?: boolean,
+  options: {openInTab?: boolean; querystring?: string},
 ) {
   const obj =
     result && result.data && 'launchPipelineExecution' in result.data
@@ -55,8 +55,8 @@ export function handleLaunchResult(
   }
 
   if (obj.__typename === 'LaunchRunSuccess') {
-    const url = `${basePath}/instance/runs/${obj.run.runId}`;
-    if (openInTab) {
+    const url = `${basePath}/instance/runs/${obj.run.runId}${options.querystring}`;
+    if (options.openInTab) {
       window.open(url, '_blank');
     } else {
       window.location.href = url;

--- a/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
@@ -1,5 +1,6 @@
 import {useMutation} from '@apollo/client';
 import * as React from 'react';
+import {useLocation} from 'react-router';
 
 import {AppContext} from '../app/AppContext';
 import {showLaunchError} from '../launchpad/showLaunchError';
@@ -24,6 +25,7 @@ export const useJobReExecution = (run: RunFragment | undefined | null) => {
     LaunchPipelineReexecutionVariables
   >(LAUNCH_PIPELINE_REEXECUTION_MUTATION);
   const repoMatch = useRepositoryForRun(run);
+  const location = useLocation();
 
   return React.useCallback(
     async (style: ReExecutionStyle) => {
@@ -40,11 +42,13 @@ export const useJobReExecution = (run: RunFragment | undefined | null) => {
 
       try {
         const result = await launchPipelineReexecution({variables});
-        handleLaunchResult(basePath, run.pipelineName, result);
+        handleLaunchResult(basePath, run.pipelineName, result, {
+          querystring: location.search,
+        });
       } catch (error) {
         showLaunchError(error as Error);
       }
     },
-    [basePath, launchPipelineReexecution, repoMatch, run],
+    [basePath, launchPipelineReexecution, repoMatch, run, location.search],
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/useLaunchSingleAssetJob.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/useLaunchSingleAssetJob.tsx
@@ -30,7 +30,9 @@ export const useLaunchSingleAssetJob = () => {
             },
           },
         });
-        handleLaunchResult(basePath, jobName, result, true);
+        handleLaunchResult(basePath, jobName, result, {
+          openInTab: true,
+        });
       } catch (error) {
         showLaunchError(error as Error);
       }


### PR DESCRIPTION
Resolves https://github.com/dagster-io/dagster/issues/2839

## Summary
- When you re-execute a run from the run details page, any selections you have in the filter bar or log query bar are preserved when you move to the new run details page. Rather than make this code aware of the specific querystring key/values that are used elsewhere on the page, I just apply the entire querystring to the new page. This seemed less likely to break in the future as we iterate on the page.
- 
![image](https://user-images.githubusercontent.com/1037212/148417646-824a2333-308c-44ca-982d-9487f4c557c8.png)




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.