### PR TITLE
Add more validation to k8s labels

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from dagster import check, seven
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 
@@ -8,6 +10,13 @@ from .client import (
     DagsterKubernetesClient,
     WaitForPodState,
 )
+
+
+def sanitize_k8s_label(label_name: str):
+    # Truncate too long label values to fit into 63-characters limit and avoid invalid characters.
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+    label_name = label_name[:63]
+    return re.sub(r"[^a-z0-9\-_\.]", "-", label_name).strip("-")
 
 
 def retrieve_pod_logs(pod_name, namespace):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -439,3 +439,22 @@ def test_construct_dagster_k8s_job_with_job_op_labels():
     )
     assert job2["metadata"]["labels"] == expected_labels2
     assert job2["spec"]["template"]["metadata"]["labels"] == expected_labels2
+
+
+def test_sanitize_labels():
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="test",
+    )
+
+    job = construct_dagster_k8s_job(
+        cfg,
+        [],
+        "job456",
+        labels={
+            "dagster/op": "-get_f\o.o[bar-0]-",  # pylint: disable=anomalous-backslash-in-string
+        },
+    ).to_dict()
+
+    assert job["metadata"]["labels"]["dagster/op"] == "get_f-o.o-bar-0"


### PR DESCRIPTION
Summary:
sometimes op names have invalid characters - add more validation before passing them in as labels

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.