### PR TITLE
[dagster-io/ui] Fix AnchorButton stories

### DIFF
--- a/js_modules/dagit/packages/ui/.storybook/preview.js
+++ b/js_modules/dagit/packages/ui/.storybook/preview.js
@@ -14,6 +14,7 @@ import {
   ColorsWIP,
 } from '../src';
 
+import {MemoryRouter} from 'react-router-dom';
 import * as React from 'react';
 
 import {createGlobalStyle} from 'styled-components/macro';
@@ -72,7 +73,7 @@ const GlobalStyle = createGlobalStyle`
 // Global decorator to apply the styles to all stories
 export const decorators = [
   (Story) => (
-    <>
+    <MemoryRouter>
       <GlobalStyle />
       <GlobalToasterStyle />
       <GlobalTooltipStyle />
@@ -80,7 +81,7 @@ export const decorators = [
       <GlobalDialogStyle />
       <GlobalSuggestStyle />
       <Story />
-    </>
+    </MemoryRouter>
   ),
 ];
 

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -60,6 +60,8 @@
     "eslint-plugin-storybook": "^0.5.5",
     "jest": "^27.4.7",
     "nearest-color": "^0.4.4",
+    "react-router": "^5.2.1",
+    "react-router-dom": "^5.3.0",
     "typescript": "^4.5.4"
   }
 }

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5540,6 +5540,8 @@ __metadata:
     nearest-color: ^0.4.4
     react-is: ^17.0.2
     react-markdown: 6.0.3
+    react-router: ^5.2.1
+    react-router-dom: ^5.3.0
     remark: 13.x
     remark-gfm: 1.0.0
     remark-plain-text: ^0.2.0


### PR DESCRIPTION
## Summary

The stories for `AnchorButton` are broken in Storybook because we aren't including a `MemoryRouter` at the root in `@dagster-io/ui`. Fix this.

## Test Plan

yarn storybook, verify that these stories work.
