### PR TITLE
Allow solid selection to use non-prefixed search if surrounded by ""

### DIFF
--- a/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
@@ -94,12 +94,14 @@ export function filterByQuery<T extends GraphQueryItem>(items: T[], query: strin
   const focus = new Set<T>();
 
   for (const clause of clauses) {
-    const parts = /(\*?\+*)([.\w\d\[\]_-]+)(\+*\*?)/.exec(clause.trim());
+    const parts = /(\*?\+*)([.\w\d\[\]\"_-]+)(\+*\*?)/.exec(clause.trim());
     if (!parts) {
       continue;
     }
     const [, parentsClause, itemName, descendentsClause] = parts;
-    const itemsMatching = items.filter((s) => s.name.includes(itemName));
+    const itemsMatching = items.filter((s) =>
+      /\".*\"/.test(itemName) ? s.name === itemName.replace(/\"/g, '') : s.name.includes(itemName),
+    );
 
     for (const item of itemsMatching) {
       const upDepth = expansionDepthForClause(parentsClause);

--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -387,7 +387,7 @@ const GanttChartInner = (props: GanttChartInnerProps) => {
           <GraphQueryInput
             items={props.graph}
             value={props.selection.query}
-            placeholder="Type a Step Subset"
+            placeholder="Type a step subset"
             onChange={props.onUpdateQuery}
             presets={metadata ? interestingQueriesFor(metadata, layout) : undefined}
             className={selection.keys.length > 0 ? 'has-step' : ''}

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
@@ -479,7 +479,7 @@ export const interestingQueriesFor = (metadata: IRunMetadataDict, layout: GanttC
         (metadata.steps[a]!.end! - metadata.steps[a]!.start!),
     )
     .slice(0, 5)
-    .map((k) => `${k}`)
+    .map((k) => `"${k}"`)
     .join(', ');
   if (slowStepsQuery) {
     results.push({name: 'Slowest Individual Steps', value: slowStepsQuery});

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -212,17 +212,19 @@ const RunWithData: React.FunctionComponent<RunWithDataProps> = ({
   const onClickStep = (stepKey: string, evt: React.MouseEvent<any>) => {
     const index = selectionStepKeys.indexOf(stepKey);
     let newSelected: string[];
-
+    const filterForExactStep = `"${stepKey}"`;
     if (evt.shiftKey) {
-      // shift-click to multi select steps
-      newSelected = [...selectionStepKeys];
+      // shift-click to multi select steps, preserving quotations if present
+      newSelected = [
+        ...selectionStepKeys.map((k) => (selectionQuery.includes(`"${k}"`) ? `"${k}"` : k)),
+      ];
 
       if (index !== -1) {
         // deselect the step if already selected
         newSelected.splice(index, 1);
       } else {
         // select the step otherwise
-        newSelected.push(stepKey);
+        newSelected.push(filterForExactStep);
       }
     } else {
       if (selectionStepKeys.length === 1 && index !== -1) {
@@ -230,7 +232,7 @@ const RunWithData: React.FunctionComponent<RunWithDataProps> = ({
         newSelected = [];
       } else {
         // select the step otherwise
-        newSelected = [stepKey];
+        newSelected = [filterForExactStep];
       }
     }
 

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -147,14 +147,10 @@ export const GraphQueryInput = React.memo(
 
     const onConfirmSuggestion = (suggestion: string) => {
       const preceding = lastClause ? pendingValue.substr(0, lastClause.index) : '';
-      setPendingValue(preceding + prefix + suggestion + suffix);
+      setPendingValue(preceding + prefix + `"${suggestion}"` + suffix);
     };
 
     React.useEffect(() => {
-      if (!active && suggestions.length) {
-        setActive({text: suggestions[0], idx: 0});
-        return;
-      }
       if (!active) {
         return;
       }
@@ -189,6 +185,7 @@ export const GraphQueryInput = React.memo(
         } else {
           e.currentTarget.blur();
         }
+        setActive(null);
       }
 
       // The up/down arrow keys shift selection in the dropdown.


### PR DESCRIPTION
Addresses #4219
## Summary
* Tweaked the filtering when clicking on a solid in the Gantt Charts so that a filter of "solidName" is provided, and then if "solidName" is in the filter string, use an === instead of an includes. 
* I also modded the selection behavior for the popover in the GraphQueryInput to match this; I believe selecting 'my_asset' there should only select 1 asset, not any which begin with that prefix.
* Removed the default selection state on the popover of GraphQueryInput because it is never unselectable. This meant typing 'myA' and pressing enter was submitting whatever the default selection was, not what was actually typed into the box.

Demo:
https://www.loom.com/share/738b944923d148b58eba526507c6075f

## Test Plan
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.