### PR TITLE
do not require context arg even when op has config

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -995,7 +995,6 @@ def do_composition(
         fn_name=graph_name,
         compute_fn=compute_fn,
         explicit_input_defs=provided_input_defs,
-        context_required=False,
         exclude_nothing=False,
     )
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/op.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op.py
@@ -106,7 +106,6 @@ class _Op:
             fn_name=self.name,
             compute_fn=compute_fn,
             explicit_input_defs=input_defs,
-            context_required=bool(self.config_schema),
             exclude_nothing=True,
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_solid.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_solid.py
@@ -293,14 +293,9 @@ def test_solid_required_resources_no_arg():
 
 
 def test_solid_config_no_arg():
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="'_noop2' decorated function requires positional parameter 'context',",
-    ):
-
-        @solid(config_schema={"foo": str})
-        def _noop2():
-            return
+    @solid(config_schema={"foo": str})
+    def _noop2():
+        return
 
 
 def test_solid_docstring():


### PR DESCRIPTION
This is motivated by the changes in https://github.com/dagster-io/dagster/pull/6197, however, I believe it stands on its own even if we choose not to go the route described in that PR.

I think Alex says it best: requiring context doesn't really defend against a meaningful error state. If you want to use the config you set schema for - you'll figure it out quick.