### PR TITLE
resolve user-defined k8s job and ops tag entirely using k8s_model_from_dict

### DIFF
--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -1,68 +1,90 @@
 ---
 title: Customizing Helm | Dagster
-description: We go over common ways to customize your Dagster Helm deployment. This includes adding Kubernetes configuration at the job and op level, and configuring your Helm release to use external resources.
+description: This section covers common ways to customize your Dagster Helm deployment.
 ---
 
 # Customizing your Kubernetes Deployment
 
-## Overview
+This section covers common ways to customize your Dagster Helm deployment.
 
-We go over common ways to customize your Dagster Helm deployment, including adding Kubernetes configuration at the job and op level, and configuring your Helm release to use external resources.
+## Job or Op Kubernetes Configuration
 
-## Walkthrough
+The `dagster-k8s/config` tag allows users to pass custom configuration through to the Kubernetes Jobs and Pods created by Dagster during execution.
 
-### Job or Op Kubernetes Configuration
+`dagster-k8s/config` is a dictionary with the following keys:
 
-The `dagster-k8s/config` allows users to pass custom configuration to the Kubernetes Job, Job metadata, JobSpec, PodSpec, and PodTemplateSpec metadata. We can specify this information in an op or job's tags.
+- `container_config`: The Pod's [Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core).
+- `pod_spec_config`: The Pod's [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core).
+- `pod_template_spec_metadata`: The Pod's [Metadata](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+- `job_spec_config`: The Job's [JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch).
+- `job_metadata`: The Job's [Metadata](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
 
-```python
-@op(
-  tags = {
-    'dagster-k8s/config': {
-      'container_config': {
-        'resources': {
-          'requests': { 'cpu': '250m', 'memory': '64Mi' },
-          'limits': { 'cpu': '500m', 'memory': '2560Mi' },
-        }
-      },
-      'pod_template_spec_metadata': {
-        'annotations': { "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
-      },
-      'pod_spec_config': {
-        'affinity': {
-          'nodeAffinity': {
-            'requiredDuringSchedulingIgnoredDuringExecution': {
-              'nodeSelectorTerms': [{
-                'matchExpressions': [{
-                  'key': 'beta.kubernetes.io/os', 'operator': 'In', 'values': ['windows', 'linux'],
-                }]
-              }]
-            }
-          }
-        }
-      },
-    },
-  },
-)
-def my_op(context):
-  context.log.info('running')
+The values for each of these keys is a dictionary with the YAML configuration for the underlying Kubernetes object. The Kubernetes object fields can be configured using either snake case (for example, `volume_mounts`) or camel case (`volumeMounts`).
 
+If your instance is using the <PyObject module="dagster_k8s" object="K8sRunLauncher" /> or <PyObject module="dagster_celery_k8s" object="CeleryK8sRunLauncher" />, you can use the `dagster-k8s/config` tag on a Dagster job. For example:
+
+```python file=/deploying/kubernetes/k8s_config_tag.py startafter=start_k8s_config_job endbefore=end_k8s_config_job
 @job(
-  tags = {
-    'dagster-k8s/config': {
-      'container_config': {
-        'resources': {
-          'requests': { 'cpu': '200m', 'memory': '32Mi' },
-        }
-      },
-    }
-  }
+    tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "250m", "memory": "64Mi"},
+                    "limits": {"cpu": "500m", "memory": "2560Mi"},
+                },
+                "volume_mounts": [
+                    {"name": "volume1", "mount_path": "foo/bar", "sub_path": "file.txt"}
+                ],
+            },
+            "pod_template_spec_metadata": {
+                "annotations": {"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
+            },
+            "pod_spec_config": {
+                "volumes": [{"name": "volume1", "secret": {"secret_name": "volume_secret_name"}}],
+                "affinity": {
+                    "node_affinity": {
+                        "required_during_scheduling_ignored_during_execution": {
+                            "node_selector_terms": [
+                                {
+                                    "match_expressions": [
+                                        {
+                                            "key": "beta.kubernetes.io/os",
+                                            "operator": "In",
+                                            "values": ["windows", "linux"],
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+            },
+        },
+    },
 )
 def my_job():
-  my_op()
+    my_op()
 ```
 
-### Configuring an External Database
+If your Dagster job is configured with an executor that runs each op in its own pod, like the <PyObject module="dagster_k8s" object="k8s_job_executor" /> or <PyObject module="dagster_celery_k8s" object="celery_k8s_job_executor" />, you can also use the `dagster-k8s/config` tag on a Dagster op to control the Kubernetes configuration for that specific op. For example:
+
+```python file=/deploying/kubernetes/k8s_config_tag.py startafter=start_k8s_config_op endbefore=end_k8s_config_op
+@op(
+    tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "200m", "memory": "32Mi"},
+                }
+            },
+        }
+    }
+)
+def my_op(context):
+    context.log.info("running")
+```
+
+## Configuring an External Database
 
 In a real deployment, users will likely want to set up an external PostgreSQL database and configure the `postgresql` section of `values.yaml`.
 
@@ -88,13 +110,13 @@ global:
 generatePostgresqlPasswordSecret: false
 ```
 
-### Security
+## Security
 
 Users will likely want to permission a ServiceAccount bound to a properly scoped Role to launch Jobs and create other Kubernetes resources.
 
 Users will likely want to use [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) for managing secure information such as database logins.
 
-### Separately Deploying Dagster infrastructure and User Code
+### Separately Deploying Dagster Infrastructure and User Code
 
 It may be desirable to manage two Helm releases for your Dagster deployment: one release for the Dagster infrastructure, which consists of Dagit and the Daemon, and another release for your User Code, which contains the definitions of your pipelines written in Dagster. This way, changes to User Code can be decoupled from upgrades to core Dagster infrastructure.
 
@@ -128,7 +150,7 @@ Finally, the `dagster-user-deployments` subchart can now be managed in its own r
 
     helm upgrade --install user-code dagster/dagster-user-deployments -f /path/to/values.yaml
 
-### Kubernetes Job and Pod TTL management
+## Kubernetes Job and Pod TTL management
 
 If you use a Kubernetes distribution that supports the [TTL Controller](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#ttl-controller), then `Completed` and `Failed` [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) (and their associated [Pods](https://kubernetes.io/docs/concepts/workloads/pods/)) will be deleted after 1 day. The TTL value can be modified in your job tags:
 

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/k8s_config_tag.py
@@ -1,0 +1,63 @@
+from dagster import job, op
+
+
+# fmt: off
+# start_k8s_config_op
+@op(
+    tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "200m", "memory": "32Mi"},
+                }
+            },
+        }
+    }
+)
+def my_op(context):
+    context.log.info("running")
+# end_k8s_config_op
+
+# start_k8s_config_job
+@job(
+    tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"cpu": "250m", "memory": "64Mi"},
+                    "limits": {"cpu": "500m", "memory": "2560Mi"},
+                },
+                "volume_mounts": [
+                    {"name": "volume1", "mount_path": "foo/bar", "sub_path": "file.txt"}
+                ],
+            },
+            "pod_template_spec_metadata": {
+                "annotations": {"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
+            },
+            "pod_spec_config": {
+                "volumes": [{"name": "volume1", "secret": {"secret_name": "volume_secret_name"}}],
+                "affinity": {
+                    "node_affinity": {
+                        "required_during_scheduling_ignored_during_execution": {
+                            "node_selector_terms": [
+                                {
+                                    "match_expressions": [
+                                        {
+                                            "key": "beta.kubernetes.io/os",
+                                            "operator": "In",
+                                            "values": ["windows", "linux"],
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+            },
+        },
+    },
+)
+def my_job():
+    my_op()
+# end_k8s_config_job
+# fmt: on

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/ttl_config_job.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/ttl_config_job.py
@@ -3,7 +3,7 @@ from dagster import job, op
 
 @op
 def my_op():
-    print("foo")
+    print("foo")  # pylint: disable=print-call
 
 
 # fmt: off

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_k8s_config_tag.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_k8s_config_tag.py
@@ -1,0 +1,38 @@
+from dagster_k8s import DagsterK8sJobConfig, construct_dagster_k8s_job
+from dagster_k8s.job import get_user_defined_k8s_config
+
+from docs_snippets.deploying.kubernetes.k8s_config_tag import my_job, my_op
+
+
+def test_k8s_tag_job():
+    assert my_job
+    user_defined_cfg = get_user_defined_k8s_config(my_job.tags)
+
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="test",
+    )
+    job = construct_dagster_k8s_job(cfg, [], "job123", user_defined_k8s_config=user_defined_cfg)
+
+    assert job.to_dict()["spec"]["template"]["spec"]["containers"][0]["resources"] == {
+        "requests": {"cpu": "250m", "memory": "64Mi"},
+        "limits": {"cpu": "500m", "memory": "2560Mi"},
+    }
+
+
+def test_k8s_tag_op():
+    assert my_op
+    user_defined_cfg = get_user_defined_k8s_config(my_op.tags)
+
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="test",
+    )
+    job = construct_dagster_k8s_job(cfg, [], "job123", user_defined_k8s_config=user_defined_cfg)
+
+    assert job.to_dict()["spec"]["template"]["spec"]["containers"][0]["resources"] == {
+        "requests": {"cpu": "200m", "memory": "32Mi"},
+        "limits": None,
+    }

--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
             "Operating System :: OS Independent",
         ],
         packages=find_packages(exclude=["test"]),
-        install_requires=["dagster"],
+        install_requires=["dagster", "dagster-k8s"],
         extras_require={
             "full": [
                 "seaborn",

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -16,6 +16,7 @@ deps =
   -e ../../python_modules/libraries/dagster-slack
   -e ../../python_modules/libraries/dagstermill
   -e ../../python_modules/libraries/dagster-dbt
+  -e ../../python_modules/libraries/dagster-k8s
   -e ../../python_modules/dagit
   -e .[full]
 usedevelop = true

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -3,7 +3,7 @@ import subprocess
 from typing import List
 
 import pytest
-from dagster_k8s.models import k8s_model_from_dict
+from dagster_k8s.models import k8s_model_from_dict, k8s_snake_case_dict
 from kubernetes import client as k8s_client
 from kubernetes.client import models
 from schema.charts.dagster.subschema.global_ import Global
@@ -557,13 +557,19 @@ def test_user_deployment_volumes(template: HelmTemplate):
 
     deployed_volume_mounts = user_deployments[0].spec.template.spec.containers[0].volume_mounts
     assert deployed_volume_mounts == [
-        k8s_model_from_dict(k8s_client.models.V1VolumeMount, volume_mount)
+        k8s_model_from_dict(
+            k8s_client.models.V1VolumeMount,
+            k8s_snake_case_dict(k8s_client.models.V1VolumeMount, volume_mount),
+        )
         for volume_mount in volume_mounts
     ]
 
     deployed_volumes = user_deployments[0].spec.template.spec.volumes
     assert deployed_volumes == [
-        k8s_model_from_dict(k8s_client.models.V1Volume, volume) for volume in volumes
+        k8s_model_from_dict(
+            k8s_client.models.V1Volume, k8s_snake_case_dict(k8s_client.models.V1Volume, volume)
+        )
+        for volume in volumes
     ]
 
     assert image_name == deployment.image.repository

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -374,7 +374,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             container = kwargs["body"].spec.template.spec.containers[0]
 
             job_resources = container.resources
-            assert job_resources == expected_resources
+            assert job_resources.to_dict() == expected_resources
 
             labels = kwargs["body"].spec.template.metadata.labels
             assert labels["foo_label_key"] == "bar_label_value"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -1,10 +1,11 @@
+import copy
 import hashlib
 import json
 import os
 import random
 import string
 from collections import namedtuple
-from typing import List
+from typing import Any, Dict, List, Optional
 
 import kubernetes
 
@@ -17,7 +18,7 @@ from dagster.core.errors import DagsterInvalidConfigError
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils import frozentags, merge_dicts
 
-from .models import k8s_model_from_dict
+from .models import k8s_model_from_dict, k8s_snake_case_dict
 from .utils import sanitize_k8s_label
 
 # To retry step job, users should raise RetryRequested() so that the dagster system is aware of the
@@ -88,6 +89,26 @@ class UserDefinedDagsterK8sConfig(
         job_config = check.opt_dict_param(job_config, "job_config", key_type=str)
         job_metadata = check.opt_dict_param(job_metadata, "job_metadata", key_type=str)
         job_spec_config = check.opt_dict_param(job_spec_config, "job_spec_config", key_type=str)
+
+        if container_config:
+            container_config = k8s_snake_case_dict(kubernetes.client.V1Container, container_config)
+
+        if pod_template_spec_metadata:
+            pod_template_spec_metadata = k8s_snake_case_dict(
+                kubernetes.client.V1ObjectMeta, pod_template_spec_metadata
+            )
+
+        if pod_spec_config:
+            pod_spec_config = k8s_snake_case_dict(kubernetes.client.V1PodSpec, pod_spec_config)
+
+        if job_config:
+            job_config = k8s_snake_case_dict(kubernetes.client.V1Job, job_config)
+
+        if job_metadata:
+            job_metadata = k8s_snake_case_dict(kubernetes.client.V1ObjectMeta, job_metadata)
+
+        if job_spec_config:
+            job_spec_config = k8s_snake_case_dict(kubernetes.client.V1JobSpec, job_spec_config)
 
         return super(UserDefinedDagsterK8sConfig, cls).__new__(
             cls,
@@ -258,7 +279,7 @@ class DagsterK8sJobConfig(
             dagster_home=check.opt_str_param(
                 dagster_home, "dagster_home", default=DAGSTER_HOME_DEFAULT
             ),
-            image_pull_policy=check.opt_str_param(image_pull_policy, "image_pull_policy"),
+            image_pull_policy=check.opt_str_param(image_pull_policy, "image_pull_policy", "Always"),
             image_pull_secrets=check.opt_list_param(
                 image_pull_secrets, "image_pull_secrets", of_type=dict
             ),
@@ -270,8 +291,14 @@ class DagsterK8sJobConfig(
             env_config_maps=check.opt_list_param(env_config_maps, "env_config_maps", of_type=str),
             env_secrets=check.opt_list_param(env_secrets, "env_secrets", of_type=str),
             env_vars=check.opt_list_param(env_vars, "env_secrets", of_type=str),
-            volume_mounts=check.opt_list_param(volume_mounts, "volume_mounts"),
-            volumes=check.opt_list_param(volumes, "volumes"),
+            volume_mounts=[
+                k8s_snake_case_dict(kubernetes.client.V1VolumeMount, mount)
+                for mount in check.opt_list_param(volume_mounts, "volume_mounts")
+            ],
+            volumes=[
+                k8s_snake_case_dict(kubernetes.client.V1Volume, volume)
+                for volume in check.opt_list_param(volumes, "volumes")
+            ],
             labels=check.opt_dict_param(labels, "labels", key_type=str, value_type=str),
         )
 
@@ -419,31 +446,20 @@ class DagsterK8sJobConfig(
         }
 
     @property
-    def env(self) -> List[kubernetes.client.V1EnvVar]:
-        return [
-            kubernetes.client.V1EnvVar(name=key, value=os.getenv(key))
-            for key in (self.env_vars or [])
-        ]
+    def env(self) -> List[Dict[str, Optional[str]]]:
+        return [{"name": key, "value": os.getenv(key)} for key in (self.env_vars or [])]
 
     @property
-    def env_from_sources(self):
+    def env_from_sources(self) -> List[Dict[str, Any]]:
         """This constructs a list of env_from sources. Along with a default base environment
         config map which we always load, the ConfigMaps and Secrets specified via
         env_config_maps and env_secrets will be pulled into the job construction here.
         """
         config_maps = [
-            kubernetes.client.V1EnvFromSource(
-                config_map_ref=kubernetes.client.V1ConfigMapEnvSource(name=config_map)
-            )
-            for config_map in self.env_config_maps
+            {"config_map_ref": {"name": config_map}} for config_map in self.env_config_maps
         ]
 
-        secrets = [
-            kubernetes.client.V1EnvFromSource(
-                secret_ref=kubernetes.client.V1SecretEnvSource(name=secret)
-            )
-            for secret in self.env_secrets
-        ]
+        secrets = [{"secret_ref": {"name": secret}} for secret in self.env_secrets]
 
         return config_maps + secrets
 
@@ -529,146 +545,132 @@ def construct_dagster_k8s_job(
     additional_labels = {k: sanitize_k8s_label(v) for k, v in (labels or {}).items()}
     dagster_labels = merge_dicts(k8s_common_labels, additional_labels)
 
-    env = [kubernetes.client.V1EnvVar(name="DAGSTER_HOME", value=job_config.dagster_home)]
+    env = [{"name": "DAGSTER_HOME", "value": job_config.dagster_home}]
     if job_config.postgres_password_secret:
         env.append(
-            kubernetes.client.V1EnvVar(
-                name=DAGSTER_PG_PASSWORD_ENV_VAR,
-                value_from=kubernetes.client.V1EnvVarSource(
-                    secret_key_ref=kubernetes.client.V1SecretKeySelector(
-                        name=job_config.postgres_password_secret, key=DAGSTER_PG_PASSWORD_SECRET_KEY
-                    )
-                ),
-            )
+            {
+                "name": DAGSTER_PG_PASSWORD_ENV_VAR,
+                "value_from": {
+                    "secret_key_ref": {
+                        "name": job_config.postgres_password_secret,
+                        "key": DAGSTER_PG_PASSWORD_SECRET_KEY,
+                    }
+                },
+            }
         )
 
     additional_k8s_env_vars = []
     if env_vars:
         for key, value in env_vars.items():
-            additional_k8s_env_vars.append(kubernetes.client.V1EnvVar(name=key, value=value))
+            additional_k8s_env_vars.append({"name": key, "value": value})
 
-    user_defined_k8s_env_vars = user_defined_k8s_config.container_config.pop("env", [])
+    container_config = copy.deepcopy(user_defined_k8s_config.container_config)
+
+    user_defined_k8s_env_vars = container_config.pop("env", [])
     for env_var in user_defined_k8s_env_vars:
-        additional_k8s_env_vars.append(
-            k8s_model_from_dict(kubernetes.client.models.V1EnvVar, env_var)
-        )
+        additional_k8s_env_vars.append(env_var)
 
-    user_defined_k8s_env_from = user_defined_k8s_config.container_config.pop("env_from", [])
+    user_defined_k8s_env_from = container_config.pop("env_from", [])
     additional_k8s_env_from = []
     for env_from in user_defined_k8s_env_from:
-        config_map_ref_args = env_from.get("config_map_ref")
-        config_map_ref = (
-            kubernetes.client.V1ConfigMapEnvSource(**config_map_ref_args)
-            if config_map_ref_args
-            else None
-        )
-        secret_ref_args = env_from.get("secret_ref")
-        secret_ref = (
-            kubernetes.client.V1SecretEnvSource(**secret_ref_args) if secret_ref_args else None
-        )
+        additional_k8s_env_from.append(env_from)
 
-        additional_k8s_env_from.append(
-            kubernetes.client.V1EnvFromSource(
-                config_map_ref=config_map_ref, prefix=env_from.get("prefix"), secret_ref=secret_ref
-            )
-        )
+    job_image = container_config.pop("image", job_config.job_image)
 
-    volume_mounts = [
-        kubernetes.client.V1VolumeMount(
-            name="dagster-instance",
-            mount_path="{dagster_home}/dagster.yaml".format(dagster_home=job_config.dagster_home),
-            sub_path="dagster.yaml",
-        )
-    ] + [
-        k8s_model_from_dict(kubernetes.client.models.V1VolumeMount, mount)
-        for mount in job_config.volume_mounts
-    ]
+    user_defined_k8s_volume_mounts = container_config.pop("volume_mounts", [])
 
-    job_image = user_defined_k8s_config.container_config.pop("image", job_config.job_image)
-
-    user_defined_k8s_volume_mounts = user_defined_k8s_config.container_config.pop(
-        "volume_mounts", []
-    )
-    for volume_mount in user_defined_k8s_volume_mounts:
-        volume_mounts.append(
-            k8s_model_from_dict(kubernetes.client.models.V1VolumeMount, volume_mount)
-        )
-
-    job_container = kubernetes.client.V1Container(
-        name="dagster",
-        image=job_image,
-        args=args,
-        image_pull_policy=job_config.image_pull_policy,
-        env=env + job_config.env + additional_k8s_env_vars,
-        env_from=job_config.env_from_sources + additional_k8s_env_from,
-        volume_mounts=volume_mounts,
-        **user_defined_k8s_config.container_config,
+    volume_mounts = (
+        [
+            {
+                "name": "dagster-instance",
+                "mount_path": "{dagster_home}/dagster.yaml".format(
+                    dagster_home=job_config.dagster_home
+                ),
+                "sub_path": "dagster.yaml",
+            }
+        ]
+        + job_config.volume_mounts
+        + user_defined_k8s_volume_mounts
     )
 
-    user_defined_volumes = user_defined_k8s_config.pod_spec_config.pop("volumes", [])
+    container_config = merge_dicts(
+        container_config,
+        {
+            "name": "dagster",
+            "image": job_image,
+            "args": args,
+            "image_pull_policy": job_config.image_pull_policy,
+            "env": env + job_config.env + additional_k8s_env_vars,
+            "env_from": job_config.env_from_sources + additional_k8s_env_from,
+            "volume_mounts": volume_mounts,
+        },
+    )
 
-    volumes = [
-        kubernetes.client.V1Volume(
-            name="dagster-instance",
-            config_map=kubernetes.client.V1ConfigMapVolumeSource(
-                name=job_config.instance_config_map
-            ),
-        )
-    ]
+    pod_spec_config = copy.deepcopy(user_defined_k8s_config.pod_spec_config)
 
-    for volume in job_config.volumes + user_defined_volumes:
-        new_volume = k8s_model_from_dict(
-            kubernetes.client.models.V1Volume,
-            volume,
-        )
-        volumes.append(new_volume)
+    user_defined_volumes = pod_spec_config.pop("volumes", [])
+
+    volumes = (
+        [{"name": "dagster-instance", "config_map": {"name": job_config.instance_config_map}}]
+        + job_config.volumes
+        + user_defined_volumes
+    )
 
     # If the user has defined custom labels, remove them from the pod_template_spec_metadata
     # key and merge them with the dagster labels
-    user_defined_pod_template_labels = user_defined_k8s_config.pod_template_spec_metadata.pop(
-        "labels", {}
-    )
+    pod_template_spec_metadata = copy.deepcopy(user_defined_k8s_config.pod_template_spec_metadata)
+    user_defined_pod_template_labels = pod_template_spec_metadata.pop("labels", {})
 
-    service_account_name = user_defined_k8s_config.pod_spec_config.pop(
+    service_account_name = pod_spec_config.pop(
         "service_account_name", job_config.service_account_name
     )
 
-    template = kubernetes.client.V1PodTemplateSpec(
-        metadata=kubernetes.client.V1ObjectMeta(
-            name=pod_name,
-            labels=merge_dicts(dagster_labels, user_defined_pod_template_labels, job_config.labels),
-            **user_defined_k8s_config.pod_template_spec_metadata,
+    user_defined_containers = pod_spec_config.pop("containers", [])
+
+    template = {
+        "metadata": merge_dicts(
+            pod_template_spec_metadata,
+            {
+                "name": pod_name,
+                "labels": merge_dicts(
+                    dagster_labels, user_defined_pod_template_labels, job_config.labels
+                ),
+            },
         ),
-        spec=kubernetes.client.V1PodSpec(
-            image_pull_secrets=[
-                kubernetes.client.V1LocalObjectReference(name=x["name"])
-                for x in job_config.image_pull_secrets
-            ],
-            service_account_name=service_account_name,
-            restart_policy="Never",
-            containers=[job_container],
-            volumes=volumes,
-            **user_defined_k8s_config.pod_spec_config,
+        "spec": merge_dicts(
+            pod_spec_config,
+            {
+                "image_pull_secrets": job_config.image_pull_secrets,
+                "service_account_name": service_account_name,
+                "restart_policy": "Never",
+                "containers": [container_config] + user_defined_containers,
+                "volumes": volumes,
+            },
         ),
-    )
+    }
 
     job_spec_config = merge_dicts(
         DEFAULT_JOB_SPEC_CONFIG,
         user_defined_k8s_config.job_spec_config,
+        {"template": template},
     )
 
-    job = kubernetes.client.V1Job(
-        api_version="batch/v1",
-        kind="Job",
-        metadata=kubernetes.client.V1ObjectMeta(
-            name=job_name, labels=dagster_labels, **user_defined_k8s_config.job_metadata
+    job = k8s_model_from_dict(
+        kubernetes.client.V1Job,
+        merge_dicts(
+            user_defined_k8s_config.job_config,
+            {
+                "api_version": "batch/v1",
+                "kind": "Job",
+                "metadata": merge_dicts(
+                    user_defined_k8s_config.job_metadata,
+                    {"name": job_name, "labels": dagster_labels},
+                ),
+                "spec": job_spec_config,
+            },
         ),
-        spec=kubernetes.client.V1JobSpec(
-            template=template,
-            **job_spec_config,
-        ),
-        **user_defined_k8s_config.job_config,
     )
+
     return job
 
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/models.py
@@ -10,21 +10,43 @@ from dagster import check
 from dagster.utils import frozendict
 
 
-def _k8s_value(data, classname, attr_name):
-    if classname.startswith("list["):
-        sub_kls = re.match(r"list\[(.*)\]", classname).group(1)
+def _get_k8s_class(classname):
+    if classname in ApiClient.NATIVE_TYPES_MAPPING:
+        return ApiClient.NATIVE_TYPES_MAPPING[classname]
+    else:
+        return getattr(kubernetes.client.models, classname)
+
+
+def _is_openapi_list_type(attr_type):
+    return attr_type.startswith("list[")
+
+
+def _get_openapi_list_element_type(attr_type):
+    return re.match(r"list\[(.*)\]", attr_type).group(1)
+
+
+def _is_openapi_dict_type(attr_type):
+    return attr_type.startswith("dict(")
+
+
+def _get_openapi_dict_value_type(attr_type):
+    # group(2) because value, not key
+    return re.match(r"dict\(([^,]*), (.*)\)", attr_type).group(2)
+
+
+def _k8s_parse_value(data, classname, attr_name):
+    if _is_openapi_list_type(classname):
+        sub_kls = _get_openapi_list_element_type(classname)
         return [
-            _k8s_value(data[index], sub_kls, f"{attr_name}[{index}]") for index in range(len(data))
+            _k8s_parse_value(value, sub_kls, f"{attr_name}[{index}]")
+            for index, value in enumerate(data)
         ]
 
-    if classname.startswith("dict("):
-        sub_kls = re.match(r"dict\(([^,]*), (.*)\)", classname).group(2)
-        return {k: _k8s_value(v, sub_kls, f"{attr_name}[{k}]") for k, v in data.items()}
+    if _is_openapi_dict_type(classname):
+        sub_kls = _get_openapi_dict_value_type(classname)
+        return {k: _k8s_parse_value(v, sub_kls, f"{attr_name}[{k}]") for k, v in data.items()}
 
-    if classname in ApiClient.NATIVE_TYPES_MAPPING:
-        klass = ApiClient.NATIVE_TYPES_MAPPING[classname]
-    else:
-        klass = getattr(kubernetes.client.models, classname)
+    klass = _get_k8s_class(classname)
 
     if klass in ApiClient.PRIMITIVE_TYPES:
         return klass(data)
@@ -43,23 +65,77 @@ def _k8s_value(data, classname, attr_name):
         return k8s_model_from_dict(klass, data)
 
 
+def _k8s_snake_case_value(val, attr_type, attr_name):
+    if _is_openapi_list_type(attr_type):
+        sub_kls = _get_openapi_list_element_type(attr_type)
+        return [
+            _k8s_snake_case_value(list_value, sub_kls, f"{attr_name}[{index}]")
+            for index, list_value in enumerate(val)
+        ]
+    elif _is_openapi_dict_type(attr_type):
+        sub_kls = _get_openapi_dict_value_type(attr_type)
+        return {k: _k8s_snake_case_value(v, sub_kls, f"{attr_name}[{k}]") for k, v in val.items()}
+    else:
+        klass = _get_k8s_class(attr_type)
+        if klass in ApiClient.PRIMITIVE_TYPES or klass in (
+            object,
+            datetime.date,
+            datetime.datetime,
+        ):
+            return val
+        else:
+            if not isinstance(val, (frozendict, dict)):
+                raise Exception(
+                    f"Attribute {attr_name} of type {klass.__name__} must be a dict, received {val} instead"
+                )
+            return k8s_snake_case_dict(klass, val)
+
+
+def k8s_snake_case_dict(model_class, model_dict: Dict[str, Any]):
+    snake_case_to_camel_case = model_class.attribute_map
+    camel_case_to_snake_case = dict((v, k) for k, v in snake_case_to_camel_case.items())
+
+    snake_case_dict = {}
+    for key, val in model_dict.items():
+        snake_case_key = camel_case_to_snake_case[key] if key in camel_case_to_snake_case else key
+
+        if snake_case_key != key and snake_case_key in model_dict:
+            raise Exception(
+                f"Model class {model_class.__name__} cannot contain both {key} and {snake_case_key} keys"
+            )
+
+        snake_case_dict[snake_case_key] = val
+
+    invalid_keys = set(snake_case_dict).difference(snake_case_to_camel_case)
+
+    if len(invalid_keys):
+        raise Exception(f"Unexpected keys in model class {model_class.__name__}: {invalid_keys}")
+
+    final_dict = {}
+    for key, val in snake_case_dict.items():
+        attr_type = model_class.openapi_types[key]
+        final_dict[key] = _k8s_snake_case_value(val, attr_type, key)
+
+    return final_dict
+
+
 # Heavily inspired by kubernetes.client.ApiClient.__deserialize_model, with more validation
-# that the keys and values match the expected format. Expects atribute names to be in camelCase.
+# that the keys and values match the expected format. Requires k8s atribute names to be in
+# snake_case.
 def k8s_model_from_dict(model_class, model_dict: Dict[str, Any]):
     check.dict_param(model_dict, "model_dict")
-    kwargs = {}
 
-    expected_keys = set(model_class.attribute_map.values())
+    expected_keys = set(model_class.attribute_map.keys())
     invalid_keys = set(model_dict).difference(expected_keys)
 
     if len(invalid_keys):
         raise Exception(f"Unexpected keys in model class {model_class.__name__}: {invalid_keys}")
 
+    kwargs = {}
     for attr, attr_type in model_class.openapi_types.items():
         # e.g. config_map => configMap
-        mapped_attr = model_class.attribute_map[attr]
-        if mapped_attr in model_dict:
-            value = model_dict[mapped_attr]
-            kwargs[attr] = _k8s_value(value, attr_type, mapped_attr)
+        if attr in model_dict:
+            value = model_dict[attr]
+            kwargs[attr] = _k8s_parse_value(value, attr_type, attr)
 
     return model_class(**kwargs)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -87,8 +87,8 @@ def test_step_handler_user_defined_config(kubeconfig_file):
 
     # Construct Dagster solid tags with user defined k8s config.
     expected_resources = {
-        "requests": {"cpu": "250m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "2560Mi"},
+        "requests": {"cpu": "250m", "memory": "64Mi"},
     }
     user_defined_k8s_config = UserDefinedDagsterK8sConfig(
         container_config={"resources": expected_resources},
@@ -118,7 +118,7 @@ def test_step_handler_user_defined_config(kubeconfig_file):
         assert method_name == "create_namespaced_job"
         assert kwargs["body"].spec.template.spec.containers[0].image == "bizbuz"
         job_resources = kwargs["body"].spec.template.spec.containers[0].resources
-        assert job_resources == expected_resources
+        assert job_resources.to_dict() == expected_resources
 
 
 def test_step_handler_image_override(kubeconfig_file):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -33,16 +33,16 @@ def test_job_serialization():
 def test_user_defined_k8s_config_serialization():
     cfg = UserDefinedDagsterK8sConfig(
         container_config={
-            "resouces": {
+            "resources": {
                 "requests": {"cpu": "250m", "memory": "64Mi"},
                 "limits": {"cpu": "500m", "memory": "2560Mi"},
             }
         },
-        pod_template_spec_metadata={"key": "value"},
-        pod_spec_config={"key": "value"},
-        job_config={"key": "value"},
-        job_metadata={"key": "value"},
-        job_spec_config={"key": "value"},
+        pod_template_spec_metadata={"namespace": "value"},
+        pod_spec_config={"dns_policy": "value"},
+        job_config={"status": {"completed_indexes": "value"}},
+        job_metadata={"namespace": "value"},
+        job_spec_config={"backoff_limit": 120},
     )
 
     assert UserDefinedDagsterK8sConfig.from_dict(cfg.to_dict()) == cfg
@@ -146,23 +146,22 @@ def test_construct_dagster_k8s_job_with_mounts():
     assert len(foo_volumes) == 1
     assert foo_volumes[0]["secret"]["secret_name"] == "settings-secret"
 
-    cfg_with_invalid_volume_key = DagsterK8sJobConfig(
-        job_image="test/foo:latest",
-        dagster_home="/opt/dagster/dagster_home",
-        image_pull_policy="Always",
-        image_pull_secrets=[{"name": "my_secret"}],
-        service_account_name=None,
-        instance_config_map="some-instance-configmap",
-        postgres_password_secret=None,
-        env_config_maps=None,
-        env_secrets=None,
-        volume_mounts=[{"name": "foo", "mountPath": "biz/buz", "subPath": "file.txt"}],
-        volumes=[
-            {"name": "foo", "invalidKey": "settings-secret"},
-        ],
-    )
     with pytest.raises(Exception, match="Unexpected keys in model class V1Volume: {'invalidKey'}"):
-        construct_dagster_k8s_job(cfg_with_invalid_volume_key, ["foo", "bar"], "job123").to_dict()
+        DagsterK8sJobConfig(
+            job_image="test/foo:latest",
+            dagster_home="/opt/dagster/dagster_home",
+            image_pull_policy="Always",
+            image_pull_secrets=[{"name": "my_secret"}],
+            service_account_name=None,
+            instance_config_map="some-instance-configmap",
+            postgres_password_secret=None,
+            env_config_maps=None,
+            env_secrets=None,
+            volume_mounts=[{"name": "foo", "mountPath": "biz/buz", "subPath": "file.txt"}],
+            volumes=[
+                {"name": "foo", "invalidKey": "settings-secret"},
+            ],
+        )
 
 
 def test_construct_dagster_k8s_job_with_env():
@@ -185,7 +184,7 @@ def test_construct_dagster_k8s_job_with_env():
         assert env_mapping["ENV_VAR_2"]["value"] == "two"
 
 
-def test_construct_dagster_k8s_job_with_user_defined_env():
+def test_construct_dagster_k8s_job_with_user_defined_env_camelcase():
     @graph
     def user_defined_k8s_env_tags_graph():
         pass
@@ -231,11 +230,12 @@ def test_construct_dagster_k8s_job_with_user_defined_env():
     }
 
 
-def test_construct_dagster_k8s_job_with_user_defined_env_from():
+def test_construct_dagster_k8s_job_with_user_defined_env_snake_case():
     @graph
     def user_defined_k8s_env_from_tags_graph():
         pass
 
+    # These fields still work even when using underscore keys
     user_defined_k8s_config = get_user_defined_k8s_config(
         user_defined_k8s_env_from_tags_graph.to_job(
             tags={
@@ -289,11 +289,71 @@ def test_construct_dagster_k8s_job_with_user_defined_env_from():
     assert env_from_mapping["user_secret_ref_two"]
 
 
-def test_construct_dagster_k8s_job_with_user_defined_volume_mounts():
+def test_construct_dagster_k8s_job_with_user_defined_env_from():
+    @graph
+    def user_defined_k8s_env_from_tags_graph():
+        pass
+
+    # These fields still work even when using underscore keys
+    user_defined_k8s_config = get_user_defined_k8s_config(
+        user_defined_k8s_env_from_tags_graph.to_job(
+            tags={
+                USER_DEFINED_K8S_CONFIG_KEY: {
+                    "container_config": {
+                        "envFrom": [
+                            {
+                                "configMapRef": {
+                                    "name": "user_config_map_ref",
+                                    "optional": "True",
+                                }
+                            },
+                            {"secretRef": {"name": "user_secret_ref_one", "optional": "True"}},
+                            {
+                                "secretRef": {
+                                    "name": "user_secret_ref_two",
+                                    "optional": "False",
+                                },
+                                "prefix": "with_prefix",
+                            },
+                        ]
+                    }
+                }
+            }
+        ).tags
+    )
+
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="some-instance-configmap",
+        env_config_maps=["config_map"],
+        env_secrets=["secret"],
+    )
+
+    job = construct_dagster_k8s_job(
+        cfg, ["foo", "bar"], "job", user_defined_k8s_config=user_defined_k8s_config
+    ).to_dict()
+
+    env_from = job["spec"]["template"]["spec"]["containers"][0]["env_from"]
+    env_from_mapping = {
+        (env_var.get("config_map_ref") or env_var.get("secret_ref")).get("name"): env_var
+        for env_var in env_from
+    }
+
+    assert len(env_from_mapping) == 5
+    assert env_from_mapping["config_map"]
+    assert env_from_mapping["user_config_map_ref"]
+    assert env_from_mapping["secret"]
+    assert env_from_mapping["user_secret_ref_one"]
+    assert env_from_mapping["user_secret_ref_two"]
+
+
+def test_construct_dagster_k8s_job_with_user_defined_volume_mounts_snake_case():
     @graph
     def user_defined_k8s_volume_mounts_tags_graph():
         pass
 
+    # volume_mounts still work even when using underscore keys
     user_defined_k8s_config = get_user_defined_k8s_config(
         user_defined_k8s_volume_mounts_tags_graph.to_job(
             tags={
@@ -340,11 +400,63 @@ def test_construct_dagster_k8s_job_with_user_defined_volume_mounts():
     assert volume_mounts_mapping["a_volume_mount_two"]
 
 
-def test_construct_dagster_k8s_job_with_user_defined_service_account_name():
+def test_construct_dagster_k8s_job_with_user_defined_volume_mounts_camel_case():
+    @graph
+    def user_defined_k8s_volume_mounts_tags_graph():
+        pass
+
+    user_defined_k8s_config = get_user_defined_k8s_config(
+        user_defined_k8s_volume_mounts_tags_graph.to_job(
+            tags={
+                USER_DEFINED_K8S_CONFIG_KEY: {
+                    "container_config": {
+                        "volumeMounts": [
+                            {
+                                "mountPath": "mount_path",
+                                "mountPropagation": "mount_propagation",
+                                "name": "a_volume_mount_one",
+                                "readOnly": "False",
+                                "subPath": "path/",
+                            },
+                            {
+                                "mountPath": "mount_path",
+                                "mountPropagation": "mount_propagation",
+                                "name": "a_volume_mount_two",
+                                "readOnly": "False",
+                                "subPathExpr": "path/",
+                            },
+                        ]
+                    }
+                }
+            }
+        ).tags
+    )
+
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="some-instance-configmap",
+    )
+
+    job = construct_dagster_k8s_job(
+        cfg, ["foo", "bar"], "job", user_defined_k8s_config=user_defined_k8s_config
+    ).to_dict()
+
+    volume_mounts = job["spec"]["template"]["spec"]["containers"][0]["volume_mounts"]
+    volume_mounts_mapping = {volume_mount["name"]: volume_mount for volume_mount in volume_mounts}
+
+    assert len(volume_mounts_mapping) == 3
+    assert volume_mounts_mapping["dagster-instance"]
+    assert volume_mounts_mapping["a_volume_mount_one"]
+    assert volume_mounts_mapping["a_volume_mount_two"]
+
+
+def test_construct_dagster_k8s_job_with_user_defined_service_account_name_snake_case():
     @graph
     def user_defined_k8s_service_account_name_tags_graph():
         pass
 
+    # service_account_name still works
     user_defined_k8s_config = get_user_defined_k8s_config(
         user_defined_k8s_service_account_name_tags_graph.to_job(
             tags={
@@ -372,15 +484,49 @@ def test_construct_dagster_k8s_job_with_user_defined_service_account_name():
     assert service_account_name == "this-should-take-precedence"
 
 
-def test_construct_dagster_k8s_job_with_ttl():
+def test_construct_dagster_k8s_job_with_user_defined_service_account_name():
+    @graph
+    def user_defined_k8s_service_account_name_tags_graph():
+        pass
+
+    user_defined_k8s_config = get_user_defined_k8s_config(
+        user_defined_k8s_service_account_name_tags_graph.to_job(
+            tags={
+                USER_DEFINED_K8S_CONFIG_KEY: {
+                    "pod_spec_config": {
+                        "serviceAccountName": "this-should-take-precedence",
+                    },
+                },
+            },
+        ).tags
+    )
+
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="some-instance-configmap",
+        service_account_name="this-should-be-overriden",
+    )
+
+    job = construct_dagster_k8s_job(
+        cfg, ["foo", "bar"], "job", user_defined_k8s_config=user_defined_k8s_config
+    ).to_dict()
+
+    service_account_name = job["spec"]["template"]["spec"]["service_account_name"]
+    assert service_account_name == "this-should-take-precedence"
+
+
+def test_construct_dagster_k8s_job_with_ttl_snake_case():
     cfg = DagsterK8sJobConfig(
         job_image="test/foo:latest",
         dagster_home="/opt/dagster/dagster_home",
         instance_config_map="test",
     )
     job = construct_dagster_k8s_job(cfg, [], "job123").to_dict()
+
     assert job["spec"]["ttl_seconds_after_finished"] == DEFAULT_K8S_JOB_TTL_SECONDS_AFTER_FINISHED
 
+    # Setting ttl_seconds_after_finished still works
     user_defined_cfg = UserDefinedDagsterK8sConfig(
         job_spec_config={"ttl_seconds_after_finished": 0},
     )
@@ -388,6 +534,64 @@ def test_construct_dagster_k8s_job_with_ttl():
         cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
     ).to_dict()
     assert job["spec"]["ttl_seconds_after_finished"] == 0
+
+
+def test_construct_dagster_k8s_job_with_ttl():
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="test",
+    )
+    job = construct_dagster_k8s_job(cfg, [], "job123").to_dict()
+
+    assert job["spec"]["ttl_seconds_after_finished"] == DEFAULT_K8S_JOB_TTL_SECONDS_AFTER_FINISHED
+
+    user_defined_cfg = UserDefinedDagsterK8sConfig(
+        job_spec_config={"ttlSecondsAfterFinished": 0},
+    )
+    job = construct_dagster_k8s_job(
+        cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
+    ).to_dict()
+    assert job["spec"]["ttl_seconds_after_finished"] == 0
+
+
+def test_construct_dagster_k8s_job_with_sidecar_container():
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="test",
+    )
+    job = construct_dagster_k8s_job(cfg, [], "job123").to_dict()
+
+    assert job["spec"]["ttl_seconds_after_finished"] == DEFAULT_K8S_JOB_TTL_SECONDS_AFTER_FINISHED
+
+    user_defined_cfg = UserDefinedDagsterK8sConfig(
+        pod_spec_config={
+            "containers": [{"command": ["echo", "HI"], "image": "sidecar:bar", "name": "sidecar"}]
+        },
+    )
+    job = construct_dagster_k8s_job(
+        cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
+    ).to_dict()
+
+    containers = job["spec"]["template"]["spec"]["containers"]
+
+    assert len(containers) == 2
+
+    assert containers[0]["image"] == "test/foo:latest"
+
+    assert containers[1]["image"] == "sidecar:bar"
+    assert containers[1]["command"] == ["echo", "HI"]
+    assert containers[1]["name"] == "sidecar"
+
+
+def test_construct_dagster_k8s_job_with_invalid_key_raises_error():
+    with pytest.raises(
+        Exception, match="Unexpected keys in model class V1JobSpec: {'nonExistantKey'}"
+    ):
+        UserDefinedDagsterK8sConfig(
+            job_spec_config={"nonExistantKey": "nonExistantValue"},
+        )
 
 
 def test_construct_dagster_k8s_job_with_labels():

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -126,7 +126,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
         container = kwargs["body"].spec.template.spec.containers[0]
 
         job_resources = container.resources
-        assert job_resources == expected_resources
+        assert job_resources.to_dict() == expected_resources
         assert DAGSTER_PG_PASSWORD_ENV_VAR in [env.name for env in container.env]
 
         labels = kwargs["body"].spec.template.metadata.labels

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
@@ -215,11 +215,11 @@ def test_user_defined_config_from_tags():
                 "limits": {"cpu": "1000m", "memory": "1Gi"},
             }
         },
-        "pod_template_spec_metadata": {"pod_template_spec_key": "pod_template_spec_value"},
-        "pod_spec_config": {"pod_spec_config_key": "pod_spec_config_value"},
-        "job_config": {"job_config_key": "job_config_value"},
-        "job_metadata": {"job_metadata_key": "job_metadata_value"},
-        "job_spec_config": {"job_spec_config_key": "job_spec_config_value"},
+        "pod_template_spec_metadata": {"namespace": "pod_template_spec_value"},
+        "pod_spec_config": {"dns_policy": "pod_spec_config_value"},
+        "job_config": {"status": {"completed_indexes": "job_config_value"}},
+        "job_metadata": {"namespace": "job_metadata_value"},
+        "job_spec_config": {"backoff_limit": 120},
     }
 
     @pipeline(tags={USER_DEFINED_K8S_CONFIG_KEY: config_args})


### PR DESCRIPTION
Summary:
This is intended to resolve the confusing patchwork state we are in where some k8s config keys (env_from) need to be specified using underscores, but others need to be specified using camelCase. Also allows us to use the full range of k8s config available when configuring a job, while still getting schema validation.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.