### PR TITLE
Fix experimental decorator so it works with NamedTuple

### DIFF
--- a/python_modules/dagster/dagster/utils/backcompat.py
+++ b/python_modules/dagster/dagster/utils/backcompat.py
@@ -200,14 +200,19 @@ def experimental(callable_):
         return _inner
 
     if inspect.isclass(callable_):
+
         undecorated_init = callable_.__init__
 
         def __init__(self, *args, **kwargs):
             experimental_class_warning(callable_.__name__, stacklevel=3)
-            undecorated_init(self, *args, **kwargs)
+            if issubclass(callable_, tuple):
+                undecorated_init(self)
+            else:
+                undecorated_init(self, *args, **kwargs)
 
         callable_.__init__ = __init__
-        return callable_
+
+    return callable_
 
 
 def experimental_decorator(decorator):

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_backcompat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_backcompat.py
@@ -1,4 +1,5 @@
 import re
+from typing import NamedTuple
 
 import pytest
 from dagster.check import CheckError
@@ -166,3 +167,13 @@ def test_experimental_decorator_class():
         match='"goodbye" is an experimental function. It may break in future versions, even between dot releases.',
     ):
         assert experimental_class_with_experimental_function.goodbye("dagster") == "goodbye dagster"
+
+    @experimental
+    class ExperimentalNamedTupleClass(NamedTuple("_", [("salutation", str)])):
+        pass
+
+    with pytest.warns(
+        ExperimentalWarning,
+        match='"ExperimentalNamedTupleClass" is an experimental class. It may break in future versions, even between dot releases.',
+    ):
+        assert ExperimentalNamedTupleClass(salutation="howdy").salutation == "howdy"


### PR DESCRIPTION
`@experimental` decorator did not work for `NamedTuple` descendants because it manipulates `__init__`. But tuple classes have nonstandard `__new__` and don't forward arguments to `__init__`.