### PR TITLE
Make the config arg on to_job only perform validation, not post-processing

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -17,7 +17,7 @@ from typing import (
 from dagster import check
 from dagster.config import Field, Shape
 from dagster.config.config_type import ConfigType
-from dagster.config.validate import process_config
+from dagster.config.validate import validate_config
 from dagster.core.definitions.config import ConfigMapping
 from dagster.core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster.core.definitions.mode import ModeDefinition
@@ -950,7 +950,7 @@ def _config_mapping_with_default_value(
         field_aliases=inner_schema.field_aliases,
     )
 
-    config_evr = process_config(config_schema, default_config)
+    config_evr = validate_config(config_schema, default_config)
     if not config_evr.success:
         raise DagsterInvalidConfigError(
             f"Error in config when building job '{job_name}' from graph '{graph_name}' ",

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
@@ -1,13 +1,15 @@
 import pytest
 from dagster import (
     DagsterInvariantViolationError,
+    Field,
+    StringSource,
     execute_pipeline,
     graph,
     job,
     op,
     reconstructable,
 )
-from dagster.core.test_utils import instance_for_test
+from dagster.core.test_utils import environ, instance_for_test
 
 
 def define_the_job():
@@ -104,3 +106,19 @@ def test_job_top_level_input():
     result = my_job_with_input.execute_in_process(run_config={"inputs": {"x": {"value": 2}}})
     assert result.success
     assert result.output_for_node("my_op") == 2
+
+
+def test_job_post_process_config():
+    @op(config_schema={"foo": Field(StringSource)})
+    def the_op(context):
+        return context.op_config["foo"]
+
+    @graph
+    def basic():
+        the_op()
+
+    # Ensure that the env var not existing will not throw an error, since resolution happens in post-processing.
+    the_job = basic.to_job(config={"ops": {"the_op": {"config": {"foo": {"env": "SOME_ENV_VAR"}}}}})
+
+    with environ({"SOME_ENV_VAR": "blah"}):
+        assert the_job.execute_in_process().success

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_job.py
@@ -117,8 +117,11 @@ def test_job_post_process_config():
     def basic():
         the_op()
 
-    # Ensure that the env var not existing will not throw an error, since resolution happens in post-processing.
-    the_job = basic.to_job(config={"ops": {"the_op": {"config": {"foo": {"env": "SOME_ENV_VAR"}}}}})
+    with environ({"SOME_ENV_VAR": None}):
+        # Ensure that the env var not existing will not throw an error, since resolution happens in post-processing.
+        the_job = basic.to_job(
+            config={"ops": {"the_op": {"config": {"foo": {"env": "SOME_ENV_VAR"}}}}}
+        )
 
     with environ({"SOME_ENV_VAR": "blah"}):
         assert the_job.execute_in_process().success


### PR DESCRIPTION
In reference to https://github.com/dagster-io/dagster/issues/6325