### PR TITLE
Log dagster_version and OS descriptor for telemetry data

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -326,6 +326,9 @@ def test_dagit_logs(
                         "python_version",
                         "metadata",
                         "version",
+                        "dagster_version",
+                        "os_desc",
+                        "os_platform",
                     ]
                 )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -29,6 +29,9 @@ EXPECTED_KEYS = set(
         "python_version",
         "metadata",
         "version",
+        "os_desc",
+        "os_platform",
+        "dagster_version",
     ]
 )
 


### PR DESCRIPTION
I might have overengineered a little bit here regarding dagster_version. Also not sure how kosher it is to store this information in a global state. Might be better to just get them functionally. I don't think that this should affect performance in any meaningful way, so maybe that's fine.