### PR TITLE
op_selection 3.1/ introduce ignored_solids_dict - config mapping ignore excess configs

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -37,7 +37,7 @@ def create_creation_data(pipeline_def):
         pipeline_def.dependency_structure,
         pipeline_def.mode_definition,
         logger_defs=default_loggers(),
-        ignored_solids=[],
+        ignored_solids_dict={},
         required_resources=set(),
         is_using_graph_job_op_apis=pipeline_def.is_job,
     )
@@ -281,7 +281,7 @@ def test_solid_config_error():
     pipeline_def = define_test_solids_config_pipeline()
     solid_dict_type = define_solid_dictionary_cls(
         solids=pipeline_def.solids,
-        ignored_solids=None,
+        ignored_solids_dict=None,
         dependency_structure=pipeline_def.dependency_structure,
         parent_handle=None,
         resource_defs={},


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
depends on #5944

This PR makes nested selection work with config mapping by ignoring excess configs that are generated by config mapping fn but not selected in op_selection.


It changes `ignored_solids: List[Node]` to `ignored_solids_dict: Dict[Union[str, Node]]`, a dict for passing around the nested structure for unselected nodes. some examples:
- `{Node(my_graph): LeafIgnoredNode}`: my_graph is the top-level node in the job and will be ignored entirely in config validation.
- `{Node(my_op): LeafIgnoredNode}`: same^
- `{Node(my_op): LeafIgnoredNode, "my_graph": {Node(my_op): LeafIgnoredNode}}`: `my_op` is the top-level node in the job and will be ignored, my_graph is the top-level node where its child node `my_graph.my_op` will be ignored. We won't ignore my_graph entirely bc there could be some other selected nodes in that graph.


## Test Plan
units
