### PR TITLE
split out stdout lines in pyspark step launcher to avoid gigantic stdout log

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import sys
 import tempfile
 import time
 
@@ -379,7 +380,13 @@ class EmrPySparkStepLauncher(StepLauncher):
                 )
             else:
                 log.debug(f"Spark Driver stderr: {record.message}")
-        log.info("Spark Driver stdout: " + stdout_log)
+
+        sys.stdout.write(
+            "---------- Spark Driver stdout: ----------\n"
+            + stdout_log
+            + "\n"
+            + "---------- End of Spark Driver stdout ----------\n"
+        )
 
     def _get_emr_step_def(self, run_id, step_key, solid_name):
         """From the local Dagster instance, construct EMR steps that will kick off execution on a


### PR DESCRIPTION
Summary:
In some cases this stdout call can be megabytes in size. Split the output into individual lines to give us some breathing room. Inspired by the corresponding stderr path in parse_hadoop_log4j_records.

I am a little unclear on how to test this in a way that actually exercises the path in question though, as I don't have experience spinning up an EMR cluster. I'm going off of an error report that linked this callsite to a 413 error about a gigantic log line getting written.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.