### PR TITLE
remove timeline flash across fetches

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -35,7 +35,7 @@ import {
   queuedStatuses,
   successStatuses,
 } from '../runs/RunStatuses';
-import {RunTimelineContainer, TimelineJob, makeJobKey} from '../runs/RunTimeline';
+import {RunTimelineContainer, TimelineJob, makeJobKey, HourWindow} from '../runs/RunTimeline';
 import {RunElapsed, RunTime, RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {RunTimeFragment} from '../runs/types/RunTimeFragment';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
@@ -415,7 +415,6 @@ const OverviewContent = () => {
 
 const LOOKAHEAD_HOURS = 1;
 const ONE_HOUR = 60 * 60 * 1000;
-type HourWindow = '1' | '6' | '12' | '24';
 
 const RunTimelineSection = ({jobs, loading}: {jobs: JobItem[]; loading: boolean}) => {
   const [shown, setShown] = React.useState(true);
@@ -485,7 +484,9 @@ const RunTimelineSection = ({jobs, loading}: {jobs: JobItem[]; loading: boolean}
           </ButtonWIP>
         </Box>
       </Box>
-      {shown ? <RunTimelineContainer range={[start, end]} jobs={timelineJobs} /> : null}
+      {shown ? (
+        <RunTimelineContainer range={[start, end]} jobs={timelineJobs} hourWindow={hourWindow} />
+      ) : null}
     </>
   );
 };

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -25,6 +25,7 @@ import {
 } from './RunStatuses';
 import {TimeElapsed} from './TimeElapsed';
 import {RunTimelineQuery, RunTimelineQueryVariables} from './types/RunTimelineQuery';
+import {LoadingSpinner} from '../ui/Loading';
 
 const ROW_HEIGHT = 24;
 const TIME_HEADER_HEIGHT = 36;
@@ -46,6 +47,8 @@ export type TimelineJob = {
   runs: TimelineRun[];
 };
 
+export type HourWindow = '1' | '6' | '12' | '24';
+
 export const makeJobKey = (repoAddress: RepoAddress, jobName: string) => {
   return `${jobName}-${repoAddressAsString(repoAddress)}`;
 };
@@ -53,12 +56,16 @@ export const makeJobKey = (repoAddress: RepoAddress, jobName: string) => {
 export const RunTimelineContainer = ({
   range,
   jobs,
+  hourWindow,
 }: {
   range: [number, number];
   jobs: TimelineJob[];
+  hourWindow: HourWindow;
 }) => {
   const [start, end] = range;
   const [jobsWithRuns, setJobsWithRuns] = React.useState<TimelineJob[]>([]);
+  const [loadedWindow, setLoadedWindow] = React.useState<HourWindow>();
+
   const {data, loading} = useQuery<RunTimelineQuery, RunTimelineQueryVariables>(
     RUN_TIMELINE_QUERY,
     {
@@ -187,8 +194,12 @@ export const RunTimelineContainer = ({
     }, {} as {[jobKey: string]: number});
 
     setJobsWithRuns(jobs.sort((a, b) => earliest[a.key] - earliest[b.key]));
+    setLoadedWindow(hourWindow);
   }, [data, start, end, loading, jobsByKey]);
 
+  if (loading && hourWindow !== loadedWindow) {
+    return <LoadingSpinner purpose="section" />;
+  }
   return <RunTimeline range={[start, end]} jobs={jobsWithRuns} />;
 };
 

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -10,6 +10,7 @@ import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {InstigationStatus, RunStatus} from '../types/globalTypes';
+import {LoadingSpinner} from '../ui/Loading';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -25,7 +26,6 @@ import {
 } from './RunStatuses';
 import {TimeElapsed} from './TimeElapsed';
 import {RunTimelineQuery, RunTimelineQueryVariables} from './types/RunTimelineQuery';
-import {LoadingSpinner} from '../ui/Loading';
 
 const ROW_HEIGHT = 24;
 const TIME_HEADER_HEIGHT = 36;
@@ -195,7 +195,7 @@ export const RunTimelineContainer = ({
 
     setJobsWithRuns(jobs.sort((a, b) => earliest[a.key] - earliest[b.key]));
     setLoadedWindow(hourWindow);
-  }, [data, start, end, loading, jobsByKey]);
+  }, [data, start, end, loading, jobsByKey, hourWindow]);
 
   if (loading && hourWindow !== loadedWindow) {
     return <LoadingSpinner purpose="section" />;


### PR DESCRIPTION
## Summary
When the `RunTimeline` is fetching more data and the query is noticeably long, you can see a flash as the runs disappear while the query is loading.

This diff puts the last set of fetched runs into state, and only recalculates the rendered runs when there is data available (i.e. not loading).

Bug tracked here: https://github.com/dagster-io/dagster/issues/6388

## Test Plan
Artificially slowed the request, saw the flash.


