### PR TITLE
Cleanup DagsterK8sJobConfig.config_type()

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -27,6 +27,7 @@ class CeleryWorkerQueue(BaseModel):
 
 class CeleryK8sRunLauncherConfig(BaseModel):
     image: kubernetes.Image
+    imagePullPolicy: Optional[kubernetes.PullPolicy]
     nameOverride: str
     configSource: dict
     workerQueues: List[CeleryWorkerQueue] = Field(min_items=1)

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -39,6 +39,17 @@ config:
   {{- if $celeryK8sRunLauncherConfig.volumes }}
   volumes: {{- $celeryK8sRunLauncherConfig.volumes | toYaml | nindent 4 }}
   {{- end }}
+
+  {{- if .Values.imagePullSecrets }}
+  image_pull_secrets: {{- .Values.imagePullSecrets | toYaml | nindent 4 }}
+  {{- end }}
+
+  service_account_name: {{ include "dagster.serviceAccountName" . }}
+
+  {{- if $celeryK8sRunLauncherConfig.imagePullPolicy }}
+  image_pull_policy: {{ $celeryK8sRunLauncherConfig.imagePullPolicy }}
+  {{- end }}
+
 {{- end }}
 
 {{- define "dagsterYaml.runLauncher.k8s" }}
@@ -55,7 +66,7 @@ config:
   image_pull_policy: {{ $k8sRunLauncherConfig.imagePullPolicy }}
 
   {{- if .Values.imagePullSecrets }}
-  image_pull_secrets: {{- .Values.imagePullSecrets | toYaml | nindent 10 }}
+  image_pull_secrets: {{- .Values.imagePullSecrets | toYaml | nindent 4 }}
   {{- end }}
   service_account_name: {{ include "dagster.serviceAccountName" . }}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1533,6 +1533,16 @@
                 "image": {
                     "$ref": "#/definitions/Image"
                 },
+                "imagePullPolicy": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PullPolicy"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "nameOverride": {
                     "title": "Nameoverride",
                     "type": "string"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -465,6 +465,11 @@ runLauncher:
 
     # This configuration will only be used if the CeleryK8sRunLauncher is selected
     celeryK8sRunLauncher:
+      # Change with caution! If you're using a fixed tag for pipeline run images, changing the
+      # image pull policy to anything other than "Always" will use a cached/stale image, which is
+      # almost certainly not what you want.
+      imagePullPolicy: "Always"
+
       # The Celery workers can be deployed with a fixed image (no user code included)
       image:
         # When a tag is not supplied for a Dagster provided image,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
@@ -8,12 +8,10 @@ from dagster_k8s.client import DEFAULT_WAIT_TIMEOUT
 CELERY_K8S_CONFIG_KEY = "celery-k8s"
 
 
-def celery_k8s_config():
+def celery_k8s_executor_config():
 
     # DagsterK8sJobConfig provides config schema for specifying Dagster K8s Jobs
-    job_config = DagsterK8sJobConfig.config_type_pipeline_run(
-        default_image_pull_policy="IfNotPresent"
-    )
+    job_config = DagsterK8sJobConfig.config_type_job()
 
     additional_config = {
         "load_incluster_config": Field(

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -47,13 +47,13 @@ from dagster_k8s.utils import (
     wait_for_job_success,
 )
 
-from .config import CELERY_K8S_CONFIG_KEY, celery_k8s_config
+from .config import CELERY_K8S_CONFIG_KEY, celery_k8s_executor_config
 from .launcher import CeleryK8sRunLauncher
 
 
 @executor(
     name=CELERY_K8S_CONFIG_KEY,
-    config_schema=celery_k8s_config(),
+    config_schema=celery_k8s_executor_config(),
     requirements=multiple_process_executor_requirements(),
 )
 def celery_k8s_job_executor(init_context):

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -31,7 +31,6 @@ def test_empty_celery_config():
     assert res == {
         "backend": "rpc://",
         "retries": {"enabled": {}},
-        "image_pull_policy": "IfNotPresent",
         "volume_mounts": [],
         "volumes": [],
         "load_incluster_config": True,
@@ -50,7 +49,6 @@ def test_get_validated_celery_k8s_executor_config():
         "backend": "rpc://",
         "retries": {"enabled": {}},
         "job_image": "foo",
-        "image_pull_policy": "IfNotPresent",
         "load_incluster_config": True,
         "job_namespace": "default",
         "repo_location_name": "<<in_process>>",
@@ -167,7 +165,6 @@ def test_get_validated_celery_k8s_executor_config_for_job():
         "backend": "rpc://",
         "retries": {"enabled": {}},
         "job_image": "foo",
-        "image_pull_policy": "IfNotPresent",
         "load_incluster_config": True,
         "job_namespace": "default",
         "repo_location_name": "<<in_process>>",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -26,7 +26,7 @@ from .utils import delete_job
 @executor(
     name="k8s",
     config_schema=merge_dicts(
-        DagsterK8sJobConfig.config_type_pipeline_run(),
+        DagsterK8sJobConfig.config_type_job(),
         {"job_namespace": Field(StringSource, is_required=False)},
         {"retries": get_retries_config()},
     ),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -1,7 +1,7 @@
 import sys
 
 import kubernetes
-from dagster import EventMetadataEntry, Field, Noneable, StringSource, check
+from dagster import EventMetadataEntry, Field, StringSource, check
 from dagster.cli.api import ExecuteRunArgs
 from dagster.core.events import EngineEventData
 from dagster.core.launcher import LaunchRunContext, ResumeRunContext, RunLauncher
@@ -47,7 +47,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
     Args:
         service_account_name (str): The name of the Kubernetes service account under which to run
-            the Job.
+            the Job. Defaults to "default"
         job_image (Optional[str]): The ``name`` of the image to use for the Job's Dagster container.
             This image will be run with the command
             ``dagster api execute_run``.
@@ -195,12 +195,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         """Include all arguments required for DagsterK8sJobConfig along with additional arguments
         needed for the RunLauncher itself.
         """
-        job_cfg = DagsterK8sJobConfig.config_type()
+        job_cfg = DagsterK8sJobConfig.config_type_run_launcher()
 
         run_launcher_extra_cfg = {
             "job_namespace": Field(StringSource, is_required=False, default_value="default"),
-            "load_incluster_config": Field(bool, is_required=False, default_value=True),
-            "kubeconfig_file": Field(Noneable(str), is_required=False, default_value=None),
         }
         return merge_dicts(job_cfg, run_launcher_extra_cfg)
 


### PR DESCRIPTION
Summary:
The different config type options for specifying config in k8s launchers and executors has gotten pretty out of hand. This splits things out into a way that I think is more sensible:

- DagsterK8sJobConfig.config_type_job: the core set of fields that define a job
- DagsterK8sJobConfig.config_type_run_launcher: the core stuff + additional run launcher specific stuff
- DagsterK8sJobConfig.config_type_executor: the core stuff + additional executor stuff (e.g. overriding the job image)

Not 100% perfect but a better foundation to build off I think.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.