### PR TITLE
docs: hide api commands from cli output

### DIFF
--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -27,7 +27,7 @@ from dagster.utils.interrupts import capture_interrupts
 from dagster.utils.log import configure_loggers
 
 
-@click.group(name="api")
+@click.group(name="api", hidden=True)
 def api_cli():
     """
     [INTERNAL] These commands are intended to support internal use cases. Users should generally


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
`dagster api` and its subcommands are internal facing. Hide it when displaying the CLI help text.


## Test Plan
eyes
