### PR TITLE
[dagster-io/ui] Disallow wrapping inside Button

### DIFF
--- a/js_modules/dagit/packages/core/.eslintrc.js
+++ b/js_modules/dagit/packages/core/.eslintrc.js
@@ -10,8 +10,8 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'plugin:prettier/recommended',
     'plugin:storybook/recommended',
+    'plugin:prettier/recommended', // Prettier plugin must be last!
   ],
   plugins: ['react-hooks', 'import', 'graphql'],
   parserOptions: {

--- a/js_modules/dagit/packages/ui/.eslintrc.js
+++ b/js_modules/dagit/packages/ui/.eslintrc.js
@@ -5,8 +5,8 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'plugin:prettier/recommended',
     'plugin:storybook/recommended',
+    'plugin:prettier/recommended', // Prettier plugin must be last!
   ],
   plugins: ['react-hooks', 'import'],
   parserOptions: {

--- a/js_modules/dagit/packages/ui/.storybook/main.js
+++ b/js_modules/dagit/packages/ui/.storybook/main.js
@@ -10,5 +10,9 @@ module.exports = {
   "framework": "@storybook/react",
   "core": {
     "builder": "webpack5"
+  },
+  // https://storybook.js.org/docs/react/configure/webpack#bundle-splitting
+  features: {
+    storyStoreV7: true,
   }
 }

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -51,6 +51,7 @@
     "@types/eslint": "^8",
     "@types/jest": "^27.4.0",
     "@types/mdx-js__react": "^1",
+    "@types/prettier": "^2",
     "@types/styled-components": "^5",
     "@types/testing-library__jest-dom": "^5.14.2",
     "babel-jest": "^27.4.6",
@@ -60,6 +61,7 @@
     "eslint-plugin-storybook": "^0.5.5",
     "jest": "^27.4.7",
     "nearest-color": "^0.4.4",
+    "prettier": "2.2.1",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "typescript": "^4.5.4"

--- a/js_modules/dagit/packages/ui/src/components/BaseButton.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {ColorsWIP} from './Colors';
-import {StyledButton} from './StyledButton';
+import {StyledButton, StyledButtonText} from './StyledButton';
 
 interface CommonButtonProps {
   icon?: React.ReactNode;
@@ -40,7 +40,7 @@ export const BaseButton = React.forwardRef(
         ref={ref}
       >
         {icon || null}
-        {label ? <span>{label}</span> : null}
+        {label ? <StyledButtonText>{label}</StyledButtonText> : null}
         {rightIcon || null}
       </StyledButton>
     );

--- a/js_modules/dagit/packages/ui/src/components/Button.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.stories.tsx
@@ -114,3 +114,15 @@ export const Disabled = () => {
     </Group>
   );
 };
+
+export const Truncation = () => {
+  return (
+    <Group direction="column" spacing={8}>
+      <Button>Normal</Button>
+      <Button style={{maxWidth: '250px'}}>Normal with max-width</Button>
+      <Button style={{maxWidth: '250px'}}>
+        Four score and seven years ago our fathers brought forth on this continent
+      </Button>
+    </Group>
+  );
+};

--- a/js_modules/dagit/packages/ui/src/components/Button.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Button.tsx
@@ -6,7 +6,7 @@ import {Link, LinkProps} from 'react-router-dom';
 import {BaseButton} from './BaseButton';
 import {ColorsWIP} from './Colors';
 import {Spinner} from './Spinner';
-import {StyledButton} from './StyledButton';
+import {StyledButton, StyledButtonText} from './StyledButton';
 
 type BlueprintIntent = React.ComponentProps<typeof BlueprintButton>['intent'];
 type BlueprintOutlined = React.ComponentProps<typeof BlueprintButton>['outlined'];
@@ -142,7 +142,7 @@ export const AnchorButton = React.forwardRef(
         ref={ref}
       >
         {icon || null}
-        {children ? <span>{children}</span> : null}
+        {children ? <StyledButtonText>{children}</StyledButtonText> : null}
         {rightIcon || null}
       </StyledButton>
     );
@@ -169,7 +169,7 @@ export const ExternalAnchorButton = React.forwardRef(
         ref={ref}
       >
         {icon || null}
-        {children ? <span>{children}</span> : null}
+        {children ? <StyledButtonText>{children}</StyledButtonText> : null}
         {rightIcon || null}
       </StyledButton>
     );

--- a/js_modules/dagit/packages/ui/src/components/StyledButton.tsx
+++ b/js_modules/dagit/packages/ui/src/components/StyledButton.tsx
@@ -25,6 +25,8 @@ export const StyledButton = styled.button<StyledButtonProps>`
   padding: 6px 12px;
   transition: background 100ms, box-shadow 150ms, filter 100ms, opacity 150ms;
   user-select: none;
+  white-space: nowrap;
+
   box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
 
   :hover {
@@ -87,4 +89,10 @@ export const StyledButton = styled.button<StyledButtonProps>`
   ${IconWrapper}:first-child:last-child {
     margin: 2px -4px;
   }
+`;
+
+export const StyledButtonText = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5529,6 +5529,7 @@ __metadata:
     "@types/eslint": ^8
     "@types/jest": ^27.4.0
     "@types/mdx-js__react": ^1
+    "@types/prettier": ^2
     "@types/styled-components": ^5
     "@types/testing-library__jest-dom": ^5.14.2
     babel-jest: ^27.4.6
@@ -5538,6 +5539,7 @@ __metadata:
     eslint-plugin-storybook: ^0.5.5
     jest: ^27.4.7
     nearest-color: ^0.4.4
+    prettier: 2.2.1
     react-markdown: 6.0.3
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
@@ -9025,6 +9027,13 @@ __metadata:
   version: 5.0.3
   resolution: "@types/parse5@npm:5.0.3"
   checksum: d6b7495cb1850f9f2e9c5e103ede9f2d30a5320669707b105c403868adc9e4bf8d3a7ff314cc23f67826bbbbbc0e6147346ce9062ab429f099dba7a01f463919
+  languageName: node
+  linkType: hard
+
+"@types/prettier@npm:^2":
+  version: 2.4.3
+  resolution: "@types/prettier@npm:2.4.3"
+  checksum: b240434daabac54700c862b0bb52a83fec396e0e9c847447119ba41fd8404d79aadfa174e6306fb094b29efadac586344b7606c3a71c286b71755ab2579d54df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

I have noticed in the past that Blueprint buttons allow their labels to wrap. I don't think we should allow this. It shows up on Instance Overview once in a while if there is limited horizontal space, with the "View run" button, and I think it looks terrible.

Fixing this, and pinning prettier so that it stops thrashing lint.

## Test Plan

View Button storybook examples, load Dagit and click around to look at various buttons and make sure they look fine.
