### PR TITLE
[Dagit] Consume materializationCountByPartition graphql endpoint

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
@@ -130,7 +130,7 @@ export const AssetMaterializations: React.FC<Props> = ({
   }, [params.asOf, assetLastMaterializedAt, refetch]);
 
   const hasLineage = materializations.some((m) => m.materializationEvent.assetLineage.length > 0);
-  const hasPartitions = materializations.some((m) => m.partition);
+  const hasPartitions = materializations.some((m) => m.partition) || assetHasDefinedPartitions;
 
   const grouped = React.useMemo<MaterializationGroup[]>(() => {
     if (!hasPartitions || xAxis !== 'partition') {

--- a/js_modules/dagit/packages/core/src/assets/types/PartitionHealthQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/PartitionHealthQuery.ts
@@ -13,22 +13,16 @@ export interface PartitionHealthQuery_assetNodeOrError_AssetNotFoundError {
   __typename: "AssetNotFoundError";
 }
 
-export interface PartitionHealthQuery_assetNodeOrError_AssetNode_latestMaterializationByPartition_materializationEvent {
-  __typename: "StepMaterializationEvent";
-  timestamp: string;
-}
-
-export interface PartitionHealthQuery_assetNodeOrError_AssetNode_latestMaterializationByPartition {
-  __typename: "AssetMaterialization";
-  partition: string | null;
-  materializationEvent: PartitionHealthQuery_assetNodeOrError_AssetNode_latestMaterializationByPartition_materializationEvent;
+export interface PartitionHealthQuery_assetNodeOrError_AssetNode_materializationCountByPartition {
+  __typename: "MaterializationCountByPartition";
+  partition: string;
+  materializationCount: number;
 }
 
 export interface PartitionHealthQuery_assetNodeOrError_AssetNode {
   __typename: "AssetNode";
   id: string;
-  partitionKeys: string[];
-  latestMaterializationByPartition: (PartitionHealthQuery_assetNodeOrError_AssetNode_latestMaterializationByPartition | null)[];
+  materializationCountByPartition: PartitionHealthQuery_assetNodeOrError_AssetNode_materializationCountByPartition[];
 }
 
 export type PartitionHealthQuery_assetNodeOrError = PartitionHealthQuery_assetNodeOrError_AssetNotFoundError | PartitionHealthQuery_assetNodeOrError_AssetNode;

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -639,11 +639,17 @@ type AssetNode {
   partitionKeys: [String!]!
   partitionDefinition: String
   latestMaterializationByPartition(partitions: [String]): [AssetMaterialization]!
+  materializationCountByPartition: [MaterializationCountByPartition!]!
 }
 
 type AssetDependency {
   inputName: String!
   asset: AssetNode!
+}
+
+type MaterializationCountByPartition {
+  partition: String!
+  materializationCount: Int!
 }
 
 union DagsterRunEvent = ExecutionStepFailureEvent | ExecutionStepInputEvent | ExecutionStepOutputEvent | ExecutionStepSkippedEvent | ExecutionStepStartEvent | ExecutionStepSuccessEvent | ExecutionStepUpForRetryEvent | ExecutionStepRestartEvent | LogMessageEvent | RunFailureEvent | RunStartEvent | RunEnqueuedEvent | RunDequeuedEvent | RunStartingEvent | RunCancelingEvent | RunCanceledEvent | RunSuccessEvent | HandledOutputEvent | LoadedInputEvent | LogsCapturedEvent | ObjectStoreOperationEvent | StepExpectationResultEvent | StepMaterializationEvent | EngineEvent | HookCompletedEvent | HookSkippedEvent | HookErroredEvent | AlertStartEvent | AlertSuccessEvent

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -76,7 +76,7 @@ class GrapheneAssetMaterialization(graphene.ObjectType):
 
 
 class GrapheneMaterializationCountByPartition(graphene.ObjectType):
-    partition = graphene.Field(graphene.String)
+    partition = graphene.NonNull(graphene.String)
     materializationCount = graphene.NonNull(graphene.Int)
 
     class Meta:


### PR DESCRIPTION
## Summary
* Consume the new graphql endpoint for counting runs by partition when rendering the PartitionHealthSummary component. 
* Also make sure that the Materializations list view is visible if runs have completed but the partitions were not assigned appropriately. Ran into an issue where there were completed runs which would not be shown because the partition was null. Only way to see these runs was to manually append ?time= onto the URL and they appeared. Checking assetHasDefinedPartitions fixed this.


## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.