### PR TITLE
[perf] PipelineIndex tweaks

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -36,27 +36,18 @@ class ExternalRepository:
         self.external_repository_data = check.inst_param(
             external_repository_data, "external_repository_data", ExternalRepositoryData
         )
-        self._pipeline_index_map = OrderedDict(
-            (
-                external_pipeline_data.pipeline_snapshot.name,
-                PipelineIndex(
-                    external_pipeline_data.pipeline_snapshot,
-                    external_pipeline_data.parent_pipeline_snapshot,
-                ),
+        self._pipeline_index_map = OrderedDict()
+        self._job_index_map = OrderedDict()
+        for external_pipeline_data in external_repository_data.external_pipeline_datas:
+            key = external_pipeline_data.pipeline_snapshot.name
+            index = PipelineIndex(
+                external_pipeline_data.pipeline_snapshot,
+                external_pipeline_data.parent_pipeline_snapshot,
             )
-            for external_pipeline_data in external_repository_data.external_pipeline_datas
-        )
-        self._job_index_map = OrderedDict(
-            (
-                external_pipeline_data.pipeline_snapshot.name,
-                PipelineIndex(
-                    external_pipeline_data.pipeline_snapshot,
-                    external_pipeline_data.parent_pipeline_snapshot,
-                ),
-            )
-            for external_pipeline_data in external_repository_data.external_pipeline_datas
-            if external_pipeline_data.is_job
-        )
+            self._pipeline_index_map[key] = index
+            if external_pipeline_data.is_job:
+                self._job_index_map[key] = index
+
         self._handle = check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
 
         instigation_list = (

--- a/python_modules/dagster/dagster/core/host_representation/historical.py
+++ b/python_modules/dagster/dagster/core/host_representation/historical.py
@@ -24,9 +24,7 @@ class HistoricalPipeline(RepresentedPipeline):
             identifying_pipeline_snapshot_id, "identifying_pipeline_snapshot_id"
         )
         super(HistoricalPipeline, self).__init__(
-            pipeline_index=PipelineIndex(
-                pipeline_snapshot, parent_pipeline_snapshot, is_historical=True
-            ),
+            pipeline_index=PipelineIndex(pipeline_snapshot, parent_pipeline_snapshot),
         )
 
     @property

--- a/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/core/host_representation/pipeline_index.py
@@ -7,7 +7,7 @@ from dagster.core.snap import (
 
 
 class PipelineIndex:
-    def __init__(self, pipeline_snapshot, parent_pipeline_snapshot, is_historical=False):
+    def __init__(self, pipeline_snapshot, parent_pipeline_snapshot):
         self.pipeline_snapshot = check.inst_param(
             pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot
         )
@@ -42,15 +42,7 @@ class PipelineIndex:
             for comp_snap in pipeline_snapshot.solid_definitions_snapshot.composite_solid_def_snaps
         }
 
-        if is_historical:
-            # defer the pipeline snapshot calculation for historical pipelines.  This tends to be an
-            # expensive operation, so we want to avoid it unless we need it.  Also, because this is
-            # a historical pipeline, we already have an identifying pipeline snapshot id (which may
-            # or may not be the same as this calculated snapshot id). The identifying pipeline
-            # snapshot id is the calculated snapshot id at the time that the run was created.
-            self._pipeline_snapshot_id = None
-        else:
-            self._pipeline_snapshot_id = create_pipeline_snapshot_id(pipeline_snapshot)
+        self._pipeline_snapshot_id = None
 
     @property
     def name(self):


### PR DESCRIPTION
* always defer snapshot id creation (still memoized so at worst should only shift cost not change it)
* avoid duplicate index creations for jobs 


## Test Plan

existing bk test suite