### PR TITLE
[dagit] Fix menu links from Instance Backfills page

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -282,7 +282,7 @@ const BackfillRow = ({
   const {canCancelPartitionBackfill, canLaunchPartitionBackfill} = usePermissions();
   const counts = React.useMemo(() => getProgressCounts(backfill), [backfill]);
   const runsUrl = `/instance/runs?${qs.stringify({
-    q: stringFromValue([{token: 'tag', value: `dagster/backfill=${backfill.backfillId}`}]),
+    q: [stringFromValue([{token: 'tag', value: `dagster/backfill=${backfill.backfillId}`}])],
   })}`;
 
   const repoAddress = backfill.partitionSet
@@ -305,7 +305,7 @@ const BackfillRow = ({
         pipelineName: backfill.partitionSet.pipelineName,
         path: `/partitions?${qs.stringify({
           partitionSet: backfill.partitionSet.name,
-          q: stringFromValue([{token: 'tag', value: `dagster/backfill=${backfill.backfillId}`}]),
+          q: [stringFromValue([{token: 'tag', value: `dagster/backfill=${backfill.backfillId}`}])],
         })}`,
         isJob,
       })

--- a/js_modules/dagit/packages/core/src/partitions/PartitionProgress.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionProgress.tsx
@@ -185,9 +185,11 @@ export const PartitionProgress = (props: Props) => {
                       to={workspacePathFromAddress(
                         repoAddress,
                         `/pipeline_or_job/${pipelineName}/runs?${qs.stringify({
-                          q: stringFromValue([
-                            {token: 'tag', value: `dagster/backfill=${backfillId}`},
-                          ]),
+                          q: [
+                            stringFromValue([
+                              {token: 'tag', value: `dagster/backfill=${backfillId}`},
+                            ]),
+                          ],
                         })}`,
                       )}
                     >


### PR DESCRIPTION
## Summary

Menu links from the Instance Backfills page (e.g. "View Partition Matrix") are currently broken because the `q` parameter is now expected to be an array, and they are currently strings.

## Test Plan

View Instance Backfills, navigate using the menu links. Verify that there are no errors upon navigation.
