### PR TITLE
Dispose DagsterInstance in its __del__ method

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/polling_event_watcher.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/polling_event_watcher.py
@@ -70,9 +70,6 @@ class SqlPollingEventWatcher:
                 if self._run_id_to_watcher_dict[run_id].should_thread_exit.is_set():
                     del self._run_id_to_watcher_dict[run_id]
 
-    def __del__(self):
-        self.close()
-
     def close(self):
         if not self._disposed:
             self._disposed = True

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_polling_event_watcher.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_polling_event_watcher.py
@@ -37,9 +37,6 @@ class SqlitePollingEventLogStorage(SqliteEventLogStorage):
         check.callable_param(handler, "handler")
         self._watcher.unwatch_run(run_id, handler)
 
-    def __del__(self):
-        self.dispose()
-
     def dispose(self):
         if not self._disposed:
             self._disposed = True

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -196,9 +196,6 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def event_watcher(self):
         return self._event_watcher
 
-    def __del__(self):
-        self.dispose()
-
     def dispose(self):
         if not self._disposed:
             self._disposed = True

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -239,10 +239,6 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def end_watch(self, run_id, handler):
         self._event_watcher.unwatch_run(run_id, handler)
 
-    def __del__(self):
-        # Keep the inherent limitations of __del__ in Python in mind!
-        self.dispose()
-
     def dispose(self):
         if not self._disposed:
             self._disposed = True


### PR DESCRIPTION
Summary:
This consolidates some dispose-on-deletion logic from various classes instantiated within the instance to the instance itself. Generally this logic shouldn't be needed since instances are always created with contextmanagers.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.