### PR TITLE
[dagit] Add a gradient behind the Gantt chart step selector

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -344,7 +344,7 @@ const GanttChartInner = (props: GanttChartInnerProps) => {
         />
       )}
       <div style={{overflow: 'scroll', flex: 1}} {...containerProps}>
-        <div style={{position: 'relative', marginBottom: 50, ...layoutSize}}>
+        <div style={{position: 'relative', marginBottom: 70, ...layoutSize}}>
           {measurementComplete && (
             <GanttChartViewportContents
               options={options}
@@ -383,7 +383,7 @@ const GanttChartInner = (props: GanttChartInnerProps) => {
             </Box>
           </WebsocketWarning>
         ) : null}
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
+        <FilterInputsBackgroundBox flex={{direction: 'row', alignItems: 'center', gap: 12}}>
           <GraphQueryInput
             items={props.graph}
             value={props.selection.query}
@@ -397,7 +397,7 @@ const GanttChartInner = (props: GanttChartInnerProps) => {
             label="Hide unselected steps"
             onChange={props.onChange}
           />
-        </Box>
+        </FilterInputsBackgroundBox>
       </GraphQueryInputContainer>
     </>
   );
@@ -771,6 +771,11 @@ const GraphQueryInputContainer = styled.div`
   left: 50%;
   transform: translateX(-50%);
   white-space: nowrap;
+`;
+
+const FilterInputsBackgroundBox = styled(Box)`
+  background: radial-gradient(${ColorsWIP.Gray50} 0%, rgba(255, 255, 255, 0) 100%);
+  padding: 15px 15px 0px 15px;
 `;
 
 export const GanttChartLoadingState = ({runId}: {runId: string}) => (


### PR DESCRIPTION
Fixes #5383. 

## Summary
Adds gradient glow around filter inputs over top of Gantt Chart, adds margin so that Gantt components cannot get stuck behind inputs box. Used the gradient suggested by Josh in the issue ticket.

ex:
![Screen Shot 2022-01-27 at 9 33 26 AM](https://user-images.githubusercontent.com/4010391/151390842-ed3d0709-d897-4871-96b6-6e84be658160.png)



## Test Plan

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.