### PR TITLE
[dagster-io/ui] Clean up TokenizingField.test

### DIFF
--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -46,6 +46,7 @@
     "@testing-library/dom": "^8.11.1",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^13.5.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
     "@types/eslint": "^8",

--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.test.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.test.tsx
@@ -1,122 +1,89 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import {unmountComponentAtNode} from 'react-dom';
-import {act} from 'react-dom/test-utils';
 
 import {TokenizingField} from './TokenizingField';
 
-// https://github.com/jsdom/jsdom/issues/317
-(global as any).document.createRange = () => ({
-  setStart: () => {},
-  setEnd: () => {},
-  commonAncestorContainer: {
-    nodeName: 'BODY',
-    ownerDocument: document,
-  },
-});
-
-// https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js
-const setValue = (node: HTMLInputElement, value: string) => {
-  Object.getOwnPropertyDescriptor((node as any).__proto__, 'value')!.set!.call(node, value);
-  node.dispatchEvent(new Event('change', {bubbles: true}));
-};
-
-const suggestions = [
-  {
-    token: 'pipeline',
-    values: () => ['airline_demo_ingest', 'airline_demo_warehouse', 'composition'],
-  },
-  {
-    token: 'status',
-    values: () => ['QUEUED', 'NOT_STARTED', 'STARTED', 'SUCCESS', 'FAILURE', 'MANAGED'],
-  },
-];
-
-let container: HTMLElement;
-
-beforeEach(() => {
-  // setup a DOM element as a render target
-  container = document.createElement('div');
-  // container *must* be attached to document so events work correctly.
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  // cleanup on exiting
-  unmountComponentAtNode(container);
-  container.remove();
-});
-
-function expectOptions(expected: string[]) {
-  const actual = Array.from(document.documentElement.querySelectorAll('.bp3-menu-item')).map(
-    (el) => el.textContent,
-  );
-
-  expect(actual).toEqual(expected);
-}
-
-// These tests render into a real DOM node so we can test interactions
-
-it('shows available autocompletion options when clicked', () => {
+describe('TokenizingField', () => {
   const onChange = jest.fn();
-  ReactDOM.render(
-    <TokenizingField values={[]} onChange={onChange} suggestionProviders={suggestions} />,
-    container,
-  );
-  act(() => {
-    container.querySelector('input')!.focus();
+  const suggestions = [
+    {
+      token: 'pipeline',
+      values: () => ['airline_demo_ingest', 'airline_demo_warehouse', 'composition'],
+    },
+    {
+      token: 'status',
+      values: () => ['QUEUED', 'NOT_STARTED', 'STARTED', 'SUCCESS', 'FAILURE', 'MANAGED'],
+    },
+  ];
+
+  const expectOptions = (expected: string[]) => {
+    const items = screen.getAllByRole('listitem');
+    const actual = items.map((item) => item.textContent);
+    expect(actual).toEqual(expected);
+  };
+
+  it('shows available autocompletion options when clicked', async () => {
+    render(<TokenizingField values={[]} onChange={onChange} suggestionProviders={suggestions} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeVisible();
+    userEvent.click(input);
+
+    await waitFor(() => {
+      expectOptions(['pipeline:', 'status:']);
+    });
   });
 
-  expectOptions(['pipeline:', 'status:']);
-});
+  it('filters properly when typing `pipeline` prefix', async () => {
+    render(<TokenizingField values={[]} onChange={onChange} suggestionProviders={suggestions} />);
 
-it('filters properly when typing `pipeline` prefix', () => {
-  const onChange = jest.fn();
-  ReactDOM.render(
-    <TokenizingField values={[]} onChange={onChange} suggestionProviders={suggestions} />,
-    container,
-  );
-  const inputEl = container.querySelector('input')!;
-  act(() => {
-    inputEl.focus();
-    setValue(inputEl, 'pipeli');
-  });
-  expectOptions([
-    'pipeline:',
-    'pipeline:airline_demo_ingest',
-    'pipeline:airline_demo_warehouse',
-    'pipeline:composition',
-  ]);
-  act(() => {
-    setValue(inputEl, 'pipeline');
-  });
-  expectOptions([
-    'pipeline:',
-    'pipeline:airline_demo_ingest',
-    'pipeline:airline_demo_warehouse',
-    'pipeline:composition',
-  ]);
-  act(() => {
-    setValue(inputEl, 'pipeline:');
-  });
-  expectOptions([
-    'pipeline:airline_demo_ingest',
-    'pipeline:airline_demo_warehouse',
-    'pipeline:composition',
-  ]);
-});
+    const input = screen.getByRole('textbox');
+    userEvent.click(input);
+    userEvent.type(input, 'pipeli');
 
-it('filters properly when typing a value without the preceding token', () => {
-  const onChange = jest.fn();
-  ReactDOM.render(
-    <TokenizingField values={[]} onChange={onChange} suggestionProviders={suggestions} />,
-    container,
-  );
-  const inputEl = container.querySelector('input')!;
-  act(() => {
-    inputEl.focus();
-    setValue(inputEl, 'airline');
-    inputEl.dispatchEvent(new Event('change', {bubbles: true}));
+    await waitFor(() => {
+      expectOptions([
+        'pipeline:',
+        'pipeline:airline_demo_ingest',
+        'pipeline:airline_demo_warehouse',
+        'pipeline:composition',
+      ]);
+    });
+
+    userEvent.clear(input);
+    userEvent.type(input, 'pipeline');
+
+    await waitFor(() => {
+      expectOptions([
+        'pipeline:',
+        'pipeline:airline_demo_ingest',
+        'pipeline:airline_demo_warehouse',
+        'pipeline:composition',
+      ]);
+    });
+
+    userEvent.clear(input);
+    userEvent.type(input, 'pipeline:');
+
+    await waitFor(() => {
+      expectOptions([
+        'pipeline:airline_demo_ingest',
+        'pipeline:airline_demo_warehouse',
+        'pipeline:composition',
+      ]);
+    });
   });
-  expectOptions(['pipeline:airline_demo_ingest', 'pipeline:airline_demo_warehouse']);
+
+  it('filters properly when typing a value without the preceding token', async () => {
+    render(<TokenizingField values={[]} onChange={onChange} suggestionProviders={suggestions} />);
+
+    const input = screen.getByRole('textbox');
+    userEvent.click(input);
+    userEvent.type(input, 'airline');
+
+    await waitFor(() => {
+      expectOptions(['pipeline:airline_demo_ingest', 'pipeline:airline_demo_warehouse']);
+    });
+  });
 });

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -5525,6 +5525,7 @@ __metadata:
     "@testing-library/dom": ^8.11.1
     "@testing-library/jest-dom": ^5.16.1
     "@testing-library/react": ^12.1.2
+    "@testing-library/user-event": ^13.5.0
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7
     "@types/eslint": ^8


### PR DESCRIPTION
## Summary

Clean up TokenizingField.test, using newer tools and libs. This eliminates the annoying `act` warnings.

## Test Plan

Run jest. No more `act` warnings!
