### PR TITLE
[dagit] Asset graph and asset detail page tweaks + fixes

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationTable.tsx
@@ -100,7 +100,17 @@ const AssetMaterializationRow: React.FC<{
 
   return (
     <>
-      <HoverableRow onClick={() => setFocused?.(group)}>
+      <HoverableRow
+        onClick={(e) => {
+          // If you're interacting with something in the row, don't trigger a focus change.
+          // Since focus is stored in the URL bar this overwrites any link click navigation.
+          // We could alternatively e.preventDefault() on every link but it's easy to forget.
+          if (e.target instanceof HTMLAnchorElement) {
+            return;
+          }
+          setFocused?.(group);
+        }}
+      >
         {hasPartitions && (
           <td style={{whiteSpace: 'nowrap', ...focusCss}}>
             <Group direction="row" spacing={2}>

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializations.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   ButtonGroup,
   ColorsWIP,
-  IconWIP,
   NonIdealState,
   Spinner,
   Caption,
@@ -12,8 +11,6 @@ import {
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
 
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {METADATA_ENTRY_FRAGMENT} from '../runs/MetadataEntry';
@@ -175,26 +172,18 @@ export const AssetMaterializations: React.FC<Props> = ({
       <>
         <CurrentRunsBanner liveData={liveData} />
         <SidebarSection title="Materialization in Last Run">
-          <>
-            {latest ? (
-              <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
-                <LatestMaterializationMetadata latest={latest} />
-              </div>
-            ) : (
-              <Box
-                margin={{horizontal: 24, bottom: 24, top: 12}}
-                style={{color: ColorsWIP.Gray500, fontSize: '0.8rem'}}
-              >
-                No materializations found
-              </Box>
-            )}
-            <Box margin={{bottom: 12, horizontal: 12, top: 20}}>
-              <AssetCatalogLink to={`/instance/assets/${assetKey.path.join('/')}`}>
-                {'View All in Asset Catalog '}
-                <IconWIP name="open_in_new" color={ColorsWIP.Link} />
-              </AssetCatalogLink>
+          {latest ? (
+            <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
+              <LatestMaterializationMetadata latest={latest} />
+            </div>
+          ) : (
+            <Box
+              margin={{horizontal: 24, bottom: 24, top: 12}}
+              style={{color: ColorsWIP.Gray500, fontSize: '0.8rem'}}
+            >
+              No materializations found
             </Box>
-          </>
+          )}
         </SidebarSection>
         <SidebarSection title="Materialization Plots">
           <AssetMaterializationGraphs
@@ -537,12 +526,4 @@ const ASSET_MATERIALIZATIONS_QUERY = gql`
   }
   ${METADATA_ENTRY_FRAGMENT}
   ${ASSET_LINEAGE_FRAGMENT}
-`;
-
-const AssetCatalogLink = styled(Link)`
-  display: flex;
-  gap: 5px;
-  align-items: center;
-  justify-content: flex-end;
-  margin-top: -10px;
 `;

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -39,12 +39,12 @@ export const AssetNodeList: React.FC<{
           >
             {asset.jobs.length ? (
               <AssetNode
-                definition={{...asset, description: null}}
+                definition={asset}
+                inAssetCatalog
                 metadata={[]}
                 jobName={asset.jobs[0].name}
                 selected={false}
                 liveData={liveDataByNode[asset.id]}
-                secondaryHighlight={false}
                 repoAddress={repoAddress}
               />
             ) : (

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -285,6 +285,11 @@ export const OP_NODE_DEFINITION_FRAGMENT = gql`
   }
 `;
 
+export const NodeHighlightColors = {
+  Border: 'rgba(255, 69, 0, 1)',
+  Background: 'rgba(255, 69, 0, 0.2)',
+};
+
 const NodeContainer = styled.div<{
   $minified: boolean;
   $selected: boolean;
@@ -297,12 +302,12 @@ const NodeContainer = styled.div<{
   .highlight-box {
     border: ${(p) =>
       p.$selected
-        ? `2px dashed rgba(255, 69, 0, 1)`
+        ? `2px dashed ${NodeHighlightColors.Border}`
         : p.$secondaryHighlight
         ? `2px solid ${ColorsWIP.Blue500}55`
         : '2px solid transparent'};
     border-radius: 6px;
-    background: ${(p) => (p.$selected ? 'rgba(255, 69, 0, 0.2)' : 'transparent')};
+    background: ${(p) => (p.$selected ? NodeHighlightColors.Background : 'transparent')};
   }
   .node-box {
     border: 2px solid #dcd5ca;

--- a/js_modules/dagit/packages/core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelinePathUtils.tsx
@@ -24,7 +24,7 @@ export function explorerPathFromString(path: string): ExplorerPath {
   const root = rootAndOps[0];
   const opNames = rootAndOps.length === 1 ? [''] : rootAndOps.slice(1);
 
-  const match = /^([^:@~]+)@?([^:~]+)?~?(.*)$/.exec(root);
+  const match = /^([^@~]+)@?([^~]+)?~?(.*)$/.exec(root);
   const [, pipelineName, snapshotId, opsQuery] = [...(match || []), '', '', ''];
 
   return {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -414,6 +414,9 @@ const ASSETS_GRAPH_QUERY = gql`
           dependencyKeys {
             path
           }
+          dependedByKeys {
+            path
+          }
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -170,7 +170,7 @@ const AssetGraphExplorerWithData: React.FC<
   const selectedGraphNodes = selectedDefinitions.map(
     (def) => Object.values(graphData.nodes).find((node) => node.definition.opName === def.name)!,
   );
-  const focusedGraphNode = selectedGraphNodes[selectedGraphNodes.length - 1];
+  const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1];
 
   const onSelectNode = React.useCallback(
     async (e: React.MouseEvent<any>, assetKey: {path: string[]}, node: Node | null) => {
@@ -201,8 +201,8 @@ const AssetGraphExplorerWithData: React.FC<
       } else if (e.shiftKey || e.metaKey) {
         const existing = explorerPath.opNames[0].split(',');
         const added =
-          e.shiftKey && focusedGraphNode && node
-            ? opsInRange({graph: graphData, from: focusedGraphNode, to: node})
+          e.shiftKey && lastSelectedNode && node
+            ? opsInRange({graph: graphData, from: lastSelectedNode, to: node})
             : [clicked.opName];
 
         nextOpsNameSelection = (existing.includes(clicked.opName)
@@ -226,7 +226,7 @@ const AssetGraphExplorerWithData: React.FC<
       onChangeExplorerPath,
       findAssetInWorkspace,
       history,
-      focusedGraphNode,
+      lastSelectedNode,
       graphData,
     ],
   );
@@ -302,10 +302,9 @@ const AssetGraphExplorerWithData: React.FC<
                             handles.find((h) => h.handleID === graphNode.definition.opName)!.solid
                               .definition.metadata
                           }
-                          selected={focusedGraphNode === graphNode}
+                          selected={selectedGraphNodes.includes(graphNode)}
                           jobName={explorerPath.pipelineName}
                           repoAddress={repoAddress}
-                          secondaryHighlight={selectedGraphNodes.includes(graphNode)}
                         />
                       )}
                     </foreignObject>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -167,9 +167,11 @@ const AssetGraphExplorerWithData: React.FC<
   const findAssetInWorkspace = useFindAssetInWorkspace();
 
   const selectedDefinitions = selectedHandles.map((h) => h.solid.definition);
-  const selectedGraphNodes = selectedDefinitions.map(
-    (def) => Object.values(graphData.nodes).find((node) => node.definition.opName === def.name)!,
-  );
+  const selectedGraphNodes = selectedDefinitions
+    .map(
+      (def) => Object.values(graphData.nodes).find((node) => node.definition.opName === def.name)!,
+    )
+    .filter(Boolean);
   const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1];
 
   const onSelectNode = React.useCallback(

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -140,6 +140,7 @@ export const AssetNode: React.FC<{
                         selection: event.stepStats.stepKey,
                         logs: `step:${event.stepStats.stepKey}`,
                       })}`}
+                      onClick={(e) => e.stopPropagation()}
                       target="_blank"
                     >
                       {titleForRun({runId: runOrError.runId})}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -37,9 +37,9 @@ export const AssetNode: React.FC<{
   selected: boolean;
   jobName: string;
   repoAddress: RepoAddress;
-  secondaryHighlight: boolean;
+  inAssetCatalog?: boolean;
 }> = React.memo(
-  ({definition, metadata, selected, liveData, repoAddress, jobName, secondaryHighlight}) => {
+  ({definition, metadata, selected, liveData, repoAddress, jobName, inAssetCatalog}) => {
     const launch = useLaunchSingleAssetJob();
     const history = useHistory();
 
@@ -65,22 +65,26 @@ export const AssetNode: React.FC<{
                 </span>
               }
             />
-            <MenuItemWIP
-              icon="link"
-              onClick={(e) => {
-                e.stopPropagation();
-                history.push(`/instance/assets/${definition.assetKey.path.join('/')}`);
-              }}
-              text="View in Asset Catalog"
-            />
+            {!inAssetCatalog && (
+              <MenuItemWIP
+                icon="link"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  history.push(`/instance/assets/${definition.assetKey.path.join('/')}`);
+                }}
+                text="View in Asset Catalog"
+              />
+            )}
           </MenuWIP>
         }
       >
-        <AssetNodeContainer $selected={selected} $secondaryHighlight={secondaryHighlight}>
+        <AssetNodeContainer $selected={selected}>
           <AssetNodeBox>
             <Name>
-              <IconWIP name="asset" />
-              <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
+              <span style={{marginTop: 1}}>
+                <IconWIP name="asset" />
+              </span>
+              <div style={{overflow: 'hidden', textOverflow: 'ellipsis', marginTop: -1}}>
                 {displayNameForAssetKey(definition.assetKey)}
               </div>
               <div style={{flex: 1}} />
@@ -102,7 +106,7 @@ export const AssetNode: React.FC<{
                 </UpstreamNotice>
               )}
             </Name>
-            {definition.description && (
+            {definition.description && !inAssetCatalog && (
               <Description>
                 {markdownToPlaintext(definition.description).split('\n')[0]}
               </Description>
@@ -220,7 +224,6 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
           runId
           status
           pipelineName
-          mode
         }
       }
     }
@@ -254,7 +257,7 @@ export const getNodeDimensions = (def: {
 };
 
 const RunLinkTooltipStyle = JSON.stringify({
-  background: '#E1EAF0',
+  background: 'rgba(236,236,248,1)',
   padding: '4px 8px',
   marginLeft: -10,
   marginTop: -8,
@@ -264,13 +267,8 @@ const RunLinkTooltipStyle = JSON.stringify({
   borderRadius: 4,
 } as CSSProperties);
 
-const AssetNodeContainer = styled.div<{$selected: boolean; $secondaryHighlight: boolean}>`
-  outline: ${(p) =>
-    p.$selected
-      ? `2px dashed rgba(255, 69, 0, 1)`
-      : p.$secondaryHighlight
-      ? `2px dashed rgba(255, 69, 0, 0.5)`
-      : 'none'};
+const AssetNodeContainer = styled.div<{$selected: boolean}>`
+  outline: ${(p) => (p.$selected ? `2px dashed rgba(255, 69, 0, 1)` : 'none')};
   border-radius: 6px;
   outline-offset: -1px;
   padding: 4px;
@@ -278,7 +276,6 @@ const AssetNodeContainer = styled.div<{$selected: boolean; $secondaryHighlight: 
   margin-right: 4px;
   margin-left: 4px;
   margin-bottom: 2px;
-  position: absolute;
   background: ${(p) => (p.$selected ? 'rgba(255, 69, 0, 0.2)' : 'white')};
   inset: 0;
 `;
@@ -288,12 +285,15 @@ const AssetNodeBox = styled.div`
   background: ${ColorsWIP.White};
   border-radius: 5px;
   position: relative;
+  &:hover {
+    box-shadow: ${ColorsWIP.Blue200} inset 0px 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 2px 12px 0px;
+  }
 `;
 
 const Name = styled.div`
   display: flex;
   padding: 4px 6px;
-  align-items: center;
+  background: ${ColorsWIP.White};
   font-family: ${FontFamily.monospace};
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -9,15 +9,17 @@ import {
   Spinner,
   Tooltip,
   FontFamily,
+  MenuLink,
 } from '@dagster-io/ui';
 import {isEqual} from 'lodash';
 import qs from 'qs';
 import React, {CSSProperties} from 'react';
-import {Link, useHistory} from 'react-router-dom';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {displayNameForAssetKey} from '../../app/Util';
 import {LATEST_MATERIALIZATION_METADATA_FRAGMENT} from '../../assets/LastMaterializationMetadata';
+import {NodeHighlightColors} from '../../graph/OpNode';
 import {OpTags} from '../../graph/OpTags';
 import {METADATA_ENTRY_FRAGMENT} from '../../runs/MetadataEntry';
 import {titleForRun} from '../../runs/RunUtils';
@@ -41,7 +43,6 @@ export const AssetNode: React.FC<{
 }> = React.memo(
   ({definition, metadata, selected, liveData, repoAddress, jobName, inAssetCatalog}) => {
     const launch = useLaunchSingleAssetJob();
-    const history = useHistory();
 
     const {materializationEvent: event, runOrError} = liveData?.lastMaterialization || {};
     const kind = metadata.find((m) => m.key === 'kind')?.value;
@@ -66,12 +67,10 @@ export const AssetNode: React.FC<{
               }
             />
             {!inAssetCatalog && (
-              <MenuItemWIP
+              <MenuLink
                 icon="link"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  history.push(`/instance/assets/${definition.assetKey.path.join('/')}`);
-                }}
+                to={`/instance/assets/${definition.assetKey.path.join('/')}`}
+                onClick={(e) => e.stopPropagation()}
                 text="View in Asset Catalog"
               />
             )}
@@ -257,8 +256,14 @@ export const getNodeDimensions = (def: {
   return {width: Math.max(250, displayNameForAssetKey(def.assetKey).length * 9.5) + 25, height};
 };
 
+const BoxColors = {
+  Divider: 'rgba(219, 219, 244, 1)',
+  Description: 'rgba(245, 245, 250, 1)',
+  Stats: 'rgba(236, 236, 248, 1)',
+};
+
 const RunLinkTooltipStyle = JSON.stringify({
-  background: 'rgba(236,236,248,1)',
+  background: BoxColors.Stats,
   padding: '4px 8px',
   marginLeft: -10,
   marginTop: -8,
@@ -269,7 +274,7 @@ const RunLinkTooltipStyle = JSON.stringify({
 } as CSSProperties);
 
 const AssetNodeContainer = styled.div<{$selected: boolean}>`
-  outline: ${(p) => (p.$selected ? `2px dashed rgba(255, 69, 0, 1)` : 'none')};
+  outline: ${(p) => (p.$selected ? `2px dashed ${NodeHighlightColors.Border}` : 'none')};
   border-radius: 6px;
   outline-offset: -1px;
   padding: 4px;
@@ -277,7 +282,7 @@ const AssetNodeContainer = styled.div<{$selected: boolean}>`
   margin-right: 4px;
   margin-left: 4px;
   margin-bottom: 2px;
-  background: ${(p) => (p.$selected ? 'rgba(255, 69, 0, 0.2)' : 'white')};
+  background: ${(p) => (p.$selected ? NodeHighlightColors.Background : 'white')};
   inset: 0;
 `;
 
@@ -303,19 +308,19 @@ const Name = styled.div`
 `;
 
 const Description = styled.div`
-  background: rgba(245, 245, 250, 1);
+  background: ${BoxColors.Description};
   padding: 4px 8px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  border-top: 1px solid rgba(219, 219, 244, 1);
+  border-top: 1px solid ${BoxColors.Divider};
   font-size: 12px;
 `;
 
 const Stats = styled.div`
-  background: rgba(236, 236, 248, 1);
+  background: ${BoxColors.Stats};
   padding: 4px 8px;
-  border-top: 1px solid rgba(219, 219, 244, 1);
+  border-top: 1px solid ${BoxColors.Divider};
   font-size: 12px;
   line-height: 18px;
 `;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -112,28 +112,22 @@ export const AssetNode: React.FC<{
                 {runOrError?.__typename === 'Run' && (
                   <StatsRow>
                     <Link
-                      data-tooltip={`${runOrError.pipelineName}${
-                        runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
-                      }`}
+                      data-tooltip={runOrError.pipelineName}
                       data-tooltip-style={RunLinkTooltipStyle}
                       style={{overflow: 'hidden', textOverflow: 'ellipsis', paddingRight: 8}}
+                      target={inAssetCatalog ? '_blank' : undefined}
+                      onClick={(e) => e.stopPropagation()}
                       to={
                         repoAddress.name
                           ? workspacePath(
                               repoAddress.name,
                               repoAddress.location,
-                              `jobs/${runOrError.pipelineName}:${runOrError.mode}`,
+                              `jobs/${runOrError.pipelineName}`,
                             )
-                          : workspacePipelinePathGuessRepo(
-                              `${runOrError.pipelineName}:${runOrError.mode}`,
-                              true,
-                              '',
-                            )
+                          : workspacePipelinePathGuessRepo(runOrError.pipelineName, true, '')
                       }
                     >
-                      {`${runOrError.pipelineName}${
-                        runOrError.mode !== 'default' ? `:${runOrError.mode}` : ''
-                      }`}
+                      {runOrError.pipelineName}
                     </Link>
                     <Link
                       style={{fontFamily: FontFamily.monospace, fontSize: 14}}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetChoosePartitionsDialog.tsx
@@ -270,7 +270,7 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
           {launching
             ? 'Launching...'
             : selected.length !== 1
-            ? `Launch ${selected.length} Run Backfill`
+            ? `Launch ${selected.length}-Run Backfill`
             : `Launch 1 Run`}
         </ButtonWIP>
       </DialogFooter>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -24,7 +24,7 @@ export const LaunchAssetExecutionButton: React.FC<{
   if (!assets.every((a) => a.opName)) {
     disabledReason = 'One or more foreign assets are selected and cannot be refreshed.';
   }
-  const partitionDefinition = assets[0].partitionDefinition;
+  const partitionDefinition = assets[0]?.partitionDefinition;
   if (assets.some((a) => a.partitionDefinition !== partitionDefinition)) {
     disabledReason = 'Assets refreshed together must share a partition definition.';
   }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -1,5 +1,7 @@
-import {Box, ColorsWIP} from '@dagster-io/ui';
+import {Box, ColorsWIP, IconWIP} from '@dagster-io/ui';
 import React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
 
 import {displayNameForAssetKey} from '../../app/Util';
 import {AssetMaterializations} from '../../assets/AssetMaterializations';
@@ -24,14 +26,18 @@ export const SidebarAssetInfo: React.FC<{
 
   return (
     <>
-      <SidebarSection title="Definition">
+      <Box flex={{gap: 4, direction: 'column'}} margin={{left: 24, right: 12, vertical: 16}}>
+        <SidebarTitle style={{marginBottom: 0}}>
+          {displayNameForAssetKey(node.assetKey)}
+        </SidebarTitle>
+        <AssetCatalogLink to={`/instance/assets/${node.assetKey.path.join('/')}`}>
+          {'View in Asset Catalog '}
+          <IconWIP name="open_in_new" color={ColorsWIP.Link} />
+        </AssetCatalogLink>
+      </Box>
+
+      <SidebarSection title="Description">
         <Box padding={{vertical: 16, horizontal: 24}}>
-          <Box
-            flex={{gap: 8, justifyContent: 'space-between', alignItems: 'baseline'}}
-            margin={{bottom: 8}}
-          >
-            <SidebarTitle>{displayNameForAssetKey(node.assetKey)}</SidebarTitle>
-          </Box>
           <Description description={node.description || null} />
         </Box>
 
@@ -64,3 +70,12 @@ export const SidebarAssetInfo: React.FC<{
     </>
   );
 };
+
+const AssetCatalogLink = styled(Link)`
+  display: flex;
+  gap: 5px;
+  padding: 6px;
+  margin: -6px;
+  align-items: center;
+  white-space: nowrap;
+`;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/Utils.tsx
@@ -257,15 +257,20 @@ export const buildLiveData = (
 ) => {
   const data: LiveData = {};
 
-  for (const node of nodes) {
-    const lastMaterialization = node.assetMaterializations[0] || null;
+  for (const liveNode of nodes) {
+    const graphNode = graph.nodes[liveNode.id];
+    if (!graphNode) {
+      continue;
+    }
+
+    const lastMaterialization = liveNode.assetMaterializations[0] || null;
     const lastStepStart = lastMaterialization?.materializationEvent.stepStats?.startTime || 0;
-    const isForeignNode = !node.opName;
-    const isPartitioned = graph.nodes[node.id].definition.partitionDefinition;
+    const isForeignNode = !liveNode.opName;
+    const isPartitioned = graphNode.definition.partitionDefinition;
 
-    const runs = inProgressRunsByStep.find((r) => r.stepKey === node.opName);
+    const runs = inProgressRunsByStep.find((r) => r.stepKey === liveNode.opName);
 
-    data[node.id] = {
+    data[liveNode.id] = {
       lastStepStart,
       lastMaterialization,
       inProgressRunIds: runs?.inProgressRuns.map((r) => r.id) || [],
@@ -282,8 +287,8 @@ export const buildLiveData = (
     };
   }
 
-  for (const asset of nodes) {
-    data[asset.id].computeStatus = findComputeStatusForId(data, graph.upstream, asset.id);
+  for (const liveNodeId of Object.keys(data)) {
+    data[liveNodeId].computeStatus = findComputeStatusForId(data, graph.upstream, liveNodeId);
   }
 
   return data;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphQuery.ts
@@ -23,6 +23,11 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencyK
   path: string[];
 }
 
+export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedByKeys {
+  __typename: "AssetKey";
+  path: string[];
+}
+
 export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes {
   __typename: "AssetNode";
   id: string;
@@ -31,6 +36,7 @@ export interface AssetGraphQuery_pipelineOrError_Pipeline_assetNodes {
   partitionDefinition: string | null;
   assetKey: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_assetKey;
   dependencyKeys: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependencyKeys[];
+  dependedByKeys: AssetGraphQuery_pipelineOrError_Pipeline_assetNodes_dependedByKeys[];
 }
 
 export interface AssetGraphQuery_pipelineOrError_Pipeline {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -130,7 +130,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             for dep in self._external_asset_node.dependencies
         ]
 
-    def resolve_dependencyByKeys(self, _graphene_info):
+    def resolve_dependedByKeys(self, _graphene_info):
         return [
             GrapheneAssetKey(path=dep.downstream_asset_key.path)
             for dep in self._external_asset_node.depended_by


### PR DESCRIPTION
This PR addresses a bunch of feedback that was logged here during user sessions and testing: https://elementl.quip.com/8FAwArOtjsmR/SDA-UI

## Summary

- Fetch `dependedByKeys` to show placeholders for downstream assets that are in other asset jobs
   - Fix a python spelling error preventing dependedByKeys from resolving
   - I broke this earlier because I was testing with foreign assets and not other-job-assets, and both are rendered the same in the asset graph UI. We might consider styling them differently to make it clear that there are two cases.
-  Move `View All in Asset Catalog` to the top of the right sidebar. It didn't totally make sense in the materializations section
-  Fixes a crash when selected graph nodes are removed from view using the bottom filter input in the Asset Graph
- `Launch 185 Run Backfill` => `Launch 185-Run Backfill`
- Fixes several issues with clickability of links inside asset nodes and materialization table rows
- Flattens primary / secondary highlight styles into one in the asset graph
- Fixes visual issues in the graph with multi-line asset names + highlight box being too small in that case
- Removes pipeline mode from several AssetNode links, which is no longer parsed and landed the user on an invalid view

Misc:
- Made buildLiveData a bit more resilient to the two objects being misaligned / not fully updated. In practice this shouldn't be necessary but when Apollo was behaving incorrectly earlier it immediately broke the entire UI so we may as well fix it.

![image](https://user-images.githubusercontent.com/1037212/150470014-341f533e-d644-4d20-b4b6-a3137974394f.png)


## Test Plan
- Tested manually for now

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.