### PR TITLE
[software-defined-assets] Enable inter-asset dependencies

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -6,11 +6,11 @@ from typing import (
     Dict,
     NamedTuple,
     Optional,
+    Sequence,
     Set,
     Type,
     TypeVar,
     Union,
-    Sequence,
 )
 
 from dagster import check

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -76,9 +76,9 @@ class OutputDefinition:
         asset_key=None,
         asset_partitions=None,
         asset_partitions_def=None,
-        # make sure new parameters are updated in combine_with_inferred below
         in_deps=None,
         out_deps=None,
+        # make sure new parameters are updated in combine_with_inferred below
     ):
         from dagster.core.definitions.partition import PartitionsDefinition
 
@@ -129,11 +129,11 @@ class OutputDefinition:
         )
 
     @property
-    def in_deps(self) -> Sequence[str]:
+    def in_deps(self) -> Optional[Sequence[str]]:
         return self._in_deps
 
     @property
-    def out_deps(self) -> Sequence[str]:
+    def out_deps(self) -> Optional[Sequence[str]]:
         return self._out_deps
 
     @property

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -10,6 +10,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    Sequence,
 )
 
 from dagster import check
@@ -74,8 +75,10 @@ class OutputDefinition:
         metadata=None,
         asset_key=None,
         asset_partitions=None,
-        asset_partitions_def=None
+        asset_partitions_def=None,
         # make sure new parameters are updated in combine_with_inferred below
+        in_deps=None,
+        out_deps=None,
     ):
         from dagster.core.definitions.partition import PartitionsDefinition
 
@@ -92,6 +95,8 @@ class OutputDefinition:
             io_manager_key, "io_manager_key", default="io_manager"
         )
         self._metadata = metadata
+        self._in_deps = in_deps
+        self._out_deps = out_deps
 
         if asset_key:
             experimental_arg_warning("asset_key", "OutputDefinition.__init__")
@@ -122,6 +127,14 @@ class OutputDefinition:
         self._asset_partitions_def = check.opt_inst_param(
             asset_partitions_def, "asset_partition_def", PartitionsDefinition
         )
+
+    @property
+    def in_deps(self) -> Sequence[str]:
+        return self._in_deps
+
+    @property
+    def out_deps(self) -> Sequence[str]:
+        return self._out_deps
 
     @property
     def name(self):
@@ -240,6 +253,8 @@ class OutputDefinition:
             asset_key=self._asset_key,
             asset_partitions=self._asset_partitions_fn,
             asset_partitions_def=self._asset_partitions_def,
+            in_deps=self._in_deps,
+            out_deps=self._out_deps,
         )
 
 
@@ -334,6 +349,8 @@ class Out(
             ("asset_key", Optional[Union[AssetKey, Callable[..., AssetKey]]]),
             ("asset_partitions", Optional[Union[Set[str], Callable[..., Set[str]]]]),
             ("asset_partitions_def", Optional["PartitionsDefinition"]),
+            ("in_deps", Optional[Sequence[str]]),
+            ("out_deps", Optional[Sequence[str]]),
         ],
     )
 ):
@@ -378,6 +395,8 @@ class Out(
         asset_partitions=None,
         asset_partitions_def=None,
         # make sure new parameters are updated in combine_with_inferred below
+        in_deps=None,
+        out_deps=None,
     ):
         if asset_partitions_def:
             experimental_arg_warning("assets_definition", "Out.__new__")
@@ -391,6 +410,8 @@ class Out(
             asset_key=asset_key,
             asset_partitions=asset_partitions,
             asset_partitions_def=asset_partitions_def,
+            in_deps=in_deps,
+            out_deps=out_deps,
         )
 
     @staticmethod
@@ -404,6 +425,8 @@ class Out(
             asset_key=output_def._asset_key,  # pylint: disable=protected-access
             asset_partitions=output_def._asset_partitions_fn,  # pylint: disable=protected-access
             asset_partitions_def=output_def._asset_partitions_def,  # pylint: disable=protected-access
+            in_deps=output_def.in_deps,
+            out_deps=output_def.out_deps,
         )
 
     def to_definition(self, annotation_type: type, name: Optional[str]) -> "OutputDefinition":
@@ -421,6 +444,8 @@ class Out(
             asset_key=self.asset_key,
             asset_partitions=self.asset_partitions,
             asset_partitions_def=self.asset_partitions_def,
+            in_deps=self.in_deps,
+            out_deps=self.out_deps,
         )
 
 

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -587,7 +587,7 @@ def external_asset_graph_from_defs(
             node_upstream_asset_keys = set(
                 filter(None, (id.hardcoded_asset_key for id in node_def.input_defs))
             )
-            all_upstream_asset_keys.union(node_upstream_asset_keys)
+            all_upstream_asset_keys.update(node_upstream_asset_keys)
 
             for output_def in node_def.output_defs:
                 asset_key = output_def.hardcoded_asset_key

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -589,8 +589,6 @@ def external_asset_graph_from_defs(
             )
             all_upstream_asset_keys.union(node_upstream_asset_keys)
 
-            node_asset_keys = set(filter(lambda od: od.hardcoded_asset_key, node_def.output_defs))
-
             for output_def in node_def.output_defs:
                 asset_key = output_def.hardcoded_asset_key
                 if asset_key is None:

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -63,6 +63,21 @@ def test_multi_asset_infer_from_empty_asset_key():
     assert my_asset.asset_keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
 
 
+def test_multi_asset_no_lambdas():
+
+    with pytest.raises(check.CheckError, match="must be a constant or None"):
+
+        @multi_asset(
+            outs={
+                "my_out_name": Out(asset_key=lambda context: AssetKey("123")),
+                "my_other_out_name": Out(),
+            }
+        )
+        def _my_asset():
+            yield Output(1, "my_out_name")
+            yield Output(2, "my_other_out_name")
+
+
 def test_asset_with_dagster_type():
     @asset(dagster_type=String)
     def my_asset(arg1):

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -385,108 +385,12 @@ def test_inter_op_dependency():
     ]
 
 
-"""
-from collections import defaultdict
-def external_asset_graph_from_defs(pipelines, foreign_assets_by_key):
-    node_defs_by_asset_key = defaultdict(list)
-
-    deps = defaultdict(dict)
-    dep_by = defaultdict(list)
-    all_upstream_asset_keys = set()
-
-    for pipeline in pipelines:
-        for node_def in pipeline.all_node_defs:
-            node_asset_keys = set()
-            for output_def in node_def.output_defs:
-                asset_key = output_def.hardcoded_asset_key
-
-                if asset_key:
-                    node_asset_keys.add(asset_key)
-                    node_defs_by_asset_key[asset_key].append((node_def, pipeline))
-
-            for input_def in node_def.input_defs:
-                upstream_asset_key = input_def.hardcoded_asset_key
-
-                if upstream_asset_key:
-                    all_upstream_asset_keys.add(upstream_asset_key)
-                    for node_asset_key in node_asset_keys:
-                        deps[node_asset_key][input_def.name] = ExternalAssetDependency(
-                            upstream_asset_key=upstream_asset_key,
-                            input_name=input_def.name,
-                        )
-                        dep_by[upstream_asset_key].append(
-                            ExternalAssetDependedBy(
-                                downstream_asset_key=node_asset_key,
-                                input_name=input_def.name,
-                            )
-                        )
-
-    asset_keys_without_definitions = all_upstream_asset_keys.difference(
-        node_defs_by_asset_key.keys()
-    ).difference(foreign_assets_by_key.keys())
-
-    asset_nodes = [
-        ExternalAssetNode(
-            asset_key=asset_key,
-            dependencies=list(deps[asset_key].values()),
-            depended_by=dep_by[asset_key],
-            job_names=[],
-        )
-        for asset_key in asset_keys_without_definitions
-    ]
-
-    for foreign_asset in foreign_assets_by_key.values():
-        if foreign_asset.key in node_defs_by_asset_key:
-            raise DagsterInvariantViolationError(
-                f"Asset with key {foreign_asset.key.to_string()} is defined both as a foreign asset"
-                " and as a non-foreign asset"
-            )
-
-        asset_nodes.append(
-            ExternalAssetNode(
-                asset_key=foreign_asset.key,
-                dependencies=list(deps[foreign_asset.key].values()),
-                depended_by=dep_by[foreign_asset.key],
-                job_names=[],
-                op_description=foreign_asset.description,
-            )
-        )
-
-    for asset_key, node_tuple_list in node_defs_by_asset_key.items():
-        node_def = node_tuple_list[0][0]
-        job_names = [node_tuple[1].name for node_tuple in node_tuple_list]
-
-        # temporary workaround to retrieve asset partition definition from job
-        output = node_def.output_dict.get("result", None)
-        partitions_def_data = None
-
-        if output and output._asset_partitions_def:  # pylint: disable=protected-access
-            partitions_def = output._asset_partitions_def  # pylint: disable=protected-access
-            if partitions_def:
-                pass
-
-        asset_nodes.append(
-            ExternalAssetNode(
-                asset_key=asset_key,
-                dependencies=list(deps[asset_key].values()),
-                depended_by=dep_by[asset_key],
-                op_name=node_def.name,
-                op_description=node_def.description,
-                job_names=job_names,
-                partitions_def_data=partitions_def_data,
-            )
-        )
-
-    return asset_nodes
-    """
-
-
 def test_source_not_foreign_asset():
 
     foo = ForeignAsset(key=AssetKey("foo"), description=None)
 
     @asset
-    def bar(foo):
+    def bar(foo):  # pylint: disable=unused-argument
         pass
 
     assets_job = build_assets_job("assets_job", [bar], source_assets=[foo])


### PR DESCRIPTION
This diff makes it possible to have a multi_asset in which some of the assets inside the multi_asset depend on other assets inside the same multi_asset.

To go along with this change, we also add in extra information to the ExternalAssetNode object, specifically the description of each output. While this isn't strictly necessary for the change, this is useful because otherwise the only description we can source for a given asset comes from the Op itself (which may have a one to many relationship with assets).