### PR TITLE
Don't install awscli v1

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -45,7 +45,6 @@ def main(quiet):
         install_targets += ["Cython==0.29.21", "numpy==1.18.5"]
 
     install_targets += [
-        "awscli",
         "-e python_modules/dagster[mypy,test]",
         "-e python_modules/dagster-graphql",
         "-e python_modules/dagster-test",


### PR DESCRIPTION
Internally, we've moved to using awscli v2 which isn't installable via pip.

We could extend `make dev_install` further if we want to [install v2 ](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) but it's not really clear to me why we should treat this as any different than other dev dependencies (python, pip, npm, yarn, etc.) that aren't installed by the Makefile.