### PR TITLE
Make connect_container_to_network idempotent

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -97,7 +97,9 @@ def current_container():
 
 
 def connect_container_to_network(container, network):
-    subprocess.check_call(["docker", "network", "connect", network, container])
+    subprocess.run(  # pylint: disable=subprocess-run-check
+        ["docker", "network", "connect", network, container]
+    )
 
 
 def disconnect_container_from_network(container, network):

--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -97,6 +97,8 @@ def current_container():
 
 
 def connect_container_to_network(container, network):
+    # subprocess.run instead of subprocess.check_call so we don't fail when
+    # trying to connect a container to a network that it's already connected to
     subprocess.run(  # pylint: disable=subprocess-run-check
         ["docker", "network", "connect", network, container]
     )

--- a/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
+++ b/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
@@ -4,6 +4,7 @@ import subprocess
 
 import pytest
 import yaml
+from dagster_test.fixtures.docker_compose import connect_container_to_network, network_name_from_yml
 
 pytest_plugins = ["dagster_test.fixtures"]
 
@@ -73,3 +74,12 @@ def test_docker_compose_cm_destroys_volumes(docker_compose_cm, test_id):
         assert subprocess.check_output(["docker", "volume", "inspect", test_id])
     with pytest.raises(Exception):
         subprocess.check_output(["docker", "volume", "inspect", test_id])
+
+
+def test_connect_container_to_network(docker_compose_cm, other_docker_compose_yml):
+    with docker_compose_cm(docker_compose_yml=other_docker_compose_yml) as docker_compose:
+        container = next(iter(docker_compose))
+        network = network_name_from_yml(other_docker_compose_yml)
+        # Connecting multiple times is idempotent
+        connect_container_to_network(container=container, network=network)
+        connect_container_to_network(container=container, network=network)


### PR DESCRIPTION
On Buildkite, if you try to use the same network with multiple docker
compose files, the Buildkite test container can't connect to the network
a second time. `connect_container_to_network` returns a returncode of 1
and the Docker daemon emits:

```
Error response from daemon: endpoint with name {container} already exists in network {network}
```

Now we just continue on if we get an error while trying to connect.
There's probably a more sophisticated approach to this (for example,
checking to see if the network is already attached before trying to
attach it) but I think this will be sufficient for now.