### PR TITLE
Split out data query for the run timeline

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -323,36 +323,10 @@ const OverviewContent = () => {
       const jobsForStatus: JobItemWithRuns[] = filteredJobsWithRuns[status];
       const toAppend = {};
       for (const jobItem of jobsForStatus) {
-        const {repoAddress, runs, job} = jobItem;
+        const {repoAddress, job} = jobItem;
         const jobKey = makeJobKey(repoAddress, job.name);
         toAppend[jobKey] = {
-          label: job.name,
-          path: workspacePipelinePath({
-            repoName: repoAddress.name,
-            repoLocation: repoAddress.location,
-            pipelineName: job.name,
-            isJob: job.isJob,
-          }),
-          runs: runs.map((run) => ({
-            id: run.id,
-            status: run.status,
-            startTime: run.startTime ? run.startTime * 1000 : null,
-            endTime: run.endTime ? run.endTime * 1000 : null,
-          })),
-        };
-      }
-      return {...accum, ...toAppend};
-    }, {} as JobMap);
-
-    for (const jobItem of scheduled) {
-      const {job, repoAddress, schedules} = jobItem;
-      const jobKey = makeJobKey(repoAddress, job.name);
-
-      // If there are no runs tracked for this job yet because they're only scheduled,
-      // add an entry.
-      if (!jobMap.hasOwnProperty(jobKey)) {
-        jobMap[jobKey] = {
-          label: job.name,
+          name: job.name,
           path: workspacePipelinePath({
             repoName: repoAddress.name,
             repoLocation: repoAddress.location,
@@ -362,20 +336,26 @@ const OverviewContent = () => {
           runs: [],
         };
       }
+      return {...accum, ...toAppend};
+    }, {} as JobMap);
 
-      const {runs} = jobMap[jobKey];
-      for (const schedule of schedules) {
-        if (schedule.scheduleState.status === InstigationStatus.RUNNING) {
-          schedule.futureTicks.results.forEach(({timestamp}) => {
-            const startTime = timestamp * 1000;
-            runs.push({
-              id: `${jobKey}-future-run-${timestamp}`,
-              status: 'SCHEDULED',
-              startTime,
-              endTime: startTime + 10 * 1000,
-            });
-          });
-        }
+    for (const jobItem of scheduled) {
+      const {job, repoAddress} = jobItem;
+      const jobKey = makeJobKey(repoAddress, job.name);
+
+      // If there are no runs tracked for this job yet because they're only scheduled,
+      // add an entry.
+      if (!jobMap.hasOwnProperty(jobKey)) {
+        jobMap[jobKey] = {
+          name: job.name,
+          path: workspacePipelinePath({
+            repoName: repoAddress.name,
+            repoLocation: repoAddress.location,
+            pipelineName: job.name,
+            isJob: job.isJob,
+          }),
+          runs: [],
+        };
       }
     }
 

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -38,9 +38,9 @@ export const OneRow = () => {
 
   const jobs = React.useMemo(() => {
     const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
-    return {
-      [jobKey]: {label: jobKey, path: `/${jobKey}`, runs: generateRuns(6, [twoHoursAgo, now])},
-    };
+    return [
+      {key: jobKey, jobName: jobKey, path: `/${jobKey}`, runs: generateRuns(6, [twoHoursAgo, now])},
+    ];
   }, [twoHoursAgo, now]);
 
   return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
@@ -53,13 +53,14 @@ export const RowWithOverlappingRuns = () => {
   const jobs = React.useMemo(() => {
     const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const [first, second, third] = generateRuns(3, [twoHoursAgo, now]);
-    return {
-      [jobKey]: {
-        label: jobKey,
+    return [
+      {
+        key: jobKey,
+        jobName: jobKey,
         path: `/${jobKey}`,
         runs: [{...first}, {...first}, {...second}, {...second}, {...second}, third],
       },
-    };
+    ];
   }, [twoHoursAgo, now]);
 
   return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
@@ -72,8 +73,16 @@ export const ManyRows = () => {
   const jobs = React.useMemo(() => {
     return [...new Array(12)].reduce((accum) => {
       const jobKey = faker.random.words(3).split(' ').join('-').toLowerCase();
-      return {...accum, [jobKey]: {path: `/${jobKey}`, runs: generateRuns(6, [twoHoursAgo, now])}};
-    }, {});
+      return [
+        ...accum,
+        {
+          key: jobKey,
+          jobName: jobKey,
+          path: `/${jobKey}`,
+          runs: generateRuns(6, [twoHoursAgo, now]),
+        },
+      ];
+    }, []);
   }, [twoHoursAgo, now]);
 
   return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
@@ -88,9 +97,10 @@ export const VeryLongRunning = () => {
   const jobs = React.useMemo(() => {
     const jobKeyA = faker.random.words(2).split(' ').join('-').toLowerCase();
     const jobKeyB = faker.random.words(2).split(' ').join('-').toLowerCase();
-    return {
-      [jobKeyA]: {
-        label: jobKeyA,
+    return [
+      {
+        key: jobKeyA,
+        jobName: jobKeyA,
         path: `/${jobKeyA}`,
         runs: [
           {
@@ -101,8 +111,9 @@ export const VeryLongRunning = () => {
           },
         ],
       },
-      [jobKeyB]: {
-        label: jobKeyB,
+      {
+        key: jobKeyB,
+        jobName: jobKeyB,
         path: `/${jobKeyB}`,
         runs: [
           {
@@ -113,7 +124,7 @@ export const VeryLongRunning = () => {
           },
         ],
       },
-    };
+    ];
   }, [twoDaysAgo, twoHoursAgo]);
 
   return <RunTimeline jobs={jobs} range={[fourHoursAgo, future]} />;

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -90,15 +90,15 @@ export const RunTimelineContainer = ({
       ...(unterminated?.__typename === 'Runs' ? unterminated.results : []),
       ...(terminated?.__typename === 'Runs' ? terminated.results : []),
     ].forEach((run) => {
-      if (!run.stats || run.stats.__typename === 'PythonError' || !run.stats.startTime) {
+      if (!run.startTime) {
         return;
       }
       if (
         !overlap(
           {start, end},
           {
-            start: run.stats.startTime * 1000,
-            end: run.stats.endTime ? run.stats.endTime * 1000 : now,
+            start: run.startTime * 1000,
+            end: run.endTime ? run.endTime * 1000 : now,
           },
         )
       ) {
@@ -109,8 +109,8 @@ export const RunTimelineContainer = ({
         {
           id: run.id,
           status: run.status,
-          startTime: run.stats.startTime * 1000,
-          endTime: run.stats.endTime ? run.stats.endTime * 1000 : now,
+          startTime: run.startTime * 1000,
+          endTime: run.endTime ? run.endTime * 1000 : now,
         },
       ];
     });

--- a/js_modules/dagit/packages/core/src/runs/types/RunTimelineQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTimelineQuery.ts
@@ -1,0 +1,188 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RunsFilter, RunStatus, RepositoryLocationLoadStatus, InstigationStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: RunTimelineQuery
+// ====================================================
+
+export interface RunTimelineQuery_unterminated_InvalidPipelineRunsFilterError {
+  __typename: "InvalidPipelineRunsFilterError" | "PythonError";
+}
+
+export interface RunTimelineQuery_unterminated_Runs_results_stats_RunStatsSnapshot {
+  __typename: "RunStatsSnapshot";
+  id: string;
+  enqueuedTime: number | null;
+  launchTime: number | null;
+  startTime: number | null;
+  endTime: number | null;
+}
+
+export interface RunTimelineQuery_unterminated_Runs_results_stats_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RunTimelineQuery_unterminated_Runs_results_stats_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: RunTimelineQuery_unterminated_Runs_results_stats_PythonError_cause | null;
+}
+
+export type RunTimelineQuery_unterminated_Runs_results_stats = RunTimelineQuery_unterminated_Runs_results_stats_RunStatsSnapshot | RunTimelineQuery_unterminated_Runs_results_stats_PythonError;
+
+export interface RunTimelineQuery_unterminated_Runs_results {
+  __typename: "Run";
+  id: string;
+  pipelineName: string;
+  runId: string;
+  status: RunStatus;
+  stats: RunTimelineQuery_unterminated_Runs_results_stats;
+}
+
+export interface RunTimelineQuery_unterminated_Runs {
+  __typename: "Runs";
+  results: RunTimelineQuery_unterminated_Runs_results[];
+}
+
+export type RunTimelineQuery_unterminated = RunTimelineQuery_unterminated_InvalidPipelineRunsFilterError | RunTimelineQuery_unterminated_Runs;
+
+export interface RunTimelineQuery_terminated_InvalidPipelineRunsFilterError {
+  __typename: "InvalidPipelineRunsFilterError" | "PythonError";
+}
+
+export interface RunTimelineQuery_terminated_Runs_results_stats_RunStatsSnapshot {
+  __typename: "RunStatsSnapshot";
+  id: string;
+  enqueuedTime: number | null;
+  launchTime: number | null;
+  startTime: number | null;
+  endTime: number | null;
+}
+
+export interface RunTimelineQuery_terminated_Runs_results_stats_PythonError_cause {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+}
+
+export interface RunTimelineQuery_terminated_Runs_results_stats_PythonError {
+  __typename: "PythonError";
+  message: string;
+  stack: string[];
+  cause: RunTimelineQuery_terminated_Runs_results_stats_PythonError_cause | null;
+}
+
+export type RunTimelineQuery_terminated_Runs_results_stats = RunTimelineQuery_terminated_Runs_results_stats_RunStatsSnapshot | RunTimelineQuery_terminated_Runs_results_stats_PythonError;
+
+export interface RunTimelineQuery_terminated_Runs_results {
+  __typename: "Run";
+  id: string;
+  pipelineName: string;
+  runId: string;
+  status: RunStatus;
+  stats: RunTimelineQuery_terminated_Runs_results_stats;
+}
+
+export interface RunTimelineQuery_terminated_Runs {
+  __typename: "Runs";
+  results: RunTimelineQuery_terminated_Runs_results[];
+}
+
+export type RunTimelineQuery_terminated = RunTimelineQuery_terminated_InvalidPipelineRunsFilterError | RunTimelineQuery_terminated_Runs;
+
+export interface RunTimelineQuery_workspaceOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_displayMetadata {
+  __typename: "RepositoryMetadata";
+  key: string;
+  value: string;
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results {
+  __typename: "FutureInstigationTick";
+  timestamp: number;
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks {
+  __typename: "FutureInstigationTicks";
+  results: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks_results[];
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  pipelineName: string;
+  scheduleState: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState;
+  executionTimezone: string | null;
+  futureTicks: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_futureTicks;
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  pipelines: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_pipelines[];
+  schedules: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules[];
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+  repositories: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories[];
+}
+
+export type RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError = RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_PythonError | RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation;
+
+export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries {
+  __typename: "WorkspaceLocationEntry";
+  id: string;
+  name: string;
+  loadStatus: RepositoryLocationLoadStatus;
+  displayMetadata: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_displayMetadata[];
+  locationOrLoadError: RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError | null;
+}
+
+export interface RunTimelineQuery_workspaceOrError_Workspace {
+  __typename: "Workspace";
+  locationEntries: RunTimelineQuery_workspaceOrError_Workspace_locationEntries[];
+}
+
+export type RunTimelineQuery_workspaceOrError = RunTimelineQuery_workspaceOrError_PythonError | RunTimelineQuery_workspaceOrError_Workspace;
+
+export interface RunTimelineQuery {
+  unterminated: RunTimelineQuery_unterminated;
+  terminated: RunTimelineQuery_terminated;
+  workspaceOrError: RunTimelineQuery_workspaceOrError;
+}
+
+export interface RunTimelineQueryVariables {
+  inProgressFilter: RunsFilter;
+  terminatedFilter: RunsFilter;
+}

--- a/js_modules/dagit/packages/core/src/runs/types/RunTimelineQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTimelineQuery.ts
@@ -13,37 +13,15 @@ export interface RunTimelineQuery_unterminated_InvalidPipelineRunsFilterError {
   __typename: "InvalidPipelineRunsFilterError" | "PythonError";
 }
 
-export interface RunTimelineQuery_unterminated_Runs_results_stats_RunStatsSnapshot {
-  __typename: "RunStatsSnapshot";
-  id: string;
-  enqueuedTime: number | null;
-  launchTime: number | null;
-  startTime: number | null;
-  endTime: number | null;
-}
-
-export interface RunTimelineQuery_unterminated_Runs_results_stats_PythonError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface RunTimelineQuery_unterminated_Runs_results_stats_PythonError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: RunTimelineQuery_unterminated_Runs_results_stats_PythonError_cause | null;
-}
-
-export type RunTimelineQuery_unterminated_Runs_results_stats = RunTimelineQuery_unterminated_Runs_results_stats_RunStatsSnapshot | RunTimelineQuery_unterminated_Runs_results_stats_PythonError;
-
 export interface RunTimelineQuery_unterminated_Runs_results {
   __typename: "Run";
   id: string;
   pipelineName: string;
   runId: string;
   status: RunStatus;
-  stats: RunTimelineQuery_unterminated_Runs_results_stats;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface RunTimelineQuery_unterminated_Runs {
@@ -57,37 +35,15 @@ export interface RunTimelineQuery_terminated_InvalidPipelineRunsFilterError {
   __typename: "InvalidPipelineRunsFilterError" | "PythonError";
 }
 
-export interface RunTimelineQuery_terminated_Runs_results_stats_RunStatsSnapshot {
-  __typename: "RunStatsSnapshot";
-  id: string;
-  enqueuedTime: number | null;
-  launchTime: number | null;
-  startTime: number | null;
-  endTime: number | null;
-}
-
-export interface RunTimelineQuery_terminated_Runs_results_stats_PythonError_cause {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-}
-
-export interface RunTimelineQuery_terminated_Runs_results_stats_PythonError {
-  __typename: "PythonError";
-  message: string;
-  stack: string[];
-  cause: RunTimelineQuery_terminated_Runs_results_stats_PythonError_cause | null;
-}
-
-export type RunTimelineQuery_terminated_Runs_results_stats = RunTimelineQuery_terminated_Runs_results_stats_RunStatsSnapshot | RunTimelineQuery_terminated_Runs_results_stats_PythonError;
-
 export interface RunTimelineQuery_terminated_Runs_results {
   __typename: "Run";
   id: string;
   pipelineName: string;
   runId: string;
   status: RunStatus;
-  stats: RunTimelineQuery_terminated_Runs_results_stats;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
 }
 
 export interface RunTimelineQuery_terminated_Runs {

--- a/js_modules/dagit/packages/core/src/runs/types/RunTimelineQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTimelineQuery.ts
@@ -115,6 +115,7 @@ export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_loc
   __typename: "Pipeline";
   id: string;
   name: string;
+  isJob: boolean;
 }
 
 export interface RunTimelineQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_schedules_scheduleState {


### PR DESCRIPTION
Stacked on top of https://github.com/dagster-io/dagster/pull/6216, which enables the range queries against pipeline runs.

We might be overfetching a bit now in the initial query.



