### PR TITLE
[dagit] Rename dagit packages

### DIFF
--- a/js_modules/dagit/Makefile
+++ b/js_modules/dagit/Makefile
@@ -2,16 +2,16 @@ dev_webapp:
 	REACT_APP_BACKEND_ORIGIN="http://localhost:3333" yarn start
 
 generate-graphql:
-	yarn workspace @dagit/core generate-graphql
+	yarn workspace @dagster-io/dagit-core generate-graphql
 
 ts:
-	yarn workspace @dagit/app ts && yarn workspace @dagit/core ts
+	yarn workspace @dagster-io/dagit-app ts && yarn workspace @dagster-io/dagit-core ts
 
 lint:
-	yarn workspace @dagit/app lint && yarn workspace @dagit/core lint
+	yarn workspace @dagster-io/dagit-app lint && yarn workspace @dagster-io/dagit-core lint
 
 test:
-	yarn workspace @dagit/core jest
+	yarn workspace @dagster-io/dagit-core jest
 
 jest:
-	yarn workspace @dagit/core jest
+	yarn workspace @dagster-io/dagit-core jest

--- a/js_modules/dagit/package.json
+++ b/js_modules/dagit/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "dagit",
+  "name": "@dagster-io/dagit-workspace",
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "yarn workspace @dagit/app build && yarn post-build",
-    "build-with-profiling": "yarn workspace @dagit/app build --profile && yarn post-build",
+    "build": "yarn workspace @dagster-io/dagit-app build && yarn post-build",
+    "build-with-profiling": "yarn workspace @dagster-io/dagit-app build --profile && yarn post-build",
     "post-build": "cd ../../python_modules/dagit/dagit && rm -rf webapp && mkdir -p webapp && cp -r ../../../js_modules/dagit/packages/app/build ./webapp/ && mkdir -p webapp/build/vendor && cp -r graphql-playground ./webapp/build/vendor",
-    "lint": "yarn workspace @dagit/app lint && yarn workspace @dagit/core lint",
-    "start": "yarn workspace @dagit/app start",
-    "ts": "yarn workspace @dagit/app ts"
+    "lint": "yarn workspace @dagster-io/dagit-app lint && yarn workspace @dagster-io/dagit-core lint",
+    "start": "yarn workspace @dagster-io/dagit-app start",
+    "ts": "yarn workspace @dagster-io/dagit-app ts"
   },
   "workspaces": {
     "packages": [

--- a/js_modules/dagit/packages/app/config/paths.js
+++ b/js_modules/dagit/packages/app/config/paths.js
@@ -72,7 +72,7 @@ module.exports = {
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
   publicUrlOrPath,
 
-  // DAGSTER: Path to @dagit/core source.
+  // DAGSTER: Path to @dagster-io/dagit-core source.
   dagitCore: path.resolve('../core/src'),
 };
 

--- a/js_modules/dagit/packages/app/config/webpack.config.js
+++ b/js_modules/dagit/packages/app/config/webpack.config.js
@@ -313,7 +313,7 @@ module.exports = function (webpackEnv) {
         // Support React Native Web
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
         'react-native': 'react-native-web',
-        '@dagit/core': paths.dagitCore,
+        '@dagster-io/dagit-core': paths.dagitCore,
         // Allows for better profiling with ReactDevTools
         ...(isEnvProductionProfile && {
           'react-dom$': 'react-dom/profiling',
@@ -379,7 +379,7 @@ module.exports = function (webpackEnv) {
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
-              // DAGSTER: Include `src` and `@dagit/core`.
+              // DAGSTER: Include `src` and `@dagster-io/dagit-core`.
               include: [paths.appSrc, paths.dagitCore],
               loader: require.resolve('babel-loader'),
               options: {

--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@dagit/app",
+  "name": "@dagster-io/dagit-app",
   "version": "1.0.0",
   "private": true,
-  "description": "Dagit Application Root",
+  "description": "Dagit Application Shell",
   "license": "MIT",
   "dependencies": {
     "@blueprintjs/core": "^3.45.0",
@@ -10,7 +10,7 @@
     "@blueprintjs/popover2": "0.10.1",
     "@blueprintjs/select": "^3.16.4",
     "@blueprintjs/table": "^3.8.33",
-    "@dagit/core": "1.0.0",
+    "@dagster-io/dagit-core": "1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.1.2"

--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -1,15 +1,15 @@
 // Before anything else, set the webpack public path.
 import './publicPath';
 
-import {App} from '@dagit/core/app/App';
-import {createAppCache} from '@dagit/core/app/AppCache';
-import {errorLink} from '@dagit/core/app/AppError';
-import {AppProvider} from '@dagit/core/app/AppProvider';
-import {AppTopNav} from '@dagit/core/app/AppTopNav';
-import {ContentRoot} from '@dagit/core/app/ContentRoot';
-import {logLink, timeStartLink} from '@dagit/core/app/apolloLinks';
-import {ColorsWIP} from '@dagit/core/ui/Colors';
-import {IconWIP, IconWrapper} from '@dagit/core/ui/Icon';
+import {App} from '@dagster-io/dagit-core/app/App';
+import {createAppCache} from '@dagster-io/dagit-core/app/AppCache';
+import {errorLink} from '@dagster-io/dagit-core/app/AppError';
+import {AppProvider} from '@dagster-io/dagit-core/app/AppProvider';
+import {AppTopNav} from '@dagster-io/dagit-core/app/AppTopNav';
+import {ContentRoot} from '@dagster-io/dagit-core/app/ContentRoot';
+import {logLink, timeStartLink} from '@dagster-io/dagit-core/app/apolloLinks';
+import {ColorsWIP} from '@dagster-io/dagit-core/ui/Colors';
+import {IconWIP, IconWrapper} from '@dagster-io/dagit-core/ui/Icon';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {Link} from 'react-router-dom';

--- a/js_modules/dagit/packages/app/src/telemetryLink.tsx
+++ b/js_modules/dagit/packages/app/src/telemetryLink.tsx
@@ -1,5 +1,5 @@
 import {ApolloLink} from '@apollo/client';
-import {TelemetryAction, logTelemetry} from '@dagit/core/app/Telemetry';
+import {TelemetryAction, logTelemetry} from '@dagster-io/dagit-core/app/Telemetry';
 
 const TELEMETRY_WHITELIST = new Set([
   'PipelineExplorerRootQuery',

--- a/js_modules/dagit/packages/app/tsconfig.json
+++ b/js_modules/dagit/packages/app/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@dagit/core/*": ["../core/src/*"]
+      "@dagster-io/dagit-core/*": ["../core/src/*"]
     },
     "target": "es5",
     "lib": [

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@dagit/core",
+  "name": "@dagster-io/dagit-core",
   "version": "1.0.0",
   "private": true,
-  "description": "Dagit Core Components",
+  "description": "Dagit Application Core",
   "license": "MIT",
   "dependencies": {
     "@apollo/client": "^3.3.16",

--- a/js_modules/dagit/packages/core/src/scripts/ignore_build.sh
+++ b/js_modules/dagit/packages/core/src/scripts/ignore_build.sh
@@ -9,9 +9,9 @@ git diff --quiet HEAD^ HEAD ./
 any_dagit_changes=$?
 
 if [[ $any_dagit_changes -eq 1 ]]; then
-  echo "✅ - Changes found in @dagit/core, proceed with build."
+  echo "✅ - Changes found in @dagster-io/dagit-core, proceed with build."
   exit 1;
 else
-  echo "🛑 - No changes to @dagit/core, cancel build."
+  echo "🛑 - No changes to @dagster-io/dagit-core, cancel build."
   exit 0;
 fi

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -22,14 +22,14 @@ commands =
   coverage erase
   echo -e "--- \033[0;32m:Running dagit webapp tests\033[0m"
   yarn install
-  yarn workspace @dagit/core generate-graphql
-  yarn workspace @dagit/app lint
-  yarn workspace @dagit/app ts
-  yarn workspace @dagit/core ts
-  yarn workspace @dagit/core jest --clearCache
-  yarn workspace @dagit/core jest --collectCoverage --watchAll=false
-  yarn workspace @dagit/core check-prettier
-  yarn workspace @dagit/core check-lint
+  yarn workspace @dagster-io/dagit-core generate-graphql
+  yarn workspace @dagster-io/dagit-app lint
+  yarn workspace @dagster-io/dagit-app ts
+  yarn workspace @dagster-io/dagit-core ts
+  yarn workspace @dagster-io/dagit-core jest --clearCache
+  yarn workspace @dagster-io/dagit-core jest --collectCoverage --watchAll=false
+  yarn workspace @dagster-io/dagit-core check-prettier
+  yarn workspace @dagster-io/dagit-core check-lint
   git diff --exit-code
 
 [testenv:pylint]

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -4165,9 +4165,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dagit/app@workspace:packages/app":
+"@dagster-io/dagit-app@workspace:packages/app":
   version: 0.0.0-use.local
-  resolution: "@dagit/app@workspace:packages/app"
+  resolution: "@dagster-io/dagit-app@workspace:packages/app"
   dependencies:
     "@babel/core": 7.12.3
     "@blueprintjs/core": ^3.45.0
@@ -4175,7 +4175,7 @@ __metadata:
     "@blueprintjs/popover2": 0.10.1
     "@blueprintjs/select": ^3.16.4
     "@blueprintjs/table": ^3.8.33
-    "@dagit/core": 1.0.0
+    "@dagster-io/dagit-core": 1.0.0
     "@pmmmwh/react-refresh-webpack-plugin": 0.4.3
     "@svgr/webpack": 5.5.0
     "@testing-library/dom": ^7.30.3
@@ -4253,9 +4253,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dagit/core@1.0.0, @dagit/core@workspace:packages/core":
+"@dagster-io/dagit-core@1.0.0, @dagster-io/dagit-core@workspace:packages/core":
   version: 0.0.0-use.local
-  resolution: "@dagit/core@workspace:packages/core"
+  resolution: "@dagster-io/dagit-core@workspace:packages/core"
   dependencies:
     "@apollo/client": ^3.3.16
     "@babel/cli": ^7.13.15
@@ -4380,6 +4380,12 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     react-router-dom: ^5.1.2
+  languageName: unknown
+  linkType: soft
+
+"@dagster-io/dagit-workspace@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@dagster-io/dagit-workspace@workspace:."
   languageName: unknown
   linkType: soft
 
@@ -12111,12 +12117,6 @@ __metadata:
   checksum: 49ca0639c7b822db670de93d4fbce44b4aa072cd848c76292c9978a8cd0fff1028763020ff4b0f147bd77bfe29b4c7f82e0f71ade76b2a06100543cdfd948d19
   languageName: node
   linkType: hard
-
-"dagit@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "dagit@workspace:."
-  languageName: unknown
-  linkType: soft
 
 "dagre@npm:^0.8.2":
   version: 0.8.5


### PR DESCRIPTION
## Summary

Rename dagit packages to match our GitHub organization name.

## Test Plan

TS, lint, jest. Build and run dagit, verify success. Build and run cloud using this OS branch, verify same.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
