### PR TITLE
Create Fivetran multi-asset

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/assets.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+from dagster import AssetKey, Out, Output
+from dagster.core.asset_defs import multi_asset
+
+from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL
+from dagster_fivetran.utils import generate_materializations
+
+
+def fivetran_assets_factory(
+    connector_id: str,
+    asset_keys: List[AssetKey],
+    name: Optional[str] = None,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    poll_timeout: Optional[float] = None,
+    io_manager_key: Optional[str] = None,
+):
+    @multi_asset(
+        name=name or f"fivetran_sync_{connector_id}",
+        outs={
+            asset_key.path[-1]: Out(io_manager_key=io_manager_key, asset_key=asset_key)
+            for asset_key in asset_keys
+        },
+        required_resource_keys={"fivetran"},
+    )
+    def _assets(context):
+        fivetran_output = context.resources.fivetran.sync_and_poll(
+            connector_id=connector_id,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout,
+        )
+        for materialization in generate_materializations(fivetran_output, asset_key_prefix=[]):
+            asset_key = materialization.asset_key
+            # scan through all tables actually created, if it was expected then emit an Output.
+            # otherwise, emit a runtime AssetMaterialization
+            if asset_key in asset_keys:
+                yield Output(
+                    value=None,
+                    output_name=asset_key.path[-1],
+                    metadata_entries=materialization.metadata_entries,
+                )
+            else:
+                yield materialization
+
+    return _assets

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/assets.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
-from dagster import AssetKey, Out, Output, experimental
+from dagster import AssetKey, Out, Output
 from dagster.core.asset_defs import AssetsDefinition, multi_asset
+from dagster.utils.backcompat import experimental
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL
 from dagster_fivetran.utils import generate_materializations
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
@@ -2,8 +2,8 @@ import responses
 from dagster import AssetKey
 from dagster.core.asset_defs import build_assets_job
 from dagster_fivetran import fivetran_resource
-from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PATH
 from dagster_fivetran.assets import fivetran_assets_factory
+from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PATH
 
 from .utils import (
     DEFAULT_CONNECTOR_ID,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
@@ -3,7 +3,7 @@ import responses
 from dagster import AssetKey, DagsterStepOutputNotFoundError
 from dagster.core.asset_defs import build_assets_job
 from dagster_fivetran import fivetran_resource
-from dagster_fivetran.assets import fivetran_assets_factory
+from dagster_fivetran.assets import build_fivetran_assets
 from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PATH
 
 from .utils import (
@@ -17,7 +17,7 @@ from .utils import (
 
 def test_fivetran_asset_keys():
 
-    ft_asset = fivetran_assets_factory(
+    ft_asset = build_fivetran_assets(
         connector_id=DEFAULT_CONNECTOR_ID, asset_keys=[AssetKey("foo"), AssetKey("bar")]
     )
     assert ft_asset.asset_keys == {AssetKey("foo"), AssetKey("bar")}
@@ -27,10 +27,10 @@ def test_fivetran_asset_keys():
     "asset_keys,should_error",
     [
         ([], False),
-        ([AssetKey(["xyz1", "abc1"])], False),
-        ([AssetKey(["xyz1", "abc1"]), AssetKey(["abc", "xyz"])], False),
+        ([AssetKey(["schema1", "table1"])], False),
+        ([AssetKey(["schema1", "table1"]), AssetKey(["schema2", "table1"])], False),
         ([AssetKey(["does", "notexist"])], True),
-        ([AssetKey(["xyz1", "abc1"]), AssetKey(["does", "notexist"])], True),
+        ([AssetKey(["schema1", "table1"]), AssetKey(["does", "notexist"])], True),
     ],
 )
 def test_fivetran_asset_run(asset_keys, should_error):
@@ -39,17 +39,21 @@ def test_fivetran_asset_run(asset_keys, should_error):
     final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
     api_prefix = f"{FIVETRAN_API_BASE}/{FIVETRAN_CONNECTOR_PATH}{DEFAULT_CONNECTOR_ID}"
 
+    fivetran_assets = build_fivetran_assets(
+        name="my_cool_ft_assets",
+        connector_id=DEFAULT_CONNECTOR_ID,
+        asset_keys=asset_keys,
+        poll_interval=0.1,
+        poll_timeout=10,
+    )
+
+    # expect the multi asset to have one asset key and one output for each specified asset key
+    assert fivetran_assets.asset_keys == set(asset_keys)
+    assert len(fivetran_assets.op.output_defs) == len(asset_keys)
+
     fivetran_assets_job = build_assets_job(
         name="fivetran_assets_job",
-        assets=[
-            fivetran_assets_factory(
-                name="my_cool_ft_assets",
-                connector_id=DEFAULT_CONNECTOR_ID,
-                asset_keys=asset_keys,
-                poll_interval=0.1,
-                poll_timeout=10,
-            )
-        ],
+        assets=[fivetran_assets],
         resource_defs={"fivetran": ft_resource},
     )
 
@@ -57,12 +61,19 @@ def test_fivetran_asset_run(asset_keys, should_error):
         rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
         rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
         # connector schema
-        rsps.add(rsps.GET, f"{api_prefix}/schemas", json=get_sample_connector_schema_config())
+        rsps.add(
+            rsps.GET,
+            f"{api_prefix}/schemas",
+            json=get_sample_connector_schema_config(
+                tables=[
+                    ("schema1", "table1"),
+                    ("schema1", "table2"),
+                    ("schema2", "table1"),
+                ]
+            ),
+        )
         # initial state
         rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
-        # n polls before updating
-        for _ in range(2):
-            rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
         # final state will be updated
         rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
 
@@ -72,19 +83,26 @@ def test_fivetran_asset_run(asset_keys, should_error):
         else:
             result = fivetran_assets_job.execute_in_process()
             assert result.success
+            # make sure we only have outputs for the explicit asset keys
+            outputs = [
+                event
+                for event in result.events_for_node("my_cool_ft_assets")
+                if event.event_type_value == "STEP_OUTPUT"
+            ]
+            assert len(outputs) == len(asset_keys)
+
+            # make sure we have asset materializations for all the schemas/tables that were actually sync'd
             asset_materializations = [
                 event
                 for event in result.events_for_node("my_cool_ft_assets")
                 if event.event_type_value == "ASSET_MATERIALIZATION"
             ]
             assert len(asset_materializations) == 3
-            asset_keys = set(
+            found_asset_keys = set(
                 mat.event_specific_data.materialization.asset_key for mat in asset_materializations
             )
-            assert asset_keys == set(
-                [
-                    AssetKey(["xyz1", "abc1"]),
-                    AssetKey(["xyz1", "abc2"]),
-                    AssetKey(["abc", "xyz"]),
-                ]
-            )
+            assert found_asset_keys == {
+                AssetKey(["schema1", "table1"]),
+                AssetKey(["schema1", "table2"]),
+                AssetKey(["schema2", "table1"]),
+            }

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
@@ -27,10 +27,10 @@ def test_fivetran_asset_keys():
     "asset_keys,should_error",
     [
         ([], False),
-        ([AssetKey(["schema1", "table1"])], False),
-        ([AssetKey(["schema1", "table1"]), AssetKey(["schema2", "table1"])], False),
+        ([AssetKey(["schema1", "tracked"])], False),
+        ([AssetKey(["schema1", "tracked"]), AssetKey(["schema2", "tracked"])], False),
         ([AssetKey(["does", "notexist"])], True),
-        ([AssetKey(["schema1", "table1"]), AssetKey(["does", "notexist"])], True),
+        ([AssetKey(["schema1", "tracked"]), AssetKey(["does", "notexist"])], True),
     ],
 )
 def test_fivetran_asset_run(asset_keys, should_error):
@@ -66,9 +66,9 @@ def test_fivetran_asset_run(asset_keys, should_error):
             f"{api_prefix}/schemas",
             json=get_sample_connector_schema_config(
                 tables=[
-                    ("schema1", "table1"),
-                    ("schema1", "table2"),
-                    ("schema2", "table1"),
+                    ("schema1", "tracked"),
+                    ("schema1", "untracked"),
+                    ("schema2", "tracked"),
                 ]
             ),
         )
@@ -102,7 +102,7 @@ def test_fivetran_asset_run(asset_keys, should_error):
                 mat.event_specific_data.materialization.asset_key for mat in asset_materializations
             )
             assert found_asset_keys == {
-                AssetKey(["schema1", "table1"]),
-                AssetKey(["schema1", "table2"]),
-                AssetKey(["schema2", "table1"]),
+                AssetKey(["schema1", "tracked"]),
+                AssetKey(["schema1", "untracked"]),
+                AssetKey(["schema2", "tracked"]),
             }

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_assets.py
@@ -1,0 +1,75 @@
+import responses
+from dagster import AssetKey
+from dagster.core.asset_defs import build_assets_job
+from dagster_fivetran import fivetran_resource
+from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PATH
+from dagster_fivetran.assets import fivetran_assets_factory
+
+from .utils import (
+    DEFAULT_CONNECTOR_ID,
+    get_sample_connector_response,
+    get_sample_connector_schema_config,
+    get_sample_sync_response,
+    get_sample_update_response,
+)
+
+
+def test_fivetran_asset_keys():
+
+    ft_asset = fivetran_assets_factory(
+        connector_id=DEFAULT_CONNECTOR_ID, asset_keys=[AssetKey("foo"), AssetKey("bar")]
+    )
+    assert ft_asset.asset_keys == {AssetKey("foo"), AssetKey("bar")}
+
+
+def test_fivetran_asset_run():
+
+    ft_resource = fivetran_resource.configured({"api_key": "foo", "api_secret": "bar"})
+    final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
+    api_prefix = f"{FIVETRAN_API_BASE}/{FIVETRAN_CONNECTOR_PATH}{DEFAULT_CONNECTOR_ID}"
+
+    fivetran_assets_job = build_assets_job(
+        name="fivetran_assets_job",
+        assets=[
+            fivetran_assets_factory(
+                name="my_cool_ft_assets",
+                connector_id=DEFAULT_CONNECTOR_ID,
+                asset_keys=[AssetKey(["xyz1", "abc1"]), AssetKey(["abc", "xyz"])],
+                poll_interval=0.1,
+                poll_timeout=10,
+            )
+        ],
+        resource_defs={"fivetran": ft_resource},
+    )
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
+        rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
+        # connector schema
+        rsps.add(rsps.GET, f"{api_prefix}/schemas", json=get_sample_connector_schema_config())
+        # initial state
+        rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
+        # n polls before updating
+        for _ in range(2):
+            rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
+        # final state will be updated
+        rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
+
+        result = fivetran_assets_job.execute_in_process()
+        assert result.success
+        asset_materializations = [
+            event
+            for event in result.events_for_node("my_cool_ft_assets")
+            if event.event_type_value == "ASSET_MATERIALIZATION"
+        ]
+        assert len(asset_materializations) == 3
+        asset_keys = set(
+            mat.event_specific_data.materialization.asset_key for mat in asset_materializations
+        )
+        assert asset_keys == set(
+            [
+                AssetKey(["xyz1", "abc1"]),
+                AssetKey(["xyz1", "abc2"]),
+                AssetKey(["abc", "xyz"]),
+            ]
+        )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_ops.py
@@ -5,8 +5,8 @@ from dagster_fivetran.resources import FIVETRAN_API_BASE, FIVETRAN_CONNECTOR_PAT
 
 from .utils import (
     DEFAULT_CONNECTOR_ID,
+    get_complex_sample_connector_schema_config,
     get_sample_connector_response,
-    get_sample_connector_schema_config,
     get_sample_sync_response,
     get_sample_update_response,
 )
@@ -43,7 +43,9 @@ def test_fivetran_sync_op():
         rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
         rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
         # connector schema
-        rsps.add(rsps.GET, f"{api_prefix}/schemas", json=get_sample_connector_schema_config())
+        rsps.add(
+            rsps.GET, f"{api_prefix}/schemas", json=get_complex_sample_connector_schema_config()
+        )
         # initial state
         rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
         # n polls before updating
@@ -55,7 +57,7 @@ def test_fivetran_sync_op():
         result = fivetran_sync_job.execute_in_process()
         assert result.output_for_node("fivetran_sync_op") == FivetranOutput(
             connector_details=get_sample_connector_response(data=final_data)["data"],
-            schema_config=get_sample_connector_schema_config()["data"],
+            schema_config=get_complex_sample_connector_schema_config()["data"],
         )
         asset_materializations = [
             event

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_resources.py
@@ -7,8 +7,8 @@ from dagster_fivetran import FivetranOutput, fivetran_resource
 
 from .utils import (
     DEFAULT_CONNECTOR_ID,
+    get_complex_sample_connector_schema_config,
     get_sample_connector_response,
-    get_sample_connector_schema_config,
     get_sample_sync_response,
     get_sample_update_response,
 )
@@ -159,7 +159,7 @@ def test_sync_and_poll(n_polls, succeed_at_end):
             rsps.add(
                 rsps.GET,
                 f"{ft_resource.api_base_url}{DEFAULT_CONNECTOR_ID}/schemas",
-                json=get_sample_connector_schema_config(),
+                json=get_complex_sample_connector_schema_config(),
             )
             rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
             rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
@@ -175,7 +175,7 @@ def test_sync_and_poll(n_polls, succeed_at_end):
     if succeed_at_end:
         assert _mock_interaction() == FivetranOutput(
             connector_details=get_sample_connector_response(data=final_data)["data"],
-            schema_config=get_sample_connector_schema_config()["data"],
+            schema_config=get_complex_sample_connector_schema_config()["data"],
         )
     else:
         with pytest.raises(Failure, match="failed!"):
@@ -198,7 +198,7 @@ def test_sync_and_poll_timeout():
             rsps.add(
                 rsps.GET,
                 f"{ft_resource.api_base_url}{DEFAULT_CONNECTOR_ID}/schemas",
-                json=get_sample_connector_schema_config(),
+                json=get_complex_sample_connector_schema_config(),
             )
             rsps.add(
                 rsps.GET,
@@ -241,7 +241,7 @@ def test_sync_and_poll_invalid(data, match):
             rsps.add(
                 rsps.GET,
                 f"{ft_resource.api_base_url}{DEFAULT_CONNECTOR_ID}/schemas",
-                json=get_sample_connector_schema_config(),
+                json=get_complex_sample_connector_schema_config(),
             )
             rsps.add(
                 rsps.GET,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
@@ -39,7 +39,30 @@ def get_sample_connector_response(**kwargs):
     )
 
 
-def get_sample_connector_schema_config():
+def get_sample_connector_schema_config(tables):
+    schemas = {schema_name for schema_name, table_name in tables}
+
+    return {
+        "code": "Success",
+        "data": {
+            "enable_new_by_default": False,
+            "schemas": {
+                schema: {
+                    "name_in_destination": schema,
+                    "enabled": True,
+                    "tables": {
+                        t: {"name_in_destination": t, "enabled": True}
+                        for s, t in tables
+                        if s == schema
+                    },
+                }
+                for schema in schemas
+            },
+        },
+    }
+
+
+def get_complex_sample_connector_schema_config():
 
     return {
         "code": "Success",


### PR DESCRIPTION
This adds a multi-asset factory for associating Fivetran syncs with assets. I found it kinda hard to explain exactly what this thing did in a docstring, but this was my best attempt.

The main struggle here is finding a good way for the user to express exactly what they expect the sync to do. While in previous iterations we just went with a list of table names, this is a bit more explicit, and has the user write out the exact asset_keys that they expect to be produced. I think this makes things slightly less magical, but also a bit less ergonomic. 