### PR TITLE
[dagit] Repair Launchpad error icon, update yaml

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -57,7 +57,7 @@
     "react-virtualized": "^9.22.3",
     "subscriptions-transport-ws": "^0.9.15",
     "worker-loader": "^3.0.8",
-    "yaml": "2.0.0-1"
+    "yaml": "2.0.0-10"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.15",

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
@@ -42,6 +42,9 @@ interface ConfigEditorProps {
   onHelpContextChange: (helpContext: ConfigEditorHelpContext | null) => void;
 }
 
+// Use `default` due to Webpack config.
+const errorIconPath = Icons.error.default;
+
 const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
 const performLint = debounce((editor: any) => {
   editor.performLint();
@@ -73,7 +76,7 @@ const CodeMirrorShimStyle = createGlobalStyle`
     .CodeMirror-lint-marker-error {
       background-image: none;
       background: ${ColorsWIP.Red500};
-      mask-image: url(${Icons.error});
+      mask-image: url(${errorIconPath});
       mask-size: cover;
       margin-bottom: 2px;
     }

--- a/js_modules/dagit/packages/core/src/configeditor/codemirror-yaml/mode.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/codemirror-yaml/mode.tsx
@@ -693,12 +693,9 @@ CodeMirror.registerHelper(
     let lastMarkLocation: CodeMirror.Position | undefined;
 
     yamlDoc.errors.slice(0, 10).forEach((error) => {
-      const from = codeMirrorDoc.posFromIndex(
-        error.source?.range ? error.source.range.start : 0,
-      ) as CodeMirror.Position;
-      const to = codeMirrorDoc.posFromIndex(
-        error.source?.range ? error.source.range.end : Number.MAX_SAFE_INTEGER,
-      ) as CodeMirror.Position;
+      const [fromPos, toPos] = error.pos;
+      const from = codeMirrorDoc.posFromIndex(fromPos) as CodeMirror.Position;
+      const to = codeMirrorDoc.posFromIndex(toPos) as CodeMirror.Position;
 
       if (!lastMarkLocation || lastMarkLocation.line < from.line) {
         lastMarkLocation = from;

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5546,7 +5546,7 @@ __metadata:
     typescript: 4.5.4
     webpack: 4.46.0
     worker-loader: ^3.0.8
-    yaml: 2.0.0-1
+    yaml: 2.0.0-10
   peerDependencies:
     "@blueprintjs/core": ^3.45.0
     "@blueprintjs/icons": ^3.26.1
@@ -30450,10 +30450,10 @@ typescript@~3.9.7:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.0.0-1":
-  version: 2.0.0-1
-  resolution: "yaml@npm:2.0.0-1"
-  checksum: ccfbd1424dbf205a8828593faa91dfd40bd21e3fb575e257280d3526ade9508f3ea0acbe7605abc81bac6b4d6729ddb5b3de6bd818232f48480fd1eda8d7fd4c
+"yaml@npm:2.0.0-10":
+  version: 2.0.0-10
+  resolution: "yaml@npm:2.0.0-10"
+  checksum: 7a0bac2f80225da6008fb8ab887f43166fb2485cc3e1350185c43499c76841ea0ca9d79b40c0970e08ab3943f25ffb184e709fef7fb8b26d73987ed0452a91cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

A couple launchpad changes:

- Fix the error icon in the gutter, which broke with the move to `@dagster-io/ui`
- Update the `yaml` package and the logic for determining error position

## Test Plan

Open launchpad, introduce some errors in the yaml. Verify proper rendering of error icon and error position information.
