### PR TITLE
[telemetry] Log sensor and schedule info from repo

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -304,12 +304,13 @@ def test_dagit_logs(
 
                 actions.add(message.get("action"))
                 if message.get("action") == UPDATE_REPO_STATS:
-                    assert message.get("pipeline_name_hash") == ""
-                    repo_hash = message.get("repo_hash")
+                    metadata = message.get("metadata")
+                    assert metadata.get("pipeline_name_hash") == ""
+                    repo_hash = metadata.get("repo_hash")
 
                     assert repo_hash in expected_repo_stats
                     expected_num_pipelines_in_repo = expected_repo_stats.get(repo_hash)
-                    assert message.get("num_pipelines_in_repo") == str(
+                    assert metadata.get("num_pipelines_in_repo") == str(
                         expected_num_pipelines_in_repo
                     )
 
@@ -320,11 +321,6 @@ def test_dagit_logs(
                         "elapsed_time",
                         "event_id",
                         "instance_id",
-                        "pipeline_name_hash",
-                        "num_pipelines_in_repo",
-                        "num_schedules_in_repo",
-                        "num_sensors_in_repo",
-                        "repo_hash",
                         "python_version",
                         "run_storage_id",
                         "metadata",

--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -322,6 +322,8 @@ def test_dagit_logs(
                         "instance_id",
                         "pipeline_name_hash",
                         "num_pipelines_in_repo",
+                        "num_schedules_in_repo",
+                        "num_sensors_in_repo",
                         "repo_hash",
                         "python_version",
                         "run_storage_id",

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -258,9 +258,11 @@ def create_backfill_run(
     log_action(
         instance,
         BACKFILL_RUN_CREATED,
-        metadata={"DAEMON_SESSION_ID": get_telemetry_daemon_session_id()},
-        repo_hash=hash_name(repo_location.name),
-        pipeline_name_hash=hash_name(external_pipeline.name),
+        metadata={
+            "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
+            "repo_hash": hash_name(repo_location.name),
+            "pipeline_name_hash": hash_name(external_pipeline.name),
+        },
     )
 
     return instance.create_run(

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -18,9 +18,9 @@ import os
 import platform
 import sys
 import uuid
-from collections import namedtuple
 from functools import wraps
 from logging.handlers import RotatingFileHandler
+from typing import Dict, NamedTuple, Optional
 
 import click
 import yaml
@@ -128,10 +128,27 @@ def get_python_version():
 
 
 class TelemetryEntry(
-    namedtuple(
-        "TelemetryEntry",
-        "action client_time elapsed_time event_id instance_id pipeline_name_hash "
-        "num_pipelines_in_repo num_schedules_in_repo num_sensors_in_repo repo_hash python_version metadata version dagster_version os_desc os_platform run_storage_id",
+    NamedTuple(
+        "_TelemetryEntry",
+        [
+            ("action", str),
+            ("client_time", str),
+            ("event_id", str),
+            ("elapsed_time", str),
+            ("instance_id", str),
+            ("metadata", Dict[str, str]),
+            ("pipeline_name_hash", str),
+            ("num_pipelines_in_repo", str),
+            ("num_schedules_in_repo", str),
+            ("num_sensors_in_repo", str),
+            ("repo_hash", str),
+            ("python_version", str),
+            ("version", str),
+            ("dagster_version", str),
+            ("os_desc", str),
+            ("os_platform", str),
+            ("run_storage_id", str),
+        ],
     )
 ):
     """
@@ -164,18 +181,18 @@ class TelemetryEntry(
 
     def __new__(
         cls,
-        action,
-        client_time,
-        event_id,
-        instance_id,
-        elapsed_time=None,
-        pipeline_name_hash=None,
-        num_pipelines_in_repo=None,
-        num_schedules_in_repo=None,
-        num_sensors_in_repo=None,
-        repo_hash=None,
-        metadata=None,
-        run_storage_id=None,
+        action: str,
+        client_time: str,
+        event_id: str,
+        instance_id: str,
+        elapsed_time: Optional[str] = None,
+        pipeline_name_hash: Optional[str] = None,
+        num_pipelines_in_repo: Optional[str] = None,
+        num_schedules_in_repo: Optional[str] = None,
+        num_sensors_in_repo: Optional[str] = None,
+        repo_hash: Optional[str] = None,
+        metadata: Optional[str] = None,
+        run_storage_id: Optional[str] = None,
     ):
         action = check.str_param(action, "action")
         client_time = check.str_param(client_time, "action")

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -185,6 +185,7 @@ class TelemetryEntry(
         client_time: str,
         event_id: str,
         instance_id: str,
+        metadata: Optional[Dict[str, str]] = None,
         elapsed_time: Optional[str] = None,
         pipeline_name_hash: Optional[str] = None,
         num_pipelines_in_repo: Optional[str] = None,

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -192,7 +192,6 @@ class TelemetryEntry(
         num_schedules_in_repo: Optional[str] = None,
         num_sensors_in_repo: Optional[str] = None,
         repo_hash: Optional[str] = None,
-        metadata: Optional[str] = None,
         run_storage_id: Optional[str] = None,
     ):
         action = check.str_param(action, "action")
@@ -201,7 +200,7 @@ class TelemetryEntry(
         event_id = check.str_param(event_id, "event_id")
         instance_id = check.str_param(instance_id, "instance_id")
         metadata = check.opt_dict_param(metadata, "metadata")
-        run_storage_id = check.opt_str_param(run_storage_id, "run_storage_id")
+        run_storage_id = check.opt_str_param(run_storage_id, "run_storage_id", default="")
 
         pipeline_name_hash = check.opt_str_param(
             pipeline_name_hash, "pipeline_name_hash", default=""

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -137,11 +137,6 @@ class TelemetryEntry(
             ("elapsed_time", str),
             ("instance_id", str),
             ("metadata", Dict[str, str]),
-            ("pipeline_name_hash", str),
-            ("num_pipelines_in_repo", str),
-            ("num_schedules_in_repo", str),
-            ("num_sensors_in_repo", str),
-            ("repo_hash", str),
             ("python_version", str),
             ("version", str),
             ("dagster_version", str),
@@ -162,12 +157,7 @@ class TelemetryEntry(
     elapsed_time - Time elapsed between start of function and end of function call
     event_id - Unique id for the event
     instance_id - Unique id for dagster instance
-    pipeline_name_hash - Hash of pipeline name, if any
     python_version - Python version
-    repo_hash - Hash of repo name, if any
-    num_pipelines_in_repo - Number of pipelines in repo, if any
-    num_schedules_in_repo - Number of schedules in repo, if any
-    num_sensors_in_repo - Number of sensors in repo, if any
     metadata - More information i.e. pipeline success (boolean)
     version - Schema version
     dagster_version - Version of the project being used.
@@ -187,11 +177,6 @@ class TelemetryEntry(
         instance_id: str,
         metadata: Optional[Dict[str, str]] = None,
         elapsed_time: Optional[str] = None,
-        pipeline_name_hash: Optional[str] = None,
-        num_pipelines_in_repo: Optional[str] = None,
-        num_schedules_in_repo: Optional[str] = None,
-        num_sensors_in_repo: Optional[str] = None,
-        repo_hash: Optional[str] = None,
         run_storage_id: Optional[str] = None,
     ):
         action = check.str_param(action, "action")
@@ -202,20 +187,6 @@ class TelemetryEntry(
         metadata = check.opt_dict_param(metadata, "metadata")
         run_storage_id = check.opt_str_param(run_storage_id, "run_storage_id", default="")
 
-        pipeline_name_hash = check.opt_str_param(
-            pipeline_name_hash, "pipeline_name_hash", default=""
-        )
-        num_pipelines_in_repo = check.opt_str_param(
-            num_pipelines_in_repo, "num_pipelines_in_repo", default=""
-        )
-        num_schedules_in_repo = check.opt_str_param(
-            num_schedules_in_repo, "num_schedules_in_repo", default=""
-        )
-        num_sensors_in_repo = check.opt_str_param(
-            num_sensors_in_repo, "num_sensors_in_repo", default=""
-        )
-        repo_hash = check.opt_str_param(repo_hash, "repo_hash", default="")
-
         return super(TelemetryEntry, cls).__new__(
             cls,
             action=action,
@@ -223,11 +194,6 @@ class TelemetryEntry(
             elapsed_time=elapsed_time,
             event_id=event_id,
             instance_id=instance_id,
-            pipeline_name_hash=pipeline_name_hash,
-            num_pipelines_in_repo=num_pipelines_in_repo,
-            num_schedules_in_repo=num_schedules_in_repo,
-            num_sensors_in_repo=num_sensors_in_repo,
-            repo_hash=repo_hash,
             python_version=get_python_version(),
             metadata=metadata,
             version=TELEMETRY_VERSION,
@@ -429,12 +395,14 @@ def log_external_repo_stats(instance, source, external_repo, external_pipeline=N
                 client_time=str(datetime.datetime.now()),
                 event_id=str(uuid.uuid4()),
                 instance_id=instance_id,
-                pipeline_name_hash=pipeline_name_hash,
-                num_pipelines_in_repo=str(num_pipelines_in_repo),
-                num_schedules_in_repo=str(num_schedules_in_repo),
-                num_sensors_in_repo=str(num_sensors_in_repo),
-                repo_hash=repo_hash,
-                metadata={"source": source},
+                metadata={
+                    "source": source,
+                    "pipeline_name_hash": pipeline_name_hash,
+                    "num_pipelines_in_repo": str(num_pipelines_in_repo),
+                    "num_schedules_in_repo": str(num_schedules_in_repo),
+                    "num_sensors_in_repo": str(num_sensors_in_repo),
+                    "repo_hash": repo_hash,
+                },
             )._asdict()
         )
 
@@ -475,12 +443,14 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
                 client_time=str(datetime.datetime.now()),
                 event_id=str(uuid.uuid4()),
                 instance_id=instance_id,
-                pipeline_name_hash=pipeline_name_hash,
-                num_pipelines_in_repo=str(num_pipelines_in_repo),
-                num_schedules_in_repo=str(num_schedules_in_repo),
-                num_sensors_in_repo=str(num_sensors_in_repo),
-                repo_hash=repo_hash,
-                metadata={"source": source},
+                metadata={
+                    "source": source,
+                    "pipeline_name_hash": pipeline_name_hash,
+                    "num_pipelines_in_repo": str(num_pipelines_in_repo),
+                    "num_schedules_in_repo": str(num_schedules_in_repo),
+                    "num_sensors_in_repo": str(num_sensors_in_repo),
+                    "repo_hash": repo_hash,
+                },
             )._asdict()
         )
 
@@ -506,8 +476,6 @@ def log_action(
     client_time=None,
     elapsed_time=None,
     metadata=None,
-    pipeline_name_hash=None,
-    repo_hash=None,
 ):
     check.inst_param(instance, "instance", DagsterInstance)
     if client_time is None:
@@ -527,8 +495,6 @@ def log_action(
                 event_id=str(uuid.uuid4()),
                 instance_id=instance_id,
                 metadata=metadata,
-                repo_hash=repo_hash,
-                pipeline_name_hash=pipeline_name_hash,
                 run_storage_id=run_storage_id,
             )._asdict()
         )

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -474,11 +474,11 @@ def _create_sensor_run(
     log_action(
         instance,
         SENSOR_RUN_CREATED,
-        pipeline_name_hash=hash_name(external_pipeline.name),
-        repo_hash=hash_name(repo_location.name),
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
             "SENSOR_NAME_HASH": hash_name(external_sensor.name),
+            "pipeline_name_hash": hash_name(external_pipeline.name),
+            "repo_hash": hash_name(repo_location.name),
         },
     )
 

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -462,11 +462,11 @@ def _create_scheduler_run(
     log_action(
         instance,
         SCHEDULED_RUN_CREATED,
-        repo_hash=hash_name(repo_location.name),
-        pipeline_name_hash=hash_name(external_pipeline.name),
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
             "SCHEDULE_NAME_HASH": hash_name(external_schedule.name),
+            "repo_hash": hash_name(repo_location.name),
+            "pipeline_name_hash": hash_name(external_pipeline.name),
         },
     )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -23,12 +23,7 @@ EXPECTED_KEYS = set(
         "elapsed_time",
         "event_id",
         "instance_id",
-        "pipeline_name_hash",
-        "num_pipelines_in_repo",
         "run_storage_id",
-        "num_schedules_in_repo",
-        "num_sensors_in_repo",
-        "repo_hash",
         "python_version",
         "metadata",
         "version",
@@ -62,9 +57,10 @@ def test_dagster_telemetry_enabled(caplog):
             for record in caplog.records:
                 message = json.loads(record.getMessage())
                 if message.get("action") == UPDATE_REPO_STATS:
-                    assert message.get("pipeline_name_hash") == hash_name(pipeline_name)
-                    assert message.get("num_pipelines_in_repo") == str(1)
-                    assert message.get("repo_hash") == hash_name(
+                    metadata = message.get("metadata")
+                    assert metadata.get("pipeline_name_hash") == hash_name(pipeline_name)
+                    assert metadata.get("num_pipelines_in_repo") == str(1)
+                    assert metadata.get("repo_hash") == hash_name(
                         get_ephemeral_repository_name(pipeline_name)
                     )
                 assert set(message.keys()) == EXPECTED_KEYS
@@ -107,9 +103,10 @@ def test_dagster_telemetry_unset(caplog):
                 for record in caplog.records:
                     message = json.loads(record.getMessage())
                     if message.get("action") == UPDATE_REPO_STATS:
-                        assert message.get("pipeline_name_hash") == hash_name(pipeline_name)
-                        assert message.get("num_pipelines_in_repo") == str(1)
-                        assert message.get("repo_hash") == hash_name(
+                        metadata = message.get("metadata")
+                        assert metadata.get("pipeline_name_hash") == hash_name(pipeline_name)
+                        assert metadata.get("num_pipelines_in_repo") == str(1)
+                        assert metadata.get("repo_hash") == hash_name(
                             get_ephemeral_repository_name(pipeline_name)
                         )
                     assert set(message.keys()) == EXPECTED_KEYS
@@ -145,9 +142,10 @@ def test_repo_stats(caplog):
                 for record in caplog.records:
                     message = json.loads(record.getMessage())
                     if message.get("action") == UPDATE_REPO_STATS:
-                        assert message.get("pipeline_name_hash") == hash_name(pipeline_name)
-                        assert message.get("num_pipelines_in_repo") == str(4)
-                        assert message.get("repo_hash") == hash_name("dagster_test_repository")
+                        metadata = message.get("metadata")
+                        assert metadata.get("pipeline_name_hash") == hash_name(pipeline_name)
+                        assert metadata.get("num_pipelines_in_repo") == str(4)
+                        assert metadata.get("repo_hash") == hash_name("dagster_test_repository")
                     assert set(message.keys()) == EXPECTED_KEYS
 
                 assert len(caplog.records) == 5

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -26,6 +26,8 @@ EXPECTED_KEYS = set(
         "pipeline_name_hash",
         "num_pipelines_in_repo",
         "run_storage_id",
+        "num_schedules_in_repo",
+        "num_sensors_in_repo",
         "repo_hash",
         "python_version",
         "metadata",


### PR DESCRIPTION
I'm wondering what this actually gets us. In the ideal world I think we would want to log the following:
- list of hashes of job names
- list of hashes of sensor names, with hashes of targeted jobs
- list of hashes of schedule names, with hashes of targeted jobs
Thoughts?