### PR TITLE
Modifies get_latest_materialization_events to filter for materializations

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/in_memory.py
@@ -247,6 +247,7 @@ class InMemoryEventLogStorage(EventLogStorage, ConfigurableClass):
                 record
                 for record in records
                 if record.is_dagster_event
+                and record.dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION
                 and record.dagster_event.asset_key
                 and record.dagster_event.asset_key in asset_keys
             ]

--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -710,8 +710,12 @@ class SqlEventLogStorage(EventLogStorage):
                     ]
                 )
                 .where(
-                    SqlEventLogStorageTable.c.asset_key.in_(
-                        [asset_key.to_string() for asset_key in to_backcompat_fetch]
+                    db.and_(
+                        SqlEventLogStorageTable.c.asset_key.in_(
+                            [asset_key.to_string() for asset_key in to_backcompat_fetch]
+                        ),
+                        SqlEventLogStorageTable.c.dagster_event_type
+                        == DagsterEventType.ASSET_MATERIALIZATION.value,
                     )
                 )
                 .group_by(SqlEventLogStorageTable.c.asset_key)

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -8,6 +8,7 @@ import pytest
 from dagster import (
     AssetKey,
     AssetMaterialization,
+    AssetObservation,
     DagsterInstance,
     InputDefinition,
     ModeDefinition,
@@ -1412,6 +1413,7 @@ class TestEventLogStorage:
             yield AssetMaterialization(AssetKey("b"), tags={"num": str(1)})
             yield AssetMaterialization(AssetKey("c"), tags={"num": str(1)})
             yield AssetMaterialization(AssetKey("d"), tags={"num": str(1)})
+            yield AssetObservation(AssetKey("a"), metadata={"foo": "bar"})
             yield Output(1)
 
         @solid
@@ -1421,6 +1423,7 @@ class TestEventLogStorage:
             yield Output(2)
 
         def _event_tags(event):
+            assert event.dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION
             return event.dagster_event.step_materialization_data.materialization.tags
 
         def _fetch_events(storage):


### PR DESCRIPTION
Since adding observation events, the `assetNodes` resolver on `GraphenePipeline` has broken due to the assumption that the only events in event log storage containing an asset key are materialization events. This PR fixes this issue.