### PR TITLE
Script to ignore vercel build for dagit-storybook if unnecessary

### DIFF
--- a/js_modules/dagit/packages/core/src/scripts/ignore_build.sh
+++ b/js_modules/dagit/packages/core/src/scripts/ignore_build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ "$VERCEL_ENV" != "production" ]]; then
+  echo "🛑 - Not production, cancel build."
+  exit 0;
+fi
+
+git diff --quiet HEAD^ HEAD ./
+any_dagit_changes=$?
+
+if [[ $any_dagit_changes -eq 1 ]]; then
+  echo "✅ - Changes found in @dagit/core, proceed with build."
+  exit 1;
+else
+  echo "🛑 - No changes to @dagit/core, cancel build."
+  exit 0;
+fi


### PR DESCRIPTION
## Summary

Don't deploy the dagit-storybook Vercel project if it's a preview, or if there are no changes to `packages/core`. Once this has landed, I'll add it to the Vercel configuration.

## Test Plan

Run `bash src/scripts/ignore_build.sh` locally with various scenarios of `VERCEL_ENV` and commits with changes. Verify that the correct values are echoed.
