### PR TITLE
op_selection 3.1/ add get_top_level_ignored_nodes to SubselectedGraphDefinition

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -623,6 +623,14 @@ class GraphDefinition(NodeDefinition):
             raise_on_error=raise_on_error,
         )
 
+    @property
+    def parent_graph_def(self) -> Optional["GraphDefinition"]:
+        return None
+
+    @property
+    def is_subselected(self) -> bool:
+        return False
+
 
 class SubselectedGraphDefinition(GraphDefinition):
     """Defines a subselected graph.
@@ -666,6 +674,19 @@ class SubselectedGraphDefinition(GraphDefinition):
             config=parent_graph_def.config_mapping,
             tags=parent_graph_def.tags,
         )
+
+    @property
+    def parent_graph_def(self) -> GraphDefinition:
+        return self._parent_graph_def
+
+    def get_top_level_omitted_nodes(self) -> List[Node]:
+        return [
+            solid for solid in self.parent_graph_def.solids if not self.has_solid_named(solid.name)
+        ]
+
+    @property
+    def is_subselected(self) -> bool:
+        return True
 
 
 def _validate_in_mappings(

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -195,11 +195,6 @@ class JobDefinition(PipelineDefinition):
 
         sub_graph = _get_subselected_graph_definition(self.graph, resolved_op_selection_dict)
 
-        # TODO: config mapping - ignore unselected nested nodes
-        ignored_solids = [
-            solid for solid in self.graph.solids if not sub_graph.has_solid_named(solid.name)
-        ]
-
         return JobDefinition(
             name=self.name,
             description=self.description,
@@ -215,7 +210,6 @@ class JobDefinition(PipelineDefinition):
                 resolved_op_selection=set(
                     resolved_op_selection_dict.keys()
                 ),  # equivalent to solids_to_execute. currently only gets top level nodes.
-                ignored_solids=ignored_solids,  # used by config resolution
                 parent_job_def=self,  # used by pipeline snapshot lineage
             ),
         )

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -32,7 +32,7 @@ from .dependency import (
     NodeInvocation,
     SolidInputHandle,
 )
-from .graph_definition import GraphDefinition
+from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
 from .mode import ModeDefinition
 from .node_definition import NodeDefinition
@@ -1022,14 +1022,12 @@ def _create_run_config_schema(
         define_run_config_schema_type,
     )
     from .run_config_schema import RunConfigSchema
-    from dagster.core.definitions.job_definition import JobDefinition
 
     # When executing with a subset pipeline, include the missing solids
     # from the original pipeline as ignored to allow execution with
     # run config that is valid for the original
-    if isinstance(pipeline_def, JobDefinition) and pipeline_def.op_selection_data:
-        # JobDefinition isn't aware of full graph but it threads ignored_solids in via OpSelectionData
-        ignored_solids = pipeline_def.op_selection_data.ignored_solids
+    if isinstance(pipeline_def.graph, SubselectedGraphDefinition):
+        ignored_solids = pipeline_def.graph.get_top_level_omitted_nodes()
     elif pipeline_def.is_subset_pipeline:
         if pipeline_def.parent_pipeline_def is None:
             check.failed("Unexpected subset pipeline state")

--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -3,7 +3,7 @@ import sys
 from collections import defaultdict
 from typing import TYPE_CHECKING, AbstractSet, Dict, List, NamedTuple
 
-from dagster.core.definitions.dependency import DependencyStructure, Node
+from dagster.core.definitions.dependency import DependencyStructure
 from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvalidSubsetError
 from dagster.utils import check
 
@@ -19,7 +19,6 @@ class OpSelectionData(
         [
             ("op_selection", List[str]),
             ("resolved_op_selection", AbstractSet[str]),
-            ("ignored_solids", List[Node]),
             ("parent_job_def", "JobDefinition"),
         ],
     )
@@ -29,13 +28,11 @@ class OpSelectionData(
     Attributes:
         op_selection (List[str]): The queries of op selection.
         resolved_op_selection (AbstractSet[str]): The names of selected ops.
-        ignored_solids (List[Node]): The solids in the original full graph but outside the current
-            selection. This is used in run config resolution to handle unsatisfied inputs correctly.
         parent_job_def (JobDefinition): The definition of the full job. This is used for constructing
             pipeline snapshot lineage.
     """
 
-    def __new__(cls, op_selection, resolved_op_selection, ignored_solids, parent_job_def):
+    def __new__(cls, op_selection, resolved_op_selection, parent_job_def):
         from dagster.core.definitions.job_definition import JobDefinition
 
         return super(OpSelectionData, cls).__new__(
@@ -44,7 +41,6 @@ class OpSelectionData(
             resolved_op_selection=check.set_param(
                 resolved_op_selection, "resolved_op_selection", str
             ),
-            ignored_solids=check.list_param(ignored_solids, "ignored_solids", Node),
             parent_job_def=check.inst_param(parent_job_def, "parent_job_def", JobDefinition),
         )
 

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -4,7 +4,7 @@ from dagster import check
 from dagster.config.evaluate_value_result import EvaluateValueResult
 from dagster.config.validate import process_config
 from dagster.core.definitions.dependency import NodeHandle
-from dagster.core.definitions.graph_definition import GraphDefinition, SubselectedGraphDefinition
+from dagster.core.definitions.graph_definition import GraphDefinition
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
 from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.definitions.run_config import define_solid_dictionary_cls

--- a/python_modules/dagster/dagster/core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/core/system_config/composite_descent.py
@@ -4,7 +4,7 @@ from dagster import check
 from dagster.config.evaluate_value_result import EvaluateValueResult
 from dagster.config.validate import process_config
 from dagster.core.definitions.dependency import NodeHandle
-from dagster.core.definitions.graph_definition import GraphDefinition
+from dagster.core.definitions.graph_definition import GraphDefinition, SubselectedGraphDefinition
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
 from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.definitions.run_config import define_solid_dictionary_cls
@@ -255,9 +255,13 @@ def _get_mapped_solids_dict(
     # Dynamically construct the type that the output of the config mapping function will
     # be evaluated against
 
+    # diff original graph and the subselected graph to find nodes to ignore so the system knows to
+    # skip the validation then when config mapping generates values where the nodes are not selected
+    ignored_solids = graph_def.get_top_level_omitted_nodes() if graph_def.is_subselected else None
+
     type_to_evaluate_against = define_solid_dictionary_cls(
         solids=graph_def.solids,
-        ignored_solids=None,
+        ignored_solids=ignored_solids,
         dependency_structure=graph_def.dependency_structure,
         parent_handle=current_stack.handle,
         resource_defs=resource_defs,


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
depends on #5944

This PR makes nested selection work with config mapping by ignoring excess configs that are generated by config mapping fn but not selected in op_selection.

It leverages the newly introduced `parent_graph_def` property on `SubselectedGraphDefinition`. When validating configs for graphs, we diff the nodes in parent graph and the nodes in the subselected graph (the validation is recursive so only need top-level ignored nodes at each level). 

Besides, also see a chance to remove `ignored_solids` from `OpSelectionData` - I believe, with `SubselectedGraphDefinition`, we can get rid of `OpSelectionData` entirely in later diffs.





## Test Plan
unit -  also adds more test cases to cover edge cases related to the ignored solids path.

