### PR TITLE
Simplify and fixture-ize scheduler tests

### DIFF
--- a/python_modules/dagster/dagster/core/test_utils.py
+++ b/python_modules/dagster/dagster/core/test_utils.py
@@ -314,6 +314,7 @@ class MockedRunLauncher(RunLauncher, ConfigurableClass):
     def __init__(self, inst_data=None, bad_run_ids=None):
         self._inst_data = inst_data
         self._queue = []
+        self._launched_run_ids = set()
         self._bad_run_ids = bad_run_ids
 
         super().__init__()
@@ -327,10 +328,14 @@ class MockedRunLauncher(RunLauncher, ConfigurableClass):
             raise Exception(f"Bad run {run.run_id}")
 
         self._queue.append(run)
+        self._launched_run_ids.add(run.run_id)
         return run
 
     def queue(self):
         return self._queue
+
+    def did_run_launch(self, run_id):
+        return run_id in self._launched_run_ids
 
     @classmethod
     def config_type(cls):

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from contextlib import contextmanager
+
+import pytest
+from dagster.core.host_representation import ManagedGrpcPythonEnvRepositoryLocationOrigin
+from dagster.core.test_utils import create_test_daemon_workspace, instance_for_test
+from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
+
+
+@pytest.fixture(name="instance_session_scoped", scope="session")
+def instance_session_scoped_fixture():
+    with instance_for_test(
+        overrides={
+            "run_launcher": {"module": "dagster.core.test_utils", "class": "MockedRunLauncher"}
+        }
+    ) as instance:
+        yield instance
+
+
+@pytest.fixture(name="instance", scope="function")
+def instance_fixture(instance_session_scoped):
+    instance_session_scoped.wipe()
+    instance_session_scoped.wipe_all_schedules()
+    yield instance_session_scoped
+
+
+@pytest.fixture(name="workspace", scope="session")
+def workspace_fixture(instance_session_scoped):  # pylint: disable=unused-argument
+    with create_test_daemon_workspace() as workspace:
+        yield workspace
+
+
+@contextmanager
+def default_repo():
+    with ManagedGrpcPythonEnvRepositoryLocationOrigin(
+        loadable_target_origin=loadable_target_origin(),
+        location_name="test_location",
+    ).create_test_location() as location:
+        yield location.get_repository("the_repo")
+
+
+@pytest.fixture(name="external_repo", scope="session")
+def external_repo_fixture(workspace):  # pylint: disable=unused-argument
+    with default_repo() as repo:
+        yield repo
+
+
+def loadable_target_origin():
+    return LoadableTargetOrigin(
+        executable_path=sys.executable,
+        module_name="dagster_tests.scheduler_tests.test_scheduler_run",
+        working_directory=os.getcwd(),
+    )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -8,7 +8,6 @@ from dagster.core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace,
     get_crash_signals,
-    get_logger_output_from_capfd,
     get_terminate_signal,
 )
 from dagster.scheduler.scheduler import launch_scheduled_runs
@@ -16,10 +15,8 @@ from dagster.seven import IS_WINDOWS, multiprocessing
 from dagster.seven.compat.pendulum import create_pendulum_time, to_timezone
 
 from .test_scheduler_run import (
-    instance_with_schedules,
     logger,
-    repos,
-    validate_run_started,
+    validate_run_exists,
     validate_tick,
     wait_for_all_runs_to_start,
 )
@@ -46,346 +43,275 @@ def _test_launch_scheduled_runs_in_subprocess(instance_ref, execution_datetime, 
 @pytest.mark.skipif(
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
-@pytest.mark.parametrize("external_repo_context", repos())
 @pytest.mark.parametrize("crash_location", ["TICK_CREATED", "TICK_HELD"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_recovery_before_run_created(
-    external_repo_context, crash_location, crash_signal, capfd
-):
+def test_failure_recovery_before_run_created(instance, external_repo, crash_location, crash_signal):
     # Verify that if the scheduler crashes or is interrupted before a run is created,
     # it will create exactly one tick/run when it is re-launched
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        initial_datetime = to_timezone(
-            create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0, tz="UTC"),
-            "US/Central",
+    initial_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0, tz="UTC"),
+        "US/Central",
+    )
+
+    frozen_datetime = initial_datetime.add()
+
+    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    with pendulum.test(frozen_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
+        )
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
+
+        assert scheduler_process.exitcode != 0
+
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.STARTED
+
+        assert instance.get_runs_count() == 0
+
+    frozen_datetime = frozen_datetime.add(minutes=5)
+    with pendulum.test(frozen_datetime):
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, None],
+        )
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
+        assert scheduler_process.exitcode == 0
+
+        assert instance.get_runs_count() == 1
+        wait_for_all_runs_to_start(instance)
+        validate_run_exists(
+            instance.get_runs()[0],
+            execution_time=initial_datetime,
+            partition_time=create_pendulum_time(2019, 2, 26),
         )
 
-        frozen_datetime = initial_datetime.add()
-
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
-        with pendulum.test(frozen_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
-
-            debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
-
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
-
-            assert scheduler_process.exitcode != 0
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000"""
-            )
-
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.STARTED
-
-            assert instance.get_runs_count() == 0
-
-        frozen_datetime = frozen_datetime.add(minutes=5)
-        with pendulum.test(frozen_datetime):
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, None],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
-            assert scheduler_process.exitcode == 0
-
-            assert instance.get_runs_count() == 1
-            wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0],
-                execution_time=initial_datetime,
-                partition_time=create_pendulum_time(2019, 2, 26),
-            )
-
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
-            )
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
-2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Resuming previously interrupted schedule execution at 2019-02-27 00:00:00 +0000
-2019-02-26 18:05:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
-                    run_id=instance.get_runs()[0].run_id
-                )
-            )
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+        )
 
 
 @pytest.mark.skipif(
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
-@pytest.mark.parametrize("external_repo_context", repos())
 @pytest.mark.parametrize("crash_location", ["RUN_CREATED", "RUN_LAUNCHED"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_recovery_after_run_created(
-    external_repo_context, crash_location, crash_signal, capfd
-):
+def test_failure_recovery_after_run_created(instance, external_repo, crash_location, crash_signal):
     # Verify that if the scheduler crashes or is interrupted after a run is created,
     # it will just re-launch the already-created run when it runs again
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    frozen_datetime = initial_datetime.add()
+    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    with pendulum.test(frozen_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
         )
-        frozen_datetime = initial_datetime.add()
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
-        with pendulum.test(frozen_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
 
-            debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        assert scheduler_process.exitcode != 0
 
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.STARTED
 
-            assert scheduler_process.exitcode != 0
+        assert instance.get_runs_count() == 1
 
-            capfd.readouterr()
+        if crash_location == "RUN_CREATED":
+            run = instance.get_runs()[0]
+            # Run was created, but hasn't launched yet
+            assert run.tags[SCHEDULED_EXECUTION_TIME_TAG] == frozen_datetime.isoformat()
+            assert run.tags[PARTITION_NAME_TAG] == "2019-02-26"
+            assert run.status == PipelineRunStatus.NOT_STARTED
+        else:
+            # The run was created and launched - running again should do nothing other than
+            # moving the tick to success state.
 
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.STARTED
-
-            assert instance.get_runs_count() == 1
-
-            if crash_location == "RUN_CREATED":
-                run = instance.get_runs()[0]
-                # Run was created, but hasn't launched yet
-                assert run.tags[SCHEDULED_EXECUTION_TIME_TAG] == frozen_datetime.isoformat()
-                assert run.tags[PARTITION_NAME_TAG] == "2019-02-26"
-                assert run.status == PipelineRunStatus.NOT_STARTED
-            else:
-                # The run was created and launched - running again should do nothing other than
-                # moving the tick to success state.
-
-                # The fact that we need to add this line indicates that there is still a theoretical
-                # possible race condition - if the scheduler fails after launching a run
-                # and then runs again between when the run was launched and when its status is changed to STARTED by the executor, we could
-                # end up launching the same run twice. Run queueing or some other way to immediately
-                # identify that a run was launched would help eliminate this race condition. For now,
-                # eliminate the possibility by waiting for the run to start before running the
-                # scheduler again.
-                wait_for_all_runs_to_start(instance)
-
-                run = instance.get_runs()[0]
-                validate_run_started(
-                    instance.get_runs()[0], frozen_datetime, create_pendulum_time(2019, 2, 26)
-                )
-
-                assert run.status in [PipelineRunStatus.STARTED, PipelineRunStatus.SUCCESS]
-
-        frozen_datetime = frozen_datetime.add(minutes=5)
-        with pendulum.test(frozen_datetime):
-
-            # Running again just launches the existing run and marks the tick as success
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, None],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
-            assert scheduler_process.exitcode == 0
-
-            assert instance.get_runs_count() == 1
+            # The fact that we need to add this line indicates that there is still a theoretical
+            # possible race condition - if the scheduler fails after launching a run
+            # and then runs again between when the run was launched and when its status is changed to STARTED by the executor, we could
+            # end up launching the same run twice. Run queueing or some other way to immediately
+            # identify that a run was launched would help eliminate this race condition. For now,
+            # eliminate the possibility by waiting for the run to start before running the
+            # scheduler again.
             wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
+
+            run = instance.get_runs()[0]
+            validate_run_exists(
+                instance.get_runs()[0], frozen_datetime, create_pendulum_time(2019, 2, 26)
             )
 
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
-            )
+    frozen_datetime = frozen_datetime.add(minutes=5)
+    with pendulum.test(frozen_datetime):
 
-            captured = capfd.readouterr()
-            if crash_location == "RUN_CREATED":
-                assert (
-                    "Run {run_id} already created for this execution of simple_schedule".format(
-                        run_id=instance.get_runs()[0].run_id
-                    )
-                    in captured.out
-                )
-            else:
-                assert (
-                    "Run {run_id} already completed for this execution of simple_schedule".format(
-                        run_id=instance.get_runs()[0].run_id
-                    )
-                    in captured.out
-                )
+        # Running again just launches the existing run and marks the tick as success
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, None],
+        )
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
+        assert scheduler_process.exitcode == 0
+
+        assert instance.get_runs_count() == 1
+        wait_for_all_runs_to_start(instance)
+        validate_run_exists(
+            instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
+        )
+
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+        )
 
 
 @pytest.mark.skipif(
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
-@pytest.mark.parametrize("external_repo_context", repos())
 @pytest.mark.parametrize("crash_location", ["TICK_SUCCESS"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_recovery_after_tick_success(external_repo_context, crash_location, crash_signal):
-    # Verify that if the scheduler crashes or is interrupted after a run is created,
-    # it will just re-launch the already-created run when it runs again
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
+def test_failure_recovery_after_tick_success(instance, external_repo, crash_location, crash_signal):
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    frozen_datetime = initial_datetime.add()
+    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    with pendulum.test(frozen_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
         )
-        frozen_datetime = initial_datetime.add()
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
-        with pendulum.test(frozen_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
 
-            debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        assert scheduler_process.exitcode != 0
 
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
+        # As above there's a possible race condition here if the scheduler crashes
+        # and launches the same run twice if we crash right after the launch and re-run
+        # before the run actually starts
+        wait_for_all_runs_to_start(instance)
 
-            assert scheduler_process.exitcode != 0
+        assert instance.get_runs_count() == 1
+        validate_run_exists(
+            instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
+        )
 
-            # As above there's a possible race condition here if the scheduler crashes
-            # and launches the same run twice if we crash right after the launch and re-run
-            # before the run actually starts
-            wait_for_all_runs_to_start(instance)
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
 
-            assert instance.get_runs_count() == 1
-            validate_run_started(
-                instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
-            )
+        if crash_signal == get_terminate_signal():
+            run_ids = []
+        else:
+            run_ids = [run.run_id for run in instance.get_runs()]
 
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.STARTED,
+            run_ids,
+        )
 
-            if crash_signal == get_terminate_signal():
-                run_ids = []
-            else:
-                run_ids = [run.run_id for run in instance.get_runs()]
+    frozen_datetime = frozen_datetime.add(minutes=1)
+    with pendulum.test(frozen_datetime):
+        # Running again just marks the tick as success since the run has already started
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, None],
+        )
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
+        assert scheduler_process.exitcode == 0
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.STARTED,
-                run_ids,
-            )
+        assert instance.get_runs_count() == 1
+        validate_run_exists(
+            instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
+        )
 
-        frozen_datetime = frozen_datetime.add(minutes=1)
-        with pendulum.test(frozen_datetime):
-            # Running again just marks the tick as success since the run has already started
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, None],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
-            assert scheduler_process.exitcode == 0
-
-            assert instance.get_runs_count() == 1
-            validate_run_started(
-                instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
-            )
-
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
-            )
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+        )
 
 
 @pytest.mark.skipif(
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
-@pytest.mark.parametrize("external_repo_context", repos())
 @pytest.mark.parametrize("crash_location", ["RUN_ADDED"])
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
-def test_failure_recovery_between_multi_runs(external_repo_context, crash_location, crash_signal):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        _grpc_server_registry,
-        external_repo,
-    ):
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=28, hour=0, minute=0, second=0
+def test_failure_recovery_between_multi_runs(instance, external_repo, crash_location, crash_signal):
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=0, second=0)
+    frozen_datetime = initial_datetime.add()
+    external_schedule = external_repo.get_external_schedule("multi_run_schedule")
+    with pendulum.test(frozen_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
         )
-        frozen_datetime = initial_datetime.add()
-        external_schedule = external_repo.get_external_schedule("multi_run_schedule")
-        with pendulum.test(frozen_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
 
-            debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        assert scheduler_process.exitcode != 0
 
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, debug_crash_flags],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
+        wait_for_all_runs_to_start(instance)
+        assert instance.get_runs_count() == 1
+        validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-            assert scheduler_process.exitcode != 0
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
 
-            wait_for_all_runs_to_start(instance)
-            assert instance.get_runs_count() == 1
-            validate_run_started(instance.get_runs()[0], initial_datetime)
-
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-
-        frozen_datetime = frozen_datetime.add(minutes=1)
-        with pendulum.test(frozen_datetime):
-            scheduler_process = multiprocessing.Process(
-                target=_test_launch_scheduled_runs_in_subprocess,
-                args=[instance.get_ref(), frozen_datetime, None],
-            )
-            scheduler_process.start()
-            scheduler_process.join(timeout=60)
-            assert scheduler_process.exitcode == 0
-            assert instance.get_runs_count() == 2
-            validate_run_started(instance.get_runs()[0], initial_datetime)
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-            )
+    frozen_datetime = frozen_datetime.add(minutes=1)
+    with pendulum.test(frozen_datetime):
+        scheduler_process = multiprocessing.Process(
+            target=_test_launch_scheduled_runs_in_subprocess,
+            args=[instance.get_ref(), frozen_datetime, None],
+        )
+        scheduler_process.start()
+        scheduler_process.join(timeout=60)
+        assert scheduler_process.exitcode == 0
+        assert instance.get_runs_count() == 2
+        validate_run_exists(instance.get_runs()[0], initial_datetime)
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+        )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -2,12 +2,10 @@ import datetime
 import os
 import random
 import string
-import sys
 import time
 from contextlib import contextmanager
 
 import pendulum
-import pytest
 from dagster import (
     Any,
     Field,
@@ -31,7 +29,6 @@ from dagster.core.host_representation import (
     GrpcServerRepositoryLocation,
     GrpcServerRepositoryLocationOrigin,
     InProcessRepositoryLocationOrigin,
-    ManagedGrpcPythonEnvRepositoryLocationOrigin,
 )
 from dagster.core.scheduler.instigation import (
     InstigatorState,
@@ -41,27 +38,23 @@ from dagster.core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
-from dagster.core.storage.pipeline_run import (
-    IN_PROGRESS_RUN_STATUSES,
-    PipelineRunStatus,
-    PipelineRunsFilter,
-)
+from dagster.core.storage.pipeline_run import PipelineRunStatus, PipelineRunsFilter
 from dagster.core.storage.tags import PARTITION_NAME_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster.core.test_utils import (
     create_test_daemon_workspace,
-    get_logger_output_from_capfd,
     instance_for_test,
     mock_system_timezone,
 )
-from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.daemon import get_default_daemon_logger
 from dagster.grpc.client import EphemeralDagsterGrpcClient
 from dagster.grpc.server import open_server_process
 from dagster.scheduler.scheduler import launch_scheduled_runs
 from dagster.seven import wait_for_process
 from dagster.seven.compat.pendulum import create_pendulum_time, to_timezone
-from dagster.utils import find_free_port, merge_dicts
+from dagster.utils import find_free_port
 from dagster.utils.partitions import DEFAULT_DATE_FORMAT
+
+from .conftest import default_repo, loadable_target_origin
 
 _COUPLE_DAYS_AGO = datetime.datetime(year=2019, month=2, day=25)
 
@@ -422,51 +415,8 @@ def the_repo():
     ]
 
 
-def schedule_instance(overrides=None):
-    return instance_for_test(
-        overrides=merge_dicts(
-            {
-                "scheduler": {
-                    "module": "dagster.core.scheduler",
-                    "class": "DagsterDaemonScheduler",
-                },
-            },
-            (overrides if overrides else {}),
-        )
-    )
-
-
 def logger():
     return get_default_daemon_logger("SchedulerDaemon")
-
-
-@contextmanager
-def instance_with_schedules(external_repo_context, overrides=None):
-    with schedule_instance(overrides) as instance:
-        with create_test_daemon_workspace() as workspace:
-            with external_repo_context() as external_repo:
-                yield (instance, workspace, external_repo)
-
-
-def _loadable_target_origin():
-    return LoadableTargetOrigin(
-        executable_path=sys.executable,
-        python_file=__file__,
-        working_directory=os.getcwd(),
-    )
-
-
-@contextmanager
-def default_repo():
-    with ManagedGrpcPythonEnvRepositoryLocationOrigin(
-        loadable_target_origin=_loadable_target_origin(),
-        location_name="test_location",
-    ).create_test_location() as location:
-        yield location.get_repository("the_repo")
-
-
-def repos():
-    return [default_repo]
 
 
 def validate_tick(
@@ -491,24 +441,30 @@ def validate_tick(
     assert tick_data.skip_reason == expected_skip_reason
 
 
-def validate_run_started(
+def validate_run_exists(
     run,
     execution_time,
     partition_time=None,
     partition_fmt=DEFAULT_DATE_FORMAT,
-    expected_success=True,
 ):
     assert run.tags[SCHEDULED_EXECUTION_TIME_TAG] == to_timezone(execution_time, "UTC").isoformat()
 
     if partition_time:
         assert run.tags[PARTITION_NAME_TAG] == partition_time.strftime(partition_fmt)
 
+
+def validate_run_started(
+    instance,
+    run,
+    execution_time,
+    partition_time=None,
+    partition_fmt=DEFAULT_DATE_FORMAT,
+    expected_success=True,
+):
+    validate_run_exists(run, execution_time, partition_time, partition_fmt)
+
     if expected_success:
-        assert (
-            run.status == PipelineRunStatus.STARTED
-            or run.status == PipelineRunStatus.STARTING
-            or run.status == PipelineRunStatus.SUCCESS
-        )
+        assert instance.run_launcher.did_run_launch(run.run_id)
 
         if partition_time:
             assert run.run_config == _solid_config(partition_time)
@@ -531,1101 +487,869 @@ def wait_for_all_runs_to_start(instance, timeout=10):
             break
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_simple_schedule(external_repo_context, capfd):
+def test_simple_schedule(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
-
-            schedule_origin = external_schedule.get_external_origin()
-
-            instance.start_schedule_and_update_storage_state(external_schedule)
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-            # launch_scheduled_runs does nothing before the first tick
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - No new runs for simple_schedule"""
-            )
-
-        freeze_datetime = freeze_datetime.add(seconds=2)
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                expected_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-            )
-
-            wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0],
-                execution_time=create_pendulum_time(2019, 2, 28),
-                partition_time=create_pendulum_time(2019, 2, 27),
-            )
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for simple_schedule""".format(
-                    run_id=instance.get_runs()[0].run_id
-                )
-            )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
-
-        # Verify advancing in time but not going past a tick doesn't add any new runs
-        freeze_datetime = freeze_datetime.add(seconds=2)
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
-
-        freeze_datetime = freeze_datetime.add(days=2)
-        with pendulum.test(freeze_datetime):
-            capfd.readouterr()
-
-            # Traveling two more days in the future before running results in two new ticks
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-            assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 3
-
-            runs_by_partition = {run.tags[PARTITION_NAME_TAG]: run for run in instance.get_runs()}
-
-            assert "2019-02-28" in runs_by_partition
-            assert "2019-03-01" in runs_by_partition
-
-            assert get_logger_output_from_capfd(
-                capfd, "dagster.daemon.SchedulerDaemon"
-            ) == """2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-01 00:00:00 +0000, 2019-03-02 00:00:00 +0000
-2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-01 18:00:03 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
-                first_run_id=instance.get_runs()[1].run_id,
-                second_run_id=instance.get_runs()[0].run_id,
-            )
-
-            # Check idempotence again
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_old_tick_schedule(external_repo_context):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
-
-            # Create an old tick from several days ago
-            instance.create_job_tick(
-                TickData(
-                    job_origin_id=external_schedule.get_external_origin_id(),
-                    job_name="simple_schedule",
-                    job_type=InstigatorType.SCHEDULE,
-                    status=TickStatus.STARTED,
-                    timestamp=pendulum.now("UTC").subtract(days=3).timestamp(),
-                )
-            )
-
-            schedule_origin = external_schedule.get_external_origin()
-
-            # the start time is what determines the number of runs, not the last tick
-            instance.start_schedule_and_update_storage_state(external_schedule)
-
-        freeze_datetime = freeze_datetime.add(seconds=2)
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 2
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_no_started_schedules(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
+    with pendulum.test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
+
         schedule_origin = external_schedule.get_external_origin()
 
-        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-        assert instance.get_runs_count() == 0
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
+        assert instance.get_runs_count() == 0
         ticks = instance.get_job_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
-        captured = capfd.readouterr()
+        # launch_scheduled_runs does nothing before the first tick
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
 
-        assert "Not checking for any runs since no schedules have been started." in captured.out
+    freeze_datetime = freeze_datetime.add(seconds=2)
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
 
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_schedule_without_timezone(external_repo_context, capfd):
-    with mock_system_timezone("US/Eastern"):
-        with instance_with_schedules(external_repo_context) as (
+        expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+        )
+
+        wait_for_all_runs_to_start(instance)
+        validate_run_started(
             instance,
-            workspace,
-            external_repo,
-        ):
-            external_schedule = external_repo.get_external_schedule(
-                "daily_schedule_without_timezone"
-            )
-            schedule_origin = external_schedule.get_external_origin()
-            initial_datetime = create_pendulum_time(
-                year=2019, month=2, day=27, hour=0, minute=0, second=0, tz="UTC"
-            )
-
-            with pendulum.test(initial_datetime):
-
-                instance.start_schedule_and_update_storage_state(external_schedule)
-
-                list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-                assert instance.get_runs_count() == 1
-
-                ticks = instance.get_job_ticks(schedule_origin.get_id())
-
-                assert len(ticks) == 1
-
-                captured = capfd.readouterr()
-
-                assert (
-                    "Using UTC as the timezone for daily_schedule_without_timezone as "
-                    "it did not specify an execution_timezone in its definition." in captured.out
-                )
-
-                expected_datetime = create_pendulum_time(year=2019, month=2, day=27, tz="UTC")
-
-                validate_tick(
-                    ticks[0],
-                    external_schedule,
-                    expected_datetime,
-                    TickStatus.SUCCESS,
-                    [run.run_id for run in instance.get_runs()],
-                )
-
-                wait_for_all_runs_to_start(instance)
-                validate_run_started(
-                    instance.get_runs()[0],
-                    execution_time=expected_datetime,
-                    partition_time=create_pendulum_time(2019, 2, 26, tz="UTC"),
-                )
-
-                # Verify idempotence
-                list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-                assert instance.get_runs_count() == 1
-                ticks = instance.get_job_ticks(schedule_origin.get_id())
-                assert len(ticks) == 1
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_bad_env_fn_no_retries(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("bad_env_fn_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
+            instance.get_runs()[0],
+            execution_time=create_pendulum_time(2019, 2, 28),
+            partition_time=create_pendulum_time(2019, 2, 27),
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [run.run_id for run in instance.get_runs()],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=1,
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-
-            captured = capfd.readouterr()
-
-            assert (
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule"
-                in captured.out
-            )
-
-            # Idempotency (tick does not retry)
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=1,
-            )
-
-        initial_datetime = initial_datetime.add(days=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 2
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=1,
-            )
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_bad_env_fn_with_retries(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("bad_env_fn_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
-                )
+    # Verify advancing in time but not going past a tick doesn't add any new runs
+    freeze_datetime = freeze_datetime.add(seconds=2)
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=1,
-            )
-
-            captured = capfd.readouterr()
-
-            assert (
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule"
-                in captured.out
-            )
-
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
-                )
-            )
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
-                )
-            )
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=3,
-            )
-
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
-                )
-            )
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=3,
-            )
-
-        initial_datetime = initial_datetime.add(days=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 2
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
-                expected_failure_count=1,
-            )
-
-
-def test_passes_on_retry():
-    with instance_with_schedules(default_repo) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("passes_on_retry_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=1
+    freeze_datetime = freeze_datetime.add(days=2)
+    with pendulum.test(freeze_datetime):
+
+        # Traveling two more days in the future before running results in two new ticks
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
+        assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 3
+
+        runs_by_partition = {run.tags[PARTITION_NAME_TAG]: run for run in instance.get_runs()}
+
+        assert "2019-02-28" in runs_by_partition
+        assert "2019-03-01" in runs_by_partition
+
+        # Check idempotence again
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
+
+
+def test_old_tick_schedule(instance, workspace, external_repo):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
+        "US/Central",
+    )
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("simple_schedule")
+
+        # Create an old tick from several days ago
+        instance.create_job_tick(
+            TickData(
+                job_origin_id=external_schedule.get_external_origin_id(),
+                job_name="simple_schedule",
+                job_type=InstigatorType.SCHEDULE,
+                status=TickStatus.STARTED,
+                timestamp=pendulum.now("UTC").subtract(days=3).timestamp(),
+            )
+        )
+
+        schedule_origin = external_schedule.get_external_origin()
+
+        # the start time is what determines the number of runs, not the last tick
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+    freeze_datetime = freeze_datetime.add(seconds=2)
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 2
+
+
+def test_no_started_schedules(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+
+    list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+    assert instance.get_runs_count() == 0
+
+    ticks = instance.get_job_ticks(schedule_origin.get_id())
+    assert len(ticks) == 0
+
+
+def test_schedule_without_timezone(instance):
+    with mock_system_timezone("US/Eastern"):
+        with create_test_daemon_workspace() as workspace:
+            with default_repo() as external_repo:
+                external_schedule = external_repo.get_external_schedule(
+                    "daily_schedule_without_timezone"
                 )
-            )
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution of run_config_fn for schedule passes_on_retry_schedule",
-                expected_failure_count=1,
-            )
-
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=1
+                schedule_origin = external_schedule.get_external_origin()
+                initial_datetime = create_pendulum_time(
+                    year=2019, month=2, day=27, hour=0, minute=0, second=0, tz="UTC"
                 )
-            )
 
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+                with pendulum.test(initial_datetime):
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-                expected_failure_count=1,
-            )
+                    instance.start_schedule_and_update_storage_state(external_schedule)
 
-        initial_datetime = initial_datetime.add(days=1)
-        with pendulum.test(initial_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=1
-                )
-            )
+                    list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 2
+                    assert instance.get_runs_count() == 1
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
-                expected_failure_count=0,
-            )
+                    ticks = instance.get_job_ticks(schedule_origin.get_id())
+
+                    assert len(ticks) == 1
+
+                    expected_datetime = create_pendulum_time(year=2019, month=2, day=27, tz="UTC")
+
+                    validate_tick(
+                        ticks[0],
+                        external_schedule,
+                        expected_datetime,
+                        TickStatus.SUCCESS,
+                        [run.run_id for run in instance.get_runs()],
+                    )
+
+                    wait_for_all_runs_to_start(instance)
+                    validate_run_started(
+                        instance,
+                        instance.get_runs()[0],
+                        execution_time=expected_datetime,
+                        partition_time=create_pendulum_time(2019, 2, 26, tz="UTC"),
+                    )
+
+                    # Verify idempotence
+                    list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+                    assert instance.get_runs_count() == 1
+                    ticks = instance.get_job_ticks(schedule_origin.get_id())
+                    assert len(ticks) == 1
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_bad_should_execute(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("bad_should_execute_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=0,
-            minute=0,
-            second=0,
+def test_bad_env_fn_no_retries(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("bad_env_fn_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [run.run_id for run in instance.get_runs()],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=1,
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        # Idempotency (tick does not retry)
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [run.run_id for run in instance.get_runs()],
-                "Error occurred during the execution of should_execute for schedule bad_should_execute_schedule",
-                expected_failure_count=1,
-            )
-
-            captured = capfd.readouterr()
-
-            assert (
-                "Error occurred during the execution of should_execute for schedule bad_should_execute_schedule"
-                in captured.out
-            )
-
-            assert "Exception: bananas" in captured.out
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_skip(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("skip_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = to_timezone(
-            create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0, tz="UTC"),
-            "US/Central",
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=1,
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+    initial_datetime = initial_datetime.add(days=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SKIPPED,
-                [run.run_id for run in instance.get_runs()],
-                expected_skip_reason="should_execute function for skip_schedule returned false.",
-            )
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 2
 
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: skip_schedule
-2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `skip_schedule` at 2019-02-27 00:00:00 +0000
-2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Schedule skip_schedule skipped: should_execute function for skip_schedule returned false."""
-            )
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_wrong_config_schedule(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=1,
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
-            assert instance.get_runs_count() == 0
+def test_bad_env_fn_with_retries(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("bad_env_fn_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.FAILURE,
-                [],
-                "DagsterInvalidConfigError",
-                expected_failure_count=1,
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
             )
-
-            captured = capfd.readouterr()
-
-            assert "DagsterInvalidConfigError" in captured.out
-            assert "Scheduler caught an error for schedule wrong_config_schedule" in captured.out
-            assert "Error in config for pipeline" in captured.out
-            assert 'Missing required config entry "solids" at the root.' in captured.out
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_schedule_run_default_config(external_repo_context):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("default_config_schedule")
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019, month=2, day=27, hour=0, minute=0, second=0
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-            assert instance.get_runs_count() == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=1,
+        )
 
-            wait_for_all_runs_to_start(instance)
-
-            run = instance.get_runs()[0]
-
-            validate_run_started(
-                run,
-                execution_time=initial_datetime,
-                expected_success=True,
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
             )
-
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
+        )
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
             )
+        )
 
-            # wait for run to complete
-            run = instance.get_run_by_id(run.run_id)
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-            while run.status in IN_PROGRESS_RUN_STATUSES:
-                time.sleep(1)
-                run = instance.get_run_by_id(run.run_id)
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=3,
+        )
 
-            assert run.status == PipelineRunStatus.SUCCESS
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=2
+            )
+        )
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=3,
+        )
+
+    initial_datetime = initial_datetime.add(days=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 2
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule bad_env_fn_schedule",
+            expected_failure_count=1,
+        )
+
+
+def test_passes_on_retry(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("passes_on_retry_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=1
+            )
+        )
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution of run_config_fn for schedule passes_on_retry_schedule",
+            expected_failure_count=1,
+        )
+
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=1
+            )
+        )
+
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+            expected_failure_count=1,
+        )
+
+    initial_datetime = initial_datetime.add(days=1)
+    with pendulum.test(initial_datetime):
+        list(
+            launch_scheduled_runs(
+                instance, workspace, logger(), pendulum.now("UTC"), max_tick_retries=1
+            )
+        )
+
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 2
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+            expected_failure_count=0,
+        )
+
+
+def test_bad_should_execute(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("bad_should_execute_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(
+        year=2019,
+        month=2,
+        day=27,
+        hour=0,
+        minute=0,
+        second=0,
+    )
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [run.run_id for run in instance.get_runs()],
+            "Error occurred during the execution of should_execute for schedule bad_should_execute_schedule",
+            expected_failure_count=1,
+        )
+
+
+def test_skip(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("skip_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0, tz="UTC"),
+        "US/Central",
+    )
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SKIPPED,
+            [run.run_id for run in instance.get_runs()],
+            expected_skip_reason="should_execute function for skip_schedule returned false.",
+        )
+
+
+def test_wrong_config_schedule(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.FAILURE,
+            [],
+            "DagsterInvalidConfigError",
+            expected_failure_count=1,
+        )
+
+
+def test_schedule_run_default_config(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("default_config_schedule")
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 1
+
+        wait_for_all_runs_to_start(instance)
+
+        run = instance.get_runs()[0]
+
+        validate_run_started(
+            instance,
+            run,
+            execution_time=initial_datetime,
+            expected_success=True,
+        )
+
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+        )
+
+        assert instance.run_launcher.did_run_launch(run.run_id)
 
 
 def _get_unloadable_schedule_origin():
     working_directory = os.path.dirname(__file__)
-    recon_repo = ReconstructableRepository.for_file(__file__, "doesnt_exist", working_directory)
+    recon_repo = ReconstructableRepository.for_module(
+        "dagster_tests.scheduler_tests.test_scheduler_run", "doesnt_exist", working_directory
+    )
     return ExternalRepositoryOrigin(
         InProcessRepositoryLocationOrigin(recon_repo), "fake_repository"
     ).get_job_origin("doesnt_exist")
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_bad_schedules_mixed_with_good_schedule(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        good_schedule = external_repo.get_external_schedule("simple_schedule")
-        bad_schedule = external_repo.get_external_schedule(
-            "bad_should_execute_schedule_on_odd_days"
+def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_repo):
+    good_schedule = external_repo.get_external_schedule("simple_schedule")
+    bad_schedule = external_repo.get_external_schedule("bad_should_execute_schedule_on_odd_days")
+
+    good_origin = good_schedule.get_external_origin()
+    bad_origin = bad_schedule.get_external_origin()
+    unloadable_origin = _get_unloadable_schedule_origin()
+    initial_datetime = create_pendulum_time(
+        year=2019,
+        month=2,
+        day=27,
+        hour=0,
+        minute=0,
+        second=0,
+    )
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(good_schedule)
+        instance.start_schedule_and_update_storage_state(bad_schedule)
+
+        unloadable_schedule_state = InstigatorState(
+            unloadable_origin,
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.RUNNING,
+            ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
+        )
+        instance.add_job_state(unloadable_schedule_state)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 1
+        wait_for_all_runs_to_start(instance)
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            execution_time=initial_datetime,
+            partition_time=create_pendulum_time(2019, 2, 26),
         )
 
-        good_origin = good_schedule.get_external_origin()
-        bad_origin = bad_schedule.get_external_origin()
-        unloadable_origin = _get_unloadable_schedule_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=0,
-            minute=0,
-            second=0,
+        good_ticks = instance.get_job_ticks(good_origin.get_id())
+        assert len(good_ticks) == 1
+        validate_tick(
+            good_ticks[0],
+            good_schedule,
+            initial_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(good_schedule)
-            instance.start_schedule_and_update_storage_state(bad_schedule)
 
-            unloadable_schedule_state = InstigatorState(
-                unloadable_origin,
-                InstigatorType.SCHEDULE,
-                InstigatorStatus.RUNNING,
-                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
-            )
-            instance.add_job_state(unloadable_schedule_state)
+        bad_ticks = instance.get_job_ticks(bad_origin.get_id())
+        assert len(bad_ticks) == 1
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert bad_ticks[0].status == TickStatus.FAILURE
 
-            assert instance.get_runs_count() == 1
-            wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0],
-                execution_time=initial_datetime,
-                partition_time=create_pendulum_time(2019, 2, 26),
-            )
-
-            good_ticks = instance.get_job_ticks(good_origin.get_id())
-            assert len(good_ticks) == 1
-            validate_tick(
-                good_ticks[0],
-                good_schedule,
-                initial_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-            )
-
-            bad_ticks = instance.get_job_ticks(bad_origin.get_id())
-            assert len(bad_ticks) == 1
-
-            assert bad_ticks[0].status == TickStatus.FAILURE
-
-            assert (
-                "Error occurred during the execution of should_execute for schedule bad_should_execute_schedule"
-                in bad_ticks[0].error.message
-            )
-
-            unloadable_ticks = instance.get_job_ticks(unloadable_origin.get_id())
-            assert len(unloadable_ticks) == 0
-
-            captured = capfd.readouterr()
-            assert "Scheduler caught an error for schedule doesnt_exist" in captured.out
-            assert "doesnt_exist not found at module scope" in captured.out
-
-        initial_datetime = initial_datetime.add(days=1)
-        with pendulum.test(initial_datetime):
-            new_now = pendulum.now("UTC")
-            list(launch_scheduled_runs(instance, workspace, logger(), new_now))
-
-            assert instance.get_runs_count() == 3
-            wait_for_all_runs_to_start(instance)
-
-            good_schedule_runs = instance.get_runs(
-                filters=PipelineRunsFilter.for_schedule(good_schedule)
-            )
-            assert len(good_schedule_runs) == 2
-            validate_run_started(
-                good_schedule_runs[0],
-                execution_time=new_now,
-                partition_time=create_pendulum_time(2019, 2, 27),
-            )
-
-            good_ticks = instance.get_job_ticks(good_origin.get_id())
-            assert len(good_ticks) == 2
-            validate_tick(
-                good_ticks[0],
-                good_schedule,
-                new_now,
-                TickStatus.SUCCESS,
-                [good_schedule_runs[0].run_id],
-            )
-
-            bad_schedule_runs = instance.get_runs(
-                filters=PipelineRunsFilter.for_schedule(bad_schedule)
-            )
-            assert len(bad_schedule_runs) == 1
-            validate_run_started(
-                bad_schedule_runs[0],
-                execution_time=new_now,
-                partition_time=create_pendulum_time(2019, 2, 27),
-            )
-
-            bad_ticks = instance.get_job_ticks(bad_origin.get_id())
-            assert len(bad_ticks) == 2
-            validate_tick(
-                bad_ticks[0],
-                bad_schedule,
-                new_now,
-                TickStatus.SUCCESS,
-                [bad_schedule_runs[0].run_id],
-            )
-
-            unloadable_ticks = instance.get_job_ticks(unloadable_origin.get_id())
-            assert len(unloadable_ticks) == 0
-
-            captured = capfd.readouterr()
-            assert "Scheduler caught an error for schedule doesnt_exist" in captured.out
-            assert "doesnt_exist not found at module scope" in captured.out
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_run_scheduled_on_time_boundary(external_repo_context):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
-
-        schedule_origin = external_schedule.get_external_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=0,
-            minute=0,
-            second=0,
+        assert (
+            "Error occurred during the execution of should_execute for schedule bad_should_execute_schedule"
+            in bad_ticks[0].error.message
         )
-        with pendulum.test(initial_datetime):
-            # Start schedule exactly at midnight
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        unloadable_ticks = instance.get_job_ticks(unloadable_origin.get_id())
+        assert len(unloadable_ticks) == 0
 
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
+    initial_datetime = initial_datetime.add(days=1)
+    with pendulum.test(initial_datetime):
+        new_now = pendulum.now("UTC")
+        list(launch_scheduled_runs(instance, workspace, logger(), new_now))
+
+        assert instance.get_runs_count() == 3
+        wait_for_all_runs_to_start(instance)
+
+        good_schedule_runs = instance.get_runs(
+            filters=PipelineRunsFilter.for_schedule(good_schedule)
+        )
+        assert len(good_schedule_runs) == 2
+        validate_run_started(
+            instance,
+            good_schedule_runs[0],
+            execution_time=new_now,
+            partition_time=create_pendulum_time(2019, 2, 27),
+        )
+
+        good_ticks = instance.get_job_ticks(good_origin.get_id())
+        assert len(good_ticks) == 2
+        validate_tick(
+            good_ticks[0],
+            good_schedule,
+            new_now,
+            TickStatus.SUCCESS,
+            [good_schedule_runs[0].run_id],
+        )
+
+        bad_schedule_runs = instance.get_runs(filters=PipelineRunsFilter.for_schedule(bad_schedule))
+        assert len(bad_schedule_runs) == 1
+        validate_run_started(
+            instance,
+            bad_schedule_runs[0],
+            execution_time=new_now,
+            partition_time=create_pendulum_time(2019, 2, 27),
+        )
+
+        bad_ticks = instance.get_job_ticks(bad_origin.get_id())
+        assert len(bad_ticks) == 2
+        validate_tick(
+            bad_ticks[0],
+            bad_schedule,
+            new_now,
+            TickStatus.SUCCESS,
+            [bad_schedule_runs[0].run_id],
+        )
+
+        unloadable_ticks = instance.get_job_ticks(unloadable_origin.get_id())
+        assert len(unloadable_ticks) == 0
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_bad_load_repository(external_repo_context, capfd):
+def test_run_scheduled_on_time_boundary(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("simple_schedule")
+
+    schedule_origin = external_schedule.get_external_origin()
+    initial_datetime = create_pendulum_time(
+        year=2019,
+        month=2,
+        day=27,
+        hour=0,
+        minute=0,
+        second=0,
+    )
+    with pendulum.test(initial_datetime):
+        # Start schedule exactly at midnight
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
+
+
+def test_bad_load_repository(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
-            valid_schedule_origin = external_schedule.get_external_origin()
-
-            # Swap out a new repository name
-            invalid_repo_origin = ExternalJobOrigin(
-                ExternalRepositoryOrigin(
-                    valid_schedule_origin.external_repository_origin.repository_location_origin,
-                    "invalid_repo_name",
-                ),
-                valid_schedule_origin.job_name,
-            )
-
-            schedule_state = InstigatorState(
-                invalid_repo_origin,
-                InstigatorType.SCHEDULE,
-                InstigatorStatus.RUNNING,
-                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
-            )
-            instance.add_job_state(schedule_state)
-
-        initial_datetime = freeze_datetime.add(seconds=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-
-            ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
-
-            assert len(ticks) == 0
-
-            captured = capfd.readouterr()
-            assert "Scheduler caught an error for schedule simple_schedule" in captured.out
-            assert (
-                "Could not find repository invalid_repo_name in location test_location to run schedule simple_schedule."
-                in captured.out
-            )
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_bad_load_schedule(external_repo_context, capfd):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
-            valid_schedule_origin = external_schedule.get_external_origin()
-
-            # Swap out a new schedule name
-            invalid_repo_origin = ExternalJobOrigin(
-                valid_schedule_origin.external_repository_origin,
-                "invalid_schedule",
-            )
-
-            schedule_state = InstigatorState(
-                invalid_repo_origin,
-                InstigatorType.SCHEDULE,
-                InstigatorStatus.RUNNING,
-                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
-            )
-            instance.add_job_state(schedule_state)
-
-        initial_datetime = freeze_datetime.add(seconds=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-
-            ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
-
-            assert len(ticks) == 0
-
-            captured = capfd.readouterr()
-            assert "Scheduler caught an error for schedule invalid_schedule" in captured.out
-            assert (
-                "Could not find schedule invalid_schedule in repository the_repo." in captured.out
-            )
-
-
-def test_bad_load_repository_location(capfd):
-    with schedule_instance() as instance, create_test_daemon_workspace() as workspace:
-        fake_origin = _get_unloadable_schedule_origin()
-        initial_datetime = create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=23,
-            minute=59,
-            second=59,
-        )
-        with pendulum.test(initial_datetime):
-            schedule_state = InstigatorState(
-                fake_origin,
-                InstigatorType.SCHEDULE,
-                InstigatorStatus.RUNNING,
-                ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
-            )
-            instance.add_job_state(schedule_state)
-
-        initial_datetime = initial_datetime.add(seconds=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-
-            assert instance.get_runs_count() == 0
-
-            ticks = instance.get_job_ticks(fake_origin.get_id())
-
-            assert len(ticks) == 0
-
-            captured = capfd.readouterr()
-            assert "Scheduler caught an error for schedule doesnt_exist" in captured.out
-            assert "doesnt_exist not found at module scope" in captured.out
-
-        initial_datetime = initial_datetime.add(days=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(fake_origin.get_id())
-            assert len(ticks) == 0
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_multiple_schedules_on_different_time_ranges(external_repo_context, capfd):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
+    with pendulum.test(freeze_datetime):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
-        external_hourly_schedule = external_repo.get_external_schedule("simple_hourly_schedule")
-        initial_datetime = to_timezone(
-            create_pendulum_time(
-                year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"
+        valid_schedule_origin = external_schedule.get_external_origin()
+
+        # Swap out a new repository name
+        invalid_repo_origin = ExternalJobOrigin(
+            ExternalRepositoryOrigin(
+                valid_schedule_origin.external_repository_origin.repository_location_origin,
+                "invalid_repo_name",
             ),
-            "US/Central",
+            valid_schedule_origin.job_name,
         )
-        with pendulum.test(initial_datetime):
-            instance.start_schedule_and_update_storage_state(external_schedule)
-            instance.start_schedule_and_update_storage_state(external_hourly_schedule)
 
-        initial_datetime = initial_datetime.add(seconds=2)
-        with pendulum.test(initial_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        schedule_state = InstigatorState(
+            invalid_repo_origin,
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.RUNNING,
+            ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
+        )
+        instance.add_job_state(schedule_state)
+
+    initial_datetime = freeze_datetime.add(seconds=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+
+        ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+
+        assert len(ticks) == 0
+
+
+def test_bad_load_schedule(instance, workspace, external_repo):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
+        "US/Central",
+    )
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("simple_schedule")
+        valid_schedule_origin = external_schedule.get_external_origin()
+
+        # Swap out a new schedule name
+        invalid_repo_origin = ExternalJobOrigin(
+            valid_schedule_origin.external_repository_origin,
+            "invalid_schedule",
+        )
+
+        schedule_state = InstigatorState(
+            invalid_repo_origin,
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.RUNNING,
+            ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
+        )
+        instance.add_job_state(schedule_state)
+
+    initial_datetime = freeze_datetime.add(seconds=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+
+        ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+
+        assert len(ticks) == 0
+
+
+def test_bad_load_repository_location(instance, workspace):
+    fake_origin = _get_unloadable_schedule_origin()
+    initial_datetime = create_pendulum_time(
+        year=2019,
+        month=2,
+        day=27,
+        hour=23,
+        minute=59,
+        second=59,
+    )
+    with pendulum.test(initial_datetime):
+        schedule_state = InstigatorState(
+            fake_origin,
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.RUNNING,
+            ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
+        )
+        instance.add_job_state(schedule_state)
+
+    initial_datetime = initial_datetime.add(seconds=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+
+        assert instance.get_runs_count() == 0
+
+        ticks = instance.get_job_ticks(fake_origin.get_id())
+
+        assert len(ticks) == 0
+
+    initial_datetime = initial_datetime.add(days=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(fake_origin.get_id())
+        assert len(ticks) == 0
+
+
+def test_multiple_schedules_on_different_time_ranges(instance, workspace, external_repo):
+    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    external_hourly_schedule = external_repo.get_external_schedule("simple_hourly_schedule")
+    initial_datetime = to_timezone(
+        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
+        "US/Central",
+    )
+    with pendulum.test(initial_datetime):
+        instance.start_schedule_and_update_storage_state(external_schedule)
+        instance.start_schedule_and_update_storage_state(external_hourly_schedule)
+
+    initial_datetime = initial_datetime.add(seconds=2)
+    with pendulum.test(initial_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
+        )
 
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
-            hourly_ticks = instance.get_job_ticks(external_hourly_schedule.get_external_origin_id())
-            assert len(hourly_ticks) == 1
-            assert hourly_ticks[0].status == TickStatus.SUCCESS
+        hourly_ticks = instance.get_job_ticks(external_hourly_schedule.get_external_origin_id())
+        assert len(hourly_ticks) == 1
+        assert hourly_ticks[0].status == TickStatus.SUCCESS
 
-            assert get_logger_output_from_capfd(
-                capfd, "dagster.daemon.SchedulerDaemon"
-            ) == """2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_hourly_schedule""".format(
-                first_run_id=instance.get_runs()[1].run_id,
-                second_run_id=instance.get_runs()[0].run_id,
-            )
+    initial_datetime = initial_datetime.add(hours=1)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
-        initial_datetime = initial_datetime.add(hours=1)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 3
 
-            assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
-            ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
-
-            hourly_ticks = instance.get_job_ticks(external_hourly_schedule.get_external_origin_id())
-            assert len(hourly_ticks) == 2
-            assert len([tick for tick in hourly_ticks if tick.status == TickStatus.SUCCESS]) == 2
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule, simple_hourly_schedule
-2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - No new runs for simple_schedule
-2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_hourly_schedule` at 2019-02-28 01:00:00 +0000
-2019-02-27 19:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {third_run_id} for simple_hourly_schedule""".format(
-                    third_run_id=instance.get_runs()[0].run_id
-                )
-            )
+        hourly_ticks = instance.get_job_ticks(external_hourly_schedule.get_external_origin_id())
+        assert len(hourly_ticks) == 2
+        assert len([tick for tick in hourly_ticks if tick.status == TickStatus.SUCCESS]) == 2
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_launch_failure(external_repo_context, capfd):
-    with instance_with_schedules(
-        external_repo_context,
+def test_launch_failure(workspace, external_repo):
+    with instance_for_test(
         overrides={
             "run_launcher": {
                 "module": "dagster.core.test_utils",
                 "class": "ExplodingRunLauncher",
             },
         },
-    ) as (instance, workspace, external_repo):
+    ) as instance:
         external_schedule = external_repo.get_external_schedule("simple_schedule")
 
         schedule_origin = external_schedule.get_external_origin()
@@ -1644,6 +1368,7 @@ def test_launch_failure(external_repo_context, capfd):
             run = instance.get_runs()[0]
 
             validate_run_started(
+                instance,
                 run,
                 execution_time=initial_datetime,
                 partition_time=create_pendulum_time(2019, 2, 26),
@@ -1660,139 +1385,105 @@ def test_launch_failure(external_repo_context, capfd):
                 [run.run_id for run in instance.get_runs()],
             )
 
-            logger_output = get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
 
-            assert (
-                """2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at 2019-02-27 00:00:00 +0000
-2019-02-26 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - ERROR - Run {run_id} created successfully but failed to launch:""".format(
-                    run_id=instance.get_runs()[0].run_id
-                )
-                in logger_output
-            )
-
-            assert "The entire purpose of this is to throw on launch" in logger_output
-
-
-def test_partitionless_schedule(capfd):
+def test_partitionless_schedule(instance, workspace, external_repo):
     initial_datetime = create_pendulum_time(year=2019, month=2, day=27, tz="US/Central")
-    with instance_with_schedules(default_repo) as (instance, workspace, external_repo):
-        with pendulum.test(initial_datetime):
-            external_schedule = external_repo.get_external_schedule("partitionless_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+    with pendulum.test(initial_datetime):
+        external_schedule = external_repo.get_external_schedule("partitionless_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-        # Travel enough in the future that many ticks have passed, but only one run executes
-        initial_datetime = initial_datetime.add(days=5)
-        with pendulum.test(initial_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 1
+    # Travel enough in the future that many ticks have passed, but only one run executes
+    initial_datetime = initial_datetime.add(days=5)
+    with pendulum.test(initial_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 1
 
-            wait_for_all_runs_to_start(instance)
+        wait_for_all_runs_to_start(instance)
 
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                create_pendulum_time(year=2019, month=3, day=4, tz="US/Central"),
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-            )
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            create_pendulum_time(year=2019, month=3, day=4, tz="US/Central"),
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+        )
 
-            validate_run_started(
-                instance.get_runs()[0],
-                execution_time=create_pendulum_time(year=2019, month=3, day=4, tz="US/Central"),
-                partition_time=None,
-            )
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: partitionless_schedule
-2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - WARNING - partitionless_schedule has no partition set, so not trying to catch up
-2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `partitionless_schedule` at 2019-03-04 00:00:00 -0600
-2019-03-04 00:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for partitionless_schedule""".format(
-                    run_id=instance.get_runs()[0].run_id
-                )
-            )
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            execution_time=create_pendulum_time(year=2019, month=3, day=4, tz="US/Central"),
+            partition_time=None,
+        )
 
 
-def test_max_catchup_runs(capfd):
+def test_max_catchup_runs(instance, workspace, external_repo):
     initial_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with instance_with_schedules(default_repo) as (instance, workspace, external_repo):
-        with pendulum.test(initial_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+    with pendulum.test(initial_datetime):
+        external_schedule = external_repo.get_external_schedule("simple_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-        initial_datetime = initial_datetime.add(days=5)
-        with pendulum.test(initial_datetime):
-            # Day is now March 4 at 11:59PM
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                    max_catchup_runs=2,
-                )
+    initial_datetime = initial_datetime.add(days=5)
+    with pendulum.test(initial_datetime):
+        # Day is now March 4 at 11:59PM
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+                max_catchup_runs=2,
             )
+        )
 
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 2
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 2
 
-            first_datetime = create_pendulum_time(year=2019, month=3, day=4)
+        first_datetime = create_pendulum_time(year=2019, month=3, day=4)
 
-            wait_for_all_runs_to_start(instance)
+        wait_for_all_runs_to_start(instance)
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                first_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
-            )
-            validate_run_started(
-                instance.get_runs()[0],
-                execution_time=first_datetime,
-                partition_time=create_pendulum_time(2019, 3, 3),
-            )
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            first_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+        )
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            execution_time=first_datetime,
+            partition_time=create_pendulum_time(2019, 3, 3),
+        )
 
-            second_datetime = create_pendulum_time(year=2019, month=3, day=3)
+        second_datetime = create_pendulum_time(year=2019, month=3, day=3)
 
-            validate_tick(
-                ticks[1],
-                external_schedule,
-                second_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[1].run_id],
-            )
+        validate_tick(
+            ticks[1],
+            external_schedule,
+            second_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[1].run_id],
+        )
 
-            validate_run_started(
-                instance.get_runs()[1],
-                execution_time=second_datetime,
-                partition_time=create_pendulum_time(2019, 3, 2),
-            )
-
-            assert get_logger_output_from_capfd(
-                capfd, "dagster.daemon.SchedulerDaemon"
-            ) == """2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: simple_schedule
-2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - WARNING - simple_schedule has fallen behind, only launching 2 runs
-2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `simple_schedule` at the following times: 2019-03-03 00:00:00 +0000, 2019-03-04 00:00:00 +0000
-2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {first_run_id} for simple_schedule
-2019-03-04 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {second_run_id} for simple_schedule""".format(
-                first_run_id=instance.get_runs()[1].run_id,
-                second_run_id=instance.get_runs()[0].run_id,
-            )
+        validate_run_started(
+            instance,
+            instance.get_runs()[1],
+            execution_time=second_datetime,
+            partition_time=create_pendulum_time(2019, 3, 2),
+        )
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_multi_runs(external_repo_context, capfd):
+def test_multi_runs(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(
             year=2019,
@@ -1805,219 +1496,146 @@ def test_multi_runs(external_repo_context, capfd):
         ),
         "US/Central",
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("multi_run_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("multi_run_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
 
-            # launch_scheduled_runs does nothing before the first tick
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        # launch_scheduled_runs does nothing before the first tick
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
 
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 17:59:59 -0600 - dagster.daemon.SchedulerDaemon - INFO - No new runs for multi_run_schedule"""
-            )
+    freeze_datetime = freeze_datetime.add(seconds=2)
+    with pendulum.test(freeze_datetime):
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-        freeze_datetime = freeze_datetime.add(seconds=2)
-        with pendulum.test(freeze_datetime):
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+        expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
 
-            expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
+        runs = instance.get_runs()
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in runs],
+        )
 
-            runs = instance.get_runs()
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                expected_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in runs],
-            )
+        wait_for_all_runs_to_start(instance)
+        runs = instance.get_runs()
+        validate_run_started(instance, runs[0], execution_time=create_pendulum_time(2019, 2, 28))
+        validate_run_started(instance, runs[1], execution_time=create_pendulum_time(2019, 2, 28))
 
-            wait_for_all_runs_to_start(instance)
-            runs = instance.get_runs()
-            validate_run_started(runs[0], execution_time=create_pendulum_time(2019, 2, 28))
-            validate_run_started(runs[1], execution_time=create_pendulum_time(2019, 2, 28))
+        # Verify idempotence
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == f"""2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-27 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
-            )
+    freeze_datetime = freeze_datetime.add(days=1)
+    with pendulum.test(freeze_datetime):
 
-            # Verify idempotence
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
-
-        freeze_datetime = freeze_datetime.add(days=1)
-        with pendulum.test(freeze_datetime):
-            capfd.readouterr()
-
-            # Traveling one more day in the future before running results in a tick
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 4
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 2
-            assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 2
-            runs = instance.get_runs()
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == f"""2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: multi_run_schedule
-2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `multi_run_schedule` at 2019-03-01 00:00:00 +0000
-2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[1].run_id} for multi_run_schedule
-2019-02-28 18:00:01 -0600 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {runs[0].run_id} for multi_run_schedule"""
-            )
+        # Traveling one more day in the future before running results in a tick
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 4
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 2
+        assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 2
+        runs = instance.get_runs()
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_multi_runs_missing_run_key(external_repo_context, capfd):
+def test_multi_runs_missing_run_key(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, tz="UTC"), "US/Central"
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule(
-                "multi_run_schedule_with_missing_run_key"
-            )
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule(
+            "multi_run_schedule_with_missing_run_key"
+        )
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                freeze_datetime,
-                TickStatus.FAILURE,
-                [],
-                "Error occurred during the execution function for schedule "
-                "multi_run_schedule_with_missing_run_key",
-                expected_failure_count=1,
-            )
-
-            captured = capfd.readouterr()
-
-            assert (
-                "Error occurred during the execution function for schedule "
-                "multi_run_schedule_with_missing_run_key" in captured.out
-            )
-
-            assert (
-                "Schedules that return multiple RunRequests must specify a "
-                "run_key in each RunRequest" in captured.out
-            )
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            freeze_datetime,
+            TickStatus.FAILURE,
+            [],
+            "Error occurred during the execution function for schedule "
+            "multi_run_schedule_with_missing_run_key",
+            expected_failure_count=1,
+        )
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_large_schedule(external_repo_context):
+def test_large_schedule(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("large_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("large_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            freeze_datetime = freeze_datetime.add(seconds=2)
+        freeze_datetime = freeze_datetime.add(seconds=2)
 
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
+        )
 
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_manual_partition_with_solid_selection(external_repo_context):
+def test_manual_partition_with_solid_selection(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
         "US/Central",
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("manual_partition_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("manual_partition_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            freeze_datetime = freeze_datetime.add(seconds=2)
+        freeze_datetime = freeze_datetime.add(seconds=2)
 
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
+        )
 
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            run_id = ticks[0].run_ids[0]
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        run_id = ticks[0].run_ids[0]
 
-            start_time = time.time()
-            while (time.time() - start_time) < 5:
-                run = instance.get_run_by_id(run_id)
-                if not run.is_finished:
-                    time.sleep(0.1)
-                else:
-                    break
-
-            events = instance.all_logs(run_id)
-            started_steps = set()
-
-            for event in events:
-                if event.is_dagster_event and event.dagster_event.is_step_start:
-                    started_steps.add(event.dagster_event.step_key)
-
-            assert started_steps == {"end"}  # matches solid_selection
+        assert instance.get_run_by_id(run_id).solid_selection == ["end"]  # matches solid_selection
 
 
 @contextmanager
@@ -2025,7 +1643,7 @@ def _grpc_server_external_repo(port):
     server_process = open_server_process(
         port=port,
         socket=None,
-        loadable_target_origin=_loadable_target_origin(),
+        loadable_target_origin=loadable_target_origin(),
     )
     try:
         # shuts down server when it leaves this contextmanager
@@ -2041,50 +1659,37 @@ def _grpc_server_external_repo(port):
             wait_for_process(server_process, timeout=30)
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_skip_reason_schedule(external_repo_context, capfd):
+def test_skip_reason_schedule(instance, workspace, external_repo):
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=28, tz="UTC"),
         "US/Central",
     )
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("empty_schedule")
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("empty_schedule")
 
-            schedule_origin = external_schedule.get_external_origin()
+        schedule_origin = external_schedule.get_external_origin()
 
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+        list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
 
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: empty_schedule
-2019-02-27 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `empty_schedule` at 2019-02-28 00:00:00 +0000
-2019-02-27 18:00:00 -0600 - dagster.daemon.SchedulerDaemon - INFO - Schedule empty_schedule skipped: Schedule function returned an empty result"""
-            )
+        expected_datetime = create_pendulum_time(year=2019, month=2, day=28, tz="UTC")
 
-            expected_datetime = create_pendulum_time(year=2019, month=2, day=28, tz="UTC")
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                expected_datetime,
-                TickStatus.SKIPPED,
-                [],
-                expected_skip_reason="Schedule function returned an empty result",
-            )
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SKIPPED,
+            [],
+            expected_skip_reason="Schedule function returned an empty result",
+        )
 
 
-def test_grpc_server_down():
+def test_grpc_server_down(instance, workspace):
     port = find_free_port()
     location_origin = GrpcServerRepositoryLocationOrigin(
         host="localhost", port=port, location_name="test_location"
@@ -2099,44 +1704,42 @@ def test_grpc_server_down():
 
     initial_datetime = create_pendulum_time(year=2019, month=2, day=27, hour=0, minute=0, second=0)
 
-    with schedule_instance() as instance:
-        with create_test_daemon_workspace() as workspace:
-            with pendulum.test(initial_datetime):
-                with _grpc_server_external_repo(port) as external_repo:
-                    external_schedule = external_repo.get_external_schedule("simple_schedule")
-                    instance.start_schedule_and_update_storage_state(external_schedule)
-                    workspace.get_location(location_origin)
+    with pendulum.test(initial_datetime):
+        with _grpc_server_external_repo(port) as external_repo:
+            external_schedule = external_repo.get_external_schedule("simple_schedule")
+            instance.start_schedule_and_update_storage_state(external_schedule)
+            workspace.get_location(location_origin)
 
-                # Server is no longer running, ticks fail but indicate it will resume once it is reachable
-                for _trial in range(3):
-                    list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-                    assert instance.get_runs_count() == 0
-                    ticks = instance.get_job_ticks(schedule_origin.get_id())
-                    assert len(ticks) == 1
+        # Server is no longer running, ticks fail but indicate it will resume once it is reachable
+        for _trial in range(3):
+            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+            assert instance.get_runs_count() == 0
+            ticks = instance.get_job_ticks(schedule_origin.get_id())
+            assert len(ticks) == 1
 
-                    validate_tick(
-                        ticks[0],
-                        external_schedule,
-                        initial_datetime,
-                        TickStatus.FAILURE,
-                        [],
-                        "Unable to reach the user code server for schedule simple_schedule. Schedule will resume execution once the server is available.",
-                        expected_failure_count=0,
-                    )
+            validate_tick(
+                ticks[0],
+                external_schedule,
+                initial_datetime,
+                TickStatus.FAILURE,
+                [],
+                "Unable to reach the user code server for schedule simple_schedule. Schedule will resume execution once the server is available.",
+                expected_failure_count=0,
+            )
 
-                # Server starts back up, tick now succeeds
-                with _grpc_server_external_repo(port) as external_repo:
-                    list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
-                    assert instance.get_runs_count() == 1
-                    ticks = instance.get_job_ticks(schedule_origin.get_id())
-                    assert len(ticks) == 1
+        # Server starts back up, tick now succeeds
+        with _grpc_server_external_repo(port) as external_repo:
+            list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
+            assert instance.get_runs_count() == 1
+            ticks = instance.get_job_ticks(schedule_origin.get_id())
+            assert len(ticks) == 1
 
-                    expected_datetime = create_pendulum_time(year=2019, month=2, day=27)
+            expected_datetime = create_pendulum_time(year=2019, month=2, day=27)
 
-                    validate_tick(
-                        ticks[0],
-                        external_schedule,
-                        expected_datetime,
-                        TickStatus.SUCCESS,
-                        [run.run_id for run in instance.get_runs()],
-                    )
+            validate_tick(
+                ticks[0],
+                external_schedule,
+                expected_datetime,
+                TickStatus.SUCCESS,
+                [run.run_id for run in instance.get_runs()],
+            )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -1,15 +1,11 @@
 import pendulum
-import pytest
 from dagster.core.scheduler.instigation import TickStatus
-from dagster.core.test_utils import get_logger_output_from_capfd
 from dagster.scheduler.scheduler import launch_scheduled_runs
 from dagster.seven.compat.pendulum import create_pendulum_time, to_timezone
 from dagster.utils.partitions import DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE
 
 from .test_scheduler_run import (
-    instance_with_schedules,
     logger,
-    repos,
     the_repo,
     validate_run_started,
     validate_tick,
@@ -17,837 +13,779 @@ from .test_scheduler_run import (
 )
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_non_utc_timezone_run(external_repo_context, capfd):
+def test_non_utc_timezone_run(instance, workspace, external_repo):
     # Verify that schedule runs at the expected time in a non-UTC timezone
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 2, 27, 23, 59, 59, tz="US/Central"), "US/Pacific"
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 2, 27, 23, 59, 59, tz="US/Central"), "US/Pacific"
+    )
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+
+        schedule_origin = external_schedule.get_external_origin()
+
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
         )
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
 
-            schedule_origin = external_schedule.get_external_origin()
-
-            instance.start_schedule_and_update_storage_state(external_schedule)
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+    freeze_datetime = freeze_datetime.add(seconds=2)
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        )
 
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 21:59:59 -0800 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 21:59:59 -0800 - dagster.daemon.SchedulerDaemon - INFO - No new runs for daily_central_time_schedule"""
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        expected_datetime = to_timezone(
+            create_pendulum_time(year=2019, month=2, day=28, tz="US/Central"), "UTC"
+        )
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+        )
+
+        wait_for_all_runs_to_start(instance)
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            expected_datetime,
+            create_pendulum_time(2019, 2, 27, tz="US/Central"),
+        )
+
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-        freeze_datetime = freeze_datetime.add(seconds=2)
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            expected_datetime = to_timezone(
-                create_pendulum_time(year=2019, month=2, day=28, tz="US/Central"), "UTC"
-            )
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                expected_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-            )
-
-            wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0],
-                expected_datetime,
-                create_pendulum_time(2019, 2, 27, tz="US/Central"),
-            )
-
-            assert (
-                get_logger_output_from_capfd(capfd, "dagster.daemon.SchedulerDaemon")
-                == """2019-02-27 22:00:01 -0800 - dagster.daemon.SchedulerDaemon - INFO - Checking for new runs for the following schedules: daily_central_time_schedule
-2019-02-27 22:00:01 -0800 - dagster.daemon.SchedulerDaemon - INFO - Evaluating schedule `daily_central_time_schedule` at 2019-02-28 00:00:00 -0600
-2019-02-27 22:00:01 -0800 - dagster.daemon.SchedulerDaemon - INFO - Completed scheduled launch of run {run_id} for daily_central_time_schedule""".format(
-                    run_id=instance.get_runs()[0].run_id
-                )
-            )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
+        )
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_differing_timezones(external_repo_context):
+def test_differing_timezones(instance, workspace, external_repo):
     # Two schedules, one using US/Central, the other on US/Eastern
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 2, 27, 23, 59, 59, tz="US/Eastern"), "US/Pacific"
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 2, 27, 23, 59, 59, tz="US/Eastern"), "US/Pacific"
+    )
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+        external_eastern_schedule = external_repo.get_external_schedule(
+            "daily_eastern_time_schedule"
         )
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
-            external_eastern_schedule = external_repo.get_external_schedule(
-                "daily_eastern_time_schedule"
+
+        schedule_origin = external_schedule.get_external_origin()
+        eastern_origin = external_eastern_schedule.get_external_origin()
+
+        instance.start_schedule_and_update_storage_state(external_schedule)
+        instance.start_schedule_and_update_storage_state(external_eastern_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        assert len(ticks) == 0
+
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
+        )
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
 
-            schedule_origin = external_schedule.get_external_origin()
-            eastern_origin = external_eastern_schedule.get_external_origin()
+        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        assert len(ticks) == 0
 
-            instance.start_schedule_and_update_storage_state(external_schedule)
-            instance.start_schedule_and_update_storage_state(external_eastern_schedule)
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-            ticks = instance.get_job_ticks(eastern_origin.get_id())
-            assert len(ticks) == 0
-
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+    # Past midnight eastern time, the eastern timezone schedule will run, but not the central timezone
+    freeze_datetime = freeze_datetime.add(minutes=1)
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        )
 
-            ticks = instance.get_job_ticks(eastern_origin.get_id())
-            assert len(ticks) == 0
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        assert len(ticks) == 1
 
-        # Past midnight eastern time, the eastern timezone schedule will run, but not the central timezone
-        freeze_datetime = freeze_datetime.add(minutes=1)
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        expected_datetime = to_timezone(
+            create_pendulum_time(year=2019, month=2, day=28, tz="US/Eastern"), "UTC"
+        )
+
+        validate_tick(
+            ticks[0],
+            external_eastern_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            [run.run_id for run in instance.get_runs()],
+        )
+
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+        wait_for_all_runs_to_start(instance)
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            expected_datetime,
+            create_pendulum_time(2019, 2, 27, tz="US/Eastern"),
+        )
+
+    # Past midnight central time, the central timezone schedule will now run
+    freeze_datetime = freeze_datetime.add(hours=1)
+    with pendulum.test(freeze_datetime):
+
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
+        )
 
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(eastern_origin.get_id())
-            assert len(ticks) == 1
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        assert len(ticks) == 1
 
-            expected_datetime = to_timezone(
-                create_pendulum_time(year=2019, month=2, day=28, tz="US/Eastern"), "UTC"
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        expected_datetime = to_timezone(
+            create_pendulum_time(year=2019, month=2, day=28, tz="US/Central"), "UTC"
+        )
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+        )
+
+        wait_for_all_runs_to_start(instance)
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            expected_datetime,
+            create_pendulum_time(2019, 2, 27, tz="US/Central"),
+        )
+
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
+        )
+        assert instance.get_runs_count() == 2
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
-            validate_tick(
-                ticks[0],
-                external_eastern_schedule,
-                expected_datetime,
-                TickStatus.SUCCESS,
-                [run.run_id for run in instance.get_runs()],
-            )
-
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-            wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0],
-                expected_datetime,
-                create_pendulum_time(2019, 2, 27, tz="US/Eastern"),
-            )
-
-        # Past midnight central time, the central timezone schedule will now run
-        freeze_datetime = freeze_datetime.add(hours=1)
-        with pendulum.test(freeze_datetime):
-
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(eastern_origin.get_id())
-            assert len(ticks) == 1
-
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-
-            expected_datetime = to_timezone(
-                create_pendulum_time(year=2019, month=2, day=28, tz="US/Central"), "UTC"
-            )
-
-            validate_tick(
-                ticks[0],
-                external_schedule,
-                expected_datetime,
-                TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
-            )
-
-            wait_for_all_runs_to_start(instance)
-            validate_run_started(
-                instance.get_runs()[0],
-                expected_datetime,
-                create_pendulum_time(2019, 2, 27, tz="US/Central"),
-            )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
-
-            ticks = instance.get_job_ticks(eastern_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
+        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
 
 
 # Verify that a schedule that runs in US/Central late enough in the day that it executes on
 # a different day in UTC still runs and creates its partition names based on the US/Central time
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_different_days_in_different_timezones(external_repo_context):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 2, 27, 22, 59, 59, tz="US/Central"), "US/Pacific"
+def test_different_days_in_different_timezones(instance, workspace, external_repo):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 2, 27, 22, 59, 59, tz="US/Central"), "US/Pacific"
+    )
+    with pendulum.test(freeze_datetime):
+        # Runs every day at 11PM (CST)
+        external_schedule = external_repo.get_external_schedule("daily_late_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
         )
-        with pendulum.test(freeze_datetime):
-            # Runs every day at 11PM (CST)
-            external_schedule = external_repo.get_external_schedule("daily_late_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+    freeze_datetime = freeze_datetime.add(seconds=2)
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        )
 
-        freeze_datetime = freeze_datetime.add(seconds=2)
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+
+        expected_datetime = to_timezone(
+            create_pendulum_time(year=2019, month=2, day=27, hour=23, tz="US/Central"), "UTC"
+        )
+
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            [instance.get_runs()[0].run_id],
+        )
+
+        wait_for_all_runs_to_start(instance)
+        validate_run_started(
+            instance,
+            instance.get_runs()[0],
+            expected_datetime,
+            create_pendulum_time(2019, 2, 26, tz="US/Central"),
+        )
+
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+        assert instance.get_runs_count() == 1
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 1
+        assert ticks[0].status == TickStatus.SUCCESS
+
+
+def test_hourly_dst_spring_forward(instance, workspace, external_repo):
+    # Verify that an hourly schedule still runs hourly during the spring DST transition
+    # 1AM CST
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 3, 10, 1, 0, 0, tz="US/Central"), "US/Pacific"
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+    freeze_datetime = freeze_datetime.add(hours=2)
+
+    # DST has now happened, 2 hours later it is 4AM CST
+    # Should be 3 runs: 1AM CST, 3AM CST, 4AM CST
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+
+        wait_for_all_runs_to_start(instance)
+
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
+
+        expected_datetimes_utc = [
+            to_timezone(create_pendulum_time(2019, 3, 10, 4, 0, 0, tz="US/Central"), "UTC"),
+            to_timezone(create_pendulum_time(2019, 3, 10, 3, 0, 0, tz="US/Central"), "UTC"),
+            to_timezone(create_pendulum_time(2019, 3, 10, 1, 0, 0, tz="US/Central"), "UTC"),
+        ]
+
+        for i in range(3):
+            validate_tick(
+                ticks[i],
+                external_schedule,
+                expected_datetimes_utc[i],
+                TickStatus.SUCCESS,
+                [instance.get_runs()[i].run_id],
             )
 
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
+            validate_run_started(
+                instance,
+                instance.get_runs()[i],
+                expected_datetimes_utc[i],
+                partition_time=to_timezone(expected_datetimes_utc[i], "US/Central").subtract(
+                    hours=1
+                ),
+                partition_fmt=DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE,
+            )
 
-            expected_datetime = to_timezone(
-                create_pendulum_time(year=2019, month=2, day=27, hour=23, tz="US/Central"), "UTC"
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
+
+
+def test_hourly_dst_fall_back(instance, workspace, external_repo):
+    # Verify that an hourly schedule still runs hourly during the fall DST transition
+    # 12:30 AM CST
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 11, 3, 0, 30, 0, tz="US/Central"), "US/Pacific"
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+    freeze_datetime = freeze_datetime.add(hours=4)
+
+    # DST has now happened, 4 hours later it is 3:30AM CST
+    # Should be 4 runs: 1AM CDT, 1AM CST, 2AM CST, 3AM CST
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+
+        wait_for_all_runs_to_start(instance)
+
+        assert instance.get_runs_count() == 4
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 4
+
+        expected_datetimes_utc = [
+            create_pendulum_time(2019, 11, 3, 9, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 3, 8, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 3, 7, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 3, 6, 0, 0, tz="UTC"),
+        ]
+
+        expected_ct_times = [
+            "2019-11-03T03:00:00-06:00",  # 3 AM CST
+            "2019-11-03T02:00:00-06:00",  # 2 AM CST
+            "2019-11-03T01:00:00-06:00",  # 1 AM CST
+            "2019-11-03T01:00:00-05:00",  # 1 AM CDT
+        ]
+
+        for i in range(4):
+            assert (
+                to_timezone(expected_datetimes_utc[i], "US/Central").isoformat()
+                == expected_ct_times[i]
             )
 
             validate_tick(
-                ticks[0],
+                ticks[i],
                 external_schedule,
-                expected_datetime,
+                expected_datetimes_utc[i],
                 TickStatus.SUCCESS,
-                [instance.get_runs()[0].run_id],
+                [instance.get_runs()[i].run_id],
             )
 
-            wait_for_all_runs_to_start(instance)
             validate_run_started(
-                instance.get_runs()[0],
-                expected_datetime,
-                create_pendulum_time(2019, 2, 26, tz="US/Central"),
+                instance,
+                instance.get_runs()[i],
+                expected_datetimes_utc[i],
+                partition_time=to_timezone(expected_datetimes_utc[i], "US/Central").subtract(
+                    hours=1
+                ),
+                partition_fmt=DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE,
             )
 
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 1
-            assert ticks[0].status == TickStatus.SUCCESS
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_hourly_dst_spring_forward(external_repo_context):
-    # Verify that an hourly schedule still runs hourly during the spring DST transition
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        # 1AM CST
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 3, 10, 1, 0, 0, tz="US/Central"), "US/Pacific"
         )
-
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-        freeze_datetime = freeze_datetime.add(hours=2)
-
-        # DST has now happened, 2 hours later it is 4AM CST
-        # Should be 3 runs: 1AM CST, 3AM CST, 4AM CST
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-
-            wait_for_all_runs_to_start(instance)
-
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-            expected_datetimes_utc = [
-                to_timezone(create_pendulum_time(2019, 3, 10, 4, 0, 0, tz="US/Central"), "UTC"),
-                to_timezone(create_pendulum_time(2019, 3, 10, 3, 0, 0, tz="US/Central"), "UTC"),
-                to_timezone(create_pendulum_time(2019, 3, 10, 1, 0, 0, tz="US/Central"), "UTC"),
-            ]
-
-            for i in range(3):
-                validate_tick(
-                    ticks[i],
-                    external_schedule,
-                    expected_datetimes_utc[i],
-                    TickStatus.SUCCESS,
-                    [instance.get_runs()[i].run_id],
-                )
-
-                validate_run_started(
-                    instance.get_runs()[i],
-                    expected_datetimes_utc[i],
-                    partition_time=to_timezone(expected_datetimes_utc[i], "US/Central").subtract(
-                        hours=1
-                    ),
-                    partition_fmt=DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE,
-                )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
+        assert instance.get_runs_count() == 4
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 4
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_hourly_dst_fall_back(external_repo_context):
-    # Verify that an hourly schedule still runs hourly during the fall DST transition
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        # 12:30 AM CST
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 11, 3, 0, 30, 0, tz="US/Central"), "US/Pacific"
-        )
-
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
-
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-        freeze_datetime = freeze_datetime.add(hours=4)
-
-        # DST has now happened, 4 hours later it is 3:30AM CST
-        # Should be 4 runs: 1AM CDT, 1AM CST, 2AM CST, 3AM CST
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-
-            wait_for_all_runs_to_start(instance)
-
-            assert instance.get_runs_count() == 4
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 4
-
-            expected_datetimes_utc = [
-                create_pendulum_time(2019, 11, 3, 9, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 3, 8, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 3, 7, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 3, 6, 0, 0, tz="UTC"),
-            ]
-
-            expected_ct_times = [
-                "2019-11-03T03:00:00-06:00",  # 3 AM CST
-                "2019-11-03T02:00:00-06:00",  # 2 AM CST
-                "2019-11-03T01:00:00-06:00",  # 1 AM CST
-                "2019-11-03T01:00:00-05:00",  # 1 AM CDT
-            ]
-
-            for i in range(4):
-                assert (
-                    to_timezone(expected_datetimes_utc[i], "US/Central").isoformat()
-                    == expected_ct_times[i]
-                )
-
-                validate_tick(
-                    ticks[i],
-                    external_schedule,
-                    expected_datetimes_utc[i],
-                    TickStatus.SUCCESS,
-                    [instance.get_runs()[i].run_id],
-                )
-
-                validate_run_started(
-                    instance.get_runs()[i],
-                    expected_datetimes_utc[i],
-                    partition_time=to_timezone(expected_datetimes_utc[i], "US/Central").subtract(
-                        hours=1
-                    ),
-                    partition_fmt=DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE,
-                )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
-            )
-            assert instance.get_runs_count() == 4
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 4
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_daily_dst_spring_forward(external_repo_context):
+def test_daily_dst_spring_forward(instance, workspace, external_repo):
     # Verify that a daily schedule still runs once per day during the spring DST transition
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        # Night before DST
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 3, 10, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    # Night before DST
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 3, 10, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+    freeze_datetime = freeze_datetime.add(days=2)
+
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
         )
 
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        wait_for_all_runs_to_start(instance)
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
 
-        freeze_datetime = freeze_datetime.add(days=2)
+        # UTC time changed by one hour after the transition, still running daily at the same
+        # time in CT
+        expected_datetimes_utc = [
+            create_pendulum_time(2019, 3, 12, 5, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 3, 11, 5, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 3, 10, 6, 0, 0, tz="UTC"),
+        ]
 
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        expected_partition_times = [
+            create_pendulum_time(2019, 3, 11, tz="US/Central"),
+            create_pendulum_time(2019, 3, 10, tz="US/Central"),
+            create_pendulum_time(2019, 3, 9, tz="US/Central"),
+        ]
+
+        for i in range(3):
+            validate_tick(
+                ticks[i],
+                external_schedule,
+                expected_datetimes_utc[i],
+                TickStatus.SUCCESS,
+                [instance.get_runs()[i].run_id],
             )
 
-            wait_for_all_runs_to_start(instance)
-
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-            # UTC time changed by one hour after the transition, still running daily at the same
-            # time in CT
-            expected_datetimes_utc = [
-                create_pendulum_time(2019, 3, 12, 5, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 3, 11, 5, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 3, 10, 6, 0, 0, tz="UTC"),
-            ]
-
-            expected_partition_times = [
-                create_pendulum_time(2019, 3, 11, tz="US/Central"),
-                create_pendulum_time(2019, 3, 10, tz="US/Central"),
-                create_pendulum_time(2019, 3, 9, tz="US/Central"),
-            ]
-
-            for i in range(3):
-                validate_tick(
-                    ticks[i],
-                    external_schedule,
-                    expected_datetimes_utc[i],
-                    TickStatus.SUCCESS,
-                    [instance.get_runs()[i].run_id],
-                )
-
-                validate_run_started(
-                    instance.get_runs()[i],
-                    expected_datetimes_utc[i],
-                    partition_time=expected_partition_times[i],
-                )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+            validate_run_started(
+                instance,
+                instance.get_runs()[i],
+                expected_datetimes_utc[i],
+                partition_time=expected_partition_times[i],
             )
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
+
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_daily_dst_fall_back(external_repo_context):
+def test_daily_dst_fall_back(instance, workspace, external_repo):
     # Verify that a daily schedule still runs once per day during the fall DST transition
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        # Night before DST
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 11, 3, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    # Night before DST
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 11, 3, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+    freeze_datetime = freeze_datetime.add(days=2)
+
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
         )
 
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
+        wait_for_all_runs_to_start(instance)
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
 
-        freeze_datetime = freeze_datetime.add(days=2)
+        # UTC time changed by one hour after the transition, still running daily at the same
+        # time in CT
+        expected_datetimes_utc = [
+            create_pendulum_time(2019, 11, 5, 6, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 4, 6, 0, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 3, 5, 0, 0, tz="UTC"),
+        ]
 
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        expected_partition_times = [
+            create_pendulum_time(2019, 11, 4, tz="US/Central"),
+            create_pendulum_time(2019, 11, 3, tz="US/Central"),
+            create_pendulum_time(2019, 11, 2, tz="US/Central"),
+        ]
+
+        for i in range(3):
+            validate_tick(
+                ticks[i],
+                external_schedule,
+                expected_datetimes_utc[i],
+                TickStatus.SUCCESS,
+                [instance.get_runs()[i].run_id],
             )
 
-            wait_for_all_runs_to_start(instance)
-
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-            # UTC time changed by one hour after the transition, still running daily at the same
-            # time in CT
-            expected_datetimes_utc = [
-                create_pendulum_time(2019, 11, 5, 6, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 4, 6, 0, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 3, 5, 0, 0, tz="UTC"),
-            ]
-
-            expected_partition_times = [
-                create_pendulum_time(2019, 11, 4, tz="US/Central"),
-                create_pendulum_time(2019, 11, 3, tz="US/Central"),
-                create_pendulum_time(2019, 11, 2, tz="US/Central"),
-            ]
-
-            for i in range(3):
-                validate_tick(
-                    ticks[i],
-                    external_schedule,
-                    expected_datetimes_utc[i],
-                    TickStatus.SUCCESS,
-                    [instance.get_runs()[i].run_id],
-                )
-
-                validate_run_started(
-                    instance.get_runs()[i],
-                    expected_datetimes_utc[i],
-                    partition_time=expected_partition_times[i],
-                )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+            validate_run_started(
+                instance,
+                instance.get_runs()[i],
+                expected_datetimes_utc[i],
+                partition_time=expected_partition_times[i],
             )
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
+
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
+        )
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
 
 
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_execute_during_dst_transition_spring_forward(external_repo_context):
+def test_execute_during_dst_transition_spring_forward(instance, workspace, external_repo):
     # Verify that a daily schedule that is supposed to execute at a time that is skipped
     # by the DST transition does not execute for that day
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        # Day before DST
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 3, 9, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    # Day before DST
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 3, 9, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule(
+            "daily_dst_transition_schedule_skipped_time"
+        )
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+    freeze_datetime = freeze_datetime.add(days=3)
+
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
+            )
         )
 
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule(
-                "daily_dst_transition_schedule_skipped_time"
+        wait_for_all_runs_to_start(instance)
+
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
+
+        expected_datetimes_utc = [
+            to_timezone(create_pendulum_time(2019, 3, 11, 2, 30, 0, tz="US/Central"), "UTC"),
+            to_timezone(create_pendulum_time(2019, 3, 10, 3, 00, 0, tz="US/Central"), "UTC"),
+            to_timezone(create_pendulum_time(2019, 3, 9, 2, 30, 0, tz="US/Central"), "UTC"),
+        ]
+
+        expected_partition_times = [
+            create_pendulum_time(2019, 3, 10, tz="US/Central"),
+            create_pendulum_time(2019, 3, 9, tz="US/Central"),
+            create_pendulum_time(2019, 3, 8, tz="US/Central"),
+        ]
+
+        partition_set_def = the_repo.get_partition_set_def(
+            "daily_dst_transition_schedule_skipped_time_partitions"
+        )
+        partition_names = partition_set_def.get_partition_names()
+
+        assert "2019-03-08" in partition_names
+        assert "2019-03-09" in partition_names
+        assert "2019-03-10" in partition_names
+
+        for i in range(3):
+            validate_tick(
+                ticks[i],
+                external_schedule,
+                expected_datetimes_utc[i],
+                TickStatus.SUCCESS,
+                [instance.get_runs()[i].run_id],
             )
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-        freeze_datetime = freeze_datetime.add(days=3)
-
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+            validate_run_started(
+                instance,
+                instance.get_runs()[i],
+                expected_datetimes_utc[i],
+                partition_time=expected_partition_times[i],
             )
 
-            wait_for_all_runs_to_start(instance)
-
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-            expected_datetimes_utc = [
-                to_timezone(create_pendulum_time(2019, 3, 11, 2, 30, 0, tz="US/Central"), "UTC"),
-                to_timezone(create_pendulum_time(2019, 3, 10, 3, 00, 0, tz="US/Central"), "UTC"),
-                to_timezone(create_pendulum_time(2019, 3, 9, 2, 30, 0, tz="US/Central"), "UTC"),
-            ]
-
-            expected_partition_times = [
-                create_pendulum_time(2019, 3, 10, tz="US/Central"),
-                create_pendulum_time(2019, 3, 9, tz="US/Central"),
-                create_pendulum_time(2019, 3, 8, tz="US/Central"),
-            ]
-
-            partition_set_def = the_repo.get_partition_set_def(
-                "daily_dst_transition_schedule_skipped_time_partitions"
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            partition_names = partition_set_def.get_partition_names()
+        )
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
 
-            assert "2019-03-08" in partition_names
-            assert "2019-03-09" in partition_names
-            assert "2019-03-10" in partition_names
 
-            for i in range(3):
-                validate_tick(
-                    ticks[i],
-                    external_schedule,
-                    expected_datetimes_utc[i],
-                    TickStatus.SUCCESS,
-                    [instance.get_runs()[i].run_id],
-                )
+def test_execute_during_dst_transition_fall_back(instance, workspace, external_repo):
+    # A schedule that runs daily during a time that occurs twice during a fall DST transition
+    # only executes once for that day
+    freeze_datetime = to_timezone(
+        create_pendulum_time(2019, 11, 2, 0, 0, 0, tz="US/Central"), "US/Pacific"
+    )
 
-                validate_run_started(
-                    instance.get_runs()[i],
-                    expected_datetimes_utc[i],
-                    partition_time=expected_partition_times[i],
-                )
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo.get_external_schedule(
+            "daily_dst_transition_schedule_doubled_time"
+        )
+        schedule_origin = external_schedule.get_external_origin()
+        instance.start_schedule_and_update_storage_state(external_schedule)
 
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 0
+
+    freeze_datetime = freeze_datetime.add(days=3)
+
+    with pendulum.test(freeze_datetime):
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-
-@pytest.mark.parametrize("external_repo_context", repos())
-def test_execute_during_dst_transition_fall_back(external_repo_context):
-    with instance_with_schedules(external_repo_context) as (
-        instance,
-        workspace,
-        external_repo,
-    ):
-        # A schedule that runs daily during a time that occurs twice during a fall DST transition
-        # only executes once for that day
-        freeze_datetime = to_timezone(
-            create_pendulum_time(2019, 11, 2, 0, 0, 0, tz="US/Central"), "US/Pacific"
         )
 
-        with pendulum.test(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule(
-                "daily_dst_transition_schedule_doubled_time"
+        wait_for_all_runs_to_start(instance)
+
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3
+
+        expected_datetimes_utc = [
+            create_pendulum_time(2019, 11, 4, 7, 30, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 3, 7, 30, 0, tz="UTC"),
+            create_pendulum_time(2019, 11, 2, 6, 30, 0, tz="UTC"),
+        ]
+
+        expected_partition_times = [
+            create_pendulum_time(2019, 11, 3, tz="US/Central"),
+            create_pendulum_time(2019, 11, 2, tz="US/Central"),
+            create_pendulum_time(2019, 11, 1, tz="US/Central"),
+        ]
+
+        for i in range(3):
+            validate_tick(
+                ticks[i],
+                external_schedule,
+                expected_datetimes_utc[i],
+                TickStatus.SUCCESS,
+                [instance.get_runs()[i].run_id],
             )
-            schedule_origin = external_schedule.get_external_origin()
-            instance.start_schedule_and_update_storage_state(external_schedule)
 
-            assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 0
-
-        freeze_datetime = freeze_datetime.add(days=3)
-
-        with pendulum.test(freeze_datetime):
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+            validate_run_started(
+                instance,
+                instance.get_runs()[i],
+                expected_datetimes_utc[i],
+                partition_time=expected_partition_times[i],
             )
 
-            wait_for_all_runs_to_start(instance)
-
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
-
-            expected_datetimes_utc = [
-                create_pendulum_time(2019, 11, 4, 7, 30, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 3, 7, 30, 0, tz="UTC"),
-                create_pendulum_time(2019, 11, 2, 6, 30, 0, tz="UTC"),
-            ]
-
-            expected_partition_times = [
-                create_pendulum_time(2019, 11, 3, tz="US/Central"),
-                create_pendulum_time(2019, 11, 2, tz="US/Central"),
-                create_pendulum_time(2019, 11, 1, tz="US/Central"),
-            ]
-
-            for i in range(3):
-                validate_tick(
-                    ticks[i],
-                    external_schedule,
-                    expected_datetimes_utc[i],
-                    TickStatus.SUCCESS,
-                    [instance.get_runs()[i].run_id],
-                )
-
-                validate_run_started(
-                    instance.get_runs()[i],
-                    expected_datetimes_utc[i],
-                    partition_time=expected_partition_times[i],
-                )
-
-            # Verify idempotence
-            list(
-                launch_scheduled_runs(
-                    instance,
-                    workspace,
-                    logger(),
-                    pendulum.now("UTC"),
-                )
+        # Verify idempotence
+        list(
+            launch_scheduled_runs(
+                instance,
+                workspace,
+                logger(),
+                pendulum.now("UTC"),
             )
-            assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
-            assert len(ticks) == 3
+        )
+        assert instance.get_runs_count() == 3
+        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        assert len(ticks) == 3


### PR DESCRIPTION
Summary:
Most of these tests spin up new workspace on each run for no good reason. Also remove this very finicky logger output logic, which maybe made some sense originally but now is more trouble than it is worth (and was breaking with the new shared fixtures).

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.