### PR TITLE
expose updateTime on runs, default instantiate GrapheneRun with records

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -10,10 +10,7 @@ type DagitQuery {
   repositoryOrError(repositorySelector: RepositorySelector!): RepositoryOrError!
   workspaceOrError: WorkspaceOrError!
   pipelineOrError(params: PipelineSelector!): PipelineOrError!
-  pipelineSnapshotOrError(
-    snapshotId: String
-    activePipelineSelector: PipelineSelector
-  ): PipelineSnapshotOrError!
+  pipelineSnapshotOrError(snapshotId: String, activePipelineSelector: PipelineSelector): PipelineSnapshotOrError!
   graphOrError(selector: GraphSelector): GraphOrError!
   scheduler: SchedulerOrError!
   scheduleOrError(scheduleSelector: ScheduleSelector!): ScheduleOrError!
@@ -22,14 +19,8 @@ type DagitQuery {
   sensorsOrError(repositorySelector: RepositorySelector!): SensorsOrError!
   instigationStateOrError(instigationSelector: InstigationSelector!): InstigationStateOrError!
   unloadableInstigationStatesOrError(instigationType: InstigationType): InstigationStatesOrError!
-  partitionSetsOrError(
-    repositorySelector: RepositorySelector!
-    pipelineName: String!
-  ): PartitionSetsOrError!
-  partitionSetOrError(
-    repositorySelector: RepositorySelector!
-    partitionSetName: String
-  ): PartitionSetOrError!
+  partitionSetsOrError(repositorySelector: RepositorySelector!, pipelineName: String!): PartitionSetsOrError!
+  partitionSetOrError(repositorySelector: RepositorySelector!, partitionSetName: String): PartitionSetOrError!
   pipelineRunsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
   pipelineRunOrError(runId: ID!): RunOrError!
   runsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
@@ -37,16 +28,8 @@ type DagitQuery {
   pipelineRunTags: [PipelineTagAndValues!]!
   runGroupOrError(runId: ID!): RunGroupOrError!
   runGroupsOrError(filter: RunsFilter, cursor: String, limit: Int): RunGroupsOrError!
-  isPipelineConfigValid(
-    pipeline: PipelineSelector!
-    runConfigData: RunConfigData
-    mode: String!
-  ): PipelineConfigValidationResult!
-  executionPlanOrError(
-    pipeline: PipelineSelector!
-    runConfigData: RunConfigData
-    mode: String!
-  ): ExecutionPlanOrError!
+  isPipelineConfigValid(pipeline: PipelineSelector!, runConfigData: RunConfigData, mode: String!): PipelineConfigValidationResult!
+  executionPlanOrError(pipeline: PipelineSelector!, runConfigData: RunConfigData, mode: String!): ExecutionPlanOrError!
   runConfigSchemaOrError(selector: PipelineSelector!, mode: String): RunConfigSchemaOrError!
   instance: Instance!
   assetsOrError(prefix: [String!], cursor: String, limit: Int): AssetsOrError!
@@ -54,11 +37,7 @@ type DagitQuery {
   assetNodes: [AssetNode!]!
   assetNodeOrError(assetKey: AssetKeyInput!): AssetNodeOrError!
   partitionBackfillOrError(backfillId: String!): PartitionBackfillOrError!
-  partitionBackfillsOrError(
-    status: BulkActionStatus
-    cursor: String
-    limit: Int
-  ): PartitionBackfillsOrError!
+  partitionBackfillsOrError(status: BulkActionStatus, cursor: String, limit: Int): PartitionBackfillsOrError!
   permissions: [GraphenePermission!]!
 }
 
@@ -343,11 +322,7 @@ interface IPipelineSnapshot {
   graphName: String!
 }
 
-union DagsterTypeOrError =
-    RegularDagsterType
-  | PipelineNotFoundError
-  | DagsterTypeNotFoundError
-  | PythonError
+union DagsterTypeOrError = RegularDagsterType | PipelineNotFoundError | DagsterTypeNotFoundError | PythonError
 
 type RegularDagsterType implements DagsterType {
   key: String!
@@ -414,6 +389,7 @@ type Run implements PipelineRun {
   resolvedOpSelection: [String!]
   startTime: Float
   endTime: Float
+  updateTime: Float
 }
 
 interface PipelineRun {
@@ -548,12 +524,7 @@ scalar RunConfigData
 type Asset {
   id: String!
   key: AssetKey!
-  assetMaterializations(
-    partitions: [String]
-    partitionInLast: Int
-    beforeTimestampMillis: String
-    limit: Int
-  ): [AssetMaterialization!]!
+  assetMaterializations(partitions: [String], partitionInLast: Int, beforeTimestampMillis: String, limit: Int): [AssetMaterialization!]!
   definition: AssetNode
 }
 
@@ -668,11 +639,7 @@ type AssetNode {
   dependedBy: [AssetDependency!]!
   dependencyKeys: [AssetKey!]!
   dependedByKeys: [AssetKey!]!
-  assetMaterializations(
-    partitions: [String]
-    beforeTimestampMillis: String
-    limit: Int
-  ): [AssetMaterialization!]!
+  assetMaterializations(partitions: [String], beforeTimestampMillis: String, limit: Int): [AssetMaterialization!]!
   partitionKeys: [String!]!
   partitionDefinition: String
   latestMaterializationByPartition(partitions: [String]): [AssetMaterialization]!
@@ -689,36 +656,7 @@ type MaterializationCountByPartition {
   materializationCount: Int!
 }
 
-union DagsterRunEvent =
-    ExecutionStepFailureEvent
-  | ExecutionStepInputEvent
-  | ExecutionStepOutputEvent
-  | ExecutionStepSkippedEvent
-  | ExecutionStepStartEvent
-  | ExecutionStepSuccessEvent
-  | ExecutionStepUpForRetryEvent
-  | ExecutionStepRestartEvent
-  | LogMessageEvent
-  | RunFailureEvent
-  | RunStartEvent
-  | RunEnqueuedEvent
-  | RunDequeuedEvent
-  | RunStartingEvent
-  | RunCancelingEvent
-  | RunCanceledEvent
-  | RunSuccessEvent
-  | HandledOutputEvent
-  | LoadedInputEvent
-  | LogsCapturedEvent
-  | ObjectStoreOperationEvent
-  | StepExpectationResultEvent
-  | StepMaterializationEvent
-  | EngineEvent
-  | HookCompletedEvent
-  | HookSkippedEvent
-  | HookErroredEvent
-  | AlertStartEvent
-  | AlertSuccessEvent
+union DagsterRunEvent = ExecutionStepFailureEvent | ExecutionStepInputEvent | ExecutionStepOutputEvent | ExecutionStepSkippedEvent | ExecutionStepStartEvent | ExecutionStepSuccessEvent | ExecutionStepUpForRetryEvent | ExecutionStepRestartEvent | LogMessageEvent | RunFailureEvent | RunStartEvent | RunEnqueuedEvent | RunDequeuedEvent | RunStartingEvent | RunCancelingEvent | RunCanceledEvent | RunSuccessEvent | HandledOutputEvent | LoadedInputEvent | LogsCapturedEvent | ObjectStoreOperationEvent | StepExpectationResultEvent | StepMaterializationEvent | EngineEvent | HookCompletedEvent | HookSkippedEvent | HookErroredEvent | AlertStartEvent | AlertSuccessEvent
 
 type ExecutionStepFailureEvent implements MessageEvent & StepEvent {
   runId: String!
@@ -1368,11 +1306,7 @@ input PipelineSelector {
   solidSelection: [String!]
 }
 
-union PipelineSnapshotOrError =
-    PipelineNotFoundError
-  | PipelineSnapshot
-  | PipelineSnapshotNotFoundError
-  | PythonError
+union PipelineSnapshotOrError = PipelineNotFoundError | PipelineSnapshot | PipelineSnapshotNotFoundError | PythonError
 
 type PipelineSnapshot implements SolidContainer & IPipelineSnapshot & PipelineReference {
   id: ID!
@@ -1540,12 +1474,7 @@ type RunGroupsOrError {
   results: [RunGroup!]!
 }
 
-union PipelineConfigValidationResult =
-    InvalidSubsetError
-  | PipelineConfigValidationValid
-  | RunConfigValidationInvalid
-  | PipelineNotFoundError
-  | PythonError
+union PipelineConfigValidationResult = InvalidSubsetError | PipelineConfigValidationValid | RunConfigValidationInvalid | PipelineNotFoundError | PythonError
 
 type PipelineConfigValidationValid {
   pipelineName: String!
@@ -1591,19 +1520,9 @@ enum EvaluationErrorReason {
   SELECTOR_FIELD_ERROR
 }
 
-union ExecutionPlanOrError =
-    ExecutionPlan
-  | RunConfigValidationInvalid
-  | PipelineNotFoundError
-  | InvalidSubsetError
-  | PythonError
+union ExecutionPlanOrError = ExecutionPlan | RunConfigValidationInvalid | PipelineNotFoundError | InvalidSubsetError | PythonError
 
-union RunConfigSchemaOrError =
-    RunConfigSchema
-  | PipelineNotFoundError
-  | InvalidSubsetError
-  | ModeNotFoundError
-  | PythonError
+union RunConfigSchemaOrError = RunConfigSchema | PipelineNotFoundError | InvalidSubsetError | ModeNotFoundError | PythonError
 
 type RunConfigSchema {
   rootConfigType: ConfigType!
@@ -1702,18 +1621,13 @@ type DagitMutation {
   stopRunningSchedule(scheduleOriginId: String!): ScheduleMutationResult!
   startSensor(sensorSelector: SensorSelector!): SensorOrError!
   stopSensor(jobOriginId: String!): StopSensorMutationResultOrError!
-  terminatePipelineExecution(
-    runId: String!
-    terminatePolicy: TerminateRunPolicy
-  ): TerminateRunResult!
+  terminatePipelineExecution(runId: String!, terminatePolicy: TerminateRunPolicy): TerminateRunResult!
   terminateRun(runId: String!, terminatePolicy: TerminateRunPolicy): TerminateRunResult!
   deletePipelineRun(runId: String!): DeletePipelineRunResult!
   deleteRun(runId: String!): DeletePipelineRunResult!
   reloadRepositoryLocation(repositoryLocationName: String!): ReloadRepositoryLocationMutationResult!
   reloadWorkspace: ReloadWorkspaceMutationResult!
-  shutdownRepositoryLocation(
-    repositoryLocationName: String!
-  ): ShutdownRepositoryLocationMutationResult!
+  shutdownRepositoryLocation(repositoryLocationName: String!): ShutdownRepositoryLocationMutationResult!
   wipeAssets(assetKeys: [AssetKeyInput!]!): AssetWipeMutationResult!
   launchPartitionBackfill(backfillParams: LaunchBackfillParams!): LaunchBackfillResult!
   resumePartitionBackfill(backfillId: String!): ResumeBackfillResult!
@@ -1721,18 +1635,7 @@ type DagitMutation {
   logTelemetry(action: String!, clientTime: String!, metadata: String!): LogTelemetryMutationResult!
 }
 
-union LaunchRunResult =
-    LaunchRunSuccess
-  | InvalidStepError
-  | InvalidOutputError
-  | RunConfigValidationInvalid
-  | PipelineNotFoundError
-  | RunConflict
-  | UnauthorizedError
-  | PythonError
-  | PresetNotFoundError
-  | ConflictingExecutionParamsError
-  | NoModeProvidedError
+union LaunchRunResult = LaunchRunSuccess | InvalidStepError | InvalidOutputError | RunConfigValidationInvalid | PipelineNotFoundError | RunConflict | UnauthorizedError | PythonError | PresetNotFoundError | ConflictingExecutionParamsError | NoModeProvidedError
 
 type LaunchRunSuccess implements LaunchPipelineRunSuccess {
   run: Run!
@@ -1797,18 +1700,7 @@ input ExecutionMetadata {
   parentRunId: String
 }
 
-union LaunchRunReexecutionResult =
-    LaunchRunSuccess
-  | InvalidStepError
-  | InvalidOutputError
-  | RunConfigValidationInvalid
-  | PipelineNotFoundError
-  | RunConflict
-  | UnauthorizedError
-  | PythonError
-  | PresetNotFoundError
-  | ConflictingExecutionParamsError
-  | NoModeProvidedError
+union LaunchRunReexecutionResult = LaunchRunSuccess | InvalidStepError | InvalidOutputError | RunConfigValidationInvalid | PipelineNotFoundError | RunConflict | UnauthorizedError | PythonError | PresetNotFoundError | ConflictingExecutionParamsError | NoModeProvidedError
 
 union ScheduleMutationResult = PythonError | ScheduleStateResult
 
@@ -1822,12 +1714,7 @@ type StopSensorMutationResult {
   instigationState: InstigationState
 }
 
-union TerminateRunResult =
-    TerminateRunSuccess
-  | TerminateRunFailure
-  | RunNotFoundError
-  | UnauthorizedError
-  | PythonError
+union TerminateRunResult = TerminateRunSuccess | TerminateRunFailure | RunNotFoundError | UnauthorizedError | PythonError
 
 type TerminateRunSuccess implements TerminatePipelineExecutionSuccess {
   run: Run!
@@ -1852,22 +1739,13 @@ enum TerminateRunPolicy {
   MARK_AS_CANCELED_IMMEDIATELY
 }
 
-union DeletePipelineRunResult =
-    DeletePipelineRunSuccess
-  | UnauthorizedError
-  | PythonError
-  | RunNotFoundError
+union DeletePipelineRunResult = DeletePipelineRunSuccess | UnauthorizedError | PythonError | RunNotFoundError
 
 type DeletePipelineRunSuccess {
   runId: String!
 }
 
-union ReloadRepositoryLocationMutationResult =
-    WorkspaceLocationEntry
-  | ReloadNotSupported
-  | RepositoryLocationNotFound
-  | UnauthorizedError
-  | PythonError
+union ReloadRepositoryLocationMutationResult = WorkspaceLocationEntry | ReloadNotSupported | RepositoryLocationNotFound | UnauthorizedError | PythonError
 
 type ReloadNotSupported implements Error {
   message: String!
@@ -1879,39 +1757,19 @@ type RepositoryLocationNotFound implements Error {
 
 union ReloadWorkspaceMutationResult = Workspace | UnauthorizedError | PythonError
 
-union ShutdownRepositoryLocationMutationResult =
-    ShutdownRepositoryLocationSuccess
-  | RepositoryLocationNotFound
-  | UnauthorizedError
-  | PythonError
+union ShutdownRepositoryLocationMutationResult = ShutdownRepositoryLocationSuccess | RepositoryLocationNotFound | UnauthorizedError | PythonError
 
 type ShutdownRepositoryLocationSuccess {
   repositoryLocationName: String!
 }
 
-union AssetWipeMutationResult =
-    AssetNotFoundError
-  | UnauthorizedError
-  | PythonError
-  | AssetWipeSuccess
+union AssetWipeMutationResult = AssetNotFoundError | UnauthorizedError | PythonError | AssetWipeSuccess
 
 type AssetWipeSuccess {
   assetKeys: [AssetKey!]!
 }
 
-union LaunchBackfillResult =
-    LaunchBackfillSuccess
-  | PartitionSetNotFoundError
-  | InvalidStepError
-  | InvalidOutputError
-  | RunConfigValidationInvalid
-  | PipelineNotFoundError
-  | RunConflict
-  | UnauthorizedError
-  | PythonError
-  | PresetNotFoundError
-  | ConflictingExecutionParamsError
-  | NoModeProvidedError
+union LaunchBackfillResult = LaunchBackfillSuccess | PartitionSetNotFoundError | InvalidStepError | InvalidOutputError | RunConfigValidationInvalid | PipelineNotFoundError | RunConflict | UnauthorizedError | PythonError | PresetNotFoundError | ConflictingExecutionParamsError | NoModeProvidedError
 
 type LaunchBackfillSuccess {
   backfillId: String!
@@ -1956,9 +1814,7 @@ type DagitSubscription {
   locationStateChangeEvents: LocationStateChangeSubscription!
 }
 
-union PipelineRunLogsSubscriptionPayload =
-    PipelineRunLogsSubscriptionSuccess
-  | PipelineRunLogsSubscriptionFailure
+union PipelineRunLogsSubscriptionPayload = PipelineRunLogsSubscriptionSuccess | PipelineRunLogsSubscriptionFailure
 
 type PipelineRunLogsSubscriptionSuccess {
   run: Run!
@@ -2189,13 +2045,7 @@ type StopRunningScheduleMutation {
   Output: ScheduleMutationResult!
 }
 
-union ConfigTypeOrError =
-    EnumConfigType
-  | CompositeConfigType
-  | RegularConfigType
-  | PipelineNotFoundError
-  | ConfigTypeNotFoundError
-  | PythonError
+union ConfigTypeOrError = EnumConfigType | CompositeConfigType | RegularConfigType | PipelineNotFoundError | ConfigTypeNotFoundError | PythonError
 
 type EnumConfigType implements ConfigType {
   key: String!

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -10,7 +10,10 @@ type DagitQuery {
   repositoryOrError(repositorySelector: RepositorySelector!): RepositoryOrError!
   workspaceOrError: WorkspaceOrError!
   pipelineOrError(params: PipelineSelector!): PipelineOrError!
-  pipelineSnapshotOrError(snapshotId: String, activePipelineSelector: PipelineSelector): PipelineSnapshotOrError!
+  pipelineSnapshotOrError(
+    snapshotId: String
+    activePipelineSelector: PipelineSelector
+  ): PipelineSnapshotOrError!
   graphOrError(selector: GraphSelector): GraphOrError!
   scheduler: SchedulerOrError!
   scheduleOrError(scheduleSelector: ScheduleSelector!): ScheduleOrError!
@@ -19,8 +22,14 @@ type DagitQuery {
   sensorsOrError(repositorySelector: RepositorySelector!): SensorsOrError!
   instigationStateOrError(instigationSelector: InstigationSelector!): InstigationStateOrError!
   unloadableInstigationStatesOrError(instigationType: InstigationType): InstigationStatesOrError!
-  partitionSetsOrError(repositorySelector: RepositorySelector!, pipelineName: String!): PartitionSetsOrError!
-  partitionSetOrError(repositorySelector: RepositorySelector!, partitionSetName: String): PartitionSetOrError!
+  partitionSetsOrError(
+    repositorySelector: RepositorySelector!
+    pipelineName: String!
+  ): PartitionSetsOrError!
+  partitionSetOrError(
+    repositorySelector: RepositorySelector!
+    partitionSetName: String
+  ): PartitionSetOrError!
   pipelineRunsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
   pipelineRunOrError(runId: ID!): RunOrError!
   runsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
@@ -28,8 +37,16 @@ type DagitQuery {
   pipelineRunTags: [PipelineTagAndValues!]!
   runGroupOrError(runId: ID!): RunGroupOrError!
   runGroupsOrError(filter: RunsFilter, cursor: String, limit: Int): RunGroupsOrError!
-  isPipelineConfigValid(pipeline: PipelineSelector!, runConfigData: RunConfigData, mode: String!): PipelineConfigValidationResult!
-  executionPlanOrError(pipeline: PipelineSelector!, runConfigData: RunConfigData, mode: String!): ExecutionPlanOrError!
+  isPipelineConfigValid(
+    pipeline: PipelineSelector!
+    runConfigData: RunConfigData
+    mode: String!
+  ): PipelineConfigValidationResult!
+  executionPlanOrError(
+    pipeline: PipelineSelector!
+    runConfigData: RunConfigData
+    mode: String!
+  ): ExecutionPlanOrError!
   runConfigSchemaOrError(selector: PipelineSelector!, mode: String): RunConfigSchemaOrError!
   instance: Instance!
   assetsOrError(prefix: [String!], cursor: String, limit: Int): AssetsOrError!
@@ -37,7 +54,11 @@ type DagitQuery {
   assetNodes: [AssetNode!]!
   assetNodeOrError(assetKey: AssetKeyInput!): AssetNodeOrError!
   partitionBackfillOrError(backfillId: String!): PartitionBackfillOrError!
-  partitionBackfillsOrError(status: BulkActionStatus, cursor: String, limit: Int): PartitionBackfillsOrError!
+  partitionBackfillsOrError(
+    status: BulkActionStatus
+    cursor: String
+    limit: Int
+  ): PartitionBackfillsOrError!
   permissions: [GraphenePermission!]!
 }
 
@@ -322,7 +343,11 @@ interface IPipelineSnapshot {
   graphName: String!
 }
 
-union DagsterTypeOrError = RegularDagsterType | PipelineNotFoundError | DagsterTypeNotFoundError | PythonError
+union DagsterTypeOrError =
+    RegularDagsterType
+  | PipelineNotFoundError
+  | DagsterTypeNotFoundError
+  | PythonError
 
 type RegularDagsterType implements DagsterType {
   key: String!
@@ -524,7 +549,12 @@ scalar RunConfigData
 type Asset {
   id: String!
   key: AssetKey!
-  assetMaterializations(partitions: [String], partitionInLast: Int, beforeTimestampMillis: String, limit: Int): [AssetMaterialization!]!
+  assetMaterializations(
+    partitions: [String]
+    partitionInLast: Int
+    beforeTimestampMillis: String
+    limit: Int
+  ): [AssetMaterialization!]!
   definition: AssetNode
 }
 
@@ -639,7 +669,11 @@ type AssetNode {
   dependedBy: [AssetDependency!]!
   dependencyKeys: [AssetKey!]!
   dependedByKeys: [AssetKey!]!
-  assetMaterializations(partitions: [String], beforeTimestampMillis: String, limit: Int): [AssetMaterialization!]!
+  assetMaterializations(
+    partitions: [String]
+    beforeTimestampMillis: String
+    limit: Int
+  ): [AssetMaterialization!]!
   partitionKeys: [String!]!
   partitionDefinition: String
   latestMaterializationByPartition(partitions: [String]): [AssetMaterialization]!
@@ -656,7 +690,36 @@ type MaterializationCountByPartition {
   materializationCount: Int!
 }
 
-union DagsterRunEvent = ExecutionStepFailureEvent | ExecutionStepInputEvent | ExecutionStepOutputEvent | ExecutionStepSkippedEvent | ExecutionStepStartEvent | ExecutionStepSuccessEvent | ExecutionStepUpForRetryEvent | ExecutionStepRestartEvent | LogMessageEvent | RunFailureEvent | RunStartEvent | RunEnqueuedEvent | RunDequeuedEvent | RunStartingEvent | RunCancelingEvent | RunCanceledEvent | RunSuccessEvent | HandledOutputEvent | LoadedInputEvent | LogsCapturedEvent | ObjectStoreOperationEvent | StepExpectationResultEvent | StepMaterializationEvent | EngineEvent | HookCompletedEvent | HookSkippedEvent | HookErroredEvent | AlertStartEvent | AlertSuccessEvent
+union DagsterRunEvent =
+    ExecutionStepFailureEvent
+  | ExecutionStepInputEvent
+  | ExecutionStepOutputEvent
+  | ExecutionStepSkippedEvent
+  | ExecutionStepStartEvent
+  | ExecutionStepSuccessEvent
+  | ExecutionStepUpForRetryEvent
+  | ExecutionStepRestartEvent
+  | LogMessageEvent
+  | RunFailureEvent
+  | RunStartEvent
+  | RunEnqueuedEvent
+  | RunDequeuedEvent
+  | RunStartingEvent
+  | RunCancelingEvent
+  | RunCanceledEvent
+  | RunSuccessEvent
+  | HandledOutputEvent
+  | LoadedInputEvent
+  | LogsCapturedEvent
+  | ObjectStoreOperationEvent
+  | StepExpectationResultEvent
+  | StepMaterializationEvent
+  | EngineEvent
+  | HookCompletedEvent
+  | HookSkippedEvent
+  | HookErroredEvent
+  | AlertStartEvent
+  | AlertSuccessEvent
 
 type ExecutionStepFailureEvent implements MessageEvent & StepEvent {
   runId: String!
@@ -1306,7 +1369,11 @@ input PipelineSelector {
   solidSelection: [String!]
 }
 
-union PipelineSnapshotOrError = PipelineNotFoundError | PipelineSnapshot | PipelineSnapshotNotFoundError | PythonError
+union PipelineSnapshotOrError =
+    PipelineNotFoundError
+  | PipelineSnapshot
+  | PipelineSnapshotNotFoundError
+  | PythonError
 
 type PipelineSnapshot implements SolidContainer & IPipelineSnapshot & PipelineReference {
   id: ID!
@@ -1474,7 +1541,12 @@ type RunGroupsOrError {
   results: [RunGroup!]!
 }
 
-union PipelineConfigValidationResult = InvalidSubsetError | PipelineConfigValidationValid | RunConfigValidationInvalid | PipelineNotFoundError | PythonError
+union PipelineConfigValidationResult =
+    InvalidSubsetError
+  | PipelineConfigValidationValid
+  | RunConfigValidationInvalid
+  | PipelineNotFoundError
+  | PythonError
 
 type PipelineConfigValidationValid {
   pipelineName: String!
@@ -1520,9 +1592,19 @@ enum EvaluationErrorReason {
   SELECTOR_FIELD_ERROR
 }
 
-union ExecutionPlanOrError = ExecutionPlan | RunConfigValidationInvalid | PipelineNotFoundError | InvalidSubsetError | PythonError
+union ExecutionPlanOrError =
+    ExecutionPlan
+  | RunConfigValidationInvalid
+  | PipelineNotFoundError
+  | InvalidSubsetError
+  | PythonError
 
-union RunConfigSchemaOrError = RunConfigSchema | PipelineNotFoundError | InvalidSubsetError | ModeNotFoundError | PythonError
+union RunConfigSchemaOrError =
+    RunConfigSchema
+  | PipelineNotFoundError
+  | InvalidSubsetError
+  | ModeNotFoundError
+  | PythonError
 
 type RunConfigSchema {
   rootConfigType: ConfigType!
@@ -1621,13 +1703,18 @@ type DagitMutation {
   stopRunningSchedule(scheduleOriginId: String!): ScheduleMutationResult!
   startSensor(sensorSelector: SensorSelector!): SensorOrError!
   stopSensor(jobOriginId: String!): StopSensorMutationResultOrError!
-  terminatePipelineExecution(runId: String!, terminatePolicy: TerminateRunPolicy): TerminateRunResult!
+  terminatePipelineExecution(
+    runId: String!
+    terminatePolicy: TerminateRunPolicy
+  ): TerminateRunResult!
   terminateRun(runId: String!, terminatePolicy: TerminateRunPolicy): TerminateRunResult!
   deletePipelineRun(runId: String!): DeletePipelineRunResult!
   deleteRun(runId: String!): DeletePipelineRunResult!
   reloadRepositoryLocation(repositoryLocationName: String!): ReloadRepositoryLocationMutationResult!
   reloadWorkspace: ReloadWorkspaceMutationResult!
-  shutdownRepositoryLocation(repositoryLocationName: String!): ShutdownRepositoryLocationMutationResult!
+  shutdownRepositoryLocation(
+    repositoryLocationName: String!
+  ): ShutdownRepositoryLocationMutationResult!
   wipeAssets(assetKeys: [AssetKeyInput!]!): AssetWipeMutationResult!
   launchPartitionBackfill(backfillParams: LaunchBackfillParams!): LaunchBackfillResult!
   resumePartitionBackfill(backfillId: String!): ResumeBackfillResult!
@@ -1635,7 +1722,18 @@ type DagitMutation {
   logTelemetry(action: String!, clientTime: String!, metadata: String!): LogTelemetryMutationResult!
 }
 
-union LaunchRunResult = LaunchRunSuccess | InvalidStepError | InvalidOutputError | RunConfigValidationInvalid | PipelineNotFoundError | RunConflict | UnauthorizedError | PythonError | PresetNotFoundError | ConflictingExecutionParamsError | NoModeProvidedError
+union LaunchRunResult =
+    LaunchRunSuccess
+  | InvalidStepError
+  | InvalidOutputError
+  | RunConfigValidationInvalid
+  | PipelineNotFoundError
+  | RunConflict
+  | UnauthorizedError
+  | PythonError
+  | PresetNotFoundError
+  | ConflictingExecutionParamsError
+  | NoModeProvidedError
 
 type LaunchRunSuccess implements LaunchPipelineRunSuccess {
   run: Run!
@@ -1700,7 +1798,18 @@ input ExecutionMetadata {
   parentRunId: String
 }
 
-union LaunchRunReexecutionResult = LaunchRunSuccess | InvalidStepError | InvalidOutputError | RunConfigValidationInvalid | PipelineNotFoundError | RunConflict | UnauthorizedError | PythonError | PresetNotFoundError | ConflictingExecutionParamsError | NoModeProvidedError
+union LaunchRunReexecutionResult =
+    LaunchRunSuccess
+  | InvalidStepError
+  | InvalidOutputError
+  | RunConfigValidationInvalid
+  | PipelineNotFoundError
+  | RunConflict
+  | UnauthorizedError
+  | PythonError
+  | PresetNotFoundError
+  | ConflictingExecutionParamsError
+  | NoModeProvidedError
 
 union ScheduleMutationResult = PythonError | ScheduleStateResult
 
@@ -1714,7 +1823,12 @@ type StopSensorMutationResult {
   instigationState: InstigationState
 }
 
-union TerminateRunResult = TerminateRunSuccess | TerminateRunFailure | RunNotFoundError | UnauthorizedError | PythonError
+union TerminateRunResult =
+    TerminateRunSuccess
+  | TerminateRunFailure
+  | RunNotFoundError
+  | UnauthorizedError
+  | PythonError
 
 type TerminateRunSuccess implements TerminatePipelineExecutionSuccess {
   run: Run!
@@ -1739,13 +1853,22 @@ enum TerminateRunPolicy {
   MARK_AS_CANCELED_IMMEDIATELY
 }
 
-union DeletePipelineRunResult = DeletePipelineRunSuccess | UnauthorizedError | PythonError | RunNotFoundError
+union DeletePipelineRunResult =
+    DeletePipelineRunSuccess
+  | UnauthorizedError
+  | PythonError
+  | RunNotFoundError
 
 type DeletePipelineRunSuccess {
   runId: String!
 }
 
-union ReloadRepositoryLocationMutationResult = WorkspaceLocationEntry | ReloadNotSupported | RepositoryLocationNotFound | UnauthorizedError | PythonError
+union ReloadRepositoryLocationMutationResult =
+    WorkspaceLocationEntry
+  | ReloadNotSupported
+  | RepositoryLocationNotFound
+  | UnauthorizedError
+  | PythonError
 
 type ReloadNotSupported implements Error {
   message: String!
@@ -1757,19 +1880,39 @@ type RepositoryLocationNotFound implements Error {
 
 union ReloadWorkspaceMutationResult = Workspace | UnauthorizedError | PythonError
 
-union ShutdownRepositoryLocationMutationResult = ShutdownRepositoryLocationSuccess | RepositoryLocationNotFound | UnauthorizedError | PythonError
+union ShutdownRepositoryLocationMutationResult =
+    ShutdownRepositoryLocationSuccess
+  | RepositoryLocationNotFound
+  | UnauthorizedError
+  | PythonError
 
 type ShutdownRepositoryLocationSuccess {
   repositoryLocationName: String!
 }
 
-union AssetWipeMutationResult = AssetNotFoundError | UnauthorizedError | PythonError | AssetWipeSuccess
+union AssetWipeMutationResult =
+    AssetNotFoundError
+  | UnauthorizedError
+  | PythonError
+  | AssetWipeSuccess
 
 type AssetWipeSuccess {
   assetKeys: [AssetKey!]!
 }
 
-union LaunchBackfillResult = LaunchBackfillSuccess | PartitionSetNotFoundError | InvalidStepError | InvalidOutputError | RunConfigValidationInvalid | PipelineNotFoundError | RunConflict | UnauthorizedError | PythonError | PresetNotFoundError | ConflictingExecutionParamsError | NoModeProvidedError
+union LaunchBackfillResult =
+    LaunchBackfillSuccess
+  | PartitionSetNotFoundError
+  | InvalidStepError
+  | InvalidOutputError
+  | RunConfigValidationInvalid
+  | PipelineNotFoundError
+  | RunConflict
+  | UnauthorizedError
+  | PythonError
+  | PresetNotFoundError
+  | ConflictingExecutionParamsError
+  | NoModeProvidedError
 
 type LaunchBackfillSuccess {
   backfillId: String!
@@ -1814,7 +1957,9 @@ type DagitSubscription {
   locationStateChangeEvents: LocationStateChangeSubscription!
 }
 
-union PipelineRunLogsSubscriptionPayload = PipelineRunLogsSubscriptionSuccess | PipelineRunLogsSubscriptionFailure
+union PipelineRunLogsSubscriptionPayload =
+    PipelineRunLogsSubscriptionSuccess
+  | PipelineRunLogsSubscriptionFailure
 
 type PipelineRunLogsSubscriptionSuccess {
   run: Run!
@@ -2045,7 +2190,13 @@ type StopRunningScheduleMutation {
   Output: ScheduleMutationResult!
 }
 
-union ConfigTypeOrError = EnumConfigType | CompositeConfigType | RegularConfigType | PipelineNotFoundError | ConfigTypeNotFoundError | PythonError
+union ConfigTypeOrError =
+    EnumConfigType
+  | CompositeConfigType
+  | RegularConfigType
+  | PipelineNotFoundError
+  | ConfigTypeNotFoundError
+  | PythonError
 
 type EnumConfigType implements ConfigType {
   key: String!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -1,6 +1,6 @@
 from dagster import check
 from dagster.core.storage.compute_log_manager import ComputeIOType
-from dagster.core.storage.pipeline_run import PipelineRunStatus
+from dagster.core.storage.pipeline_run import PipelineRunStatus, PipelineRunsFilter
 from dagster.serdes import serialize_dagster_namedtuple
 from dagster.utils.error import serializable_error_info_from_exc_info
 from graphql.execution.base import ResolveInfo
@@ -24,17 +24,17 @@ def _force_mark_as_canceled(graphene_info, run_id):
 
     instance = graphene_info.context.instance
 
-    reloaded_run = instance.get_run_by_id(run_id)
+    reloaded_record = instance.get_run_records(PipelineRunsFilter(run_ids=[run_id]))[0]
 
-    if not reloaded_run.is_finished:
+    if not reloaded_record.pipeline_run.is_finished:
         message = (
             "This pipeline was forcibly marked as canceled from outside the execution context. The "
             "computational resources created by the run may not have been fully cleaned up."
         )
-        instance.report_run_canceled(reloaded_run, message=message)
-        reloaded_run = instance.get_run_by_id(run_id)
+        instance.report_run_canceled(reloaded_record.pipeline_run, message=message)
+        reloaded_record = instance.get_run_records(PipelineRunsFilter(run_ids=[run_id]))[0]
 
-    return GrapheneTerminateRunSuccess(GrapheneRun(reloaded_run))
+    return GrapheneTerminateRunSuccess(GrapheneRun(reloaded_record))
 
 
 @capture_error
@@ -51,16 +51,18 @@ def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
     check.str_param(run_id, "run_id")
 
     instance = graphene_info.context.instance
-    run = instance.get_run_by_id(run_id)
+    records = instance.get_run_records(PipelineRunsFilter(run_ids=[run_id]))
 
     force_mark_as_canceled = (
         terminate_policy == GrapheneTerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY
     )
 
-    if not run:
+    if not records:
         return GrapheneRunNotFoundError(run_id)
 
-    pipeline_run = GrapheneRun(run)
+    record = records[0]
+    run = records.pipeline_run
+    graphene_run = GrapheneRun(record)
 
     valid_status = not run.is_finished and (
         force_mark_as_canceled
@@ -69,7 +71,7 @@ def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
 
     if not valid_status:
         return GrapheneTerminateRunFailure(
-            run=pipeline_run,
+            run=graphene_run,
             message="Run {run_id} could not be terminated due to having status {status}.".format(
                 run_id=run.run_id, status=run.status.value
             ),
@@ -84,14 +86,14 @@ def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
         return (
             _force_mark_as_canceled(graphene_info, run_id)
             if force_mark_as_canceled
-            else GrapheneTerminateRunSuccess(pipeline_run)
+            else GrapheneTerminateRunSuccess(graphene_run)
         )
 
     return (
         _force_mark_as_canceled(graphene_info, run_id)
         if force_mark_as_canceled
         else GrapheneTerminateRunFailure(
-            run=pipeline_run, message="Unable to terminate run {run_id}".format(run_id=run.run_id)
+            run=graphene_run, message="Unable to terminate run {run_id}".format(run_id=run.run_id)
         )
     )
 
@@ -123,9 +125,9 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
     check.str_param(run_id, "run_id")
     check.opt_int_param(after, "after")
     instance = graphene_info.context.instance
-    run = instance.get_run_by_id(run_id)
+    records = instance.get_run_records(PipelineRunsFilter(run_ids=[run_id]))
 
-    if not run:
+    if not records:
 
         def _get_error_observable(observer):
             observer.on_next(
@@ -136,10 +138,13 @@ def get_pipeline_run_observable(graphene_info, run_id, after=None):
 
         return Observable.create(_get_error_observable)  # pylint: disable=E1101
 
+    record = records[0]
+    run = record.pipeline_run
+
     def _handle_events(payload):
         events, loading_past = payload
         return GraphenePipelineRunLogsSubscriptionSuccess(
-            run=GrapheneRun(run),
+            run=GrapheneRun(record),
             messages=[from_event_record(event, run.pipeline_name) for event in events],
             hasMorePastEvents=loading_past,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -61,7 +61,7 @@ def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
         return GrapheneRunNotFoundError(run_id)
 
     record = records[0]
-    run = records.pipeline_run
+    run = record.pipeline_run
     graphene_run = GrapheneRun(record)
 
     valid_status = not run.is_finished and (

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -1,4 +1,5 @@
 from dagster import check
+from dagster.core.storage.pipeline_run import PipelineRunsFilter
 from graphql.execution.base import ResolveInfo
 
 from ..external import get_external_pipeline_or_raise
@@ -48,5 +49,8 @@ def _launch_pipeline_execution(graphene_info, execution_params, is_reexecuted=Fa
     check.bool_param(is_reexecuted, "is_reexecuted")
 
     run = do_launch(graphene_info, execution_params, is_reexecuted)
+    records = graphene_info.context.instance.get_run_records(
+        PipelineRunsFilter(run_ids=[run.run_id])
+    )
 
-    return GrapheneLaunchRunSuccess(run=GrapheneRun(run))
+    return GrapheneLaunchRunSuccess(run=GrapheneRun(records[0]))

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -178,7 +178,7 @@ def get_run_groups(graphene_info, filters=None, cursor=None, limit=None):
 
     instance = graphene_info.context.instance
     run_groups = instance.get_run_groups(filters=filters, cursor=cursor, limit=limit)
-    run_ids = {run.run_id for runs in run_groups.values() for run in runs}
+    run_ids = {run.run_id for run_group in run_groups.values() for run in run_group.get("runs", [])}
     records_by_ids = {
         record.pipeline_run.run_id: record
         for record in instance.get_run_records(PipelineRunsFilter(run_ids=list(run_ids)))

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -87,24 +87,27 @@ def get_runs(graphene_info, filters, cursor=None, limit=None):
     check.opt_int_param(limit, "limit")
 
     instance = graphene_info.context.instance
-    runs = []
 
     if filters and filters.run_ids and len(filters.run_ids) == 1:
         run = instance.get_run_by_id(filters.run_ids[0])
         if run:
-            runs = [run]
-    elif filters and (
+            return [GrapheneRun(run)]
+        else:
+            return []
+
+    if filters and (
         filters.pipeline_name
         or filters.tags
         or filters.statuses
         or filters.snapshot_id
         or filters.run_ids
     ):
-        runs = instance.get_runs(filters, cursor, limit)
-    else:
-        runs = instance.get_runs(cursor=cursor, limit=limit)
+        return [
+            GrapheneRun(record)
+            for record in instance.get_run_records(filters=filters, cursor=cursor, limit=limit)
+        ]
 
-    return [GrapheneRun(run) for run in runs]
+    return [GrapheneRun(record) for record in instance.get_run_records(cursor=cursor, limit=limit)]
 
 
 def get_in_progress_runs_for_job(graphene_info, job_name):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -117,8 +117,8 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
         filters = PipelineRunsFilter.for_backfill(self._backfill_job.backfill_id)
         return [
-            GrapheneRun(r)
-            for r in graphene_info.context.instance.get_runs(
+            GrapheneRun(record)
+            for record in graphene_info.context.instance.get_run_records(
                 filters=filters,
                 limit=kwargs.get("limit"),
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -8,10 +8,7 @@ from dagster.core.host_representation import (
 )
 from dagster.core.scheduler.instigation import InstigatorType
 from dagster.core.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
-from dagster_graphql.implementation.fetch_runs import (
-    get_in_progress_runs_by_step,
-    get_in_progress_runs_for_job,
-)
+from dagster_graphql.implementation.fetch_runs import get_in_progress_runs_by_step
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
 
 from .asset_graph import GrapheneAssetNode
@@ -268,20 +265,16 @@ class GrapheneRepository(graphene.ObjectType):
             for external_asset_node in self._repository.get_external_asset_nodes()
         ]
 
-    def resolve_inProgressRunsByStep(self, _graphene_info):
+    def resolve_inProgressRunsByStep(self, graphene_info):
         job_names = [
             job.name for job in self._repository.get_all_external_pipelines() if job.is_job
         ]
 
-        in_progress_runs = []
-        for job_name in job_names:
-            in_progress_runs.extend(get_in_progress_runs_for_job(_graphene_info, job_name))
-
-        # We exclude foreign assets from the search. Foreign assets do not contain an op_name.
         asset_node_keys = [
             node.op_name for node in self._repository.get_external_asset_nodes() if node.op_name
         ]
-        return get_in_progress_runs_by_step(_graphene_info, in_progress_runs, asset_node_keys)
+
+        return get_in_progress_runs_by_step(graphene_info, job_names, asset_node_keys)
 
 
 class GrapheneRepositoryConnection(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -6,7 +6,6 @@ from dagster.core.events.log import EventLogEntry
 from dagster.core.host_representation.external import ExternalExecutionPlan, ExternalPipeline
 from dagster.core.host_representation.external_data import ExternalPresetData
 from dagster.core.storage.pipeline_run import (
-    PipelineRun,
     PipelineRunStatus,
     PipelineRunsFilter,
     RunRecord,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -12,6 +12,7 @@ from dagster.core.storage.pipeline_run import (
     RunRecord,
 )
 from dagster.core.storage.tags import TagType, get_tag_type
+from dagster.utils import datetime_as_float
 
 from ...implementation.events import construct_basic_params, from_event_record
 from ...implementation.fetch_assets import get_assets_for_run_id
@@ -229,6 +230,7 @@ class GrapheneRun(graphene.ObjectType):
     )
     startTime = graphene.Float()
     endTime = graphene.Float()
+    updateTime = graphene.Float()
 
     class Meta:
         interfaces = (GraphenePipelineRun,)
@@ -366,6 +368,10 @@ class GrapheneRun(graphene.ObjectType):
                 self._run_stats = graphene_info.context.instance.get_run_stats(self.runId)
             return self._run_stats.end_time
         return run_record.end_time
+
+    def resolve_updateTime(self, graphene_info):
+        run_record = self._get_run_record(graphene_info.context.instance)
+        return datetime_as_float(run_record.update_timestamp)
 
 
 class GrapheneIPipelineSnapshotMixin:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -349,7 +349,9 @@ class GrapheneRun(graphene.ObjectType):
 
     def _get_run_record(self, instance):
         if not self._run_record:
-            self._run_record = instance.get_run_records(run_ids=[self.runId])[0]
+            self._run_record = instance.get_run_records(PipelineRunsFilter(run_ids=[self.run_id]))[
+                0
+            ]
         return self._run_record
 
     def resolve_startTime(self, graphene_info):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -231,7 +231,8 @@ class GrapheneRun(graphene.ObjectType):
         interfaces = (GraphenePipelineRun,)
         name = "Run"
 
-    def __init__(self, record: RunRecord):
+    def __init__(self, record):
+        check.inst_param(record, "record", RunRecord)
         pipeline_run = record.pipeline_run
         super().__init__(
             runId=pipeline_run.run_id,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -5,11 +5,7 @@ from dagster.core.events import AssetKey, StepMaterializationData
 from dagster.core.events.log import EventLogEntry
 from dagster.core.host_representation.external import ExternalExecutionPlan, ExternalPipeline
 from dagster.core.host_representation.external_data import ExternalPresetData
-from dagster.core.storage.pipeline_run import (
-    PipelineRunStatus,
-    PipelineRunsFilter,
-    RunRecord,
-)
+from dagster.core.storage.pipeline_run import PipelineRunStatus, PipelineRunsFilter, RunRecord
 from dagster.core.storage.tags import TagType, get_tag_type
 from dagster.utils import datetime_as_float
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -236,15 +236,15 @@ class GrapheneRun(graphene.ObjectType):
         interfaces = (GraphenePipelineRun,)
         name = "Run"
 
-    def __init__(self, run):
-        pipeline_run = run.pipeline_run if isinstance(run, RunRecord) else run
+    def __init__(self, record: RunRecord):
+        pipeline_run = record.pipeline_run
         super().__init__(
             runId=pipeline_run.run_id,
             status=PipelineRunStatus(pipeline_run.status),
             mode=pipeline_run.mode,
         )
-        self._pipeline_run = check.inst_param(pipeline_run, "pipeline_run", PipelineRun)
-        self._run_record = run if isinstance(run, RunRecord) else None
+        self._pipeline_run = pipeline_run
+        self._run_record = record
         self._run_stats = None
 
     def resolve_id(self, _graphene_info):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/ticks.py
@@ -1,5 +1,6 @@
 import graphene
 from dagster.core.scheduler.instigation import TickStatus
+from dagster.core.storage.pipeline_run import PipelineRunsFilter
 
 from ..errors import GraphenePythonError
 from ..instigation import GrapheneInstigationTickStatus
@@ -24,9 +25,10 @@ def tick_specific_data_from_dagster_tick(graphene_info, tick):
 
     if tick.status == TickStatus.SUCCESS:
         if tick.run_ids and graphene_info.context.instance.has_run(tick.run_ids[0]):
-            return GrapheneScheduleTickSuccessData(
-                run=GrapheneRun(graphene_info.context.instance.get_run_by_id(tick.run_ids[0]))
-            )
+            record = graphene_info.context.instance.get_run_records(
+                PipelineRunsFilter(run_ids=[tick.run_ids[0]])
+            )[0]
+            return GrapheneScheduleTickSuccessData(run=GrapheneRun(record))
         return GrapheneScheduleTickSuccessData(run=None)
     elif tick.status == TickStatus.FAILURE:
         error = tick.error

--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -16,10 +16,40 @@ from dagster.core.snap import (
     create_pipeline_snapshot_id,
 )
 from dagster.daemon.types import DaemonHeartbeat
-from dagster.utils import frozendict, merge_dicts
+from dagster.utils import EPOCH, frozendict, merge_dicts
 
 from ..pipeline_run import PipelineRun, PipelineRunsFilter, RunRecord
 from .base import RunStorage
+
+
+def run_filter(filters):
+    def _filter_fn(run):
+        if not filters:
+            return True
+
+        if filters.run_ids and run.run_id not in filters.run_ids:
+            return False
+
+        if filters.statuses and run.status not in filters.statuses:
+            return False
+
+        if filters.pipeline_name and filters.pipeline_name != run.pipeline_name:
+            return False
+
+        if filters.mode and filters.mode != run.mode:
+            return False
+
+        if filters.tags and not all(
+            run.tags.get(key) == value for key, value in filters.tags.items()
+        ):
+            return False
+
+        if filters.snapshot_id and filters.snapshot_id != run.pipeline_snapshot_id:
+            return False
+
+        return True
+
+    return _filter_fn
 
 
 class InMemoryRunStorage(RunStorage):
@@ -88,33 +118,8 @@ class InMemoryRunStorage(RunStorage):
         check.opt_str_param(cursor, "cursor")
         check.opt_int_param(limit, "limit")
 
-        if not filters:
-            return self._slice(list(self._runs.values())[::-1], cursor, limit)
-
-        def run_filter(run):
-            if filters.run_ids and run.run_id not in filters.run_ids:
-                return False
-
-            if filters.statuses and run.status not in filters.statuses:
-                return False
-
-            if filters.pipeline_name and filters.pipeline_name != run.pipeline_name:
-                return False
-
-            if filters.mode and filters.mode != run.mode:
-                return False
-
-            if filters.tags and not all(
-                run.tags.get(key) == value for key, value in filters.tags.items()
-            ):
-                return False
-
-            if filters.snapshot_id and filters.snapshot_id != run.pipeline_snapshot_id:
-                return False
-
-            return True
-
-        matching_runs = list(filter(run_filter, list(self._runs.values())[::-1]))
+        filter_fn = run_filter(filters)
+        matching_runs = list(filter(filter_fn, list(self._runs.values())[::-1]))
         return self._slice(matching_runs, cursor=cursor, limit=limit)
 
     def get_runs_count(self, filters: PipelineRunsFilter = None) -> int:
@@ -158,7 +163,26 @@ class InMemoryRunStorage(RunStorage):
         ascending: bool = False,
         cursor: str = None,
     ) -> List[RunRecord]:
-        raise NotImplementedError("In memory run storage does not track timestamp yet.")
+        check.opt_inst_param(filters, "filters", PipelineRunsFilter)
+        check.opt_str_param(cursor, "cursor")
+        check.opt_int_param(limit, "limit")
+
+        # record here is a tuple of storage_id, run
+        records = enumerate(list(self._runs.values()))
+        run_filter_fn = run_filter(filters)
+        record_filter_fn = lambda record: run_filter_fn(record[1])
+
+        matching_records = list(filter(record_filter_fn, list(records)[::-1]))
+        sliced = self._slice(matching_records, cursor=cursor, limit=limit)
+        return [
+            RunRecord(
+                storage_id=record[0],
+                pipeline_run=record[1],
+                create_timestamp=EPOCH,  # hack just to populate some timestamp
+                update_timestamp=EPOCH,  # hack just to populate some timestamp
+            )
+            for record in sliced
+        ]
 
     def get_run_tags(self) -> List[Tuple[str, Set[str]]]:
         all_tags = defaultdict(set)


### PR DESCRIPTION
## Summary
In order to display the `RunTime` component for a given run without accessing `RunStatsSnapshot`, we need to approximate the queued time / launch time by grabbing updateTime for runs with queued / starting status.


## Test Plan
BK


