### PR TITLE
[cli tests] use inprocess executor for jobs

### DIFF
--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -18,6 +18,7 @@ from dagster import (
     String,
     execute_pipeline,
     graph,
+    in_process_executor,
     job,
     lambda_solid,
     op,
@@ -85,10 +86,11 @@ qux_job = qux.to_job(
         partitions_def=StaticPartitionsDefinition(["abc"]), run_config_for_partition_fn=lambda _: {}
     ),
     tags={"foo": "bar"},
+    executor_def=in_process_executor,
 )
 
 
-@job
+@job(executor_def=in_process_executor)
 def quux_job():
     do_something_op()
 


### PR DESCRIPTION
The cli tests are regularly timing out.

Removes one set of process hops to reduce overall time spent by changing the test jobs to use an in process executor.

### Test Plan

observer time reduction in buildkite
