### PR TITLE
[dagit] Fix runtime errors in useViewport

### DIFF
--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -18,15 +18,15 @@
     "@blueprintjs/select": "^3.16.4",
     "@blueprintjs/table": "^3.8.33",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-is": "^17.0.2",
+    "styled-components": "^5.3.3"
   },
   "dependencies": {
-    "react-is": "^17.0.2",
     "react-markdown": "6.0.3",
     "remark": "13.x",
     "remark-gfm": "1.0.0",
-    "remark-plain-text": "^0.2.0",
-    "styled-components": "^5.3.3"
+    "remark-plain-text": "^0.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",

--- a/js_modules/dagit/packages/ui/src/components/useSuggestionsForString.tsx
+++ b/js_modules/dagit/packages/ui/src/components/useSuggestionsForString.tsx
@@ -7,10 +7,10 @@ export const useSuggestionsForString = (
   const tokens = value.toLocaleLowerCase().trim().split(/\s+/);
   const queryString = tokens.length ? tokens[tokens.length - 1] : '';
 
-  const suggestions = React.useMemo(
-    () => buildSuggestions(queryString),
-    [buildSuggestions, queryString],
-  );
+  const suggestions = React.useMemo(() => buildSuggestions(queryString), [
+    buildSuggestions,
+    queryString,
+  ]);
 
   const onSelectSuggestion = React.useCallback(
     (suggestion: string) => {

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5538,14 +5538,12 @@ __metadata:
     eslint-plugin-storybook: ^0.5.5
     jest: ^27.4.7
     nearest-color: ^0.4.4
-    react-is: ^17.0.2
     react-markdown: 6.0.3
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
     remark: 13.x
     remark-gfm: 1.0.0
     remark-plain-text: ^0.2.0
-    styled-components: ^5.3.3
     typescript: ^4.5.4
   peerDependencies:
     "@blueprintjs/core": ^3.45.0
@@ -5555,6 +5553,8 @@ __metadata:
     "@blueprintjs/table": ^3.8.33
     react: ^17.0.2
     react-dom: ^17.0.2
+    react-is: ^17.0.2
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

There is an occasional Cloud runtime error within `useViewport`, where the ref is not actually an element. The ref is currently being set to `any`, so there are no TS safeguards in place to prevent this.

Fix this up by tracking a typed object.

![image](https://user-images.githubusercontent.com/2823852/150031517-28484077-fa37-4b8e-884a-8dacf8e0a2a7.png)

## Test Plan

View Gantt chart and parition matrix. Verify that they behave correctly, with no errors.
