### PR TITLE
[dagit] Look at upstream asset partition health, discourage backfills that will fail

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -15,13 +15,14 @@ import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNotice';
 import {AssetNodeList} from './AssetNodeList';
-import {PartitionHealthSummary} from './PartitionHealthSummary';
+import {PartitionHealthSummary, usePartitionHealthData} from './PartitionHealthSummary';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinitionFragment';
 
 export const AssetNodeDefinition: React.FC<{
   assetNode: AssetNodeDefinitionFragment;
   liveDataByNode: LiveData;
 }> = ({assetNode, liveDataByNode}) => {
+  const partitionHealthData = usePartitionHealthData([assetNode.assetKey]);
   const repoAddress = buildRepoAddress(
     assetNode.repository.name,
     assetNode.repository.location.name,
@@ -84,7 +85,7 @@ export const AssetNodeDefinition: React.FC<{
                 flex={{direction: 'column', gap: 16}}
               >
                 <p>{assetNode.partitionDefinition}</p>
-                <PartitionHealthSummary assetKey={assetNode.assetKey} />
+                <PartitionHealthSummary assetKey={assetNode.assetKey} data={partitionHealthData} />
               </Box>
             </>
           )}

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -112,6 +112,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
             {definition && definition.jobs.length > 0 && repoAddress && (
               <LaunchAssetExecutionButton
                 assets={[definition]}
+                upstreamAssetKeys={definition.dependencies.map((d) => d.asset.assetKey)}
                 assetJobName={definition.jobs[0].name}
                 title={lastMaterializedAt ? 'Rematerialize' : 'Materialize'}
               />

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRangeInput.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRangeInput.tsx
@@ -62,6 +62,13 @@ export function assembleIntoSpans(keys: string[], keyTestFn: (key: string) => bo
   return spans;
 }
 
+export function stringForSpan(
+  {startIdx, endIdx}: {startIdx: number; endIdx: number},
+  all: string[],
+) {
+  return startIdx === endIdx ? all[startIdx] : `[${all[startIdx]}...${all[endIdx]}]`;
+}
+
 function placeholderForPartitions(names: string[]) {
   if (names.length < 4) {
     return `ex: ${names[0]}, ${names[1]}`;
@@ -100,12 +107,8 @@ function textToPartitions(selected: string, all: string[]) {
 }
 
 function partitionsToText(selected: string[], all: string[]) {
-  const spans = assembleIntoSpans(all, (key) => selected.includes(key));
-  const spanStrings = [];
-  for (const {startIdx, endIdx, status} of spans) {
-    if (status) {
-      spanStrings.push(startIdx === endIdx ? all[startIdx] : `[${all[startIdx]}...${all[endIdx]}]`);
-    }
-  }
-  return spanStrings.join(', ');
+  return assembleIntoSpans(all, (key) => selected.includes(key))
+    .filter((s) => s.status)
+    .map((s) => stringForSpan(s, all))
+    .join(', ');
 }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -1,6 +1,6 @@
 import {gql, QueryResult, useQuery} from '@apollo/client';
 import {Box, ColorsWIP, IconWIP, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
-import _, {uniq, without} from 'lodash';
+import _, {flatMap, uniq, uniqBy, without} from 'lodash';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -204,6 +204,9 @@ const AssetGraphExplorerWithData: React.FC<
     selectedAssetValues.includes(tokenForAssetKey(node.definition.assetKey)),
   );
   const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1];
+  const launchAssetNodes = selectedGraphNodes.length
+    ? selectedGraphNodes
+    : Object.values(assetGraphData.nodes);
 
   const onSelectNode = React.useCallback(
     async (e: React.MouseEvent<any>, assetKey: {path: string[]}, node: Node | null) => {
@@ -348,10 +351,14 @@ const AssetGraphExplorerWithData: React.FC<
             <LaunchAssetExecutionButton
               title={titleForLaunch(selectedGraphNodes, liveDataByNode)}
               assetJobName={explorerPath.pipelineName}
-              assets={(selectedGraphNodes.length
-                ? selectedGraphNodes
-                : Object.values(assetGraphData.nodes)
-              ).map((n) => n.definition)}
+              assets={launchAssetNodes.map((n) => n.definition)}
+              upstreamAssetKeys={uniqBy(
+                flatMap(launchAssetNodes.map((n) => n.definition.dependencyKeys)),
+                (key) => JSON.stringify(key),
+              ).filter(
+                (key) =>
+                  !launchAssetNodes.some((n) => JSON.stringify(n.assetKey) === JSON.stringify(key)),
+              )}
             />
           </div>
           <div style={{position: 'absolute', left: 24, top: 16}}>

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetChoosePartitionsDialog.tsx
@@ -25,7 +25,11 @@ import {
   ConfigPartitionSelectionQuery,
   ConfigPartitionSelectionQueryVariables,
 } from '../../launchpad/types/ConfigPartitionSelectionQuery';
-import {assembleIntoSpans, PartitionRangeInput} from '../../partitions/PartitionRangeInput';
+import {
+  assembleIntoSpans,
+  PartitionRangeInput,
+  stringForSpan,
+} from '../../partitions/PartitionRangeInput';
 import {
   LAUNCH_PARTITION_BACKFILL_MUTATION,
   messageForLaunchBackfillError,
@@ -279,13 +283,7 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
               title="Upstream Data Missing"
               description={
                 <>
-                  {upstreamUnavailableSpans
-                    .map((a) =>
-                      a.startIdx === a.endIdx
-                        ? `${selected[a.startIdx]}`
-                        : `${selected[a.startIdx]} through ${selected[a.endIdx]}`,
-                    )
-                    .join(', ')}
+                  {upstreamUnavailableSpans.map((span) => stringForSpan(span, selected)).join(', ')}
                   {
                     ' cannot be materialized because upstream materializations are missing. Consider materializing upstream assets or '
                   }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetChoosePartitionsDialog.tsx
@@ -8,8 +8,9 @@ import {
   ButtonWIP,
   ButtonLink,
   DialogFooter,
+  Alert,
 } from '@dagster-io/ui';
-import {flatten, pick} from 'lodash';
+import {pick, reject} from 'lodash';
 import React from 'react';
 import {useHistory} from 'react-router-dom';
 import * as yaml from 'yaml';
@@ -18,12 +19,13 @@ import {AppContext} from '../../app/AppContext';
 import {SharedToaster} from '../../app/DomUtils';
 import {displayNameForAssetKey} from '../../app/Util';
 import {PartitionHealthSummary, usePartitionHealthData} from '../../assets/PartitionHealthSummary';
+import {AssetKey} from '../../assets/types';
 import {CONFIG_PARTITION_SELECTION_QUERY} from '../../launchpad/ConfigEditorConfigPicker';
 import {
   ConfigPartitionSelectionQuery,
   ConfigPartitionSelectionQueryVariables,
 } from '../../launchpad/types/ConfigPartitionSelectionQuery';
-import {PartitionRangeInput} from '../../partitions/PartitionRangeInput';
+import {assembleIntoSpans, PartitionRangeInput} from '../../partitions/PartitionRangeInput';
 import {
   LAUNCH_PARTITION_BACKFILL_MUTATION,
   messageForLaunchBackfillError,
@@ -50,28 +52,27 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
   setOpen: (open: boolean) => void;
   repoAddress: RepoAddress;
   assetJobName: string;
-  assets: {assetKey: {path: string[]}; opName: string | null; partitionDefinition: string | null}[];
-}> = ({open, setOpen, assets, repoAddress, assetJobName}) => {
-  const data = usePartitionHealthData(assets[0].assetKey);
+  assets: {assetKey: AssetKey; opName: string | null; partitionDefinition: string | null}[];
+  upstreamAssetKeys: AssetKey[]; // single layer of upstream dependencies
+}> = ({open, setOpen, assets, repoAddress, assetJobName, upstreamAssetKeys}) => {
+  const data = usePartitionHealthData(assets.map((a) => a.assetKey));
+  const upstreamData = usePartitionHealthData(upstreamAssetKeys);
+
+  const allKeys = data[0] ? data[0].keys : [];
+  const mostRecentKey = allKeys[allKeys.length - 1];
 
   const [selected, setSelected] = React.useState<string[]>([]);
   const [previewCount, setPreviewCount] = React.useState(4);
   const [launching, setLaunching] = React.useState(false);
 
-  const setMostRecent = () => setSelected([data.keys[data.keys.length - 1]]);
-  const setAll = () => setSelected([...data.keys]);
+  const setMostRecent = () => setSelected([mostRecentKey]);
+  const setAll = () => setSelected([...allKeys]);
   const setMissing = () =>
-    setSelected(
-      flatten(
-        data.spans
-          .filter((s) => s.status === false)
-          .map((s) => data.keys.slice(s.startIdx, s.endIdx + 1)),
-      ),
-    );
+    setSelected(allKeys.filter((key) => data.every((d) => !d.statusByPartition[key])));
 
   React.useEffect(() => {
-    setSelected([data.keys[data.keys.length - 1]]);
-  }, [data.keys]);
+    setSelected([mostRecentKey]);
+  }, [mostRecentKey]);
 
   const title = `Launch runs to materialize ${
     assets.length > 1 ? `${assets.length} assets` : displayNameForAssetKey(assets[0].assetKey)
@@ -208,6 +209,17 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
     }
   };
 
+  const upstreamUnavailable = (key: string) =>
+    upstreamData.length > 0 &&
+    upstreamData.some((a) => a.keys.includes(key) && !a.statusByPartition[key]);
+
+  const upstreamUnavailableSpans = assembleIntoSpans(selected, upstreamUnavailable).filter(
+    (s) => s.status === true,
+  );
+  const onRemoveUpstreamUnavailable = () => {
+    setSelected(reject(selected, upstreamUnavailable));
+  };
+
   return (
     <DialogWIP
       style={{width: 700}}
@@ -225,7 +237,7 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
               <PartitionRangeInput
                 value={selected}
                 onChange={setSelected}
-                partitionNames={data.keys}
+                partitionNames={allKeys}
               />
             </Box>
             <ButtonWIP small onClick={setMostRecent}>
@@ -248,6 +260,7 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
               assetKey={a.assetKey}
               showAssetKey
               key={displayNameForAssetKey(a.assetKey)}
+              data={data}
               selected={selected}
             />
           ))}
@@ -259,6 +272,30 @@ export const LaunchAssetChoosePartitionsDialog: React.FC<{
             </Box>
           ) : undefined}
         </Box>
+        {upstreamUnavailableSpans.length > 0 && (
+          <Box margin={{top: 16}}>
+            <Alert
+              intent="warning"
+              title="Upstream Data Missing"
+              description={
+                <>
+                  {upstreamUnavailableSpans
+                    .map((a) =>
+                      a.startIdx === a.endIdx
+                        ? `${selected[a.startIdx]}`
+                        : `${selected[a.startIdx]} through ${selected[a.endIdx]}`,
+                    )
+                    .join(', ')}
+                  {
+                    ' cannot be materialized because upstream materializations are missing. Consider materializing upstream assets or '
+                  }
+                  <a onClick={onRemoveUpstreamUnavailable}>remove these partitions</a>
+                  {` to avoid failures.`}
+                </>
+              }
+            />
+          </Box>
+        )}
       </DialogBody>
       <DialogFooter
         left={partitionSet && <RunningBackfillsNotice partitionSetName={partitionSet.name} />}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -1,6 +1,7 @@
 import {ButtonWIP, IconWIP, Tooltip} from '@dagster-io/ui';
 import React from 'react';
 
+import {AssetKey} from '../../assets/types';
 import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
 import {buildRepoAddress} from '../buildRepoAddress';
 
@@ -16,8 +17,9 @@ type AssetMinimal = {
 export const LaunchAssetExecutionButton: React.FC<{
   assetJobName: string;
   assets: AssetMinimal[];
+  upstreamAssetKeys: AssetKey[];
   title?: string;
-}> = ({assets, assetJobName, title}) => {
+}> = ({assets, assetJobName, upstreamAssetKeys, title}) => {
   const [showingPartitionDialog, setShowingPartitionDialog] = React.useState(false);
   const repoAddress = buildRepoAddress(
     assets[0]?.repository.name || '',
@@ -66,9 +68,10 @@ export const LaunchAssetExecutionButton: React.FC<{
           <LaunchAssetChoosePartitionsDialog
             assets={assets}
             assetJobName={assetJobName}
+            upstreamAssetKeys={upstreamAssetKeys}
+            repoAddress={repoAddress}
             open={showingPartitionDialog}
             setOpen={setShowingPartitionDialog}
-            repoAddress={repoAddress}
           />
         </>
       ) : (

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro';
 
 import {displayNameForAssetKey} from '../../app/Util';
 import {AssetMaterializations} from '../../assets/AssetMaterializations';
-import {PartitionHealthSummary} from '../../assets/PartitionHealthSummary';
+import {PartitionHealthSummary, usePartitionHealthData} from '../../assets/PartitionHealthSummary';
 import {Description} from '../../pipelines/Description';
 import {SidebarSection, SidebarTitle} from '../../pipelines/SidebarComponents';
 import {GraphExplorerSolidHandleFragment_solid_definition} from '../../pipelines/types/GraphExplorerSolidHandleFragment';
@@ -20,6 +20,7 @@ export const SidebarAssetInfo: React.FC<{
   node: AssetGraphQuery_assetNodes;
   liveData: LiveDataForNode;
 }> = ({node, definition, liveData}) => {
+  const partitionHealthData = usePartitionHealthData([node.assetKey]);
   const Plugin = pluginForMetadata(definition?.metadata || []);
   const {lastMaterialization} = liveData || {};
   const displayName = displayNameForAssetKey(node.assetKey);
@@ -56,7 +57,7 @@ export const SidebarAssetInfo: React.FC<{
         <SidebarSection title="Partitions">
           <Box padding={{vertical: 16, horizontal: 24}} flex={{direction: 'column', gap: 16}}>
             <p>{node.partitionDefinition}</p>
-            <PartitionHealthSummary assetKey={node.assetKey} />
+            <PartitionHealthSummary assetKey={node.assetKey} data={partitionHealthData} />
           </Box>
         </SidebarSection>
       )}


### PR DESCRIPTION
## Summary
This PR makes use of the very performant `AssetNode.materializationCountByPartition` query to display a warning when launching a backfill will result in one or more failures due to missing upstream materializations.

When you open the Rematerialize modal for a partitioned asset, we look at the materializations for all assets one level upstream. If any dependencies 1) have the same asset key and 2) have not materialized for that asset key, we display a warning. The warning offers to "Fix" the selection by removing offending partition keys so the selection is valid and no runs in the backfill will fail.

![Screen Shot 2022-01-25 at 4 24 37 PM](https://user-images.githubusercontent.com/1037212/151070653-47675ca6-1db4-46b0-a02c-0e9bb34c8e5d.png)


## Test Plan
No tests for SDA UI just yet

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.