### PR TITLE
Allow negative end_offsets in partitioned job config

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/core/definitions/time_window_partitions.py
@@ -49,7 +49,6 @@ class TimeWindowPartitionsDefinition(
         else:
             start_dt = start
 
-        check.param_invariant(end_offset >= 0, "end_offset", "end_offset must be non-negative")
         return super(TimeWindowPartitionsDefinition, cls).__new__(
             cls, schedule_type, start_dt, timezone or "UTC", fmt, end_offset
         )
@@ -96,6 +95,9 @@ class TimeWindowPartitionsDefinition(
                 break
 
             prev_time = next_time
+
+        if end_offset < 0:
+            partitions = partitions[:end_offset]
 
         return partitions
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_time_window_partitions.py
@@ -58,6 +58,24 @@ def test_daily_partitions_with_end_offset():
     ]
 
 
+def test_daily_partitions_with_negative_end_offset():
+    @daily_partitioned_config(start_date="2021-05-01", end_offset=-2)
+    def my_partitioned_config(_start, _end):
+        return {}
+
+    assert [
+        partition.value
+        for partition in my_partitioned_config.partitions_def.get_partitions(
+            datetime.strptime("2021-05-07", DATE_FORMAT)
+        )
+    ] == [
+        time_window("2021-05-01", "2021-05-02"),
+        time_window("2021-05-02", "2021-05-03"),
+        time_window("2021-05-03", "2021-05-04"),
+        time_window("2021-05-04", "2021-05-05"),
+    ]
+
+
 def test_monthly_partitions():
     @monthly_partitioned_config(start_date="2021-05-01")
     def my_partitioned_config(_start, _end):


### PR DESCRIPTION
Summary:
This gives a migration path for schedules that were doing things like 'fill in last week's partition today'. (Not sure if there's a better recommended way to port over a partitioned schedule that was using a partition_days_offset > 1 - if there is, happy to recommend that instead).

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.