### PR TITLE
add batch loaders to GraphenePipeline

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -110,7 +110,11 @@ def fetch_repositories(graphene_info):
     check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     return GrapheneRepositoryConnection(
         nodes=[
-            GrapheneRepository(repository=repository, repository_location=location)
+            GrapheneRepository(
+                instance=graphene_info.context.instance,
+                repository=repository,
+                repository_location=location,
+            )
             for location in graphene_info.context.repository_locations
             for repository in location.get_repositories().values()
         ]
@@ -129,6 +133,7 @@ def fetch_repository(graphene_info, repository_selector):
         repo_loc = graphene_info.context.get_repository_location(repository_selector.location_name)
         if repo_loc.has_repository(repository_selector.repository_name):
             return GrapheneRepository(
+                instance=graphene_info.context.instance,
                 repository=repo_loc.get_repository(repository_selector.repository_name),
                 repository_location=repo_loc,
             )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -1,0 +1,55 @@
+from collections import defaultdict
+
+from dagster import check
+from dagster.core.storage.pipeline_run import RunBucketLimit
+
+
+class BatchJobRunLoader:
+    def __init__(self, graphene_info, job_names):
+        self._instance = graphene_info.context.instance
+        self._job_names = check.list_param(job_names, "job_names", of_type=str)
+        self._fetched = False
+        self._fetched_limit = None
+        self._data = None
+
+    def get_runs_for_job(self, job_name, limit):
+        check.invariant(job_name in self._job_names)
+        if not self._fetched or limit > self._fetched_limit:
+            self.fetch(limit)
+        return self._data[job_name][:limit]
+
+    def fetch(self, limit):
+        runs = self._instance.get_runs(limit=RunBucketLimit.by_job(bucket_limit=limit))
+        self._data = defaultdict(list)
+        for run in runs:
+            self._data[run.pipeline_name].append(run)
+        self._fetched_limit = limit
+        self._fetched = True
+
+
+class BatchTagRunLoader:
+    def __init__(self, graphene_info, tag_key):
+        self._instance = graphene_info.context.instance
+        self._tag_key = check.str_param(tag_key, "tag_key")
+        self._fetched = False
+        self._fetched_limit = None
+        self._data = None
+
+    @property
+    def tag_key(self):
+        return self._tag_key
+
+    def get_runs_for_tag(self, tag_value, limit):
+        if not self._fetched or limit > self._fetched_limit:
+            self.fetch(limit)
+        return self._data[tag_value][:limit]
+
+    def fetch(self, limit):
+        runs = self._instance.get_runs(
+            limit=RunBucketLimit.by_tag(self._tag_key, bucket_limit=limit)
+        )
+        self._data = defaultdict(list)
+        for run in runs:
+            self._data[run.tags.get(self._tag_key)].append(run)
+        self._fetched_limit = limit
+        self._fetched = True

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -19,7 +19,9 @@ class BatchJobRunLoader:
         return self._data[job_name][:limit]
 
     def fetch(self, limit):
-        runs = self._instance.get_runs(limit=RunBucketLimit.by_job(bucket_limit=limit))
+        runs = self._instance.get_runs(
+            limit=RunBucketLimit.by_job(bucket_limit=limit, job_names=self._job_names)
+        )
         self._data = defaultdict(list)
         for run in runs:
             self._data[run.pipeline_name].append(run)
@@ -28,9 +30,10 @@ class BatchJobRunLoader:
 
 
 class BatchTagRunLoader:
-    def __init__(self, graphene_info, tag_key):
+    def __init__(self, graphene_info, tag_key, tag_values):
         self._instance = graphene_info.context.instance
         self._tag_key = check.str_param(tag_key, "tag_key")
+        self._tag_values = check.list_param(tag_values, "tag_values", of_type=str)
         self._fetched = False
         self._fetched_limit = None
         self._data = None
@@ -46,7 +49,9 @@ class BatchTagRunLoader:
 
     def fetch(self, limit):
         runs = self._instance.get_runs(
-            limit=RunBucketLimit.by_tag(self._tag_key, bucket_limit=limit)
+            limit=RunBucketLimit.by_tag(
+                self._tag_key, tag_values=self._tag_values, bucket_limit=limit
+            )
         )
         self._data = defaultdict(list)
         for run in runs:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -55,37 +55,37 @@ class RepositoryScopedBatchLoader:
 
         if data_type == RepositoryDataType.JOB_RUNS:
             job_names = [x.name for x in self._repository.get_all_external_pipelines()]
-            runs = self._instance.get_runs(
-                bucket=JobBucket(bucket_limit=limit, job_names=job_names),
+            records = self._instance.get_run_records(
+                bucket_by=JobBucket(bucket_limit=limit, job_names=job_names),
             )
-            for run in runs:
-                fetched[run.pipeline_name].append(run)
+            for record in records:
+                fetched[record.pipeline_run.pipeline_name].append(record)
 
         elif data_type == RepositoryDataType.SCHEDULE_RUNS:
             schedule_names = [
                 schedule.name for schedule in self._repository.get_external_schedules()
             ]
-            runs = self._instance.get_runs(
-                bucket=TagBucket(
+            records = self._instance.get_run_records(
+                bucket_by=TagBucket(
                     tag_key=SCHEDULE_NAME_TAG,
                     bucket_limit=limit,
                     tag_values=schedule_names,
                 ),
             )
-            for run in runs:
-                fetched[run.tags.get(SCHEDULE_NAME_TAG)].append(run)
+            for record in records:
+                fetched[record.pipeline_run.tags.get(SCHEDULE_NAME_TAG)].append(record)
 
         elif data_type == RepositoryDataType.SENSOR_RUNS:
             sensor_names = [sensor.name for sensor in self._repository.get_external_sensors()]
-            runs = self._instance.get_runs(
-                bucket=TagBucket(
+            records = self._instance.get_run_records(
+                bucket_by=TagBucket(
                     tag_key=SENSOR_NAME_TAG,
                     bucket_limit=limit,
                     tag_values=sensor_names,
                 ),
             )
-            for run in runs:
-                fetched[run.tags.get(SENSOR_NAME_TAG)].append(run)
+            for record in records:
+                fetched[record.pipeline_run.tags.get(SENSOR_NAME_TAG)].append(record)
 
         elif data_type == RepositoryDataType.SCHEDULE_STATES:
             schedule_states = self._instance.all_stored_job_state(
@@ -108,21 +108,21 @@ class RepositoryScopedBatchLoader:
         self._data[data_type] = fetched
         self._limits[data_type] = limit
 
-    def get_runs_for_job(self, job_name, limit):
+    def get_run_records_for_job(self, job_name, limit):
         check.invariant(
             job_name
             in [pipeline.name for pipeline in self._repository.get_all_external_pipelines()]
         )
         return self._get(RepositoryDataType.JOB_RUNS, job_name, limit)
 
-    def get_runs_for_schedule(self, schedule_name, limit):
+    def get_run_records_for_schedule(self, schedule_name, limit):
         check.invariant(
             schedule_name
             in [schedule.name for schedule in self._repository.get_external_schedules()]
         )
         return self._get(RepositoryDataType.SCHEDULE_RUNS, schedule_name, limit)
 
-    def get_runs_for_sensor(self, sensor_name, limit):
+    def get_run_records_for_sensor(self, sensor_name, limit):
         check.invariant(
             sensor_name in [sensor.name for sensor in self._repository.get_external_sensors()]
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -100,12 +100,14 @@ class GrapheneAssetNode(graphene.ObjectType):
             description=external_asset_node.op_description,
         )
 
-    def resolve_repository(self, _graphene_info):
+    def resolve_repository(self, graphene_info):
         loc = None
-        for location in _graphene_info.context.repository_locations:
+        for location in graphene_info.context.repository_locations:
             if self._external_repository in location.get_repositories().values():
                 loc = location
-        return external.GrapheneRepository(self._external_repository, loc)
+        return external.GrapheneRepository(
+            graphene_info.context.instance, self._external_repository, loc
+        )
 
     def resolve_dependencies(self, _graphene_info):
         return [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -1,16 +1,15 @@
 import graphene
-from dagster import check
+from dagster import DagsterInstance, check
 from dagster.core.host_representation import (
     ExternalRepository,
     GrpcServerRepositoryLocation,
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
     RepositoryLocation,
 )
-from dagster.core.scheduler.instigation import InstigatorType
 from dagster.core.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
 from dagster_graphql.implementation.fetch_runs import get_in_progress_runs_by_step
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
-from dagster_graphql.implementation.loader import BatchJobRunLoader, BatchTagRunLoader
+from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
 
 from .asset_graph import GrapheneAssetNode
 from .errors import GraphenePythonError, GrapheneRepositoryNotFoundError
@@ -86,9 +85,9 @@ class GrapheneRepositoryLocation(graphene.ObjectType):
     def resolve_id(self, _):
         return self.name
 
-    def resolve_repositories(self, _graphene_info):
+    def resolve_repositories(self, graphene_info):
         return [
-            GrapheneRepository(repository, self._location)
+            GrapheneRepository(graphene_info.context.instance, repository, self._location)
             for repository in self._location.get_repositories().values()
         ]
 
@@ -165,11 +164,13 @@ class GrapheneRepository(graphene.ObjectType):
     class Meta:
         name = "Repository"
 
-    def __init__(self, repository, repository_location):
+    def __init__(self, instance, repository, repository_location):
         self._repository = check.inst_param(repository, "repository", ExternalRepository)
         self._repository_location = check.inst_param(
             repository_location, "repository_location", RepositoryLocation
         )
+        check.inst_param(instance, "instance", DagsterInstance)
+        self._batch_loader = RepositoryScopedBatchLoader(instance, repository)
         super().__init__(name=repository.name)
 
     def resolve_id(self, _graphene_info):
@@ -182,88 +183,43 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_location(self, _graphene_info):
         return GrapheneRepositoryLocation(self._repository_location)
 
-    def resolve_schedules(self, graphene_info):
-        from dagster.core.storage.tags import SCHEDULE_NAME_TAG
-
-        schedules = self._repository.get_external_schedules()
-
-        # Instantiates a batch tag run loader, to be passed to all of the repository schedules, so
-        # that all of their runs can be fetched in a batched database request. This can be done
-        # because all runs for a schedule will have thier schedule name as the value for the
-        # SCHEDULE_NAME_TAG.
-        batch_run_loader = BatchTagRunLoader(
-            graphene_info, SCHEDULE_NAME_TAG, [schedule.name for schedule in schedules]
-        )
-
-        schedule_states_by_name = {
-            state.name: state
-            for state in graphene_info.context.instance.all_stored_job_state(
-                repository_origin_id=self._repository.get_external_origin_id(),
-                job_type=InstigatorType.SCHEDULE,
-            )
-        }
-
+    def resolve_schedules(self, _graphene_info):
         return sorted(
             [
                 GrapheneSchedule(
-                    schedule, schedule_states_by_name.get(schedule.name), batch_run_loader
+                    schedule,
+                    self._batch_loader.get_schedule_state(schedule.name),
+                    self._batch_loader,
                 )
-                for schedule in schedules
+                for schedule in self._repository.get_external_schedules()
             ],
             key=lambda schedule: schedule.name,
         )
 
-    def resolve_sensors(self, graphene_info):
-        from dagster.core.storage.tags import SENSOR_NAME_TAG
-
-        sensors = self._repository.get_external_sensors()
-
-        # Instantiates a batch tag run loader, to be passed to all of the repository sensors, so
-        # that all of their runs can be fetched in a batched database request. This can be done
-        # because all runs for a sensor will have thier sensor name as the value for the
-        # SENSOR_NAME_TAG.
-        batch_run_loader = BatchTagRunLoader(
-            graphene_info, SENSOR_NAME_TAG, [sensor.name for sensor in sensors]
-        )
-        sensor_states_by_name = {
-            state.name: state
-            for state in graphene_info.context.instance.all_stored_job_state(
-                repository_origin_id=self._repository.get_external_origin_id(),
-                job_type=InstigatorType.SENSOR,
-            )
-        }
+    def resolve_sensors(self, _graphene_info):
         return sorted(
             [
                 GrapheneSensor(
                     sensor,
-                    sensor_states_by_name.get(sensor.name),
-                    batch_run_loader,
+                    self._batch_loader.get_sensor_state(sensor.name),
+                    self._batch_loader,
                 )
-                for sensor in sensors
+                for sensor in self._repository.get_external_sensors()
             ],
             key=lambda sensor: sensor.name,
         )
 
-    def resolve_pipelines(self, graphene_info):
-        external_pipelines = self._repository.get_all_external_pipelines()
-
-        # Instantiates a batch job run loader, to be passed to all of the repository sensors, so
-        # that all of their runs can be fetched in a batched database request.
-        batch_run_loader = BatchJobRunLoader(graphene_info, [x.name for x in external_pipelines])
+    def resolve_pipelines(self, _graphene_info):
         return [
-            GraphenePipeline(pipeline, batch_run_loader)
-            for pipeline in sorted(external_pipelines, key=lambda pipeline: pipeline.name)
+            GraphenePipeline(pipeline, self._batch_loader)
+            for pipeline in sorted(
+                self._repository.get_all_external_pipelines(), key=lambda pipeline: pipeline.name
+            )
         ]
 
-    def resolve_jobs(self, graphene_info):
-        external_jobs = [
-            pipeline
-            for pipeline in self._repository.get_all_external_pipelines()
-            if pipeline.is_job
-        ]
-        batch_run_loader = BatchJobRunLoader(graphene_info, [x.name for x in external_jobs])
+    def resolve_jobs(self, _graphene_info):
         return [
-            GrapheneJob(pipeline, batch_run_loader)
+            GrapheneJob(pipeline, self._batch_loader)
             for pipeline in sorted(
                 self._repository.get_all_external_pipelines(), key=lambda pipeline: pipeline.name
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -186,6 +186,11 @@ class GrapheneRepository(graphene.ObjectType):
         from dagster.core.storage.tags import SCHEDULE_NAME_TAG
 
         schedules = self._repository.get_external_schedules()
+
+        # Instantiates a batch tag run loader, to be passed to all of the repository schedules, so
+        # that all of their runs can be fetched in a batched database request. This can be done
+        # because all runs for a schedule will have thier schedule name as the value for the
+        # SCHEDULE_NAME_TAG.
         batch_run_loader = BatchTagRunLoader(
             graphene_info, SCHEDULE_NAME_TAG, [schedule.name for schedule in schedules]
         )
@@ -212,6 +217,11 @@ class GrapheneRepository(graphene.ObjectType):
         from dagster.core.storage.tags import SENSOR_NAME_TAG
 
         sensors = self._repository.get_external_sensors()
+
+        # Instantiates a batch tag run loader, to be passed to all of the repository sensors, so
+        # that all of their runs can be fetched in a batched database request. This can be done
+        # because all runs for a sensor will have thier sensor name as the value for the
+        # SENSOR_NAME_TAG.
         batch_run_loader = BatchTagRunLoader(
             graphene_info, SENSOR_NAME_TAG, [sensor.name for sensor in sensors]
         )
@@ -235,8 +245,10 @@ class GrapheneRepository(graphene.ObjectType):
         )
 
     def resolve_pipelines(self, graphene_info):
-
         external_pipelines = self._repository.get_all_external_pipelines()
+
+        # Instantiates a batch job run loader, to be passed to all of the repository sensors, so
+        # that all of their runs can be fetched in a batched database request.
         batch_run_loader = BatchJobRunLoader(graphene_info, [x.name for x in external_pipelines])
         return [
             GraphenePipeline(pipeline, batch_run_loader)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -185,9 +185,11 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_schedules(self, graphene_info):
         from dagster.core.storage.tags import SCHEDULE_NAME_TAG
 
-        batch_run_loader = BatchTagRunLoader(graphene_info, SCHEDULE_NAME_TAG)
-
         schedules = self._repository.get_external_schedules()
+        batch_run_loader = BatchTagRunLoader(
+            graphene_info, SCHEDULE_NAME_TAG, [schedule.name for schedule in schedules]
+        )
+
         schedule_states_by_name = {
             state.name: state
             for state in graphene_info.context.instance.all_stored_job_state(
@@ -209,8 +211,10 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_sensors(self, graphene_info):
         from dagster.core.storage.tags import SENSOR_NAME_TAG
 
-        batch_run_loader = BatchTagRunLoader(graphene_info, SENSOR_NAME_TAG)
         sensors = self._repository.get_external_sensors()
+        batch_run_loader = BatchTagRunLoader(
+            graphene_info, SENSOR_NAME_TAG, [sensor.name for sensor in sensors]
+        )
         sensor_states_by_name = {
             state.name: state
             for state in graphene_info.context.instance.all_stored_job_state(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -314,12 +314,12 @@ class GrapheneInstigationState(graphene.ObjectType):
 
         if kwargs.get("limit") and self._batch_loader:
             limit = kwargs["limit"]
-            runs = (
-                self._batch_loader.get_runs_for_sensor(self._job_state.name, limit)
+            records = (
+                self._batch_loader.get_run_records_for_sensor(self._job_state.name, limit)
                 if self._job_state.job_type == InstigatorType.SENSOR
-                else self._batch_loader.get_runs_for_schedule(self._job_state.name, limit)
+                else self._batch_loader.get_run_records_for_schedule(self._job_state.name, limit)
             )
-            return [GrapheneRun(run) for run in runs]
+            return [GrapheneRun(record) for record in records]
 
         if self._job_state.job_type == InstigatorType.SENSOR:
             filters = PipelineRunsFilter.for_sensor(self._job_state)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -15,7 +15,7 @@ from dagster.core.scheduler.instigation import (
     SensorInstigatorData,
 )
 from dagster.core.storage.pipeline_run import PipelineRunsFilter
-from dagster.core.storage.tags import TagType, get_tag_type
+from dagster.core.storage.tags import SCHEDULE_NAME_TAG, SENSOR_NAME_TAG, TagType, get_tag_type
 from dagster.seven.compat.pendulum import to_timezone
 from dagster.utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -280,6 +280,9 @@ class GrapheneInstigationState(graphene.ObjectType):
         batch_run_loader=None,
     ):
         self._job_state = check.inst_param(job_state, "job_state", InstigatorState)
+
+        # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
+        # that instantiates multiple schedules/sensors
         self._batch_run_loader = check.opt_inst_param(
             batch_run_loader, "batch_run_loader", BatchTagRunLoader
         )
@@ -308,7 +311,6 @@ class GrapheneInstigationState(graphene.ObjectType):
 
     def resolve_runs(self, graphene_info, **kwargs):
         from .pipelines.pipeline import GrapheneRun
-        from dagster.core.storage.tags import SENSOR_NAME_TAG, SCHEDULE_NAME_TAG
 
         tag_key = (
             SENSOR_NAME_TAG

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -605,6 +605,8 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         self._external_pipeline = check.inst_param(
             external_pipeline, "external_pipeline", ExternalPipeline
         )
+        # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
+        # that instantiates multiple pipelines
         self._batch_run_loader = check.opt_inst_param(
             batch_run_loader, "batch_run_loader", BatchJobRunLoader
         )
@@ -644,6 +646,8 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
                 self._external_pipeline.name, kwargs.get("limit")
             )
             return [GrapheneRun(run) for run in runs]
+
+        # otherwise, fall back to the default implementation
         return super().resolve_runs(graphene_info, **kwargs)
 
     def resolve_assetNodes(self, graphene_info, **kwargs):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -14,7 +14,7 @@ from ...implementation.fetch_pipelines import get_pipeline_reference_or_raise
 from ...implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from ...implementation.fetch_schedules import get_schedules_for_pipeline
 from ...implementation.fetch_sensors import get_sensors_for_pipeline
-from ...implementation.loader import BatchJobRunLoader
+from ...implementation.loader import RepositoryScopedBatchLoader
 from ...implementation.utils import UserFacingGraphQLError, capture_error
 from ..asset_key import GrapheneAssetKey
 from ..dagster_types import GrapheneDagsterType, GrapheneDagsterTypeOrError, to_dagster_type
@@ -600,15 +600,15 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
         name = "Pipeline"
 
-    def __init__(self, external_pipeline, batch_run_loader=None):
+    def __init__(self, external_pipeline, batch_loader=None):
         super().__init__()
         self._external_pipeline = check.inst_param(
             external_pipeline, "external_pipeline", ExternalPipeline
         )
-        # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
-        # that instantiates multiple pipelines
-        self._batch_run_loader = check.opt_inst_param(
-            batch_run_loader, "batch_run_loader", BatchJobRunLoader
+        # optional run loader, provided by a parent GrapheneRepository object that instantiates
+        # multiple pipelines
+        self._batch_loader = check.opt_inst_param(
+            batch_loader, "batch_loader", RepositoryScopedBatchLoader
         )
 
     def resolve_id(self, _graphene_info):
@@ -637,12 +637,16 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
 
         handle = self._external_pipeline.repository_handle
         location = graphene_info.context.get_repository_location(handle.location_name)
-        return GrapheneRepository(location.get_repository(handle.repository_name), location)
+        return GrapheneRepository(
+            graphene_info.context.instance,
+            location.get_repository(handle.repository_name),
+            location,
+        )
 
     def resolve_runs(self, graphene_info, **kwargs):
         # override the implementation to use the batch run loader
-        if not kwargs.get("cursor") and kwargs.get("limit") and self._batch_run_loader:
-            runs = self._batch_run_loader.get_runs_for_job(
+        if not kwargs.get("cursor") and kwargs.get("limit") and self._batch_loader:
+            runs = self._batch_loader.get_runs_for_job(
                 self._external_pipeline.name, kwargs.get("limit")
             )
             return [GrapheneRun(run) for run in runs]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -14,6 +14,7 @@ from ...implementation.fetch_pipelines import get_pipeline_reference_or_raise
 from ...implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from ...implementation.fetch_schedules import get_schedules_for_pipeline
 from ...implementation.fetch_sensors import get_sensors_for_pipeline
+from ...implementation.loader import BatchJobRunLoader
 from ...implementation.utils import UserFacingGraphQLError, capture_error
 from ..asset_key import GrapheneAssetKey
 from ..dagster_types import GrapheneDagsterType, GrapheneDagsterTypeOrError, to_dagster_type
@@ -599,10 +600,13 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
         name = "Pipeline"
 
-    def __init__(self, external_pipeline):
+    def __init__(self, external_pipeline, batch_run_loader=None):
         super().__init__()
         self._external_pipeline = check.inst_param(
             external_pipeline, "external_pipeline", ExternalPipeline
+        )
+        self._batch_run_loader = check.opt_inst_param(
+            batch_run_loader, "batch_run_loader", BatchJobRunLoader
         )
 
     def resolve_id(self, _graphene_info):
@@ -632,6 +636,15 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         handle = self._external_pipeline.repository_handle
         location = graphene_info.context.get_repository_location(handle.location_name)
         return GrapheneRepository(location.get_repository(handle.repository_name), location)
+
+    def resolve_runs(self, graphene_info, **kwargs):
+        # override the implementation to use the batch run loader
+        if not kwargs.get("cursor") and kwargs.get("limit") and self._batch_run_loader:
+            runs = self._batch_run_loader.get_runs_for_job(
+                self._external_pipeline.name, kwargs.get("limit")
+            )
+            return [GrapheneRun(run) for run in runs]
+        return super().resolve_runs(graphene_info, **kwargs)
 
     def resolve_assetNodes(self, graphene_info, **kwargs):
         from ..asset_graph import GrapheneAssetNode

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -646,10 +646,10 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
     def resolve_runs(self, graphene_info, **kwargs):
         # override the implementation to use the batch run loader
         if not kwargs.get("cursor") and kwargs.get("limit") and self._batch_loader:
-            runs = self._batch_loader.get_runs_for_job(
+            records = self._batch_loader.get_run_records_for_job(
                 self._external_pipeline.name, kwargs.get("limit")
             )
-            return [GrapheneRun(run) for run in runs]
+            return [GrapheneRun(record) for record in records]
 
         # otherwise, fall back to the default implementation
         return super().resolve_runs(graphene_info, **kwargs)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -3,6 +3,7 @@ from dagster import check
 from dagster.core.host_representation import ExternalSensor, ExternalTargetData, SensorSelector
 from dagster.core.scheduler.instigation import InstigatorState
 from dagster.core.workspace.permissions import Permissions
+from dagster_graphql.implementation.loader import BatchTagRunLoader
 from dagster_graphql.implementation.utils import capture_error, check_permission
 
 from ..implementation.fetch_sensors import get_sensor_next_tick, start_sensor, stop_sensor
@@ -58,9 +59,12 @@ class GrapheneSensor(graphene.ObjectType):
     class Meta:
         name = "Sensor"
 
-    def __init__(self, external_sensor, sensor_state):
+    def __init__(self, external_sensor, sensor_state, batch_run_loader=None):
         self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
         self._sensor_state = check.opt_inst_param(sensor_state, "sensor_state", InstigatorState)
+        self._batch_run_loader = check.opt_inst_param(
+            batch_run_loader, "batch_run_loader", BatchTagRunLoader
+        )
 
         if not self._sensor_state:
             self._sensor_state = self._external_sensor.get_default_instigation_state()
@@ -80,7 +84,7 @@ class GrapheneSensor(graphene.ObjectType):
         return self._external_sensor.get_external_origin_id()
 
     def resolve_sensorState(self, _graphene_info):
-        return GrapheneInstigationState(self._sensor_state)
+        return GrapheneInstigationState(self._sensor_state, self._batch_run_loader)
 
     def resolve_nextTick(self, graphene_info):
         return get_sensor_next_tick(graphene_info, self._sensor_state)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -62,6 +62,9 @@ class GrapheneSensor(graphene.ObjectType):
     def __init__(self, external_sensor, sensor_state, batch_run_loader=None):
         self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
         self._sensor_state = check.opt_inst_param(sensor_state, "sensor_state", InstigatorState)
+
+        # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
+        # that instantiates multiple sensors
         self._batch_run_loader = check.opt_inst_param(
             batch_run_loader, "batch_run_loader", BatchTagRunLoader
         )
@@ -84,6 +87,7 @@ class GrapheneSensor(graphene.ObjectType):
         return self._external_sensor.get_external_origin_id()
 
     def resolve_sensorState(self, _graphene_info):
+        # forward the batch run loader to the instigation state, which provides the sensor runs
         return GrapheneInstigationState(self._sensor_state, self._batch_run_loader)
 
     def resolve_nextTick(self, graphene_info):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -3,7 +3,7 @@ from dagster import check
 from dagster.core.host_representation import ExternalSensor, ExternalTargetData, SensorSelector
 from dagster.core.scheduler.instigation import InstigatorState
 from dagster.core.workspace.permissions import Permissions
-from dagster_graphql.implementation.loader import BatchTagRunLoader
+from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
 from dagster_graphql.implementation.utils import capture_error, check_permission
 
 from ..implementation.fetch_sensors import get_sensor_next_tick, start_sensor, stop_sensor
@@ -59,14 +59,14 @@ class GrapheneSensor(graphene.ObjectType):
     class Meta:
         name = "Sensor"
 
-    def __init__(self, external_sensor, sensor_state, batch_run_loader=None):
+    def __init__(self, external_sensor, sensor_state, batch_loader=None):
         self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
         self._sensor_state = check.opt_inst_param(sensor_state, "sensor_state", InstigatorState)
 
-        # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
-        # that instantiates multiple sensors
-        self._batch_run_loader = check.opt_inst_param(
-            batch_run_loader, "batch_run_loader", BatchTagRunLoader
+        # optional run loader, provided by a parent GrapheneRepository object that instantiates
+        # multiple sensors
+        self._batch_loader = check.opt_inst_param(
+            batch_loader, "batch_loader", RepositoryScopedBatchLoader
         )
 
         if not self._sensor_state:
@@ -88,7 +88,7 @@ class GrapheneSensor(graphene.ObjectType):
 
     def resolve_sensorState(self, _graphene_info):
         # forward the batch run loader to the instigation state, which provides the sensor runs
-        return GrapheneInstigationState(self._sensor_state, self._batch_run_loader)
+        return GrapheneInstigationState(self._sensor_state, self._batch_loader)
 
     def resolve_nextTick(self, graphene_info):
         return get_sensor_next_tick(graphene_info, self._sensor_state)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -843,4 +843,6 @@ def test_repository_batching():
             counts = counter.counts()
             assert counts
             assert len(counts) == 1
+            # We should have a single batch call to fetch run records, instead of 3 separate calls
+            # to fetch run records (which is fetched to instantiate GrapheneRun)
             assert counts.get("DagsterInstance.get_run_records") == 1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -843,4 +843,4 @@ def test_repository_batching():
             counts = counter.counts()
             assert counts
             assert len(counts) == 1
-            assert counts.get("DagsterInstance.get_runs") == 1
+            assert counts.get("DagsterInstance.get_run_records") == 1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -507,5 +507,11 @@ def test_repository_batching(graphql_context):
     counts = counter.counts()
     assert counts
     assert len(counts) == 2
-    assert counts.get("DagsterInstance.get_runs") == 1
+
+    # We should have a single batch call to fetch run records (to fetch schedule runs) and a single
+    # batch call to fetch instigator state, instead of separate calls for each schedule (~18
+    # distinct schedules in the repo)
+    # 1) `get_run_records` is fetched to instantiate GrapheneRun
+    # 2) `all_stored_job_state` is fetched to instantiate GrapheneSchedule
+    assert counts.get("DagsterInstance.get_run_records") == 1
     assert counts.get("DagsterInstance.all_stored_job_state") == 1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -394,5 +394,11 @@ def test_repository_batching(graphql_context):
     counts = counter.counts()
     assert counts
     assert len(counts) == 2
-    assert counts.get("DagsterInstance.get_runs") == 1
+
+    # We should have a single batch call to fetch run records (to fetch sensor runs) and a single
+    # batch call to fetch instigator state, instead of separate calls for each sensor (~5 distinct
+    # sensors in the repo)
+    # 1) `get_run_records` is fetched to instantiate GrapheneRun
+    # 2) `all_stored_job_state` is fetched to instantiate GrapheneSensor
+    assert counts.get("DagsterInstance.get_run_records") == 1
     assert counts.get("DagsterInstance.all_stored_job_state") == 1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -4,6 +4,7 @@ from dagster.core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster.core.test_utils import create_test_daemon_workspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
+from dagster.utils import Counter, traced_counter
 from dagster_graphql.test.utils import (
     execute_dagster_graphql,
     infer_repository_selector,
@@ -158,6 +159,27 @@ mutation($jobOriginId: String!) {
       }
     }
   }
+}
+"""
+
+REPOSITORY_SENSORS_QUERY = """
+query RepositorySensorsQuery($repositorySelector: RepositorySelector!) {
+    repositoryOrError(repositorySelector: $repositorySelector) {
+        ... on Repository {
+            id
+            sensors {
+                id
+                name
+                sensorState {
+                    id
+                    runs(limit: 1) {
+                      id
+                      runId
+                    }
+                }
+            }
+        }
+    }
 }
 """
 
@@ -355,3 +377,22 @@ def test_sensor_tick_range(graphql_context):
         },
     )
     assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 2
+
+
+def test_repository_batching(graphql_context):
+    traced_counter.set(Counter())
+    selector = infer_repository_selector(graphql_context)
+    result = execute_dagster_graphql(
+        graphql_context,
+        REPOSITORY_SENSORS_QUERY,
+        variables={"repositorySelector": selector},
+    )
+    assert result.data
+    assert "repositoryOrError" in result.data
+    assert "sensors" in result.data["repositoryOrError"]
+    counter = traced_counter.get()
+    counts = counter.counts()
+    assert counts
+    assert len(counts) == 2
+    assert counts.get("DagsterInstance.get_runs") == 1
+    assert counts.get("DagsterInstance.all_stored_job_state") == 1


### PR DESCRIPTION
This should enable batching of runs at the repository level, making use of the new `RunBatchLimit` argument to `get_runs` / `get_run_records`.


## Test Plan
BK


