### PR TITLE
Add an 'entry_point' field to PipelinePythonOrigin that supersedes executable_path

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -25,7 +25,11 @@ from dagster.core.host_representation.origin import (
     ExternalPipelineOrigin,
     ExternalRepositoryOrigin,
 )
-from dagster.core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
+from dagster.core.origin import (
+    DEFAULT_DAGSTER_ENTRY_POINT,
+    PipelinePythonOrigin,
+    RepositoryPythonOrigin,
+)
 from dagster.core.test_utils import in_process_test_workspace
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils import file_relative_path, git_repository_root
@@ -149,6 +153,7 @@ class ReOriginatedReconstructablePipelineForTest(ReconstructablePipeline):
                     "define_demo_execution_repo",
                 ),
                 container_image=self.repository.container_image,
+                entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
             ),
         )
 
@@ -182,6 +187,7 @@ class ReOriginatedExternalPipelineForTest(ExternalPipeline):
                     "define_demo_execution_repo",
                 ),
                 container_image=self._container_image,
+                entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
             ),
         )
 
@@ -203,6 +209,7 @@ class ReOriginatedExternalPipelineForTest(ExternalPipeline):
                         ),
                         container_image=self._container_image,
                         executable_path="python",
+                        entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
                     )
                 ),
                 repository_name="demo_execution_repo",
@@ -241,6 +248,7 @@ class ReOriginatedExternalScheduleForTest(ExternalSchedule):
                         ),
                         container_image=self._container_image,
                         executable_path="python",
+                        entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
                     )
                 ),
                 repository_name="demo_execution_repo",

--- a/python_modules/dagster/dagster/cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/cli/workspace/cli_target.py
@@ -11,7 +11,11 @@ from dagster.core.definitions.reconstructable import repository_def_from_target_
 from dagster.core.host_representation.external import ExternalRepository
 from dagster.core.host_representation.repository_location import RepositoryLocation
 from dagster.core.instance import DagsterInstance
-from dagster.core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
+from dagster.core.origin import (
+    DEFAULT_DAGSTER_ENTRY_POINT,
+    PipelinePythonOrigin,
+    RepositoryPythonOrigin,
+)
 from dagster.core.workspace.context import WorkspaceRequestContext
 from dagster.core.workspace.load_target import (
     EmptyWorkspaceTarget,
@@ -554,7 +558,11 @@ def get_repository_python_origin_from_kwargs(kwargs):
             )
         else:
             check.failed("Must specify a Python file or module name")
-        return RepositoryPythonOrigin(executable_path=sys.executable, code_pointer=code_pointer)
+        return RepositoryPythonOrigin(
+            executable_path=sys.executable,
+            code_pointer=code_pointer,
+            entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
+        )
 
     code_pointer_dict = _get_code_pointer_dict_from_kwargs(kwargs)
     if provided_repo_name is None and len(code_pointer_dict) == 1:
@@ -576,7 +584,11 @@ def get_repository_python_origin_from_kwargs(kwargs):
     else:
         code_pointer = code_pointer_dict[provided_repo_name]
 
-    return RepositoryPythonOrigin(executable_path=sys.executable, code_pointer=code_pointer)
+    return RepositoryPythonOrigin(
+        executable_path=sys.executable,
+        code_pointer=code_pointer,
+        entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
+    )
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/core/definitions/reconstructable.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstructable.py
@@ -3,7 +3,7 @@ import os
 import sys
 from collections import namedtuple
 from functools import lru_cache
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union, overload
+from typing import TYPE_CHECKING, List, NamedTuple, Optional, Union, overload
 
 from dagster import check, seven
 from dagster.core.code_pointer import (
@@ -14,9 +14,14 @@ from dagster.core.code_pointer import (
     get_python_file_from_target,
 )
 from dagster.core.errors import DagsterInvalidSubsetError, DagsterInvariantViolationError
-from dagster.core.origin import PipelinePythonOrigin, RepositoryPythonOrigin, SchedulePythonOrigin
+from dagster.core.origin import (
+    DEFAULT_DAGSTER_ENTRY_POINT,
+    PipelinePythonOrigin,
+    RepositoryPythonOrigin,
+)
 from dagster.core.selector import parse_solid_selection
 from dagster.serdes import pack_value, unpack_value, whitelist_for_serdes
+from dagster.utils import frozenlist
 from dagster.utils.backcompat import experimental
 
 from .pipeline_base import IPipeline
@@ -40,6 +45,7 @@ class ReconstructableRepository(
             ("pointer", CodePointer),
             ("container_image", Optional[str]),
             ("executable_path", Optional[str]),
+            ("entry_point", List[str]),
         ],
     )
 ):
@@ -48,12 +54,18 @@ class ReconstructableRepository(
         pointer,
         container_image=None,
         executable_path=None,
+        entry_point=None,
     ):
         return super(ReconstructableRepository, cls).__new__(
             cls,
             pointer=check.inst_param(pointer, "pointer", CodePointer),
             container_image=check.opt_str_param(container_image, "container_image"),
             executable_path=check.opt_str_param(executable_path, "executable_path"),
+            entry_point=(
+                frozenlist(check.list_param(entry_point, "entry_point", of_type=str))
+                if entry_point != None
+                else DEFAULT_DAGSTER_ENTRY_POINT
+            ),
         )
 
     @lru_cache(maxsize=1)
@@ -62,9 +74,6 @@ class ReconstructableRepository(
 
     def get_reconstructable_pipeline(self, name):
         return ReconstructablePipeline(self, name)
-
-    def get_reconstructable_schedule(self, name):
-        return ReconstructableSchedule(self, name)
 
     @classmethod
     def for_file(cls, file, fn_name, working_directory=None, container_image=None):
@@ -81,6 +90,7 @@ class ReconstructableRepository(
             executable_path=self.executable_path if self.executable_path else sys.executable,
             code_pointer=self.pointer,
             container_image=self.container_image,
+            entry_point=self.entry_point,
         )
 
     def get_python_origin_id(self):
@@ -222,35 +232,6 @@ class ReconstructablePipeline(
 
     def get_python_origin_id(self):
         return self.get_python_origin().get_id()
-
-
-@whitelist_for_serdes
-class ReconstructableSchedule(
-    namedtuple(
-        "_ReconstructableSchedule",
-        "repository schedule_name",
-    )
-):
-    def __new__(
-        cls,
-        repository,
-        schedule_name,
-    ):
-        return super(ReconstructableSchedule, cls).__new__(
-            cls,
-            repository=check.inst_param(repository, "repository", ReconstructableRepository),
-            schedule_name=check.str_param(schedule_name, "schedule_name"),
-        )
-
-    def get_python_origin(self):
-        return SchedulePythonOrigin(self.schedule_name, self.repository.get_python_origin())
-
-    def get_python_origin_id(self):
-        return self.get_python_origin().get_id()
-
-    @lru_cache(maxsize=1)
-    def get_definition(self):
-        return self.repository.get_definition().get_schedule_def(self.schedule_name)
 
 
 def reconstructable(target):

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -143,6 +143,7 @@ def step_context_to_step_run_ref(
                     ),
                     container_image=recon_pipeline.repository.container_image,
                     executable_path=recon_pipeline.repository.executable_path,
+                    entry_point=recon_pipeline.repository.entry_point,
                 ),
                 pipeline_name=recon_pipeline.pipeline_name,
                 solids_to_execute=recon_pipeline.solids_to_execute,

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -242,6 +242,11 @@ class RepositoryLocation(AbstractContextManager):
 
     @property
     @abstractmethod
+    def entry_point(self) -> Optional[List[str]]:
+        pass
+
+    @property
+    @abstractmethod
     def repository_code_pointer_dict(self) -> Dict[str, CodePointer]:
         pass
 
@@ -256,6 +261,7 @@ class RepositoryLocation(AbstractContextManager):
             executable_path=self.executable_path,
             code_pointer=code_pointer,
             container_image=self.container_image,
+            entry_point=self.entry_point,
         )
 
 
@@ -295,6 +301,10 @@ class InProcessRepositoryLocation(RepositoryLocation):
     @property
     def container_image(self) -> Optional[str]:
         return self._recon_repo.container_image
+
+    @property
+    def entry_point(self) -> Optional[List[str]]:
+        return self._recon_repo.entry_point
 
     @property
     def repository_code_pointer_dict(self) -> Dict[str, CodePointer]:
@@ -506,6 +516,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         self._executable_path = None
         self._container_image = None
         self._repository_code_pointer_dict = None
+        self._entry_point = None
 
         try:
             self.client = DagsterGrpcClient(
@@ -539,6 +550,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             self._repository_code_pointer_dict = (
                 list_repositories_response.repository_code_pointer_dict
             )
+            self._entry_point = list_repositories_response.entry_point
 
             self._container_image = self._reload_current_image()
 
@@ -576,6 +588,10 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
     @property
     def executable_path(self) -> Optional[str]:
         return self._executable_path
+
+    @property
+    def entry_point(self) -> Optional[List[str]]:
+        return self._entry_point
 
     @property
     def port(self) -> Optional[int]:

--- a/python_modules/dagster/dagster/core/origin.py
+++ b/python_modules/dagster/dagster/core/origin.py
@@ -1,25 +1,55 @@
 from collections import namedtuple
+from typing import List, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.code_pointer import CodePointer
 from dagster.serdes import create_snapshot_id, whitelist_for_serdes
+from dagster.utils import frozenlist
+
+DEFAULT_DAGSTER_ENTRY_POINT = frozenlist(["dagster"])
+
+
+def get_python_environment_entry_point(executable_path: str) -> List[str]:
+    return frozenlist([executable_path, "-m", "dagster"])
 
 
 @whitelist_for_serdes
 class RepositoryPythonOrigin(
-    namedtuple("_RepositoryPythonOrigin", "executable_path code_pointer container_image"),
+    NamedTuple(
+        "_RepositoryPythonOrigin",
+        [
+            ("executable_path", str),
+            ("code_pointer", CodePointer),
+            ("container_image", Optional[str]),
+            ("entry_point", Optional[List[str]]),
+        ],
+    ),
 ):
     """
     Derived from the handle structure in the host process, this is the subset of information
     necessary to load a target RepositoryDefinition in a "user process" locally.
+
+    Args:
+      executable_path (str): The Python executable of the user process.
+      code_pointer (CodePoitner): Once the process has started, an object that can be used to
+          find and load the repository in code.
+      container_image (Optinonal[str]): The image to use when creating a new container that
+          loads the repository. Only used in execution environments that start containers.
+      entry_point (Optional[List[str]]): The entry point to use when starting a new process
+          to load the repository. Defaults to ["dagster"] (and may differ from the executable_path).
     """
 
-    def __new__(cls, executable_path, code_pointer, container_image=None):
+    def __new__(cls, executable_path, code_pointer, container_image=None, entry_point=None):
         return super(RepositoryPythonOrigin, cls).__new__(
             cls,
             check.str_param(executable_path, "executable_path"),
             check.inst_param(code_pointer, "code_pointer", CodePointer),
             check.opt_str_param(container_image, "container_image"),
+            (
+                frozenlist(check.list_param(entry_point, "entry_point", of_type=str))
+                if entry_point != None
+                else None
+            ),
         )
 
     def get_id(self):
@@ -45,29 +75,6 @@ class PipelinePythonOrigin(namedtuple("_PipelinePythonOrigin", "pipeline_name re
     @property
     def executable_path(self):
         return self.repository_origin.executable_path
-
-    def get_repo_pointer(self):
-        return self.repository_origin.code_pointer
-
-
-@whitelist_for_serdes
-class SchedulePythonOrigin(namedtuple("_SchedulePythonOrigin", "schedule_name repository_origin")):
-    def __new__(cls, schedule_name, repository_origin):
-        return super(SchedulePythonOrigin, cls).__new__(
-            cls,
-            check.str_param(schedule_name, "schedule_name"),
-            check.inst_param(repository_origin, "repository_origin", RepositoryPythonOrigin),
-        )
-
-    def get_id(self):
-        return create_snapshot_id(self)
-
-    @property
-    def executable_path(self):
-        return self.repository_origin.executable_path
-
-    def get_repo_origin(self):
-        return self.repository_origin
 
     def get_repo_pointer(self):
         return self.repository_origin.code_pointer

--- a/python_modules/dagster/dagster/grpc/server.py
+++ b/python_modules/dagster/dagster/grpc/server.py
@@ -21,6 +21,7 @@ from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.core.host_representation.external_data import external_repository_data_from_def
 from dagster.core.host_representation.origin import ExternalPipelineOrigin, ExternalRepositoryOrigin
 from dagster.core.instance import DagsterInstance
+from dagster.core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.serdes import (
     deserialize_json_to_dagster_namedtuple,
@@ -29,7 +30,7 @@ from dagster.serdes import (
 )
 from dagster.serdes.ipc import IPCErrorMessage, ipc_write_stream, open_ipc_subprocess
 from dagster.seven import multiprocessing
-from dagster.utils import find_free_port, safe_tempfile_path_unmanaged
+from dagster.utils import find_free_port, frozenlist, safe_tempfile_path_unmanaged
 from dagster.utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
@@ -169,6 +170,7 @@ class DagsterApiServer(DagsterApiServicer):
         heartbeat_timeout=30,
         lazy_load_user_code=False,
         fixed_server_id=None,
+        entry_point=None,
     ):
         super(DagsterApiServer, self).__init__()
 
@@ -200,6 +202,12 @@ class DagsterApiServer(DagsterApiServicer):
         self._execution_lock = threading.Lock()
 
         self._serializable_load_error = None
+
+        self._entry_point = (
+            frozenlist(check.list_param(entry_point, "entry_point", of_type=str))
+            if entry_point != None
+            else DEFAULT_DAGSTER_ENTRY_POINT
+        )
 
         self._repository_symbols_and_code_pointers = RepositorySymbolsAndCodePointers(
             loadable_target_origin
@@ -302,6 +310,7 @@ class DagsterApiServer(DagsterApiServicer):
             ],
             self._get_current_image(),
             sys.executable,
+            entry_point=self._entry_point,
         )
 
     def _recon_pipeline_from_origin(self, external_pipeline_origin):
@@ -363,6 +372,7 @@ class DagsterApiServer(DagsterApiServicer):
             repository_code_pointer_dict=(
                 self._repository_symbols_and_code_pointers.code_pointers_by_repo_name
             ),
+            entry_point=self._entry_point,
         )
 
         return api_pb2.ListRepositoriesReply(
@@ -782,6 +792,7 @@ class DagsterGrpcServer:
         lazy_load_user_code=False,
         ipc_output_file=None,
         fixed_server_id=None,
+        entry_point=None,
     ):
         check.opt_str_param(host, "host")
         check.opt_int_param(port, "port")
@@ -830,6 +841,7 @@ class DagsterGrpcServer:
                 heartbeat_timeout=heartbeat_timeout,
                 lazy_load_user_code=lazy_load_user_code,
                 fixed_server_id=fixed_server_id,
+                entry_point=entry_point,
             )
         except Exception:
             if self._ipc_output_file:
@@ -973,14 +985,15 @@ def open_server_process(
 
     mocked_system_timezone = get_mocked_system_timezone()
 
+    executable_path = loadable_target_origin.executable_path if loadable_target_origin else None
+
     subprocess_args = (
-        [
-            loadable_target_origin.executable_path
-            if loadable_target_origin and loadable_target_origin.executable_path
-            else sys.executable,
-            "-m",
-            "dagster.grpc",
-        ]
+        (
+            get_python_environment_entry_point(executable_path)
+            if executable_path
+            else DEFAULT_DAGSTER_ENTRY_POINT
+        )
+        + ["api", "grpc"]
         + ["--lazy-load-user-code"]
         + (["--port", str(port)] if port else [])
         + (["--socket", socket] if socket else [])
@@ -990,6 +1003,7 @@ def open_server_process(
         + (["--fixed-server-id", fixed_server_id] if fixed_server_id else [])
         + (["--override-system-timezone", mocked_system_timezone] if mocked_system_timezone else [])
         + (["--log-level", "WARNING"])  # don't log INFO messages for automatically spun up servers
+        + (["--use-python-environment-entry-point"] if executable_path else [])
     )
 
     if loadable_target_origin:

--- a/python_modules/dagster/dagster/utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/utils/hosted_user_process.py
@@ -28,7 +28,10 @@ def recon_pipeline_from_origin(origin):
 def recon_repository_from_origin(origin):
     check.inst_param(origin, "origin", RepositoryPythonOrigin)
     return ReconstructableRepository(
-        origin.code_pointer, origin.container_image, origin.executable_path
+        origin.code_pointer,
+        origin.container_image,
+        origin.executable_path,
+        origin.entry_point,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
@@ -6,7 +6,11 @@ import pytest
 from dagster import DagsterInvariantViolationError, PipelineDefinition, lambda_solid, pipeline
 from dagster.core.code_pointer import FileCodePointer
 from dagster.core.definitions.reconstructable import reconstructable
-from dagster.core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
+from dagster.core.origin import (
+    DEFAULT_DAGSTER_ENTRY_POINT,
+    PipelinePythonOrigin,
+    RepositoryPythonOrigin,
+)
 from dagster.core.snap import PipelineSnapshot, create_pipeline_snapshot_id
 from dagster.utils import file_relative_path
 from dagster.utils.hosted_user_process import recon_pipeline_from_origin
@@ -152,6 +156,7 @@ def test_reconstruct_from_origin():
                 working_directory="/",
             ),
             container_image="my_image",
+            entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
         ),
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_pipeline_run.py
@@ -9,7 +9,11 @@ from dagster.core.host_representation.origin import (
     ExternalRepositoryOrigin,
     InProcessRepositoryLocationOrigin,
 )
-from dagster.core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
+from dagster.core.origin import (
+    DEFAULT_DAGSTER_ENTRY_POINT,
+    PipelinePythonOrigin,
+    RepositoryPythonOrigin,
+)
 from dagster.core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     NON_IN_PROGRESS_RUN_STATUSES,
@@ -33,6 +37,7 @@ def test_queued_pipeline_origin_check():
         repository_origin=RepositoryPythonOrigin(
             sys.executable,
             code_pointer,
+            entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
         ),
     )
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -6,14 +6,16 @@ import uuid
 
 import pytest
 from dagster import seven
+from dagster.api.list_repositories import sync_list_repositories_grpc
 from dagster.core.errors import DagsterUserCodeUnreachableError
 from dagster.core.host_representation.origin import (
     ExternalRepositoryOrigin,
     GrpcServerRepositoryLocationOrigin,
 )
 from dagster.core.test_utils import environ, instance_for_test, new_cwd
+from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.grpc.client import DagsterGrpcClient
-from dagster.grpc.server import wait_for_grpc_server
+from dagster.grpc.server import open_server_process, wait_for_grpc_server
 from dagster.grpc.types import SensorExecutionArgs
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 from dagster.seven import get_system_temp_directory
@@ -27,7 +29,7 @@ def _get_ipc_output_file():
     )
 
 
-def test_ping(capfd):
+def test_load_grpc_server(capfd):
     port = find_free_port()
     python_file = file_relative_path(__file__, "grpc_repo.py")
 
@@ -44,10 +46,15 @@ def test_ping(capfd):
     process = subprocess.Popen(subprocess_args)
 
     try:
-        wait_for_grpc_server(
-            process, DagsterGrpcClient(port=port, host="localhost"), subprocess_args
-        )
-        assert DagsterGrpcClient(port=port).ping("foobar") == "foobar"
+
+        client = DagsterGrpcClient(port=port, host="localhost")
+
+        wait_for_grpc_server(process, client, subprocess_args)
+        assert client.ping("foobar") == "foobar"
+
+        list_repositories_response = sync_list_repositories_grpc(client)
+        assert list_repositories_response.entry_point == ["dagster"]
+        assert list_repositories_response.executable_path == sys.executable
 
         subprocess.check_call(["dagster", "api", "grpc-health-check", "--port", str(port)])
 
@@ -62,6 +69,71 @@ def test_ping(capfd):
     out, _err = capfd.readouterr()
 
     assert f"Started Dagster code server for file {python_file} on port {port} in process" in out
+
+
+def test_python_environment_args():
+    port = find_free_port()
+    python_file = file_relative_path(__file__, "grpc_repo.py")
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=sys.executable, python_file=python_file
+    )
+
+    process = None
+    try:
+        process = open_server_process(
+            port, socket=None, loadable_target_origin=loadable_target_origin
+        )
+        assert process.args[:5] == [sys.executable, "-m", "dagster", "api", "grpc"]
+    finally:
+        if process:
+            process.terminate()
+
+
+def test_empty_executable_args():
+    port = find_free_port()
+    python_file = file_relative_path(__file__, "grpc_repo.py")
+    loadable_target_origin = LoadableTargetOrigin(executable_path="", python_file=python_file)
+    # with an empty executable_path, the args change
+    process = None
+    try:
+        process = open_server_process(
+            port, socket=None, loadable_target_origin=loadable_target_origin
+        )
+        assert process.args[:3] == ["dagster", "api", "grpc"]
+    finally:
+        if process:
+            process.terminate()
+
+
+def test_load_grpc_server_python_env():
+    port = find_free_port()
+    python_file = file_relative_path(__file__, "grpc_repo.py")
+
+    subprocess_args = [
+        "dagster",
+        "api",
+        "grpc",
+        "--port",
+        str(port),
+        "--python-file",
+        python_file,
+        "--use-python-environment-entry-point",
+    ]
+
+    process = subprocess.Popen(subprocess_args)
+
+    try:
+
+        client = DagsterGrpcClient(port=port, host="localhost")
+
+        wait_for_grpc_server(process, client, subprocess_args)
+
+        list_repositories_response = sync_list_repositories_grpc(client)
+        assert list_repositories_response.entry_point == [sys.executable, "-m", "dagster"]
+        assert list_repositories_response.executable_path == sys.executable
+
+    finally:
+        process.terminate()
 
 
 def test_load_via_env_var():


### PR DESCRIPTION
Summary:
Before, our command launchers always assumed that dagster was in a python environment that you could append -m to. This is not always true though - users might have binaries or some other dagster entrypoint.

Now, the gRPC server serves an 'entry_point' string that you can append 'api grpc' or 'api execute_run' or whatever other command you need to run. This maps better to other systems like docker or k8s and allowed flexibilty for both the python environment case (entry_point == ['/bin/my_python', '-m', 'dagster']) and the binary case (entry_point='/bin/path_to_my_dagster_binary']

By default, the gRPC server returns just 'dagster' as the entrypoint. Users who really want the server to point all commands at the right python environment (e.g. you have two venvs on one docker image) have a flag that they can set on the `dagster api grpc` call.