### PR TITLE
[context logging 3/n] APIs for context logging via direct invocation

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_invocation.py
@@ -187,6 +187,7 @@ def _type_check_output_wrapper(
 
             async for event in async_gen:
                 if isinstance(event, (AssetMaterialization, Materialization, ExpectationResult)):
+                    context.log_event(event)
                     yield event
                 else:
                     if not isinstance(event, (Output, DynamicOutput)):
@@ -228,6 +229,7 @@ def _type_check_output_wrapper(
             outputs_seen = set()
             for event in gen:
                 if isinstance(event, (AssetMaterialization, Materialization, ExpectationResult)):
+                    context.log_event(event)
                     yield event
                 else:
                     if not isinstance(event, (Output, DynamicOutput)):

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -245,9 +245,6 @@ class UnboundSolidExecutionContext(OpExecutionContext):
     def get_events(self) -> List[UserEvent]:
         return self._user_events
 
-    def scrub_events(self) -> None:
-        self._user_events = []
-
 
 def _validate_resource_requirements(resources: "Resources", solid_def: SolidDefinition) -> None:
     """Validate correctness of resources against required resource keys"""

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -243,6 +243,27 @@ class UnboundSolidExecutionContext(OpExecutionContext):
         )
 
     def get_events(self) -> List[UserEvent]:
+        """Retrieve the list of user-generated events that were either yielded or logged via the context.
+
+        **Examples:**
+
+        .. code-block:: python
+
+            from dagster import op, build_op_context, AssetMaterialization, ExpectationResult
+
+            @op
+            def my_op(context):
+                ...
+
+            def test_my_op():
+                context = build_op_context()
+                my_op(context)
+                all_user_events = context.get_events()
+                materializations = [event for event in all_user_events if isinstance(event, AssetMaterialization)]
+                expectation_results = [event for event in all_user_events if isinstance(event, ExpectationResult)]
+                ...
+        """
+
         return self._user_events
 
 

--- a/python_modules/dagster/dagster/core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/core/execution/context/invocation.py
@@ -10,6 +10,7 @@ from dagster.core.definitions.events import (
     AssetObservation,
     ExpectationResult,
     Materialization,
+    UserEvent,
 )
 from dagster.core.definitions.hook_definition import HookDefinition
 from dagster.core.definitions.mode import ModeDefinition
@@ -44,9 +45,6 @@ def _property_msg(prop_name: str, method_name: str) -> str:
     return (
         f"The {prop_name} {method_name} is not set on the context when a solid is directly invoked."
     )
-
-
-UserEvent = Union[AssetMaterialization, AssetObservation, Materialization, ExpectationResult]
 
 
 class UnboundSolidExecutionContext(OpExecutionContext):

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -949,5 +949,3 @@ def test_logged_user_events():
         ExpectationResult,
         AssetObservation,
     ]
-    context.scrub_events()
-    assert context.get_events() == []


### PR DESCRIPTION
https://github.com/dagster-io/dagster/issues/6394
Some interesting design decisions here:
- Note that BoundSolidExecutionContext has the `log_event` method, while UnboundSolidExecutionContext has `get_events`. Because users will inspect the contents of an UnboundSolidExecutionContext after invoking an op, we need to make sure that events are available for retrieval from there, but during invocation itself, the context becomes a  BoundSolidExecutionContext, and thus the method to actually log a user event lives there.
- I intentionally named `get_events` differently than `retrieve_events` from the parent class, because if people end up accidentally using that, they'll scrub their event history.
- I added a `scrub_events` method which wipes the list for folks who may be passing the same context argument through to multiple ops. For folks who are doing that, they may be accumulating the events from multiple ops, making it hard to examine individual results.