### PR TITLE
batch run fetching on run storage

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1076,9 +1076,9 @@ class DagsterInstance:
         filters: PipelineRunsFilter = None,
         cursor: str = None,
         limit: int = None,
-        bucket: Optional[Union[JobBucket, TagBucket]] = None,
+        bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> Iterable[PipelineRun]:
-        return self._run_storage.get_runs(filters, cursor, limit, bucket)
+        return self._run_storage.get_runs(filters, cursor, limit, bucket_by)
 
     @traced
     def get_runs_count(self, filters: PipelineRunsFilter = None) -> int:
@@ -1098,7 +1098,7 @@ class DagsterInstance:
         order_by: str = None,
         ascending: bool = False,
         cursor: str = None,
-        bucket: Optional[Union[JobBucket, TagBucket]] = None,
+        bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> List[RunRecord]:
         """Return a list of run records stored in the run storage, sorted by the given column in given order.
 
@@ -1113,7 +1113,7 @@ class DagsterInstance:
             List[RunRecord]: List of run records stored in the run storage.
         """
         return self._run_storage.get_run_records(
-            filters, limit, order_by, ascending, cursor, bucket
+            filters, limit, order_by, ascending, cursor, bucket_by
         )
 
     def wipe(self):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -43,11 +43,13 @@ from dagster.core.errors import (
 from dagster.core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
+    JobBucket,
     PipelineRun,
     PipelineRunStatsSnapshot,
     PipelineRunStatus,
     PipelineRunsFilter,
     RunRecord,
+    TagBucket,
 )
 from dagster.core.storage.tags import MEMOIZED_RUN_TAG
 from dagster.core.system_config.objects import ResolvedRunConfig
@@ -1070,9 +1072,13 @@ class DagsterInstance:
 
     @traced
     def get_runs(
-        self, filters: PipelineRunsFilter = None, cursor: str = None, limit: int = None
+        self,
+        filters: PipelineRunsFilter = None,
+        cursor: str = None,
+        limit: int = None,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> Iterable[PipelineRun]:
-        return self._run_storage.get_runs(filters, cursor, limit)
+        return self._run_storage.get_runs(filters, cursor, limit, bucket)
 
     @traced
     def get_runs_count(self, filters: PipelineRunsFilter = None) -> int:
@@ -1092,6 +1098,7 @@ class DagsterInstance:
         order_by: str = None,
         ascending: bool = False,
         cursor: str = None,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> List[RunRecord]:
         """Return a list of run records stored in the run storage, sorted by the given column in given order.
 
@@ -1105,7 +1112,9 @@ class DagsterInstance:
         Returns:
             List[RunRecord]: List of run records stored in the run storage.
         """
-        return self._run_storage.get_run_records(filters, limit, order_by, ascending, cursor)
+        return self._run_storage.get_run_records(
+            filters, limit, order_by, ascending, cursor, bucket
+        )
 
     def wipe(self):
         self._run_storage.wipe()

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -2,7 +2,7 @@ import warnings
 from collections import namedtuple
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, NamedTuple, Optional, Type
+from typing import Any, Dict, List, NamedTuple, Optional, Type
 
 from dagster import check
 from dagster.core.origin import PipelinePythonOrigin
@@ -476,6 +476,17 @@ class PipelineRunsFilter(
     @staticmethod
     def for_backfill(backfill_id):
         return PipelineRunsFilter(tags=PipelineRun.tags_for_backfill_id(backfill_id))
+
+
+class JobBucket(NamedTuple):
+    job_names: List[str]
+    bucket_limit: Optional[int]
+
+
+class TagBucket(NamedTuple):
+    tag_key: str
+    tag_values: List[str]
+    bucket_limit: Optional[int]
 
 
 class RunRecord(

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -5,7 +5,13 @@ from dagster.core.events import DagsterEvent
 from dagster.core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster.core.instance import MayHaveInstanceWeakref
 from dagster.core.snap import ExecutionPlanSnapshot, PipelineSnapshot
-from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunsFilter, RunRecord
+from dagster.core.storage.pipeline_run import (
+    JobBucket,
+    PipelineRun,
+    PipelineRunsFilter,
+    RunRecord,
+    TagBucket,
+)
 from dagster.daemon.types import DaemonHeartbeat
 
 
@@ -43,7 +49,11 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
 
     @abstractmethod
     def get_runs(
-        self, filters: PipelineRunsFilter = None, cursor: str = None, limit: int = None
+        self,
+        filters: PipelineRunsFilter = None,
+        cursor: str = None,
+        limit: int = None,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> Iterable[PipelineRun]:
         """Return all the runs present in the storage that match the given filters.
 
@@ -142,6 +152,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         order_by: str = None,
         ascending: bool = False,
         cursor: str = None,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> List[RunRecord]:
         """Return a list of run records stored in the run storage, sorted by the given column in given order.
 

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -53,7 +53,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         filters: PipelineRunsFilter = None,
         cursor: str = None,
         limit: int = None,
-        bucket: Optional[Union[JobBucket, TagBucket]] = None,
+        bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> Iterable[PipelineRun]:
         """Return all the runs present in the storage that match the given filters.
 
@@ -152,7 +152,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         order_by: str = None,
         ascending: bool = False,
         cursor: str = None,
-        bucket: Optional[Union[JobBucket, TagBucket]] = None,
+        bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> List[RunRecord]:
         """Return a list of run records stored in the run storage, sorted by the given column in given order.
 

--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -191,7 +191,7 @@ class InMemoryRunStorage(RunStorage):
 
         # record here is a tuple of storage_id, run
         records = enumerate(list(self._runs.values()))
-        run_filter_fn = run_filter(filters)
+        run_filter_fn = build_run_filter(filters)
         record_filter_fn = lambda record: run_filter_fn(record[1])
 
         matching_records = list(filter(record_filter_fn, list(records)[::-1]))

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -33,7 +33,7 @@ from dagster.serdes import (
 from dagster.seven import JSONDecodeError
 from dagster.utils import datetime_as_float, merge_dicts, utc_datetime_from_timestamp
 
-from ..pipeline_run import PipelineRun, PipelineRunsFilter, RunRecord
+from ..pipeline_run import JobBucket, PipelineRun, PipelineRunsFilter, RunRecord, TagBucket
 from .base import RunStorage
 from .migration import OPTIONAL_DATA_MIGRATIONS, REQUIRED_DATA_MIGRATIONS, RUN_PARTITIONS
 from .schema import (
@@ -232,6 +232,19 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         return query
 
+    def _bucket_rank_column(self, bucket, order_by, ascending):
+        check.inst_param(bucket, "bucket", (JobBucket, TagBucket))
+        sorting_column = getattr(RunsTable.c, order_by) if order_by else RunsTable.c.id
+        direction = db.asc if ascending else db.desc
+        bucket_column = (
+            RunsTable.c.pipeline_name if isinstance(bucket, JobBucket) else RunTagsTable.c.value
+        )
+        return (
+            db.func.rank()
+            .over(order_by=direction(sorting_column), partition_by=bucket_column)
+            .label("rank")
+        )
+
     def _runs_query(
         self,
         filters: PipelineRunsFilter = None,
@@ -240,8 +253,8 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         columns: List[str] = None,
         order_by: str = None,
         ascending: bool = False,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ):
-
         filters = check.opt_inst_param(
             filters, "filters", PipelineRunsFilter, default=PipelineRunsFilter()
         )
@@ -254,26 +267,63 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         if columns is None:
             columns = ["run_body"]
 
-        base_query_columns = [getattr(RunsTable.c, column) for column in columns]
+        query_columns = [getattr(RunsTable.c, column) for column in columns]
 
-        # If we have a tags filter, then we need to select from a joined table
-        if filters.tags:
-            base_query = db.select(base_query_columns).select_from(
-                RunsTable.join(RunTagsTable, RunsTable.c.run_id == RunTagsTable.c.run_id)
-            )
+        if bucket:
+            if limit or cursor:
+                check.failed("cannot specify bucket and limit/cursor at the same time")
+
+            # this is a bucketed query, so we need to calculate rank to apply bucket-based limits
+            # and ordering
+            query_columns.append(self._bucket_rank_column(bucket, order_by, ascending))
+
+            if isinstance(bucket, JobBucket):
+                base_query = (
+                    db.select(query_columns)
+                    .select_from(
+                        RunsTable.join(RunTagsTable, RunsTable.c.run_id == RunTagsTable.c.run_id)
+                        if filters.tags
+                        else RunsTable
+                    )
+                    .where(RunsTable.c.pipeline_name.in_(bucket.job_names))
+                )
+            else:
+                check.invariant(isinstance(bucket, TagBucket))
+                base_query = (
+                    db.select(query_columns)
+                    .select_from(
+                        RunsTable.join(RunTagsTable, RunsTable.c.run_id == RunTagsTable.c.run_id)
+                    )
+                    .where(RunTagsTable.c.key == bucket.tag_key)
+                    .where(RunTagsTable.c.value.in_(bucket.tag_values))
+                )
+
+            base_query = self._add_filters_to_query(base_query, filters)
+            subquery = base_query.subquery()
+            query = db.select(subquery).order_by(subquery.c.rank.asc())
+            if bucket.bucket_limit:
+                query = query.where(subquery.c.rank <= bucket.bucket_limit)
         else:
-            base_query = db.select(base_query_columns).select_from(RunsTable)
+            if filters.tags:
+                base_query = db.select(query_columns).select_from(
+                    RunsTable.join(RunTagsTable, RunsTable.c.run_id == RunTagsTable.c.run_id)
+                )
+            else:
+                base_query = db.select(query_columns).select_from(RunsTable)
 
-        query = self._add_filters_to_query(base_query, filters)
-        query = self._add_cursor_limit_to_query(query, cursor, limit, order_by, ascending)
+            query = self._add_filters_to_query(base_query, filters)
+            query = self._add_cursor_limit_to_query(query, cursor, limit, order_by, ascending)
 
         return query
 
     def get_runs(
-        self, filters: PipelineRunsFilter = None, cursor: str = None, limit: int = None
+        self,
+        filters: PipelineRunsFilter = None,
+        cursor: str = None,
+        limit: int = None,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> List[PipelineRun]:
-        query = self._runs_query(filters, cursor, limit)
-
+        query = self._runs_query(filters, cursor, limit, bucket=bucket)
         rows = self.fetchall(query)
         return self._rows_to_runs(rows)
 
@@ -311,11 +361,12 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         order_by: str = None,
         ascending: bool = False,
         cursor: str = None,
+        bucket: Optional[Union[JobBucket, TagBucket]] = None,
     ) -> List[RunRecord]:
         filters = check.opt_inst_param(
             filters, "filters", PipelineRunsFilter, default=PipelineRunsFilter()
         )
-        limit = check.opt_int_param(limit, "limit")
+        check.opt_int_param(limit, "limit")
 
         columns = ["id", "run_body", "create_timestamp", "update_timestamp"]
 
@@ -329,6 +380,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             order_by=order_by,
             ascending=ascending,
             cursor=cursor,
+            bucket=bucket,
         )
 
         rows = self.fetchall(query)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -1234,7 +1234,7 @@ class TestRunStorage:
         runs_by_job = {
             run.pipeline_name: run
             for run in storage.get_runs(
-                bucket=JobBucket(
+                bucket_by=JobBucket(
                     job_names=["a_pipeline", "b_pipeline", "c_pipeline"], bucket_limit=1
                 )
             )
@@ -1249,7 +1249,7 @@ class TestRunStorage:
             run.pipeline_name: run
             for run in storage.get_runs(
                 filters=PipelineRunsFilter(tags={"a": "A"}),
-                bucket=JobBucket(
+                bucket_by=JobBucket(
                     job_names=["a_pipeline", "b_pipeline", "c_pipeline"], bucket_limit=1
                 ),
             )
@@ -1278,7 +1278,7 @@ class TestRunStorage:
         runs_by_tag = {
             run.tags.get("a"): run
             for run in storage.get_runs(
-                bucket=TagBucket(tag_key="a", tag_values=["1", "2", "3", "4"], bucket_limit=1)
+                bucket_by=TagBucket(tag_key="a", tag_values=["1", "2", "3", "4"], bucket_limit=1)
             )
         }
         assert set(runs_by_tag.keys()) == {"1", "2", "3", "4"}
@@ -1291,7 +1291,7 @@ class TestRunStorage:
             run.tags.get("a"): run
             for run in storage.get_runs(
                 filters=PipelineRunsFilter(pipeline_name="a"),
-                bucket=TagBucket(tag_key="a", tag_values=["1", "2", "3", "4"], bucket_limit=1),
+                bucket_by=TagBucket(tag_key="a", tag_values=["1", "2", "3", "4"], bucket_limit=1),
             )
         }
         assert set(runs_by_tag.keys()) == {"1", "2", "3"}

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -16,7 +16,13 @@ from dagster.core.host_representation import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
 from dagster.core.snap import create_pipeline_snapshot_id
-from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus, PipelineRunsFilter
+from dagster.core.storage.pipeline_run import (
+    DagsterRun,
+    JobBucket,
+    PipelineRunStatus,
+    PipelineRunsFilter,
+    TagBucket,
+)
 from dagster.core.storage.runs.migration import REQUIRED_DATA_MIGRATIONS
 from dagster.core.storage.runs.sql_run_storage import SqlRunStorage
 from dagster.core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
@@ -1209,3 +1215,86 @@ class TestRunStorage:
         assert run_record.start_time is not None
         assert run_record.end_time is not None
         assert run_record.end_time >= run_record.start_time
+
+    def test_by_job(self, storage):
+        def _add_run(job_name, tags=None):
+            return storage.add_run(
+                TestRunStorage.build_run(
+                    pipeline_name=job_name, run_id=make_new_run_id(), tags=tags
+                )
+            )
+
+        _a_one = _add_run("a_pipeline", tags={"a": "A"})
+        a_two = _add_run("a_pipeline", tags={"a": "A"})
+        _b_one = _add_run("b_pipeline", tags={"a": "A"})
+        b_two = _add_run("b_pipeline", tags={"a": "A"})
+        c_one = _add_run("c_pipeline", tags={"a": "A"})
+        c_two = _add_run("c_pipeline", tags={"a": "B"})
+
+        runs_by_job = {
+            run.pipeline_name: run
+            for run in storage.get_runs(
+                bucket=JobBucket(
+                    job_names=["a_pipeline", "b_pipeline", "c_pipeline"], bucket_limit=1
+                )
+            )
+        }
+        assert set(runs_by_job.keys()) == {"a_pipeline", "b_pipeline", "c_pipeline"}
+        assert runs_by_job.get("a_pipeline").run_id == a_two.run_id
+        assert runs_by_job.get("b_pipeline").run_id == b_two.run_id
+        assert runs_by_job.get("c_pipeline").run_id == c_two.run_id
+
+        # fetch with a runs filter applied
+        runs_by_job = {
+            run.pipeline_name: run
+            for run in storage.get_runs(
+                filters=PipelineRunsFilter(tags={"a": "A"}),
+                bucket=JobBucket(
+                    job_names=["a_pipeline", "b_pipeline", "c_pipeline"], bucket_limit=1
+                ),
+            )
+        }
+        assert set(runs_by_job.keys()) == {"a_pipeline", "b_pipeline", "c_pipeline"}
+        assert runs_by_job.get("a_pipeline").run_id == a_two.run_id
+        assert runs_by_job.get("b_pipeline").run_id == b_two.run_id
+        assert runs_by_job.get("c_pipeline").run_id == c_one.run_id
+
+    def test_by_tag(self, storage):
+        def _add_run(job_name, tags=None):
+            return storage.add_run(
+                TestRunStorage.build_run(
+                    pipeline_name=job_name, run_id=make_new_run_id(), tags=tags
+                )
+            )
+
+        _one = _add_run("a", tags={"a": "1"})
+        _two = _add_run("a", tags={"a": "2"})
+        three = _add_run("a", tags={"a": "3"})
+        _none = _add_run("a")
+        b = _add_run("b", tags={"a": "4"})
+        one = _add_run("a", tags={"a": "1"})
+        two = _add_run("a", tags={"a": "2"})
+
+        runs_by_tag = {
+            run.tags.get("a"): run
+            for run in storage.get_runs(
+                bucket=TagBucket(tag_key="a", tag_values=["1", "2", "3", "4"], bucket_limit=1)
+            )
+        }
+        assert set(runs_by_tag.keys()) == {"1", "2", "3", "4"}
+        assert runs_by_tag.get("1").run_id == one.run_id
+        assert runs_by_tag.get("2").run_id == two.run_id
+        assert runs_by_tag.get("3").run_id == three.run_id
+        assert runs_by_tag.get("4").run_id == b.run_id
+
+        runs_by_tag = {
+            run.tags.get("a"): run
+            for run in storage.get_runs(
+                filters=PipelineRunsFilter(pipeline_name="a"),
+                bucket=TagBucket(tag_key="a", tag_values=["1", "2", "3", "4"], bucket_limit=1),
+            )
+        }
+        assert set(runs_by_tag.keys()) == {"1", "2", "3"}
+        assert runs_by_tag.get("1").run_id == one.run_id
+        assert runs_by_tag.get("2").run_id == two.run_id
+        assert runs_by_tag.get("3").run_id == three.run_id


### PR DESCRIPTION
## Summary
Add run storage methods for batch fetching runs for jobs, tags.

These instance methods can be used to fetch repository-level runs for jobs, schedules, sensors, etc.


## Test Plan
BK


