### PR TITLE
[dagit] Fix Terminate button on Run page

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -12,6 +12,7 @@
     "@blueprintjs/table": "^3.8.33",
     "@dagster-io/dagit-core": "workspace:*",
     "@dagster-io/ui": "workspace:*",
+    "graphql": "^15.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.1.2"

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -27,7 +27,8 @@
     "@dagster-io/ui": "workspace:*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^5.1.2"
+    "react-router-dom": "^5.1.2",
+    "styled-components": "^5.3.3"
   },
   "dependencies": {
     "@apollo/client": "^3.3.16",
@@ -54,7 +55,6 @@
     "react-codemirror2": "^7.2.1",
     "react-is": "^17.0.2",
     "react-virtualized": "^9.22.3",
-    "styled-components": "^5.3.3",
     "subscriptions-transport-ws": "^0.9.15",
     "worker-loader": "^3.0.8",
     "yaml": "2.0.0-1"
@@ -138,7 +138,7 @@
     "react-test-renderer": "^17.0.2",
     "rgb-hex": "^4.0.0",
     "source-map-explorer": "^2.5.0",
-    "styled-components": "^5.2.1",
+    "styled-components": "^5.3.3",
     "ts-node": "9.1.1",
     "ts-prune": "0.8.9",
     "typescript": "4.5.4",

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.test.tsx
@@ -1,0 +1,168 @@
+import {gql, useQuery} from '@apollo/client';
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+import {RunStatus} from '../types/globalTypes';
+
+import {RunActionButtons} from './RunActionButtons';
+import {RunFragments} from './RunFragments';
+import {RunActionButtonsTestQuery} from './types/RunActionButtonsTestQuery';
+
+describe('RunActionButtons', () => {
+  const props = {
+    selection: {
+      keys: [],
+      query: '',
+    },
+    graph: [],
+    metadata: {
+      firstLogAt: 0,
+      mostRecentLogAt: 0,
+      globalMarkers: [],
+      steps: {},
+    },
+    onLaunch: jest.fn(),
+  };
+
+  const Test = () => {
+    const {data} = useQuery<RunActionButtonsTestQuery>(RUN_ACTION_BUTTONS_TEST_QUERY);
+    if (data) {
+      const run = data.pipelineRunOrError;
+      if (run.__typename === 'Run') {
+        return <RunActionButtons {...props} run={run} />;
+      }
+      return <div>Error</div>;
+    }
+    return <div>Loading</div>;
+  };
+
+  const defaultMocks = {
+    RunConfigData: () => 'foo',
+  };
+
+  describe('`Terminate` button', () => {
+    it('is visible for `STARTED` runs', async () => {
+      const mocks = {
+        Run: () => ({
+          status: () => RunStatus.STARTED,
+        }),
+      };
+
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', {
+            name: /terminate/i,
+          }),
+        ).toBeVisible();
+      });
+    });
+
+    it('is visible for `STARTING` runs', async () => {
+      const mocks = {
+        Run: () => ({
+          status: () => RunStatus.STARTING,
+        }),
+      };
+
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', {
+            name: /terminate/i,
+          }),
+        ).toBeVisible();
+      });
+    });
+
+    it('is NOT visible for `FAILURE` runs', async () => {
+      const mocks = {
+        Run: () => ({
+          status: () => RunStatus.FAILURE,
+        }),
+      };
+
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', {
+            name: /terminate/i,
+          }),
+        ).toBeNull();
+      });
+    });
+
+    it('is NOT visible for `CANCELED` runs', async () => {
+      const mocks = {
+        Run: () => ({
+          status: () => RunStatus.CANCELED,
+        }),
+      };
+
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', {
+            name: /terminate/i,
+          }),
+        ).toBeNull();
+      });
+    });
+
+    it('is NOT visible for `SUCCESS` runs', async () => {
+      const mocks = {
+        Run: () => ({
+          status: () => RunStatus.SUCCESS,
+        }),
+      };
+
+      render(
+        <TestProvider apolloProps={{mocks: [defaultMocks, mocks]}}>
+          <Test />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', {
+            name: /terminate/i,
+          }),
+        ).toBeNull();
+      });
+    });
+  });
+});
+
+const RUN_ACTION_BUTTONS_TEST_QUERY = gql`
+  query RunActionButtonsTestQuery {
+    pipelineRunOrError(runId: "foo") {
+      ... on Run {
+        id
+        ...RunFragment
+      }
+    }
+  }
+
+  ${RunFragments.RunFragment}
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -164,7 +164,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   const fromSelected: LaunchButtonConfiguration = {
     icon: 'arrow_forward',
     title: 'From Selected',
-    disabled: !doneStatuses.has(run.status) || selection.keys.length !== 1,
+    disabled: !canRunAllSteps(run) || selection.keys.length !== 1,
     tooltip: 'Re-execute the pipeline downstream from the selected steps',
     onClick: () => {
       if (!run.executionPlan) {
@@ -234,7 +234,7 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
           disabled={pipelineError?.disabled || !canLaunchPipelineReexecution}
         />
       </Box>
-      <CancelRunButton run={run} isFinalStatus={!doneStatuses.has(run.status)} />
+      <CancelRunButton run={run} isFinalStatus={canRunAllSteps(run)} />
     </Group>
   );
 };

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtonsTestQuery.ts
@@ -1,0 +1,113 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunStatus, StepKind, StepEventStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: RunActionButtonsTestQuery
+// ====================================================
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_RunNotFoundError {
+  __typename: "RunNotFoundError" | "PythonError";
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_tags {
+  __typename: "PipelineTag";
+  key: string;
+  value: string;
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan_steps_inputs_dependsOn {
+  __typename: "ExecutionStep";
+  key: string;
+  kind: StepKind;
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan_steps_inputs {
+  __typename: "ExecutionStepInput";
+  dependsOn: RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan_steps_inputs_dependsOn[];
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan_steps {
+  __typename: "ExecutionStep";
+  key: string;
+  kind: StepKind;
+  inputs: RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan_steps_inputs[];
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan {
+  __typename: "ExecutionPlan";
+  artifactsPersisted: boolean;
+  steps: RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan_steps[];
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_repositoryOrigin {
+  __typename: "RepositoryOrigin";
+  id: string;
+  repositoryName: string;
+  repositoryLocationName: string;
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stats_PythonError {
+  __typename: "PythonError";
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stats_RunStatsSnapshot {
+  __typename: "RunStatsSnapshot";
+  id: string;
+  endTime: number | null;
+  startTime: number | null;
+}
+
+export type RunActionButtonsTestQuery_pipelineRunOrError_Run_stats = RunActionButtonsTestQuery_pipelineRunOrError_Run_stats_PythonError | RunActionButtonsTestQuery_pipelineRunOrError_Run_stats_RunStatsSnapshot;
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats_attempts {
+  __typename: "RunMarker";
+  startTime: number | null;
+  endTime: number | null;
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats_markers {
+  __typename: "RunMarker";
+  startTime: number | null;
+  endTime: number | null;
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  status: StepEventStatus | null;
+  startTime: number | null;
+  endTime: number | null;
+  attempts: RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats_attempts[];
+  markers: RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats_markers[];
+}
+
+export interface RunActionButtonsTestQuery_pipelineRunOrError_Run {
+  __typename: "Run";
+  id: string;
+  runConfig: any;
+  runId: string;
+  canTerminate: boolean;
+  status: RunStatus;
+  mode: string;
+  tags: RunActionButtonsTestQuery_pipelineRunOrError_Run_tags[];
+  rootRunId: string | null;
+  parentRunId: string | null;
+  pipelineName: string;
+  solidSelection: string[] | null;
+  pipelineSnapshotId: string | null;
+  executionPlan: RunActionButtonsTestQuery_pipelineRunOrError_Run_executionPlan | null;
+  stepKeysToExecute: string[] | null;
+  repositoryOrigin: RunActionButtonsTestQuery_pipelineRunOrError_Run_repositoryOrigin | null;
+  stats: RunActionButtonsTestQuery_pipelineRunOrError_Run_stats;
+  stepStats: RunActionButtonsTestQuery_pipelineRunOrError_Run_stepStats[];
+}
+
+export type RunActionButtonsTestQuery_pipelineRunOrError = RunActionButtonsTestQuery_pipelineRunOrError_RunNotFoundError | RunActionButtonsTestQuery_pipelineRunOrError_Run;
+
+export interface RunActionButtonsTestQuery {
+  pipelineRunOrError: RunActionButtonsTestQuery_pipelineRunOrError;
+}

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^17.0.2"
   },
   "dependencies": {
+    "react-is": "^17.0.2",
     "react-markdown": "6.0.3",
     "remark": "13.x",
     "remark-gfm": "1.0.0",

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5396,6 +5396,7 @@ __metadata:
     eslint-webpack-plugin: 3.1.1
     file-loader: 6.1.1
     fs-extra: ^9.0.1
+    graphql: ^15.5.0
     html-webpack-plugin: 4.5.0
     jest: 26.6.0
     jest-circus: 26.6.0
@@ -5538,7 +5539,7 @@ __metadata:
     react-virtualized: ^9.22.3
     rgb-hex: ^4.0.0
     source-map-explorer: ^2.5.0
-    styled-components: ^5.2.1
+    styled-components: ^5.3.3
     subscriptions-transport-ws: ^0.9.15
     ts-node: 9.1.1
     ts-prune: 0.8.9
@@ -5556,6 +5557,7 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     react-router-dom: ^5.1.2
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -5620,6 +5622,7 @@ __metadata:
     eslint-plugin-storybook: ^0.5.5
     jest: ^27.4.7
     nearest-color: ^0.4.4
+    react-is: ^17.0.2
     react-markdown: 6.0.3
     remark: 13.x
     remark-gfm: 1.0.0
@@ -27809,28 +27812,6 @@ resolve@^2.0.0-next.3:
   dependencies:
     inline-style-parser: 0.1.1
   checksum: 4d7084015207f2a606dfc10c29cb5ba569f2fe8005551df7396110dd694d6ff650f2debafa95bd5d147dfb4ca50f57868e2a7f91bf5d11ef734fe7ccbd7abf59
-  languageName: node
-  linkType: hard
-
-"styled-components@npm:^5.2.1":
-  version: 5.2.3
-  resolution: "styled-components@npm:5.2.3"
-  dependencies:
-    "@babel/helper-module-imports": ^7.0.0
-    "@babel/traverse": ^7.4.5
-    "@emotion/is-prop-valid": ^0.8.8
-    "@emotion/stylis": ^0.8.4
-    "@emotion/unitless": ^0.7.4
-    babel-plugin-styled-components: ">= 1.12.0"
-    css-to-react-native: ^3.0.0
-    hoist-non-react-statics: ^3.0.0
-    shallowequal: ^1.1.0
-    supports-color: ^5.5.0
-  peerDependencies:
-    react: ">= 16.8.0"
-    react-dom: ">= 16.8.0"
-    react-is: ">= 16.8.0"
-  checksum: 12e5cc02b8edf3caceffd2d4e323a617b1eb5de2b4073e09acedc5b75f9b05c9493de5434de3d38dd28a2d759e9cd7d03f7fb3d0185f632c6fe848cbb962a732
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves #6160.

I accidentally flipped a boolean for the run Termination button.

Also cleaning up some dependency issues that showed up during testing, namely a repeated installation of `styled-components` in the yarn workspace that needed to be ironed out. I might need to do another pass through the deps in the workspace tree to make sure there aren't anymore of these.

## Test Plan

Run Dagit, view an in-progress run. Verify that the termination button is present and functional. View a completed run, verify that it is not.
