### PR TITLE
[dagit] Clean up sourcemap warnings

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -5,6 +5,7 @@
   "description": "Dagit Application Shell",
   "license": "Apache-2.0",
   "dependencies": {
+    "@apollo/client": "^3.5.7",
     "@blueprintjs/core": "^3.45.0",
     "@blueprintjs/icons": "^3.26.1",
     "@blueprintjs/popover2": "0.10.1",

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -19,6 +19,7 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'"
   },
   "peerDependencies": {
+    "@apollo/client": "^3.5.7",
     "@blueprintjs/core": "^3.45.0",
     "@blueprintjs/icons": "^3.26.1",
     "@blueprintjs/popover2": "0.10.1",
@@ -32,7 +33,6 @@
     "styled-components": "^5.3.3"
   },
   "dependencies": {
-    "@apollo/client": "^3.3.16",
     "@vx/shape": "^0.0.192",
     "amator": "^1.1.0",
     "ansi-to-react": "^5.1.0",
@@ -131,7 +131,6 @@
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-storybook": "^0.5.5",
     "faker": "5.5.3",
-    "graphql-tag": "^2.12.1",
     "graphql.macro": "^1.4.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -1,11 +1,5 @@
 import '../fonts/fonts.css';
 
-import '@blueprintjs/core/lib/css/blueprint.css';
-import '@blueprintjs/icons/lib/css/blueprint-icons.css';
-import '@blueprintjs/select/lib/css/blueprint-select.css';
-import '@blueprintjs/table/lib/css/table.css';
-import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
-
 import {
   ApolloLink,
   ApolloClient,

--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -145,7 +145,9 @@ const OverviewContent = () => {
 
   const {hiddenRepos, searchValue} = state;
 
-  React.useEffect(() => retrieveLastTenRuns(), [retrieveLastTenRuns]);
+  React.useEffect(() => {
+    retrieveLastTenRuns();
+  }, [retrieveLastTenRuns]);
 
   const optionAddresses = React.useMemo(() => {
     if (!options) {

--- a/js_modules/dagit/packages/ui/src/blueprint.css
+++ b/js_modules/dagit/packages/ui/src/blueprint.css
@@ -1,0 +1,5 @@
+@import '~@blueprintjs/core';
+@import '~@blueprintjs/icons';
+@import '~@blueprintjs/select';
+@import '~@blueprintjs/table';
+@import '~@blueprintjs/popover2';

--- a/js_modules/dagit/packages/ui/src/index.ts
+++ b/js_modules/dagit/packages/ui/src/index.ts
@@ -1,3 +1,5 @@
+import './blueprint.css';
+
 export * from './components/Alert';
 export * from './components/BaseButton';
 export * from './components/BaseTag';

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -18,33 +18,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "@apollo/client@npm:3.3.16"
+"@apollo/client@npm:^3.5.7":
+  version: 3.5.7
+  resolution: "@apollo/client@npm:3.5.7"
   dependencies:
     "@graphql-typed-document-node/core": ^3.0.0
-    "@types/zen-observable": ^0.8.0
     "@wry/context": ^0.6.0
-    "@wry/equality": ^0.4.0
-    fast-json-stable-stringify: ^2.0.0
-    graphql-tag: ^2.12.0
+    "@wry/equality": ^0.5.0
+    "@wry/trie": ^0.3.0
+    graphql-tag: ^2.12.3
     hoist-non-react-statics: ^3.3.2
-    optimism: ^0.15.0
+    optimism: ^0.16.1
     prop-types: ^15.7.2
-    symbol-observable: ^2.0.0
-    ts-invariant: ^0.7.0
-    tslib: ^1.10.0
-    zen-observable: ^0.8.14
+    symbol-observable: ^4.0.0
+    ts-invariant: ^0.9.4
+    tslib: ^2.3.0
+    zen-observable-ts: ^1.2.0
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     react: ^16.8.0 || ^17.0.0
-    subscriptions-transport-ws: ^0.9.0
+    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
   peerDependenciesMeta:
     react:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 550de09063a070bc8771e7e787166fe54c29a046173a3a85eb3d5e43bdce67e873a19773710699968f0e617246396c4443f28b3c581c7fb24ae391c1c030a1bc
+  checksum: ddecf62b4bf402948892bf993d58933432fc743b6859ef557fcd137e9b9398c081279dce75e037396f9b22fd54bf578cb88819b4b55bd5e2c30428f100c519b6
   languageName: node
   linkType: hard
 
@@ -5237,6 +5236,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dagster-io/dagit-app@workspace:packages/app"
   dependencies:
+    "@apollo/client": ^3.5.7
     "@blueprintjs/core": ^3.45.0
     "@blueprintjs/icons": ^3.26.1
     "@blueprintjs/popover2": 0.10.1
@@ -5279,7 +5279,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dagster-io/dagit-core@workspace:packages/core"
   dependencies:
-    "@apollo/client": ^3.3.16
     "@babel/cli": ^7.13.15
     "@babel/core": ^7.13.15
     "@babel/plugin-proposal-class-properties": ^7.14.5
@@ -5364,7 +5363,6 @@ __metadata:
     faker: 5.5.3
     fuse.js: ^6.4.2
     graphql: ^15.5.0
-    graphql-tag: ^2.12.1
     graphql.macro: ^1.4.2
     highlight.js: ^10.4.0
     identity-obj-proxy: ^3.0.0
@@ -5395,6 +5393,7 @@ __metadata:
     worker-loader: ^3.0.8
     yaml: 2.0.0-10
   peerDependencies:
+    "@apollo/client": ^3.5.7
     "@blueprintjs/core": ^3.45.0
     "@blueprintjs/icons": ^3.26.1
     "@blueprintjs/popover2": 0.10.1
@@ -9424,13 +9423,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/zen-observable@npm:^0.8.0":
-  version: 0.8.2
-  resolution: "@types/zen-observable@npm:0.8.2"
-  checksum: 558959fc0482d329cedbd9eabb591849a3dab9574880d3b0781e6916d57cd87fc2268f85d5fe236b58eab8c4063e4aaebd4e9c302b9e56af372d15732c26bb99
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:5.8.0, @typescript-eslint/eslint-plugin@npm:^5.5.0":
   version: 5.8.0
   resolution: "@typescript-eslint/eslint-plugin@npm:5.8.0"
@@ -9987,12 +9979,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/equality@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@wry/equality@npm:0.4.0"
+"@wry/equality@npm:^0.5.0":
+  version: 0.5.2
+  resolution: "@wry/equality@npm:0.5.2"
   dependencies:
-    tslib: ^2.1.0
-  checksum: f8e5f47724cd068a0e4e848c59f9980989d89042b9b388b355e095dedf1109d0e83f4eec8a03225c44fafd10fd490e7eff6adc75b2ccfb78e84b15a6766838e1
+    tslib: ^2.3.0
+  checksum: 19a01043a0583663924ed9f4ea109818b9b4cb540877ca75ea49545689f54c6bfc69e725a8b3b129a2ac15ea368fd40bbb94c22e7a5e4ec370f7c4697e64b8b1
   languageName: node
   linkType: hard
 
@@ -17273,7 +17265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:2.12.4, graphql-tag@npm:^2.12.1":
+"graphql-tag@npm:2.12.4":
   version: 2.12.4
   resolution: "graphql-tag@npm:2.12.4"
   dependencies:
@@ -17293,14 +17285,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:^2.12.0":
-  version: 2.12.3
-  resolution: "graphql-tag@npm:2.12.3"
+"graphql-tag@npm:^2.12.3":
+  version: 2.12.6
+  resolution: "graphql-tag@npm:2.12.6"
   dependencies:
     tslib: ^2.1.0
   peerDependencies:
-    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-  checksum: e189b727bd2bbbe601d02970c2fc964516307a2d4d041ef5e7f3e1e51335335f4fbc2d0f77ffaa6320a79833e952d98c31ae8a4daa908d29ffe9a4e71c961fa9
+    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: b15162a3d62f17b9b79302445b9ee330e041582f1c7faca74b9dec5daa74272c906ec1c34e1c50592bb6215e5c3eba80a309103f6ba9e4c1cddc350c46f010df
   languageName: node
   linkType: hard
 
@@ -22612,13 +22604,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "optimism@npm:0.15.0"
+"optimism@npm:^0.16.1":
+  version: 0.16.1
+  resolution: "optimism@npm:0.16.1"
   dependencies:
     "@wry/context": ^0.6.0
     "@wry/trie": ^0.3.0
-  checksum: f1b00ef6b5c50eeb3928d0d1cfc8d23f89ea2021fc77c7bb40f614afe4803a5ea570713bebc6f06d1bde4ca0e8eb62dc3534b5a6670b221cbbbc4fc8a2ae1271
+  checksum: 7506a3e5e37b8945059ffacd68039e920ad121aab3eeff27483b7a8b594f6f694f2a3b61a198aeecc43b81753d35c8cb32b7f662d2b5e2d2449fe7068da678e1
   languageName: node
   linkType: hard
 
@@ -27573,10 +27565,10 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "symbol-observable@npm:2.0.3"
-  checksum: 533dcf7a7925bada60dbaa06d678e7c4966dbf0959ccba7f60c22b0494ba5d9160d6a66f2951d45a80bf20e655a89f8b91c5f0458dd12faef28716b54f91f49c
+"symbol-observable@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "symbol-observable@npm:4.0.0"
+  checksum: 212c7edce6186634d671336a88c0e0bbd626c2ab51ed57498dc90698cce541839a261b969c2a1e8dd43762133d47672e8b62e0b1ce9cf4157934ba45fd172ba8
   languageName: node
   linkType: hard
 
@@ -28129,12 +28121,12 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ts-invariant@npm:^0.7.0":
-  version: 0.7.3
-  resolution: "ts-invariant@npm:0.7.3"
+"ts-invariant@npm:^0.9.4":
+  version: 0.9.4
+  resolution: "ts-invariant@npm:0.9.4"
   dependencies:
     tslib: ^2.1.0
-  checksum: 27599f6d0de5bee65dfa8c0c70a63ca78c1f3b3428f1422821fc97dbdeea8171e1ff979656ce6e7626f65974d633d1a01971d289c796059b66c8ec1a15e74af2
+  checksum: c9e5726361fa266916966b2070605f8664b6dd1d8b0ef7565dbf056abb6a87be26195985ef62dd97aeb0894cf2f4ad5b7f0d89dadadc197eaa38e99222afa29c
   languageName: node
   linkType: hard
 
@@ -30251,7 +30243,16 @@ typescript@~3.9.7:
   languageName: node
   linkType: hard
 
-"zen-observable@npm:^0.8.0, zen-observable@npm:^0.8.14":
+"zen-observable-ts@npm:^1.2.0":
+  version: 1.2.3
+  resolution: "zen-observable-ts@npm:1.2.3"
+  dependencies:
+    zen-observable: 0.8.15
+  checksum: 0548b555c67671f1240fb416755d2c27abf095b74a9e25c1abf23b2e15de40e6b076c678a162021358fe62914864eb9f0a57cd65e203d66c4988a08b220e6172
+  languageName: node
+  linkType: hard
+
+"zen-observable@npm:0.8.15, zen-observable@npm:^0.8.0":
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: b7289084bc1fc74a559b7259faa23d3214b14b538a8843d2b001a35e27147833f4107590b1b44bf5bc7f6dfe6f488660d3a3725f268e09b3925b3476153b7821


### PR DESCRIPTION
## Summary

With the recent update to our CRA usage, there are some noisy sourcemap warnings that show up during dev.

Clean these up:

- Blueprint CSS: Import these via a single `blueprint.css` in `@dagster-io/ui`, which is a more appropriate place to import these anyway.
- graphql-tag: Upgrade `@apollo/client`, which includes a relevant upgrade to `graphql-tag`.

I took a look through the `@apollo/client` changelog, and it looks like things should be safe.

## Test Plan

Run dev and prod builds. Verify success and no more sourcemap warnings.
