### PR TITLE
[airbyte] add requests dependency

### DIFF
--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -31,6 +31,9 @@ if __name__ == "__main__":
             "Operating System :: OS Independent",
         ],
         packages=find_packages(exclude=["test"]),
-        install_requires=[f"dagster{pin}"],
+        install_requires=[
+            f"dagster{pin}",
+            "requests",
+        ],
         zip_safe=False,
     )


### PR DESCRIPTION
## Summary

- adds dependency on `requests` to `daster-airbyte`
- found when packaging downstream on https://github.com/conda-forge/dagster-feedstock/pull/176 ([CI logs](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=444556&view=logs&j=4f922444-fdfe-5dcf-b824-02f86439ef14&t=b2a8456a-fb11-5506-ca32-5ccd32538dc0&l=3312))

## Test Plan

```
pip install dagster-airbyte
import dagster_airbyte
```

should not fail

## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.