### PR TITLE
[dagit] SDA improvements for multi-asset ops, multi-component asset paths

### DIFF
--- a/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagit/packages/core/src/app/GraphQueryImpl.ts
@@ -56,7 +56,10 @@ class GraphTraverser<T extends GraphQueryItem> {
   fetchUpstream(item: T, depth: number) {
     const step: TraverseStepFunction<T> = (item, callback) =>
       item.inputs.forEach((input) =>
-        input.dependsOn.forEach((d) => callback(this.itemNamed(d.solid.name)!)),
+        input.dependsOn.forEach((d) => {
+          const item = this.itemNamed(d.solid.name);
+          item && callback(item);
+        }),
       );
 
     return this.traverse(item, step, depth);
@@ -65,7 +68,10 @@ class GraphTraverser<T extends GraphQueryItem> {
   fetchDownstream(item: T, depth: number) {
     const step: TraverseStepFunction<T> = (item, callback) =>
       item.outputs.forEach((output) =>
-        output.dependedBy.forEach((d) => callback(this.itemNamed(d.solid.name)!)),
+        output.dependedBy.forEach((d) => {
+          const item = this.itemNamed(d.solid.name);
+          item && callback(item);
+        }),
       );
 
     return this.traverse(item, step, depth);
@@ -94,7 +100,7 @@ export function filterByQuery<T extends GraphQueryItem>(items: T[], query: strin
   const focus = new Set<T>();
 
   for (const clause of clauses) {
-    const parts = /(\*?\+*)([.\w\d\[\]\"_-]+)(\+*\*?)/.exec(clause.trim());
+    const parts = /(\*?\+*)([.\w\d>\[\]\"_-]+)(\+*\*?)/.exec(clause.trim());
     if (!parts) {
       continue;
     }

--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -20,6 +20,10 @@ export const formatElapsedTime = (msec: number) => {
   return `${hours}:${twoDigit(min)}:${twoDigit(sec)}`;
 };
 
+export function tokenForAssetKey(key: {path: string[]}) {
+  return key.path.join('>');
+}
+
 export function displayNameForAssetKey(key: {path: string[]}) {
   return key.path.join(' > ');
 }

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -51,7 +51,6 @@ export const PipelineExplorerContainer: React.FC<{
     explodeComposites: false,
   });
 
-  const selectedName = explorerPath.opNames[explorerPath.opNames.length - 1];
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
   const {flagAssetGraph} = useFeatureFlags();
@@ -81,28 +80,6 @@ export const PipelineExplorerContainer: React.FC<{
           ? explodeCompositesInHandleGraph(result.solidHandles)
           : result.solidHandles;
 
-        const selectedHandles = displayedHandles.filter((h) =>
-          selectedName.split(',').includes(h.solid.name),
-        );
-
-        // Run a few assertions on the state of the world and redirect the user
-        // back to safety if they've landed in an invalid place. Note that we can
-        // pop one layer at a time and this renders recursively until we reach a
-        // valid parent.
-        const invalidSelection = selectedName && !selectedHandles;
-        const invalidParent =
-          parentHandle && parentHandle.solid.definition.__typename !== 'CompositeSolidDefinition';
-
-        if (invalidSelection || invalidParent) {
-          onChangeExplorerPath(
-            {
-              ...explorerPath,
-              opNames: explorerPath.opNames.slice(0, explorerPath.opNames.length - 1),
-            },
-            'replace',
-          );
-        }
-
         const isAssetJob = pipelineOrError.__typename === 'Pipeline' && pipelineOrError.isAssetJob;
 
         if (flagAssetGraph && isAssetJob) {
@@ -123,7 +100,6 @@ export const PipelineExplorerContainer: React.FC<{
               handles={displayedHandles}
               explorerPath={explorerPath}
               onChangeExplorerPath={onChangeExplorerPath}
-              selectedHandles={selectedHandles}
             />
           );
         }
@@ -137,7 +113,6 @@ export const PipelineExplorerContainer: React.FC<{
             repoAddress={repoAddress}
             handles={displayedHandles}
             parentHandle={parentHandle ? parentHandle : undefined}
-            selectedHandle={selectedHandles[0]}
             isGraph={isGraph}
             getInvocations={(definitionName) =>
               displayedHandles

--- a/js_modules/dagit/packages/core/src/search/useAssetSearch.test.tsx
+++ b/js_modules/dagit/packages/core/src/search/useAssetSearch.test.tsx
@@ -64,7 +64,7 @@ describe('useAssetSearch', () => {
     await waitFor(() => {
       // Two matches, `foo`, and Gettysburg.
       expect(screen.queryByText(/Results \(2\)/)).toBeVisible();
-      expect(screen.queryByText(/Item: foo \u203a bar/)).toBeVisible();
+      expect(screen.queryByText(/Item: foo > bar/)).toBeVisible();
     });
   });
 
@@ -85,7 +85,7 @@ describe('useAssetSearch', () => {
     await waitFor(() => {
       // No matches.
       expect(screen.queryByText(/Results \(0\)/)).toBeVisible();
-      expect(screen.queryByText(/Item: foo \u203a bar/)).toBeNull();
+      expect(screen.queryByText(/Item: foo > bar/)).toBeNull();
     });
   });
 
@@ -106,7 +106,7 @@ describe('useAssetSearch', () => {
     await waitFor(() => {
       // Gettysburg is our only match.
       expect(screen.queryByText(/Results \(1\)/)).toBeVisible();
-      expect(screen.queryByText(`Item: ${GETTYSBURG.split(' ').join(' \u203a ')}`)).toBeVisible();
+      expect(screen.queryByText(`Item: ${GETTYSBURG.split(' ').join(' > ')}`)).toBeVisible();
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -3,6 +3,7 @@ import Fuse from 'fuse.js';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
+import {displayNameForAssetKey} from '../app/Util';
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 import {workspacePath} from '../workspace/workspacePath';
 
@@ -112,12 +113,10 @@ const secondaryDataToSearchResults = (data?: SearchSecondaryQuery) => {
   }
 
   const {nodes} = data.assetsOrError;
-  const allEntries = nodes.map((node) => {
-    const {key} = node;
-    const path = key.path.join(' › ');
+  const allEntries = nodes.map(({key}) => {
     return {
-      key: path,
-      label: path,
+      key: displayNameForAssetKey(key),
+      label: displayNameForAssetKey(key),
       segments: key.path,
       description: 'Asset',
       href: `/instance/assets/${key.path.map(encodeURIComponent).join('/')}`,

--- a/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
@@ -66,11 +66,9 @@ const GraphExplorerRoot: React.FC<Props> = (props) => {
     explodeComposites: false,
   });
 
-  const selectedName = explorerPath.opNames[explorerPath.opNames.length - 1];
-  const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
-
   useDocumentTitle(`Graph: ${explorerPath.pipelineName}`);
 
+  const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const graphResult = useQuery<GraphExplorerRootQuery, GraphExplorerRootQueryVariables>(
     GRAPH_EXPLORER_ROOT_QUERY,
     {
@@ -102,7 +100,6 @@ const GraphExplorerRoot: React.FC<Props> = (props) => {
           ? explodeCompositesInHandleGraph(result.solidHandles)
           : result.solidHandles;
 
-        const selectedHandle = displayedHandles.find((h) => h.solid.name === selectedName);
         return (
           <GraphExplorer
             options={options}
@@ -123,7 +120,6 @@ const GraphExplorerRoot: React.FC<Props> = (props) => {
             repoAddress={repoAddress}
             handles={displayedHandles}
             parentHandle={parentHandle ? parentHandle : undefined}
-            selectedHandle={selectedHandle}
             isGraph={true}
             getInvocations={(definitionName) =>
               displayedHandles

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/ForeignNode.tsx
@@ -27,5 +27,5 @@ const ForeignNodeLink = styled.div`
 `;
 export const getForeignNodeDimensions = (id: string) => {
   const path = JSON.parse(id);
-  return {width: displayNameForAssetKey({path}).length * 7 + 30, height: 30};
+  return {width: displayNameForAssetKey({path}).length * 8 + 30, height: 30};
 };

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -23,12 +23,19 @@ export const SidebarAssetInfo: React.FC<{
 }> = ({node, definition, repoAddress, liveData}) => {
   const Plugin = pluginForMetadata(definition.metadata);
   const {lastMaterialization} = liveData || {};
+  const displayName = displayNameForAssetKey(node.assetKey);
 
   return (
     <>
       <Box flex={{gap: 4, direction: 'column'}} margin={{left: 24, right: 12, vertical: 16}}>
-        <SidebarTitle style={{marginBottom: 0}}>
-          {displayNameForAssetKey(node.assetKey)}
+        <SidebarTitle style={{marginBottom: 0, display: 'flex', justifyContent: 'space-between'}}>
+          {displayName}
+          {displayName !== node.opName ? (
+            <Box style={{opacity: 0.5}} flex={{gap: 6, alignItems: 'center'}}>
+              <IconWIP name="op" size={16} />
+              {node.opName}
+            </Box>
+          ) : undefined}
         </SidebarTitle>
         <AssetCatalogLink to={`/instance/assets/${node.assetKey.path.join('/')}`}>
           {'View in Asset Catalog '}
@@ -38,7 +45,7 @@ export const SidebarAssetInfo: React.FC<{
 
       <SidebarSection title="Description">
         <Box padding={{vertical: 16, horizontal: 24}}>
-          <Description description={node.description || null} />
+          <Description description={node.description || 'No description provided'} />
         </Box>
 
         {definition.metadata && Plugin && Plugin.SidebarComponent && (


### PR DESCRIPTION
## Summary

This PR fixes a bunch of issues with asset graphs where a single op yields multiple assets (eg: where `assetNode.opName` is NOT the same as `assetNode.path[0]`) and several issues involving assets with multi-component asset paths. This was fairly broken because the asset graph was built on the same foundation as the op graph, and we stored selected opNames NOT asset key paths, etc.

There are still shared helpers and types that refer to an `opsQuery` but are really dealing with an `stringified-asset-paths-query`, but we can refine the naming later in a rename-only PR.

Example DAG:

```@op(
    out={
        "foo": Out(asset_key=AssetKey("foo")),
        "bar": Out(asset_key=AssetKey(["bar", "prod"])),
    }
)
def my_multi_asset(my_asset_2):
    pass


@job
def my_job_multi():
    my_multi_asset()
```

Given this DAG, you can now:

- Individually select each asset in the asset graph

- Use the asset graph query input to filter the view using asset paths, NOT op names, including multi-component asset path keys (which have the spaces removed for easier parsing and use the display style rather than the path style to be url-encoding friendly)

![image](https://user-images.githubusercontent.com/1037212/150913902-f178f863-bab3-45b5-a062-51a4a92d56c9.png)

- See tokenized asset paths in the URL rather than op names: (example: `http://localhost:3000/workspace/software_defined_assets@repo.py/jobs/my_job_multi~+%22bar%3Eprod%22/bar%3Eprod`)

- Click "View upstream graph" on the asset details page (previously broken because it used the opName)

- If you view an SDA that is part of an op with a different name, we now show the name of the op next to the name of the job for clarity, since you might need the op name to find it in code easily: 
![image](https://user-images.githubusercontent.com/1037212/150914212-bd4244f8-3a9f-45b6-9b8d-280855845e02.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.