### PR TITLE
Show users timezone on runs table

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -123,7 +123,7 @@ export const RunTable = (props: RunTableProps) => {
             <th style={{width: 90}}>Run ID</th>
             <th>{anyPipelines ? 'Job / Pipeline' : 'Job'}</th>
             <th style={{width: 90}}>Snapshot ID</th>
-            <th style={{width: 180}}>Timing</th>
+            <th style={{width: 200}}>Timing</th>
             {props.additionalColumnHeaders}
             <th style={{width: 52}} />
           </tr>

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -271,14 +271,14 @@ export const RunTime: React.FC<RunTimeProps> = React.memo(({run}) => {
   }
 
   const content = () => {
-    if (stats.startTime) {
-      return <Timestamp timestamp={{unix: stats.startTime}} />;
-    }
-    if (stats.launchTime) {
-      return <Timestamp timestamp={{unix: stats.launchTime}} />;
-    }
-    if (stats.enqueuedTime) {
-      return <Timestamp timestamp={{unix: stats.enqueuedTime}} />;
+    const showTimeUnix = stats.startTime || stats.launchTime || stats.enqueuedTime;
+    if (showTimeUnix) {
+      return (
+        <Timestamp
+          timeFormat={{showSeconds: true, showTimezone: true}}
+          timestamp={{unix: showTimeUnix}}
+        />
+      );
     }
 
     switch (run.status) {


### PR DESCRIPTION
## Summary
Fixes #5626 by adding timezone to the runs table. Widen column to keep TZ on same line as timestamp.
<img width="1145" alt="Screen Shot 2022-01-19 at 2 39 28 PM" src="https://user-images.githubusercontent.com/4010391/150210049-d033e9bb-1873-4607-baa5-80a91f4c665e.png">

## Test Plan
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.