### PR TITLE
make asset partitions available on context objects

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -10889,6 +10889,19 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         },
         "type_param_keys": null
       },
+      "Permissive": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [],
+        "given_name": null,
+        "key": "Permissive",
+        "kind": {
+          "__enum__": "ConfigTypeKind.PERMISSIVE_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -11286,50 +11299,6 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.2f685c21666300490477185b19cda395e65a0a99": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"inputs\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "first_asset",
-            "type_key": "Shape.ec5afc1dbe49562b0b7ea7258a9d0f15a5081f63"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "hanging_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "never_runs_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.2f685c21666300490477185b19cda395e65a0a99",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
       "Shape.3baab16166bacfaf4705811e64d356112fd733cb": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -11347,6 +11316,73 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         ],
         "given_name": null,
         "key": "Shape.3baab16166bacfaf4705811e64d356112fd733cb",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.3e82e1b335a3dbc2b84542d9c4e6cbfe1555dae0": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"assets\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "inputs",
+            "type_key": "Shape.6d54715173bb030786220dac04f632dfdbb95d11"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "outputs",
+            "type_key": "Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.3e82e1b335a3dbc2b84542d9c4e6cbfe1555dae0",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "assets",
+            "type_key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -11578,6 +11614,91 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.b1c25327b554a944f02507f816dd374b9fffada5": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "execution",
+            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "loggers",
+            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"first_asset\\": {\\"config\\": {\\"assets\\": {}}, \\"inputs\\": {}}, \\"hanging_asset\\": {\\"config\\": {\\"assets\\": {}}}, \\"never_runs_asset\\": {\\"config\\": {\\"assets\\": {}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "ops",
+            "type_key": "Shape.f53bf4147126cf923d5d50ae10b571a83c31c236"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": true,
+            "name": "resources",
+            "type_key": "Shape.ce80c8878e9f80d953f9042fe3a1b65fbc57abb0"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.b1c25327b554a944f02507f816dd374b9fffada5",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "input_partitions",
+            "type_key": "Permissive"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "output_partitions",
+            "type_key": "Permissive"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.ce80c8878e9f80d953f9042fe3a1b65fbc57abb0": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -11632,7 +11753,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5": {
+      "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -11642,12 +11763,12 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"assets\\": {}}",
             "description": null,
             "is_required": false,
             "name": "config",
-            "type_key": "Any"
+            "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -11660,7 +11781,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5",
+        "key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -11690,51 +11811,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.ec5afc1dbe49562b0b7ea7258a9d0f15a5081f63": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "inputs",
-            "type_key": "Shape.6d54715173bb030786220dac04f632dfdbb95d11"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "outputs",
-            "type_key": "Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.ec5afc1dbe49562b0b7ea7258a9d0f15a5081f63",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
-      "Shape.f367b67267b38f41194c45fc59bc4bd8acbb45eb": {
+      "Shape.f53bf4147126cf923d5d50ae10b571a83c31c236": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -11745,42 +11822,33 @@ snapshots['test_all_snapshot_ids 25'] = '''{
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}, \\"inputs\\": {}}",
             "description": null,
             "is_required": false,
-            "name": "execution",
-            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+            "name": "first_asset",
+            "type_key": "Shape.3e82e1b335a3dbc2b84542d9c4e6cbfe1555dae0"
           },
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{}",
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
             "description": null,
             "is_required": false,
-            "name": "loggers",
-            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+            "name": "hanging_asset",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
           },
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{\\"first_asset\\": {\\"inputs\\": {}}, \\"hanging_asset\\": {}, \\"never_runs_asset\\": {}}",
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
             "description": null,
             "is_required": false,
-            "name": "ops",
-            "type_key": "Shape.2f685c21666300490477185b19cda395e65a0a99"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": true,
-            "name": "resources",
-            "type_key": "Shape.ce80c8878e9f80d953f9042fe3a1b65fbc57abb0"
+            "name": "never_runs_asset",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
           }
         ],
         "given_name": null,
-        "key": "Shape.f367b67267b38f41194c45fc59bc4bd8acbb45eb",
+        "key": "Shape.f53bf4147126cf923d5d50ae10b571a83c31c236",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -12023,7 +12091,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
           "name": "root_manager"
         }
       ],
-      "root_config_key": "Shape.f367b67267b38f41194c45fc59bc4bd8acbb45eb"
+      "root_config_key": "Shape.b1c25327b554a944f02507f816dd374b9fffada5"
     }
   ],
   "name": "hanging_job",
@@ -12035,12 +12103,12 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [
@@ -12069,12 +12137,12 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": "Asset that hangs forever, used to test in-progress ops.",
         "input_def_snaps": [
@@ -12105,12 +12173,12 @@ snapshots['test_all_snapshot_ids 25'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [
@@ -12140,7 +12208,7 @@ snapshots['test_all_snapshot_ids 25'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 26'] = '98ad0b43581c28e71f5f1553a32cccf259974d25'
+snapshots['test_all_snapshot_ids 26'] = 'eb3ec98db700ac28820e308a5e86077aa0237186'
 
 snapshots['test_all_snapshot_ids 27'] = '''{
   "__class__": "PipelineSnapshot",
@@ -30255,6 +30323,19 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         },
         "type_param_keys": null
       },
+      "Permissive": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [],
+        "given_name": null,
+        "key": "Permissive",
+        "kind": {
+          "__enum__": "ConfigTypeKind.PERMISSIVE_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -30643,6 +30724,29 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "assets",
+            "type_key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.41de0e2d7b75524510155d0bdab8723c6feced3b": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -30683,6 +30787,32 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         ],
         "given_name": null,
         "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.5592faa25ec1a64904a69cac388ede7438da6e21": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
+            "description": null,
+            "is_required": false,
+            "name": "yield_partition_materialization",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.5592faa25ec1a64904a69cac388ede7438da6e21",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -30744,7 +30874,7 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.8501986951105a6034f11b54455f881b958d9e35": {
+      "Shape.9743ce507aef32803fdd7a3729b99e0a71d6c188": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -30773,11 +30903,11 @@ snapshots['test_all_snapshot_ids 55'] = '''{
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{\\"yield_partition_materialization\\": {}}",
+            "default_value_as_json_str": "{\\"yield_partition_materialization\\": {\\"config\\": {\\"assets\\": {}}}}",
             "description": null,
             "is_required": false,
             "name": "ops",
-            "type_key": "Shape.a84f81f2a10b45ef698acc4beeb6968b60a72503"
+            "type_key": "Shape.5592faa25ec1a64904a69cac388ede7438da6e21"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -30790,7 +30920,7 @@ snapshots['test_all_snapshot_ids 55'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.8501986951105a6034f11b54455f881b958d9e35",
+        "key": "Shape.9743ce507aef32803fdd7a3729b99e0a71d6c188",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -30829,32 +30959,6 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.a84f81f2a10b45ef698acc4beeb6968b60a72503": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "yield_partition_materialization",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.a84f81f2a10b45ef698acc4beeb6968b60a72503",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
       "Shape.ca5906d9a0377218b4ee7d940ad55957afa73d1b": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -30878,6 +30982,38 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "input_partitions",
+            "type_key": "Permissive"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "output_partitions",
+            "type_key": "Permissive"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -30891,7 +31027,7 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5": {
+      "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -30901,12 +31037,12 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"assets\\": {}}",
             "description": null,
             "is_required": false,
             "name": "config",
-            "type_key": "Any"
+            "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -30919,7 +31055,7 @@ snapshots['test_all_snapshot_ids 55'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5",
+        "key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -31122,7 +31258,7 @@ snapshots['test_all_snapshot_ids 55'] = '''{
           "name": "root_manager"
         }
       ],
-      "root_config_key": "Shape.8501986951105a6034f11b54455f881b958d9e35"
+      "root_config_key": "Shape.9743ce507aef32803fdd7a3729b99e0a71d6c188"
     }
   ],
   "name": "partition_materialization_job",
@@ -31134,12 +31270,12 @@ snapshots['test_all_snapshot_ids 55'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [],
@@ -31162,7 +31298,7 @@ snapshots['test_all_snapshot_ids 55'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 56'] = 'db2e1d2f727eb0b04e0464b654d77f4281058a12'
+snapshots['test_all_snapshot_ids 56'] = 'f3a60f7bddced697d157d531bc8e945cd4a548eb'
 
 snapshots['test_all_snapshot_ids 57'] = '''{
   "__class__": "PipelineSnapshot",
@@ -49681,6 +49817,19 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         },
         "type_param_keys": null
       },
+      "Permissive": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [],
+        "given_name": null,
+        "key": "Permissive",
+        "kind": {
+          "__enum__": "ConfigTypeKind.PERMISSIVE_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -50101,6 +50250,29 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "assets",
+            "type_key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.41de0e2d7b75524510155d0bdab8723c6feced3b": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -50147,6 +50319,59 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.6bbb617caf3412e51743bb34aaae0349e9d8c899": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "execution",
+            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "loggers",
+            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"downstream_static_partitioned_asset\\": {\\"config\\": {\\"assets\\": {}}}, \\"upstream_static_partitioned_asset\\": {\\"config\\": {\\"assets\\": {}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "ops",
+            "type_key": "Shape.d1d0be17df836fd3955284404a7c6179490dbc5d"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"io_manager\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "resources",
+            "type_key": "Shape.788ec0f863e3898904af5781d72def73bfd11e55"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.6bbb617caf3412e51743bb34aaae0349e9d8c899",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -50164,41 +50389,6 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         ],
         "given_name": null,
         "key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
-      "Shape.72717f039c455d8695122ff885a8f039a01b70f1": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "downstream_static_partitioned_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "upstream_static_partitioned_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.72717f039c455d8695122ff885a8f039a01b70f1",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -50324,7 +50514,39 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.c244ab8da2667a8dd21c7b573d3ae4fe247f12d8": {
+      "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "input_partitions",
+            "type_key": "Permissive"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "output_partitions",
+            "type_key": "Permissive"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.d1d0be17df836fd3955284404a7c6179490dbc5d": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -50335,42 +50557,24 @@ snapshots['test_all_snapshot_ids 87'] = '''{
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
             "description": null,
             "is_required": false,
-            "name": "execution",
-            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+            "name": "downstream_static_partitioned_asset",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
           },
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{}",
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
             "description": null,
             "is_required": false,
-            "name": "loggers",
-            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"downstream_static_partitioned_asset\\": {}, \\"upstream_static_partitioned_asset\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "ops",
-            "type_key": "Shape.72717f039c455d8695122ff885a8f039a01b70f1"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"io_manager\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "resources",
-            "type_key": "Shape.788ec0f863e3898904af5781d72def73bfd11e55"
+            "name": "upstream_static_partitioned_asset",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
           }
         ],
         "given_name": null,
-        "key": "Shape.c244ab8da2667a8dd21c7b573d3ae4fe247f12d8",
+        "key": "Shape.d1d0be17df836fd3955284404a7c6179490dbc5d",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -50390,7 +50594,7 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5": {
+      "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -50400,12 +50604,12 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"assets\\": {}}",
             "description": null,
             "is_required": false,
             "name": "config",
-            "type_key": "Any"
+            "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -50418,7 +50622,7 @@ snapshots['test_all_snapshot_ids 87'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5",
+        "key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -50642,7 +50846,7 @@ snapshots['test_all_snapshot_ids 87'] = '''{
           "name": "root_manager"
         }
       ],
-      "root_config_key": "Shape.c244ab8da2667a8dd21c7b573d3ae4fe247f12d8"
+      "root_config_key": "Shape.6bbb617caf3412e51743bb34aaae0349e9d8c899"
     }
   ],
   "name": "static_partitioned_assets_job",
@@ -50654,12 +50858,12 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [
@@ -50688,12 +50892,12 @@ snapshots['test_all_snapshot_ids 87'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [],
@@ -50716,7 +50920,7 @@ snapshots['test_all_snapshot_ids 87'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 88'] = '1bed3b563e8c3b21e5eda5b5c781c55a73565933'
+snapshots['test_all_snapshot_ids 88'] = 'f0b8d5a94c9cc7ef849bb0ec1956ae81cc718b51'
 
 snapshots['test_all_snapshot_ids 89'] = '''{
   "__class__": "PipelineSnapshot",
@@ -53014,6 +53218,19 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         },
         "type_param_keys": null
       },
+      "Permissive": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [],
+        "given_name": null,
+        "key": "Permissive",
+        "kind": {
+          "__enum__": "ConfigTypeKind.PERMISSIVE_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -53434,6 +53651,29 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "assets",
+            "type_key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.41de0e2d7b75524510155d0bdab8723c6feced3b": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -53474,6 +53714,41 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         ],
         "given_name": null,
         "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.579e7b027a595dc55751c8ada1f2ccc09779b63a": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
+            "description": null,
+            "is_required": false,
+            "name": "downstream_time_partitioned_asset",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
+            "description": null,
+            "is_required": false,
+            "name": "upstream_time_partitioned_asset",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.579e7b027a595dc55751c8ada1f2ccc09779b63a",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -53558,59 +53833,6 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.94ee84d7eeed48c6e56fb146b6fcbd6349ebc7be": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
-            "description": null,
-            "is_required": false,
-            "name": "execution",
-            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "loggers",
-            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"downstream_time_partitioned_asset\\": {}, \\"upstream_time_partitioned_asset\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "ops",
-            "type_key": "Shape.e5e7df24329d8b3bdb1f4cdefbd6bca89e67df9f"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"io_manager\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "resources",
-            "type_key": "Shape.788ec0f863e3898904af5781d72def73bfd11e55"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.94ee84d7eeed48c6e56fb146b6fcbd6349ebc7be",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
       "Shape.979b3d2fece4f3eb92e90f2ec9fb4c85efe9ea5c": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -53675,6 +53897,91 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.b39d2c83a487c3bc80a600bac3b3d216b898f4da": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "execution",
+            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "loggers",
+            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"downstream_time_partitioned_asset\\": {\\"config\\": {\\"assets\\": {}}}, \\"upstream_time_partitioned_asset\\": {\\"config\\": {\\"assets\\": {}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "ops",
+            "type_key": "Shape.579e7b027a595dc55751c8ada1f2ccc09779b63a"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"io_manager\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "resources",
+            "type_key": "Shape.788ec0f863e3898904af5781d72def73bfd11e55"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.b39d2c83a487c3bc80a600bac3b3d216b898f4da",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "input_partitions",
+            "type_key": "Permissive"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "output_partitions",
+            "type_key": "Permissive"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -53688,7 +53995,7 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5": {
+      "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -53698,12 +54005,12 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"assets\\": {}}",
             "description": null,
             "is_required": false,
             "name": "config",
-            "type_key": "Any"
+            "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -53716,42 +54023,7 @@ snapshots['test_all_snapshot_ids 91'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
-      "Shape.e5e7df24329d8b3bdb1f4cdefbd6bca89e67df9f": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "downstream_time_partitioned_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "upstream_time_partitioned_asset",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.e5e7df24329d8b3bdb1f4cdefbd6bca89e67df9f",
+        "key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -53975,7 +54247,7 @@ snapshots['test_all_snapshot_ids 91'] = '''{
           "name": "root_manager"
         }
       ],
-      "root_config_key": "Shape.94ee84d7eeed48c6e56fb146b6fcbd6349ebc7be"
+      "root_config_key": "Shape.b39d2c83a487c3bc80a600bac3b3d216b898f4da"
     }
   ],
   "name": "time_partitioned_assets_job",
@@ -53987,12 +54259,12 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [
@@ -54021,12 +54293,12 @@ snapshots['test_all_snapshot_ids 91'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [],
@@ -54049,7 +54321,7 @@ snapshots['test_all_snapshot_ids 91'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 92'] = 'c5f2b8b61a87d8d6adb8d1f6ee3f9aa2bd6aba9a'
+snapshots['test_all_snapshot_ids 92'] = '5727f364f4b5afe1d42752e478787b42915f5b62'
 
 snapshots['test_all_snapshot_ids 93'] = '''{
   "__class__": "PipelineSnapshot",
@@ -54127,6 +54399,19 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "scalar_kind": {
           "__enum__": "ConfigScalarKind.INT"
         },
+        "type_param_keys": null
+      },
+      "Permissive": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [],
+        "given_name": null,
+        "key": "Permissive",
+        "kind": {
+          "__enum__": "ConfigTypeKind.PERMISSIVE_SHAPE"
+        },
+        "scalar_kind": null,
         "type_param_keys": null
       },
       "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
@@ -54494,59 +54779,6 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.0cc07de7e56ffd31b9050ba1af40f3d9c0cefbfa": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
-            "description": null,
-            "is_required": false,
-            "name": "execution",
-            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "loggers",
-            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"asset_one\\": {}, \\"asset_two\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "ops",
-            "type_key": "Shape.7ac7d1537ebd44f8f0d2d06b43e2c82804bdfb88"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{\\"io_manager\\": {}}",
-            "description": null,
-            "is_required": false,
-            "name": "resources",
-            "type_key": "Shape.788ec0f863e3898904af5781d72def73bfd11e55"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.0cc07de7e56ffd31b9050ba1af40f3d9c0cefbfa",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
       "Shape.241ac489ffa5f718db6444bae7849fb86a62e441": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -54596,6 +54828,29 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         ],
         "given_name": null,
         "key": "Shape.3baab16166bacfaf4705811e64d356112fd733cb",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "assets",
+            "type_key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -54726,41 +54981,6 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.7ac7d1537ebd44f8f0d2d06b43e2c82804bdfb88": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "asset_one",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "asset_two",
-            "type_key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.7ac7d1537ebd44f8f0d2d06b43e2c82804bdfb88",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
       "Shape.979b3d2fece4f3eb92e90f2ec9fb4c85efe9ea5c": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -54825,6 +55045,126 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
+      "Shape.c00b7646bc5339cff1920a8df0cfddf2fcde42e2": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
+            "description": null,
+            "is_required": false,
+            "name": "asset_one",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"assets\\": {}}}",
+            "description": null,
+            "is_required": false,
+            "name": "asset_two",
+            "type_key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.c00b7646bc5339cff1920a8df0cfddf2fcde42e2",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "input_partitions",
+            "type_key": "Permissive"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "output_partitions",
+            "type_key": "Permissive"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.ca9d191bc601d7df07b309fbcc1a5848eafee07a",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.d6c3dc7648f5588a36d3d58134afd0bf15dbb709": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"config\\": {\\"multiprocess\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "execution",
+            "type_key": "Shape.6eed5e43812fc2db07a53a5c86abfa02ef577154"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "loggers",
+            "type_key": "Shape.ebeaf4550c200fb540f2e1f3f2110debd8c4157c"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"asset_one\\": {\\"config\\": {\\"assets\\": {}}}, \\"asset_two\\": {\\"config\\": {\\"assets\\": {}}}}",
+            "description": null,
+            "is_required": false,
+            "name": "ops",
+            "type_key": "Shape.c00b7646bc5339cff1920a8df0cfddf2fcde42e2"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"io_manager\\": {}}",
+            "description": null,
+            "is_required": false,
+            "name": "resources",
+            "type_key": "Shape.788ec0f863e3898904af5781d72def73bfd11e55"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.d6c3dc7648f5588a36d3d58134afd0bf15dbb709",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
       "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
         "__class__": "ConfigTypeSnap",
         "description": null,
@@ -54838,7 +55178,7 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5": {
+      "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -54848,12 +55188,12 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "fields": [
           {
             "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
+            "default_provided": true,
+            "default_value_as_json_str": "{\\"assets\\": {}}",
             "description": null,
             "is_required": false,
             "name": "config",
-            "type_key": "Any"
+            "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -54866,7 +55206,7 @@ snapshots['test_all_snapshot_ids 93'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.e20183fcf9f186a6569b322579dcc1e6fae8d0d5",
+        "key": "Shape.de7a778abb11df13f7d18c8ea327e21f3a17e14e",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -55090,7 +55430,7 @@ snapshots['test_all_snapshot_ids 93'] = '''{
           "name": "root_manager"
         }
       ],
-      "root_config_key": "Shape.0cc07de7e56ffd31b9050ba1af40f3d9c0cefbfa"
+      "root_config_key": "Shape.d6c3dc7648f5588a36d3d58134afd0bf15dbb709"
     }
   ],
   "name": "two_assets_job",
@@ -55102,12 +55442,12 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [],
@@ -55129,12 +55469,12 @@ snapshots['test_all_snapshot_ids 93'] = '''{
         "__class__": "SolidDefSnap",
         "config_field_snap": {
           "__class__": "ConfigFieldSnap",
-          "default_provided": false,
-          "default_value_as_json_str": null,
+          "default_provided": true,
+          "default_value_as_json_str": "{\\"assets\\": {}}",
           "description": null,
           "is_required": false,
           "name": "config",
-          "type_key": "Any"
+          "type_key": "Shape.4190c6873afddcfd2b8e5c79671674bc3a3286e6"
         },
         "description": null,
         "input_def_snaps": [
@@ -55164,7 +55504,7 @@ snapshots['test_all_snapshot_ids 93'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 94'] = 'fefe65543162c9d87c6a875574318f3fcb2a82fd'
+snapshots['test_all_snapshot_ids 94'] = 'e8ec5d96ca4c8e3666f7f4fd542968b644735c39'
 
 snapshots['test_all_snapshot_ids 95'] = '''{
   "__class__": "PipelineSnapshot",

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -15,6 +15,7 @@ from dagster.core.definitions.job_definition import JobDefinition
 from dagster.core.definitions.op_definition import OpDefinition
 from dagster.core.definitions.output import Out, OutputDefinition
 from dagster.core.definitions.partition import PartitionedConfig, PartitionsDefinition
+from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.resource_definition import ResourceDefinition
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.execution.context.input import InputContext, build_input_context
@@ -24,6 +25,7 @@ from dagster.utils.backcompat import experimental
 from dagster.utils.merger import merge_dicts
 
 from .asset import AssetsDefinition
+from .asset_partitions import get_upstream_partitions_for_partition_range
 from .foreign_asset import ForeignAsset
 
 
@@ -101,25 +103,78 @@ def build_job_partitions_from_assets(
     assets: Sequence[AssetsDefinition],
 ) -> Optional[PartitionedConfig]:
     assets_with_partitions_defs = [assets_def for assets_def in assets if assets_def.partitions_def]
-    if assets_with_partitions_defs:
-        for assets_def in assets_with_partitions_defs:
-            if assets_def.partitions_def != assets_with_partitions_defs[0].partitions_def:
-                first_asset_key = next(iter(assets_def.asset_keys)).to_string()
-                second_asset_key = next(iter(assets_with_partitions_defs[0].asset_keys)).to_string()
-                raise DagsterInvalidDefinitionError(
-                    "When an assets job contains multiple partitions assets, they must have the "
-                    f"same partitions definitions, but asset '{first_asset_key}' and asset "
-                    f"'{second_asset_key}' have different partitions definitions. "
-                )
 
-        return PartitionedConfig(
-            partitions_def=cast(
-                PartitionsDefinition, assets_with_partitions_defs[0].partitions_def
-            ),
-            run_config_for_partition_fn=lambda p: {},
-        )
-    else:
+    if len(assets_with_partitions_defs) == 0:
         return None
+
+    for assets_def in assets_with_partitions_defs:
+        if assets_def.partitions_def != assets_with_partitions_defs[0].partitions_def:
+            first_asset_key = next(iter(assets_def.asset_keys)).to_string()
+            second_asset_key = next(iter(assets_with_partitions_defs[0].asset_keys)).to_string()
+            raise DagsterInvalidDefinitionError(
+                "When an assets job contains multiple partitions assets, they must have the "
+                f"same partitions definitions, but asset '{first_asset_key}' and asset "
+                f"'{second_asset_key}' have different partitions definitions. "
+            )
+
+    assets_defs_by_asset_key = {
+        asset_key: assets_def for assets_def in assets for asset_key in assets_def.asset_keys
+    }
+
+    def asset_partitions_for_job_partition(
+        job_partition_key: str,
+    ) -> Mapping[AssetKey, PartitionKeyRange]:
+        return {
+            asset_key: PartitionKeyRange(job_partition_key, job_partition_key)
+            for assets_def in assets
+            for asset_key in assets_def.asset_keys
+            if assets_def.partitions_def
+        }
+
+    def run_config_for_partition_fn(partition_key: str) -> Dict[str, Any]:
+        ops_config: Dict[str, Any] = {}
+        asset_partitions_by_asset_key = asset_partitions_for_job_partition(partition_key)
+
+        for assets_def in assets:
+            outputs_dict: Dict[str, Dict[str, Any]] = {}
+            if assets_def.partitions_def is not None:
+                for asset_key, output_def in assets_def.output_defs_by_asset_key.items():
+                    asset_partition_key_range = asset_partitions_by_asset_key[asset_key]
+                    outputs_dict[output_def.name] = {
+                        "start": asset_partition_key_range.start,
+                        "end": asset_partition_key_range.end,
+                    }
+
+            inputs_dict: Dict[str, Dict[str, Any]] = {}
+            for in_asset_key, input_def in assets_def.input_defs_by_asset_key.items():
+                upstream_assets_def = assets_defs_by_asset_key[in_asset_key]
+                if (
+                    assets_def.partitions_def is not None
+                    and upstream_assets_def.partitions_def is not None
+                ):
+                    upstream_partition_key_range = get_upstream_partitions_for_partition_range(
+                        assets_def, upstream_assets_def, in_asset_key, asset_partition_key_range
+                    )
+                    inputs_dict[input_def.name] = {
+                        "start": upstream_partition_key_range.start,
+                        "end": upstream_partition_key_range.end,
+                    }
+
+            ops_config[assets_def.op.name] = {
+                "config": {
+                    "assets": {
+                        "input_partitions": inputs_dict,
+                        "output_partitions": outputs_dict,
+                    }
+                }
+            }
+
+        return {"ops": ops_config}
+
+    return PartitionedConfig(
+        partitions_def=cast(PartitionsDefinition, assets_with_partitions_defs[0].partitions_def),
+        run_config_for_partition_fn=lambda p: run_config_for_partition_fn(p.name),
+    )
 
 
 def build_source_assets_by_key(

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -107,10 +107,11 @@ def build_job_partitions_from_assets(
     if len(assets_with_partitions_defs) == 0:
         return None
 
+    first_assets_with_partitions_def = assets_with_partitions_defs[0]
     for assets_def in assets_with_partitions_defs:
-        if assets_def.partitions_def != assets_with_partitions_defs[0].partitions_def:
+        if assets_def.partitions_def != first_assets_with_partitions_def.partitions_def:
             first_asset_key = next(iter(assets_def.asset_keys)).to_string()
-            second_asset_key = next(iter(assets_with_partitions_defs[0].asset_keys)).to_string()
+            second_asset_key = next(iter(first_assets_with_partitions_def.asset_keys)).to_string()
             raise DagsterInvalidDefinitionError(
                 "When an assets job contains multiple partitions assets, they must have the "
                 f"same partitions definitions, but asset '{first_asset_key}' and asset "
@@ -172,7 +173,7 @@ def build_job_partitions_from_assets(
         return {"ops": ops_config}
 
     return PartitionedConfig(
-        partitions_def=cast(PartitionsDefinition, assets_with_partitions_defs[0].partitions_def),
+        partitions_def=cast(PartitionsDefinition, first_assets_with_partitions_def.partitions_def),
         run_config_for_partition_fn=lambda p: run_config_for_partition_fn(p.name),
     )
 

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Set
 
 from dagster import check
 from dagster.builtins import Nothing
+from dagster.config import Field
 from dagster.core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster.core.definitions.decorators.op import _Op
 from dagster.core.definitions.events import AssetKey
@@ -157,6 +158,12 @@ class _Asset:
             out=out,
             required_resource_keys=self.required_resource_keys,
             tags={"kind": self.compute_kind} if self.compute_kind else None,
+            config_schema={
+                "assets": {
+                    "input_partitions": Field(dict, is_required=False),
+                    "output_partitions": Field(dict, is_required=False),
+                }
+            },
         )(fn)
 
         out_asset_key = AssetKey(list(filter(None, [self.namespace, asset_name])))

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -160,6 +160,10 @@ class OutputDefinition:
         return self._asset_key is not None
 
     @property
+    def asset_partitions_def(self):
+        return self._asset_partitions_def
+
+    @property
     def hardcoded_asset_key(self) -> Optional[AssetKey]:
         if not callable(self._asset_key):
             return self._asset_key

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -209,6 +209,12 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.partition_key
 
+    def output_asset_partition_key(self, output_name: str = "result") -> str:
+        """Returns the asset partition key for the given output. Defaults to "result", which is the
+        name of the default output.
+        """
+        return self._step_execution_context.asset_partition_key_for_output(output_name)
+
     def has_tag(self, key: str) -> bool:
         """Check if a logging tag is set.
 

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -93,10 +93,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
 
     @property
     def solid_config(self) -> Any:
-        solid_config = self._step_execution_context.resolved_run_config.solids.get(
-            str(self.solid_handle)
-        )
-        return solid_config.config if solid_config else None
+        return self._step_execution_context.op_config
 
     @property
     def pipeline_run(self) -> PipelineRun:

--- a/python_modules/dagster/dagster/core/execution/context/input.py
+++ b/python_modules/dagster/dagster/core/execution/context/input.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 from dagster import check
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.op_definition import OpDefinition
+from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.solid_definition import SolidDefinition
 from dagster.core.errors import DagsterInvariantViolationError
 
@@ -223,6 +224,27 @@ class InputContext:
         Raises an error if the current run is not a partitioned run.
         """
         return self.step_context.partition_key
+
+    @property
+    def has_asset_partitions(self) -> bool:
+        return self.step_context.has_asset_partitions_for_input(self.name)
+
+    @property
+    def asset_partition_key(self) -> str:
+        """The partition key for input asset.
+
+        Raises an error if the input asset has no partitioning, or if the run covers a partition
+        range for the input asset.
+        """
+        return self.step_context.asset_partition_key_for_input(self.name)
+
+    @property
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        """The partition key range for input asset.
+
+        Raises an error if the input asset has no partitioning.
+        """
+        return self.step_context.asset_partition_key_range_for_input(self.name)
 
 
 def build_input_context(

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 from dagster import check
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.op_definition import OpDefinition
+from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.solid_definition import SolidDefinition
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.plan.utils import build_resources_for_manager
@@ -255,6 +256,27 @@ class OutputContext:
         Raises an error if the current run is not a partitioned run.
         """
         return self.step_context.partition_key
+
+    @property
+    def has_asset_partitions(self) -> bool:
+        return self.step_context.has_asset_partitions_for_output(self.name)
+
+    @property
+    def asset_partition_key(self) -> str:
+        """The partition key for output asset.
+
+        Raises an error if the output asset has no partitioning, or if the run covers a partition
+        range for the output asset.
+        """
+        return self.step_context.asset_partition_key_for_output(self.name)
+
+    @property
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        """The partition key range for output asset.
+
+        Raises an error if the output asset has no partitioning.
+        """
+        return self.step_context.asset_partition_key_range_for_output(self.name)
 
     def get_run_scoped_output_identifier(self) -> List[str]:
         """Utility method to get a collection of identifiers that as a whole represent a unique

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -11,6 +11,7 @@ from dagster import check
 from dagster.core.definitions.hook_definition import HookDefinition
 from dagster.core.definitions.mode import ModeDefinition
 from dagster.core.definitions.op_definition import OpDefinition
+from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.pipeline_base import IPipeline
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
 from dagster.core.definitions.policy import RetryPolicy
@@ -553,6 +554,79 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
     @property
     def previous_attempt_count(self) -> int:
         return self._previous_attempt_count
+
+    @property
+    def op_config(self) -> Any:
+        solid_config = self.resolved_run_config.solids.get(str(self.solid_handle))
+        return solid_config.config if solid_config else None
+
+    def has_asset_partitions_for_input(self, input_name: str) -> bool:
+        op_config = self.op_config
+        if op_config is not None and "assets" in op_config:
+            all_input_asset_partitions = op_config["assets"].get("input_partitions")
+            if all_input_asset_partitions is not None:
+                this_input_asset_partitions = all_input_asset_partitions.get(input_name)
+                if this_input_asset_partitions is not None:
+                    return True
+
+        return False
+
+    def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
+        op_config = self.op_config
+        if op_config is not None and "assets" in op_config:
+            all_input_asset_partitions = op_config["assets"].get("input_partitions")
+            if all_input_asset_partitions is not None:
+                this_input_asset_partitions = all_input_asset_partitions.get(input_name)
+                if this_input_asset_partitions is not None:
+                    return PartitionKeyRange(
+                        this_input_asset_partitions["start"], this_input_asset_partitions["end"]
+                    )
+
+        check.failed("The input has no asset partitions")
+
+    def asset_partition_key_for_input(self, input_name: str) -> str:
+        start, end = self.asset_partition_key_range_for_input(input_name)
+        if start == end:
+            return start
+        else:
+            check.failed(
+                f"Tried to access partition key for input '{input_name}' of step '{self.step.key}', "
+                f"but the step input has a partition range: '{start}' to '{end}'."
+            )
+
+    def has_asset_partitions_for_output(self, output_name: str) -> bool:
+        op_config = self.op_config
+        if op_config is not None and "assets" in op_config:
+            all_output_asset_partitions = op_config["assets"].get("output_partitions")
+            if all_output_asset_partitions is not None:
+                this_output_asset_partitions = all_output_asset_partitions.get(output_name)
+                if this_output_asset_partitions is not None:
+                    return True
+
+        return False
+
+    def asset_partition_key_range_for_output(self, output_name: str) -> PartitionKeyRange:
+        op_config = self.op_config
+        if op_config is not None and "assets" in op_config:
+            all_output_asset_partitions = op_config["assets"].get("output_partitions")
+            if all_output_asset_partitions is not None:
+                this_output_asset_partitions = all_output_asset_partitions.get(output_name)
+                if this_output_asset_partitions is not None:
+                    return PartitionKeyRange(
+                        this_output_asset_partitions["start"], this_output_asset_partitions["end"]
+                    )
+
+        check.failed("The output has no asset partitions")
+
+    def asset_partition_key_for_output(self, output_name: str) -> str:
+        start, end = self.asset_partition_key_range_for_output(output_name)
+        if start == end:
+            return start
+        else:
+            check.failed(
+                f"Tried to access partition key for output '{output_name}' of step '{self.step.key}', "
+                f"but the step output has a partition range: '{start}' to '{end}'."
+            )
 
 
 class TypeCheckContext:

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_partitioned_assets.py
@@ -2,6 +2,8 @@ import pytest
 from dagster import (
     AssetMaterialization,
     DagsterInvalidDefinitionError,
+    IOManager,
+    IOManagerDefinition,
     PartitionsDefinition,
     StaticPartitionsDefinition,
 )
@@ -118,11 +120,22 @@ def test_filter_mapping_partitions_dep():
 def test_single_partitioned_asset_job():
     partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
 
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert context.asset_partition_key == "b"
+
+        def load_input(self, context):
+            assert False, "shouldn't get here"
+
     @asset(partitions_def=partitions_def)
     def my_asset():
         pass
 
-    my_job = build_assets_job("my_job", assets=[my_asset])
+    my_job = build_assets_job(
+        "my_job",
+        assets=[my_asset],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
     result = my_job.execute_in_process(partition_key="b")
     assert result.asset_materializations_for_node("my_asset") == [
         AssetMaterialization(asset_key=AssetKey(["my_asset"]), partition="b")
@@ -160,3 +173,103 @@ def test_assets_job_with_different_partitions_defs():
             assert upstream is None
 
         build_assets_job("my_job", assets=[upstream, downstream])
+
+
+def test_access_partition_keys_from_context_non_identity_partition_mapping():
+    upstream_partitions_def = StaticPartitionsDefinition(["1", "2", "3"])
+    downstream_partitions_def = StaticPartitionsDefinition(["1", "2", "3"])
+
+    class TrailingWindowPartitionMapping(PartitionMapping):
+        """
+        Maps each downstream partition to two partitions in the upstream asset: itself and the
+        preceding partition.
+        """
+
+        def get_upstream_partitions_for_partition_range(
+            self,
+            downstream_partition_key_range: PartitionKeyRange,
+            downstream_partitions_def: PartitionsDefinition,
+            upstream_partitions_def: PartitionsDefinition,
+        ) -> PartitionKeyRange:
+            assert downstream_partitions_def
+            assert upstream_partitions_def
+
+            start, end = downstream_partition_key_range
+            return PartitionKeyRange(str(max(1, int(start) - 1)), end)
+
+        def get_downstream_partitions_for_partition_range(
+            self,
+            upstream_partition_key_range: PartitionKeyRange,
+            downstream_partitions_def: PartitionsDefinition,
+            upstream_partitions_def: PartitionsDefinition,
+        ) -> PartitionKeyRange:
+            raise NotImplementedError()
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert context.asset_partition_key == "2"
+
+        def load_input(self, context):
+            start, end = context.asset_partition_key_range
+            assert start, end == ("1", "2")
+
+    @asset(partitions_def=upstream_partitions_def)
+    def upstream_asset(context):
+        assert context.output_asset_partition_key() == "2"
+
+    @asset(
+        partitions_def=downstream_partitions_def,
+        partition_mappings={"upstream_asset": TrailingWindowPartitionMapping()},
+    )
+    def downstream_asset(context, upstream_asset):
+        assert context.output_asset_partition_key() == "2"
+        assert upstream_asset is None
+
+    my_job = build_assets_job(
+        "my_job",
+        assets=[upstream_asset, downstream_asset],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    result = my_job.execute_in_process(partition_key="2")
+    assert result.asset_materializations_for_node("upstream_asset") == [
+        AssetMaterialization(AssetKey(["upstream_asset"]), partition="2")
+    ]
+    assert result.asset_materializations_for_node("downstream_asset") == [
+        AssetMaterialization(AssetKey(["downstream_asset"]), partition="2")
+    ]
+
+
+def test_access_partition_keys_from_context_only_one_asset_partitioned():
+    upstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            if context.op_def.name == "upstream_asset":
+                assert context.asset_partition_key == "b"
+            elif context.op_def.name == "downstream_asset":
+                assert not context.has_asset_partitions
+                with pytest.raises(Exception):  # TODO: better error message
+                    assert context.asset_partition_key_range
+            else:
+                assert False
+
+        def load_input(self, context):
+            assert not context.has_asset_partitions
+
+    @asset(partitions_def=upstream_partitions_def)
+    def upstream_asset(context):
+        assert context.output_asset_partition_key() == "b"
+
+    @asset
+    def downstream_asset(upstream_asset):
+        assert upstream_asset is None
+
+    my_job = build_assets_job(
+        "my_job",
+        assets=[upstream_asset, downstream_asset],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    result = my_job.execute_in_process(partition_key="b")
+    assert result.asset_materializations_for_node("upstream_asset") == [
+        AssetMaterialization(asset_key=AssetKey(["upstream_asset"]), partition="b")
+    ]


### PR DESCRIPTION
This makes asset partitions information available on OpExecutionContexts, InputContexts, and OutputContexts, so it can be used by op bodies and IOManager implementations.

This will enable finally making the assets version of the hacker news jobs work.

This relies on op config for passing information down to the execution. Other options we've discussed include:
* Tags
* Resource config