### PR TITLE
Add abbr timezone into schedule column

### DIFF
--- a/js_modules/dagit/packages/core/src/app/time/timestampToString.tsx
+++ b/js_modules/dagit/packages/core/src/app/time/timestampToString.tsx
@@ -29,3 +29,7 @@ export const timestampToString = (config: Config) => {
     timeZoneName: timeFormat.showTimezone ? 'short' : undefined,
   });
 };
+
+export const timeZoneAbbr = (tzIn: string) => {
+  return moment().tz(tzIn).zoneAbbr();
+};

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
@@ -13,6 +13,7 @@ import {
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {timeZoneAbbr} from '../app/time/timestampToString';
 import {TickTag} from '../instigation/InstigationTick';
 import {InstigatedRunStatus} from '../instigation/InstigationUtils';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -177,7 +178,10 @@ const ScheduleRow: React.FC<{
       <td>
         {cronSchedule ? (
           <Tooltip position="bottom" content={cronSchedule}>
-            {humanCronString(cronSchedule)}
+            <span>
+              {humanCronString(cronSchedule)}
+              {executionTimezone ? ` ${timeZoneAbbr(executionTimezone)}` : ` UTC`}
+            </span>
           </Tooltip>
         ) : (
           <span style={{color: ColorsWIP.Gray300}}>None</span>


### PR DESCRIPTION
## Summary
Fixes #5626
- Abbreviate the timezone using moment, as the tz from `executionTimezone` displayed as longer 'US/Central', instead of just CST

Ex:
<img width="1006" alt="Screen Shot 2022-01-19 at 4 42 50 PM" src="https://user-images.githubusercontent.com/4010391/150230610-15b8a7a3-a064-4e65-8fcd-a94306ff2007.png">

## Test Plan
N/A



## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.