### PR TITLE
[docs] correct fivetran docstring in sync_and_poll

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -286,7 +286,7 @@ class FivetranResource:
                 out. By default, this will never time out.
 
         Returns:
-            :py:class:`~DbtCloudOutput`:
+            :py:class:`~FivetranOutput`:
                 Object containing details about the connector and the tables it updates
         """
         schema_config = self.get_connector_schema_config(connector_id)


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Only correct the return type in docstring in Fivetran connector.




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.