### PR TITLE
[dagit] Add refreshable countdown to Instance Overview

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -22,6 +22,7 @@ const RUN_STATUS_COLORS = {
 
 const MIN_OPACITY = 0.2;
 const MAX_OPACITY = 1.0;
+const MIN_OPACITY_STEPS = 3;
 
 interface Props {
   opacity?: number;
@@ -43,7 +44,9 @@ interface ListProps {
 
 export const RunStatusPezList = (props: ListProps) => {
   const {fade, runs} = props;
-  const step = (MAX_OPACITY - MIN_OPACITY) / (runs.length || 1);
+  const count = runs.length;
+  const countForStep = Math.max(MIN_OPACITY_STEPS, count);
+  const step = (MAX_OPACITY - MIN_OPACITY) / countForStep;
   return (
     <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>
       {runs.map((run, ii) => (
@@ -58,7 +61,7 @@ export const RunStatusPezList = (props: ListProps) => {
             key={run.runId}
             runId={run.runId}
             status={run.status}
-            opacity={fade ? MIN_OPACITY + ii * step : 1.0}
+            opacity={fade ? MAX_OPACITY - (count - ii - 1) * step : 1.0}
           />
         </Popover>
       ))}

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -305,16 +305,18 @@ const RunTimelineRow = (props: RowProps) => {
   const batched = React.useMemo(() => {
     const batches: RunBatch[] = runs
       .map((run) => {
-        const left = Math.floor(((run.startTime - start) / rangeLength) * width);
+        const startTime = run.startTime;
+        const endTime = run.endTime || Date.now();
+        const left = Math.floor(((startTime - start) / rangeLength) * width);
         const runWidth = Math.max(
           MIN_CHUNK_WIDTH,
-          Math.ceil(((run.endTime - run.startTime) / rangeLength) * width),
+          Math.ceil(((endTime - startTime) / rangeLength) * width),
         );
 
         return {
           runs: [run],
-          startTime: run.startTime,
-          endTime: run.endTime,
+          startTime,
+          endTime,
           left,
           width: runWidth,
         };
@@ -463,6 +465,8 @@ const RunChunk = styled.div<ChunkProps>`
   position: absolute;
   top: 2px;
   ${({$multiple}) => ($multiple ? `min-width: ${MIN_WIDTH_FOR_MULTIPLE}px` : null)};
+
+  transition: background-color 300ms linear, width 300ms ease-in-out;
 
   .chunk-popover-target {
     display: block;


### PR DESCRIPTION
## Summary

Add a `QueryCountdown` to the top of Instance Overview. The top-level query is refreshed via the countdown control, and refreshes every 15 seconds.

When polling returns a result, the timeline and tables will update accordingly.

The last-ten-runs query is also polled every 15 seconds, but is not controlled by the countdown button.

Also tweaked the pez fading logic so that shorter pez lists render with better opacities, and added some color and width transitions to the timeline chunks.

## Test Plan

View Instance Overview, kick off some runs. Verify that the query refresh works as expected, and that the timeline and tables update as well.
