### PR TITLE
Make ellipsis invalid substring in partition keys

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -184,6 +184,12 @@ class StaticPartitionsDefinition(
 ):  # pylint: disable=unsubscriptable-object
     def __init__(self, partition_keys: List[str]):
         check.list_param(partition_keys, "partition_keys", of_type=str)
+
+        # Dagit selects partition ranges following the format '2022-01-13...2022-01-14'
+        # "..." is an invalid substring in partition keys
+        if any(["..." in partition_key for partition_key in partition_keys]):
+            raise DagsterInvalidDefinitionError("'...' is an invalid substring in a partition key")
+
         self._partitions = [Partition(key) for key in partition_keys]
 
     def get_partitions(

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional
 import pendulum
 import pytest
 from dagster import (
+    DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
@@ -43,6 +44,11 @@ def test_static_partitions(partition_keys: List[str]):
         (p, p) for p in partition_keys
     ]
     assert static_partitions.get_partition_keys() == partition_keys
+
+
+def test_invalid_partition_key():
+    with pytest.raises(DagsterInvalidDefinitionError, match="'...'"):
+        StaticPartitionsDefinition(["foo", "foo...bar"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Dagit selects partition key ranges using ellipsis (e.g. "2022-01-13...2022-01-14"). We need to make ellipsis an invalid substring in partition keys.