### PR TITLE
[dagit] Repair very long running runs in RunTimeline

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -78,3 +78,43 @@ export const ManyRows = () => {
 
   return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
 };
+
+export const VeryLongRunning = () => {
+  const fourHoursAgo = React.useMemo(() => Date.now() - 4 * 60 * 60 * 1000, []);
+  const twoHoursAgo = React.useMemo(() => Date.now() - 2 * 60 * 60 * 1000, []);
+  const twoDaysAgo = React.useMemo(() => Date.now() - 48 * 60 * 60 * 1000, []);
+  const future = React.useMemo(() => Date.now() + 1 * 60 * 60 * 1000, []);
+
+  const jobs = React.useMemo(() => {
+    const jobKeyA = faker.random.words(2).split(' ').join('-').toLowerCase();
+    const jobKeyB = faker.random.words(2).split(' ').join('-').toLowerCase();
+    return {
+      [jobKeyA]: {
+        label: jobKeyA,
+        path: `/${jobKeyA}`,
+        runs: [
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.FAILURE,
+            startTime: twoDaysAgo,
+            endTime: twoHoursAgo,
+          },
+        ],
+      },
+      [jobKeyB]: {
+        label: jobKeyB,
+        path: `/${jobKeyB}`,
+        runs: [
+          {
+            id: faker.datatype.uuid(),
+            status: RunStatus.STARTED,
+            startTime: twoDaysAgo,
+            endTime: Date.now(),
+          },
+        ],
+      },
+    };
+  }, [twoDaysAgo, twoHoursAgo]);
+
+  return <RunTimeline jobs={jobs} range={[fourHoursAgo, future]} />;
+};

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -303,10 +303,13 @@ const RunTimelineRow = (props: RowProps) => {
       .map((run) => {
         const startTime = run.startTime;
         const endTime = run.endTime || Date.now();
-        const left = Math.floor(((startTime - start) / rangeLength) * width);
+        const left = Math.max(0, Math.floor(((startTime - start) / rangeLength) * width));
         const runWidth = Math.max(
           MIN_CHUNK_WIDTH,
-          Math.ceil(((endTime - startTime) / rangeLength) * width),
+          Math.min(
+            Math.ceil(((endTime - startTime) / rangeLength) * width),
+            Math.ceil(((endTime - start) / rangeLength) * width),
+          ),
         );
 
         return {


### PR DESCRIPTION
## Summary

Very long runs that began before the RunTimeline range are currently broken. Fix this by ensuring that `left` cannot be lower than `0`, and that `width` calculates a appropriately for the range.

## Test Plan

View new Storybook example.
