### PR TITLE
Unskip a bunch of celery tests

### DIFF
--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_cli.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_cli.py
@@ -1,66 +1,32 @@
 # pylint: disable=unused-argument
 
-import os
-import sys
 import time
-from contextlib import contextmanager
-from unittest import mock
 
-import pytest
 from click.testing import CliRunner
 from dagster import check
-from dagster.core.test_utils import instance_for_test
 from dagster.utils import file_relative_path
 from dagster_celery.cli import main
 
 
-def assert_called(mck):
-    if hasattr(mck, "assert_called"):
-        mck.assert_called()
-    else:
-        # py35
-        assert mck.called
-
-
-@contextmanager
-def pythonpath(path):
-    """Inserts a path into the PYTHONPATH, then restores the previous PYTHONPATH when it
-    cleans up"""
-    unset = "PYTHONPATH" not in os.environ
-    old_path = os.environ.get("PYTHONPATH", "")
-    old_sys_path = sys.path
-    try:
-        os.environ["PYTHONPATH"] = "{old_path}{path}:".format(old_path=old_path, path=path)
-        sys.path.insert(0, path)
-        yield
-    finally:
-        if unset:
-            del os.environ["PYTHONPATH"]
-        else:
-            os.environ["PYTHONPATH"] = old_path
-        sys.path = old_sys_path
-
-
-def start_worker(name, args=None, exit_code=0, exception_str=""):
+def start_worker(name, config_yaml=None, args=None, exit_code=0, exception_str=""):
     args = check.opt_list_param(args, "args")
     runner = CliRunner()
-    result = runner.invoke(
-        main,
-        ["worker", "start", "-A", "dagster_celery.app", "-d", "--name", name] + args,
-    )
-    assert result.exit_code == exit_code, str(result.exception)
-    if exception_str:
-        assert exception_str in str(result.exception)
 
-
-@contextmanager
-def cleanup_worker(name, args=None):
-    args = check.opt_list_param(args, "args")
+    config_args = ["-y", config_yaml] if config_yaml else []
     try:
-        yield
+        result = runner.invoke(
+            main,
+            ["worker", "start", "-A", "dagster_celery.app", "-d", "--name", name]
+            + config_args
+            + args,
+        )
+        assert result.exit_code == exit_code, str(result.exception)
+        if exception_str:
+            assert exception_str in str(result.exception)
+        else:
+            check_for_worker(name, config_args)
     finally:
-        runner = CliRunner()
-        result = runner.invoke(main, ["worker", "terminate", name] + args)
+        result = runner.invoke(main, ["worker", "terminate", name] + config_args)
         assert result.exit_code == 0, str(result.exception)
 
 
@@ -98,106 +64,33 @@ def test_invoke_entrypoint():
     assert "Start a dagster celery worker" in result.output
 
 
-# https://github.com/dagster-io/dagster/issues/3494
-@pytest.mark.skip
-def test_start_worker(rabbitmq):
-    with cleanup_worker("dagster_test_worker"):
-        start_worker("dagster_test_worker")
-        assert check_for_worker("dagster_test_worker")
+def test_start_worker(rabbitmq, instance):
+    start_worker("dagster_test_worker")
 
 
-# https://github.com/dagster-io/dagster/issues/3494
-@pytest.mark.skip
-def test_start_worker_too_many_queues(rabbitmq):
+def test_start_worker_too_many_queues(rabbitmq, instance):
     args = ["-q", "1", "-q", "2", "-q", "3", "-q", "4", "-q", "5"]
 
-    with cleanup_worker("dagster_test_worker"):
-        start_worker(
-            "dagster_test_worker",
-            args=args,
-            exit_code=1,
-            exception_str=(
-                "Can't start a dagster_celery worker that listens on more than four queues, due to a "
-                "bug in Celery 4."
-            ),
-        )
+    start_worker(
+        "dagster_test_worker",
+        args=args,
+        exit_code=1,
+        exception_str=(
+            "Can't start a dagster_celery worker that listens on more than four queues, due to a "
+            "bug in Celery 4."
+        ),
+    )
 
 
-# https://github.com/dagster-io/dagster/issues/3494
-@pytest.mark.skip
-def test_start_worker_addargs(rabbitmq):
-    args = ["--", "--uid", "42"]
-
-    # Omitting check that uid is actually 42 to avoid a heavy test dependency on psutil
-    with cleanup_worker("dagster_test_worker"):
-        start_worker(
-            "dagster_test_worker",
-            args=args,
-        )
+def test_start_worker_config_from_empty_yaml(rabbitmq, instance):
+    start_worker("dagster_test_worker", config_yaml=file_relative_path(__file__, "empty.yaml"))
 
 
-# https://github.com/dagster-io/dagster/issues/3494
-@pytest.mark.skip
-def test_start_worker_config_from_empty_yaml(rabbitmq):
-    args = ["-y", file_relative_path(__file__, "empty.yaml")]
-    with cleanup_worker("dagster_test_worker", args=args):
-        start_worker("dagster_test_worker", args=args)
-        assert check_for_worker("dagster_test_worker", args=args)
+def test_start_worker_config_from_partial_yaml(rabbitmq, instance):
+    start_worker("dagster_test_worker", config_yaml=file_relative_path(__file__, "partial.yaml"))
 
 
-# https://github.com/dagster-io/dagster/issues/3494
-@pytest.mark.skip
-def test_start_worker_config_from_partial_yaml(rabbitmq):
-    args = ["-y", file_relative_path(__file__, "partial.yaml")]
-    with cleanup_worker("dagster_test_worker", args=args):
-        start_worker("dagster_test_worker", args=args)
-        assert check_for_worker("dagster_test_worker", args=args)
-
-
-# https://github.com/dagster-io/dagster/issues/3494
-@pytest.mark.skip
-def test_start_worker_config_from_yaml(rabbitmq):
-    args = ["-y", file_relative_path(__file__, "engine_config.yaml")]
-
-    with cleanup_worker("dagster_test_worker", args=args):
-        start_worker("dagster_test_worker", args=args)
-        assert check_for_worker("dagster_test_worker", args=args)
-
-
-@mock.patch("dagster_celery.cli.launch_background_worker")
-def test_mock_start_worker(worker_patch):
-    with instance_for_test():
-        start_worker("dagster_test_worker")
-        assert_called(worker_patch)
-
-
-@mock.patch("dagster_celery.cli.launch_background_worker")
-def test_mock_start_worker_config_from_empty_yaml(worker_patch):
-    with instance_for_test():
-        args = ["-y", file_relative_path(__file__, "empty.yaml")]
-        start_worker("dagster_test_worker", args=args)
-        assert_called(worker_patch)
-
-
-@mock.patch("dagster_celery.cli.launch_background_worker")
-def test_start_mock_worker_config_from_yaml(worker_patch):
-    with instance_for_test():
-        args = ["-y", file_relative_path(__file__, "engine_config.yaml")]
-        start_worker("dagster_test_worker", args=args)
-        assert_called(worker_patch)
-
-
-@mock.patch("dagster_celery.cli.launch_background_worker")
-def test_mock_start_worker_too_many_queues(_worker_patch):
-    with instance_for_test():
-        args = ["-q", "1", "-q", "2", "-q", "3", "-q", "4", "-q", "5"]
-
-        start_worker(
-            "dagster_test_worker",
-            args=args,
-            exit_code=1,
-            exception_str=(
-                "Can't start a dagster_celery worker that listens on more than four queues, due to a "
-                "bug in Celery 4."
-            ),
-        )
+def test_start_worker_config_from_yaml(rabbitmq, instance):
+    start_worker(
+        "dagster_test_worker", config_yaml=file_relative_path(__file__, "engine_config.yaml")
+    )

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
@@ -5,7 +5,6 @@ import threading
 import time
 from collections import OrderedDict
 
-import pytest
 from dagster import ModeDefinition, default_executors
 from dagster.core.storage.pipeline_run import PipelineRunsFilter
 from dagster.core.test_utils import instance_for_test
@@ -35,10 +34,6 @@ def test_eager_priority_pipeline():
         ]
 
 
-# If this test is failing locally, it likely means that there is a rogue
-# celery worker still running on your machine.
-# https://github.com/dagster-io/dagster/issues/3493
-@pytest.mark.skip
 def test_run_priority_pipeline(rabbitmq):
     with tempfile.TemporaryDirectory() as tempdir:
         with instance_for_test(temp_dir=tempdir) as instance:


### PR DESCRIPTION

My theory is that these failures were caused by lingering celery workers, which are now fixed as a result of some combo of the changes in https://github.com/dagster-io/dagster/pull/6153 and the c\
hanges here.

