### PR TITLE
Add version to error dialog copyable for bug reporting

### DIFF
--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -19,7 +19,7 @@ import {telemetryLink} from './telemetryLink';
 
 const {pathPrefix, telemetryEnabled} = extractInitializationData();
 
-const apolloLinks = [logLink, errorLink, timeStartLink];
+const apolloLinks = [logLink, errorLink(pathPrefix), timeStartLink];
 
 if (telemetryEnabled) {
   apolloLinks.unshift(telemetryLink(pathPrefix));


### PR DESCRIPTION
## Summary
Fixes Issue #2283

Note that standard apollo useQuery GraphQL hook cannot be used, because the error dialog exists outside of the scope of the apollo client provider. Instead, I followed the same pattern as the apollo telemetrylink (which also faces this problem). 

Example of dialog 
<img width="1212" alt="Screen Shot 2022-01-19 at 12 22 00 PM" src="https://user-images.githubusercontent.com/4010391/150191029-ea5bfd06-4095-4e61-bb63-f32f1cfa3a07.png">

## Test Plan
N/A

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.