### PR TITLE
support run range queries with a `created_before` filter

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1146,7 +1146,8 @@ input RunsFilter {
   tags: [ExecutionTag!]
   statuses: [RunStatus!]
   snapshotId: String
-  updatedAfter: String
+  updatedAfter: Float
+  createdBefore: Float
   mode: String
 }
 

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -226,7 +226,8 @@ export interface RunsFilter {
   tags?: ExecutionTag[] | null;
   statuses?: RunStatus[] | null;
   snapshotId?: string | null;
-  updatedAfter?: string | null;
+  updatedAfter?: number | null;
+  createdBefore?: number | null;
   mode?: string | null;
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -28,7 +28,8 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     tags = graphene.List(graphene.NonNull(GrapheneExecutionTag))
     statuses = graphene.List(graphene.NonNull(GrapheneRunStatus))
     snapshotId = graphene.Field(graphene.String)
-    updatedAfter = graphene.Field(graphene.String)
+    updatedAfter = graphene.Field(graphene.Float)
+    createdBefore = graphene.Field(graphene.Float)
     mode = graphene.Field(graphene.String)
 
     class Meta:
@@ -50,7 +51,8 @@ class GrapheneRunsFilter(graphene.InputObjectType):
         else:
             statuses = None
 
-        updated_after = pendulum.parse(self.updatedAfter) if self.updatedAfter else None
+        updated_after = pendulum.from_timestamp(self.updatedAfter) if self.updatedAfter else None
+        created_before = pendulum.from_timestamp(self.createdBefore) if self.createdBefore else None
 
         return PipelineRunsFilter(
             run_ids=self.runIds,
@@ -60,6 +62,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
             snapshot_id=self.snapshotId,
             updated_after=updated_after,
             mode=self.mode,
+            created_before=created_before,
         )
 
 

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -434,7 +434,8 @@ register_serdes_tuple_fallbacks({"PipelineRun": DagsterRun})
 @whitelist_for_serdes
 class PipelineRunsFilter(
     namedtuple(
-        "_PipelineRunsFilter", "run_ids pipeline_name statuses tags snapshot_id updated_after mode"
+        "_PipelineRunsFilter",
+        "run_ids pipeline_name statuses tags snapshot_id updated_after mode created_before",
     )
 ):
     def __new__(
@@ -446,6 +447,7 @@ class PipelineRunsFilter(
         snapshot_id=None,
         updated_after=None,
         mode=None,
+        created_before=None,
     ):
         return super(PipelineRunsFilter, cls).__new__(
             cls,
@@ -456,6 +458,7 @@ class PipelineRunsFilter(
             snapshot_id=check.opt_str_param(snapshot_id, "snapshot_id"),
             updated_after=check.opt_inst_param(updated_after, "updated_after", datetime),
             mode=check.opt_str_param(mode, "mode"),
+            created_before=check.opt_inst_param(created_before, "created_before", datetime),
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -212,6 +212,9 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         if filters.updated_after:
             query = query.where(RunsTable.c.update_timestamp > filters.updated_after)
 
+        if filters.created_before:
+            query = query.where(RunsTable.c.create_timestamp < filters.created_before)
+
         return query
 
     def _runs_query(


### PR DESCRIPTION
This diff adds a `created_before` field to the runs filter, which enables time window run queries from the frontend.

I'll add an index migration for create_timestamp / update_timestamp in a separate PR.






