### PR TITLE
RFC: op_selection 5/ dagit - add flatten subgraphs toggle to allow nested graph queries

### DIFF
--- a/js_modules/dagit/packages/core/src/app/LocalStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/LocalStorage.tsx
@@ -31,6 +31,7 @@ export interface IExecutionSession {
   needsRefresh: boolean;
   solidSelection: string[] | null;
   solidSelectionQuery: string | null;
+  flattenGraphs: boolean;
   tags: PipelineRunTag[] | null;
 
   // this is set when you execute the session and freeze it
@@ -90,6 +91,7 @@ export function applyCreateSession(
         needsRefresh: false,
         solidSelection: null,
         solidSelectionQuery: '*',
+        flattenGraphs: false,
         tags: null,
         runId: undefined,
         ...initial,

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -211,6 +211,10 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
     });
   };
 
+  const onFlattenGraphsChange = (flattenGraphs: boolean) => {
+    onSaveSession({flattenGraphs});
+  };
+
   const onModeChange = (mode: string) => {
     onSaveSession({mode});
   };
@@ -561,6 +565,8 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
                 value={currentSession.solidSelection || null}
                 query={currentSession.solidSelectionQuery || null}
                 onChange={onOpSelectionChange}
+                flattenGraphs={currentSession.flattenGraphs}
+                onFlattenGraphsChange={onFlattenGraphsChange}
                 repoAddress={repoAddress}
               />
               {isJob ? (

--- a/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
@@ -20,6 +20,8 @@ interface IOpSelectorProps {
   value: string[] | null;
   query: string | null;
   onChange: (value: string[] | null, query: string | null) => void;
+  flattenGraphs: boolean;
+  onFlattenGraphsChange: (v: boolean) => void;
   repoAddress: RepoAddress;
 }
 
@@ -53,11 +55,17 @@ const SOLID_SELECTOR_QUERY = gql`
 `;
 
 export const OpSelector = (props: IOpSelectorProps) => {
-  const {serverProvidedSubsetError, onChange, pipelineName, repoAddress} = props;
+  const {
+    serverProvidedSubsetError,
+    onChange,
+    pipelineName,
+    repoAddress,
+    onFlattenGraphsChange,
+  } = props;
   const [focused, setFocused] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const [flattenGraphs, setFlattenGraphs] = React.useState(false);
 
+  const flattenGraphs = props.flattenGraphs || false;
   const selector = {...repoAddressToSelector(repoAddress), pipelineName};
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, pipelineName);
@@ -145,7 +153,7 @@ export const OpSelector = (props: IOpSelectorProps) => {
             flattenGraphsEnabled={flattenGraphsEnabled}
             flattenGraphs={flattenGraphs}
             setFlattenGraphs={() => {
-              setFlattenGraphs(!flattenGraphs);
+              onFlattenGraphsChange(!flattenGraphs);
             }}
           />
         </ShortcutHandler>

--- a/js_modules/dagit/packages/core/src/launchpad/types/OpSelectorQuery.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/OpSelectorQuery.ts
@@ -9,86 +9,240 @@ import { PipelineSelector } from "./../../types/globalTypes";
 // GraphQL query operation: OpSelectorQuery
 // ====================================================
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_definition {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_definition {
   __typename: "InputDefinition";
   name: string;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn_definition_type {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn_definition_type {
   __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
   displayName: string;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn_definition {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn_definition {
   __typename: "OutputDefinition";
   name: string;
-  type: OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn_definition_type;
+  type: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn_definition_type;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn_solid {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn_solid {
   __typename: "Solid";
   name: string;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn {
   __typename: "Output";
-  definition: OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn_definition;
-  solid: OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn_solid;
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn_definition;
+  solid: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn_solid;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs {
   __typename: "Input";
-  definition: OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_definition;
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_definition;
   isDynamicCollect: boolean;
-  dependsOn: OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs_dependsOn[];
+  dependsOn: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs_dependsOn[];
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_definition {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_definition {
   __typename: "OutputDefinition";
   name: string;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy_solid {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy_solid {
   __typename: "Solid";
   name: string;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy_definition_type {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy_definition_type {
   __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
   displayName: string;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy_definition {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy_definition {
   __typename: "InputDefinition";
   name: string;
-  type: OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy_definition_type;
+  type: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy_definition_type;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy {
   __typename: "Input";
-  solid: OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy_solid;
-  definition: OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy_definition;
+  solid: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy_solid;
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy_definition;
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs {
   __typename: "Output";
-  definition: OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_definition;
-  dependedBy: OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs_dependedBy[];
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_definition;
+  dependedBy: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs_dependedBy[];
 }
 
-export interface OpSelectorQuery_pipelineOrError_Pipeline_solids {
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_metadata {
+  __typename: "MetadataItemDefinition";
+  key: string;
+  value: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_inputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_inputDefinitions {
+  __typename: "InputDefinition";
+  name: string;
+  type: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_inputDefinitions_type;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_outputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_outputDefinitions {
+  __typename: "OutputDefinition";
+  name: string;
+  isDynamic: boolean | null;
+  type: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_outputDefinitions_type;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_configField_configType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ArrayConfigType" | "NullableConfigType" | "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_configField {
+  __typename: "ConfigTypeField";
+  configType: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_configField_configType;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition {
+  __typename: "SolidDefinition";
+  name: string;
+  description: string | null;
+  metadata: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_metadata[];
+  inputDefinitions: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_inputDefinitions[];
+  outputDefinitions: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_outputDefinitions[];
+  configField: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition_configField | null;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_metadata {
+  __typename: "MetadataItemDefinition";
+  key: string;
+  value: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions {
+  __typename: "InputDefinition";
+  name: string;
+  type: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions_type;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions {
+  __typename: "OutputDefinition";
+  name: string;
+  isDynamic: boolean | null;
+  type: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions_type;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput {
+  __typename: "Input";
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_definition;
+  solid: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_solid;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings {
+  __typename: "InputMapping";
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_definition;
+  mappedInput: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput {
+  __typename: "Output";
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_definition;
+  solid: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_solid;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings {
+  __typename: "OutputMapping";
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_definition;
+  mappedOutput: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition {
+  __typename: "CompositeSolidDefinition";
+  name: string;
+  description: string | null;
+  metadata: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_metadata[];
+  inputDefinitions: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions[];
+  outputDefinitions: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions[];
+  id: string;
+  inputMappings: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings[];
+  outputMappings: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings[];
+}
+
+export type OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition = OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_SolidDefinition | OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition_CompositeSolidDefinition;
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid {
   __typename: "Solid";
   name: string;
   isDynamicMapped: boolean;
-  inputs: OpSelectorQuery_pipelineOrError_Pipeline_solids_inputs[];
-  outputs: OpSelectorQuery_pipelineOrError_Pipeline_solids_outputs[];
+  inputs: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_inputs[];
+  outputs: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_outputs[];
+  definition: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid_definition;
+}
+
+export interface OpSelectorQuery_pipelineOrError_Pipeline_solidHandles {
+  __typename: "SolidHandle";
+  handleID: string;
+  solid: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles_solid;
 }
 
 export interface OpSelectorQuery_pipelineOrError_Pipeline {
   __typename: "Pipeline";
   id: string;
   name: string;
-  solids: OpSelectorQuery_pipelineOrError_Pipeline_solids[];
+  solidHandles: OpSelectorQuery_pipelineOrError_Pipeline_solidHandles[];
 }
 
 export interface OpSelectorQuery_pipelineOrError_PipelineNotFoundError {
@@ -114,4 +268,5 @@ export interface OpSelectorQuery {
 
 export interface OpSelectorQueryVariables {
   selector: PipelineSelector;
+  requestScopeHandleID?: string | null;
 }

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -213,7 +213,7 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
           {explodeCompositesEnabled && (
             <OptionsOverlay>
               <Checkbox
-                label="Explode composites"
+                label="Explode graphs"
                 checked={options.explodeComposites}
                 onChange={() => {
                   handleQueryChange('');

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -48,7 +48,7 @@ export const PipelineExplorerContainer: React.FC<{
   isGraph?: boolean;
 }> = ({explorerPath, repoAddress, onChangeExplorerPath, isGraph = false}) => {
   const [options, setOptions] = React.useState<GraphExplorerOptions>({
-    explodeComposites: false,
+    explodeComposites: explorerPath.explodeComposites ?? false,
   });
 
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);

--- a/js_modules/dagit/packages/core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelinePathUtils.tsx
@@ -6,6 +6,7 @@ export interface ExplorerPath {
   pipelineName: string;
   snapshotId?: string;
   opsQuery: string;
+  explodeComposites?: boolean;
   opNames: string[];
 }
 
@@ -13,7 +14,7 @@ export function explorerPathToString(path: ExplorerPath) {
   const root = [
     path.pipelineName,
     path.snapshotId ? `@${path.snapshotId}` : ``,
-    path.opsQuery ? `~${path.opsQuery}` : ``,
+    path.opsQuery ? `~${path.explodeComposites ? '!' : ''}${path.opsQuery}` : ``,
   ].join('');
 
   return `${root}/${path.opNames.join('/')}`;
@@ -24,13 +25,20 @@ export function explorerPathFromString(path: string): ExplorerPath {
   const root = rootAndOps[0];
   const opNames = rootAndOps.length === 1 ? [''] : rootAndOps.slice(1);
 
-  const match = /^([^@~]+)@?([^~]+)?~?(.*)$/.exec(root);
-  const [, pipelineName, snapshotId, opsQuery] = [...(match || []), '', '', ''];
+  const match = /^([^@~]+)@?([^~]+)?~?(!)?(.*)$/.exec(root);
+  const [, pipelineName, snapshotId, explodeComposites, opsQuery] = [
+    ...(match || []),
+    '',
+    '',
+    '',
+    '',
+  ];
 
   return {
     pipelineName,
     snapshotId,
     opsQuery,
+    explodeComposites: explodeComposites === '!',
     opNames,
   };
 }

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpInvocation.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpInvocation.tsx
@@ -67,7 +67,7 @@ export const SidebarOpInvocation: React.FC<ISidebarOpInvocationProps> = (props) 
                 icon={<IconWIP name="zoom_in" />}
                 onClick={() => onEnterSubgraph({name: solid.name})}
               >
-                Expand composite
+                Expand graph
               </ButtonWIP>
             </Box>
           )}

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -2,12 +2,14 @@ import {Intent} from '@blueprintjs/core';
 import {
   Box,
   ButtonWIP,
+  Checkbox,
   ColorsWIP,
   IconWIP,
   MenuItemWIP,
   MenuWIP,
   Popover,
   TextInput,
+  Tooltip,
 } from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
@@ -37,7 +39,9 @@ interface GraphQueryInputProps {
     isJob: boolean;
   };
 
-  explodeComposites?: boolean;
+  flattenGraphsEnabled?: boolean;
+  flattenGraphs?: boolean;
+  setFlattenGraphs?: () => void;
   onChange: (value: string) => void;
   onKeyDown?: (e: React.KeyboardEvent<any>) => void;
   onFocus?: () => void;
@@ -203,11 +207,12 @@ export const GraphQueryInput = React.memo(
     };
 
     const uncomitted = (pendingValue || '*') !== (props.value || '*');
-    const explodeCompositesFlag = props.explodeComposites ? '!' : '';
+    const flattenGraphsFlag = props.flattenGraphs ? '!' : '';
 
     return (
       <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
         <Popover
+          enforceFocus={false}
           isOpen={focused}
           position="top-left"
           content={
@@ -253,6 +258,27 @@ export const GraphQueryInput = React.memo(
               style={{width: props.width || '30vw'}}
               className={props.className}
               ref={inputRef}
+              rightElement={
+                props.flattenGraphsEnabled ? (
+                  <Tooltip
+                    content={`${
+                      props.flattenGraphs ? 'Select flattened ops' : 'Select top-level nodes'
+                    }`}
+                    placement="right"
+                  >
+                    <div style={{position: 'absolute', right: '6px', top: '6px'}}>
+                      <Checkbox
+                        checked={props.flattenGraphs ?? false}
+                        onChange={() => {
+                          props.setFlattenGraphs?.();
+                          setFocused(true);
+                        }}
+                        format="switch"
+                      />
+                    </div>
+                  </Tooltip>
+                ) : undefined
+              }
             />
             {focused && uncomitted && <EnterHint>Enter</EnterHint>}
             {focused && props.linkToPreview && (
@@ -264,7 +290,7 @@ export const GraphQueryInput = React.memo(
                   onMouseDown={(e) => e.currentTarget.click()}
                   to={workspacePipelinePath({
                     ...props.linkToPreview,
-                    pipelineName: `${props.linkToPreview.pipelineName}~${explodeCompositesFlag}${pendingValue}`,
+                    pipelineName: `${props.linkToPreview.pipelineName}~${flattenGraphsFlag}${pendingValue}`,
                   })}
                 >
                   Graph Preview <IconWIP color={ColorsWIP.Link} name="open_in_new" />
@@ -337,7 +363,7 @@ const OpCountWrap = styled.div`
 
 const EnterHint = styled.div`
   position: absolute;
-  right: 6px;
+  right: 40px;
   top: 5px;
   border-radius: 5px;
   border: 1px solid ${ColorsWIP.Gray500};

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -37,6 +37,7 @@ interface GraphQueryInputProps {
     isJob: boolean;
   };
 
+  explodeComposites?: boolean;
   onChange: (value: string) => void;
   onKeyDown?: (e: React.KeyboardEvent<any>) => void;
   onFocus?: () => void;
@@ -202,6 +203,7 @@ export const GraphQueryInput = React.memo(
     };
 
     const uncomitted = (pendingValue || '*') !== (props.value || '*');
+    const explodeCompositesFlag = props.explodeComposites ? '!' : '';
 
     return (
       <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
@@ -262,7 +264,7 @@ export const GraphQueryInput = React.memo(
                   onMouseDown={(e) => e.currentTarget.click()}
                   to={workspacePipelinePath({
                     ...props.linkToPreview,
-                    pipelineName: `${props.linkToPreview.pipelineName}~${pendingValue}`,
+                    pipelineName: `${props.linkToPreview.pipelineName}~${explodeCompositesFlag}${pendingValue}`,
                   })}
                 >
                   Graph Preview <IconWIP color={ColorsWIP.Link} name="open_in_new" />

--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -9,11 +9,12 @@ interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'type' | 'onC
   icon?: IconName;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   strokeColor?: string;
+  rightElement?: JSX.Element;
 }
 
 export const TextInput = React.forwardRef(
   (props: Props, ref: React.ForwardedRef<HTMLInputElement>) => {
-    const {icon, disabled, strokeColor = ColorsWIP.Gray300, ...rest} = props;
+    const {icon, disabled, strokeColor = ColorsWIP.Gray300, rightElement, ...rest} = props;
 
     return (
       <Container $disabled={!!disabled}>
@@ -26,6 +27,7 @@ export const TextInput = React.forwardRef(
           $hasIcon={!!icon}
           type="text"
         />
+        {rightElement ? rightElement : null}
       </Container>
     );
   },


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Final user-facing piece for https://github.com/dagster-io/dagster/issues/5594

This PR enables selecting ops inside nested graph by adding a "Flatten subgraphs" toggle inside the op selection dropdown:

- when a graph has nested graphs, we'll show two rows of info: 1) "Flatten subgraphs" switch w/ info icon 2) "X matching ops" and preview:

https://user-images.githubusercontent.com/4531914/151640467-1371602c-61bd-466a-a36c-164077ea580f.mov

- when a graph that doesn’t have nested graphs, nothing changes from status quo
   <img width="300" src="https://user-images.githubusercontent.com/4531914/151640483-bd5d6c61-d6ce-42be-8467-c0b49bd23334.png">

Other changes:
- add icons to suggest items to indicate op v.s. graph, which applies to all the op selection input component like:

https://user-images.githubusercontent.com/4531914/151640944-57866366-66e8-4c73-8346-86270d1660ad.mov

- "Graph Preview" leverages the existing “explode composites” flag from the graph overview page: 
<img height="200" alt="Screen Shot 2022-01-25 at 5 55 19 PM" src="https://user-images.githubusercontent.com/4531914/151090737-667160c3-1f20-4a9d-827c-b4a50dd7b909.png">
- "Explode composites" -> "Explode graphs"
- "Expand composite" -> "Expand graph"


## Test Plan

Test cases:
- graph with a graph inside
- graph with a graph of a graph (2 layer nesting)
- job with pre-defined op selection
- graph without nesting

-----
v0: [pic](https://user-images.githubusercontent.com/4531914/151090656-ac878f67-6ff6-41b7-839b-002262ed0d77.png), [video](https://user-images.githubusercontent.com/4531914/151091128-af074c87-a300-4b6b-9c4e-bd4a1c487a88.mov)
