### PR TITLE
Add build_resources to the top level API, add documentation on usage

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -476,7 +476,7 @@ def the_db_connection(init_context):
 @sensor(job=the_job)
 def uses_db_connection():
     with build_resources(
-        {"db_connection": the_db_connection, "credentials": credentials}
+        {"db_connection": the_db_connection, "credentials": the_credentials}
     ) as resources:
         conn = resources.db_connection
         ...

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -454,3 +454,32 @@ def my_s3_sensor(context):
     for s3_key in new_s3_keys:
         yield RunRequest(run_key=s3_key, run_config={})
 ```
+
+### Using resources in sensors
+
+If you want to use resources within your sensor, you can use the <PyObject object="build_resources"/> API to perform the initialization.
+
+```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_build_resources_example endbefore=end_build_resources_example
+from dagster import resource, build_resources, sensor
+
+
+@resource
+def the_credentials():
+    ...
+
+
+@resource(required_resource_keys={"credentials"})
+def the_db_connection(init_context):
+    get_the_db_connection(init_context.resources.credentials)
+
+
+@sensor(job=the_job)
+def uses_db_connection():
+    with build_resources(
+        {"db_connection": the_db_connection, "credentials": credentials}
+    ) as resources:
+        conn = resources.db_connection
+        ...
+```
+
+If a resource you want to initialize has dependencies on other resources, those can be included in the dictionary passed to <PyObject object="build_resources"/>.

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -482,4 +482,4 @@ def uses_db_connection():
         ...
 ```
 
-If a resource you want to initialize has dependencies on other resources, those can be included in the dictionary passed to <PyObject object="build_resources"/>.
+If a resource you want to initialize has dependencies on other resources, those can be included in the dictionary passed to <PyObject object="build_resources"/>. For more in-depth usage, check out the [Initializing Resources Outside of Execution](/concepts/resources#initializing-resources-outside-of-execution) section.

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -15,7 +15,7 @@ Resources provide a way to manage dependencies to external components and share 
 | <PyObject object="ResourceDefinition" />         | Class for resource definitions. You almost never want to use initialize this class directly. Instead, you should use the <PyObject object="resource" decorator /> which returns a <PyObject object="ResourceDefinition" />. |
 | <PyObject object="InitResourceContext"/>         | The context object provided to a resource during initialization. This object contains required resource, config, and other run information.                                                                                 |
 | <PyObject object="build_init_resource_context"/> | Function for building an <PyObject object="InitResourceContext"/> outside of execution, intended to be used when testing a resource.                                                                                        |
-| <PyObject object="build_resources"/> | Function for initializing a set of resources outside of the context of a job's execution.                                                                                        |
+| <PyObject object="build_resources"/>             | Function for initializing a set of resources outside of the context of a job's execution.                                                                                                                                   |
 
 ## Overview
 
@@ -195,9 +195,28 @@ def test_cm_resource():
 
 ## Initializing Resources Outside of Execution
 
-There are scenarios where you might want to reuse the code written within your resources outside of the context of execution. Consider that I have a resource `db_connection`, and I want to use that resource within my sensor. I can use the `build_resources` API to initialize this resource outside of execution.
+There are scenarios where you might want to reuse the code written within your resources outside of the context of execution. Consider that I have a resource `db_connection`, and I want to use that resource outside of the context of an execution. I can use the <PyObject object="build_resources"/> API to initialize this resource outside of execution.
 
 ```python file=/concepts/resources/resources.py startafter=start_build_resources_example endbefore=end_build_resources_example
+from dagster import resource, build_resources
+
+
+@resource
+def the_credentials():
+    ...
+
+
+@resource(required_resource_keys={"credentials"})
+def the_db_connection(init_context):
+    get_the_db_connection(init_context.resources.credentials)
+
+
+def uses_db_connection():
+    with build_resources(
+        {"db_connection": the_db_connection, "credentials": credentials}
+    ) as resources:
+        conn = resources.db_connection
+        ...
 ```
 
 ## Resource to Resource Dependencies

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -195,7 +195,7 @@ def test_cm_resource():
 
 ## Initializing Resources Outside of Execution
 
-There are scenarios where you might want to reuse the code written within your resources outside of the context of execution. Consider that I have a resource `db_connection`, and I want to use that resource outside of the context of an execution. I can use the <PyObject object="build_resources"/> API to initialize this resource outside of execution.
+There are scenarios where you might want to reuse the code written within your resources outside of the context of execution. Consider a case where you have a resource `db_connection`, and you want to use that resource outside of the context of an execution. You can use the <PyObject object="build_resources"/> API to initialize this resource outside of execution.
 
 ```python file=/concepts/resources/resources.py startafter=start_build_resources_example endbefore=end_build_resources_example
 from dagster import resource, build_resources

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -15,6 +15,7 @@ Resources provide a way to manage dependencies to external components and share 
 | <PyObject object="ResourceDefinition" />         | Class for resource definitions. You almost never want to use initialize this class directly. Instead, you should use the <PyObject object="resource" decorator /> which returns a <PyObject object="ResourceDefinition" />. |
 | <PyObject object="InitResourceContext"/>         | The context object provided to a resource during initialization. This object contains required resource, config, and other run information.                                                                                 |
 | <PyObject object="build_init_resource_context"/> | Function for building an <PyObject object="InitResourceContext"/> outside of execution, intended to be used when testing a resource.                                                                                        |
+| <PyObject object="build_resources"/> | Function for initializing a set of resources outside of the context of a job's execution.                                                                                        |
 
 ## Overview
 
@@ -190,6 +191,13 @@ def my_cm_resource(_):
 def test_cm_resource():
     with my_cm_resource(None) as initialized_resource:
         assert initialized_resource == "foo"
+```
+
+## Initializing Resources Outside of Execution
+
+There are scenarios where you might want to reuse the code written within your resources outside of the context of execution. Consider that I have a resource `db_connection`, and I want to use that resource within my sensor. I can use the `build_resources` API to initialize this resource outside of execution.
+
+```python file=/concepts/resources/resources.py startafter=start_build_resources_example endbefore=end_build_resources_example
 ```
 
 ## Resource to Resource Dependencies

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -213,7 +213,7 @@ def the_db_connection(init_context):
 
 def uses_db_connection():
     with build_resources(
-        {"db_connection": the_db_connection, "credentials": credentials}
+        {"db_connection": the_db_connection, "credentials": the_credentials}
     ) as resources:
         conn = resources.db_connection
         ...

--- a/docs/sphinx/sections/api/apidocs/resources.rst
+++ b/docs/sphinx/sections/api/apidocs/resources.rst
@@ -15,4 +15,6 @@ Resources
 
 .. autofunction:: build_init_resource_context
 
+.. autofunction:: build_resources
+
 .. currentmodule:: dagster

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -247,10 +247,11 @@ def the_job():
     ...
 
 
-def get_the_db_connection(creds):
+def get_the_db_connection(_):
     ...
 
 
+# pylint: disable=unused-variable,reimported
 # start_build_resources_example
 from dagster import resource, build_resources, sensor
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -242,6 +242,41 @@ def my_s3_sensor(context):
 # end_s3_sensors_marker
 
 
+@job
+def the_job():
+    ...
+
+
+def get_the_db_connection(creds):
+    ...
+
+
+# start_build_resources_example
+from dagster import resource, build_resources, sensor
+
+
+@resource
+def the_credentials():
+    ...
+
+
+@resource(required_resource_keys={"credentials"})
+def the_db_connection(init_context):
+    get_the_db_connection(init_context.resources.credentials)
+
+
+@sensor(job=the_job)
+def uses_db_connection():
+    with build_resources(
+        {"db_connection": the_db_connection, "credentials": the_credentials}
+    ) as resources:
+        conn = resources.db_connection
+        ...
+
+
+# end_build_resources_example
+
+
 @repository
 def my_repository():
     return [my_job, log_file_job, my_directory_sensor, sensor_A, sensor_B]

--- a/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
@@ -1,7 +1,7 @@
 """isort:skip_file"""
 # pylint: disable=unused-argument
 # pylint: disable=reimported
-from dagster import ResourceDefinition, graph
+from dagster import ResourceDefinition, graph, job
 
 
 # start_resource_example
@@ -203,3 +203,38 @@ def use_db_connection(context):
 
 
 # end_cm_resource_op
+
+
+@job
+def the_job():
+    ...
+
+
+def get_the_db_connection(creds):
+    ...
+
+
+# start_build_resources_example
+from dagster import resource, build_resources, sensor
+
+
+@resource
+def the_credentials():
+    ...
+
+
+@resource(required_resource_keys={"credentials"})
+def the_db_connection(init_context):
+    get_the_db_connection(init_context.resources.credentials)
+
+
+@sensor(job=the_job)
+def uses_db_connection():
+    with build_resources(
+        {"db_connection": the_db_connection, "credentials": credentials}
+    ) as resources:
+        conn = resources.db_connection
+        ...
+
+
+# end_build_resources_example

--- a/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
@@ -215,7 +215,7 @@ def get_the_db_connection(creds):
 
 
 # start_build_resources_example
-from dagster import resource, build_resources, sensor
+from dagster import resource, build_resources
 
 
 @resource
@@ -228,10 +228,9 @@ def the_db_connection(init_context):
     get_the_db_connection(init_context.resources.credentials)
 
 
-@sensor(job=the_job)
 def uses_db_connection():
     with build_resources(
-        {"db_connection": the_db_connection, "credentials": credentials}
+        {"db_connection": the_db_connection, "credentials": the_credentials}
     ) as resources:
         conn = resources.db_connection
         ...

--- a/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/resources.py
@@ -210,10 +210,11 @@ def the_job():
     ...
 
 
-def get_the_db_connection(creds):
+def get_the_db_connection(_):
     ...
 
 
+# pylint: disable=unused-variable,reimported
 # start_build_resources_example
 from dagster import resource, build_resources
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
@@ -14,6 +14,7 @@ from docs_snippets.concepts.partitions_schedules_sensors.sensors.sensors import 
     sensor_B,
     test_my_directory_sensor_cursor,
     test_sensor,
+    uses_db_connection,
 )
 
 
@@ -71,3 +72,7 @@ def test_run_failure_sensor_def():
 def test_sensor_testing_example():
     test_sensor()
     test_my_directory_sensor_cursor()
+
+
+def test_resource_sensor_example():
+    uses_db_connection()

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_resources.py
@@ -12,6 +12,7 @@ from docs_snippets.concepts.resources.resources import (
     test_my_resource,
     test_my_resource_with_context,
     use_db_connection,
+    uses_db_connection,
 )
 
 
@@ -57,3 +58,7 @@ def test_cm_resource_example():
 def test_cm_resource_op():
     with build_op_context(resources={"db_connection": db_connection}) as context:
         use_db_connection(context)
+
+
+def test_build_resources_example():
+    uses_db_connection()

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -338,6 +338,7 @@ __all__ = [
     "OpExecutionContext",
     "PipelineExecutionResult",
     "RetryRequested",
+    "build_resources",
     "SolidExecutionResult",
     "SolidExecutionContext",
     "build_solid_context",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -162,6 +162,7 @@ from dagster.core.execution.api import (
     reexecute_pipeline,
     reexecute_pipeline_iterator,
 )
+from dagster.core.execution.build_resources import build_resources
 from dagster.core.execution.context.compute import OpExecutionContext, SolidExecutionContext
 from dagster.core.execution.context.hook import HookContext, build_hook_context
 from dagster.core.execution.context.init import InitResourceContext, build_init_resource_context

--- a/python_modules/dagster/dagster/core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/core/execution/build_resources.py
@@ -78,9 +78,9 @@ def build_resources(
         def the_resource():
             return "foo"
 
-        with build_resources(resources={"from_def": the_resource, "from_val": "foo"}) as resources:
+        with build_resources(resources={"from_def": the_resource, "from_val": "bar"}) as resources:
             assert resources.from_def == "foo"
-            assert resources.from_val == "foo"
+            assert resources.from_val == "bar"
 
     """
 

--- a/python_modules/dagster/dagster/core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/core/execution/build_resources.py
@@ -67,6 +67,19 @@ def build_resources(
             teardown, this must be provided, or initialization will fail.
         log_manager (Optional[DagsterLogManager]): Log Manager to use during resource
             initialization. Defaults to system log manager.
+
+    Examples:
+        .. code-block:: python
+            from dagster import resource, build_resources
+
+            @resource
+            def the_resource():
+                return "foo"
+
+            with build_resources(resources={"from_def": the_resource, "from_val": "foo"}) as resources:
+                assert resources.from_def == "foo"
+                assert resources.from_val == "foo"
+
     """
 
     resources = check.dict_param(resources, "resource_defs", key_type=str)

--- a/python_modules/dagster/dagster/core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/core/execution/build_resources.py
@@ -69,16 +69,18 @@ def build_resources(
             initialization. Defaults to system log manager.
 
     Examples:
-        .. code-block:: python
-            from dagster import resource, build_resources
 
-            @resource
-            def the_resource():
-                return "foo"
+    .. code-block:: python
 
-            with build_resources(resources={"from_def": the_resource, "from_val": "foo"}) as resources:
-                assert resources.from_def == "foo"
-                assert resources.from_val == "foo"
+        from dagster import resource, build_resources
+
+        @resource
+        def the_resource():
+            return "foo"
+
+        with build_resources(resources={"from_def": the_resource, "from_val": "foo"}) as resources:
+            assert resources.from_def == "foo"
+            assert resources.from_val == "foo"
 
     """
 


### PR DESCRIPTION
One of the [top issues](https://github.com/dagster-io/dagster/issues/3794) on our github is allowing resources to be usable within sensors. `build_resources` provides a way to do this, albeit in a hacky way. Since we don't have a better solution right now, though, we should bring `build_resources` to the top-level API and document the solution.

Not sure if it's worth linking back to the sensors docs page.

The downside to this approach is that Dagster doesn't track the initialization in a first class way, meaning that errors may not surface as nicely as they could. It also makes testability difficult, because you are using a fixed set of resources. However, this can be circumvented with a factory pattern that ingests a set of resources and constructs a sensor using that set.