### PR TITLE
allow previous dynamic output values to deallocate

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -163,9 +163,13 @@ class HookContext:
             * a dictionary from mapping key to corresponding value in the mapped case
         """
         results: Dict[str, Union[Any, Dict[str, Any]]] = {}
+        captured = self._step_execution_context.step_output_capture
+
+        if captured is None:
+            check.failed("Outputs were unexpectedly not captured for hook")
 
         # make the returned values more user-friendly
-        for step_output_handle, value in self._step_execution_context.step_output_capture.items():
+        for step_output_handle, value in captured.items():
             if step_output_handle.mapping_key:
                 if results.get(step_output_handle.output_name) is None:
                     results[step_output_handle.output_name] = {

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -356,7 +356,13 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             self._step_launcher = step_launcher_resources[0]
 
         self._step_exception: Optional[BaseException] = None
-        self._step_output_capture: Dict[StepOutputHandle, Any] = {}
+
+        self._step_output_capture: Optional[Dict[StepOutputHandle, Any]] = None
+        # Enable step output capture if there are any hooks which will receive them.
+        # Expect in the future that hooks may control whether or not they get outputs,
+        # but for now presence of any will cause output capture.
+        if self.pipeline_def.get_all_hooks_for_handle(self.solid_handle):
+            self._step_output_capture = {}
 
     @property
     def step(self) -> ExecutionStep:
@@ -541,7 +547,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return self._step_exception
 
     @property
-    def step_output_capture(self) -> Dict[StepOutputHandle, Any]:
+    def step_output_capture(self) -> Optional[Dict[StepOutputHandle, Any]]:
         return self._step_output_capture
 
     @property

--- a/python_modules/dagster/dagster/core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute.py
@@ -143,13 +143,12 @@ def execute_core_compute(
 
     step = step_context.step
 
-    all_results = []
+    emitted_result_names = set()
     for step_output in _yield_compute_results(step_context, inputs, compute_fn):
         yield step_output
         if isinstance(step_output, (DynamicOutput, Output)):
-            all_results.append(step_output)
+            emitted_result_names.add(step_output.output_name)
 
-    emitted_result_names = {r.output_name for r in all_results}
     solid_output_names = {output.name for output in step.step_outputs}
     omitted_outputs = solid_output_names.difference(emitted_result_names)
     if omitted_outputs:

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -365,8 +365,9 @@ def _type_check_and_store_output(
     # to be directly captured to a dictionary after they are computed.
     if step_context.output_capture is not None:
         step_context.output_capture[step_output_handle] = output.value
-    # capture output at the step level for threading th computed output values to hook context
-    step_context.step_output_capture[step_output_handle] = output.value
+    # capture output at the step level for threading the computed output values to hook context
+    if step_context.step_output_capture is not None:
+        step_context.step_output_capture[step_output_handle] = output.value
 
     version = (
         resolve_step_output_versions(

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -98,6 +98,7 @@ if __name__ == "__main__":
                 "grpcio-tools==1.32.0",
                 "isort>=4.3.21,<5",
                 "mock==3.0.5",
+                "objgraph",
                 "protobuf==3.13.0",  # without this, pip will install the most up-to-date protobuf
                 "pylint==2.6.0",
                 "pytest-cov==2.10.1",


### PR DESCRIPTION
Allow for users to use dynamic outputs as a means to chunk large data for incremental computation without having all outputs accumulated in memory.

To accomplish this we
1. fix a spot where we were unnecessarily holding the values.
2. disable step output capture in the condition there are no hooks to receive them. 

I imagine in the future we may want hooks to be able to opt in / out of value capture but didn't attempt to address that at this point. 

## Test Plan

added a test to verify and prevent regression 