### PR TITLE
[dagit] Repair date strings in charts

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -43,6 +43,7 @@
     "color": "^3.0.0",
     "cronstrue": "^1.84.0",
     "dagre": "^0.8.2",
+    "date-fns": "^2.28.0",
     "deepmerge": "^4.2.2",
     "fuse.js": "^6.4.2",
     "graphql": "^15.5.0",

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5350,6 +5350,7 @@ __metadata:
     color: ^3.0.0
     cronstrue: ^1.84.0
     dagre: ^0.8.2
+    date-fns: ^2.28.0
     deepmerge: ^4.2.2
     eslint: 8.5.0
     eslint-config-prettier: 8.3.0
@@ -14158,6 +14159,13 @@ __metadata:
   version: 1.30.1
   resolution: "date-fns@npm:1.30.1"
   checksum: 86b1f3269cbb1f3ee5ac9959775ea6600436f4ee2b78430cd427b41a0c9fabf740b1a5d401c085f3003539a6f4755c7c56c19fbd70ce11f6f673f6bc8075b710
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^2.28.0":
+  version: 2.28.0
+  resolution: "date-fns@npm:2.28.0"
+  checksum: a0516b2e4f99b8bffc6cc5193349f185f195398385bdcaf07f17c2c4a24473c99d933eb0018be4142a86a6d46cb0b06be6440ad874f15e795acbedd6fd727a1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves #6268.

In our chart.js usage, we are using `chartjs-adapter-date-fns` for timestamp rendering...but we haven't actually asked for `date-fns` as a dependency. We end up with some busted date/time strings in our charts as a result.

Fix this by actually repairing the missing dependency.

<img width="276" alt="Screen Shot 2022-01-20 at 1 26 28 PM" src="https://user-images.githubusercontent.com/2823852/150408800-0dfc0b7f-3f1a-4b39-9379-81fbbef94420.png">

## Test Plan

View asset graph and scheduled ticks charts. Verify proper timestamp string rendering on tooltips.
