### PR TITLE
[dagster-io/ui] Turn on noUncheckedIndexedAccess in TS

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Icon.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Icon.stories.tsx
@@ -37,15 +37,24 @@ export const Size24 = () => {
 };
 
 export const IconColors = () => {
+  const colorKeys = Object.keys(ColorsWIP);
+  const numColors = colorKeys.length;
+  const colorAtIndex = (index: number) => {
+    const colorKey = colorKeys[index % numColors];
+    if (colorKey) {
+      const colorAtKey = ColorsWIP[colorKey];
+      if (colorAtKey) {
+        return colorAtKey;
+      }
+    }
+    return ColorsWIP.Gray100;
+  };
+
   return (
     <Box flex={{gap: 6, wrap: 'wrap'}}>
       {IconNames.map((name, idx) => (
         <Tooltip content={name} key={name}>
-          <Icon
-            name={name}
-            color={ColorsWIP[Object.keys(ColorsWIP)[idx % Object.keys(ColorsWIP).length]]}
-            size={24}
-          />
+          <Icon name={name} color={colorAtIndex(idx)} size={24} />
         </Tooltip>
       ))}
     </Box>

--- a/js_modules/dagit/packages/ui/src/components/Slider.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Slider.stories.tsx
@@ -38,7 +38,8 @@ export const Sizes = () => {
           <span style={{whiteSpace: 'nowrap'}}>Value: {value.toFixed(1)}</span>
         )}
         onChange={(values: number[]) => {
-          setValue(values[0]);
+          const [first] = values;
+          first && setValue(first);
         }}
       >
         <MultiSlider.Handle value={value} type="full" intentAfter={Intent.PRIMARY} />
@@ -53,8 +54,11 @@ export const Sizes = () => {
           <span style={{whiteSpace: 'nowrap'}}>Value: {value.toFixed(1)}</span>
         )}
         onChange={(values: number[]) => {
-          setMinValue(Math.min(values[0], values[1]));
-          setValue(Math.max(values[0], values[1]));
+          const [first, second] = values;
+          if (typeof first === 'number' && typeof second === 'number') {
+            setMinValue(Math.min(first, second));
+            setValue(Math.max(first, second));
+          }
         }}
       >
         <MultiSlider.Handle value={minValue} type="full" intentAfter={Intent.PRIMARY} />

--- a/js_modules/dagit/packages/ui/src/components/useSuggestionsForString.tsx
+++ b/js_modules/dagit/packages/ui/src/components/useSuggestionsForString.tsx
@@ -5,7 +5,7 @@ export const useSuggestionsForString = (
   value: string,
 ) => {
   const tokens = value.toLocaleLowerCase().trim().split(/\s+/);
-  const queryString = tokens.length ? tokens[tokens.length - 1] : '';
+  const queryString = tokens[tokens.length - 1] || '';
 
   const suggestions = React.useMemo(() => buildSuggestions(queryString), [
     buildSuggestions,

--- a/js_modules/dagit/packages/ui/tsconfig.json
+++ b/js_modules/dagit/packages/ui/tsconfig.json
@@ -17,6 +17,7 @@
       "noImplicitAny": true,
       "strictNullChecks": true,
       "suppressImplicitAnyIndexErrors": true,
+      "noUncheckedIndexedAccess": true,
       "allowSyntheticDefaultImports": true,
       "types": [
         "jest",


### PR DESCRIPTION
## Summary

Add some strictness to array index referencing in `@dagster-io/ui`. Right now we don't do anything to ensure that we're getting defined values from array access, which opens us up to runtime errors. TS has an optional flag to make this stricter, so I'm enabling it in the UI library. We can expand to the rest of the TS codebase if this seems reasonable.

## Test Plan

Lint, ts, jest. View these components in dagit and storybook, verify that everything still works.
