### PR TITLE
Fix default execution day for monthly cron schedules

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/partition.py
+++ b/python_modules/dagster/dagster/core/definitions/partition.py
@@ -824,19 +824,18 @@ def dynamic_partitioned_config(
 def get_cron_schedule(
     schedule_type: ScheduleType,
     time_of_day: time = time(0, 0),
-    day_of_week: Optional[int] = 0,
+    execution_day: Optional[int] = None,
 ) -> str:
     minute = time_of_day.minute
     hour = time_of_day.hour
-    day = day_of_week
 
     if schedule_type is ScheduleType.HOURLY:
         return f"{minute} * * * *"
     elif schedule_type is ScheduleType.DAILY:
         return f"{minute} {hour} * * *"
     elif schedule_type is ScheduleType.WEEKLY:
-        return f"{minute} {hour} * * {day}"
+        return f"{minute} {hour} * * {execution_day if execution_day != None else 0}"
     elif schedule_type is ScheduleType.MONTHLY:
-        return f"{minute} {hour} {day} * *"
+        return f"{minute} {hour} {execution_day if execution_day != None else 1} * *"
     else:
         check.assert_never(schedule_type)


### PR DESCRIPTION
Summary:
Default month start day is 1, not 0.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.