### PR TITLE
narrow scope of fields fetched for runs on the overview page

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -5,7 +5,7 @@ import {Redirect} from 'react-router-dom';
 import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {QueryCountdown} from '../app/QueryCountdown';
-import {RUN_METADATA_FRAGMENT, ScheduleOrSensorTag} from '../nav/JobMetadata';
+import {JOB_METADATA_FRAGMENT, ScheduleOrSensorTag} from '../nav/JobMetadata';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
@@ -19,8 +19,6 @@ import {
 import {JobMap, RunTimeline} from '../runs/RunTimeline';
 import {RunElapsed, RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {RunTimeFragment} from '../runs/types/RunTimeFragment';
-import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
-import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {InstigationStatus, RunStatus} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {AnchorButton, ButtonWIP} from '../ui/Button';
@@ -661,43 +659,34 @@ const OVERVIEW_JOB_FRAGMENT = gql`
       mode
       runId
       status
-      ...RunMetadataFragment
       ...RunTimeFragment
     }
+    ...JobMetadataFragment
     modes {
       id
       name
     }
     schedules {
       id
-      mode
       name
       scheduleState {
         id
         status
       }
       ...ScheduleFutureTicksFragment
-      ...ScheduleSwitchFragment
     }
     sensors {
       id
       name
-      targets {
-        mode
-        pipelineName
-      }
       sensorState {
         id
         status
       }
-      ...SensorSwitchFragment
     }
   }
 
-  ${SCHEDULE_SWITCH_FRAGMENT}
   ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
-  ${SENSOR_SWITCH_FRAGMENT}
-  ${RUN_METADATA_FRAGMENT}
+  ${JOB_METADATA_FRAGMENT}
   ${RUN_TIME_FRAGMENT}
 `;
 

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
@@ -15,17 +15,6 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   value: string;
 }
 
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_assets_key {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_assets {
-  __typename: "Asset";
-  id: string;
-  key: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_assets_key;
-}
-
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_stats_RunStatsSnapshot {
   __typename: "RunStatsSnapshot";
   id: string;
@@ -56,7 +45,6 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   mode: string;
   runId: string;
   status: RunStatus;
-  assets: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_assets[];
   stats: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_stats;
 }
 

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
@@ -60,12 +60,6 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   stats: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_stats;
 }
 
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes {
-  __typename: "Mode";
-  id: string;
-  name: string;
-}
-
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
@@ -87,16 +81,16 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   id: string;
   mode: string;
   name: string;
+  cronSchedule: string;
   scheduleState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState;
   executionTimezone: string | null;
   futureTicks: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks;
-  cronSchedule: string;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_targets {
   __typename: "Target";
-  mode: string;
   pipelineName: string;
+  mode: string;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState {
@@ -108,10 +102,16 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors {
   __typename: "Sensor";
   id: string;
-  name: string;
   targets: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_targets[] | null;
-  sensorState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState;
   jobOriginId: string;
+  name: string;
+  sensorState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes {
+  __typename: "Mode";
+  id: string;
+  name: string;
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
@@ -120,9 +120,9 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   name: string;
   isJob: boolean;
   runs: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs[];
-  modes: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];
   schedules: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules[];
   sensors: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors[];
+  modes: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_location {

--- a/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
@@ -54,12 +54,6 @@ export interface OverviewJobFragment_runs {
   stats: OverviewJobFragment_runs_stats;
 }
 
-export interface OverviewJobFragment_modes {
-  __typename: "Mode";
-  id: string;
-  name: string;
-}
-
 export interface OverviewJobFragment_schedules_scheduleState {
   __typename: "InstigationState";
   id: string;
@@ -81,16 +75,16 @@ export interface OverviewJobFragment_schedules {
   id: string;
   mode: string;
   name: string;
+  cronSchedule: string;
   scheduleState: OverviewJobFragment_schedules_scheduleState;
   executionTimezone: string | null;
   futureTicks: OverviewJobFragment_schedules_futureTicks;
-  cronSchedule: string;
 }
 
 export interface OverviewJobFragment_sensors_targets {
   __typename: "Target";
-  mode: string;
   pipelineName: string;
+  mode: string;
 }
 
 export interface OverviewJobFragment_sensors_sensorState {
@@ -102,10 +96,16 @@ export interface OverviewJobFragment_sensors_sensorState {
 export interface OverviewJobFragment_sensors {
   __typename: "Sensor";
   id: string;
-  name: string;
   targets: OverviewJobFragment_sensors_targets[] | null;
-  sensorState: OverviewJobFragment_sensors_sensorState;
   jobOriginId: string;
+  name: string;
+  sensorState: OverviewJobFragment_sensors_sensorState;
+}
+
+export interface OverviewJobFragment_modes {
+  __typename: "Mode";
+  id: string;
+  name: string;
 }
 
 export interface OverviewJobFragment {
@@ -114,7 +114,7 @@ export interface OverviewJobFragment {
   name: string;
   isJob: boolean;
   runs: OverviewJobFragment_runs[];
-  modes: OverviewJobFragment_modes[];
   schedules: OverviewJobFragment_schedules[];
   sensors: OverviewJobFragment_sensors[];
+  modes: OverviewJobFragment_modes[];
 }

--- a/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
@@ -9,17 +9,6 @@ import { RunStatus, InstigationStatus } from "./../../types/globalTypes";
 // GraphQL fragment: OverviewJobFragment
 // ====================================================
 
-export interface OverviewJobFragment_runs_assets_key {
-  __typename: "AssetKey";
-  path: string[];
-}
-
-export interface OverviewJobFragment_runs_assets {
-  __typename: "Asset";
-  id: string;
-  key: OverviewJobFragment_runs_assets_key;
-}
-
 export interface OverviewJobFragment_runs_stats_RunStatsSnapshot {
   __typename: "RunStatsSnapshot";
   id: string;
@@ -50,7 +39,6 @@ export interface OverviewJobFragment_runs {
   mode: string;
   runId: string;
   status: RunStatus;
-  assets: OverviewJobFragment_runs_assets[];
   stats: OverviewJobFragment_runs_stats;
 }
 

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -25,11 +25,11 @@ import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {
-  JobMetadataQuery,
-  JobMetadataQuery_pipelineOrError_Pipeline as Job,
-  JobMetadataQuery_pipelineOrError_Pipeline_schedules as Schedule,
-  JobMetadataQuery_pipelineOrError_Pipeline_sensors as Sensor,
-} from './types/JobMetadataQuery';
+  JobMetadataFragment as Job,
+  JobMetadataFragment_schedules as Schedule,
+  JobMetadataFragment_sensors as Sensor,
+} from './types/JobMetadataFragment';
+import {JobMetadataQuery} from './types/JobMetadataQuery';
 import {RunMetadataFragment} from './types/RunMetadataFragment';
 
 interface Props {
@@ -441,26 +441,35 @@ export const RUN_METADATA_FRAGMENT = gql`
   ${RUN_TIME_FRAGMENT}
 `;
 
+export const JOB_METADATA_FRAGMENT = gql`
+  fragment JobMetadataFragment on Pipeline {
+    id
+    isJob
+    name
+    schedules {
+      id
+      mode
+      ...ScheduleSwitchFragment
+    }
+    sensors {
+      id
+      targets {
+        pipelineName
+        mode
+      }
+      ...SensorSwitchFragment
+    }
+  }
+  ${SCHEDULE_SWITCH_FRAGMENT}
+  ${SENSOR_SWITCH_FRAGMENT}
+`;
+
 const JOB_METADATA_QUERY = gql`
   query JobMetadataQuery($params: PipelineSelector!, $runsFilter: RunsFilter) {
     pipelineOrError(params: $params) {
       ... on Pipeline {
         id
-        isJob
-        name
-        schedules {
-          id
-          mode
-          ...ScheduleSwitchFragment
-        }
-        sensors {
-          id
-          targets {
-            pipelineName
-            mode
-          }
-          ...SensorSwitchFragment
-        }
+        ...JobMetadataFragment
       }
     }
     pipelineRunsOrError(filter: $runsFilter, limit: 5) {
@@ -472,7 +481,6 @@ const JOB_METADATA_QUERY = gql`
       }
     }
   }
-  ${SCHEDULE_SWITCH_FRAGMENT}
-  ${SENSOR_SWITCH_FRAGMENT}
+  ${JOB_METADATA_FRAGMENT}
   ${RUN_METADATA_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadataFragment.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadataFragment.ts
@@ -1,0 +1,55 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: JobMetadataFragment
+// ====================================================
+
+export interface JobMetadataFragment_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface JobMetadataFragment_schedules {
+  __typename: "Schedule";
+  id: string;
+  mode: string;
+  name: string;
+  cronSchedule: string;
+  scheduleState: JobMetadataFragment_schedules_scheduleState;
+}
+
+export interface JobMetadataFragment_sensors_targets {
+  __typename: "Target";
+  pipelineName: string;
+  mode: string;
+}
+
+export interface JobMetadataFragment_sensors_sensorState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface JobMetadataFragment_sensors {
+  __typename: "Sensor";
+  id: string;
+  targets: JobMetadataFragment_sensors_targets[] | null;
+  jobOriginId: string;
+  name: string;
+  sensorState: JobMetadataFragment_sensors_sensorState;
+}
+
+export interface JobMetadataFragment {
+  __typename: "Pipeline";
+  id: string;
+  isJob: boolean;
+  name: string;
+  schedules: JobMetadataFragment_schedules[];
+  sensors: JobMetadataFragment_sensors[];
+}


### PR DESCRIPTION
## Summary
We were overfetching a bit by fetching `RunMetadataFragment` for every job run.  Narrows the scope of the fields we're fetching, making sure we're not hitting `DagsterInstance.all_logs` in our call trace for `InstanceOverviewInitialQuery`.



## Test Plan
Inspection, BK

