### PR TITLE
Fix quieten bug

### DIFF
--- a/python_modules/dagster/dagster/utils/log.py
+++ b/python_modules/dagster/dagster/utils/log.py
@@ -232,10 +232,13 @@ def define_default_formatter():
 
 @contextmanager
 def quieten(quiet=True, level=logging.WARNING):
-    if quiet:
-        logging.disable(level)
-    try:
+    if not quiet:
         yield
-    finally:
-        if quiet:
+    else:
+
+        logging.disable(level)
+
+        try:
+            yield
+        finally:
             logging.disable(logging.NOTSET)

--- a/python_modules/dagster/dagster_tests/utils_tests/test_log.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_log.py
@@ -1,0 +1,25 @@
+import logging
+
+from dagster.utils.log import quieten
+
+
+def test_quieten(caplog):
+    logging.log(msg="Now you see me!", level=logging.WARNING)
+    with quieten():
+        logging.log(msg="Now you don't!", level=logging.WARNING)
+    logging.log(msg="Now you see me again!", level=logging.WARNING)
+
+    assert "Now you see me!" in caplog.text
+    assert "Now you don't!" not in caplog.text
+    assert "Now you see me again!" in caplog.text
+
+
+def test_quieten_quiet(caplog):
+    logging.log(msg="Now you see me!", level=logging.WARNING)
+    with quieten(quiet=False):
+        logging.log(msg="Now you see me too!", level=logging.WARNING)
+    logging.log(msg="Now you see me again!", level=logging.WARNING)
+
+    assert "Now you see me!" in caplog.text
+    assert "Now you see me too!" in caplog.text
+    assert "Now you see me again!" in caplog.text


### PR DESCRIPTION
When `quieten` is called with `quiet=True`, it interferes with PyTest's `caplog` fixture (and maybe other logging related things too?)

The first commit reproduces the bug - the first test passes but the second fails.

The second commit fixes the bug - both tests pass.

I have no idea why this fix works and would love if anybody can offer an explanation 🤷 