### PR TITLE
[telemetry] Increase the length of heartbeat interval

### DIFF
--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -75,6 +75,8 @@ def telemetry_wrapper(metadata):
 
 
 def _telemetry_wrapper(f, metadata=None):
+    metadata = check.opt_dict_param(metadata, "metadata", key_type=str, value_type=str)
+
     if f.__name__ not in TELEMETRY_WHITELISTED_FUNCTIONS:
         raise DagsterInvariantViolationError(
             "Attempted to log telemetry for function {name} that is not in telemetry whitelisted "

--- a/python_modules/dagster/dagster/daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/daemon/cli/__init__.py
@@ -19,6 +19,7 @@ from dagster.daemon.controller import (
     debug_daemon_heartbeats,
     get_daemon_status,
 )
+from dagster.daemon.daemon import get_telemetry_daemon_session_id
 from dagster.utils.interrupts import capture_interrupts, raise_interrupts_as
 
 
@@ -39,7 +40,7 @@ def run_command():
             _daemon_run_command(instance)
 
 
-@telemetry_wrapper
+@telemetry_wrapper(metadata={"DAEMON_SESSION_ID": get_telemetry_daemon_session_id()})
 def _daemon_run_command(instance):
     with daemon_controller_from_instance(
         instance, heartbeat_tolerance_seconds=_get_heartbeat_tolerance()

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -24,7 +24,11 @@ def get_default_daemon_logger(daemon_name):
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors
 TELEMETRY_LOGGING_INTERVAL = 3600 * 24  # Interval (in seconds) at which to log that daemon is alive
-TELEMETRY_DAEMON_SESSION_ID = str(uuid.uuid4())
+_telemetry_daemon_session_id = str(uuid.uuid4())
+
+
+def get_telemetry_daemon_session_id() -> str:
+    return _telemetry_daemon_session_id
 
 
 class DagsterDaemon(AbstractContextManager):
@@ -157,7 +161,9 @@ class DagsterDaemon(AbstractContextManager):
             or (curr_time - self._last_log_time).total_seconds() >= TELEMETRY_LOGGING_INTERVAL
         ):
             log_action(
-                instance, DAEMON_ALIVE, metadata={"DAEMON_SESSION_ID": TELEMETRY_DAEMON_SESSION_ID}
+                instance,
+                DAEMON_ALIVE,
+                metadata={"DAEMON_SESSION_ID": get_telemetry_daemon_session_id()},
             )
             self._last_log_time = curr_time
 

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import time
+import uuid
 from abc import abstractclassmethod, abstractmethod
 from collections import deque
 from contextlib import AbstractContextManager
@@ -23,6 +24,7 @@ def get_default_daemon_logger(daemon_name):
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors
 TELEMETRY_LOGGING_INTERVAL = 3600 * 24  # Interval (in seconds) at which to log that daemon is alive
+TELEMETRY_DAEMON_SESSION_ID = str(uuid.uuid4())
 
 
 class DagsterDaemon(AbstractContextManager):
@@ -154,7 +156,9 @@ class DagsterDaemon(AbstractContextManager):
             not self._last_log_time
             or (curr_time - self._last_log_time).total_seconds() >= TELEMETRY_LOGGING_INTERVAL
         ):
-            log_action(instance, DAEMON_ALIVE)
+            log_action(
+                instance, DAEMON_ALIVE, metadata={"DAEMON_SESSION_ID": TELEMETRY_DAEMON_SESSION_ID}
+            )
             self._last_log_time = curr_time
 
     @abstractmethod

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -22,7 +22,7 @@ def get_default_daemon_logger(daemon_name):
 
 
 DAEMON_HEARTBEAT_ERROR_LIMIT = 5  # Show at most 5 errors
-TELEMETRY_LOGGING_INTERVAL = 3600  # Interval (in seconds) at which to log that daemon is alive
+TELEMETRY_LOGGING_INTERVAL = 3600 * 24  # Interval (in seconds) at which to log that daemon is alive
 
 
 class DagsterDaemon(AbstractContextManager):


### PR DESCRIPTION
The reason we want to log that the daemon is alive, is to verify that the daemon is long-standing. 
- Logging every hour is too often. We'd expect a long running daemon to be running for a day or more, so increasing the interval is advantageous.
- We need to be able to link heartbeats together to see how long the daemon runs. Hence the session id.