### PR TITLE
[dagit] Update tox file, ts configs

### DIFF
--- a/js_modules/dagit/packages/app/tsconfig.json
+++ b/js_modules/dagit/packages/app/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@dagster-io/dagit-core/*": ["../core/src/*"],
       "@dagster-io/ui": ["../ui"]

--- a/js_modules/dagit/packages/core/tsconfig.json
+++ b/js_modules/dagit/packages/core/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@dagster-io/ui": ["../ui"]
     },

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -30,6 +30,10 @@ commands =
   yarn workspace @dagster-io/dagit-core jest --collectCoverage --watchAll=false
   yarn workspace @dagster-io/dagit-core check-prettier
   yarn workspace @dagster-io/dagit-core check-lint
+  yarn workspace @dagster-io/ui ts
+  yarn workspace @dagster-io/ui lint
+  yarn workspace @dagster-io/ui jest --clearCache
+  yarn workspace @dagster-io/ui jest
   git diff --exit-code
 
 [testenv:pylint]


### PR DESCRIPTION
## Summary

I noticed that the tox.ini file for dagit doesn't run ts/lint/jest on `@dagster-io/ui`, so let's go ahead and start doing that.

I'm also pretty sure that we don't need the `baseUrl` value on the `app` or `core` tsconfig files.

## Test Plan

BK
