### PR TITLE
Fix race condition with interrupts

### DIFF
--- a/python_modules/dagster/dagster/utils/interrupts.py
+++ b/python_modules/dagster/dagster/utils/interrupts.py
@@ -68,10 +68,6 @@ def raise_interrupts_as(error_cls):
         yield
         return
 
-    if _received_interrupt["received"]:
-        _received_interrupt["received"] = False
-        raise error_cls()
-
     original_signal_handler = signal.getsignal(signal.SIGINT)
 
     def _new_signal_handler(signo, _):
@@ -82,6 +78,12 @@ def raise_interrupts_as(error_cls):
     try:
         _replace_interrupt_signal(_new_signal_handler)
         signal_replaced = True
+
+        # Raise if the previous signal handler received anything
+        if _received_interrupt["received"]:
+            _received_interrupt["received"] = False
+            raise error_cls()
+
         yield
     finally:
         if signal_replaced:


### PR DESCRIPTION
Summary:
For some reason this just popped in now on py36.

Test Plan: https://buildkite.com/dagster/dagster/builds/24414#825224f6-a2c2-49f0-8c46-cc373755da13 , was previously failing about 25% of the time now for some reason

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.