### PR TITLE
[dagit] Fix undefined querystring on run launch

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -55,7 +55,7 @@ export function handleLaunchResult(
   }
 
   if (obj.__typename === 'LaunchRunSuccess') {
-    const url = `${basePath}/instance/runs/${obj.run.runId}${options.querystring}`;
+    const url = `${basePath}/instance/runs/${obj.run.runId}${options.querystring || ''}`;
     if (options.openInTab) {
       window.open(url, '_blank');
     } else {


### PR DESCRIPTION
## Summary

A recent change added a `querystring` option to the end of the launched run URL. This can be undefined, though, if there is no querystring, in which case we end up with `undefined` appended to the end of the URL. Fall back to empty string instead.

## Test Plan

Launch a run, verify correct redirect.
