### PR TITLE
Docs - Fix typo in op factory example

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/ops.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/ops.mdx
@@ -162,7 +162,7 @@ def x_op(
 ):
     """
     Args:
-        args (any): One or more arguments used to generate the nwe op
+        args (any): One or more arguments used to generate the new op
         name (str): The name of the new op.
         ins (Dict[str, In]): Any Ins for the new op. Default: None.
 


### PR DESCRIPTION
## Summary

One-line PR to fix a typo in the Op factory example
