### PR TITLE
RFC: Map config type for variable mappings

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,5 +1,5 @@
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
-from dagster.config import Enum, EnumValue, Field, Permissive, Selector, Shape, KeyedCollection
+from dagster.config import Enum, EnumValue, Field, KeyedCollection, Permissive, Selector, Shape
 from dagster.config.config_schema import ConfigSchema
 from dagster.config.config_type import Array, Noneable, ScalarUnion
 from dagster.core.definitions import (

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,5 +1,5 @@
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
-from dagster.config import Enum, EnumValue, Field, KeyedCollection, Permissive, Selector, Shape
+from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Shape
 from dagster.config.config_schema import ConfigSchema
 from dagster.config.config_type import Array, Noneable, ScalarUnion
 from dagster.core.definitions import (
@@ -258,7 +258,7 @@ __all__ = [
     "ExpectationResult",
     "Failure",
     "Field",
-    "KeyedCollection",
+    "Map",
     "GraphDefinition",
     "GraphIn",
     "GraphOut",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,5 +1,5 @@
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
-from dagster.config import Enum, EnumValue, Field, Permissive, Selector, Shape
+from dagster.config import Enum, EnumValue, Field, Permissive, Selector, Shape, KeyedCollection
 from dagster.config.config_schema import ConfigSchema
 from dagster.config.config_type import Array, Noneable, ScalarUnion
 from dagster.core.definitions import (
@@ -258,6 +258,7 @@ __all__ = [
     "ExpectationResult",
     "Failure",
     "Field",
+    "KeyedCollection",
     "GraphDefinition",
     "GraphIn",
     "GraphOut",

--- a/python_modules/dagster/dagster/cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/config_scaffolder.py
@@ -47,6 +47,8 @@ def scaffold_type(config_type, skip_non_required=True):
         return defaults[config_type.given_name]
     elif config_type.kind == ConfigTypeKind.ARRAY:
         return []
+    elif config_type.kind == ConfigTypeKind.KEYED_COLLECTION:
+        return {}
     elif config_type.kind == ConfigTypeKind.ENUM:
         return "|".join(sorted(map(lambda v: v.config_value, config_type.enum_values)))
     else:

--- a/python_modules/dagster/dagster/cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/config_scaffolder.py
@@ -47,7 +47,7 @@ def scaffold_type(config_type, skip_non_required=True):
         return defaults[config_type.given_name]
     elif config_type.kind == ConfigTypeKind.ARRAY:
         return []
-    elif config_type.kind == ConfigTypeKind.KEYED_COLLECTION:
+    elif config_type.kind == ConfigTypeKind.map:
         return {}
     elif config_type.kind == ConfigTypeKind.ENUM:
         return "|".join(sorted(map(lambda v: v.config_value, config_type.enum_values)))

--- a/python_modules/dagster/dagster/cli/config_scaffolder.py
+++ b/python_modules/dagster/dagster/cli/config_scaffolder.py
@@ -47,7 +47,7 @@ def scaffold_type(config_type, skip_non_required=True):
         return defaults[config_type.given_name]
     elif config_type.kind == ConfigTypeKind.ARRAY:
         return []
-    elif config_type.kind == ConfigTypeKind.map:
+    elif config_type.kind == ConfigTypeKind.MAP:
         return {}
     elif config_type.kind == ConfigTypeKind.ENUM:
         return "|".join(sorted(map(lambda v: v.config_value, config_type.enum_values)))

--- a/python_modules/dagster/dagster/config/__init__.py
+++ b/python_modules/dagster/dagster/config/__init__.py
@@ -1,5 +1,5 @@
 from .config_type import ConfigScalar, ConfigScalarKind, ConfigType, Enum, EnumValue, ScalarUnion
 from .errors import PostProcessingError
 from .field import Field
-from .field_utils import Permissive, Selector, Shape
+from .field_utils import KeyedCollection, Permissive, Selector, Shape
 from .validate import validate_config

--- a/python_modules/dagster/dagster/config/__init__.py
+++ b/python_modules/dagster/dagster/config/__init__.py
@@ -1,5 +1,5 @@
 from .config_type import ConfigScalar, ConfigScalarKind, ConfigType, Enum, EnumValue, ScalarUnion
 from .errors import PostProcessingError
 from .field import Field
-from .field_utils import KeyedCollection, Permissive, Selector, Shape
+from .field_utils import Map, Permissive, Selector, Shape
 from .validate import validate_config

--- a/python_modules/dagster/dagster/config/config_schema.py
+++ b/python_modules/dagster/dagster/config/config_schema.py
@@ -28,6 +28,7 @@ class ConfigSchema:
        * :py:data:`~dagster.IntSource`
        * :py:data:`~dagster.Noneable`
        * :py:class:`~dagster.Permissive`
+       * :py:class:`~dagster.Map`
        * :py:class:`~dagster.ScalarUnion`
        * :py:class:`~dagster.Selector`
        * :py:class:`~dagster.Shape`

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -15,6 +15,7 @@ class ConfigTypeKind(PythonEnum):
     SELECTOR = "SELECTOR"
     STRICT_SHAPE = "STRICT_SHAPE"
     PERMISSIVE_SHAPE = "PERMISSIVE_SHAPE"
+    KEYED_COLLECTION = "KEYED_COLLECTION"
     SCALAR_UNION = "SCALAR_UNION"
 
     @staticmethod
@@ -33,6 +34,7 @@ class ConfigTypeKind(PythonEnum):
             kind == ConfigTypeKind.ARRAY
             or kind == ConfigTypeKind.NONEABLE
             or kind == ConfigTypeKind.SCALAR_UNION
+            or kind == ConfigTypeKind.KEYED_COLLECTION
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -15,17 +15,18 @@ class ConfigTypeKind(PythonEnum):
     SELECTOR = "SELECTOR"
     STRICT_SHAPE = "STRICT_SHAPE"
     PERMISSIVE_SHAPE = "PERMISSIVE_SHAPE"
-    MAP = "MAP"
     SCALAR_UNION = "SCALAR_UNION"
+
+    MAP = "MAP"
+
+    # Closed generic types
+    ARRAY = "ARRAY"
+    NONEABLE = "NONEABLE"
 
     @staticmethod
     def has_fields(kind: "ConfigTypeKind") -> bool:
         check.inst_param(kind, "kind", ConfigTypeKind)
         return kind == ConfigTypeKind.SELECTOR or ConfigTypeKind.is_shape(kind)
-
-    # Closed generic types
-    ARRAY = "ARRAY"
-    NONEABLE = "NONEABLE"
 
     @staticmethod
     def is_closed_generic(kind: "ConfigTypeKind") -> bool:

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -15,7 +15,7 @@ class ConfigTypeKind(PythonEnum):
     SELECTOR = "SELECTOR"
     STRICT_SHAPE = "STRICT_SHAPE"
     PERMISSIVE_SHAPE = "PERMISSIVE_SHAPE"
-    KEYED_COLLECTION = "KEYED_COLLECTION"
+    map = "map"
     SCALAR_UNION = "SCALAR_UNION"
 
     @staticmethod
@@ -34,7 +34,7 @@ class ConfigTypeKind(PythonEnum):
             kind == ConfigTypeKind.ARRAY
             or kind == ConfigTypeKind.NONEABLE
             or kind == ConfigTypeKind.SCALAR_UNION
-            or kind == ConfigTypeKind.KEYED_COLLECTION
+            or kind == ConfigTypeKind.map
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -15,7 +15,7 @@ class ConfigTypeKind(PythonEnum):
     SELECTOR = "SELECTOR"
     STRICT_SHAPE = "STRICT_SHAPE"
     PERMISSIVE_SHAPE = "PERMISSIVE_SHAPE"
-    map = "map"
+    MAP = "MAP"
     SCALAR_UNION = "SCALAR_UNION"
 
     @staticmethod
@@ -34,7 +34,7 @@ class ConfigTypeKind(PythonEnum):
             kind == ConfigTypeKind.ARRAY
             or kind == ConfigTypeKind.NONEABLE
             or kind == ConfigTypeKind.SCALAR_UNION
-            or kind == ConfigTypeKind.map
+            or kind == ConfigTypeKind.MAP
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/config/errors.py
+++ b/python_modules/dagster/dagster/config/errors.py
@@ -254,6 +254,25 @@ def create_array_error(context, config_value):
     )
 
 
+def create_keyed_collection_error(context, config_value):
+    check.inst_param(context, "context", ContextData)
+    check.param_invariant(
+        context.config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION, "config_type"
+    )
+
+    return EvaluationError(
+        stack=context.stack,
+        reason=DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH,
+        message='Value {path_msg} must be dict. Expected: "{type_name}"'.format(
+            path_msg=get_friendly_path_msg(context.stack),
+            type_name=print_config_type_key_to_string(
+                context.config_schema_snapshot, context.config_type_key, with_lines=False
+            ),
+        ),
+        error_data=RuntimeMismatchErrorData(context.config_type_snap, repr(config_value)),
+    )
+
+
 def create_missing_required_field_error(
     context: ContextData, expected_field: str
 ) -> EvaluationError:

--- a/python_modules/dagster/dagster/config/errors.py
+++ b/python_modules/dagster/dagster/config/errors.py
@@ -254,11 +254,9 @@ def create_array_error(context, config_value):
     )
 
 
-def create_keyed_collection_error(context, config_value):
+def create_map_error(context, config_value):
     check.inst_param(context, "context", ContextData)
-    check.param_invariant(
-        context.config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION, "config_type"
-    )
+    check.param_invariant(context.config_type_snap.kind == ConfigTypeKind.map, "config_type")
 
     return EvaluationError(
         stack=context.stack,

--- a/python_modules/dagster/dagster/config/errors.py
+++ b/python_modules/dagster/dagster/config/errors.py
@@ -256,7 +256,7 @@ def create_array_error(context, config_value):
 
 def create_map_error(context, config_value):
     check.inst_param(context, "context", ContextData)
-    check.param_invariant(context.config_type_snap.kind == ConfigTypeKind.map, "config_type")
+    check.param_invariant(context.config_type_snap.kind == ConfigTypeKind.MAP, "config_type")
 
     return EvaluationError(
         stack=context.stack,

--- a/python_modules/dagster/dagster/config/field.py
+++ b/python_modules/dagster/dagster/config/field.py
@@ -8,7 +8,7 @@ from dagster.utils import is_enum_value
 from dagster.utils.typing_api import is_closed_python_optional_type, is_typing_type
 
 from .config_type import Array, ConfigAnyInstance, ConfigType, ConfigTypeKind
-from .field_utils import FIELD_NO_DEFAULT_PROVIDED, KeyedCollection, all_optional_type
+from .field_utils import FIELD_NO_DEFAULT_PROVIDED, Map, all_optional_type
 
 
 def _is_config_type_class(obj):
@@ -52,7 +52,7 @@ def resolve_to_config_type(dagster_type) -> Union[ConfigType, bool]:
         return dagster_type
 
     if isinstance(dagster_type, dict):
-        # Dicts of the special form {type: value} are treated as KeyedCollections
+        # Dicts of the special form {type: value} are treated as Maps
         # mapping from the type to value type, otherwise treat as dict type
         if len(dagster_type) == 1:
             key = list(dagster_type.keys())[0]
@@ -60,14 +60,14 @@ def resolve_to_config_type(dagster_type) -> Union[ConfigType, bool]:
             if not isinstance(key, str):
                 if not key_type:
                     raise DagsterInvalidDefinitionError(
-                        "Invalid key in keyed collection specification: {key} collection {collection}".format(
+                        "Invalid key in map specification: {key} in map {collection}".format(
                             key=repr(key), collection=dagster_type
                         )
                     )
 
                 if not key_type.kind == ConfigTypeKind.SCALAR:
                     raise DagsterInvalidDefinitionError(
-                        "Non-scalar key in keyed collection specification: {key} collection {collection}".format(
+                        "Non-scalar key in map specification: {key} in map {collection}".format(
                             key=repr(key), collection=dagster_type
                         )
                     )
@@ -76,11 +76,11 @@ def resolve_to_config_type(dagster_type) -> Union[ConfigType, bool]:
 
                 if not inner_type:
                     raise DagsterInvalidDefinitionError(
-                        "Invalid value in keyed collection specification: {value} collection {collection}".format(
+                        "Invalid value in map specification: {value} in map {collection}".format(
                             value=repr(dagster_type[str]), collection=dagster_type
                         )
                     )
-                return KeyedCollection(key_type, inner_type)
+                return Map(key_type, inner_type)
         return convert_fields_to_dict_type(dagster_type)
 
     if isinstance(dagster_type, list):

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -182,7 +182,7 @@ class Map(ConfigType):
                 key_type=self.key_type.key, inner_type=self.inner_type.key
             ),
             type_params=[self.key_type, self.inner_type],
-            kind=ConfigTypeKind.map,
+            kind=ConfigTypeKind.MAP,
         )
 
     @property

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -149,7 +149,6 @@ class Map(ConfigType):
     type checked values. Unlike :py:class:`Shape` and :py:class:`Permissive`, scalar
     keys other than strings can be used, and unlike :py:class:`Permissive`, all
     values are type checked.
-
     Args:
         key_type (type):
             The type of keys this map can contain. Must be a scalar type.
@@ -395,10 +394,13 @@ def _convert_potential_type(original_root: object, potential_type, stack: List[s
     from .field import resolve_to_config_type
 
     if isinstance(potential_type, dict):
+        # A dictionary, containing a single key which is a type (int, str, etc) and not a string is interpreted as a Map
         if len(potential_type) == 1:
             key = list(potential_type.keys())[0]
             if not isinstance(key, str) and _convert_potential_type(original_root, key, stack):
                 return expand_map(original_root, potential_type, stack)
+
+        # Otherwise, the dictionary is interpreted as a Shape
         return Shape(_expand_fields_dict(original_root, potential_type, stack))
 
     if isinstance(potential_type, list):

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -142,7 +142,7 @@ class Shape(_ConfigHasFields):
         )
 
 
-class KeyedCollection(ConfigType):
+class Map(ConfigType):
     def __init__(self, key_type, inner_type):
         from .field import resolve_to_config_type
 
@@ -155,17 +155,17 @@ class KeyedCollection(ConfigType):
             self.key_type.kind == ConfigTypeKind.SCALAR, "key_type", "Key type must be a scalar"
         )
 
-        super(KeyedCollection, self).__init__(
-            key="KeyedCollection.{key_type}.{inner_type}".format(
+        super(Map, self).__init__(
+            key="Map.{key_type}.{inner_type}".format(
                 key_type=self.key_type.key, inner_type=self.inner_type.key
             ),
             type_params=[self.key_type, self.inner_type],
-            kind=ConfigTypeKind.KEYED_COLLECTION,
+            kind=ConfigTypeKind.map,
         )
 
     @property
     def description(self):
-        return "Keyed Collection {key_type} -> {inner_type}".format(
+        return "map {key_type} -> {inner_type}".format(
             key_type=self.key_type.key, inner_type=self.inner_type.key
         )
 
@@ -334,13 +334,11 @@ def expand_list(original_root: object, the_list: List[object], stack: List[str])
     return Array(inner_type)
 
 
-def expand_keyed_collection(
-    original_root: object, the_dict: Dict[object, object], stack: List[str]
-) -> KeyedCollection:
+def expand_map(original_root: object, the_dict: Dict[object, object], stack: List[str]) -> Map:
 
     if len(the_dict) != 1:
         raise DagsterInvalidConfigDefinitionError(
-            original_root, the_dict, stack, "KeyedCollection dict must be of length 1"
+            original_root, the_dict, stack, "Map dict must be of length 1"
         )
 
     key = list(the_dict.keys())[0]
@@ -350,9 +348,7 @@ def expand_keyed_collection(
             original_root,
             the_dict,
             stack,
-            "KeyedCollection dict must have a scalar type as its only key. Got key {}".format(
-                repr(key)
-            ),
+            "Map dict must have a scalar type as its only key. Got key {}".format(repr(key)),
         )
 
     inner_type = _convert_potential_type(original_root, the_dict[key], stack)
@@ -361,12 +357,12 @@ def expand_keyed_collection(
             original_root,
             the_dict,
             stack,
-            "KeyedCollection must have a single value and contain a valid type i.e. {{str: int}}. Got item {}".format(
+            "Map must have a single value and contain a valid type i.e. {{str: int}}. Got item {}".format(
                 repr(the_dict[key])
             ),
         )
 
-    return KeyedCollection(key_type, inner_type)
+    return Map(key_type, inner_type)
 
 
 def convert_potential_field(potential_field: object) -> "Field":
@@ -380,7 +376,7 @@ def _convert_potential_type(original_root: object, potential_type, stack: List[s
         if len(potential_type) == 1:
             key = list(potential_type.keys())[0]
             if not isinstance(key, str) and _convert_potential_type(original_root, key, stack):
-                return expand_keyed_collection(original_root, potential_type, stack)
+                return expand_map(original_root, potential_type, stack)
         return Shape(_expand_fields_dict(original_root, potential_type, stack))
 
     if isinstance(potential_type, list):

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -143,6 +143,28 @@ class Shape(_ConfigHasFields):
 
 
 class Map(ConfigType):
+    """Defines a config dict with arbitrary scalar keys and typed values.
+
+    A map can contrain arbitrary keys of the specified scalar type, each of which has
+    type checked values. Unlike :py:class:`Shape` and :py:class:`Permissive`, scalar
+    keys other than strings can be used, and unlike :py:class:`Permissive`, all
+    values are type checked.
+
+    Args:
+        key_type (type):
+            The type of keys this map can contain. Must be a scalar type.
+        inner_type (type):
+            The type of the values that this map type can contain.
+
+    **Examples:**
+
+    .. code-block:: python
+
+        @op(config_schema=Field(Map({str: int})))
+        def partially_specified_config(context) -> List:
+            return sorted(list(context.op_config.items()))
+    """
+
     def __init__(self, key_type, inner_type):
         from .field import resolve_to_config_type
 

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -184,12 +184,6 @@ class Map(ConfigType):
             kind=ConfigTypeKind.MAP,
         )
 
-    @property
-    def description(self):
-        return "map {key_type} -> {inner_type}".format(
-            key_type=self.key_type.key, inner_type=self.inner_type.key
-        )
-
 
 def _define_permissive_dict_key(fields, description):
     return (

--- a/python_modules/dagster/dagster/config/iterate_types.py
+++ b/python_modules/dagster/dagster/config/iterate_types.py
@@ -12,7 +12,11 @@ def iterate_config_types(config_type: ConfigType) -> Generator[ConfigType, None,
 
     # type-ignore comments below are because static type checkers don't
     # understand the `ConfigTypeKind` system.
-    if config_type.kind == ConfigTypeKind.ARRAY or config_type.kind == ConfigTypeKind.NONEABLE:
+    if (
+        config_type.kind == ConfigTypeKind.ARRAY
+        or config_type.kind == ConfigTypeKind.NONEABLE
+        or config_type.kind == ConfigTypeKind.KEYED_COLLECTION
+    ):
         yield from iterate_config_types(config_type.inner_type)  # type: ignore
 
     if ConfigTypeKind.has_fields(config_type.kind):

--- a/python_modules/dagster/dagster/config/iterate_types.py
+++ b/python_modules/dagster/dagster/config/iterate_types.py
@@ -12,11 +12,11 @@ def iterate_config_types(config_type: ConfigType) -> Generator[ConfigType, None,
 
     # type-ignore comments below are because static type checkers don't
     # understand the `ConfigTypeKind` system.
-    if (
-        config_type.kind == ConfigTypeKind.ARRAY
-        or config_type.kind == ConfigTypeKind.NONEABLE
-        or config_type.kind == ConfigTypeKind.KEYED_COLLECTION
-    ):
+    if config_type.kind == ConfigTypeKind.KEYED_COLLECTION:
+        yield from iterate_config_types(config_type.key_type)  # type: ignore
+        yield from iterate_config_types(config_type.inner_type)  # type: ignore
+
+    if config_type.kind == ConfigTypeKind.ARRAY or config_type.kind == ConfigTypeKind.NONEABLE:
         yield from iterate_config_types(config_type.inner_type)  # type: ignore
 
     if ConfigTypeKind.has_fields(config_type.kind):

--- a/python_modules/dagster/dagster/config/iterate_types.py
+++ b/python_modules/dagster/dagster/config/iterate_types.py
@@ -12,7 +12,7 @@ def iterate_config_types(config_type: ConfigType) -> Generator[ConfigType, None,
 
     # type-ignore comments below are because static type checkers don't
     # understand the `ConfigTypeKind` system.
-    if config_type.kind == ConfigTypeKind.map:
+    if config_type.kind == ConfigTypeKind.MAP:
         yield from iterate_config_types(config_type.key_type)  # type: ignore
         yield from iterate_config_types(config_type.inner_type)  # type: ignore
 

--- a/python_modules/dagster/dagster/config/iterate_types.py
+++ b/python_modules/dagster/dagster/config/iterate_types.py
@@ -12,7 +12,7 @@ def iterate_config_types(config_type: ConfigType) -> Generator[ConfigType, None,
 
     # type-ignore comments below are because static type checkers don't
     # understand the `ConfigTypeKind` system.
-    if config_type.kind == ConfigTypeKind.KEYED_COLLECTION:
+    if config_type.kind == ConfigTypeKind.map:
         yield from iterate_config_types(config_type.key_type)  # type: ignore
         yield from iterate_config_types(config_type.inner_type)  # type: ignore
 

--- a/python_modules/dagster/dagster/config/post_process.py
+++ b/python_modules/dagster/dagster/config/post_process.py
@@ -59,7 +59,7 @@ def _recursively_resolve_defaults(
         return _recurse_in_to_shape(context, config_value)
     elif kind == ConfigTypeKind.ARRAY:
         return _recurse_in_to_array(context, config_value)
-    elif kind == ConfigTypeKind.map:
+    elif kind == ConfigTypeKind.MAP:
         return _recurse_in_to_map(context, config_value)
     elif kind == ConfigTypeKind.NONEABLE:
         if config_value is None:
@@ -212,7 +212,7 @@ def _recurse_in_to_array(context: TraversalContext, config_value: Any) -> Evalua
 
 def _recurse_in_to_map(context: TraversalContext, config_value: Any) -> EvaluateValueResult:
     check.invariant(
-        context.config_type.kind == ConfigTypeKind.map,
+        context.config_type.kind == ConfigTypeKind.MAP,
         "Unexpected non map type",
     )
 

--- a/python_modules/dagster/dagster/config/post_process.py
+++ b/python_modules/dagster/dagster/config/post_process.py
@@ -221,8 +221,10 @@ def _recurse_in_to_keyed_collection(
     if not config_value:
         return EvaluateValueResult.for_value({})
 
-    config_value = cast(Dict[str, object], config_value)
+    config_value = cast(Dict[object, object], config_value)
 
+    if any((ck is None for ck in config_value.keys())):
+        check.failed("Null keyed collection key not caught in validation")
     if context.config_type.inner_type.kind != ConfigTypeKind.NONEABLE:  # type: ignore
         if any((cv is None for cv in config_value.values())):
             check.failed("Null keyed collection member not caught in validation")

--- a/python_modules/dagster/dagster/config/snap.py
+++ b/python_modules/dagster/dagster/config/snap.py
@@ -114,7 +114,11 @@ class ConfigTypeSnap(
     @property
     def inner_type_key(self) -> str:
         # valid for Noneable and Array
-        check.invariant(self.kind == ConfigTypeKind.NONEABLE or self.kind == ConfigTypeKind.ARRAY)
+        check.invariant(
+            self.kind == ConfigTypeKind.NONEABLE
+            or self.kind == ConfigTypeKind.ARRAY
+            or self.kind == ConfigTypeKind.KEYED_COLLECTION
+        )
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
         check.invariant(len(type_param_keys) == 1)
         return type_param_keys[0]
@@ -284,6 +288,8 @@ def minimal_config_for_type_snap(
         return defaults.get(config_type_snap.given_name, "<unknown>")  # type: ignore
     elif config_type_snap.kind == ConfigTypeKind.ARRAY:
         return []
+    elif config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION:
+        return {}
     elif config_type_snap.kind == ConfigTypeKind.ENUM:
         # guard against the edge case that an enum is defined with zero options
         return (

--- a/python_modules/dagster/dagster/config/snap.py
+++ b/python_modules/dagster/dagster/config/snap.py
@@ -113,7 +113,8 @@ class ConfigTypeSnap(
 
     @property
     def key_type_key(self) -> str:
-        # valid for Map
+        """For a type which has keys such as Map, returns the type of the key."""
+        # valid for Map, which has its key type as the first entry in type_param_keys
         check.invariant(self.kind == ConfigTypeKind.MAP)
 
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
@@ -122,6 +123,7 @@ class ConfigTypeSnap(
 
     @property
     def inner_type_key(self) -> str:
+        """For container types such as Array or Noneable, the contained type. For a Map, the value type."""
         # valid for Noneable, Map, and Array
         check.invariant(
             self.kind == ConfigTypeKind.NONEABLE
@@ -131,6 +133,7 @@ class ConfigTypeSnap(
 
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
         if self.kind == ConfigTypeKind.MAP:
+            # For a Map, the inner (value) type is the second entry (the first is the key type)
             check.invariant(len(type_param_keys) == 2)
             return type_param_keys[1]
         else:

--- a/python_modules/dagster/dagster/config/snap.py
+++ b/python_modules/dagster/dagster/config/snap.py
@@ -114,7 +114,7 @@ class ConfigTypeSnap(
     @property
     def key_type_key(self) -> str:
         # valid for Map
-        check.invariant(self.kind == ConfigTypeKind.map)
+        check.invariant(self.kind == ConfigTypeKind.MAP)
 
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
         check.invariant(len(type_param_keys) == 2)
@@ -126,11 +126,11 @@ class ConfigTypeSnap(
         check.invariant(
             self.kind == ConfigTypeKind.NONEABLE
             or self.kind == ConfigTypeKind.ARRAY
-            or self.kind == ConfigTypeKind.map
+            or self.kind == ConfigTypeKind.MAP
         )
 
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
-        if self.kind == ConfigTypeKind.map:
+        if self.kind == ConfigTypeKind.MAP:
             check.invariant(len(type_param_keys) == 2)
             return type_param_keys[1]
         else:
@@ -302,7 +302,7 @@ def minimal_config_for_type_snap(
         return defaults.get(config_type_snap.given_name, "<unknown>")  # type: ignore
     elif config_type_snap.kind == ConfigTypeKind.ARRAY:
         return []
-    elif config_type_snap.kind == ConfigTypeKind.map:
+    elif config_type_snap.kind == ConfigTypeKind.MAP:
         return {}
     elif config_type_snap.kind == ConfigTypeKind.ENUM:
         # guard against the edge case that an enum is defined with zero options

--- a/python_modules/dagster/dagster/config/snap.py
+++ b/python_modules/dagster/dagster/config/snap.py
@@ -112,16 +112,30 @@ class ConfigTypeSnap(
         )
 
     @property
+    def key_type_key(self) -> str:
+        # valid for KeyedCollection
+        check.invariant(self.kind == ConfigTypeKind.KEYED_COLLECTION)
+
+        type_param_keys = check.is_list(self.type_param_keys, of_type=str)
+        check.invariant(len(type_param_keys) == 2)
+        return type_param_keys[0]
+
+    @property
     def inner_type_key(self) -> str:
-        # valid for Noneable and Array
+        # valid for Noneable, KeyedCollection, and Array
         check.invariant(
             self.kind == ConfigTypeKind.NONEABLE
             or self.kind == ConfigTypeKind.ARRAY
             or self.kind == ConfigTypeKind.KEYED_COLLECTION
         )
+
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
-        check.invariant(len(type_param_keys) == 1)
-        return type_param_keys[0]
+        if self.kind == ConfigTypeKind.KEYED_COLLECTION:
+            check.invariant(len(type_param_keys) == 2)
+            return type_param_keys[1]
+        else:
+            check.invariant(len(type_param_keys) == 1)
+            return type_param_keys[0]
 
     @property
     def scalar_type_key(self) -> str:

--- a/python_modules/dagster/dagster/config/snap.py
+++ b/python_modules/dagster/dagster/config/snap.py
@@ -113,8 +113,8 @@ class ConfigTypeSnap(
 
     @property
     def key_type_key(self) -> str:
-        # valid for KeyedCollection
-        check.invariant(self.kind == ConfigTypeKind.KEYED_COLLECTION)
+        # valid for Map
+        check.invariant(self.kind == ConfigTypeKind.map)
 
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
         check.invariant(len(type_param_keys) == 2)
@@ -122,15 +122,15 @@ class ConfigTypeSnap(
 
     @property
     def inner_type_key(self) -> str:
-        # valid for Noneable, KeyedCollection, and Array
+        # valid for Noneable, Map, and Array
         check.invariant(
             self.kind == ConfigTypeKind.NONEABLE
             or self.kind == ConfigTypeKind.ARRAY
-            or self.kind == ConfigTypeKind.KEYED_COLLECTION
+            or self.kind == ConfigTypeKind.map
         )
 
         type_param_keys = check.is_list(self.type_param_keys, of_type=str)
-        if self.kind == ConfigTypeKind.KEYED_COLLECTION:
+        if self.kind == ConfigTypeKind.map:
             check.invariant(len(type_param_keys) == 2)
             return type_param_keys[1]
         else:
@@ -302,7 +302,7 @@ def minimal_config_for_type_snap(
         return defaults.get(config_type_snap.given_name, "<unknown>")  # type: ignore
     elif config_type_snap.kind == ConfigTypeKind.ARRAY:
         return []
-    elif config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION:
+    elif config_type_snap.kind == ConfigTypeKind.map:
         return {}
     elif config_type_snap.kind == ConfigTypeKind.ENUM:
         # guard against the edge case that an enum is defined with zero options

--- a/python_modules/dagster/dagster/config/stack.py
+++ b/python_modules/dagster/dagster/config/stack.py
@@ -24,6 +24,11 @@ class EvaluationStack(NamedTuple("_EvaluationStack", [("entries", List["Evaluati
     def for_array_index(self, list_index: int) -> "EvaluationStack":
         return EvaluationStack(entries=self.entries + [EvaluationStackListItemEntry(list_index)])
 
+    def for_keyed_collection_key(self, keyed_collection_key: str) -> "EvaluationStack":
+        return EvaluationStack(
+            entries=self.entries + [EvaluationStackKeyedCollectionItemEntry(keyed_collection_key)]
+        )
+
 
 class EvaluationStackEntry:  # marker interface
     pass
@@ -48,6 +53,17 @@ class EvaluationStackListItemEntry(
         return super(EvaluationStackListItemEntry, cls).__new__(cls, list_index)
 
 
+class EvaluationStackKeyedCollectionItemEntry(
+    NamedTuple("_EvaluationStackKeyedCollectionItemEntry", [("keyed_collection_key", str)]),
+    EvaluationStackEntry,
+):
+    def __new__(cls, keyed_collection_key: str):
+        check.str_param(keyed_collection_key, "keyed_collection_key")
+        return super(EvaluationStackKeyedCollectionItemEntry, cls).__new__(
+            cls, keyed_collection_key
+        )
+
+
 def get_friendly_path_msg(stack: EvaluationStack) -> str:
     return get_friendly_path_info(stack)[0]
 
@@ -64,6 +80,9 @@ def get_friendly_path_info(stack: EvaluationStack) -> Tuple[str, str]:
                 comps.append(comp)
             elif isinstance(entry, EvaluationStackListItemEntry):
                 comps.append("[{i}]".format(i=entry.list_index))
+            elif isinstance(entry, EvaluationStackKeyedCollectionItemEntry):
+                comp = ":" + entry.keyed_collection_key
+                comps.append(comp)
             else:
                 check.failed("unsupported")
 

--- a/python_modules/dagster/dagster/config/stack.py
+++ b/python_modules/dagster/dagster/config/stack.py
@@ -24,15 +24,11 @@ class EvaluationStack(NamedTuple("_EvaluationStack", [("entries", List["Evaluati
     def for_array_index(self, list_index: int) -> "EvaluationStack":
         return EvaluationStack(entries=self.entries + [EvaluationStackListItemEntry(list_index)])
 
-    def for_keyed_collection_key(self, keyed_collection_key: object) -> "EvaluationStack":
-        return EvaluationStack(
-            entries=self.entries + [EvaluationStackKeyedCollectionKeyEntry(keyed_collection_key)]
-        )
+    def for_map_key(self, map_key: object) -> "EvaluationStack":
+        return EvaluationStack(entries=self.entries + [EvaluationStackMapKeyEntry(map_key)])
 
-    def for_keyed_collection_value(self, keyed_collection_key: object) -> "EvaluationStack":
-        return EvaluationStack(
-            entries=self.entries + [EvaluationStackKeyedCollectionValueEntry(keyed_collection_key)]
-        )
+    def for_map_value(self, map_key: object) -> "EvaluationStack":
+        return EvaluationStack(entries=self.entries + [EvaluationStackMapValueEntry(map_key)])
 
 
 class EvaluationStackEntry:  # marker interface
@@ -58,22 +54,20 @@ class EvaluationStackListItemEntry(
         return super(EvaluationStackListItemEntry, cls).__new__(cls, list_index)
 
 
-class EvaluationStackKeyedCollectionKeyEntry(
-    NamedTuple("EvaluationStackKeyedCollectionKeyEntry", [("keyed_collection_key", object)]),
+class EvaluationStackMapKeyEntry(
+    NamedTuple("EvaluationStackMapKeyEntry", [("map_key", object)]),
     EvaluationStackEntry,
 ):
-    def __new__(cls, keyed_collection_key: object):
-        return super(EvaluationStackKeyedCollectionKeyEntry, cls).__new__(cls, keyed_collection_key)
+    def __new__(cls, map_key: object):
+        return super(EvaluationStackMapKeyEntry, cls).__new__(cls, map_key)
 
 
-class EvaluationStackKeyedCollectionValueEntry(
-    NamedTuple("_EvaluationStackKeyedCollectionItemEntry", [("keyed_collection_key", object)]),
+class EvaluationStackMapValueEntry(
+    NamedTuple("_EvaluationStackMapItemEntry", [("map_key", object)]),
     EvaluationStackEntry,
 ):
-    def __new__(cls, keyed_collection_key: object):
-        return super(EvaluationStackKeyedCollectionValueEntry, cls).__new__(
-            cls, keyed_collection_key
-        )
+    def __new__(cls, map_key: object):
+        return super(EvaluationStackMapValueEntry, cls).__new__(cls, map_key)
 
 
 def get_friendly_path_msg(stack: EvaluationStack) -> str:
@@ -92,11 +86,11 @@ def get_friendly_path_info(stack: EvaluationStack) -> Tuple[str, str]:
                 comps.append(comp)
             elif isinstance(entry, EvaluationStackListItemEntry):
                 comps.append("[{i}]".format(i=entry.list_index))
-            elif isinstance(entry, EvaluationStackKeyedCollectionKeyEntry):
-                comp = ":" + repr(entry.keyed_collection_key) + ":key"
+            elif isinstance(entry, EvaluationStackMapKeyEntry):
+                comp = ":" + repr(entry.map_key) + ":key"
                 comps.append(comp)
-            elif isinstance(entry, EvaluationStackKeyedCollectionValueEntry):
-                comp = ":" + repr(entry.keyed_collection_key) + ":value"
+            elif isinstance(entry, EvaluationStackMapValueEntry):
+                comp = ":" + repr(entry.map_key) + ":value"
                 comps.append(comp)
             else:
                 check.failed("unsupported")

--- a/python_modules/dagster/dagster/config/traversal_context.py
+++ b/python_modules/dagster/dagster/config/traversal_context.py
@@ -167,7 +167,7 @@ class TraversalContext(ContextData):
             all_config_types=self.all_config_types,
         )
 
-    def for_keyed_collection(self, key: int) -> "TraversalContext":
+    def for_keyed_collection(self, key: str) -> "TraversalContext":
         check.str_param(key, "key")
         return TraversalContext(
             config_schema_snapshot=self.config_schema_snapshot,

--- a/python_modules/dagster/dagster/config/traversal_context.py
+++ b/python_modules/dagster/dagster/config/traversal_context.py
@@ -72,6 +72,16 @@ class ValidationContext(ContextData):
             stack=self.stack.for_array_index(index),
         )
 
+    def for_keyed_collection(self, key: str) -> "ValidationContext":
+        check.str_param(key, "key")
+        return ValidationContext(
+            config_schema_snapshot=self.config_schema_snapshot,
+            config_type_snap=self.config_schema_snapshot.get_config_snap(
+                self.config_type_snap.inner_type_key
+            ),
+            stack=self.stack.for_keyed_collection_key(key),
+        )
+
     def for_new_config_type_key(self, config_type_key: str) -> "ValidationContext":
         check.str_param(config_type_key, "config_type_key")
         return ValidationContext(
@@ -153,6 +163,19 @@ class TraversalContext(ContextData):
             ),
             config_type=self.config_type.inner_type,  # type: ignore
             stack=self.stack.for_array_index(index),
+            traversal_type=self.traversal_type,
+            all_config_types=self.all_config_types,
+        )
+
+    def for_keyed_collection(self, key: int) -> "TraversalContext":
+        check.str_param(key, "key")
+        return TraversalContext(
+            config_schema_snapshot=self.config_schema_snapshot,
+            config_type_snap=self.config_schema_snapshot.get_config_snap(
+                self.config_type_snap.inner_type_key
+            ),
+            config_type=self.config_type.inner_type,  # type: ignore
+            stack=self.stack.for_keyed_collection_key(key),
             traversal_type=self.traversal_type,
             all_config_types=self.all_config_types,
         )

--- a/python_modules/dagster/dagster/config/traversal_context.py
+++ b/python_modules/dagster/dagster/config/traversal_context.py
@@ -72,14 +72,22 @@ class ValidationContext(ContextData):
             stack=self.stack.for_array_index(index),
         )
 
-    def for_keyed_collection(self, key: str) -> "ValidationContext":
-        check.str_param(key, "key")
+    def for_keyed_collection_key(self, key: object) -> "ValidationContext":
+        return ValidationContext(
+            config_schema_snapshot=self.config_schema_snapshot,
+            config_type_snap=self.config_schema_snapshot.get_config_snap(
+                self.config_type_snap.key_type_key
+            ),
+            stack=self.stack.for_keyed_collection_key(key),
+        )
+
+    def for_keyed_collection_value(self, key: object) -> "ValidationContext":
         return ValidationContext(
             config_schema_snapshot=self.config_schema_snapshot,
             config_type_snap=self.config_schema_snapshot.get_config_snap(
                 self.config_type_snap.inner_type_key
             ),
-            stack=self.stack.for_keyed_collection_key(key),
+            stack=self.stack.for_keyed_collection_value(key),
         )
 
     def for_new_config_type_key(self, config_type_key: str) -> "ValidationContext":
@@ -167,15 +175,14 @@ class TraversalContext(ContextData):
             all_config_types=self.all_config_types,
         )
 
-    def for_keyed_collection(self, key: str) -> "TraversalContext":
-        check.str_param(key, "key")
+    def for_keyed_collection(self, key: object) -> "TraversalContext":
         return TraversalContext(
             config_schema_snapshot=self.config_schema_snapshot,
             config_type_snap=self.config_schema_snapshot.get_config_snap(
                 self.config_type_snap.inner_type_key
             ),
             config_type=self.config_type.inner_type,  # type: ignore
-            stack=self.stack.for_keyed_collection_key(key),
+            stack=self.stack.for_keyed_collection_value(key),
             traversal_type=self.traversal_type,
             all_config_types=self.all_config_types,
         )

--- a/python_modules/dagster/dagster/config/traversal_context.py
+++ b/python_modules/dagster/dagster/config/traversal_context.py
@@ -72,22 +72,22 @@ class ValidationContext(ContextData):
             stack=self.stack.for_array_index(index),
         )
 
-    def for_keyed_collection_key(self, key: object) -> "ValidationContext":
+    def for_map_key(self, key: object) -> "ValidationContext":
         return ValidationContext(
             config_schema_snapshot=self.config_schema_snapshot,
             config_type_snap=self.config_schema_snapshot.get_config_snap(
                 self.config_type_snap.key_type_key
             ),
-            stack=self.stack.for_keyed_collection_key(key),
+            stack=self.stack.for_map_key(key),
         )
 
-    def for_keyed_collection_value(self, key: object) -> "ValidationContext":
+    def for_map_value(self, key: object) -> "ValidationContext":
         return ValidationContext(
             config_schema_snapshot=self.config_schema_snapshot,
             config_type_snap=self.config_schema_snapshot.get_config_snap(
                 self.config_type_snap.inner_type_key
             ),
-            stack=self.stack.for_keyed_collection_value(key),
+            stack=self.stack.for_map_value(key),
         )
 
     def for_new_config_type_key(self, config_type_key: str) -> "ValidationContext":
@@ -175,14 +175,14 @@ class TraversalContext(ContextData):
             all_config_types=self.all_config_types,
         )
 
-    def for_keyed_collection(self, key: object) -> "TraversalContext":
+    def for_map(self, key: object) -> "TraversalContext":
         return TraversalContext(
             config_schema_snapshot=self.config_schema_snapshot,
             config_type_snap=self.config_schema_snapshot.get_config_snap(
                 self.config_type_snap.inner_type_key
             ),
             config_type=self.config_type.inner_type,  # type: ignore
-            stack=self.stack.for_keyed_collection_value(key),
+            stack=self.stack.for_map_value(key),
             traversal_type=self.traversal_type,
             all_config_types=self.all_config_types,
         )

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -47,6 +47,18 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
         printer.append(" | ")
         _do_print(config_schema_snapshot, config_type_snap.non_scalar_type_key, printer)
         printer.append(")")
+    elif kind == ConfigTypeKind.KEYED_COLLECTION:
+        line_break_fn("{")
+        with printer.with_indent():
+            printer.append("*String: ")
+            _do_print(
+                config_schema_snapshot,
+                config_type_snap.inner_type_key,
+                printer,
+                with_lines=with_lines,
+            )
+            line_break_fn("")
+        printer.append("}")
     elif ConfigTypeKind.has_fields(kind):
         line_break_fn("{")
         with printer.with_indent():

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -48,6 +48,10 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
         _do_print(config_schema_snapshot, config_type_snap.non_scalar_type_key, printer)
         printer.append(")")
     elif kind == ConfigTypeKind.MAP:
+        # e.g.
+        # {
+        #   [String]: Int
+        # }
         line_break_fn("{")
         with printer.with_indent():
             printer.append("[")

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -47,7 +47,7 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
         printer.append(" | ")
         _do_print(config_schema_snapshot, config_type_snap.non_scalar_type_key, printer)
         printer.append(")")
-    elif kind == ConfigTypeKind.KEYED_COLLECTION:
+    elif kind == ConfigTypeKind.map:
         line_break_fn("{")
         with printer.with_indent():
             printer.append("[")

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -47,7 +47,7 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
         printer.append(" | ")
         _do_print(config_schema_snapshot, config_type_snap.non_scalar_type_key, printer)
         printer.append(")")
-    elif kind == ConfigTypeKind.map:
+    elif kind == ConfigTypeKind.MAP:
         line_break_fn("{")
         with printer.with_indent():
             printer.append("[")

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -50,7 +50,9 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
     elif kind == ConfigTypeKind.KEYED_COLLECTION:
         line_break_fn("{")
         with printer.with_indent():
-            printer.append("*String: ")
+            printer.append("[")
+            _do_print(config_schema_snapshot, config_type_snap.key_type_key, printer)
+            printer.append("]: ")
             _do_print(
                 config_schema_snapshot,
                 config_type_snap.inner_type_key,

--- a/python_modules/dagster/dagster/config/validate.py
+++ b/python_modules/dagster/dagster/config/validate.py
@@ -13,6 +13,7 @@ from .errors import (
     create_field_not_defined_error,
     create_field_substitution_collision_error,
     create_fields_not_defined_error,
+    create_keyed_collection_error,
     create_missing_required_field_error,
     create_missing_required_fields_error,
     create_none_not_allowed_error,
@@ -110,6 +111,8 @@ def _validate_config(context: ValidationContext, config_value: object) -> Evalua
         return validate_shape_config(context, config_value)
     elif kind == ConfigTypeKind.PERMISSIVE_SHAPE:
         return validate_permissive_shape_config(context, config_value)
+    elif kind == ConfigTypeKind.KEYED_COLLECTION:
+        return validate_keyed_collection_config(context, config_value)
     elif kind == ConfigTypeKind.ARRAY:
         return validate_array_config(context, config_value)
     elif kind == ConfigTypeKind.ENUM:
@@ -297,6 +300,30 @@ def validate_permissive_shape_config(
     check.not_none_param(config_value, "config_value")
 
     return _validate_shape_config(context, config_value, check_for_extra_incoming_fields=False)
+
+
+def validate_keyed_collection_config(
+    context: ValidationContext, config_value: object
+) -> EvaluateValueResult[Dict[str, object]]:
+    check.inst_param(context, "context", ValidationContext)
+    check.invariant(context.config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION)
+    check.not_none_param(config_value, "config_value")
+
+    if not isinstance(config_value, dict):
+        return EvaluateValueResult.for_error(create_keyed_collection_error(context, config_value))
+    config_value = cast(Dict[str, object], config_value)
+
+    evaluation_results = [
+        _validate_config(context.for_keyed_collection(key), config_item)
+        for key, config_item in config_value.items()
+    ]
+
+    errors = []
+    for result in evaluation_results:
+        if not result.success:
+            errors += cast(List, result.errors)
+
+    return EvaluateValueResult(not bool(errors), frozendict(config_value), errors)  # type: ignore
 
 
 def validate_shape_config(

--- a/python_modules/dagster/dagster/config/validate.py
+++ b/python_modules/dagster/dagster/config/validate.py
@@ -111,7 +111,7 @@ def _validate_config(context: ValidationContext, config_value: object) -> Evalua
         return validate_shape_config(context, config_value)
     elif kind == ConfigTypeKind.PERMISSIVE_SHAPE:
         return validate_permissive_shape_config(context, config_value)
-    elif kind == ConfigTypeKind.map:
+    elif kind == ConfigTypeKind.MAP:
         return validate_map_config(context, config_value)
     elif kind == ConfigTypeKind.ARRAY:
         return validate_array_config(context, config_value)
@@ -306,7 +306,7 @@ def validate_map_config(
     context: ValidationContext, config_value: object
 ) -> EvaluateValueResult[Dict[str, object]]:
     check.inst_param(context, "context", ValidationContext)
-    check.invariant(context.config_type_snap.kind == ConfigTypeKind.map)
+    check.invariant(context.config_type_snap.kind == ConfigTypeKind.MAP)
     check.not_none_param(config_value, "config_value")
 
     if not isinstance(config_value, dict):

--- a/python_modules/dagster/dagster/config/validate.py
+++ b/python_modules/dagster/dagster/config/validate.py
@@ -311,10 +311,12 @@ def validate_keyed_collection_config(
 
     if not isinstance(config_value, dict):
         return EvaluateValueResult.for_error(create_keyed_collection_error(context, config_value))
-    config_value = cast(Dict[str, object], config_value)
+    config_value = cast(Dict[object, object], config_value)
 
     evaluation_results = [
-        _validate_config(context.for_keyed_collection(key), config_item)
+        _validate_config(context.for_keyed_collection_key(key), key) for key in config_value.keys()
+    ] + [
+        _validate_config(context.for_keyed_collection_value(key), config_item)
         for key, config_item in config_value.items()
     ]
 

--- a/python_modules/dagster/dagster/config/validate.py
+++ b/python_modules/dagster/dagster/config/validate.py
@@ -13,7 +13,7 @@ from .errors import (
     create_field_not_defined_error,
     create_field_substitution_collision_error,
     create_fields_not_defined_error,
-    create_keyed_collection_error,
+    create_map_error,
     create_missing_required_field_error,
     create_missing_required_fields_error,
     create_none_not_allowed_error,
@@ -111,8 +111,8 @@ def _validate_config(context: ValidationContext, config_value: object) -> Evalua
         return validate_shape_config(context, config_value)
     elif kind == ConfigTypeKind.PERMISSIVE_SHAPE:
         return validate_permissive_shape_config(context, config_value)
-    elif kind == ConfigTypeKind.KEYED_COLLECTION:
-        return validate_keyed_collection_config(context, config_value)
+    elif kind == ConfigTypeKind.map:
+        return validate_map_config(context, config_value)
     elif kind == ConfigTypeKind.ARRAY:
         return validate_array_config(context, config_value)
     elif kind == ConfigTypeKind.ENUM:
@@ -302,21 +302,21 @@ def validate_permissive_shape_config(
     return _validate_shape_config(context, config_value, check_for_extra_incoming_fields=False)
 
 
-def validate_keyed_collection_config(
+def validate_map_config(
     context: ValidationContext, config_value: object
 ) -> EvaluateValueResult[Dict[str, object]]:
     check.inst_param(context, "context", ValidationContext)
-    check.invariant(context.config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION)
+    check.invariant(context.config_type_snap.kind == ConfigTypeKind.map)
     check.not_none_param(config_value, "config_value")
 
     if not isinstance(config_value, dict):
-        return EvaluateValueResult.for_error(create_keyed_collection_error(context, config_value))
+        return EvaluateValueResult.for_error(create_map_error(context, config_value))
     config_value = cast(Dict[object, object], config_value)
 
     evaluation_results = [
-        _validate_config(context.for_keyed_collection_key(key), key) for key in config_value.keys()
+        _validate_config(context.for_map_key(key), key) for key in config_value.keys()
     ] + [
-        _validate_config(context.for_keyed_collection_value(key), config_item)
+        _validate_config(context.for_map_value(key), config_item)
         for key, config_item in config_value.items()
     ]
 

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -60,7 +60,7 @@ This value can be a:
     - Field
     - Python primitive types that resolve to dagster config types
         - int, float, bool, str, list.
-    - A dagster config type: Int, Float, Bool, List, Optional, Selector, Shape, Permissive, Map
+    - A dagster config type: Int, Float, Bool, Array, Optional, Selector, Shape, Permissive, Map
     - A bare python dictionary, which is wrapped in Field(Shape(...)). Any values
       in the dictionary get resolved by the same rules, recursively.
     - A python list with a single entry that can resolve to a type, e.g. [int]

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -60,7 +60,7 @@ This value can be a:
     - Field
     - Python primitive types that resolve to dagster config types
         - int, float, bool, str, list.
-    - A dagster config type: Int, Float, Bool, List, Optional, Selector, Shape, Permissive
+    - A dagster config type: Int, Float, Bool, List, Optional, Selector, Shape, Permissive, Map
     - A bare python dictionary, which is wrapped in Field(Shape(...)). Any values
       in the dictionary get resolved by the same rules, recursively.
     - A python list with a single entry that can resolve to a type, e.g. [int]

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -1,6 +1,6 @@
 from typing import AbstractSet, Any, Dict, List, NamedTuple, Optional, Union, cast
 
-from dagster import Field, Permissive, Selector, Shape, check, KeyedCollection
+from dagster import Field, KeyedCollection, Permissive, Selector, Shape, check
 from dagster.config.config_type import (
     Array,
     ConfigTypeKind,

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -353,7 +353,7 @@ def _construct_map_from_snap(config_type_snap, config_snap_map):
     check.list_param(config_type_snap.type_param_keys, "type_param_keys", str)
     check.invariant(
         len(config_type_snap.type_param_keys) == 2,
-        "Expect map to provide exactly two types. Snapshot provided: {}".format(
+        "Expect map to provide exactly two types (key, value). Snapshot provided: {}".format(
             config_type_snap.type_param_keys
         ),
     )

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -352,17 +352,21 @@ def _construct_array_from_snap(config_type_snap, config_snap_map):
 def _construct_keyed_collection_from_snap(config_type_snap, config_snap_keyed_collection):
     check.list_param(config_type_snap.type_param_keys, "type_param_keys", str)
     check.invariant(
-        len(config_type_snap.type_param_keys) == 1,
-        "Expect KEYED_COLLECTION to provide a single inner type. Snapshot provided: {}".format(
+        len(config_type_snap.type_param_keys) == 2,
+        "Expect KEYED_COLLECTION to provide exactly two types. Snapshot provided: {}".format(
             config_type_snap.type_param_keys
         ),
     )
 
     return KeyedCollection(
-        inner_type=construct_config_type_from_snap(
+        key_type=construct_config_type_from_snap(
             config_snap_keyed_collection[config_type_snap.type_param_keys[0]],
             config_snap_keyed_collection,
-        )
+        ),
+        inner_type=construct_config_type_from_snap(
+            config_snap_keyed_collection[config_type_snap.type_param_keys[1]],
+            config_snap_keyed_collection,
+        ),
     )
 
 

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -1,6 +1,6 @@
 from typing import AbstractSet, Any, Dict, List, NamedTuple, Optional, Union, cast
 
-from dagster import Field, KeyedCollection, Permissive, Selector, Shape, check
+from dagster import Field, Map, Permissive, Selector, Shape, check
 from dagster.config.config_type import (
     Array,
     ConfigTypeKind,
@@ -349,23 +349,23 @@ def _construct_array_from_snap(config_type_snap, config_snap_map):
     )
 
 
-def _construct_keyed_collection_from_snap(config_type_snap, config_snap_keyed_collection):
+def _construct_map_from_snap(config_type_snap, config_snap_map):
     check.list_param(config_type_snap.type_param_keys, "type_param_keys", str)
     check.invariant(
         len(config_type_snap.type_param_keys) == 2,
-        "Expect KEYED_COLLECTION to provide exactly two types. Snapshot provided: {}".format(
+        "Expect map to provide exactly two types. Snapshot provided: {}".format(
             config_type_snap.type_param_keys
         ),
     )
 
-    return KeyedCollection(
+    return Map(
         key_type=construct_config_type_from_snap(
-            config_snap_keyed_collection[config_type_snap.type_param_keys[0]],
-            config_snap_keyed_collection,
+            config_snap_map[config_type_snap.type_param_keys[0]],
+            config_snap_map,
         ),
         inner_type=construct_config_type_from_snap(
-            config_snap_keyed_collection[config_type_snap.type_param_keys[1]],
-            config_snap_keyed_collection,
+            config_snap_map[config_type_snap.type_param_keys[1]],
+            config_snap_map,
         ),
     )
 
@@ -405,8 +405,8 @@ def construct_config_type_from_snap(
         return _construct_scalar_union_from_snap(config_type_snap, config_snap_map)
     elif config_type_snap.kind == ConfigTypeKind.ARRAY:
         return _construct_array_from_snap(config_type_snap, config_snap_map)
-    elif config_type_snap.kind == ConfigTypeKind.KEYED_COLLECTION:
-        return _construct_keyed_collection_from_snap(config_type_snap, config_snap_map)
+    elif config_type_snap.kind == ConfigTypeKind.map:
+        return _construct_map_from_snap(config_type_snap, config_snap_map)
     elif config_type_snap.kind == ConfigTypeKind.NONEABLE:
         return _construct_noneable_from_snap(config_type_snap, config_snap_map)
     check.failed("Could not evaluate config type snap kind: {}".format(config_type_snap.kind))

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -405,7 +405,7 @@ def construct_config_type_from_snap(
         return _construct_scalar_union_from_snap(config_type_snap, config_snap_map)
     elif config_type_snap.kind == ConfigTypeKind.ARRAY:
         return _construct_array_from_snap(config_type_snap, config_snap_map)
-    elif config_type_snap.kind == ConfigTypeKind.map:
+    elif config_type_snap.kind == ConfigTypeKind.MAP:
         return _construct_map_from_snap(config_type_snap, config_snap_map)
     elif config_type_snap.kind == ConfigTypeKind.NONEABLE:
         return _construct_noneable_from_snap(config_type_snap, config_snap_map)

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_defaults.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_defaults.py
@@ -23,8 +23,8 @@ def test_post_process_config():
         post_process_config(enum_config_type, "baz")
     with pytest.raises(CheckError):
         post_process_config(enum_config_type, None)
-    list_config_type = resolve_to_config_type([str])
 
+    list_config_type = resolve_to_config_type([str])
     assert post_process_config(list_config_type, ["foo"]).value == ["foo"]
     assert post_process_config(list_config_type, None).value == []
     with pytest.raises(CheckError, match="Null array member not caught"):
@@ -35,12 +35,30 @@ def test_post_process_config():
     assert post_process_config(nullable_list_config_type, [None]).value == [None]
     assert post_process_config(nullable_list_config_type, None).value == []
 
+    keyed_collection_config_type = resolve_to_config_type({str: int})
+    assert post_process_config(keyed_collection_config_type, {"foo": 5}).value == {"foo": 5}
+    assert post_process_config(keyed_collection_config_type, None).value == {}
+    with pytest.raises(CheckError, match="Null keyed collection member not caught"):
+        assert post_process_config(keyed_collection_config_type, {"foo": None}).value == {
+            "foo": None
+        }
+
+    nullable_keyed_collection_config_type = resolve_to_config_type({str: Noneable(int)})
+    assert post_process_config(nullable_keyed_collection_config_type, {"foo": 5}).value == {
+        "foo": 5
+    }
+    assert post_process_config(nullable_keyed_collection_config_type, {"foo": None}).value == {
+        "foo": None
+    }
+    assert post_process_config(nullable_keyed_collection_config_type, None).value == {}
+
     composite_config_type = resolve_to_config_type(
         {
             "foo": String,
             "bar": {"baz": [str]},
             "quux": Field(str, is_required=False, default_value="zip"),
             "quiggle": Field(str, is_required=False),
+            "werty": Field({str: [int]}, is_required=False),
         }
     )
     with pytest.raises(CheckError, match="Missing required composite member"):
@@ -63,6 +81,22 @@ def test_post_process_config():
     assert post_process_config(
         composite_config_type, {"foo": "zowie", "bar": {"baz": ["giraffe"]}, "quiggle": "squiggle"}
     ).value == {"foo": "zowie", "bar": {"baz": ["giraffe"]}, "quux": "zip", "quiggle": "squiggle"}
+
+    assert post_process_config(
+        composite_config_type,
+        {
+            "foo": "zowie",
+            "bar": {"baz": ["giraffe"]},
+            "quiggle": "squiggle",
+            "werty": {"asdf": [1, 2, 3]},
+        },
+    ).value == {
+        "foo": "zowie",
+        "bar": {"baz": ["giraffe"]},
+        "quux": "zip",
+        "quiggle": "squiggle",
+        "werty": {"asdf": [1, 2, 3]},
+    }
 
     nested_composite_config_type = resolve_to_config_type(
         {

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_defaults.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_defaults.py
@@ -35,22 +35,16 @@ def test_post_process_config():
     assert post_process_config(nullable_list_config_type, [None]).value == [None]
     assert post_process_config(nullable_list_config_type, None).value == []
 
-    keyed_collection_config_type = resolve_to_config_type({str: int})
-    assert post_process_config(keyed_collection_config_type, {"foo": 5}).value == {"foo": 5}
-    assert post_process_config(keyed_collection_config_type, None).value == {}
-    with pytest.raises(CheckError, match="Null keyed collection member not caught"):
-        assert post_process_config(keyed_collection_config_type, {"foo": None}).value == {
-            "foo": None
-        }
+    map_config_type = resolve_to_config_type({str: int})
+    assert post_process_config(map_config_type, {"foo": 5}).value == {"foo": 5}
+    assert post_process_config(map_config_type, None).value == {}
+    with pytest.raises(CheckError, match="Null map member not caught"):
+        assert post_process_config(map_config_type, {"foo": None}).value == {"foo": None}
 
-    nullable_keyed_collection_config_type = resolve_to_config_type({str: Noneable(int)})
-    assert post_process_config(nullable_keyed_collection_config_type, {"foo": 5}).value == {
-        "foo": 5
-    }
-    assert post_process_config(nullable_keyed_collection_config_type, {"foo": None}).value == {
-        "foo": None
-    }
-    assert post_process_config(nullable_keyed_collection_config_type, None).value == {}
+    nullable_map_config_type = resolve_to_config_type({str: Noneable(int)})
+    assert post_process_config(nullable_map_config_type, {"foo": 5}).value == {"foo": 5}
+    assert post_process_config(nullable_map_config_type, {"foo": None}).value == {"foo": None}
+    assert post_process_config(nullable_map_config_type, None).value == {}
 
     composite_config_type = resolve_to_config_type(
         {

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_evaluator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_evaluator.py
@@ -3,9 +3,9 @@ from dagster.config.errors import DagsterEvaluationErrorReason
 from dagster.config.evaluate_value_result import EvaluateValueResult
 from dagster.config.field import resolve_to_config_type
 from dagster.config.stack import (
-    EvaluationStackKeyedCollectionKeyEntry,
-    EvaluationStackKeyedCollectionValueEntry,
     EvaluationStackListItemEntry,
+    EvaluationStackMapKeyEntry,
+    EvaluationStackMapValueEntry,
     EvaluationStackPathEntry,
 )
 from dagster.config.validate import process_config
@@ -364,70 +364,70 @@ def test_selector_with_defaults():
     assert result.value == {"default": "foo"}
 
 
-def test_evaluate_keyed_collection_string():
-    string_keyed_collection = {str: str}
-    result = eval_config_value_from_dagster_type(string_keyed_collection, {"foo": "bar"})
+def test_evaluate_map_string():
+    string_map = {str: str}
+    result = eval_config_value_from_dagster_type(string_map, {"foo": "bar"})
     assert result.success
     assert result.value == {"foo": "bar"}
 
 
-def test_evaluate_keyed_collection_int():
-    int_keyed_collection = {int: str}
-    result = eval_config_value_from_dagster_type(int_keyed_collection, {5: "bar"})
+def test_evaluate_map_int():
+    int_map = {int: str}
+    result = eval_config_value_from_dagster_type(int_map, {5: "bar"})
     assert result.success
     assert result.value == {5: "bar"}
 
 
-def test_evaluate_keyed_collection_bool():
-    int_keyed_collection = {bool: float}
-    result = eval_config_value_from_dagster_type(int_keyed_collection, {False: 5.5})
+def test_evaluate_map_bool():
+    int_map = {bool: float}
+    result = eval_config_value_from_dagster_type(int_map, {False: 5.5})
     assert result.success
     assert result.value == {False: 5.5}
 
 
-def test_evaluate_keyed_collection_float():
-    int_keyed_collection = {float: bool}
-    result = eval_config_value_from_dagster_type(int_keyed_collection, {5.5: True})
+def test_evaluate_map_float():
+    int_map = {float: bool}
+    result = eval_config_value_from_dagster_type(int_map, {5.5: True})
     assert result.success
     assert result.value == {5.5: True}
 
 
-def test_evaluate_keyed_collection_error_item_mismatch():
+def test_evaluate_map_error_item_mismatch():
     result = eval_config_value_from_dagster_type({str: str}, {"a": 1})
     assert not result.success
     assert len(result.errors) == 1
     assert result.errors[0].reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
 
 
-def test_evaluate_keyed_collection_error_top_level_mismatch():
-    string_keyed_collection = {str: str}
-    result = eval_config_value_from_dagster_type(string_keyed_collection, 1)
+def test_evaluate_map_error_top_level_mismatch():
+    string_map = {str: str}
+    result = eval_config_value_from_dagster_type(string_map, 1)
     assert not result.success
     assert len(result.errors) == 1
     assert result.errors[0].reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
 
 
-def test_evaluate_double_keyed_collection():
-    string_double_keyed_collection = {int: {str: str}}
-    result = eval_config_value_from_dagster_type(string_double_keyed_collection, {5: {"b": "foo"}})
+def test_evaluate_double_map():
+    string_double_map = {int: {str: str}}
+    result = eval_config_value_from_dagster_type(string_double_map, {5: {"b": "foo"}})
     assert result.success
     assert result.value == {5: {"b": "foo"}}
 
 
-def test_config_keyed_collection_in_dict():
-    nested_keyed_collection = {"nested_keyed_collection": {str: int}}
+def test_config_map_in_dict():
+    nested_map = {"nested_map": {str: int}}
 
-    value = {"nested_keyed_collection": {"a": 1, "b": 2, "c": 3}}
-    result = eval_config_value_from_dagster_type(nested_keyed_collection, value)
+    value = {"nested_map": {"a": 1, "b": 2, "c": 3}}
+    result = eval_config_value_from_dagster_type(nested_map, value)
     assert result.success
     assert result.value == value
 
 
-def test_config_keyed_collection_in_dict_error():
-    nested_keyed_collection = {"nested_keyed_collection": {str: int}}
+def test_config_map_in_dict_error():
+    nested_map = {"nested_map": {str: int}}
 
-    value = {"nested_keyed_collection": {"a": 1, "b": "bar", "c": 3}}
-    result = eval_config_value_from_dagster_type(nested_keyed_collection, value)
+    value = {"nested_map": {"a": 1, "b": "bar", "c": 3}}
+    result = eval_config_value_from_dagster_type(nested_map, value)
     assert not result.success
     assert len(result.errors) == 1
     error = result.errors[0]
@@ -435,17 +435,17 @@ def test_config_keyed_collection_in_dict_error():
     assert len(error.stack.entries) == 2
     stack_entry = error.stack.entries[0]
     assert isinstance(stack_entry, EvaluationStackPathEntry)
-    assert stack_entry.field_name == "nested_keyed_collection"
-    keyed_collection_entry = error.stack.entries[1]
-    assert isinstance(keyed_collection_entry, EvaluationStackKeyedCollectionValueEntry)
-    assert keyed_collection_entry.keyed_collection_key == "b"
+    assert stack_entry.field_name == "nested_map"
+    map_entry = error.stack.entries[1]
+    assert isinstance(map_entry, EvaluationStackMapValueEntry)
+    assert map_entry.map_key == "b"
 
 
-def test_config_keyed_collection_in_dict_error_two_errors():
-    nested_keyed_collection = {"nested_keyed_collection": {str: int}}
+def test_config_map_in_dict_error_two_errors():
+    nested_map = {"nested_map": {str: int}}
 
-    value = {"nested_keyed_collection": {"a": 1, 5: 3, "c": "bar"}}
-    result = eval_config_value_from_dagster_type(nested_keyed_collection, value)
+    value = {"nested_map": {"a": 1, 5: 3, "c": "bar"}}
+    result = eval_config_value_from_dagster_type(nested_map, value)
     assert not result.success
     assert len(result.errors) == 2
     error = result.errors[0]
@@ -453,50 +453,50 @@ def test_config_keyed_collection_in_dict_error_two_errors():
     assert len(error.stack.entries) == 2
     stack_entry = error.stack.entries[0]
     assert isinstance(stack_entry, EvaluationStackPathEntry)
-    assert stack_entry.field_name == "nested_keyed_collection"
-    keyed_collection_entry = error.stack.entries[1]
-    assert isinstance(keyed_collection_entry, EvaluationStackKeyedCollectionKeyEntry)
-    assert keyed_collection_entry.keyed_collection_key == 5
-    keyed_collection_entry = result.errors[1].stack.entries[1]
-    assert isinstance(keyed_collection_entry, EvaluationStackKeyedCollectionValueEntry)
-    assert keyed_collection_entry.keyed_collection_key == "c"
+    assert stack_entry.field_name == "nested_map"
+    map_entry = error.stack.entries[1]
+    assert isinstance(map_entry, EvaluationStackMapKeyEntry)
+    assert map_entry.map_key == 5
+    map_entry = result.errors[1].stack.entries[1]
+    assert isinstance(map_entry, EvaluationStackMapValueEntry)
+    assert map_entry.map_key == "c"
 
 
-def test_config_double_keyed_collection():
-    nested_keyed_collections = {
-        "nested_keyed_collection_one": {str: int},
-        "nested_keyed_collection_two": {int: str},
+def test_config_double_map():
+    nested_maps = {
+        "nested_map_one": {str: int},
+        "nested_map_two": {int: str},
     }
 
     value = {
-        "nested_keyed_collection_one": {"a": 1, "b": 2, "c": 3},
-        "nested_keyed_collection_two": {1: "foo", 2: "bar"},
+        "nested_map_one": {"a": 1, "b": 2, "c": 3},
+        "nested_map_two": {1: "foo", 2: "bar"},
     }
 
-    result = eval_config_value_from_dagster_type(nested_keyed_collections, value)
+    result = eval_config_value_from_dagster_type(nested_maps, value)
     assert result.success
     assert result.value == value
 
     error_value = {
-        "nested_keyed_collection_one": "kjdfkdj",
-        "nested_keyed_collection_two": {1: "bar"},
+        "nested_map_one": "kjdfkdj",
+        "nested_map_two": {1: "bar"},
     }
 
-    error_result = eval_config_value_from_dagster_type(nested_keyed_collections, error_value)
+    error_result = eval_config_value_from_dagster_type(nested_maps, error_value)
     assert not error_result.success
 
 
-def test_config_double_keyed_collection_double_error():
-    nested_keyed_collections = {
-        "nested_keyed_collection_one": {str: int},
-        "nested_keyed_collection_two": {str: str},
+def test_config_double_map_double_error():
+    nested_maps = {
+        "nested_map_one": {str: int},
+        "nested_map_two": {str: str},
     }
 
     error_value = {
-        "nested_keyed_collection_one": "kjdfkdj",
-        "nested_keyed_collection_two": {"x": "bar", 2: "y"},
+        "nested_map_one": "kjdfkdj",
+        "nested_map_two": {"x": "bar", 2: "y"},
     }
-    error_result = eval_config_value_from_dagster_type(nested_keyed_collections, error_value)
+    error_result = eval_config_value_from_dagster_type(nested_maps, error_value)
     assert not error_result.success
     assert len(error_result.errors) == 2
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_validate.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_validate.py
@@ -2,9 +2,9 @@ from dagster import Field, Noneable, Permissive, ScalarUnion, Selector, Shape
 from dagster.config.errors import DagsterEvaluationErrorReason
 from dagster.config.field import resolve_to_config_type
 from dagster.config.stack import (
-    EvaluationStackKeyedCollectionKeyEntry,
-    EvaluationStackKeyedCollectionValueEntry,
     EvaluationStackListItemEntry,
+    EvaluationStackMapKeyEntry,
+    EvaluationStackMapValueEntry,
     EvaluationStackPathEntry,
 )
 from dagster.config.validate import validate_config
@@ -338,71 +338,71 @@ def test_selector_within_dict_no_subfields():
     )
 
 
-def test_evaluate_keyed_collection_string():
+def test_evaluate_map_string():
     result = validate_config({str: str}, {"x": "foo"})
     assert result.success
     assert result.value == {"x": "foo"}
 
 
-def test_evaluate_keyed_collection_int():
+def test_evaluate_map_int():
     result = validate_config({int: str}, {5: "foo"})
     assert result.success
     assert result.value == {5: "foo"}
 
 
-def test_evaluate_keyed_collection_bool():
+def test_evaluate_map_bool():
     result = validate_config({bool: int}, {False: 10})
     assert result.success
     assert result.value == {False: 10}
 
 
-def test_evaluate_keyed_collection_float():
+def test_evaluate_map_float():
     result = validate_config({float: bool}, {5.5: True})
     assert result.success
     assert result.value == {5.5: True}
 
 
-def test_evaluate_keyed_collection_error_item_mismatch():
+def test_evaluate_map_error_item_mismatch():
     result = validate_config({str: str}, {"x": 5})
     assert not result.success
     assert len(result.errors) == 1
     assert result.errors[0].reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
 
 
-def test_evaluate_keyed_collection_error_key_mismatch():
+def test_evaluate_map_error_key_mismatch():
     result = validate_config({str: str}, {5: "foo"})
     assert not result.success
     assert len(result.errors) == 1
     assert result.errors[0].reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
 
 
-def test_evaluate_keyed_collection_error_top_level_mismatch():
+def test_evaluate_map_error_top_level_mismatch():
     result = validate_config({str: str}, 1)
     assert not result.success
     assert len(result.errors) == 1
     assert result.errors[0].reason == DagsterEvaluationErrorReason.RUNTIME_TYPE_MISMATCH
 
 
-def test_evaluate_double_keyed_collection():
+def test_evaluate_double_map():
     result = validate_config({str: {int: str}}, {"a": {5: "foo"}})
     assert result.success
     assert result.value == {"a": {5: "foo"}}
 
 
-def test_config_keyed_collection_in_dict():
-    nested_keyed_collection_type = {"nested_keyed_collection": {str: int}}
+def test_config_map_in_dict():
+    nested_map_type = {"nested_map": {str: int}}
 
-    value = {"nested_keyed_collection": {"a": 1, "b": 2}}
-    result = validate_config(nested_keyed_collection_type, value)
+    value = {"nested_map": {"a": 1, "b": 2}}
+    result = validate_config(nested_map_type, value)
     assert result.success
     assert result.value == value
 
 
-def test_config_keyed_collection_in_dict_error():
-    nested_keyed_collection = {"nested_keyed_collection": {str: int}}
+def test_config_map_in_dict_error():
+    nested_map = {"nested_map": {str: int}}
 
-    value = {"nested_keyed_collection": {"a": 1, "b": "bar", "c": 3}}
-    result = validate_config(nested_keyed_collection, value)
+    value = {"nested_map": {"a": 1, "b": "bar", "c": 3}}
+    result = validate_config(nested_map, value)
     assert not result.success
     assert len(result.errors) == 1
     error = result.errors[0]
@@ -410,17 +410,17 @@ def test_config_keyed_collection_in_dict_error():
     assert len(error.stack.entries) == 2
     stack_entry = error.stack.entries[0]
     assert isinstance(stack_entry, EvaluationStackPathEntry)
-    assert stack_entry.field_name == "nested_keyed_collection"
-    keyed_collection_entry = error.stack.entries[1]
-    assert isinstance(keyed_collection_entry, EvaluationStackKeyedCollectionValueEntry)
-    assert keyed_collection_entry.keyed_collection_key == "b"
+    assert stack_entry.field_name == "nested_map"
+    map_entry = error.stack.entries[1]
+    assert isinstance(map_entry, EvaluationStackMapValueEntry)
+    assert map_entry.map_key == "b"
 
 
-def test_config_keyed_collection_in_dict_error_double_error():
-    nested_keyed_collection = {"nested_keyed_collection": {str: int}}
+def test_config_map_in_dict_error_double_error():
+    nested_map = {"nested_map": {str: int}}
 
-    value = {"nested_keyed_collection": {"a": 1, 3: 3, "c": "asdf"}}
-    result = validate_config(nested_keyed_collection, value)
+    value = {"nested_map": {"a": 1, 3: 3, "c": "asdf"}}
+    result = validate_config(nested_map, value)
     assert not result.success
     assert len(result.errors) == 2
     error = result.errors[0]
@@ -428,13 +428,13 @@ def test_config_keyed_collection_in_dict_error_double_error():
     assert len(error.stack.entries) == 2
     stack_entry = error.stack.entries[0]
     assert isinstance(stack_entry, EvaluationStackPathEntry)
-    assert stack_entry.field_name == "nested_keyed_collection"
-    keyed_collection_entry = error.stack.entries[1]
-    assert isinstance(keyed_collection_entry, EvaluationStackKeyedCollectionKeyEntry)
-    assert keyed_collection_entry.keyed_collection_key == 3
-    keyed_collection_entry = result.errors[1].stack.entries[1]
-    assert isinstance(keyed_collection_entry, EvaluationStackKeyedCollectionValueEntry)
-    assert keyed_collection_entry.keyed_collection_key == "c"
+    assert stack_entry.field_name == "nested_map"
+    map_entry = error.stack.entries[1]
+    assert isinstance(map_entry, EvaluationStackMapKeyEntry)
+    assert map_entry.map_key == 3
+    map_entry = result.errors[1].stack.entries[1]
+    assert isinstance(map_entry, EvaluationStackMapValueEntry)
+    assert map_entry.map_key == "c"
 
 
 def test_evaluate_list_string():

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
@@ -21,6 +21,9 @@ def test_kitchen_sink():
             "selector_of_things": Selector(
                 {"select_list_dict_field": [{"an_int": int}], "select_int": int}
             ),
+            "keyed_collection_int": {str: int},
+            "keyed_collection_keyed_collection_int": {str: {str: int}},
+            "keyed_collection_dict_field": {str: {"an_int": int}},
             # this is a good argument to use () instead of [] for type parameterization in
             # the config system
             "optional_list_of_optional_string": Noneable([Noneable(str)]),
@@ -37,6 +40,9 @@ def test_kitchen_sink():
         "dict_field": {"a_string": "kdjfkd"},
         "list_dict_field": [{"an_int": 2}, {"an_int": 4}],
         "selector_of_things": {"select_int": 3},
+        "keyed_collection_int": {"a": 1},
+        "keyed_collection_keyed_collection_int": {"a": {"b": 1}},
+        "keyed_collection_dict_field": {"a": {"an_int": 5}},
         "optional_list_of_optional_string": ["foo", None],
     }
 
@@ -56,6 +62,9 @@ def test_kitchen_sink():
         "dict_field": {"a_string": "kdjfkd"},
         "list_dict_field": [{"an_int": 2}, {"an_int": 4}],
         "selector_of_things": {"select_list_dict_field": [{"an_int": 5}]},
+        "keyed_collection_int": {"b": 2},
+        "keyed_collection_keyed_collection_int": {"b": {"b": 3}},
+        "keyed_collection_dict_field": {"b": {"an_int": 6}},
         "optional_list_of_optional_string": None,
     }
 
@@ -121,6 +130,18 @@ def test_bad_solid_config_argument_list_wrong_length():
         "Error defining config. Original value passed: {'bad_list': []}. "
         "Error at stack path :bad_list. [] cannot be resolved. "
         "Reason: List must be of length 1."
+    )
+
+
+def test_bad_solid_config_argument_keyed_config_bad_value():
+    with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
+
+        @solid(config_schema={"bad_keyed_config": {str: "asdf"}})
+        def _bad_keyed_config(_):
+            pass
+
+    assert "KeyedCollection must have a single value and contain a valid type" in str(
+        exc_info.value
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
@@ -22,7 +22,7 @@ def test_kitchen_sink():
                 {"select_list_dict_field": [{"an_int": int}], "select_int": int}
             ),
             "keyed_collection_int": {str: int},
-            "keyed_collection_keyed_collection_int": {str: {str: int}},
+            "keyed_collection_keyed_collection_int": {int: {str: int}},
             "keyed_collection_dict_field": {str: {"an_int": int}},
             # this is a good argument to use () instead of [] for type parameterization in
             # the config system
@@ -41,7 +41,7 @@ def test_kitchen_sink():
         "list_dict_field": [{"an_int": 2}, {"an_int": 4}],
         "selector_of_things": {"select_int": 3},
         "keyed_collection_int": {"a": 1},
-        "keyed_collection_keyed_collection_int": {"a": {"b": 1}},
+        "keyed_collection_keyed_collection_int": {5: {"b": 1}},
         "keyed_collection_dict_field": {"a": {"an_int": 5}},
         "optional_list_of_optional_string": ["foo", None],
     }
@@ -63,7 +63,7 @@ def test_kitchen_sink():
         "list_dict_field": [{"an_int": 2}, {"an_int": 4}],
         "selector_of_things": {"select_list_dict_field": [{"an_int": 5}]},
         "keyed_collection_int": {"b": 2},
-        "keyed_collection_keyed_collection_int": {"b": {"b": 3}},
+        "keyed_collection_keyed_collection_int": {6: {"b": 3}},
         "keyed_collection_dict_field": {"b": {"an_int": 6}},
         "optional_list_of_optional_string": None,
     }

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
@@ -21,9 +21,9 @@ def test_kitchen_sink():
             "selector_of_things": Selector(
                 {"select_list_dict_field": [{"an_int": int}], "select_int": int}
             ),
-            "keyed_collection_int": {str: int},
-            "keyed_collection_keyed_collection_int": {int: {str: int}},
-            "keyed_collection_dict_field": {str: {"an_int": int}},
+            "map_int": {str: int},
+            "map_map_int": {int: {str: int}},
+            "map_dict_field": {str: {"an_int": int}},
             # this is a good argument to use () instead of [] for type parameterization in
             # the config system
             "optional_list_of_optional_string": Noneable([Noneable(str)]),
@@ -40,9 +40,9 @@ def test_kitchen_sink():
         "dict_field": {"a_string": "kdjfkd"},
         "list_dict_field": [{"an_int": 2}, {"an_int": 4}],
         "selector_of_things": {"select_int": 3},
-        "keyed_collection_int": {"a": 1},
-        "keyed_collection_keyed_collection_int": {5: {"b": 1}},
-        "keyed_collection_dict_field": {"a": {"an_int": 5}},
+        "map_int": {"a": 1},
+        "map_map_int": {5: {"b": 1}},
+        "map_dict_field": {"a": {"an_int": 5}},
         "optional_list_of_optional_string": ["foo", None],
     }
 
@@ -62,9 +62,9 @@ def test_kitchen_sink():
         "dict_field": {"a_string": "kdjfkd"},
         "list_dict_field": [{"an_int": 2}, {"an_int": 4}],
         "selector_of_things": {"select_list_dict_field": [{"an_int": 5}]},
-        "keyed_collection_int": {"b": 2},
-        "keyed_collection_keyed_collection_int": {6: {"b": 3}},
-        "keyed_collection_dict_field": {"b": {"an_int": 6}},
+        "map_int": {"b": 2},
+        "map_map_int": {6: {"b": 3}},
+        "map_dict_field": {"b": {"an_int": 6}},
         "optional_list_of_optional_string": None,
     }
 
@@ -133,16 +133,14 @@ def test_bad_solid_config_argument_list_wrong_length():
     )
 
 
-def test_bad_solid_config_argument_keyed_config_bad_value():
+def test_bad_solid_config_argument_map_bad_value():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
-        @solid(config_schema={"bad_keyed_config": {str: "asdf"}})
-        def _bad_keyed_config(_):
+        @solid(config_schema={"bad_map": {str: "asdf"}})
+        def _bad_map(_):
             pass
 
-    assert "KeyedCollection must have a single value and contain a valid type" in str(
-        exc_info.value
-    )
+    assert "Map must have a single value and contain a valid type" in str(exc_info.value)
 
 
 def test_bad_solid_config_argument_list_bad_item():

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_error_messages.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_error_messages.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 from dagster import DagsterInvalidDefinitionError, Dict, List, Noneable, Optional, solid
+from dagster.core.errors import DagsterInvalidConfigDefinitionError
 
 
 def test_invalid_optional_in_config():
@@ -46,3 +47,14 @@ def test_invalid_list_element():
         ),
     ):
         _ = List[Noneable(int)]
+
+
+def test_non_scalar_key_keyed_collection():
+    with pytest.raises(
+        DagsterInvalidConfigDefinitionError,
+        match=re.escape("KeyedCollection dict must have a scalar type as its only key."),
+    ):
+
+        @solid(config_schema={Noneable(int): str})
+        def _solid(_):
+            pass

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_error_messages.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_error_messages.py
@@ -49,10 +49,10 @@ def test_invalid_list_element():
         _ = List[Noneable(int)]
 
 
-def test_non_scalar_key_keyed_collection():
+def test_non_scalar_key_map():
     with pytest.raises(
         DagsterInvalidConfigDefinitionError,
-        match=re.escape("KeyedCollection dict must have a scalar type as its only key."),
+        match=re.escape("Map dict must have a scalar type as its only key."),
     ):
 
         @solid(config_schema={Noneable(int): str})

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_new_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_new_config_types.py
@@ -50,3 +50,15 @@ def test_list_nullable_int():
     assert validate_config(lni, [1, None]).success
     assert not validate_config(lni, None).success
     assert not validate_config(lni, [1, "absdf"]).success
+
+
+def test_keyed_collection_int():
+    keyed_collection_int = resolve_to_config_type({str: Int})
+
+    assert validate_config(keyed_collection_int, {"a": 1}).success
+    assert validate_config(keyed_collection_int, {"a": 1, "b": 2}).success
+    assert validate_config(keyed_collection_int, {}).success
+    assert not validate_config(keyed_collection_int, {"a": None}).success
+    assert not validate_config(keyed_collection_int, {"a": 1, "b": None}).success
+    assert not validate_config(keyed_collection_int, None).success
+    assert not validate_config(keyed_collection_int, {"a": 1, "b": "absdf"}).success

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_new_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_new_config_types.py
@@ -52,27 +52,27 @@ def test_list_nullable_int():
     assert not validate_config(lni, [1, "absdf"]).success
 
 
-def test_keyed_collection_int():
-    keyed_collection_str_int = resolve_to_config_type({str: Int})
+def test_map_int():
+    map_str_int = resolve_to_config_type({str: Int})
 
-    assert validate_config(keyed_collection_str_int, {"a": 1}).success
-    assert validate_config(keyed_collection_str_int, {"a": 1, "b": 2}).success
-    assert validate_config(keyed_collection_str_int, {}).success
-    assert not validate_config(keyed_collection_str_int, {"a": None}).success
-    assert not validate_config(keyed_collection_str_int, {"a": 1, "b": None}).success
-    assert not validate_config(keyed_collection_str_int, None).success
-    assert not validate_config(keyed_collection_str_int, {"a": 1, "b": "absdf"}).success
-    assert not validate_config(keyed_collection_str_int, {"a": 1, 4: 4}).success
-    assert not validate_config(keyed_collection_str_int, {"a": 1, None: 4}).success
+    assert validate_config(map_str_int, {"a": 1}).success
+    assert validate_config(map_str_int, {"a": 1, "b": 2}).success
+    assert validate_config(map_str_int, {}).success
+    assert not validate_config(map_str_int, {"a": None}).success
+    assert not validate_config(map_str_int, {"a": 1, "b": None}).success
+    assert not validate_config(map_str_int, None).success
+    assert not validate_config(map_str_int, {"a": 1, "b": "absdf"}).success
+    assert not validate_config(map_str_int, {"a": 1, 4: 4}).success
+    assert not validate_config(map_str_int, {"a": 1, None: 4}).success
 
-    keyed_collection_int_int = resolve_to_config_type({Int: Int})
+    map_int_int = resolve_to_config_type({Int: Int})
 
-    assert validate_config(keyed_collection_int_int, {1: 1}).success
-    assert validate_config(keyed_collection_int_int, {2: 1, 3: 2}).success
-    assert validate_config(keyed_collection_int_int, {}).success
-    assert not validate_config(keyed_collection_int_int, {1: None}).success
-    assert not validate_config(keyed_collection_int_int, {1: 1, 2: None}).success
-    assert not validate_config(keyed_collection_int_int, None).success
-    assert not validate_config(keyed_collection_int_int, {1: 1, 2: "absdf"}).success
-    assert not validate_config(keyed_collection_int_int, {4: 1, "a": 4}).success
-    assert not validate_config(keyed_collection_int_int, {5: 1, None: 4}).success
+    assert validate_config(map_int_int, {1: 1}).success
+    assert validate_config(map_int_int, {2: 1, 3: 2}).success
+    assert validate_config(map_int_int, {}).success
+    assert not validate_config(map_int_int, {1: None}).success
+    assert not validate_config(map_int_int, {1: 1, 2: None}).success
+    assert not validate_config(map_int_int, None).success
+    assert not validate_config(map_int_int, {1: 1, 2: "absdf"}).success
+    assert not validate_config(map_int_int, {4: 1, "a": 4}).success
+    assert not validate_config(map_int_int, {5: 1, None: 4}).success

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_new_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_new_config_types.py
@@ -53,12 +53,26 @@ def test_list_nullable_int():
 
 
 def test_keyed_collection_int():
-    keyed_collection_int = resolve_to_config_type({str: Int})
+    keyed_collection_str_int = resolve_to_config_type({str: Int})
 
-    assert validate_config(keyed_collection_int, {"a": 1}).success
-    assert validate_config(keyed_collection_int, {"a": 1, "b": 2}).success
-    assert validate_config(keyed_collection_int, {}).success
-    assert not validate_config(keyed_collection_int, {"a": None}).success
-    assert not validate_config(keyed_collection_int, {"a": 1, "b": None}).success
-    assert not validate_config(keyed_collection_int, None).success
-    assert not validate_config(keyed_collection_int, {"a": 1, "b": "absdf"}).success
+    assert validate_config(keyed_collection_str_int, {"a": 1}).success
+    assert validate_config(keyed_collection_str_int, {"a": 1, "b": 2}).success
+    assert validate_config(keyed_collection_str_int, {}).success
+    assert not validate_config(keyed_collection_str_int, {"a": None}).success
+    assert not validate_config(keyed_collection_str_int, {"a": 1, "b": None}).success
+    assert not validate_config(keyed_collection_str_int, None).success
+    assert not validate_config(keyed_collection_str_int, {"a": 1, "b": "absdf"}).success
+    assert not validate_config(keyed_collection_str_int, {"a": 1, 4: 4}).success
+    assert not validate_config(keyed_collection_str_int, {"a": 1, None: 4}).success
+
+    keyed_collection_int_int = resolve_to_config_type({Int: Int})
+
+    assert validate_config(keyed_collection_int_int, {1: 1}).success
+    assert validate_config(keyed_collection_int_int, {2: 1, 3: 2}).success
+    assert validate_config(keyed_collection_int_int, {}).success
+    assert not validate_config(keyed_collection_int_int, {1: None}).success
+    assert not validate_config(keyed_collection_int_int, {1: 1, 2: None}).success
+    assert not validate_config(keyed_collection_int_int, None).success
+    assert not validate_config(keyed_collection_int_int, {1: 1, 2: "absdf"}).success
+    assert not validate_config(keyed_collection_int_int, {4: 1, "a": 4}).success
+    assert not validate_config(keyed_collection_int_int, {5: 1, None: 4}).success

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -52,48 +52,56 @@ def test_basic_keyed_collection_type_print():
     assert (
         print_config_type_to_string({str: int})
         == """{
-  *String: Int
+  [String]: Int
 }"""
     )
-    assert_inner_types({str: int}, int)
+    assert_inner_types({str: int}, int, str)
+
+    assert (
+        print_config_type_to_string({int: int})
+        == """{
+  [Int]: Int
+}"""
+    )
+    assert_inner_types({int: int}, int, int)
 
 
 def test_double_keyed_collection_type_print():
     assert (
         print_config_type_to_string({str: {str: int}})
         == """{
-  *String: {
-    *String: Int
+  [String]: {
+    [String]: Int
   }
 }"""
     )
     int_keyed_collection = {str: int}
     keyed_collection_int_keyed_collection = {str: int_keyed_collection}
-    assert_inner_types(keyed_collection_int_keyed_collection, Int, int_keyed_collection)
+    assert_inner_types(keyed_collection_int_keyed_collection, Int, int_keyed_collection, String)
 
 
 def test_list_keyed_collection_nullable_combos():
     # Don't care about newlines here for brevity's sake, those are tested elsewhere
-    assert print_config_type_to_string({str: [int]}, with_lines=False) == "{ *String: [Int] }"
+    assert print_config_type_to_string({str: [int]}, with_lines=False) == "{ [String]: [Int] }"
     assert (
         print_config_type_to_string(Noneable({str: [int]}), with_lines=False)
-        == "{ *String: [Int] }?"
+        == "{ [String]: [Int] }?"
     )
     assert (
         print_config_type_to_string({str: Noneable([int])}, with_lines=False)
-        == "{ *String: [Int]? }"
+        == "{ [String]: [Int]? }"
     )
     assert (
         print_config_type_to_string({str: [Noneable(int)]}, with_lines=False)
-        == "{ *String: [Int?] }"
+        == "{ [String]: [Int?] }"
     )
     assert (
         print_config_type_to_string(Noneable({str: [Noneable(int)]}), with_lines=False)
-        == "{ *String: [Int?] }?"
+        == "{ [String]: [Int?] }?"
     )
     assert (
         print_config_type_to_string(Noneable({str: Noneable([Noneable(int)])}), with_lines=False)
-        == "{ *String: [Int?]? }?"
+        == "{ [String]: [Int?]? }?"
     )
 
 
@@ -160,7 +168,7 @@ def test_single_level_dict_lists_keyed_collections_and_nullable():
   optional_int_field?: Int
   string_list_field: [String]
   zkeyed_collection_list_field: {
-    *String: Int
+    [String]: Int
   }
 }"""
 
@@ -171,9 +179,9 @@ def test_nested_dicts_and_keyed_collections():
     output = print_config_type_to_string({"field_one": {str: {"field_two": {str: int}}}})
     expected = """{
   field_one: {
-    *String: {
+    [String]: {
       field_two: {
-        *String: Int
+        [String]: Int
       }
     }
   }

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -48,7 +48,7 @@ def test_nullable_list_combos():
     assert print_config_type_to_string(Noneable([Noneable(int)])) == "[Int?]?"
 
 
-def test_basic_keyed_collection_type_print():
+def test_basic_map_type_print():
     assert (
         print_config_type_to_string({str: int})
         == """{
@@ -66,7 +66,7 @@ def test_basic_keyed_collection_type_print():
     assert_inner_types({int: int}, int, int)
 
 
-def test_double_keyed_collection_type_print():
+def test_double_map_type_print():
     assert (
         print_config_type_to_string({str: {str: int}})
         == """{
@@ -75,12 +75,12 @@ def test_double_keyed_collection_type_print():
   }
 }"""
     )
-    int_keyed_collection = {str: int}
-    keyed_collection_int_keyed_collection = {str: int_keyed_collection}
-    assert_inner_types(keyed_collection_int_keyed_collection, Int, int_keyed_collection, String)
+    int_map = {str: int}
+    map_int_map = {str: int_map}
+    assert_inner_types(map_int_map, Int, int_map, String)
 
 
-def test_list_keyed_collection_nullable_combos():
+def test_list_map_nullable_combos():
     # Don't care about newlines here for brevity's sake, those are tested elsewhere
     assert print_config_type_to_string({str: [int]}, with_lines=False) == "{ [String]: [Int] }"
     assert (
@@ -153,13 +153,13 @@ def test_optional_field():
     assert output == expected
 
 
-def test_single_level_dict_lists_keyed_collections_and_nullable():
+def test_single_level_dict_lists_maps_and_nullable():
     output = print_config_type_to_string(
         {
             "nullable_int_field": Noneable(int),
             "optional_int_field": Field(int, is_required=False),
             "string_list_field": [str],
-            "zkeyed_collection_list_field": {str: int},
+            "zmap_list_field": {str: int},
         }
     )
 
@@ -167,7 +167,7 @@ def test_single_level_dict_lists_keyed_collections_and_nullable():
   nullable_int_field?: Int?
   optional_int_field?: Int
   string_list_field: [String]
-  zkeyed_collection_list_field: {
+  zmap_list_field: {
     [String]: Int
   }
 }"""
@@ -175,7 +175,7 @@ def test_single_level_dict_lists_keyed_collections_and_nullable():
     assert output == expected
 
 
-def test_nested_dicts_and_keyed_collections():
+def test_nested_dicts_and_maps():
     output = print_config_type_to_string({"field_one": {str: {"field_two": {str: int}}}})
     expected = """{
   field_one: {

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_basic_dep_fan_out 1'] = '''{

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
@@ -4,11 +4,10 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots[
-    'test_basic_dep_fan_out 1'
-] = '''{
+snapshots['test_basic_dep_fan_out 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -1153,9 +1152,7 @@ snapshots[
 
 snapshots['test_basic_dep_fan_out 2'] = '9028d026f4732a6e5bc7e86f99c5fdee35619abc'
 
-snapshots[
-    'test_basic_fan_in 1'
-] = '''{
+snapshots['test_basic_fan_in 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -2318,9 +2315,7 @@ snapshots[
 
 snapshots['test_basic_fan_in 2'] = 'fcbb74fb1ffa0600fc799f4d03df64b0a1c014d2'
 
-snapshots[
-    'test_deserialize_solid_def_snaps_multi_type_config 1'
-] = '''{
+snapshots['test_deserialize_solid_def_snaps_multi_type_config 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -2353,9 +2348,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_empty_pipeline_snap_props 1'
-] = '''{
+snapshots['test_empty_pipeline_snap_props 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -3406,9 +3399,7 @@ snapshots[
 
 snapshots['test_empty_pipeline_snap_props 2'] = '2290b3c558988d5ac3b68b109c7a6da33a237696'
 
-snapshots[
-    'test_empty_pipeline_snap_snapshot 1'
-] = '''{
+snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -4457,9 +4448,7 @@ snapshots[
   "tags": {}
 }'''
 
-snapshots[
-    'test_multi_type_config_array_dict_fields[Permissive] 1'
-] = '''{
+snapshots['test_multi_type_config_array_dict_fields[Permissive] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Permissive.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4475,9 +4464,7 @@ snapshots[
   ]
 }'''
 
-snapshots[
-    'test_multi_type_config_array_dict_fields[Selector] 1'
-] = '''{
+snapshots['test_multi_type_config_array_dict_fields[Selector] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Selector.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4493,9 +4480,7 @@ snapshots[
   ]
 }'''
 
-snapshots[
-    'test_multi_type_config_array_dict_fields[Shape] 1'
-] = '''{
+snapshots['test_multi_type_config_array_dict_fields[Shape] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Shape.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4511,9 +4496,23 @@ snapshots[
   ]
 }'''
 
-snapshots[
-    'test_multi_type_config_nested_dicts[nested_dict_types0] 1'
-] = '''{
+snapshots['test_multi_type_config_array_keyed_collection 1'] = '''{
+  "__class__": "ConfigTypeSnap",
+  "description": "List of Array.KeyedCollection.Int",
+  "enum_values": null,
+  "fields": null,
+  "given_name": null,
+  "key": "Array.KeyedCollection.Int",
+  "kind": {
+    "__enum__": "ConfigTypeKind.ARRAY"
+  },
+  "scalar_kind": null,
+  "type_param_keys": [
+    "KeyedCollection.Int"
+  ]
+}'''
+
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types0] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4537,9 +4536,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_multi_type_config_nested_dicts[nested_dict_types1] 1'
-] = '''{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types1] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4563,9 +4560,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_multi_type_config_nested_dicts[nested_dict_types2] 1'
-] = '''{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types2] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4589,9 +4584,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_multi_type_config_nested_dicts[nested_dict_types3] 1'
-] = '''{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types3] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4615,9 +4608,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_multi_type_config_nested_dicts[nested_dict_types4] 1'
-] = '''{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types4] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4641,9 +4632,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_multi_type_config_nested_dicts[nested_dict_types5] 1'
-] = '''{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types5] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4667,9 +4656,7 @@ snapshots[
   "type_param_keys": null
 }'''
 
-snapshots[
-    'test_pipeline_snap_all_props 1'
-] = '''{
+snapshots['test_pipeline_snap_all_props 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -5722,9 +5709,7 @@ snapshots[
 
 snapshots['test_pipeline_snap_all_props 2'] = '65d6b223a7426ba89b261b19570ebbc8f51861e2'
 
-snapshots[
-    'test_two_invocations_deps_snap 1'
-] = '''{
+snapshots['test_two_invocations_deps_snap 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
@@ -4497,17 +4497,17 @@ snapshots['test_multi_type_config_array_dict_fields[Shape] 1'] = '''{
 
 snapshots['test_multi_type_config_array_keyed_collection 1'] = '''{
   "__class__": "ConfigTypeSnap",
-  "description": "List of Array.KeyedCollection.Int",
+  "description": "List of Array.KeyedCollection.String.Int",
   "enum_values": null,
   "fields": null,
   "given_name": null,
-  "key": "Array.KeyedCollection.Int",
+  "key": "Array.KeyedCollection.String.Int",
   "kind": {
     "__enum__": "ConfigTypeKind.ARRAY"
   },
   "scalar_kind": null,
   "type_param_keys": [
-    "KeyedCollection.Int"
+    "KeyedCollection.String.Int"
   ]
 }'''
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
@@ -4,11 +4,10 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots[
-    "test_basic_dep_fan_out 1"
-] = """{
+snapshots['test_basic_dep_fan_out 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -1149,13 +1148,11 @@ snapshots[
     ]
   },
   "tags": {}
-}"""
+}'''
 
-snapshots["test_basic_dep_fan_out 2"] = "9028d026f4732a6e5bc7e86f99c5fdee35619abc"
+snapshots['test_basic_dep_fan_out 2'] = '9028d026f4732a6e5bc7e86f99c5fdee35619abc'
 
-snapshots[
-    "test_basic_fan_in 1"
-] = """{
+snapshots['test_basic_fan_in 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -2314,13 +2311,11 @@ snapshots[
     ]
   },
   "tags": {}
-}"""
+}'''
 
-snapshots["test_basic_fan_in 2"] = "fcbb74fb1ffa0600fc799f4d03df64b0a1c014d2"
+snapshots['test_basic_fan_in 2'] = 'fcbb74fb1ffa0600fc799f4d03df64b0a1c014d2'
 
-snapshots[
-    "test_deserialize_solid_def_snaps_multi_type_config 1"
-] = """{
+snapshots['test_deserialize_solid_def_snaps_multi_type_config 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -2351,11 +2346,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_empty_pipeline_snap_props 1"
-] = """{
+snapshots['test_empty_pipeline_snap_props 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -3402,13 +3395,11 @@ snapshots[
     ]
   },
   "tags": {}
-}"""
+}'''
 
-snapshots["test_empty_pipeline_snap_props 2"] = "2290b3c558988d5ac3b68b109c7a6da33a237696"
+snapshots['test_empty_pipeline_snap_props 2'] = '2290b3c558988d5ac3b68b109c7a6da33a237696'
 
-snapshots[
-    "test_empty_pipeline_snap_snapshot 1"
-] = """{
+snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -4455,11 +4446,9 @@ snapshots[
     ]
   },
   "tags": {}
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_array_dict_fields[Permissive] 1"
-] = """{
+snapshots['test_multi_type_config_array_dict_fields[Permissive] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Permissive.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4473,11 +4462,9 @@ snapshots[
   "type_param_keys": [
     "Permissive.1f37a068c7c51aba23e9c41475c78eebc4e58471"
   ]
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_array_dict_fields[Selector] 1"
-] = """{
+snapshots['test_multi_type_config_array_dict_fields[Selector] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Selector.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4491,11 +4478,9 @@ snapshots[
   "type_param_keys": [
     "Selector.1f37a068c7c51aba23e9c41475c78eebc4e58471"
   ]
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_array_dict_fields[Shape] 1"
-] = """{
+snapshots['test_multi_type_config_array_dict_fields[Shape] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Shape.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4509,12 +4494,9 @@ snapshots[
   "type_param_keys": [
     "Shape.1f37a068c7c51aba23e9c41475c78eebc4e58471"
   ]
-}"""
+}'''
 
-
-snapshots[
-    "test_multi_type_config_array_map 1"
-] = """{
+snapshots['test_multi_type_config_array_map 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Map.String.Int",
   "enum_values": null,
@@ -4528,11 +4510,9 @@ snapshots[
   "type_param_keys": [
     "Map.String.Int"
   ]
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_nested_dicts[nested_dict_types0] 1"
-] = """{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types0] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4554,11 +4534,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_nested_dicts[nested_dict_types1] 1"
-] = """{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types1] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4580,11 +4558,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_nested_dicts[nested_dict_types2] 1"
-] = """{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types2] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4606,11 +4582,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_nested_dicts[nested_dict_types3] 1"
-] = """{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types3] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4632,11 +4606,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_nested_dicts[nested_dict_types4] 1"
-] = """{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types4] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4658,11 +4630,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_multi_type_config_nested_dicts[nested_dict_types5] 1"
-] = """{
+snapshots['test_multi_type_config_nested_dicts[nested_dict_types5] 1'] = '''{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4684,11 +4654,9 @@ snapshots[
   },
   "scalar_kind": null,
   "type_param_keys": null
-}"""
+}'''
 
-snapshots[
-    "test_pipeline_snap_all_props 1"
-] = """{
+snapshots['test_pipeline_snap_all_props 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -5737,13 +5705,11 @@ snapshots[
   "tags": {
     "key": "value"
   }
-}"""
+}'''
 
-snapshots["test_pipeline_snap_all_props 2"] = "65d6b223a7426ba89b261b19570ebbc8f51861e2"
+snapshots['test_pipeline_snap_all_props 2'] = '65d6b223a7426ba89b261b19570ebbc8f51861e2'
 
-snapshots[
-    "test_two_invocations_deps_snap 1"
-] = """{
+snapshots['test_two_invocations_deps_snap 1'] = '''{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -6807,6 +6773,6 @@ snapshots[
     ]
   },
   "tags": {}
-}"""
+}'''
 
-snapshots["test_two_invocations_deps_snap 2"] = "3cef1512951bc4e813f0de88f41247d6753672dc"
+snapshots['test_two_invocations_deps_snap 2'] = '3cef1512951bc4e813f0de88f41247d6753672dc'

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_pipeline_snap.py
@@ -6,7 +6,9 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_basic_dep_fan_out 1'] = '''{
+snapshots[
+    "test_basic_dep_fan_out 1"
+] = """{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -1147,11 +1149,13 @@ snapshots['test_basic_dep_fan_out 1'] = '''{
     ]
   },
   "tags": {}
-}'''
+}"""
 
-snapshots['test_basic_dep_fan_out 2'] = '9028d026f4732a6e5bc7e86f99c5fdee35619abc'
+snapshots["test_basic_dep_fan_out 2"] = "9028d026f4732a6e5bc7e86f99c5fdee35619abc"
 
-snapshots['test_basic_fan_in 1'] = '''{
+snapshots[
+    "test_basic_fan_in 1"
+] = """{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -2310,11 +2314,13 @@ snapshots['test_basic_fan_in 1'] = '''{
     ]
   },
   "tags": {}
-}'''
+}"""
 
-snapshots['test_basic_fan_in 2'] = 'fcbb74fb1ffa0600fc799f4d03df64b0a1c014d2'
+snapshots["test_basic_fan_in 2"] = "fcbb74fb1ffa0600fc799f4d03df64b0a1c014d2"
 
-snapshots['test_deserialize_solid_def_snaps_multi_type_config 1'] = '''{
+snapshots[
+    "test_deserialize_solid_def_snaps_multi_type_config 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -2345,9 +2351,11 @@ snapshots['test_deserialize_solid_def_snaps_multi_type_config 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_empty_pipeline_snap_props 1'] = '''{
+snapshots[
+    "test_empty_pipeline_snap_props 1"
+] = """{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -3394,11 +3402,13 @@ snapshots['test_empty_pipeline_snap_props 1'] = '''{
     ]
   },
   "tags": {}
-}'''
+}"""
 
-snapshots['test_empty_pipeline_snap_props 2'] = '2290b3c558988d5ac3b68b109c7a6da33a237696'
+snapshots["test_empty_pipeline_snap_props 2"] = "2290b3c558988d5ac3b68b109c7a6da33a237696"
 
-snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
+snapshots[
+    "test_empty_pipeline_snap_snapshot 1"
+] = """{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -4445,9 +4455,11 @@ snapshots['test_empty_pipeline_snap_snapshot 1'] = '''{
     ]
   },
   "tags": {}
-}'''
+}"""
 
-snapshots['test_multi_type_config_array_dict_fields[Permissive] 1'] = '''{
+snapshots[
+    "test_multi_type_config_array_dict_fields[Permissive] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Permissive.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4461,9 +4473,11 @@ snapshots['test_multi_type_config_array_dict_fields[Permissive] 1'] = '''{
   "type_param_keys": [
     "Permissive.1f37a068c7c51aba23e9c41475c78eebc4e58471"
   ]
-}'''
+}"""
 
-snapshots['test_multi_type_config_array_dict_fields[Selector] 1'] = '''{
+snapshots[
+    "test_multi_type_config_array_dict_fields[Selector] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Selector.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4477,9 +4491,11 @@ snapshots['test_multi_type_config_array_dict_fields[Selector] 1'] = '''{
   "type_param_keys": [
     "Selector.1f37a068c7c51aba23e9c41475c78eebc4e58471"
   ]
-}'''
+}"""
 
-snapshots['test_multi_type_config_array_dict_fields[Shape] 1'] = '''{
+snapshots[
+    "test_multi_type_config_array_dict_fields[Shape] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": "List of Array.Shape.1f37a068c7c51aba23e9c41475c78eebc4e58471",
   "enum_values": null,
@@ -4493,25 +4509,30 @@ snapshots['test_multi_type_config_array_dict_fields[Shape] 1'] = '''{
   "type_param_keys": [
     "Shape.1f37a068c7c51aba23e9c41475c78eebc4e58471"
   ]
-}'''
+}"""
 
-snapshots['test_multi_type_config_array_keyed_collection 1'] = '''{
+
+snapshots[
+    "test_multi_type_config_array_map 1"
+] = """{
   "__class__": "ConfigTypeSnap",
-  "description": "List of Array.KeyedCollection.String.Int",
+  "description": "List of Array.Map.String.Int",
   "enum_values": null,
   "fields": null,
   "given_name": null,
-  "key": "Array.KeyedCollection.String.Int",
+  "key": "Array.Map.String.Int",
   "kind": {
     "__enum__": "ConfigTypeKind.ARRAY"
   },
   "scalar_kind": null,
   "type_param_keys": [
-    "KeyedCollection.String.Int"
+    "Map.String.Int"
   ]
-}'''
+}"""
 
-snapshots['test_multi_type_config_nested_dicts[nested_dict_types0] 1'] = '''{
+snapshots[
+    "test_multi_type_config_nested_dicts[nested_dict_types0] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4533,9 +4554,11 @@ snapshots['test_multi_type_config_nested_dicts[nested_dict_types0] 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_multi_type_config_nested_dicts[nested_dict_types1] 1'] = '''{
+snapshots[
+    "test_multi_type_config_nested_dicts[nested_dict_types1] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4557,9 +4580,11 @@ snapshots['test_multi_type_config_nested_dicts[nested_dict_types1] 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_multi_type_config_nested_dicts[nested_dict_types2] 1'] = '''{
+snapshots[
+    "test_multi_type_config_nested_dicts[nested_dict_types2] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4581,9 +4606,11 @@ snapshots['test_multi_type_config_nested_dicts[nested_dict_types2] 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_multi_type_config_nested_dicts[nested_dict_types3] 1'] = '''{
+snapshots[
+    "test_multi_type_config_nested_dicts[nested_dict_types3] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4605,9 +4632,11 @@ snapshots['test_multi_type_config_nested_dicts[nested_dict_types3] 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_multi_type_config_nested_dicts[nested_dict_types4] 1'] = '''{
+snapshots[
+    "test_multi_type_config_nested_dicts[nested_dict_types4] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4629,9 +4658,11 @@ snapshots['test_multi_type_config_nested_dicts[nested_dict_types4] 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_multi_type_config_nested_dicts[nested_dict_types5] 1'] = '''{
+snapshots[
+    "test_multi_type_config_nested_dicts[nested_dict_types5] 1"
+] = """{
   "__class__": "ConfigTypeSnap",
   "description": null,
   "enum_values": null,
@@ -4653,9 +4684,11 @@ snapshots['test_multi_type_config_nested_dicts[nested_dict_types5] 1'] = '''{
   },
   "scalar_kind": null,
   "type_param_keys": null
-}'''
+}"""
 
-snapshots['test_pipeline_snap_all_props 1'] = '''{
+snapshots[
+    "test_pipeline_snap_all_props 1"
+] = """{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -5704,11 +5737,13 @@ snapshots['test_pipeline_snap_all_props 1'] = '''{
   "tags": {
     "key": "value"
   }
-}'''
+}"""
 
-snapshots['test_pipeline_snap_all_props 2'] = '65d6b223a7426ba89b261b19570ebbc8f51861e2'
+snapshots["test_pipeline_snap_all_props 2"] = "65d6b223a7426ba89b261b19570ebbc8f51861e2"
 
-snapshots['test_two_invocations_deps_snap 1'] = '''{
+snapshots[
+    "test_two_invocations_deps_snap 1"
+] = """{
   "__class__": "PipelineSnapshot",
   "config_schema_snapshot": {
     "__class__": "ConfigSchemaSnapshot",
@@ -6772,6 +6807,6 @@ snapshots['test_two_invocations_deps_snap 1'] = '''{
     ]
   },
   "tags": {}
-}'''
+}"""
 
-snapshots['test_two_invocations_deps_snap 2'] = '3cef1512951bc4e813f0de88f41247d6753672dc'
+snapshots["test_two_invocations_deps_snap 2"] = "3cef1512951bc4e813f0de88f41247d6753672dc"

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -157,21 +157,23 @@ def test_selector_of_things():
 
 
 def test_basic_keyed_collection():
-    keyed_collection_snap = snap_from_dagster_type(KeyedCollection(int))
+    keyed_collection_snap = snap_from_dagster_type(KeyedCollection(str, int))
     assert keyed_collection_snap.key.startswith("KeyedCollection")
     child_type_keys = keyed_collection_snap.get_child_type_keys()
     assert child_type_keys
-    assert len(child_type_keys) == 1
-    assert child_type_keys[0] == "Int"
+    assert len(child_type_keys) == 2
+    assert child_type_keys[0] == "String"
+    assert child_type_keys[1] == "Int"
 
 
 def test_basic_keyed_collection_nested():
-    keyed_collection_snap = snap_from_dagster_type({str: {str: int}})
+    keyed_collection_snap = snap_from_dagster_type({int: {str: int}})
     assert keyed_collection_snap.key.startswith("KeyedCollection")
     child_type_keys = keyed_collection_snap.get_child_type_keys()
     assert child_type_keys
-    assert len(child_type_keys) == 1
-    assert child_type_keys[0] == "KeyedCollection.Int"
+    assert len(child_type_keys) == 2
+    assert child_type_keys[0] == "Int"
+    assert child_type_keys[1] == "KeyedCollection.String.Int"
     assert keyed_collection_snap.enum_values is None
 
 
@@ -182,8 +184,9 @@ def test_keyed_collection_of_dict():
     assert keyed_collection_of_dict_snap.key.startswith("KeyedCollection")
     child_type_keys = keyed_collection_of_dict_snap.get_child_type_keys()
     assert child_type_keys
-    assert len(child_type_keys) == 1
-    assert child_type_keys[0].startswith("Shape")
+    assert len(child_type_keys) == 2
+    assert child_type_keys[0] == "String"
+    assert child_type_keys[1].startswith("Shape")
 
 
 def test_kitchen_sink():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -340,7 +340,7 @@ def test_kitchen_sink_break_out():
     assert list_bool.kind == ConfigTypeKind.ARRAY
 
     map = config_snaps[dict_within_list.get_field("map").type_key]
-    assert map.kind == ConfigTypeKind.map
+    assert map.kind == ConfigTypeKind.MAP
     map_dict = config_snaps[map.inner_type_key]
     assert len(map_dict.fields) == 2
     map_a = config_snaps[map_dict.get_field("map_a").type_key]

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -4,12 +4,12 @@ import pytest
 from dagster import (
     Field,
     InputDefinition,
+    KeyedCollection,
     Nothing,
     OutputDefinition,
     Permissive,
     Selector,
     Shape,
-    KeyedCollection,
     pipeline,
     solid,
 )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -254,6 +254,7 @@ def _keyed_collection_has_stable_hashes(hydrated_keyed_collection, snapshot_conf
     assert isinstance(hydrated_keyed_collection, KeyedCollection)
     assert hydrated_keyed_collection.key in snapshot_config_snap_map
     assert hydrated_keyed_collection.inner_type.key in snapshot_config_snap_map
+    assert hydrated_keyed_collection.key_type.key in snapshot_config_snap_map
 
 
 def test_deserialize_solid_def_snaps_default_field():
@@ -481,7 +482,7 @@ def test_multi_type_config_array_dict_fields(dict_config_type, snapshot):
 
 
 def test_multi_type_config_array_keyed_collection(snapshot):
-    @solid(config_schema=Array(KeyedCollection(int)))
+    @solid(config_schema=Array(KeyedCollection(str, int)))
     def fancy_solid(_):
         pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -4,7 +4,7 @@ import pytest
 from dagster import (
     Field,
     InputDefinition,
-    KeyedCollection,
+    Map,
     Nothing,
     OutputDefinition,
     Permissive,
@@ -237,7 +237,7 @@ def test_basic_fan_in(snapshot):
     snapshot.assert_match(create_pipeline_snapshot_id(pipeline_snapshot))
 
 
-def _map_has_stable_hashes(hydrated_map, snapshot_config_snap_map):
+def _dict_has_stable_hashes(hydrated_map, snapshot_config_snap_map):
     assert isinstance(hydrated_map, (Shape, Permissive, Selector))
     assert hydrated_map.key in snapshot_config_snap_map
     for field in hydrated_map.fields.values():
@@ -250,11 +250,11 @@ def _array_has_stable_hashes(hydrated_array, snapshot_config_snap_map):
     assert hydrated_array.inner_type.key in snapshot_config_snap_map
 
 
-def _keyed_collection_has_stable_hashes(hydrated_keyed_collection, snapshot_config_snap_map):
-    assert isinstance(hydrated_keyed_collection, KeyedCollection)
-    assert hydrated_keyed_collection.key in snapshot_config_snap_map
-    assert hydrated_keyed_collection.inner_type.key in snapshot_config_snap_map
-    assert hydrated_keyed_collection.key_type.key in snapshot_config_snap_map
+def _map_has_stable_hashes(hydrated_map, snapshot_config_snap_map):
+    assert isinstance(hydrated_map, Map)
+    assert hydrated_map.key in snapshot_config_snap_map
+    assert hydrated_map.inner_type.key in snapshot_config_snap_map
+    assert hydrated_map.key_type.key in snapshot_config_snap_map
 
 
 def test_deserialize_solid_def_snaps_default_field():
@@ -279,7 +279,7 @@ def test_deserialize_solid_def_snaps_default_field():
     assert isinstance(recevied_config_type.fields["bar"].config_type, String)
     assert not recevied_config_type.fields["foo"].is_required
     assert recevied_config_type.fields["foo"].default_value == "hello"
-    _map_has_stable_hashes(
+    _dict_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )
 
@@ -324,7 +324,7 @@ def test_deserialize_solid_def_snaps_strict_shape():
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     assert isinstance(recevied_config_type.fields["bar"].config_type, String)
     assert not recevied_config_type.fields["foo"].is_required
-    _map_has_stable_hashes(
+    _dict_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )
 
@@ -344,7 +344,7 @@ def test_deserialize_solid_def_snaps_selector():
     assert isinstance(recevied_config_type, Selector)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     assert isinstance(recevied_config_type.fields["bar"].config_type, Int)
-    _map_has_stable_hashes(
+    _dict_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )
 
@@ -363,7 +363,7 @@ def test_deserialize_solid_def_snaps_permissive():
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Permissive)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
-    _map_has_stable_hashes(
+    _dict_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )
 
@@ -387,7 +387,7 @@ def test_deserialize_solid_def_snaps_array():
     )
 
 
-def test_deserialize_solid_def_snaps_keyed_collection():
+def test_deserialize_solid_def_snaps_map():
     @solid(config_schema=Field({str: str}))
     def noop_solid(_):
         pass
@@ -399,9 +399,9 @@ def test_deserialize_solid_def_snaps_keyed_collection():
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_pipeline)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_solid")
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
-    assert isinstance(recevied_config_type, KeyedCollection)
+    assert isinstance(recevied_config_type, Map)
     assert isinstance(recevied_config_type.inner_type, String)
-    _keyed_collection_has_stable_hashes(
+    _map_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )
 
@@ -457,7 +457,7 @@ def test_deserialize_solid_def_snaps_multi_type_config(snapshot):
     solid_def_snap = pipeline_snapshot.get_node_def_snap("fancy_solid")
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
-    _map_has_stable_hashes(
+    _dict_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )
 
@@ -481,8 +481,8 @@ def test_multi_type_config_array_dict_fields(dict_config_type, snapshot):
     )
 
 
-def test_multi_type_config_array_keyed_collection(snapshot):
-    @solid(config_schema=Array(KeyedCollection(str, int)))
+def test_multi_type_config_array_map(snapshot):
+    @solid(config_schema=Array(Map(str, int)))
     def fancy_solid(_):
         pass
 
@@ -518,6 +518,6 @@ def test_multi_type_config_nested_dicts(nested_dict_types, snapshot):
     solid_def_snap = pipeline_snapshot.get_node_def_snap("fancy_solid")
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
-    _map_has_stable_hashes(
+    _dict_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )


### PR DESCRIPTION
## Summary

Adds a new config type, tentatively called `Map` (previously `KeyedCollection`). It represents a YAML mapping between any scalar type and a user-specified inner config type. For example:

`Map(str, int)` (short form `{str: int}`) could represent:
```python
{
  "a": 5,
  "b": 6
}
```
```python
{
  "x": 12
}
```

`Map(str, Shape({"id": Field(int), "description": Field(str)}))` 
(short form `{str: {"id": int, "description": str}}`):
```python
{
  "foo": {
    "id": 5,
    "description": "Example one",
  },
  "bar": {
    "id": 6,
    "description": "Example two",
  }
}
```

### Use Case

Mappings from arbitary (usually string) scalars are a common YAML pattern. In the Dagster Cloud `workspace.yaml` file, we have previously employed this pattern to allow user-specified keys to act as location names. Here, `foo`, `bar`, and `baz` are user-created:

```yaml
    locations:
      foo:
        image: foo:latest
        python_file: {python_file}
        working_directory: {working_directory}
      bar:
        image: bar:latest
        package_name: repo_package
        git:
          commit_hash: abc123
          url: https://github.com
      baz:
        image: baz:latest
        module_name: repo_module
        attribute: my_attribute
        executable_path: my_dir/my_python
```

This structure was not defined using our schema tools, instead manually verified with Python. `Map` would be useful internally to validate this schema and to enable editing on the rich YAML editor.

In general, `Map` fits a previously unfilled niche between `Shape` and `Permissive`. `Shape` requires all field names to be explicitly specified, but provides rigorous schema checks on the field values. `Permissive` allows arbitrary field names, but does not provide any schema checks on these values. 

`Map` allows arbitrary field names but provides schema checked values. It also allows for non-string scalar keys, e.g. maps keyed by integers. Users would likely find `Map` useful in specifying flexible config for their own Ops, without having to sacrifice checks by using `Permissive`.

### Syntax

A `Map` is used similarly to an `Array` config type. It has a long form representation which specifies the key and value types, e.g. `Map(str, Array(int))` for data like:
```python
{
  "a": [1, 2, 3],
  "b": [4, 5, 6]
}
```
This can also be represented through the short form, similar to the `Array` short form: `{str: [int]}`.

Disambiguating the `Map` and `Shape` short forms is done by checking for a single, non-string key, since `Shape` short form keys must be strings.

### Print Format

The type printer represents a `Map` similarly to a `Shape`, but uses a [typescript-like](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html) square bracket representation for the key:
```python
{int: [str]}

"""{
  [Int]: [String]
}"""
```

### Remaining Work

Beyond the work contained in this PR, support for `Map` needs to be implemented on the GraphQL and Dagit layers, in particular the YAML editor. Docs also need to be written.

The name `Map` (formerly `KeyedCollection`) is open for change.