### PR TITLE
Remove has_permission abstract method on process context

### DIFF
--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -302,7 +302,11 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
         return self._process_context.permissions
 
     def has_permission(self, permission: str) -> bool:
-        return self._process_context.has_permission(permission)
+        permissions = self._process_context.permissions
+        check.invariant(
+            permission in permissions, f"Permission {permission} not listed in permissions map"
+        )
+        return permissions[permission]
 
 
 class IWorkspaceProcessContext(ABC):
@@ -322,10 +326,6 @@ class IWorkspaceProcessContext(ABC):
                 The source of the request, such as an object representing the web request
                 or http connection.
         """
-
-    @abstractmethod
-    def has_permission(self, permission: str) -> bool:
-        pass
 
     @property
     @abstractmethod
@@ -491,13 +491,6 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
     @property
     def permissions(self) -> Dict[str, bool]:
         return get_user_permissions(self)
-
-    def has_permission(self, permission: str) -> bool:
-        permissions = self.permissions
-        check.invariant(
-            permission in permissions, f"Permission {permission} not listed in permissions map"
-        )
-        return permissions[permission]
 
     @property
     def version(self) -> str:


### PR DESCRIPTION
Summary:
Permissions only need to be checked at the request level, not the process level.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.