### PR TITLE
split out run migrations to required/optional data migrations

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -641,7 +641,7 @@ class DagsterInstance:
             if print_fn:
                 print_fn("Updating run storage...")
             self._run_storage.upgrade()
-            self._run_storage.build_missing_indexes(print_fn=print_fn)
+            self._run_storage.execute_required_migrations(print_fn)
 
             if print_fn:
                 print_fn("Updating event storage...")
@@ -662,6 +662,7 @@ class DagsterInstance:
         print_fn("Checking for reindexing...")
         self._event_storage.reindex_events(print_fn)
         self._event_storage.reindex_assets(print_fn)
+        self._run_storage.execute_optional_migrations(print_fn)
         print_fn("Done.")
 
     def dispose(self):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -641,7 +641,7 @@ class DagsterInstance:
             if print_fn:
                 print_fn("Updating run storage...")
             self._run_storage.upgrade()
-            self._run_storage.execute_required_migrations(print_fn)
+            self._run_storage.migrate(print_fn)
 
             if print_fn:
                 print_fn("Updating event storage...")
@@ -662,7 +662,7 @@ class DagsterInstance:
         print_fn("Checking for reindexing...")
         self._event_storage.reindex_events(print_fn)
         self._event_storage.reindex_assets(print_fn)
-        self._run_storage.execute_optional_migrations(print_fn)
+        self._run_storage.optimize(print_fn)
         print_fn("Done.")
 
     def dispose(self):

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -304,9 +304,15 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
     def delete_run(self, run_id: str):
         """Remove a run from storage"""
 
-    @abstractmethod
-    def build_missing_indexes(self, print_fn: Callable = None, force_rebuild_all: bool = False):
-        """Call this method to run any data migrations"""
+    def execute_required_migrations(
+        self, print_fn: Callable = None, force_rebuild_all: bool = False
+    ):
+        """Call this method to run any required data migrations"""
+
+    def execute_optional_migrations(
+        self, print_fn: Callable = None, force_rebuild_all: bool = False
+    ):
+        """Call this method to run any optional data migrations"""
 
     def dispose(self):
         """Explicit lifecycle management."""

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -304,15 +304,11 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
     def delete_run(self, run_id: str):
         """Remove a run from storage"""
 
-    def execute_required_migrations(
-        self, print_fn: Callable = None, force_rebuild_all: bool = False
-    ):
+    def migrate(self, print_fn: Callable = None, force_rebuild_all: bool = False):
         """Call this method to run any required data migrations"""
 
-    def execute_optional_migrations(
-        self, print_fn: Callable = None, force_rebuild_all: bool = False
-    ):
-        """Call this method to run any optional data migrations"""
+    def optimize(self, print_fn: Callable = None, force_rebuild_all: bool = False):
+        """Call this method to run any optional data migrations for optimized reads"""
 
     def dispose(self):
         """Explicit lifecycle management."""

--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -249,9 +249,6 @@ class InMemoryRunStorage(RunStorage):
     def wipe(self):
         self._init_storage()
 
-    def build_missing_indexes(self, print_fn: Callable = None, force_rebuild_all: bool = False):
-        pass
-
     def get_run_group(self, run_id: str) -> Optional[Tuple[str, List[PipelineRun]]]:
         check.str_param(run_id, "run_id")
         pipeline_run = self._runs.get(run_id)

--- a/python_modules/dagster/dagster/core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/core/storage/runs/migration.py
@@ -11,9 +11,11 @@ from ..tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 RUN_PARTITIONS = "run_partitions"
 RUN_START_END = "run_start_end"
 
+# for `dagster instance migrate`, paired with schema changes
 REQUIRED_DATA_MIGRATIONS = {
     RUN_PARTITIONS: lambda: migrate_run_partition,
 }
+# for `dagster instance reindex`, optionally run for better read performance
 OPTIONAL_DATA_MIGRATIONS = {
     RUN_START_END: lambda: migrate_run_start_end,
 }

--- a/python_modules/dagster/dagster/core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/core/storage/runs/migration.py
@@ -11,8 +11,10 @@ from ..tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 RUN_PARTITIONS = "run_partitions"
 RUN_START_END = "run_start_end"
 
-RUN_DATA_MIGRATIONS = {
+REQUIRED_DATA_MIGRATIONS = {
     RUN_PARTITIONS: lambda: migrate_run_partition,
+}
+OPTIONAL_DATA_MIGRATIONS = {
     RUN_START_END: lambda: migrate_run_start_end,
 }
 

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -35,7 +35,7 @@ from dagster.utils import datetime_as_float, merge_dicts, utc_datetime_from_time
 
 from ..pipeline_run import PipelineRun, PipelineRunsFilter, RunRecord
 from .base import RunStorage
-from .migration import RUN_DATA_MIGRATIONS, RUN_PARTITIONS
+from .migration import OPTIONAL_DATA_MIGRATIONS, REQUIRED_DATA_MIGRATIONS, RUN_PARTITIONS
 from .schema import (
     BulkActionsTable,
     DaemonHeartbeatsTable,
@@ -710,8 +710,10 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     # Tracking data migrations over secondary indexes
 
-    def build_missing_indexes(self, print_fn: Callable = None, force_rebuild_all: bool = False):
-        for migration_name, migration_fn in RUN_DATA_MIGRATIONS.items():
+    def _execute_required_migrations(
+        self, migrations, print_fn: Callable = None, force_rebuild_all: bool = False
+    ):
+        for migration_name, migration_fn in migrations.items():
             if self.has_built_index(migration_name):
                 if not force_rebuild_all:
                     continue
@@ -721,6 +723,17 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             self.mark_index_built(migration_name)
             if print_fn:
                 print_fn(f"Finished data migration: {migration_name}")
+
+    def execute_required_migrations(
+        self, print_fn: Callable = None, force_rebuild_all: bool = False
+    ):
+        self._execute_required_migrations(REQUIRED_DATA_MIGRATIONS, print_fn, force_rebuild_all)
+
+    def execute_optional_migrations(
+        self, print_fn: Callable = None, force_rebuild_all: bool = False
+    ):
+        all_migrations = {**REQUIRED_DATA_MIGRATIONS, **OPTIONAL_DATA_MIGRATIONS}
+        self._execute_required_migrations(all_migrations, print_fn, force_rebuild_all)
 
     def has_built_index(self, migration_name: str) -> bool:
         query = (

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -710,7 +710,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     # Tracking data migrations over secondary indexes
 
-    def _execute_required_migrations(
+    def _execute_data_migrations(
         self, migrations, print_fn: Callable = None, force_rebuild_all: bool = False
     ):
         for migration_name, migration_fn in migrations.items():
@@ -724,16 +724,11 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             if print_fn:
                 print_fn(f"Finished data migration: {migration_name}")
 
-    def execute_required_migrations(
-        self, print_fn: Callable = None, force_rebuild_all: bool = False
-    ):
-        self._execute_required_migrations(REQUIRED_DATA_MIGRATIONS, print_fn, force_rebuild_all)
+    def migrate(self, print_fn: Callable = None, force_rebuild_all: bool = False):
+        self._execute_data_migrations(REQUIRED_DATA_MIGRATIONS, print_fn, force_rebuild_all)
 
-    def execute_optional_migrations(
-        self, print_fn: Callable = None, force_rebuild_all: bool = False
-    ):
-        all_migrations = {**REQUIRED_DATA_MIGRATIONS, **OPTIONAL_DATA_MIGRATIONS}
-        self._execute_required_migrations(all_migrations, print_fn, force_rebuild_all)
+    def optimize(self, print_fn: Callable = None, force_rebuild_all: bool = False):
+        self._execute_data_migrations(OPTIONAL_DATA_MIGRATIONS, print_fn, force_rebuild_all)
 
     def has_built_index(self, migration_name: str) -> bool:
         query = (

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -85,7 +85,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
 
         if should_mark_indexes:
             # mark all secondary indexes
-            run_storage.build_missing_indexes()
+            run_storage.execute_required_migrations()
 
         return run_storage
 

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -84,8 +84,8 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         run_storage = SqliteRunStorage(conn_string, inst_data)
 
         if should_mark_indexes:
-            # mark all secondary indexes
-            run_storage.execute_required_migrations()
+            run_storage.migrate()
+            run_storage.optimize()
 
         return run_storage
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -17,7 +17,7 @@ from dagster.core.host_representation import (
 )
 from dagster.core.snap import create_pipeline_snapshot_id
 from dagster.core.storage.pipeline_run import DagsterRun, PipelineRunStatus, PipelineRunsFilter
-from dagster.core.storage.runs.migration import RUN_DATA_MIGRATIONS
+from dagster.core.storage.runs.migration import REQUIRED_DATA_MIGRATIONS
 from dagster.core.storage.runs.sql_run_storage import SqlRunStorage
 from dagster.core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
@@ -1084,7 +1084,7 @@ class TestRunStorage:
         if not isinstance(storage, SqlRunStorage):
             return
 
-        for name in RUN_DATA_MIGRATIONS.keys():
+        for name in REQUIRED_DATA_MIGRATIONS.keys():
             assert storage.has_built_index(name)
 
     def test_handle_run_event_pipeline_success_test(self, storage):

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -377,7 +377,7 @@ def test_run_partition_data_migration():
         assert len(run_storage._get_partition_runs(partition_set_name, partition_name)) == 0
 
         # actually migrate the data
-        run_storage.build_missing_indexes(force_rebuild_all=True)
+        run_storage.execute_required_migrations(force_rebuild_all=True)
 
         # ensure that we get the same partitioned runs returned
         assert run_storage.has_built_index(RUN_PARTITIONS)
@@ -606,3 +606,4 @@ def test_start_time_end_time():
         instance._run_storage._alembic_downgrade(rev="7f2b1a4ca7a5")
 
         assert get_current_alembic_version(db_path) == "7f2b1a4ca7a5"
+        assert True

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -377,7 +377,7 @@ def test_run_partition_data_migration():
         assert len(run_storage._get_partition_runs(partition_set_name, partition_name)) == 0
 
         # actually migrate the data
-        run_storage.execute_required_migrations(force_rebuild_all=True)
+        run_storage.migrate(force_rebuild_all=True)
 
         # ensure that we get the same partitioned runs returned
         assert run_storage.has_built_index(RUN_PARTITIONS)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -55,7 +55,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         # revision because alembic config may be shared with other storage classes)
         if "runs" not in table_names:
             retry_mysql_creation_fn(self._init_db)
-            self.build_missing_indexes()
+            self.execute_required_migrations()
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -55,7 +55,8 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         # revision because alembic config may be shared with other storage classes)
         if "runs" not in table_names:
             retry_mysql_creation_fn(self._init_db)
-            self.execute_required_migrations()
+            self.migrate()
+            self.optimize()
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -56,7 +56,8 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         # revision because alembic config may be shared with other storage classes)
         if self.should_autocreate_tables and "runs" not in table_names:
             retry_pg_creation_fn(self._init_db)
-            self.execute_required_migrations()
+            self.migrate()
+            self.optimize()
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -56,7 +56,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         # revision because alembic config may be shared with other storage classes)
         if self.should_autocreate_tables and "runs" not in table_names:
             retry_pg_creation_fn(self._init_db)
-            self.build_missing_indexes()
+            self.execute_required_migrations()
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -391,6 +391,7 @@ def test_0_13_12_add_start_time_end_time(hostname, conn_string):
         assert len(instance.get_runs()) == 2
 
         instance.upgrade()
+        instance.reindex()
 
         result = execute_pipeline(reconstructable(get_the_job), instance=instance)
         assert result.success


### PR DESCRIPTION
## Summary
I think we want the runs migration to be optional.  This diff splits out run storage migrations into a set of required and optional migrations.

This is so that the startTime/endTime migration on run storage is only run when a user runs `dagster instance reindex` using the CLI.



## Test Plan
BK



