### PR TITLE
[dagster-io/ui] MenuExternalLink

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -4,6 +4,7 @@ import {
   HighlightedCodeBlock,
   IconWIP,
   MenuDividerWIP,
+  MenuExternalLink,
   MenuItemWIP,
   MenuLink,
   MenuWIP,
@@ -157,11 +158,11 @@ export const RunActionsMenu: React.FC<{
               )}
               <MenuDividerWIP />
             </>
-            <MenuLink
+            <MenuExternalLink
               text="Download Debug File"
               icon="download_for_offline"
               download
-              to={`${rootServerURI}/download_debug/${run.runId}`}
+              href={`${rootServerURI}/download_debug/${run.runId}`}
             />
             {canDeletePipelineRun ? (
               <MenuItemWIP

--- a/js_modules/dagit/packages/core/tsconfig.json
+++ b/js_modules/dagit/packages/core/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@dagster-io/ui": ["../ui"]
+    },
     "module": "esnext",
     "target": "es5",
     "lib": [

--- a/js_modules/dagit/packages/ui/src/components/Menu.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Menu.tsx
@@ -96,6 +96,28 @@ export const MenuLink: React.FC<MenuLinkProps> = (props) => {
   );
 };
 
+interface MenuExternalLinkProps
+  extends CommonMenuItemProps,
+    Omit<React.ComponentProps<typeof MenuItem>, 'href' | 'icon'> {
+  href: string;
+}
+
+/**
+ * If you want to use a menu item as a link, use `MenuLink` and provide a `to` prop.
+ */
+export const MenuExternalLink: React.FC<MenuExternalLinkProps> = (props) => {
+  const {icon, intent, ...rest} = props;
+  return (
+    <StyledMenuItem
+      {...rest}
+      target="_blank"
+      rel="noreferrer nofollow"
+      $textColor={intentToTextColor(intent)}
+      icon={iconWithColor(icon, intent)}
+    />
+  );
+};
+
 export const MenuDividerWIP = styled(MenuDivider)`
   border-top: 1px solid ${ColorsWIP.Gray100};
   margin: 2px 0;


### PR DESCRIPTION
## Summary

Resolves #6108.

Add `MenuExternalLink` to the Menu item component list. This is a menu item that is known to be an external link, e.g. not to be handled by react-router. Use it for the "Download Debug File" menu item on Runs lists.

## Test Plan

View menu, click link. Verify that it downloads the file instead of redirecting to nonsense.
