### PR TITLE
[dagit] Make asset key segments individually searchable

### DIFF
--- a/js_modules/dagit/packages/core/src/search/useAssetSearch.test.tsx
+++ b/js_modules/dagit/packages/core/src/search/useAssetSearch.test.tsx
@@ -1,0 +1,112 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Fuse from 'fuse.js';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+
+import {SearchResult} from './types';
+import {useAssetSearch} from './useRepoSearch';
+
+const GETTYSBURG =
+  'four score and seven years ago our fathers brought forth upon this continent a new nation conceived in liberty and dedicated to the proposition that all men are created equal';
+
+describe('useAssetSearch', () => {
+  const mocks = {
+    AssetConnection: () => ({
+      nodes: () => [
+        {id: 'foo', key: {path: ['foo', 'bar']}},
+        {id: 'bar', key: {path: ['baz', 'derp']}},
+        {
+          id: 'gettysburg',
+          key: {
+            path: GETTYSBURG.split(' '),
+          },
+        },
+      ],
+    }),
+  };
+
+  const Test = () => {
+    const {loading, performSearch} = useAssetSearch();
+    const [value, setValue] = React.useState('');
+    const [results, setResults] = React.useState<Fuse.FuseResult<SearchResult>[]>(() => []);
+
+    const onClick = () => setResults(performSearch(value));
+
+    return (
+      <div>
+        <input type="text" onChange={(e) => setValue(e.target.value)} value={value} />
+        <div>Loading: {String(loading)}</div>
+        <div>{`Results (${results.length}):`}</div>
+        {results.map((result, ii) => (
+          <div key={ii}>{`Item: ${result.item.label}`}</div>
+        ))}
+        <button onClick={onClick}>Search</button>
+      </div>
+    );
+  };
+
+  it('finds a matching asset', async () => {
+    render(
+      <TestProvider apolloProps={{mocks}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Loading: true/)).toBeVisible();
+    });
+
+    userEvent.type(screen.getByRole('textbox'), 'fo');
+    userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      // Two matches, `foo`, and Gettysburg.
+      expect(screen.queryByText(/Results \(2\)/)).toBeVisible();
+      expect(screen.queryByText(/Item: foo \u203a bar/)).toBeVisible();
+    });
+  });
+
+  it('fails to find a matching asset if no string match', async () => {
+    render(
+      <TestProvider apolloProps={{mocks}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Loading: true/)).toBeVisible();
+    });
+
+    userEvent.type(screen.getByRole('textbox'), 'ZILCH NADA');
+    userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      // No matches.
+      expect(screen.queryByText(/Results \(0\)/)).toBeVisible();
+      expect(screen.queryByText(/Item: foo \u203a bar/)).toBeNull();
+    });
+  });
+
+  it('finds a matching asset deep in the key path due to segment matching', async () => {
+    render(
+      <TestProvider apolloProps={{mocks}}>
+        <Test />
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Loading: true/)).toBeVisible();
+    });
+
+    userEvent.type(screen.getByRole('textbox'), 'equal');
+    userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      // Gettysburg is our only match.
+      expect(screen.queryByText(/Results \(1\)/)).toBeVisible();
+      expect(screen.queryByText(`Item: ${GETTYSBURG.split(' ').join(' \u203a ')}`)).toBeVisible();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -14,7 +14,7 @@ import {
 import {SearchSecondaryQuery} from './types/SearchSecondaryQuery';
 
 const fuseOptions = {
-  keys: ['label', 'tags', 'type'],
+  keys: ['label', 'segments', 'tags', 'type'],
   limit: 10,
   threshold: 0.5,
   useExtendedSearch: true,
@@ -118,6 +118,7 @@ const secondaryDataToSearchResults = (data?: SearchSecondaryQuery) => {
     return {
       key: path,
       label: path,
+      segments: key.path,
       description: 'Asset',
       href: `/instance/assets/${key.path.map(encodeURIComponent).join('/')}`,
       type: SearchResultType.Asset,
@@ -165,22 +166,15 @@ export const useRepoSearch = () => {
 };
 
 export const useAssetSearch = () => {
-  const [performQuery, {data, loading, called}] = useLazyQuery<SearchSecondaryQuery>(
-    SEARCH_SECONDARY_QUERY,
-    {
-      fetchPolicy: 'cache-and-network',
-    },
-  );
+  const {data, loading} = useQuery<SearchSecondaryQuery>(SEARCH_SECONDARY_QUERY, {
+    fetchPolicy: 'cache-and-network',
+  });
 
   const fuse = React.useMemo(() => secondaryDataToSearchResults(data), [data]);
+
   const performSearch = React.useCallback(
-    (queryString: string): Fuse.FuseResult<SearchResult>[] => {
-      if (!called) {
-        performQuery();
-      }
-      return fuse.search(queryString);
-    },
-    [fuse, performQuery, called],
+    (queryString: string): Fuse.FuseResult<SearchResult>[] => fuse.search(queryString),
+    [fuse],
   );
 
   return {loading, performSearch};


### PR DESCRIPTION
## Summary

We received a report from a Cloud user that asset search was not functioning correctly when searching for a substring deep in the key path. Based on testing, I believe this is because the match is past the threshold/distance settings we provide to Fuse. This is not incorrect behavior, necessarily, but we can improve upon it.

I have added a `segments` field to our search results that allows the individual items in the key path to be searched as well. This should allow keys deep in the path to be searched and returned.

Additionally, the current behavior of `useAssetSearch` is to use a lazy query, but given that we already retrieve the asset keys for display on the page, I'm not sure we benefit from making the query lazy here. It also means that we always need to call `performSearch` twice, since the first call will always kick off the lazy query and return an empty Fuse result. By making it a normal `useQuery`, we should be able to get results on the first call.

I have added a test for `useAssetSearch`.

## Test Plan

The Jest test should cover the relevant bug. Sanity check asset search in Dagit to verify that everything is still working fine.
