### PR TITLE
dagster types type annotations

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -158,7 +158,10 @@ class ModuleBuildSpec(
         if self.directory not in MYPY_EXCLUDES:
             tests.append(
                 StepBuilder(f":mypy: {package}")
-                .run("pip install -e python_modules/dagster[mypy]", f"mypy --config-file mypy/config {self.directory}")
+                .run(
+                    "pip install -e python_modules/dagster[mypy]",
+                    f"mypy --config-file mypy/config {self.directory}",
+                )
                 .on_integration_image(SupportedPython.V3_8)
                 .build()
             )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -158,7 +158,7 @@ class ModuleBuildSpec(
         if self.directory not in MYPY_EXCLUDES:
             tests.append(
                 StepBuilder(f":mypy: {package}")
-                .run("pip install mypy==0.931", f"mypy --config-file mypy/config {self.directory}")
+                .run("pip install -e python_modules/dagster[mypy]", f"mypy --config-file mypy/config {self.directory}")
                 .on_integration_image(SupportedPython.V3_8)
                 .build()
             )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -160,7 +160,10 @@ class ModuleBuildSpec(
                 StepBuilder(f":mypy: {package}")
                 .run(
                     "pip install -e python_modules/dagster[mypy]",
-                    f"mypy --config-file mypy/config {self.directory}",
+                    # mypy raises an error for missing stubs. We try to specify them in
+                    # dependencies, but inclusion of `--install-types
+                    # --non-interactive` will cause mypy to automatically download any missing ones.
+                    f"mypy --config-file mypy/config --install-types --non-interactive {self.directory}",
                 )
                 .on_integration_image(SupportedPython.V3_8)
                 .build()

--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -158,7 +158,7 @@ class ModuleBuildSpec(
         if self.directory not in MYPY_EXCLUDES:
             tests.append(
                 StepBuilder(f":mypy: {package}")
-                .run("pip install mypy==0.812", f"mypy --config-file mypy/config {self.directory}")
+                .run("pip install mypy==0.931", f"mypy --config-file mypy/config {self.directory}")
                 .on_integration_image(SupportedPython.V3_8)
                 .build()
             )

--- a/python_modules/dagster/dagster/api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/api/snapshot_execution_plan.py
@@ -11,6 +11,9 @@ from dagster.grpc.types import ExecutionPlanSnapshotArgs
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 
 
+def x(y: str) -> int:
+    return y
+
 def sync_get_external_execution_plan_grpc(
     api_client,
     pipeline_origin,

--- a/python_modules/dagster/dagster/api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/api/snapshot_execution_plan.py
@@ -11,9 +11,6 @@ from dagster.grpc.types import ExecutionPlanSnapshotArgs
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 
 
-def x(y: str) -> int:
-    return y
-
 def sync_get_external_execution_plan_grpc(
     api_client,
     pipeline_origin,

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -36,6 +36,7 @@ class ElementCheckError(CheckError):
 class NotImplementedCheckError(CheckError):
     pass
 
+
 def _param_type_mismatch_exception(
     obj: Any, ttype: Type, param_name: str, additional_message: str = None
 ) -> ParameterCheckError:

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -276,8 +276,16 @@ def str_param(obj: Any, param_name: str) -> str:
         raise _param_type_mismatch_exception(obj, str, param_name)
     return obj
 
+@overload
+def opt_str_param(obj: object, param_name: str, default: str) -> str:
+    ...
 
-def opt_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
+@overload
+def opt_str_param(obj: object, param_name: str) -> Optional[str]:
+    ...
+
+def opt_str_param(obj, param_name, default = None):
+# def opt_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
     if obj is not None and not isinstance(obj, str):
         raise _param_type_mismatch_exception(obj, str, param_name)
     return default if obj is None else obj

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -36,7 +36,6 @@ class ElementCheckError(CheckError):
 class NotImplementedCheckError(CheckError):
     pass
 
-
 def _param_type_mismatch_exception(
     obj: Any, ttype: Type, param_name: str, additional_message: str = None
 ) -> ParameterCheckError:

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -288,7 +288,6 @@ def opt_str_param(obj: object, param_name: str) -> Optional[str]:
 
 
 def opt_str_param(obj, param_name, default=None):
-    # def opt_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
     if obj is not None and not isinstance(obj, str):
         raise _param_type_mismatch_exception(obj, str, param_name)
     return default if obj is None else obj

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -276,16 +276,19 @@ def str_param(obj: Any, param_name: str) -> str:
         raise _param_type_mismatch_exception(obj, str, param_name)
     return obj
 
+
 @overload
 def opt_str_param(obj: object, param_name: str, default: str) -> str:
     ...
+
 
 @overload
 def opt_str_param(obj: object, param_name: str) -> Optional[str]:
     ...
 
-def opt_str_param(obj, param_name, default = None):
-# def opt_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
+
+def opt_str_param(obj, param_name, default=None):
+    # def opt_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
     if obj is not None and not isinstance(obj, str):
         raise _param_type_mismatch_exception(obj, str, param_name)
     return default if obj is None else obj

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -291,7 +291,7 @@ class AssetObservation(
         asset_key: Union[List[str], AssetKey, str],
         metadata_entries: Optional[List[EventMetadataEntry]] = None,
         partition: Optional[str] = None,
-        metadata: Optional[Dict[str, MetadataValues]] = None,
+        metadata: Optional[Dict[str, ParseableMetadataEntryData]] = None,
     ):
         if isinstance(asset_key, AssetKey):
             check.inst_param(asset_key, "asset_key", AssetKey)

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -262,9 +262,6 @@ class DynamicOutput(
         )
 
 
-MetadataValues = Union[str, float, int, Dict, EventMetadataEntry]
-
-
 @whitelist_for_serdes
 class AssetObservation(
     NamedTuple(
@@ -369,7 +366,7 @@ class AssetMaterialization(
         metadata_entries: Optional[List[EventMetadataEntry]] = None,
         partition: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
-        metadata: Optional[Dict[str, MetadataValues]] = None,
+        metadata: Optional[Dict[str, ParseableMetadataEntryData]] = None,
     ):
         if isinstance(asset_key, AssetKey):
             check.inst_param(asset_key, "asset_key", AssetKey)
@@ -571,7 +568,7 @@ class ExpectationResult(
         label: Optional[str] = None,
         description: Optional[str] = None,
         metadata_entries: Optional[List[EventMetadataEntry]] = None,
-        metadata: Optional[Dict[str, MetadataValues]] = None,
+        metadata: Optional[Dict[str, ParseableMetadataEntryData]] = None,
     ):
         metadata_entries = check.opt_list_param(
             metadata_entries, "metadata_entries", of_type=EventMetadataEntry
@@ -625,7 +622,7 @@ class TypeCheck(
         success: bool,
         description: Optional[str] = None,
         metadata_entries: Optional[List[EventMetadataEntry]] = None,
-        metadata: Optional[Dict[str, MetadataValues]] = None,
+        metadata: Optional[Dict[str, ParseableMetadataEntryData]] = None,
     ):
 
         metadata_entries = check.opt_list_param(
@@ -664,7 +661,7 @@ class Failure(Exception):
         self,
         description: Optional[str] = None,
         metadata_entries: Optional[List[EventMetadataEntry]] = None,
-        metadata: Optional[Dict[str, MetadataValues]] = None,
+        metadata: Optional[Dict[str, ParseableMetadataEntryData]] = None,
     ):
         metadata_entries = check.opt_list_param(
             metadata_entries, "metadata_entries", of_type=EventMetadataEntry

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -435,12 +435,14 @@ class ScheduleDefinition:
             run_requests = [item] if isinstance(item, RunRequest) else []
             skip_message = item.skip_message if isinstance(item, SkipReason) else None
         else:
-            check.is_list(result, of_type=RunRequest)
+            # NOTE: mypy is not correctly reading this cast-- not sure why
+            # (pyright reads it fine). Hence the type-ignores below.
+            result = cast(List[RunRequest], check.is_list(result, of_type=RunRequest))  # type: ignore
             check.invariant(
-                not any(not request.run_key for request in result),
+                not any(not request.run_key for request in result),  # type: ignore
                 "Schedules that return multiple RunRequests must specify a run_key in each RunRequest",
             )
-            run_requests = result
+            run_requests = result  # type: ignore
             skip_message = None
 
         # clone all the run requests with the required schedule tags

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -305,6 +305,8 @@ class SensorDefinition:
 
         skip_message: Optional[str] = None
 
+        run_requests: List[Any]
+        pipeline_run_reactions: List[Any]
         if not result or result == [None]:
             run_requests = []
             pipeline_run_reactions = []

--- a/python_modules/dagster/dagster/core/snap/dagster_types.py
+++ b/python_modules/dagster/dagster/core/snap/dagster_types.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from typing import Dict, List, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
@@ -6,14 +6,16 @@ from dagster.core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster.serdes import whitelist_for_serdes
 
 
-def build_dagster_type_namespace_snapshot(pipeline_def):
+def build_dagster_type_namespace_snapshot(
+    pipeline_def: PipelineDefinition,
+) -> "DagsterTypeNamespaceSnapshot":
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     return DagsterTypeNamespaceSnapshot(
         {dt.key: build_dagster_type_snap(dt) for dt in pipeline_def.all_dagster_types()}
     )
 
 
-def build_dagster_type_snap(dagster_type):
+def build_dagster_type_snap(dagster_type: DagsterType) -> "DagsterTypeSnap":
     check.inst_param(dagster_type, "dagster_type", DagsterType)
     return DagsterTypeSnap(
         kind=dagster_type.kind,
@@ -30,9 +32,12 @@ def build_dagster_type_snap(dagster_type):
 
 @whitelist_for_serdes
 class DagsterTypeNamespaceSnapshot(
-    namedtuple("_DagsterTypeNamespaceSnapshot", "all_dagster_type_snaps_by_key")
+    NamedTuple(
+        "_DagsterTypeNamespaceSnapshot",
+        [("all_dagster_type_snaps_by_key", Dict[str, "DagsterTypeSnap"])],
+    )
 ):
-    def __new__(cls, all_dagster_type_snaps_by_key):
+    def __new__(cls, all_dagster_type_snaps_by_key: Dict[str, "DagsterTypeSnap"]):
         return super(DagsterTypeNamespaceSnapshot, cls).__new__(
             cls,
             all_dagster_type_snaps_by_key=check.dict_param(
@@ -43,17 +48,26 @@ class DagsterTypeNamespaceSnapshot(
             ),
         )
 
-    def get_dagster_type_snap(self, key):
+    def get_dagster_type_snap(self, key: str) -> "DagsterTypeSnap":
         check.str_param(key, "key")
         return self.all_dagster_type_snaps_by_key[key]
 
 
 @whitelist_for_serdes
 class DagsterTypeSnap(
-    namedtuple(
+    NamedTuple(
         "_DagsterTypeSnap",
-        "kind key name description display_name is_builtin type_param_keys "
-        "loader_schema_key materializer_schema_key ",
+        [
+            ("kind", DagsterTypeKind),
+            ("key", str),
+            ("name", Optional[str]),
+            ("description", Optional[str]),
+            ("display_name", str),
+            ("is_builtin", bool),
+            ("type_param_keys", List[str]),
+            ("loader_schema_key", Optional[str]),
+            ("materializer_schema_key", Optional[str]),
+        ],
     )
 ):
     def __new__(

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -1,19 +1,18 @@
-from abc import ABC, abstractmethod
 import hashlib
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Generator, Optional, Set
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Generator, Optional
 
 from dagster import check
 from dagster.config.config_type import ConfigType
 from dagster.core.decorator_utils import get_function_params, validate_expected_params
 from dagster.core.definitions.events import AssetMaterialization
 from dagster.core.errors import DagsterInvalidDefinitionError
-if TYPE_CHECKING:
-    from dagster.core.execution.context.system import StepExecutionContext
 from dagster.utils import ensure_gen
 from dagster.utils.backcompat import experimental_arg_warning
 
+if TYPE_CHECKING:
+    from dagster.core.execution.context.system import StepExecutionContext
 
-from typing import cast, Type
 
 class DagsterTypeLoader(ABC):
     """
@@ -268,5 +267,5 @@ def dagster_type_materializer(
 
     config_type = resolve_to_config_type(config_schema)
     return lambda func: _create_output_materializer_for_decorator(
-        config_type, func, required_resource_keys
+        config_type, func, required_resource_keys  # type: ignore
     )

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -1,14 +1,21 @@
+from abc import ABC, abstractmethod
 import hashlib
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Generator, Optional, Set
 
 from dagster import check
 from dagster.config.config_type import ConfigType
 from dagster.core.decorator_utils import get_function_params, validate_expected_params
+from dagster.core.definitions.events import AssetMaterialization
 from dagster.core.errors import DagsterInvalidDefinitionError
+if TYPE_CHECKING:
+    from dagster.core.execution.context.system import StepExecutionContext
 from dagster.utils import ensure_gen
 from dagster.utils.backcompat import experimental_arg_warning
 
 
-class DagsterTypeLoader:
+from typing import cast, Type
+
+class DagsterTypeLoader(ABC):
     """
     Dagster type loaders are used to load unconnected inputs of the dagster type they are attached
     to.
@@ -18,29 +25,30 @@ class DagsterTypeLoader:
     """
 
     @property
-    def schema_type(self):
-        check.not_implemented(
-            "Must override schema_type in {klass}".format(klass=type(self).__name__)
-        )
+    @abstractmethod
+    def schema_type(self) -> ConfigType:
+        pass
 
     @property
-    def loader_version(self):
+    def loader_version(self) -> Optional[str]:
         return None
 
-    def compute_loaded_input_version(self, _config_value):
+    def compute_loaded_input_version(self, _config_value: object) -> Optional[str]:
         return None
 
-    def construct_from_config_value(self, _context, config_value):
+    def construct_from_config_value(
+        self, _context: "StepExecutionContext", config_value: object
+    ) -> object:
         """
         How to create a runtime value from config data.
         """
         return config_value
 
-    def required_resource_keys(self):
+    def required_resource_keys(self) -> AbstractSet[str]:
         return frozenset()
 
 
-class DagsterTypeMaterializer:
+class DagsterTypeMaterializer(ABC):
     """
     Dagster type materializers are used to materialize outputs of the dagster type they are attached
     to.
@@ -50,18 +58,20 @@ class DagsterTypeMaterializer:
     """
 
     @property
-    def schema_type(self):
-        check.not_implemented(
-            "Must override schema_type in {klass}".format(klass=type(self).__name__)
-        )
+    @abstractmethod
+    def schema_type(self) -> ConfigType:
+        pass
 
-    def materialize_runtime_values(self, _context, _config_value, _runtime_value):
+    @abstractmethod
+    def materialize_runtime_values(
+        self, _context: "StepExecutionContext", _config_value: object, _runtime_value: object
+    ) -> object:
         """
         How to materialize a runtime value given configuration.
         """
-        check.not_implemented("Must implement")
+        pass
 
-    def required_resource_keys(self):
+    def required_resource_keys(self) -> AbstractSet[str]:
         return frozenset()
 
 
@@ -91,18 +101,18 @@ class DagsterTypeLoaderFromDecorator(DagsterTypeLoader):
             )
 
     @property
-    def schema_type(self):
+    def schema_type(self) -> ConfigType:
         return self._config_type
 
     @property
-    def loader_version(self):
+    def loader_version(self) -> Optional[str]:
         return self._loader_version
 
-    def compute_loaded_input_version(self, config_value):
+    def compute_loaded_input_version(self, config_value: object) -> Optional[str]:
         """Compute the type-loaded input from a given config_value.
 
         Args:
-            config_value (Union[Any, Dict]): Config value to be ingested by the external version
+            config_value (object): Config value to be ingested by the external version
                 loading function.
         Returns:
             Optional[str]: Hash of concatenated loader version and external input version if both
@@ -120,7 +130,7 @@ class DagsterTypeLoaderFromDecorator(DagsterTypeLoader):
         else:
             return hashlib.sha1(version.encode("utf-8")).hexdigest()
 
-    def construct_from_config_value(self, context, config_value):
+    def construct_from_config_value(self, context: "StepExecutionContext", config_value: object):
         return self._func(context, config_value)
 
     def required_resource_keys(self):
@@ -128,9 +138,9 @@ class DagsterTypeLoaderFromDecorator(DagsterTypeLoader):
 
 
 def _create_type_loader_for_decorator(
-    config_type,
+    config_type: ConfigType,
     func,
-    required_resource_keys,
+    required_resource_keys: AbstractSet[str],
     loader_version=None,
     external_version_fn=None,
 ):
@@ -140,7 +150,7 @@ def _create_type_loader_for_decorator(
 
 
 def dagster_type_loader(
-    config_schema,
+    config_schema: object,
     required_resource_keys=None,
     loader_version=None,
     external_version_fn=None,
@@ -202,30 +212,41 @@ class DagsterTypeMaterializerForDecorator(DagsterTypeMaterializer):
         )
 
     @property
-    def schema_type(self):
+    def schema_type(self) -> ConfigType:
         return self._config_type
 
-    def materialize_runtime_values(self, context, config_value, runtime_value):
+    def materialize_runtime_values(
+        self, context: "StepExecutionContext", config_value: object, runtime_value: object
+    ) -> Generator[AssetMaterialization, Any, Any]:
         return ensure_gen(self._func(context, config_value, runtime_value))
 
-    def required_resource_keys(self):
+    def required_resource_keys(self) -> AbstractSet[str]:
         return frozenset(self._required_resource_keys)
 
 
-def _create_output_materializer_for_decorator(config_type, func, required_resource_keys):
+def _create_output_materializer_for_decorator(
+    config_type: ConfigType,
+    func: Callable[["StepExecutionContext", object, object], AssetMaterialization],
+    required_resource_keys: Optional[AbstractSet[str]],
+) -> DagsterTypeMaterializerForDecorator:
     return DagsterTypeMaterializerForDecorator(config_type, func, required_resource_keys)
 
 
-def dagster_type_materializer(config_schema, required_resource_keys=None):
+def dagster_type_materializer(
+    config_schema: object, required_resource_keys: Optional[AbstractSet[str]] = None
+) -> Callable[
+    [Callable[["StepExecutionContext", object, object], AssetMaterialization]],
+    DagsterTypeMaterializerForDecorator,
+]:
     """Create an output materialization hydration config that configurably materializes a runtime
     value.
 
     The decorated function should take the execution context, the parsed config value, and the
-    runtime value and the parsed config data, should materialize the runtime value, and should
+    runtime value. It should materialize the runtime value, and should
     return an appropriate :py:class:`AssetMaterialization`.
 
     Args:
-        config_schema (Any): The type of the config data expected by the decorated function.
+        config_schema (object): The type of the config data expected by the decorated function.
 
     Examples:
 

--- a/python_modules/dagster/dagster/core/types/config_schema.py
+++ b/python_modules/dagster/dagster/core/types/config_schema.py
@@ -68,7 +68,6 @@ class DagsterTypeMaterializer(ABC):
         """
         How to materialize a runtime value given configuration.
         """
-        pass
 
     def required_resource_keys(self) -> AbstractSet[str]:
         return frozenset()

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -505,7 +505,7 @@ class PythonObjectDagsterType(DagsterType):
             self.type_str = "Union[{}]".format(
                 ", ".join(python_type.__name__ for python_type in python_type)
             )
-            typing_type = object
+            typing_type = t.Union[python_type]
         else:
             self.python_type = check.type_param(python_type, "python_type")  # type: ignore
             self.type_str = cast(str, python_type.__name__)

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -19,7 +19,7 @@ from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
 if t.TYPE_CHECKING:
     from dagster.core.execution.context.system import StepExecutionContext, TypeCheckContext
 
-TypeCheckFn = t.Callable[[TypeCheckContext, object], t.Union[TypeCheck, bool]]
+TypeCheckFn = t.Callable[["TypeCheckContext", object], t.Union[TypeCheck, bool]]
 
 
 @whitelist_for_serdes
@@ -505,12 +505,12 @@ class PythonObjectDagsterType(DagsterType):
             self.type_str = "Union[{}]".format(
                 ", ".join(python_type.__name__ for python_type in python_type)
             )
-            typing_type = t.Union[python_type]
+            typing_type = t.Union[python_type]  # type: ignore
 
         else:
             self.python_type = check.type_param(python_type, "python_type")  # type: ignore
             self.type_str = cast(str, python_type.__name__)
-            typing_type = python_type
+            typing_type = self.python_type  # type: ignore
         name = check.opt_str_param(name, "name", self.type_str)
         key = check.opt_str_param(key, "key", name)
         super(PythonObjectDagsterType, self).__init__(

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -1,18 +1,27 @@
-import typing
 from abc import abstractmethod
 from enum import Enum as PythonEnum
 from functools import partial
 
 from dagster import check
 from dagster.builtins import BuiltinEnum
-from dagster.config.config_type import Array
+from dagster.config.config_type import Array, ConfigType
 from dagster.config.config_type import Noneable as ConfigNoneable
+# from dagster.core.definitions.event_metadata import MetadataEntry
 from dagster.core.definitions.events import TypeCheck
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+from dagster.core.definitions.event_metadata import MetadataEntry
 from dagster.serdes import whitelist_for_serdes
 
 from .builtin_config_schemas import BuiltinSchemas
 from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
+
+import typing as t
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from dagster.core.execution.context.system import StepExecutionContext, TypeCheckContext
+
+TypeCheckFn = t.Callable[["TypeCheckContext", object], t.Union[TypeCheck, bool]]
 
 
 @whitelist_for_serdes
@@ -36,13 +45,13 @@ class DagsterType:
             return either ``False`` or a :py:class:`~dagster.TypeCheck` with ``success`` set to ``False``.
             The first argument must be named ``context`` (or, if unused, ``_``, ``_context``, or ``context_``).
             Use ``required_resource_keys`` for access to resources.
-        key (Optional[str]): The unique key to identify types programatically.
+        key (Optional[str]): The unique key to identify types programmatically.
             The key property always has a value. If you omit key to the argument
             to the init function, it instead receives the value of ``name``. If
             neither ``key`` nor ``name`` is provided, a ``CheckError`` is thrown.
 
             In the case of a generic type such as ``List`` or ``Optional``, this is
-            generated programatically based on the type parameters.
+            generated programmatically based on the type parameters.
 
             For most use cases, name should be set and the key argument should
             not be specified.
@@ -71,24 +80,25 @@ class DagsterType:
             value contained within the DagsterType. Meant for internal use.
     """
 
+    key: str
+
     def __init__(
         self,
-        type_check_fn,
-        key=None,
-        name=None,
-        is_builtin=False,
-        description=None,
-        loader=None,
-        materializer=None,
-        required_resource_keys=None,
-        kind=DagsterTypeKind.REGULAR,
-        typing_type=None,
+        type_check_fn: TypeCheckFn,
+        key: t.Optional[str] = None,
+        name: t.Optional[str] = None,
+        is_builtin: bool = False,
+        description: t.Optional[str] =None,
+        loader: t.Optional[DagsterTypeLoader] = None,
+        materializer: t.Optional[DagsterTypeMaterializer] = None,
+        required_resource_keys: t.Set[str] = None,
+        kind: DagsterTypeKind = DagsterTypeKind.REGULAR,
+        typing_type: t.Optional[t.Type] = None,
     ):
         check.opt_str_param(key, "key")
         check.opt_str_param(name, "name")
 
         check.invariant(not (name is None and key is None), "Must set key or name")
-
         if name is None:
             check.param_invariant(
                 bool(key),
@@ -131,7 +141,7 @@ class DagsterType:
 
         self.typing_type = typing_type
 
-    def type_check(self, context, value):
+    def type_check(self, context: "TypeCheckContext", value: object) -> TypeCheck:
         retval = self._type_check_fn(context, value)
 
         if not isinstance(retval, (bool, TypeCheck)):
@@ -152,22 +162,23 @@ class DagsterType:
         return not self.__eq__(other)
 
     @staticmethod
-    def from_builtin_enum(builtin_enum):
+    def from_builtin_enum(builtin_enum) -> "DagsterType":
         check.invariant(BuiltinEnum.contains(builtin_enum), "must be member of BuiltinEnum")
         return _RUNTIME_MAP[builtin_enum]
 
     @property
-    def metadata_entries(self):
+    def metadata_entries(self) -> t.List[MetadataEntry]:
         return []
 
     @property
-    def display_name(self):
-        """Asserted in __init__ to be not None, overridden in many subclasses"""
-        return self._name
+    def display_name(self) -> str:
+        """Either the name or key (if name is `None`) of the type, overridden in many subclasses"""
+        return cast(str, self._name or self.key)
 
     @property
-    def unique_name(self):
+    def unique_name(self) -> t.Optional[str]:
         """The unique name of this type. Can be None if the type is not unique, such as container types"""
+        # TODO: docstring and body inconsistent-- can this be None or not?
         check.invariant(
             self._name is not None,
             "unique_name requested but is None for type {}".format(self.display_name),
@@ -175,42 +186,42 @@ class DagsterType:
         return self._name
 
     @property
-    def has_unique_name(self):
+    def has_unique_name(self) -> bool:
         return self._name is not None
 
     @property
-    def inner_types(self):
+    def inner_types(self) -> t.List["DagsterType"]:
         return []
 
     @property
-    def loader_schema_key(self):
+    def loader_schema_key(self) -> t.Optional[str]:
         return self.loader.schema_type.key if self.loader else None
 
     @property
-    def materializer_schema_key(self):
+    def materializer_schema_key(self) -> t.Optional[str]:
         return self.materializer.schema_type.key if self.materializer else None
 
     @property
-    def type_param_keys(self):
+    def type_param_keys(self) -> t.List[str]:
         return []
 
     @property
-    def is_nothing(self):
+    def is_nothing(self) -> bool:
         return self.kind == DagsterTypeKind.NOTHING
 
     @property
-    def supports_fan_in(self):
+    def supports_fan_in(self) -> bool:
         return False
 
-    def get_inner_type_for_fan_in(self):
-        check.invariant(
+    def get_inner_type_for_fan_in(self) -> "DagsterType":
+        check.failed(
             "DagsterType {name} does not support fan-in, should have checked supports_fan_in before calling getter.".format(
                 name=self.display_name
             )
         )
 
 
-def _validate_type_check_fn(fn, name):
+def _validate_type_check_fn(fn: t.Callable, name: t.Optional[str]) -> bool:
     from dagster.seven import get_args
 
     args = get_args(fn)
@@ -242,7 +253,7 @@ def _validate_type_check_fn(fn, name):
 
 
 class BuiltinScalarDagsterType(DagsterType):
-    def __init__(self, name, type_check_fn, typing_type, *args, **kwargs):
+    def __init__(self, name: str, type_check_fn: TypeCheckFn, typing_type: t.Type, *args, **kwargs):
         super(BuiltinScalarDagsterType, self).__init__(
             key=name,
             name=name,
@@ -254,12 +265,28 @@ class BuiltinScalarDagsterType(DagsterType):
             **kwargs,
         )
 
-    def type_check_fn(self, _context, value):
+    # This is passed to the constructor of subclasses as the argument `type_check_fn`-- that's why
+    # it exists together with the `type_check_fn arg.
+    def type_check_fn(self, _context, value) -> TypeCheck:
         return self.type_check_scalar_value(value)
 
     @abstractmethod
-    def type_check_scalar_value(self, _value):
+    def type_check_scalar_value(self, _value) -> TypeCheck:
         raise NotImplementedError()
+
+def _typemismatch_error_str(value: object, expected_type_desc: str) -> str:
+    return 'Value "{value}" of python type "{python_type}" must be a {type_desc}.'.format(
+        value=value, python_type=type(value).__name__, type_desc=expected_type_desc
+    )
+
+
+def _fail_if_not_of_type(value: object, value_type: t.Type[t.Any], value_type_desc: str) -> TypeCheck:
+
+    if not isinstance(value, value_type):
+        return TypeCheck(success=False, description=_typemismatch_error_str(value, value_type_desc))
+
+    return TypeCheck(success=True)
+
 
 
 class _Int(BuiltinScalarDagsterType):
@@ -272,22 +299,8 @@ class _Int(BuiltinScalarDagsterType):
             typing_type=int,
         )
 
-    def type_check_scalar_value(self, value):
+    def type_check_scalar_value(self, value) -> TypeCheck:
         return _fail_if_not_of_type(value, int, "int")
-
-
-def _typemismatch_error_str(value, expected_type_desc):
-    return 'Value "{value}" of python type "{python_type}" must be a {type_desc}.'.format(
-        value=value, python_type=type(value).__name__, type_desc=expected_type_desc
-    )
-
-
-def _fail_if_not_of_type(value, value_type, value_type_desc):
-
-    if not isinstance(value, value_type):
-        return TypeCheck(success=False, description=_typemismatch_error_str(value, value_type_desc))
-
-    return TypeCheck(success=True)
 
 
 class _String(BuiltinScalarDagsterType):
@@ -300,7 +313,7 @@ class _String(BuiltinScalarDagsterType):
             typing_type=str,
         )
 
-    def type_check_scalar_value(self, value):
+    def type_check_scalar_value(self, value: object) -> TypeCheck:
         return _fail_if_not_of_type(value, str, "string")
 
 
@@ -314,7 +327,7 @@ class _Float(BuiltinScalarDagsterType):
             typing_type=float,
         )
 
-    def type_check_scalar_value(self, value):
+    def type_check_scalar_value(self, value: object) -> TypeCheck:
         return _fail_if_not_of_type(value, float, "float")
 
 
@@ -328,19 +341,19 @@ class _Bool(BuiltinScalarDagsterType):
             typing_type=bool,
         )
 
-    def type_check_scalar_value(self, value):
+    def type_check_scalar_value(self, value: object) -> TypeCheck:
         return _fail_if_not_of_type(value, bool, "bool")
 
 
 class Anyish(DagsterType):
     def __init__(
         self,
-        key,
-        name,
-        loader=None,
-        materializer=None,
-        is_builtin=False,
-        description=None,
+        key: t.Optional[str],
+        name: t.Optional[str],
+        loader: t.Optional[DagsterTypeLoader]=None,
+        materializer: t.Optional[DagsterTypeMaterializer]=None,
+        is_builtin: bool=False,
+        description: t.Optional[str]=None,
     ):
         super(Anyish, self).__init__(
             key=key,
@@ -351,17 +364,17 @@ class Anyish(DagsterType):
             is_builtin=is_builtin,
             type_check_fn=self.type_check_method,
             description=description,
-            typing_type=typing.Any,
+            typing_type=t.Any,
         )
 
-    def type_check_method(self, _context, _value):
+    def type_check_method(self, _context: "TypeCheckContext", _value: object) -> TypeCheck:
         return TypeCheck(success=True)
 
     @property
-    def supports_fan_in(self):
+    def supports_fan_in(self) -> bool:
         return True
 
-    def get_inner_type_for_fan_in(self):
+    def get_inner_type_for_fan_in(self) -> DagsterType:
         # Anyish all the way down
         return self
 
@@ -378,11 +391,11 @@ class _Any(Anyish):
 
 
 def create_any_type(
-    name,
-    loader=None,
-    materializer=None,
-    description=None,
-):
+    name: str,
+    loader: t.Optional[DagsterTypeLoader]=None,
+    materializer: t.Optional[DagsterTypeMaterializer]=None,
+    description: t.Optional[str]=None,
+) -> Anyish:
     return Anyish(
         key=name,
         name=name,
@@ -404,7 +417,7 @@ class _Nothing(DagsterType):
             is_builtin=True,
         )
 
-    def type_check_method(self, _context, value):
+    def type_check_method(self, _context: "TypeCheckContext", value: object) -> TypeCheck:
         if value is not None:
             return TypeCheck(
                 success=False,
@@ -414,17 +427,17 @@ class _Nothing(DagsterType):
         return TypeCheck(success=True)
 
     @property
-    def supports_fan_in(self):
+    def supports_fan_in(self) -> bool:
         return True
 
-    def get_inner_type_for_fan_in(self):
+    def get_inner_type_for_fan_in(self) -> DagsterType:
         return self
 
 
 def isinstance_type_check_fn(
-    expected_python_type: typing.Type, dagster_type_name: str, expected_python_type_str: str
-):
-    def type_check(_context, value):
+    expected_python_type: t.Union[t.Type, t.Tuple[t.Type, ...]], dagster_type_name: str, expected_python_type_str: str
+) -> TypeCheckFn:
+    def type_check(_context: "TypeCheckContext", value: object) -> TypeCheck:
         if not isinstance(value, expected_python_type):
             return TypeCheck(
                 success=False,
@@ -481,7 +494,7 @@ class PythonObjectDagsterType(DagsterType):
             decorator to construct these arguments.
     """
 
-    def __init__(self, python_type, key=None, name=None, **kwargs):
+    def __init__(self, python_type: t.Union[t.Type, t.Tuple[t.Type, ...]], key: t.Optional[str]=None, name: t.Optional[str]=None, **kwargs):
         if isinstance(python_type, tuple):
             self.python_type = check.tuple_param(
                 python_type, "python_type", of_type=tuple(type for item in python_type)
@@ -489,49 +502,51 @@ class PythonObjectDagsterType(DagsterType):
             self.type_str = "Union[{}]".format(
                 ", ".join(python_type.__name__ for python_type in python_type)
             )
-            typing_type = typing.Union[python_type]
+            typing_type = t.Union[python_type]
         else:
             self.python_type = check.type_param(python_type, "python_type")
             self.type_str = python_type.__name__
-            typing_type = python_type
-        name = check.opt_str_param(name, "name", self.type_str)
-        key = check.opt_str_param(key, "key", name)
+        typing_type = python_type
+
+        # We have to set these here rather than in the superclass constructor to make sure
+        # `display_name` is defined.
+        self._name = check.opt_str_param(name, "name", self.type_str)
+        self.key = check.opt_str_param(key, "key", name)
         super(PythonObjectDagsterType, self).__init__(
             key=key,
             name=name,
-            type_check_fn=isinstance_type_check_fn(python_type, name, self.type_str),
+            type_check_fn=isinstance_type_check_fn(python_type, self.display_name, self.type_str),
             typing_type=typing_type,
             **kwargs,
         )
 
 
 class NoneableInputSchema(DagsterTypeLoader):
-    def __init__(self, inner_dagster_type):
+    def __init__(self, inner_dagster_type: DagsterType):
         self._inner_dagster_type = check.inst_param(
             inner_dagster_type, "inner_dagster_type", DagsterType
         )
-        check.param_invariant(inner_dagster_type.loader, "inner_dagster_type")
-        self._schema_type = ConfigNoneable(inner_dagster_type.loader.schema_type)
+        self._inner_loader = check.not_none_param(inner_dagster_type.loader, "inner_dagster_type")
+        self._schema_type = ConfigNoneable(self._inner_loader.schema_type)
 
     @property
-    def schema_type(self):
+    def schema_type(self) -> ConfigType:
         return self._schema_type
 
-    def construct_from_config_value(self, context, config_value):
+    def construct_from_config_value(self, context: "StepExecutionContext", config_value: object) -> object:
         if config_value is None:
             return None
-        return self._inner_dagster_type.loader.construct_from_config_value(context, config_value)
+        return self._inner_loader.construct_from_config_value(context, config_value)
 
 
-def _create_nullable_input_schema(inner_type):
+def _create_nullable_input_schema(inner_type: DagsterType) -> t.Optional[DagsterTypeLoader]:
     if not inner_type.loader:
         return None
 
     return NoneableInputSchema(inner_type)
 
-
 class OptionalType(DagsterType):
-    def __init__(self, inner_type):
+    def __init__(self, inner_type: DagsterType):
         inner_type = resolve_dagster_type(inner_type)
 
         if inner_type is Nothing:
@@ -539,7 +554,7 @@ class OptionalType(DagsterType):
                 "Type Nothing can not be wrapped in List or Optional"
             )
 
-        key = "Optional." + inner_type.key
+        key = "Optional." + cast(str, inner_type.key)
         self.inner_type = inner_type
         super(OptionalType, self).__init__(
             key=key,
@@ -547,11 +562,12 @@ class OptionalType(DagsterType):
             kind=DagsterTypeKind.NULLABLE,
             type_check_fn=self.type_check_method,
             loader=_create_nullable_input_schema(inner_type),
-            typing_type=typing.Optional[inner_type.typing_type],
+            # This throws a type error with Py
+            typing_type=t.Optional[inner_type.typing_type],  # type: ignore
         )
 
     @property
-    def display_name(self):
+    def display_name(self) -> str:
         return self.inner_type.display_name + "?"
 
     def type_check_method(self, context, value):
@@ -600,7 +616,7 @@ def _create_list_input_schema(inner_type):
 
 
 class ListType(DagsterType):
-    def __init__(self, inner_type):
+    def __init__(self, inner_type: DagsterType):
         key = "List." + inner_type.key
         self.inner_type = inner_type
         super(ListType, self).__init__(
@@ -609,7 +625,7 @@ class ListType(DagsterType):
             kind=DagsterTypeKind.LIST,
             type_check_fn=self.type_check_method,
             loader=_create_list_input_schema(inner_type),
-            typing_type=typing.List[inner_type.typing_type],
+            typing_type=t.List[inner_type.typing_type],
         )
 
     @property
@@ -665,7 +681,7 @@ def _List(inner_type):
 
 
 class Stringish(DagsterType):
-    def __init__(self, key=None, name=None, **kwargs):
+    def __init__(self, key: t.Optional[str]=None, name: t.Optional[str]=None, **kwargs: object):
         name = check.opt_str_param(name, "name", type(self).__name__)
         key = check.opt_str_param(key, "key", name)
         super(Stringish, self).__init__(
@@ -679,7 +695,7 @@ class Stringish(DagsterType):
             **kwargs,
         )
 
-    def type_check_method(self, _context, value):
+    def type_check_method(self, _context: "TypeCheckContext", value: object) -> TypeCheck:
         return _fail_if_not_of_type(value, str, "string")
 
 
@@ -703,13 +719,13 @@ _RUNTIME_MAP = {
     BuiltinEnum.NOTHING: Nothing,
 }
 
-_PYTHON_TYPE_TO_DAGSTER_TYPE_MAPPING_REGISTRY: typing.Dict[type, DagsterType] = {}
+_PYTHON_TYPE_TO_DAGSTER_TYPE_MAPPING_REGISTRY: t.Dict[type, DagsterType] = {}
 """Python types corresponding to user-defined RunTime types created using @map_to_dagster_type or
 as_dagster_type are registered here so that we can remap the Python types to runtime types."""
 
 
 def make_python_type_usable_as_dagster_type(
-    python_type: typing.Type, dagster_type: DagsterType
+    python_type: t.Type, dagster_type: DagsterType
 ) -> None:
     """
     Take any existing python type and map it to a dagster type (generally created with
@@ -752,7 +768,7 @@ DAGSTER_INVALID_TYPE_ERROR_MESSAGE = (
 
 
 class TypeHintInferredDagsterType(DagsterType):
-    def __init__(self, python_type: typing.Type):
+    def __init__(self, python_type: t.Type):
         qualified_name = f"{python_type.__module__}.{python_type.__name__}"
         self.python_type = python_type
         super(TypeHintInferredDagsterType, self).__init__(
@@ -769,7 +785,7 @@ class TypeHintInferredDagsterType(DagsterType):
         return self.python_type.__name__
 
 
-def resolve_dagster_type(dagster_type):
+def resolve_dagster_type(dagster_type: object) -> DagsterType:
     # circular dep
     from .python_dict import PythonDict, Dict
     from .python_set import PythonSet, DagsterSetApi
@@ -792,7 +808,7 @@ def resolve_dagster_type(dagster_type):
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 
-    # First check to see if it part of python's typing library
+    # First check to see if it is part of python's typing library
     if is_typing_type(dagster_type):
         dagster_type = transform_typing_type(dagster_type)
 
@@ -842,7 +858,7 @@ def resolve_dagster_type(dagster_type):
     )
 
 
-def resolve_python_type_to_dagster_type(python_type: typing.Type) -> DagsterType:
+def resolve_python_type_to_dagster_type(python_type: t.Type) -> DagsterType:
     """
     Resolves a Python type to a Dagster type.
     """
@@ -857,7 +873,6 @@ def resolve_python_type_to_dagster_type(python_type: typing.Type) -> DagsterType
 
 
 ALL_RUNTIME_BUILTINS = list(_RUNTIME_MAP.values())
-
 
 def construct_dagster_type_dictionary(solid_defs):
     type_dict_by_name = {t.unique_name: t for t in ALL_RUNTIME_BUILTINS}
@@ -888,9 +903,8 @@ def construct_dagster_type_dictionary(solid_defs):
 
 
 class DagsterOptionalApi:
-    def __getitem__(self, inner_type):
+    def __getitem__(self, inner_type: DagsterType) -> OptionalType:
         check.not_none_param(inner_type, "inner_type")
         return OptionalType(inner_type)
-
 
 Optional = DagsterOptionalApi()

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -8,10 +8,9 @@ from dagster import check
 from dagster.builtins import BuiltinEnum
 from dagster.config.config_type import Array, ConfigType
 from dagster.config.config_type import Noneable as ConfigNoneable
-
+from dagster.core.definitions.event_metadata import EventMetadataEntry
 from dagster.core.definitions.events import TypeCheck
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
-from dagster.core.definitions.event_metadata import EventMetadataEntry
 from dagster.serdes import whitelist_for_serdes
 
 from .builtin_config_schemas import BuiltinSchemas
@@ -78,8 +77,6 @@ class DagsterType:
         typing_type: Defaults to None. A valid python typing type (e.g. Optional[List[int]]) for the
             value contained within the DagsterType. Meant for internal use.
     """
-
-    key: str
 
     def __init__(
         self,
@@ -262,7 +259,7 @@ class BuiltinScalarDagsterType(DagsterType):
         )
 
     # This is passed to the constructor of subclasses as the argument `type_check_fn`-- that's why
-    # it exists together with the `type_check_fn arg.
+    # it exists together with the `type_check_fn` arg.
     def type_check_fn(self, _context, value) -> TypeCheck:
         return self.type_check_scalar_value(value)
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -17,7 +17,7 @@ from .builtin_config_schemas import BuiltinSchemas
 from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
 
 if t.TYPE_CHECKING:
-    from dagster.core.execution.context.system import (   # pylint: disable=unused-import
+    from dagster.core.execution.context.system import (  # pylint: disable=unused-import
         StepExecutionContext,
         TypeCheckContext,
     )

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -19,7 +19,7 @@ from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
 if t.TYPE_CHECKING:
     from dagster.core.execution.context.system import StepExecutionContext, TypeCheckContext
 
-TypeCheckFn = t.Callable[["TypeCheckContext", object], t.Union[TypeCheck, bool]]
+TypeCheckFn = t.Callable[[TypeCheckContext, object], t.Union[TypeCheck, bool]]
 
 
 @whitelist_for_serdes
@@ -506,6 +506,7 @@ class PythonObjectDagsterType(DagsterType):
                 ", ".join(python_type.__name__ for python_type in python_type)
             )
             typing_type = t.Union[python_type]
+
         else:
             self.python_type = check.type_param(python_type, "python_type")  # type: ignore
             self.type_str = cast(str, python_type.__name__)
@@ -792,7 +793,6 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     from .python_set import PythonSet, DagsterSetApi
     from .python_tuple import PythonTuple, DagsterTupleApi
     from .transform_typing import transform_typing_type
-    from dagster.config.config_type import ConfigType
     from dagster.primitive_mapping import (
         remap_python_builtin_for_runtime,
         is_supported_runtime_python_builtin,

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -17,7 +17,10 @@ from .builtin_config_schemas import BuiltinSchemas
 from .config_schema import DagsterTypeLoader, DagsterTypeMaterializer
 
 if t.TYPE_CHECKING:
-    from dagster.core.execution.context.system import StepExecutionContext, TypeCheckContext
+    from dagster.core.execution.context.system import (   # pylint: disable=unused-import
+        StepExecutionContext,
+        TypeCheckContext,
+    )
 
 TypeCheckFn = t.Callable[["TypeCheckContext", object], t.Union[TypeCheck, bool]]
 

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -15,7 +15,7 @@ import threading
 from collections import OrderedDict, defaultdict, namedtuple
 from datetime import timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, ContextManager, Generator, Generic, Iterator
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Generator, Generic, Iterator
 from typing import Mapping as TypingMapping
 from typing import Optional, Type, TypeVar, Union, cast
 from warnings import warn
@@ -38,6 +38,7 @@ else:
 if TYPE_CHECKING:
     from dagster.core.events import DagsterEvent
 
+T = TypeVar("T")
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 
@@ -309,11 +310,11 @@ def safe_tempfile_path() -> Iterator[str]:
             os.unlink(path)
 
 
-def ensure_gen(thing_or_gen):
+def ensure_gen(thing_or_gen: Union[Generator[T, Any, Any], T]) -> Generator[T, Any, Any]:
     if not inspect.isgenerator(thing_or_gen):
 
         def _gen_thing():
-            yield thing_or_gen
+            yield cast(T, thing_or_gen)
 
         return _gen_thing()
 

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -17,7 +17,7 @@ from datetime import timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, ContextManager, Generator, Generic, Iterator
 from typing import Mapping as TypingMapping
-from typing import Optional, Type, TypeVar, Union, cast
+from typing import Optional, Type, TypeVar, Union, cast, overload
 from warnings import warn
 
 import _thread as thread
@@ -310,11 +310,21 @@ def safe_tempfile_path() -> Iterator[str]:
             os.unlink(path)
 
 
-def ensure_gen(thing_or_gen: Union[Generator[T, Any, Any], T]) -> Generator[T, Any, Any]:
+@overload
+def ensure_gen(thing_or_gen: Generator[T, Any, Any]) -> Generator[T, Any, Any]:
+    pass
+
+
+@overload
+def ensure_gen(thing_or_gen: T) -> Generator[T, Any, Any]:
+    pass
+
+
+def ensure_gen(thing_or_gen):
     if not inspect.isgenerator(thing_or_gen):
 
         def _gen_thing():
-            yield cast(T, thing_or_gen)
+            yield thing_or_gen
 
         return _gen_thing()
 
@@ -373,8 +383,6 @@ def start_termination_thread(termination_event):
     int_thread.daemon = True
     int_thread.start()
 
-
-T = TypeVar("T")
 
 # Executes the next() function within an instance of the supplied context manager class
 # (leaving the context before yielding each result)

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -74,6 +74,7 @@ if __name__ == "__main__":
             "protobuf>=3.13.0",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
             "python-dateutil",
             "pytz",
+            "requests",
             "rx>=1.6,<2",  # https://github.com/dagster-io/dagster/issues/4089
             "tabulate",
             "tqdm",
@@ -119,6 +120,7 @@ if __name__ == "__main__":
                 "types-python-dateutil",  # version will be resolved against python-dateutil
                 "types-PyYAML",  # version will be resolved against PyYAML
                 "types-pytz",  # version will be resolved against pytz
+                "types-requests",  # version will be resolved against requests
                 "types-tabulate",  # version will be resolved against tabulate
                 "yamllint",
             ],

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -114,6 +114,10 @@ if __name__ == "__main__":
                 "tox==3.14.2",
                 "tox-pip-version==0.0.7",
                 "tqdm==4.48.0",  # pylint crash 48.1+
+                "yamllint",
+            ],
+            "mypy": [
+                "mypy==0.931",
                 "types-croniter",  # version will be resolved against croniter
                 "types-mock",  # version will be resolved against mock
                 "types-pkg-resources",  # version will be resolved against setuptools (contains pkg_resources)
@@ -122,7 +126,6 @@ if __name__ == "__main__":
                 "types-pytz",  # version will be resolved against pytz
                 "types-requests",  # version will be resolved against requests
                 "types-tabulate",  # version will be resolved against tabulate
-                "yamllint",
             ],
         },
         entry_points={

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -46,7 +46,7 @@ def main(quiet):
 
     install_targets += [
         "awscli",
-        "-e python_modules/dagster[test]",
+        "-e python_modules/dagster[mypy,test]",
         "-e python_modules/dagster-graphql",
         "-e python_modules/dagster-test",
         "-e python_modules/dagit[test]",


### PR DESCRIPTION
Type annotations factored out of #6226. Once this is merged I'll rebase #6226 onto these.

NOTE: `requests` was added as a core dependency because there is a new telemetry script in the `dagster` package (not added by me) that uses it (mypy picked this up).