### PR TITLE
Error when attempting to invoke run status sensors

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/run_status_sensor_definition.py
@@ -11,7 +11,11 @@ from dagster.core.definitions.sensor_definition import (
     SensorEvaluationContext,
     SkipReason,
 )
-from dagster.core.errors import RunStatusSensorExecutionError, user_code_error_boundary
+from dagster.core.errors import (
+    DagsterInvalidInvocationError,
+    RunStatusSensorExecutionError,
+    user_code_error_boundary,
+)
 from dagster.core.events import PIPELINE_RUN_STATUS_TO_EVENT_TYPE, DagsterEvent
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.pipeline_run import (
@@ -443,6 +447,11 @@ class RunStatusSensorDefinition(SensorDefinition):
             evaluation_fn=_wrapped_fn,
             minimum_interval_seconds=minimum_interval_seconds,
             description=description,
+        )
+
+    def __call__(self, *args, **kwargs):
+        raise DagsterInvalidInvocationError(
+            "Direct invocation of RunStatusSensors is not yet supported."
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -4,10 +4,12 @@ import pytest
 from dagster import (
     DagsterInstance,
     DagsterInvariantViolationError,
+    PipelineRunStatus,
     RunRequest,
     SensorEvaluationContext,
     SensorExecutionContext,
     build_sensor_context,
+    run_status_sensor,
     sensor,
 )
 from dagster.core.errors import DagsterInvalidInvocationError
@@ -92,3 +94,15 @@ def test_instance_access_built_sensor():
 def test_instance_access_with_mock():
     mock_instance = mock.MagicMock(spec=DagsterInstance)
     assert build_sensor_context(instance=mock_instance).instance == mock_instance
+
+
+def test_run_status_sensor_invocation():
+    @run_status_sensor(pipeline_run_status=PipelineRunStatus.SUCCESS)
+    def the_sensor(_):
+        pass
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match="Direct invocation of RunStatusSensors is not yet supported.",
+    ):
+        the_sensor(None)


### PR DESCRIPTION
We don't have an invocation API for run status sensors yet, and we should error to make that clear. In response to https://github.com/dagster-io/dagster/issues/6375