### PR TITLE
Add labels/volumes/volumeMounts to example values.yaml for user code deployments in  helm chart

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -270,6 +270,35 @@ dagster-user-deployments:
       #   - name: secret
       envSecrets: []
 
+      # Additional labels that should be included. See:
+      # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+      #
+      # Example:
+      # labels:
+      #   my-label-key: my_label-value
+      labels: {}
+
+      # Additional volumes that should be included. See:
+      # https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
+      #
+      # Example:
+      #
+      # volumes:
+      #   - name: my-volume
+      #     configMap: my-config-map
+      volumes: []
+
+      # Additional volume mounts that should be included. See:
+      # See: https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
+      #
+      # Example:
+      #
+      # volumeMounts:
+      #   - name: test-volume
+      #     mountPath: /opt/dagster/test_folder
+      #     subPath: test_file.yaml
+      volumeMounts: []
+
       annotations: {}
       nodeSelector: {}
       affinity: {}


### PR DESCRIPTION
Summary:
These fields were settable but were not included as examples in the values.yaml. Fix that.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.