### PR TITLE
[dagit] When launching asset runs, pass stepKeys not solidSelection

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -68,11 +68,11 @@ export const LaunchAssetExecutionButton: React.FC<{
               mode: 'default',
               executionMetadata: {},
               runConfigData: {},
+              stepKeys: assets.map((o) => o.opName!),
               selector: {
                 repositoryLocationName: repoAddress.location,
                 repositoryName: repoAddress.name,
                 pipelineName: assetJobName,
-                solidSelection: assets.map((o) => o.opName!),
               },
             },
           })}


### PR DESCRIPTION
## Summary
This only impacted the non-partitioned "Rematerialize" button - the partitioned case was handled correctly. Slack discussion here: https://dagster.slack.com/archives/C029C2N3C64/p1643343844934769


## Test Plan

Tested with asset graph below, re-executing `asset2` would fail previously:

```
from dagster.core.asset_defs import asset, build_assets_job


@asset
def asset1():
    pass


@asset
def asset2(asset1):
    pass


asset_job = build_assets_job("my_job", assets=[asset1, asset2])
```



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.