### PR TITLE
batch calls to fetch schedule/sensors on the overview page

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -5,7 +5,7 @@ import {Redirect} from 'react-router-dom';
 import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {QueryCountdown} from '../app/QueryCountdown';
-import {JOB_METADATA_FRAGMENT, ScheduleOrSensorTag} from '../nav/JobMetadata';
+import {ScheduleOrSensorTag} from '../nav/JobMetadata';
 import {LegacyPipelineTag} from '../pipelines/LegacyPipelineTag';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
@@ -19,6 +19,8 @@ import {
 import {JobMap, RunTimeline} from '../runs/RunTimeline';
 import {RunElapsed, RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {RunTimeFragment} from '../runs/types/RunTimeFragment';
+import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
+import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {InstigationStatus, RunStatus} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {AnchorButton, ButtonWIP} from '../ui/Button';
@@ -45,7 +47,11 @@ import {InstanceTabs} from './InstanceTabs';
 import {JobMenu} from './JobMenu';
 import {NextTick, SCHEDULE_FUTURE_TICKS_FRAGMENT} from './NextTick';
 import {StepSummaryForRun} from './StepSummaryForRun';
-import {InstanceOverviewInitialQuery} from './types/InstanceOverviewInitialQuery';
+import {
+  InstanceOverviewInitialQuery,
+  InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules as Schedule,
+  InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors as Sensor,
+} from './types/InstanceOverviewInitialQuery';
 import {LastTenRunsPerJobQuery} from './types/LastTenRunsPerJobQuery';
 import {OverviewJobFragment} from './types/OverviewJobFragment';
 
@@ -79,6 +85,8 @@ const makeJobKey = (repoAddress: RepoAddress, jobName: string) => {
 type JobItem = {
   job: OverviewJobFragment;
   repoAddress: RepoAddress;
+  schedules: Schedule[];
+  sensors: Sensor[];
 };
 
 type JobItemWithRuns = JobItem & {
@@ -180,7 +188,13 @@ const OverviewContent = () => {
         ) {
           for (const repository of locationEntry.locationOrLoadError.repositories) {
             for (const pipeline of repository.pipelines) {
-              const {runs, schedules} = pipeline;
+              const {runs} = pipeline;
+              const schedules: Schedule[] = (repository.schedules || []).filter(
+                (schedule) => schedule.pipelineName === pipeline.name,
+              );
+              const sensors: Sensor[] = (repository.sensors || []).filter((sensor) =>
+                sensor.targets?.map((t) => t.pipelineName).includes(pipeline.name),
+              );
               const repoAddress = buildRepoAddress(
                 repository.name,
                 locationEntry.locationOrLoadError.name,
@@ -188,8 +202,10 @@ const OverviewContent = () => {
 
               if (runs.length) {
                 const {status} = runs[0];
-                const item = {
+                const item: JobItem = {
                   job: pipeline,
+                  schedules,
+                  sensors,
                   repoAddress,
                 };
                 if (failedStatuses.has(status)) {
@@ -215,6 +231,8 @@ const OverviewContent = () => {
                   scheduled.push({
                     job: pipeline,
                     repoAddress,
+                    schedules,
+                    sensors,
                   });
                 }
               }
@@ -333,7 +351,7 @@ const OverviewContent = () => {
     }, {} as JobMap);
 
     for (const jobItem of scheduled) {
-      const {job, repoAddress} = jobItem;
+      const {job, repoAddress, schedules} = jobItem;
       const jobKey = makeJobKey(repoAddress, job.name);
 
       // If there are no runs tracked for this job yet because they're only scheduled,
@@ -352,7 +370,6 @@ const OverviewContent = () => {
       }
 
       const {runs} = jobMap[jobKey];
-      const {schedules} = job;
       for (const schedule of schedules) {
         if (schedule.scheduleState.status === InstigationStatus.RUNNING) {
           schedule.futureTicks.results.forEach(({timestamp}) => {
@@ -569,7 +586,7 @@ const JobSection = (props: JobSectionProps) => {
           </tr>
         </thead>
         <tbody>
-          {jobs.map(({job, repoAddress, runs}) => {
+          {jobs.map(({job, repoAddress, runs, schedules, sensors}) => {
             const jobKey = makeJobKey(repoAddress, job.name);
             return (
               <tr key={jobKey}>
@@ -602,10 +619,14 @@ const JobSection = (props: JobSectionProps) => {
                   </Box>
                 </td>
                 <td>
-                  {job.schedules.length || job.sensors.length ? (
+                  {schedules.length || sensors.length ? (
                     <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
-                      <ScheduleOrSensorTag job={job} repoAddress={repoAddress} />
-                      {job.schedules.length ? <NextTick schedules={job.schedules} /> : null}
+                      <ScheduleOrSensorTag
+                        schedules={schedules}
+                        sensors={sensors}
+                        repoAddress={repoAddress}
+                      />
+                      {schedules.length ? <NextTick schedules={schedules} /> : null}
                     </Box>
                   ) : (
                     <div style={{color: ColorsWIP.Gray500}}>None</div>
@@ -661,32 +682,12 @@ const OVERVIEW_JOB_FRAGMENT = gql`
       status
       ...RunTimeFragment
     }
-    ...JobMetadataFragment
     modes {
       id
       name
     }
-    schedules {
-      id
-      name
-      scheduleState {
-        id
-        status
-      }
-      ...ScheduleFutureTicksFragment
-    }
-    sensors {
-      id
-      name
-      sensorState {
-        id
-        status
-      }
-    }
   }
 
-  ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
-  ${JOB_METADATA_FRAGMENT}
   ${RUN_TIME_FRAGMENT}
 `;
 
@@ -714,6 +715,29 @@ const INSTANCE_OVERVIEW_INITIAL_QUERY = gql`
                   ...OverviewJobFragment
                 }
                 ...RepositoryInfoFragment
+                schedules {
+                  id
+                  name
+                  pipelineName
+                  scheduleState {
+                    id
+                    status
+                  }
+                  ...ScheduleFutureTicksFragment
+                  ...ScheduleSwitchFragment
+                }
+                sensors {
+                  id
+                  name
+                  targets {
+                    pipelineName
+                  }
+                  sensorState {
+                    id
+                    status
+                  }
+                  ...SensorSwitchFragment
+                }
               }
             }
             ... on PythonError {
@@ -728,6 +752,9 @@ const INSTANCE_OVERVIEW_INITIAL_QUERY = gql`
 
   ${OVERVIEW_JOB_FRAGMENT}
   ${REPOSITORY_INFO_FRAGMENT}
+  ${SCHEDULE_FUTURE_TICKS_FRAGMENT}
+  ${SCHEDULE_SWITCH_FRAGMENT}
+  ${SENSOR_SWITCH_FRAGMENT}
   ${PYTHON_ERROR_FRAGMENT}
 `;
 

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceOverviewInitialQuery.ts
@@ -48,54 +48,6 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   stats: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs_stats;
 }
 
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState {
-  __typename: "InstigationState";
-  id: string;
-  status: InstigationStatus;
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks_results {
-  __typename: "FutureInstigationTick";
-  timestamp: number;
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks {
-  __typename: "FutureInstigationTicks";
-  results: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks_results[];
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules {
-  __typename: "Schedule";
-  id: string;
-  mode: string;
-  name: string;
-  cronSchedule: string;
-  scheduleState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_scheduleState;
-  executionTimezone: string | null;
-  futureTicks: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules_futureTicks;
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_targets {
-  __typename: "Target";
-  pipelineName: string;
-  mode: string;
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState {
-  __typename: "InstigationState";
-  id: string;
-  status: InstigationStatus;
-}
-
-export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors {
-  __typename: "Sensor";
-  id: string;
-  targets: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_targets[] | null;
-  jobOriginId: string;
-  name: string;
-  sensorState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors_sensorState;
-}
-
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes {
   __typename: "Mode";
   id: string;
@@ -108,8 +60,6 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   name: string;
   isJob: boolean;
   runs: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_runs[];
-  schedules: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_schedules[];
-  sensors: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_sensors[];
   modes: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines_modes[];
 }
 
@@ -125,6 +75,53 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   value: string;
 }
 
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks {
+  __typename: "FutureInstigationTicks";
+  results: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results[];
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  pipelineName: string;
+  scheduleState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState;
+  executionTimezone: string | null;
+  futureTicks: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks;
+  cronSchedule: string;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets {
+  __typename: "Target";
+  pipelineName: string;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors {
+  __typename: "Sensor";
+  id: string;
+  name: string;
+  targets: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_targets[] | null;
+  sensorState: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors_sensorState;
+  jobOriginId: string;
+}
+
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
   __typename: "Repository";
   id: string;
@@ -132,6 +129,8 @@ export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locatio
   pipelines: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
   location: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_location;
   displayMetadata: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_displayMetadata[];
+  schedules: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules[];
+  sensors: InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_sensors[];
 }
 
 export interface InstanceOverviewInitialQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {

--- a/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/OverviewJobFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RunStatus, InstigationStatus } from "./../../types/globalTypes";
+import { RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: OverviewJobFragment
@@ -42,54 +42,6 @@ export interface OverviewJobFragment_runs {
   stats: OverviewJobFragment_runs_stats;
 }
 
-export interface OverviewJobFragment_schedules_scheduleState {
-  __typename: "InstigationState";
-  id: string;
-  status: InstigationStatus;
-}
-
-export interface OverviewJobFragment_schedules_futureTicks_results {
-  __typename: "FutureInstigationTick";
-  timestamp: number;
-}
-
-export interface OverviewJobFragment_schedules_futureTicks {
-  __typename: "FutureInstigationTicks";
-  results: OverviewJobFragment_schedules_futureTicks_results[];
-}
-
-export interface OverviewJobFragment_schedules {
-  __typename: "Schedule";
-  id: string;
-  mode: string;
-  name: string;
-  cronSchedule: string;
-  scheduleState: OverviewJobFragment_schedules_scheduleState;
-  executionTimezone: string | null;
-  futureTicks: OverviewJobFragment_schedules_futureTicks;
-}
-
-export interface OverviewJobFragment_sensors_targets {
-  __typename: "Target";
-  pipelineName: string;
-  mode: string;
-}
-
-export interface OverviewJobFragment_sensors_sensorState {
-  __typename: "InstigationState";
-  id: string;
-  status: InstigationStatus;
-}
-
-export interface OverviewJobFragment_sensors {
-  __typename: "Sensor";
-  id: string;
-  targets: OverviewJobFragment_sensors_targets[] | null;
-  jobOriginId: string;
-  name: string;
-  sensorState: OverviewJobFragment_sensors_sensorState;
-}
-
 export interface OverviewJobFragment_modes {
   __typename: "Mode";
   id: string;
@@ -102,7 +54,5 @@ export interface OverviewJobFragment {
   name: string;
   isJob: boolean;
   runs: OverviewJobFragment_runs[];
-  schedules: OverviewJobFragment_schedules[];
-  sensors: OverviewJobFragment_sensors[];
   modes: OverviewJobFragment_modes[];
 }

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -8,7 +8,9 @@ import {RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {ScheduleSwitch, SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {humanCronString} from '../schedules/humanCronString';
+import {ScheduleSwitchFragment} from '../schedules/types/ScheduleSwitchFragment';
 import {SensorSwitch, SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
+import {SensorSwitchFragment} from '../sensors/types/SensorSwitchFragment';
 import {RunStatus} from '../types/globalTypes';
 import {Box} from '../ui/Box';
 import {ButtonWIP} from '../ui/Button';
@@ -24,11 +26,7 @@ import {FontFamily} from '../ui/styles';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {
-  JobMetadataFragment as Job,
-  JobMetadataFragment_schedules as Schedule,
-  JobMetadataFragment_sensors as Sensor,
-} from './types/JobMetadataFragment';
+import {JobMetadataFragment as Job} from './types/JobMetadataFragment';
 import {JobMetadataQuery} from './types/JobMetadataQuery';
 import {RunMetadataFragment} from './types/RunMetadataFragment';
 
@@ -71,19 +69,17 @@ export const JobMetadata: React.FC<Props> = (props) => {
 
   return (
     <>
-      {job ? <ScheduleOrSensorTag job={job} repoAddress={repoAddress} /> : null}
+      {job ? <JobScheduleOrSensorTag job={job} repoAddress={repoAddress} /> : null}
       {lastRun ? <LatestRunTag run={lastRun} /> : null}
       {runs.length ? <RelatedAssetsTag runs={runs} /> : null}
     </>
   );
 };
 
-export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}> = ({
+const JobScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}> = ({
   job,
   repoAddress,
 }) => {
-  const [open, setOpen] = React.useState(false);
-
   const matchingSchedules = React.useMemo(() => {
     if (job?.__typename === 'Pipeline' && job.schedules.length) {
       return job.schedules;
@@ -98,8 +94,24 @@ export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}>
     return [];
   }, [job]);
 
-  const scheduleCount = matchingSchedules.length;
-  const sensorCount = matchingSensors.length;
+  return (
+    <ScheduleOrSensorTag
+      schedules={matchingSchedules}
+      sensors={matchingSensors}
+      repoAddress={repoAddress}
+    />
+  );
+};
+
+export const ScheduleOrSensorTag: React.FC<{
+  schedules: ScheduleSwitchFragment[];
+  sensors: SensorSwitchFragment[];
+  repoAddress: RepoAddress;
+}> = ({schedules, sensors, repoAddress}) => {
+  const [open, setOpen] = React.useState(false);
+
+  const scheduleCount = schedules.length;
+  const sensorCount = sensors.length;
 
   if (scheduleCount > 1 || sensorCount > 1 || (scheduleCount && sensorCount)) {
     const buttonText =
@@ -134,11 +146,11 @@ export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}>
           onClose={() => setOpen(false)}
         >
           <Box padding={{bottom: 12}}>
-            {matchingSchedules.length ? (
+            {schedules.length ? (
               <>
-                {matchingSensors.length ? (
+                {sensors.length ? (
                   <Box padding={{vertical: 16, horizontal: 24}}>
-                    <Subheading>Schedules ({matchingSchedules.length})</Subheading>
+                    <Subheading>Schedules ({schedules.length})</Subheading>
                   </Box>
                 ) : null}
                 <Table>
@@ -150,7 +162,7 @@ export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}>
                     </tr>
                   </thead>
                   <tbody>
-                    {matchingSchedules.map((schedule) => (
+                    {schedules.map((schedule) => (
                       <tr key={schedule.name}>
                         <td>
                           <ScheduleSwitch repoAddress={repoAddress} schedule={schedule} />
@@ -172,11 +184,11 @@ export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}>
                 </Table>
               </>
             ) : null}
-            {matchingSensors.length ? (
+            {sensors.length ? (
               <>
-                {matchingSchedules.length ? (
+                {schedules.length ? (
                   <Box padding={{vertical: 16, horizontal: 24}}>
-                    <Subheading>Sensors ({matchingSensors.length})</Subheading>
+                    <Subheading>Sensors ({sensors.length})</Subheading>
                   </Box>
                 ) : null}
                 <Table>
@@ -187,7 +199,7 @@ export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}>
                     </tr>
                   </thead>
                   <tbody>
-                    {matchingSensors.map((sensor) => (
+                    {sensors.map((sensor) => (
                       <tr key={sensor.name}>
                         <td>
                           <SensorSwitch repoAddress={repoAddress} sensor={sensor} />
@@ -217,17 +229,17 @@ export const ScheduleOrSensorTag: React.FC<{job: Job; repoAddress: RepoAddress}>
   }
 
   if (scheduleCount) {
-    return <MatchingSchedule schedule={matchingSchedules[0]} repoAddress={repoAddress} />;
+    return <MatchingSchedule schedule={schedules[0]} repoAddress={repoAddress} />;
   }
 
   if (sensorCount) {
-    return <MatchingSensor sensor={matchingSensors[0]} repoAddress={repoAddress} />;
+    return <MatchingSensor sensor={sensors[0]} repoAddress={repoAddress} />;
   }
 
   return null;
 };
 
-const MatchingSchedule: React.FC<{schedule: Schedule; repoAddress: RepoAddress}> = ({
+const MatchingSchedule: React.FC<{schedule: ScheduleSwitchFragment; repoAddress: RepoAddress}> = ({
   schedule,
   repoAddress,
 }) => {
@@ -268,7 +280,7 @@ const MatchingSchedule: React.FC<{schedule: Schedule; repoAddress: RepoAddress}>
   );
 };
 
-const MatchingSensor: React.FC<{sensor: Sensor; repoAddress: RepoAddress}> = ({
+const MatchingSensor: React.FC<{sensor: SensorSwitchFragment; repoAddress: RepoAddress}> = ({
   sensor,
   repoAddress,
 }) => {


### PR DESCRIPTION
This one's a little bit messy, but in order to avoid hitting the DB to query for every schedule, we try to fetch them at the repository level and match them with the individual jobs client side.

Had to do a little rejiggering of the fragments in order for this to work out.

Plan is to do something similar with runs / runStats, again, to minimize the number of data fetching round trips.




## Test Plan
BK, loaded overview page


