### PR TITLE
[logging] fix issue that could cause infinite loops while capturing python logs

### DIFF
--- a/python_modules/dagster/dagster/core/log_manager.py
+++ b/python_modules/dagster/dagster/core/log_manager.py
@@ -192,6 +192,7 @@ class DagsterLogHandler(logging.Handler):
         self._logging_metadata = logging_metadata
         self._loggers = loggers
         self._handlers = handlers
+        self._should_capture = True
         super().__init__()
 
     @property
@@ -242,23 +243,33 @@ class DagsterLogHandler(logging.Handler):
         multiple times, as the DagsterLogHandler will be invoked at each level of the hierarchy as
         the message is propagated. This filter prevents this from happening.
         """
-        return not isinstance(getattr(record, DAGSTER_META_KEY, None), dict)
+        return self._should_capture and not isinstance(
+            getattr(record, DAGSTER_META_KEY, None), dict
+        )
 
     def emit(self, record: logging.LogRecord):
         """For any received record, add Dagster metadata, and have handlers handle it"""
-        dagster_record = self._convert_record(record)
-        # built-in handlers
-        for handler in self._handlers:
-            if dagster_record.levelno >= handler.level:
-                handler.handle(dagster_record)
-        # user-defined @loggers
-        for logger in self._loggers:
-            logger.log(
-                dagster_record.levelno,
-                dagster_record.msg,
-                exc_info=dagster_record.exc_info,
-                extra=self._extract_extra(record),
-            )
+
+        try:
+            # to prevent the potential for infinite loops in which a handler produces log messages
+            # which are then captured and then handled by that same handler (etc.), do not capture
+            # any log messages while one is currently being emitted
+            self._should_capture = False
+            dagster_record = self._convert_record(record)
+            # built-in handlers
+            for handler in self._handlers:
+                if dagster_record.levelno >= handler.level:
+                    handler.handle(dagster_record)
+            # user-defined @loggers
+            for logger in self._loggers:
+                logger.log(
+                    dagster_record.levelno,
+                    dagster_record.msg,
+                    exc_info=dagster_record.exc_info,
+                    extra=self._extract_extra(record),
+                )
+        finally:
+            self._should_capture = True
 
 
 class DagsterLogManager(logging.Logger):

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -379,3 +379,4 @@ def test_failure_logging(managed_loggers):
             reconstructable(define_logging_pipeline),
             instance=instance,
         )
+        assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_python_logging.py
@@ -358,7 +358,7 @@ def define_logging_pipeline():
         ),
     ],
 )
-def test_multiprocess_logging(managed_loggers, run_config):
+def test_execution_logging(managed_loggers, run_config):
     reset_logging()
 
     log_records = get_log_records(


### PR DESCRIPTION
quick and dirty -- just sets a class attribute whenever it's currently in the process of emitting a record. if that class attribute is set, then new log messages will not be handled.

This will only have an effect in the specific case that a) a new message is created using the python logging module and b) the logger used to create that message is captured by dagster (basically only happens if the root logger is being captured).

In those cases, the new message would also need to be handled by the same machinery, and this process would then (presumably) once again create a new log message, which would once again need to be handled by the same machinery, etc., etc.