### PR TITLE
[context logging 2/n] Log output metadata via context

### DIFF
--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -295,7 +295,37 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         else:
             check.failed("Unexpected event {event}".format(event=event))
 
-    def add_output_metadata(self, metadata: Mapping[str, Any], output_name: Optional[str] = None):
+    def add_output_metadata(
+        self, metadata: Mapping[str, Any], output_name: Optional[str] = None
+    ) -> None:
+        """Add metadata to one of the outputs of an op.
+
+        This can only be used once per output in the body of an op. Using this method with the same output_name more than once within an op will result in an error.
+
+        Args:
+            metadata (Mapping[str, Any]): The metadata to attach to the output
+            output_name (Optional[str]): The name of the output to attach metadata to. If there is only one output on the op, then this argument does not need to be provided. The metadata will automatically be attached to the only output.
+
+        **Examples:**
+
+        .. code-block:: python
+
+            from dagster import Out, op
+            from typing import Tuple
+
+            @op
+            def add_metadata(context):
+                context.add_output_metadata({"foo", "bar"})
+                return 5 # Since the default output is called "result", metadata will be attached to the output "result".
+
+            @op(out={"a": Out(), "b": Out()})
+            def add_metadata_two_outputs(context) -> Tuple[str, int]:
+                context.add_output_metadata({"foo": "bar"}, output_name="b")
+                context.add_output_metadata({"baz": "bat"}, output_name="a")
+
+                return ("dog", 5)
+
+        """
         metadata = check.dict_param(metadata, "metadata", key_type=str)
         output_name = check.opt_str_param(output_name, "output_name")
 

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod, abstractproperty
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Mapping, Dict, Iterator, List, Optional
 
 from dagster import check
 from dagster.core.definitions.dependency import Node, NodeHandle
@@ -296,7 +296,7 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
         else:
             check.failed("Unexpected event {event}".format(event=event))
 
-    def log_metadata_for_output(self, metadata: Dict[str, Any], output_name: Optional[str] = None):
+    def add_output_metadata(self, metadata: Mapping[str, Any], output_name: Optional[str] = None):
         metadata = check.dict_param(metadata, "metadata", key_type=str)
         output_name = check.opt_str_param(output_name, "output_name")
 
@@ -304,13 +304,13 @@ class SolidExecutionContext(AbstractComputeExecutionContext):
             output_name = self.solid_def.output_defs[0].name
         elif output_name is None:
             raise DagsterInvariantViolationError(
-                "Attempted to log metadata without providing output_name, but multiple outputs exist. Please provide an output_name to the invocation of `context.log_metadata_for_output`."
+                "Attempted to log metadata without providing output_name, but multiple outputs exist. Please provide an output_name to the invocation of `context.add_output_metadata`."
             )
         self._output_metadata[output_name] = merge_dicts(
             self._output_metadata.get(output_name, {}), metadata
         )
 
-    def get_metadata_for_output(self, output_name: str) -> Optional[Dict[str, Any]]:
+    def get_output_metadata(self, output_name: str) -> Optional[Mapping[str, Any]]:
         return self._output_metadata.get(output_name)
 
     def get_step_execution_context(self) -> StepExecutionContext:

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -100,7 +100,7 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                     node_type=context.solid_def.node_type_str,
                 )
             )
-        metadata = context.get_metadata_for_output(output_defs[0].name)
+        metadata = context.get_output_metadata(output_defs[0].name)
         yield Output(value=result, output_name=output_defs[0].name, metadata=metadata)
     elif len(output_defs) > 1 and isinstance(result, tuple):
         if len(result) != len(output_defs):
@@ -110,7 +110,7 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
             )
 
         for output_def, element in zip(output_defs, result):
-            metadata = context.get_metadata_for_output(output_def.name)
+            metadata = context.get_output_metadata(output_def.name)
             yield Output(output_name=output_def.name, value=element, metadata=metadata)
     elif result is not None:
         if not output_defs:

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -100,7 +100,8 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                     node_type=context.solid_def.node_type_str,
                 )
             )
-        yield Output(value=result, output_name=output_defs[0].name)
+        metadata = context.get_metadata_for_output(output_defs[0].name)
+        yield Output(value=result, output_name=output_defs[0].name, metadata=metadata)
     elif len(output_defs) > 1 and isinstance(result, tuple):
         if len(result) != len(output_defs):
             check.failed(
@@ -108,8 +109,9 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                 f"returned a tuple with {len(result)} elements"
             )
 
-        for output_defs, element in zip(output_defs, result):
-            yield Output(output_name=output_defs.name, value=element)
+        for output_def, element in zip(output_defs, result):
+            metadata = context.get_metadata_for_output(output_def.name)
+            yield Output(output_name=output_def.name, value=element, metadata=metadata)
     elif result is not None:
         if not output_defs:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -608,7 +608,7 @@ def test_yield_event_ordering():
 def test_metadata_logging():
     @op
     def basic(context):
-        context.log_metadata_for_output({"foo": "bar"})
+        context.add_output_metadata({"foo": "bar"})
         return "baz"
 
     result = execute_op_in_graph(basic)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -603,3 +603,18 @@ def test_yield_event_ordering():
 
         assert second.timestamp - first.timestamp >= 1
         assert log.timestamp - first.timestamp >= 1
+
+
+def test_metadata_logging():
+    @op
+    def basic(context):
+        context.log_metadata_for_output({"foo": "bar"})
+        return "baz"
+
+    result = execute_op_in_graph(basic)
+    assert result.success
+    assert result.output_for_node("basic") == "baz"
+    events = result.events_for_node("basic")
+    metadata_entry = events[1].event_specific_data.metadata_entries[0]
+    assert metadata_entry.label == "foo"
+    assert metadata_entry.entry_data.text == "bar"

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -618,3 +618,16 @@ def test_metadata_logging():
     metadata_entry = events[1].event_specific_data.metadata_entries[0]
     assert metadata_entry.label == "foo"
     assert metadata_entry.entry_data.text == "bar"
+
+
+def test_metadata_logging_multiple_entries():
+    @op
+    def basic(context):
+        context.add_output_metadata({"foo": "bar"})
+        context.add_output_metadata({"baz": "bat"})
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="In op 'basic', attempted to log metadata for output 'result' more than once.",
+    ):
+        execute_op_in_graph(basic)


### PR DESCRIPTION
https://github.com/dagster-io/dagster/issues/6394
Spurred by a comment from https://github.com/dagster-io/dagster/pull/6304. Allows logging metadata for an output via an API on the context:
```python
@op
def basic(context):
    context.log_metadata_for_output({"foo": "bar"})
    return "baz"
```

Considerations:
- This does not play nicely with yield yet. If you have an already-constructed Output object, then we need to reconcile the metadata within that object with the metadata you may have logged.
- How does this work with dynamic outputs? Should you be able to log separate metadata for each mapping key?