### PR TITLE
[dagit] Truncate long job names in PipelineReference

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
@@ -1,0 +1,74 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+
+import {PipelineReference, Props as PipelineReferenceProps} from './PipelineReference';
+
+describe('PipelineReference', () => {
+  const Test = (props: PipelineReferenceProps) => (
+    <TestProvider>
+      <PipelineReference {...props} />
+    </TestProvider>
+  );
+
+  describe('Job name truncation', () => {
+    const props: PipelineReferenceProps = {
+      pipelineName: 'foobar',
+      pipelineHrefContext: 'repo-unknown',
+      isJob: true,
+    };
+
+    it('does not truncate job name if below threshold', async () => {
+      render(<Test {...props} />);
+      await waitFor(() => {
+        expect(screen.getByRole('link', {name: /foobar/i})).toBeVisible();
+      });
+    });
+
+    it('truncates job name if above threshold, buffering back a bit', async () => {
+      render(<Test {...props} pipelineName="washington_adams_jefferson_madison_monroe" />);
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', {name: /washington_adams_jefferson_madison_…/i}),
+        ).toBeVisible();
+      });
+    });
+  });
+
+  describe('Links', () => {
+    const props: PipelineReferenceProps = {
+      pipelineName: 'foobar',
+      pipelineHrefContext: 'repo-unknown',
+      isJob: true,
+    };
+
+    it('if `repo-unknown`, links to job disambiguation page', async () => {
+      render(<Test {...props} />);
+      await waitFor(() => {
+        const link = screen.getByRole('link', {name: /foobar/i});
+        expect(link).toBeVisible();
+        expect(link.getAttribute('href')).toBe('/workspace/jobs/foobar/');
+      });
+    });
+
+    it('if RepoAddress, links to job within repo', async () => {
+      render(<Test {...props} pipelineHrefContext={buildRepoAddress('lorem', 'ipsum')} />);
+      await waitFor(() => {
+        const link = screen.getByRole('link', {name: /foobar/i});
+        expect(link).toBeVisible();
+        expect(link.getAttribute('href')).toBe('/workspace/lorem@ipsum/jobs/foobar/');
+      });
+    });
+
+    it('if `no-link`, renders plain text', async () => {
+      render(<Test {...props} pipelineHrefContext="no-link" />);
+      await waitFor(() => {
+        const link = screen.queryByRole('link', {name: /foobar/i});
+        expect(link).toBeNull();
+        expect(screen.getByText('foobar')).toBeVisible();
+      });
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineReference.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineReference.tsx
@@ -7,7 +7,7 @@ import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspac
 
 import {PipelineSnapshotLink} from './PipelinePathUtils';
 
-interface Props {
+export interface Props {
   pipelineName: string;
   pipelineHrefContext: 'repo-unknown' | RepoAddress | 'no-link';
   isJob: boolean;
@@ -15,6 +15,9 @@ interface Props {
   showIcon?: boolean;
   size?: 'small' | 'normal';
 }
+
+const TRUNCATION_THRESHOLD = 40;
+const TRUNCATION_BUFFER = 5;
 
 export const PipelineReference: React.FC<Props> = ({
   pipelineName,
@@ -24,11 +27,16 @@ export const PipelineReference: React.FC<Props> = ({
   showIcon,
   size = 'normal',
 }) => {
+  const truncatedName =
+    pipelineName.length > TRUNCATION_THRESHOLD
+      ? `${pipelineName.slice(0, TRUNCATION_THRESHOLD - TRUNCATION_BUFFER)}…`
+      : pipelineName;
+
   const pipeline =
     pipelineHrefContext === 'repo-unknown' ? (
-      <Link to={workspacePipelinePathGuessRepo(pipelineName, isJob)}>{pipelineName}</Link>
+      <Link to={workspacePipelinePathGuessRepo(pipelineName, isJob)}>{truncatedName}</Link>
     ) : pipelineHrefContext === 'no-link' ? (
-      <>{pipelineName}</>
+      <>{truncatedName}</>
     ) : (
       <Link
         to={workspacePipelinePath({
@@ -38,7 +46,7 @@ export const PipelineReference: React.FC<Props> = ({
           isJob,
         })}
       >
-        {pipelineName}
+        {truncatedName}
       </Link>
     );
 


### PR DESCRIPTION
## Summary

A cloud user with very long job names noted that the tag on the RunRoot header is truncated in an unfortunate position based on the CSS truncation. We can just go ahead and truncate this in JS, since there's no risk to losing meaning in a sentence or anything, it's just a job name.

Added a handful of test specs as well.

## Test Plan

Jest.
