### PR TITLE
Destroy volumes on fixture cleanup

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -71,7 +71,7 @@ def docker_compose_down(docker_compose_yml, context, service):
     else:
         compose_command = ["docker-compose"]
 
-    compose_command += ["--file", str(docker_compose_yml), "down", "--volumes"]
+    compose_command += ["--file", str(docker_compose_yml), "down", "--volumes", "--remove-orphans"]
 
     if service:
         compose_command.append(service)

--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -71,11 +71,7 @@ def docker_compose_down(docker_compose_yml, context, service):
     else:
         compose_command = ["docker-compose"]
 
-    compose_command += [
-        "--file",
-        str(docker_compose_yml),
-        "down",
-    ]
+    compose_command += ["--file", str(docker_compose_yml), "down", "--volumes"]
 
     if service:
         compose_command.append(service)

--- a/python_modules/dagster-test/dagster_test_tests/fixtures_tests/docker-compose.yml
+++ b/python_modules/dagster-test/dagster_test_tests/fixtures_tests/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       - 8000:8000
     command: python -m http.server
     container_name: server
+    volumes:
+      - test_volume:/tmp
+
+
+volumes:
+  test_volume:
+    name: ${TEST_VOLUME}


### PR DESCRIPTION
By default, `docker-compose down` doesn't remove volumes.

This can cause unintended interactions between tests that use the same
docker compose file because later runs of `docker-compose up`
might use an existing volume.

Passing `docker-compose down --volumes` removes the volumes along with
the containers.
