### PR TITLE
Add database watermarking for telemetry

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -324,6 +324,7 @@ def test_dagit_logs(
                         "num_pipelines_in_repo",
                         "repo_hash",
                         "python_version",
+                        "db_watermark",
                         "metadata",
                         "version",
                         "dagster_version",

--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -324,7 +324,7 @@ def test_dagit_logs(
                         "num_pipelines_in_repo",
                         "repo_hash",
                         "python_version",
-                        "db_watermark",
+                        "run_storage_id",
                         "metadata",
                         "version",
                         "dagster_version",

--- a/python_modules/dagster/dagster/core/storage/runs/__init__.py
+++ b/python_modules/dagster/dagster/core/storage/runs/__init__.py
@@ -1,5 +1,5 @@
 from .base import RunStorage
 from .in_memory import InMemoryRunStorage
-from .schema import DaemonHeartbeatsTable, RunStorageSqlMetadata
+from .schema import DaemonHeartbeatsTable, InstanceInfo, RunStorageSqlMetadata
 from .sql_run_storage import SqlRunStorage
 from .sqlite import SqliteRunStorage

--- a/python_modules/dagster/dagster/core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/core/storage/runs/schema.py
@@ -78,7 +78,7 @@ BulkActionsTable = db.Table(
 )
 
 InstanceInfo = db.Table(
-    "telemetry_info",
+    "instance_info",
     RunStorageSqlMetadata,
     db.Column("telemetry_id", db.Text),
 )

--- a/python_modules/dagster/dagster/core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/core/storage/runs/schema.py
@@ -80,7 +80,7 @@ BulkActionsTable = db.Table(
 InstanceInfo = db.Table(
     "instance_info",
     RunStorageSqlMetadata,
-    db.Column("telemetry_id", db.Text),
+    db.Column("run_storage_id", db.Text),
 )
 
 db.Index("idx_run_tags", RunTagsTable.c.key, RunTagsTable.c.value, mysql_length=64)

--- a/python_modules/dagster/dagster/core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/core/storage/runs/schema.py
@@ -77,7 +77,7 @@ BulkActionsTable = db.Table(
     db.Column("body", db.Text),
 )
 
-TelemetryTable = db.Table(
+InstanceInfo = db.Table(
     "telemetry_info",
     RunStorageSqlMetadata,
     db.Column("telemetry_id", db.Text),

--- a/python_modules/dagster/dagster/core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/core/storage/runs/schema.py
@@ -77,6 +77,12 @@ BulkActionsTable = db.Table(
     db.Column("body", db.Text),
 )
 
+TelemetryTable = db.Table(
+    "telemetry_info",
+    RunStorageSqlMetadata,
+    db.Column("telemetry_id", db.Text),
+)
+
 db.Index("idx_run_tags", RunTagsTable.c.key, RunTagsTable.c.value, mysql_length=64)
 db.Index("idx_run_partitions", RunsTable.c.partition_set, RunsTable.c.partition, mysql_length=64)
 db.Index("idx_bulk_actions", BulkActionsTable.c.key, mysql_length=32)

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -40,11 +40,11 @@ from .migration import RUN_DATA_MIGRATIONS, RUN_PARTITIONS
 from .schema import (
     BulkActionsTable,
     DaemonHeartbeatsTable,
+    InstanceInfo,
     RunTagsTable,
     RunsTable,
     SecondaryIndexMigrationTable,
     SnapshotsTable,
-    TelemetryTable,
 )
 
 
@@ -670,12 +670,12 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             return snapshot_id
 
     def get_telemetry_watermark(self) -> str:
-        query = db.select([TelemetryTable.c.telemetry_id])
+        query = db.select([InstanceInfo.c.telemetry_id])
         row = self.fetchone(query)
         if not row:
             telemetry_id = str(uuid.uuid4())
             with self.connect() as conn:
-                conn.execute(TelemetryTable.insert().values(telemetry_id=telemetry_id))
+                conn.execute(InstanceInfo.insert().values(telemetry_id=telemetry_id))
             return telemetry_id
         else:
             return row[0]

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -669,14 +669,14 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             conn.execute(snapshot_insert)
             return snapshot_id
 
-    def get_telemetry_watermark(self) -> str:
-        query = db.select([InstanceInfo.c.telemetry_id])
+    def get_run_storage_id(self) -> str:
+        query = db.select([InstanceInfo.c.run_storage_id])
         row = self.fetchone(query)
         if not row:
-            telemetry_id = str(uuid.uuid4())
+            run_storage_id = str(uuid.uuid4())
             with self.connect() as conn:
-                conn.execute(InstanceInfo.insert().values(telemetry_id=telemetry_id))
-            return telemetry_id
+                conn.execute(InstanceInfo.insert().values(run_storage_id=run_storage_id))
+            return run_storage_id
         else:
             return row[0]
 

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -18,7 +18,7 @@ from dagster.serdes import ConfigurableClass, ConfigurableClassData
 from dagster.utils import mkdir_p
 from sqlalchemy.pool import NullPool
 
-from ..schema import RunStorageSqlMetadata, RunTagsTable, RunsTable
+from ..schema import InstanceInfo, RunStorageSqlMetadata, RunTagsTable, RunsTable
 from ..sql_run_storage import SqlRunStorage
 
 
@@ -82,8 +82,8 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
                 should_mark_indexes = True
 
             table_names = db.inspect(engine).get_table_names()
-            if "telemetry_info" not in table_names:
-                RunStorageSqlMetadata.create_all(engine)
+            if "instance_info" not in table_names:
+                InstanceInfo.create(engine)
 
         run_storage = SqliteRunStorage(conn_string, inst_data)
 

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -81,6 +81,10 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
                 stamp_alembic_rev(alembic_config, connection)
                 should_mark_indexes = True
 
+            table_names = db.inspect(engine).get_table_names()
+            if "telemetry_info" not in table_names:
+                RunStorageSqlMetadata.create_all(engine)
+
         run_storage = SqliteRunStorage(conn_string, inst_data)
 
         if should_mark_indexes:

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -131,7 +131,7 @@ class TelemetryEntry(
     namedtuple(
         "TelemetryEntry",
         "action client_time elapsed_time event_id instance_id pipeline_name_hash "
-        "num_pipelines_in_repo repo_hash python_version metadata version dagster_version os_desc os_platform",
+        "num_pipelines_in_repo repo_hash python_version metadata version dagster_version os_desc os_platform db_watermark",
     )
 ):
     """
@@ -154,6 +154,7 @@ class TelemetryEntry(
     dagster_version - Version of the project being used.
     os_desc - String describing OS in use
     os_platform - Terse string describing OS platform - linux, windows, darwin, etc.
+    db_watermark - Unique identifier of run storage database
 
     If $DAGSTER_HOME is set, then use $DAGSTER_HOME/logs/
     Otherwise, use ~/.dagster/logs/
@@ -170,6 +171,7 @@ class TelemetryEntry(
         num_pipelines_in_repo=None,
         repo_hash=None,
         metadata=None,
+        db_watermark=None,
     ):
         action = check.str_param(action, "action")
         client_time = check.str_param(client_time, "action")
@@ -177,6 +179,7 @@ class TelemetryEntry(
         event_id = check.str_param(event_id, "event_id")
         instance_id = check.str_param(instance_id, "instance_id")
         metadata = check.opt_dict_param(metadata, "metadata")
+        db_watermark = check.opt_str_param(db_watermark, "db_watermark")
 
         pipeline_name_hash = check.opt_str_param(
             pipeline_name_hash, "pipeline_name_hash", default=""
@@ -202,6 +205,7 @@ class TelemetryEntry(
             dagster_version=dagster_module_version,
             os_desc=OS_DESC,
             os_platform=OS_PLATFORM,
+            db_watermark=db_watermark,
         )
 
 
@@ -310,12 +314,18 @@ def write_telemetry_log_line(log_line):
 
 
 def _get_instance_telemetry_info(instance):
+    from dagster.core.storage.runs import SqlRunStorage
+
     check.inst_param(instance, "instance", DagsterInstance)
     dagster_telemetry_enabled = _get_instance_telemetry_enabled(instance)
     instance_id = None
     if dagster_telemetry_enabled:
         instance_id = _get_or_set_instance_id()
-    return (dagster_telemetry_enabled, instance_id)
+
+    db_watermark = None
+    if isinstance(instance.run_storage, SqlRunStorage):
+        db_watermark = instance.run_storage.get_telemetry_watermark()
+    return (dagster_telemetry_enabled, instance_id, db_watermark)
 
 
 def _get_instance_telemetry_enabled(instance):
@@ -462,7 +472,7 @@ def log_action(
     if client_time is None:
         client_time = datetime.datetime.now()
 
-    (dagster_telemetry_enabled, instance_id) = _get_instance_telemetry_info(instance)
+    (dagster_telemetry_enabled, instance_id, db_watermark) = _get_instance_telemetry_info(instance)
 
     if dagster_telemetry_enabled:
         # Log general statistics
@@ -476,6 +486,7 @@ def log_action(
                 metadata=metadata,
                 repo_hash=repo_hash,
                 pipeline_name_hash=pipeline_name_hash,
+                db_watermark=db_watermark,
             )._asdict()
         )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -25,6 +25,7 @@ EXPECTED_KEYS = set(
         "instance_id",
         "pipeline_name_hash",
         "num_pipelines_in_repo",
+        "db_watermark",
         "repo_hash",
         "python_version",
         "metadata",

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -25,7 +25,7 @@ EXPECTED_KEYS = set(
         "instance_id",
         "pipeline_name_hash",
         "num_pipelines_in_repo",
-        "db_watermark",
+        "run_storage_id",
         "repo_hash",
         "python_version",
         "metadata",

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
@@ -33,3 +33,6 @@ class TestInMemoryImplementation(TestRunStorage):
     def run_storage(self, request):
         with request.param() as s:
             yield s
+
+    def test_storage_telemetry(self, storage):
+        pass

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -128,10 +128,10 @@ class TestRunStorage:
 
     def test_storage_telemetry(self, storage):
         assert storage
-        watermark = storage.get_telemetry_watermark()
-        assert isinstance(watermark, str)
-        watermark_again = storage.get_telemetry_watermark()
-        assert watermark == watermark_again
+        storage_id = storage.get_run_storage_id()
+        assert isinstance(storage_id, str)
+        storage_id_again = storage.get_run_storage_id()
+        assert storage_id == storage_id_again
 
     def test_fetch_by_pipeline(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -126,6 +126,13 @@ class TestRunStorage:
         storage.wipe()
         assert list(storage.get_runs()) == []
 
+    def test_storage_telemetry(self, storage):
+        assert storage
+        watermark = storage.get_telemetry_watermark()
+        assert isinstance(watermark, str)
+        watermark_again = storage.get_telemetry_watermark()
+        assert watermark == watermark_again
+
     def test_fetch_by_pipeline(self, storage):
         assert storage
         one = make_new_run_id()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -62,7 +62,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             retry_mysql_creation_fn(self._init_db)
             self.build_missing_indexes()
 
-        if "instance_info" not in table_names:
+        elif "instance_info" not in table_names:
             InstanceInfo.create(self._engine)
 
         super().__init__()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -53,7 +53,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        if "runs" not in table_names:
+        if "runs" not in table_names or "telemetry_info" not in table_names:
             retry_mysql_creation_fn(self._init_db)
             self.build_missing_indexes()
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -1,6 +1,11 @@
 import sqlalchemy as db
 from dagster import check
-from dagster.core.storage.runs import DaemonHeartbeatsTable, RunStorageSqlMetadata, SqlRunStorage
+from dagster.core.storage.runs import (
+    DaemonHeartbeatsTable,
+    InstanceInfo,
+    RunStorageSqlMetadata,
+    SqlRunStorage,
+)
 from dagster.core.storage.sql import stamp_alembic_rev  # pylint: disable=unused-import
 from dagster.core.storage.sql import create_engine, run_alembic_upgrade
 from dagster.serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
@@ -53,9 +58,12 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        if "runs" not in table_names or "telemetry_info" not in table_names:
+        if "runs" not in table_names:
             retry_mysql_creation_fn(self._init_db)
             self.build_missing_indexes()
+
+        if "instance_info" not in table_names:
+            InstanceInfo.create(self._engine)
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -54,7 +54,9 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        if self.should_autocreate_tables and "runs" not in table_names:
+        if self.should_autocreate_tables and (
+            "runs" not in table_names or "telemetry_info" not in table_names
+        ):
             retry_pg_creation_fn(self._init_db)
             self.build_missing_indexes()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -54,11 +54,12 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        if self.should_autocreate_tables and (
-            "runs" not in table_names or "telemetry_info" not in table_names
-        ):
+        if self.should_autocreate_tables and "runs" not in table_names:
             retry_pg_creation_fn(self._init_db)
             self.build_missing_indexes()
+
+        if "telemetry_info" not in table_names:
+            RunStorageSqlMetadata.create_all(self._engine)
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -63,7 +63,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             retry_pg_creation_fn(self._init_db)
             self.build_missing_indexes()
 
-        if "instance_info" not in table_names:
+        elif "instance_info" not in table_names:
             InstanceInfo.create(self._engine)
 
         super().__init__()

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -1,6 +1,11 @@
 import sqlalchemy as db
 from dagster import check
-from dagster.core.storage.runs import DaemonHeartbeatsTable, RunStorageSqlMetadata, SqlRunStorage
+from dagster.core.storage.runs import (
+    DaemonHeartbeatsTable,
+    InstanceInfo,
+    RunStorageSqlMetadata,
+    SqlRunStorage,
+)
 from dagster.core.storage.sql import create_engine, run_alembic_upgrade, stamp_alembic_rev
 from dagster.serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
 from dagster.utils import utc_datetime_from_timestamp
@@ -58,8 +63,8 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             retry_pg_creation_fn(self._init_db)
             self.build_missing_indexes()
 
-        if "telemetry_info" not in table_names:
-            RunStorageSqlMetadata.create_all(self._engine)
+        if "instance_info" not in table_names:
+            InstanceInfo.create(self._engine)
 
         super().__init__()
 


### PR DESCRIPTION
First pass at a watermarking scheme for the db. Hooks in to the run storage instead of setting up individual infrastructure. 
A few open questions:
1. Is there any additional data that we want to store outside of the id?
2. What should we do in the in-memory run storage case?
3. Are we ok hooking into the run storage like this?