### PR TITLE
[dagit] Regenerate GraphQL, fix master

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -5,7 +5,6 @@
   "description": "Dagit Application Core",
   "license": "Apache-2.0",
   "scripts": {
-    "prettier": "prettier --write \"./src/**/*.tsx\"",
     "find-dead-code": "yarn ts-prune | grep -Ev '/types/\\|stories.tsx'",
     "jest": "jest",
     "jest:debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand --no-cache",

--- a/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
+++ b/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
@@ -5,6 +5,8 @@ import {buildClientSchema, getIntrospectionQuery, printSchema} from 'graphql';
 
 console.log('Downloading schema...');
 
+const TARGET_FILE = './src/graphql/schema.graphql';
+
 // https://github.com/dagster-io/dagster/issues/2623
 const result = execSync(
   `dagster-graphql --ephemeral-instance --empty-workspace -t '${getIntrospectionQuery({
@@ -20,7 +22,7 @@ const sdl = printSchema(buildClientSchema(schemaJson));
 
 console.log('Generating schema.graphql...');
 
-writeFileSync('./src/graphql/schema.graphql', sdl);
+writeFileSync(TARGET_FILE, sdl);
 
 // Write `possibleTypes.generated.json`, used in prod for `AppCache` and in tests for creating
 // a mocked schema.
@@ -39,8 +41,10 @@ writeFileSync('./src/graphql/possibleTypes.generated.json', JSON.stringify(possi
 console.log('Generating TypeScript types...');
 
 execSync(
-  'find src -type d -name types | xargs rm -r && yarn apollo codegen:generate --includes "./src/**/*.tsx" --target typescript types --localSchemaFile ./src/graphql/schema.graphql --globalTypesFile ./src/types/globalTypes.ts',
+  `find src -type d -name types | xargs rm -r && yarn apollo codegen:generate --includes "./src/**/*.tsx" --target typescript types --localSchemaFile ${TARGET_FILE} --globalTypesFile ./src/types/globalTypes.ts`,
   {stdio: 'inherit'},
 );
+
+execSync(`yarn prettier --loglevel silent --write ${TARGET_FILE}`, {stdio: 'inherit'});
 
 console.log('Done!');

--- a/js_modules/dagit/packages/ui/src/components/useSuggestionsForString.tsx
+++ b/js_modules/dagit/packages/ui/src/components/useSuggestionsForString.tsx
@@ -7,10 +7,10 @@ export const useSuggestionsForString = (
   const tokens = value.toLocaleLowerCase().trim().split(/\s+/);
   const queryString = tokens.length ? tokens[tokens.length - 1] : '';
 
-  const suggestions = React.useMemo(() => buildSuggestions(queryString), [
-    buildSuggestions,
-    queryString,
-  ]);
+  const suggestions = React.useMemo(
+    () => buildSuggestions(queryString),
+    [buildSuggestions, queryString],
+  );
 
   const onSelectSuggestion = React.useCallback(
     (suggestion: string) => {


### PR DESCRIPTION
## Summary

It looks like a local prettier run on `schema.graphql` is breaking master. I'm not sure how this didn't break earlier, but I'm adding a `prettier` run to the end of `generateGraphQLTypes` to ensure that this is consistent in the future.

A local `lint` run also picked up another file.

## Test Plan

Buildkite
