### PR TITLE
Jobs - Inherit description when creating from graph

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -512,7 +512,7 @@ class GraphDefinition(NodeDefinition):
 
         return JobDefinition(
             name=job_name,
-            description=description,
+            description=description or self.description,
             graph_def=self,
             mode_def=ModeDefinition(
                 resource_defs=resource_defs_with_defaults,

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -403,8 +403,7 @@ def test_desc():
         pass
 
     job = empty.to_job()
-    # should we inherit from the graph instead?
-    assert job.description == None
+    assert job.description == "graph desc"
 
     desc = "job desc"
     job = empty.to_job(description=desc)


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary

When we create jobs from graphs using the `to_job` method the job description is always empty if not specified.
With this PR, the job description will be inherited from the graph if it is not specified

Fixes #6027
