### PR TITLE
[dagit] Replace Buffer with TextEncoder

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -102,7 +102,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/mdx-js__react": "^1",
     "@types/moment-timezone": "^0.5.30",
-    "@types/node": "^12.12.6",
     "@types/qs": "^6.9.6",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",

--- a/js_modules/dagit/packages/core/src/runs/ComputeLogContent.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ComputeLogContent.tsx
@@ -10,6 +10,14 @@ const TRUNCATE_PREFIX = '\u001b[33m...logs truncated...\u001b[39m\n';
 const SCROLLER_LINK_TIMEOUT_MS = 3000;
 export const MAX_STREAMING_LOG_BYTES = 5242880; // 5 MB
 
+const shouldTruncate = (content: string | null | undefined) => {
+  if (!content) {
+    return false;
+  }
+  const encoder = new TextEncoder();
+  return encoder.encode(content).length >= MAX_STREAMING_LOG_BYTES;
+};
+
 export class ComputeLogContent extends React.Component<{
   logData?: ComputeLogContentFileFragment | null;
   downloadUrl?: string | null;
@@ -87,7 +95,7 @@ export class ComputeLogContent extends React.Component<{
   render() {
     const {logData, isLoading, isVisible, downloadUrl} = this.props;
     let content = logData?.data;
-    const isTruncated = content && Buffer.byteLength(content, 'utf8') >= MAX_STREAMING_LOG_BYTES;
+    const isTruncated = shouldTruncate(content);
 
     if (content && isTruncated) {
       const nextLine = content.indexOf('\n') + 1;

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5320,7 +5320,6 @@ __metadata:
     "@types/lru-cache": ^5.1.0
     "@types/mdx-js__react": ^1
     "@types/moment-timezone": ^0.5.30
-    "@types/node": ^12.12.6
     "@types/qs": ^6.9.6
     "@types/react": ^17.0.3
     "@types/react-dom": ^17.0.3
@@ -8975,7 +8974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^12.12.6, @types/node@npm:^12.7.1":
+"@types/node@npm:^12.7.1":
   version: 12.20.11
   resolution: "@types/node@npm:12.20.11"
   checksum: 27c14253e35dad92e9f5d955832625cb7f76b94c17d8d36f145b2a5641952790c74e521865055e30ee14474613197886082205fde54fa2f784754e6f4003f3d7


### PR DESCRIPTION
## Summary

We have a callsite in `dagit-core` to `Buffer.byteLength`. We don't have a `Buffer` polyfill in the new version of react-scripts.

- Use `TextEncoder` instead. https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
- Remove `@types/node` from the deps. Ideally this lets us avoid accidentally referencing any node libraries that we can't actually use.

## Test Plan

View a run, switch to raw compute logs. Verify rendering, no errors.
