### PR TITLE
[context logging 1/n] Log user events via context

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -816,3 +816,6 @@ class HookExecutionResult(
             hook_name=check.str_param(hook_name, "hook_name"),
             is_skipped=cast(bool, check.opt_bool_param(is_skipped, "is_skipped", default=False)),
         )
+
+
+UserEvent = Union[Materialization, AssetMaterialization, AssetObservation, ExpectationResult]

--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -495,6 +495,10 @@ class DagsterEvent(
         return self.event_type == DagsterEventType.ASSET_MATERIALIZATION
 
     @property
+    def is_expectation_result(self) -> bool:
+        return self.event_type == DagsterEventType.STEP_EXPECTATION_RESULT
+
+    @property
     def is_asset_observation(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_OBSERVATION
 

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -266,9 +266,10 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         Args:
             event (Union[AssetMaterialization, Materialization, AssetObservation, ExpectationResult]): The event to log.
 
-        Examples:
+        **Examples:**
 
         .. code-block:: python
+
             from dagster import op, AssetMaterialization
 
             @op

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -8,6 +8,7 @@ from dagster.core.definitions.events import (
     AssetObservation,
     ExpectationResult,
     Materialization,
+    UserEvent,
 )
 from dagster.core.definitions.mode import ModeDefinition
 from dagster.core.definitions.pipeline_definition import PipelineDefinition
@@ -252,7 +253,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         while self._events:
             yield self._events.pop(0)
 
-    def log_event(self, event) -> None:
+    def log_event(self, event: UserEvent) -> None:
         if isinstance(event, (AssetMaterialization, Materialization)):
             self._events.append(
                 DagsterEvent.asset_materialization(

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -249,7 +249,11 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
     def has_events(self) -> bool:
         return bool(self._events)
 
-    def retrieve_events(self) -> Iterator[DagsterEvent]:
+    def consume_events(self) -> Iterator[DagsterEvent]:
+        """Yields all user-generated events that have been recorded from this context since the last consumption event.
+
+        Designed for internal use. Users should never need to invoke this method.
+        """
         events = self._events
         self._events = []
         yield from events

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -250,8 +250,9 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         return bool(self._events)
 
     def retrieve_events(self) -> Iterator[DagsterEvent]:
-        while self._events:
-            yield self._events.pop(0)
+        events = self._events
+        self._events = []
+        yield from events
 
     def log_event(self, event: UserEvent) -> None:
         """Log an AssetMaterialization, AssetObservation, or ExpectationResult from within the body of an op.

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -258,7 +258,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         self._events = []
         yield from events
 
-    def report_event(self, event: UserEvent) -> None:
+    def log_event(self, event: UserEvent) -> None:
         """Log an AssetMaterialization, AssetObservation, or ExpectationResult from within the body of an op.
 
         Events logged with this method will appear in the list of DagsterEvents, as well as the event log.
@@ -273,7 +273,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
 
             @op
             def log_materialization(context):
-                context.report_event(AssetMaterialization("foo"))
+                context.log_event(AssetMaterialization("foo"))
         """
 
         if isinstance(event, (AssetMaterialization, Materialization)):

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -258,7 +258,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         self._events = []
         yield from events
 
-    def log_event(self, event: UserEvent) -> None:
+    def report_event(self, event: UserEvent) -> None:
         """Log an AssetMaterialization, AssetObservation, or ExpectationResult from within the body of an op.
 
         Events logged with this method will appear in the list of DagsterEvents, as well as the event log.
@@ -273,7 +273,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
 
             @op
             def log_materialization(context):
-                context.log_event(AssetMaterialization("foo"))
+                context.report_event(AssetMaterialization("foo"))
         """
 
         if isinstance(event, (AssetMaterialization, Materialization)):

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -250,9 +250,9 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         return bool(self._events)
 
     def consume_events(self) -> Iterator[DagsterEvent]:
-        """Yields all user-generated events that have been recorded from this context since the last consumption event.
+        """Pops and yields all user-generated events that have been recorded from this context.
 
-        Designed for internal use. Users should never need to invoke this method.
+        If consume_events has not yet been called, this will yield all logged events since the beginning of the op's computation. If consume_events has been called, it will yield all events since the last time consume_events was called. Designed for internal use. Users should never need to invoke this method.
         """
         events = self._events
         self._events = []

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -250,12 +250,16 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
 
     def retrieve_events(self) -> Iterator[DagsterEvent]:
         while self._events:
-            yield self._events.pop()
+            yield self._events.pop(0)
 
     def log_event(self, event) -> None:
         if isinstance(event, (AssetMaterialization, Materialization)):
             self._events.append(
-                DagsterEvent.asset_materialization(self._step_execution_context, event)
+                DagsterEvent.asset_materialization(
+                    self._step_execution_context,
+                    event,
+                    self._step_execution_context.get_input_lineage(),
+                )
             )
         elif isinstance(event, AssetObservation):
             self._events.append(DagsterEvent.asset_observation(self._step_execution_context, event))

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -254,6 +254,23 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
             yield self._events.pop(0)
 
     def log_event(self, event: UserEvent) -> None:
+        """Log an AssetMaterialization, AssetObservation, or ExpectationResult from within the body of an op.
+
+        Events logged with this method will appear in the list of DagsterEvents, as well as the event log.
+
+        Args:
+            event (Union[AssetMaterialization, Materialization, AssetObservation, ExpectationResult]): The event to log.
+
+        Examples:
+
+        .. code-block:: python
+            from dagster import op, AssetMaterialization
+
+            @op
+            def log_materialization(context):
+                context.log_event(AssetMaterialization("foo"))
+        """
+
         if isinstance(event, (AssetMaterialization, Materialization)):
             self._events.append(
                 DagsterEvent.asset_materialization(

--- a/python_modules/dagster/dagster/core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute.py
@@ -146,11 +146,11 @@ def _yield_compute_results(
         user_event_generator,
     ):
         if context.has_events():
-            yield from context.retrieve_events()
+            yield from context.consume_events()
         yield _validate_event(event, step_context)
 
     if context.has_events():
-        yield from context.retrieve_events()
+        yield from context.consume_events()
 
 
 def execute_core_compute(

--- a/python_modules/dagster/dagster/core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute.py
@@ -14,6 +14,7 @@ from dagster.core.definitions import (
     Output,
 )
 from dagster.core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
+from dagster.core.events import DagsterEvent
 from dagster.core.execution.context.compute import SolidExecutionContext
 from dagster.core.execution.context.system import StepExecutionContext
 from dagster.core.system_config.objects import ResolvedRunConfig
@@ -29,6 +30,7 @@ SolidOutputUnion = Union[
     Materialization,
     ExpectationResult,
     AssetObservation,
+    DagsterEvent,
 ]
 
 
@@ -72,6 +74,7 @@ def _validate_event(event: Any, step_context: StepExecutionContext) -> SolidOutp
             Materialization,
             ExpectationResult,
             AssetObservation,
+            DagsterEvent,
         ),
     ):
         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -64,7 +64,12 @@ async def _coerce_async_solid_to_async_gen(awaitable, context, output_defs):
 def _coerce_solid_compute_fn_to_iterator(fn, output_defs, context, context_arg_provided, kwargs):
     result = fn(context, **kwargs) if context_arg_provided else fn(**kwargs)
     for event in _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
+        if context.has_events():
+            yield from context.retrieve_events()
         yield event
+
+    if context.has_events():
+        yield from context.retrieve_events()
 
 
 def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -64,12 +64,7 @@ async def _coerce_async_solid_to_async_gen(awaitable, context, output_defs):
 def _coerce_solid_compute_fn_to_iterator(fn, output_defs, context, context_arg_provided, kwargs):
     result = fn(context, **kwargs) if context_arg_provided else fn(**kwargs)
     for event in _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
-        if context.has_events():
-            yield from context.retrieve_events()
         yield event
-
-    if context.has_events():
-        yield from context.retrieve_events()
 
 
 def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -325,8 +325,9 @@ def core_dagster_event_sequence_for_step(
         for user_event in check.generator(
             _step_output_error_checked_user_event_sequence(step_context, user_event_sequence)
         ):
-
-            if isinstance(user_event, (Output, DynamicOutput)):
+            if isinstance(user_event, DagsterEvent):
+                yield user_event
+            elif isinstance(user_event, (Output, DynamicOutput)):
                 for evt in _type_check_and_store_output(step_context, user_event, input_lineage):
                     yield evt
             # for now, I'm ignoring AssetMaterializations yielded manually, but we might want

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -277,6 +277,11 @@ def core_dagster_event_sequence_for_step(
     inputs = {}
 
     for step_input in step_context.step.step_inputs:
+        input_def = step_input.source.get_input_def(step_context.pipeline_def)
+        dagster_type = input_def.dagster_type
+
+        if dagster_type.kind == DagsterTypeKind.NOTHING:
+            continue
         for event_or_input_value in ensure_gen(step_input.source.load_input_object(step_context)):
             if isinstance(event_or_input_value, DagsterEvent):
                 yield event_or_input_value

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -498,11 +498,11 @@ def test_error_message_mixed_ops_and_solids():
 def test_log_events():
     @op
     def basic_op(context):
-        context.log_event(AssetMaterialization("first"))
-        context.log_event(Materialization("second"))
-        context.log_event(AssetMaterialization("third"))
-        context.log_event(ExpectationResult(success=True))
-        context.log_event(AssetObservation("fourth"))
+        context.report_event(AssetMaterialization("first"))
+        context.report_event(Materialization("second"))
+        context.report_event(AssetMaterialization("third"))
+        context.report_event(ExpectationResult(success=True))
+        context.report_event(AssetObservation("fourth"))
 
     with instance_for_test() as instance:
         result = execute_op_in_graph(basic_op, instance=instance)
@@ -554,10 +554,10 @@ def test_log_events():
 def test_yield_event_ordering():
     @op
     def yielding_op(context):
-        context.log_event(AssetMaterialization("first"))
+        context.report_event(AssetMaterialization("first"))
         time.sleep(1)
         context.log.debug("A log")
-        context.log_event(AssetMaterialization("second"))
+        context.report_event(AssetMaterialization("second"))
         yield AssetMaterialization("third")
         yield Output("foo")
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -498,11 +498,11 @@ def test_error_message_mixed_ops_and_solids():
 def test_log_events():
     @op
     def basic_op(context):
-        context.report_event(AssetMaterialization("first"))
-        context.report_event(Materialization("second"))
-        context.report_event(AssetMaterialization("third"))
-        context.report_event(ExpectationResult(success=True))
-        context.report_event(AssetObservation("fourth"))
+        context.log_event(AssetMaterialization("first"))
+        context.log_event(Materialization("second"))
+        context.log_event(AssetMaterialization("third"))
+        context.log_event(ExpectationResult(success=True))
+        context.log_event(AssetObservation("fourth"))
 
     with instance_for_test() as instance:
         result = execute_op_in_graph(basic_op, instance=instance)
@@ -554,10 +554,10 @@ def test_log_events():
 def test_yield_event_ordering():
     @op
     def yielding_op(context):
-        context.report_event(AssetMaterialization("first"))
+        context.log_event(AssetMaterialization("first"))
         time.sleep(1)
         context.log.debug("A log")
-        context.report_event(AssetMaterialization("second"))
+        context.log_event(AssetMaterialization("second"))
         yield AssetMaterialization("third")
         yield Output("foo")
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -2,6 +2,7 @@ from typing import Dict, Generator, Tuple
 
 import pytest
 from dagster import (
+    AssetMaterialization,
     DagsterInvalidConfigError,
     DagsterInvariantViolationError,
     DagsterType,
@@ -487,3 +488,13 @@ def test_error_message_mixed_ops_and_solids():
         "{'config': {'foo': '...'}}}}}",
     ):
         nested_job.execute_in_process()
+
+
+def test_log_materialization():
+    @op
+    def basic_op(context):
+        context.log_event(AssetMaterialization("first"))
+
+    result = execute_op_in_graph(basic_op)
+    asset_materialization = result.asset_materializations_for_node("basic_op")[0]
+    assert asset_materialization.label == "first"

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -1,13 +1,17 @@
+import time
 from typing import Dict, Generator, Tuple
 
 import pytest
 from dagster import (
     AssetMaterialization,
+    AssetObservation,
     DagsterInvalidConfigError,
     DagsterInvariantViolationError,
     DagsterType,
     DagsterTypeCheckDidNotPass,
+    ExpectationResult,
     In,
+    Materialization,
     Nothing,
     Out,
     Output,
@@ -18,15 +22,16 @@ from dagster import (
     solid,
 )
 from dagster.core.definitions.op_definition import OpDefinition
+from dagster.core.test_utils import instance_for_test
 from dagster.core.types.dagster_type import Int, String
 
 
-def execute_op_in_graph(an_op):
+def execute_op_in_graph(an_op, instance=None):
     @graph
     def my_graph():
         an_op()
 
-    result = my_graph.execute_in_process()
+    result = my_graph.execute_in_process(instance=instance)
     return result
 
 
@@ -490,11 +495,101 @@ def test_error_message_mixed_ops_and_solids():
         nested_job.execute_in_process()
 
 
-def test_log_materialization():
+def test_log_events():
     @op
     def basic_op(context):
         context.log_event(AssetMaterialization("first"))
+        context.log_event(Materialization("second"))
+        context.log_event(AssetMaterialization("third"))
+        context.log_event(ExpectationResult(success=True))
+        context.log_event(AssetObservation("fourth"))
 
-    result = execute_op_in_graph(basic_op)
-    asset_materialization = result.asset_materializations_for_node("basic_op")[0]
-    assert asset_materialization.label == "first"
+    with instance_for_test() as instance:
+        result = execute_op_in_graph(basic_op, instance=instance)
+        asset_materialization_keys = [
+            materialization.label
+            for materialization in result.asset_materializations_for_node("basic_op")
+        ]
+
+        assert asset_materialization_keys == ["first", "second", "third"]
+
+        relevant_events_from_execution = [
+            event
+            for event in result.all_node_events
+            if event.is_asset_observation
+            or event.is_step_materialization
+            or event.is_expectation_result
+        ]
+
+        relevant_events_from_event_log = [
+            event_log.dagster_event
+            for event_log in instance.all_logs(result.run_id)
+            if event_log.dagster_event is not None
+            and (
+                event_log.dagster_event.is_asset_observation
+                or event_log.dagster_event.is_step_materialization
+                or event_log.dagster_event.is_expectation_result
+            )
+        ]
+
+        def _assertions_from_event_list(events):
+            assert events[0].is_step_materialization
+            assert events[0].event_specific_data.materialization.label == "first"
+
+            assert events[1].is_step_materialization
+            assert events[1].event_specific_data.materialization.label == "second"
+
+            assert events[2].is_step_materialization
+            assert events[2].event_specific_data.materialization.label == "third"
+
+            assert events[3].is_expectation_result
+
+            assert events[4].is_asset_observation
+
+        _assertions_from_event_list(relevant_events_from_execution)
+
+        _assertions_from_event_list(relevant_events_from_event_log)
+
+
+def test_yield_event_ordering():
+    @op
+    def yielding_op(context):
+        context.log_event(AssetMaterialization("first"))
+        time.sleep(1)
+        context.log_event(AssetMaterialization("second"))
+        yield AssetMaterialization("third")
+        yield Output("foo")
+
+    with instance_for_test() as instance:
+        result = execute_op_in_graph(yielding_op, instance=instance)
+
+        assert result.success
+
+        asset_materialization_keys = [
+            materialization.label
+            for materialization in result.asset_materializations_for_node("yielding_op")
+        ]
+
+        assert asset_materialization_keys == ["first", "second", "third"]
+
+        relevant_event_logs = [
+            event_log
+            for event_log in instance.all_logs(result.run_id)
+            if event_log.dagster_event is not None
+            and (
+                event_log.dagster_event.is_asset_observation
+                or event_log.dagster_event.is_step_materialization
+                or event_log.dagster_event.is_expectation_result
+            )
+        ]
+
+        first = relevant_event_logs[0]
+        assert first.dagster_event.event_specific_data.materialization.label == "first"
+
+        second = relevant_event_logs[1]
+        assert second.dagster_event.event_specific_data.materialization.label == "second"
+
+        third = relevant_event_logs[2]
+        assert third.dagster_event.event_specific_data.materialization.label == "third"
+
+        assert second.timestamp - first.timestamp >= 1


### PR DESCRIPTION
https://github.com/dagster-io/dagster/issues/6394
Proposed API: 
log events like so
```python
@op
def my_op(context):
    context.log_event(AssetMaterialization(...))
```

**Things to do**
- [x] Basic implementation
- [x] Input lineage information
- [x] expand test cases

**Considerations**
- The current approach maintains ordering in both the event log and among yielded user events. 

**Problems**
- We now go through step inputs list twice for each step. This is an artifact from the chosen API, and could be changed.