### PR TITLE
chore: add `dagster cloud` as an optional CLI command

### DIFF
--- a/python_modules/dagster/dagster/cli/__init__.py
+++ b/python_modules/dagster/dagster/cli/__init__.py
@@ -18,6 +18,20 @@ from .sensor import sensor_cli
 
 
 def create_dagster_cli():
+    try:
+        import typer
+        from dagster_cloud.cli.entrypoint import app
+
+        cloud_cli = typer.main.get_command(app)
+    except ImportError:
+
+        @click.command(help="CLI tools for working with Dagster Cloud.")
+        def cloud_cli():
+            raise click.ClickException(
+                "The `dagster cloud` commands are only available if the `dagster-cloud` package is installed. "
+                "To install `dagster-cloud`, run `pip install dagster[cloud]."
+            )
+
     commands = {
         "api": api_cli,
         "pipeline": pipeline_cli,
@@ -29,6 +43,7 @@ def create_dagster_cli():
         "asset": asset_cli,
         "debug": debug_cli,
         "new-project": new_project_cli,
+        "cloud": cloud_cli,
     }
 
     @click.group(

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -114,6 +114,7 @@ if __name__ == "__main__":
                 "tqdm==4.48.0",  # pylint crash 48.1+
                 "yamllint",
             ],
+            "cloud": ["typer", "dagster-cloud"],
         },
         entry_points={
             "console_scripts": [


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
### With `dagster-cloud` installed
```sh
~/elementl/dagster rl/typer*
internal-3.8.7 ❯ dagster cloud --help
Usage: dagster cloud [OPTIONS] COMMAND [ARGS]...

  CLI tools for working with Dagster Cloud.

Options:
  --install-completion [bash|zsh|fish|powershell|pwsh]
                                  Install completion for the specified shell.  [env var:
                                  DAGSTER_CLI_CLOUD_INSTALL_COMPLETION]

  --show-completion [bash|zsh|fish|powershell|pwsh]
                                  Show completion for the specified shell, to copy it or customize the installation.
                                  [env var: DAGSTER_CLI_CLOUD_SHOW_COMPLETION]

  -h, --help                      Show this message and exit.

Commands:
  agent      Commands for interacting with the Dagster Cloud agent.
  config     Configure the dagster-cloud CLI
  settings   Customize your dagster-cloud settings.
  workspace  Commands for managing a Dagster Cloud workspace.
```

### With `dagster-cloud` uninstalled
```sh
~/elementl/dagster rl/typer*
internal-3.8.7 ❯ pip uninstall dagster-cloud
Found existing installation: dagster-cloud dev
Uninstalling dagster-cloud-dev:
  Would remove:
    /Users/rexledesma/.pyenv/versions/3.8.7/envs/internal-3.8.7/bin/dagster-cloud
    /Users/rexledesma/.pyenv/versions/3.8.7/envs/internal-3.8.7/lib/python3.8/site-packages/dagster-cloud.egg-link
Proceed (Y/n)? y
  Successfully uninstalled dagster-cloud-dev

~/elementl/dagster rl/typer*
internal-3.8.7 ❯ dagster cloud --help
Usage: dagster cloud [OPTIONS]

  CLI tools for working with Dagster Cloud.

Options:
  -h, --help  Show this message and exit.

~/elementl/dagster rl/typer*
internal-3.8.7 ❯ dagster cloud
Error: The `dagster cloud` commands are only available if the `dagster-cloud` package is installed. To install `dagster-cloud`, run `pip install dagster[cloud].
```



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.