### PR TITLE
[dagit] Update Worker for Webpack 5

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/getFullOpLayout.ts
+++ b/js_modules/dagit/packages/core/src/graph/getFullOpLayout.ts
@@ -1,5 +1,4 @@
 import memoize from 'lodash/memoize';
-import LayoutWorker from 'worker-loader!../workers/dagre_layout.worker.ts';
 
 import {asyncMemoize} from '../app/Util';
 
@@ -20,7 +19,7 @@ export const getDagrePipelineLayout = memoize(layoutPipeline, _layoutCacheKey);
 
 const _asyncDagrePipelineLayout = (solids: ILayoutOp[], parentSolid?: ILayoutOp) => {
   return new Promise((resolve) => {
-    const worker = new LayoutWorker();
+    const worker = new Worker(new URL('../workers/dagre_layout.worker', import.meta.url));
     worker.addEventListener('message', (event) => {
       resolve(event.data);
       worker.terminate();

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRoot.test.tsx
@@ -14,6 +14,9 @@ jest.mock('./GraphExplorer', () => ({
   GraphExplorer: () => <div />,
 }));
 
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../graph/getFullOpLayout', () => ({}));
+
 const REPO_NAME = 'foo';
 const REPO_LOCATION = 'bar';
 const PIPELINE_NAME = 'pipez';


### PR DESCRIPTION
## Summary

With the update to the CRA in Dagit, we are now using Webpack 5. Webpack 5 has a different syntax for importing WebWorkers:

https://webpack.js.org/guides/web-workers/

Update accordingly.

This appears to be necessary for dagit-cloud to be unejected as well, as there is a compilation error without this change.

## Test Plan

TS, lint, jest. Verify successful prod build. Run dev app with DAG forced to load with WebWorker if only two nodes, verify that the worker loads and behaves correctly.
