### PR TITLE
Make disconnect_container_from_network idempotent

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 import json
+import logging
 import os
 import subprocess
 from contextlib import contextmanager
@@ -105,11 +106,21 @@ def connect_container_to_network(container, network):
 
 
 def disconnect_container_from_network(container, network):
-    # subprocess.run instead of subprocess.check_call so we don't fail when
-    # trying to disconnect a container from a network that it's not connected to
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        ["docker", "network", "disconnect", network, container]
-    )
+    try:
+        subprocess.check_call(["docker", "network", "disconnect", network, container])
+        logging.info(
+            "Disconnected {container} from network {network}.".format(
+                container=container,
+                network=network,
+            )
+        )
+    except subprocess.CalledProcessError:
+        logging.warning(
+            "Unable to disconnect {container} from network {network}.".format(
+                container=container,
+                network=network,
+            )
+        )
 
 
 def hostnames(network):

--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -100,9 +100,23 @@ def current_container():
 def connect_container_to_network(container, network):
     # subprocess.run instead of subprocess.check_call so we don't fail when
     # trying to connect a container to a network that it's already connected to
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        ["docker", "network", "connect", network, container]
-    )
+    try:
+        subprocess.check_call(  # pylint: disable=subprocess-run-check
+            ["docker", "network", "connect", network, container]
+        )
+        logging.info(
+            "Connected {container} to network {network}.".format(
+                container=container,
+                network=network,
+            )
+        )
+    except subprocess.CalledProcessError:
+        logging.warning(
+            "Unable to connect {container} to network {network}.".format(
+                container=container,
+                network=network,
+            )
+        )
 
 
 def disconnect_container_from_network(container, network):

--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -105,7 +105,11 @@ def connect_container_to_network(container, network):
 
 
 def disconnect_container_from_network(container, network):
-    subprocess.check_call(["docker", "network", "disconnect", network, container])
+    # subprocess.run instead of subprocess.check_call so we don't fail when
+    # trying to disconnect a container from a network that it's not connected to
+    subprocess.run(  # pylint: disable=subprocess-run-check
+        ["docker", "network", "disconnect", network, container]
+    )
 
 
 def hostnames(network):

--- a/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
+++ b/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
@@ -80,13 +80,18 @@ def test_docker_compose_cm_destroys_volumes(docker_compose_cm, test_id):
         subprocess.check_output(["docker", "volume", "inspect", test_id])
 
 
-def test_connect_container_to_network(docker_compose_cm, other_docker_compose_yml):
+def test_connect_container_to_network(docker_compose_cm, other_docker_compose_yml, caplog):
+    caplog.set_level("INFO")
+
     with docker_compose_cm(docker_compose_yml=other_docker_compose_yml) as docker_compose:
         container = next(iter(docker_compose))
         network = network_name_from_yml(other_docker_compose_yml)
+        disconnect_container_from_network(container=container, network=network)
         # Connecting multiple times is idempotent
         connect_container_to_network(container=container, network=network)
+        assert f"Connected {container} to network {network}." in caplog.text
         connect_container_to_network(container=container, network=network)
+        assert f"Unable to connect {container} to network {network}." in caplog.text
 
 
 def test_disconnect_container_from_network(docker_compose_cm, other_docker_compose_yml, caplog):

--- a/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
+++ b/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
@@ -4,7 +4,11 @@ import subprocess
 
 import pytest
 import yaml
-from dagster_test.fixtures.docker_compose import connect_container_to_network, network_name_from_yml
+from dagster_test.fixtures.docker_compose import (
+    connect_container_to_network,
+    disconnect_container_from_network,
+    network_name_from_yml,
+)
 
 pytest_plugins = ["dagster_test.fixtures"]
 
@@ -83,3 +87,12 @@ def test_connect_container_to_network(docker_compose_cm, other_docker_compose_ym
         # Connecting multiple times is idempotent
         connect_container_to_network(container=container, network=network)
         connect_container_to_network(container=container, network=network)
+
+
+def test_disconnect_container_from_network(docker_compose_cm, other_docker_compose_yml):
+    with docker_compose_cm(docker_compose_yml=other_docker_compose_yml) as docker_compose:
+        container = next(iter(docker_compose))
+        network = network_name_from_yml(other_docker_compose_yml)
+        # Disconnecting multiple times is idempotent
+        disconnect_container_from_network(container=container, network=network)
+        disconnect_container_from_network(container=container, network=network)

--- a/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
+++ b/python_modules/dagster-test/dagster_test_tests/fixtures_tests/test_docker_compose.py
@@ -89,10 +89,14 @@ def test_connect_container_to_network(docker_compose_cm, other_docker_compose_ym
         connect_container_to_network(container=container, network=network)
 
 
-def test_disconnect_container_from_network(docker_compose_cm, other_docker_compose_yml):
+def test_disconnect_container_from_network(docker_compose_cm, other_docker_compose_yml, caplog):
+    caplog.set_level("INFO")
+
     with docker_compose_cm(docker_compose_yml=other_docker_compose_yml) as docker_compose:
         container = next(iter(docker_compose))
         network = network_name_from_yml(other_docker_compose_yml)
         # Disconnecting multiple times is idempotent
         disconnect_container_from_network(container=container, network=network)
+        assert f"Disconnected {container} from network {network}." in caplog.text
         disconnect_container_from_network(container=container, network=network)
+        assert f"Unable to disconnect {container} from network {network}." in caplog.text


### PR DESCRIPTION
The inverse of a377e799a50bcc2b02fbf6fe3a5de95bdf0a056b

On Buildkite, if you use the same network with multiple docker compose
files fixtures, the first fixture to tear down removes the Buildkite
test container from the network. The second fixture to teardown fails
because the container has already been disconnected.

Now, the second attempt to disconnect the container won't fail.

There are certainly some edge cases here - like if you're intentionally
having one docker compose fixture live for much longer scope than the
other - but we can handle those when they occur.
