### PR TITLE
[SDA] allow asset namespace to be a list

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_in.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_in.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, NamedTuple, Optional
+from typing import Any, Mapping, NamedTuple, Optional, Sequence
 
 from dagster import AssetKey, check
 
@@ -9,7 +9,7 @@ class AssetIn(
         [
             ("asset_key", Optional[AssetKey]),
             ("metadata", Optional[Mapping[str, Any]]),
-            ("namespace", Optional[str]),
+            ("namespace", Optional[Sequence[str]]),
         ],
     )
 ):
@@ -17,16 +17,19 @@ class AssetIn(
         cls,
         asset_key: Optional[AssetKey] = None,
         metadata: Optional[Mapping[str, Any]] = None,
-        namespace: Optional[str] = None,
+        namespace: Optional[Sequence[str]] = None,
     ):
         check.invariant(
             not (asset_key and namespace),
             ("Asset key and namespace cannot both be set on AssetIn"),
         )
 
+        # if user inputs a single string, coerce to list
+        namespace = [namespace] if isinstance(namespace, str) else namespace
+
         return super(AssetIn, cls).__new__(
             cls,
             asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             metadata=check.opt_inst_param(metadata, "metadata", Mapping),
-            namespace=check.opt_str_param(namespace, "namespace"),
+            namespace=check.opt_list_param(namespace, "namespace", str),
         )

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -295,8 +295,8 @@ def build_asset_ins(
         )
 
     for asset_key in non_argument_deps:
-        stringified_asset_key = asset_key.to_string(legacy=True)
+        stringified_asset_key = "_".join(asset_key.path)
         if stringified_asset_key:
-            ins[str(stringified_asset_key)] = In(dagster_type=Nothing, asset_key=asset_key)
+            ins[stringified_asset_key] = In(dagster_type=Nothing, asset_key=asset_key)
 
     return ins

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Mapping, Optional, Set
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Set
 
 from dagster import check
 from dagster.builtins import Nothing
@@ -21,7 +21,7 @@ from .partition_mapping import PartitionMapping
 @experimental_decorator
 def asset(
     name: Optional[str] = None,
-    namespace: Optional[str] = None,
+    namespace: Optional[Sequence[str]] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
     non_argument_deps: Optional[Set[AssetKey]] = None,
     metadata: Optional[Mapping[str, Any]] = None,
@@ -47,7 +47,7 @@ def asset(
     Args:
         name (Optional[str]): The name of the asset.  If not provided, defaults to the name of the
             decorated function.
-        namespace (Optional[str]): The namespace that the asset resides in.  The namespace + the
+        namespace (Optional[Sequence[str]]): The namespace that the asset resides in.  The namespace + the
             name forms the asset key.
         ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to their metadata
             and namespaces.
@@ -103,7 +103,7 @@ class _Asset:
     def __init__(
         self,
         name: Optional[str] = None,
-        namespace: Optional[str] = None,
+        namespace: Optional[Sequence[str]] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
         non_argument_deps: Optional[Set[AssetKey]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
@@ -116,7 +116,8 @@ class _Asset:
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
     ):
         self.name = name
-        self.namespace = namespace
+        # if user inputs a single string, coerce to list
+        self.namespace = [namespace] if isinstance(namespace, str) else namespace
         self.ins = ins or {}
         self.non_argument_deps = non_argument_deps
         self.metadata = metadata
@@ -141,8 +142,9 @@ class _Asset:
             def partition_fn(context):  # pylint: disable=function-redefined
                 return [context.partition_key]
 
+        out_asset_key = AssetKey(list(filter(None, [*(self.namespace or []), asset_name])))
         out = Out(
-            asset_key=AssetKey(list(filter(None, [self.namespace, asset_name]))),
+            asset_key=out_asset_key,
             metadata=self.metadata or {},
             io_manager_key=self.io_manager_key,
             dagster_type=self.dagster_type,
@@ -166,7 +168,6 @@ class _Asset:
             },
         )(fn)
 
-        out_asset_key = AssetKey(list(filter(None, [self.namespace, asset_name])))
         return AssetsDefinition(
             input_names_by_asset_key={
                 in_def.asset_key: input_name for input_name, in_def in ins_by_input_names.items()
@@ -245,7 +246,7 @@ def multi_asset(
 
 def build_asset_ins(
     fn: Callable,
-    asset_namespace: Optional[str],
+    asset_namespace: Optional[Sequence[str]],
     asset_ins: Mapping[str, AssetIn],
     non_argument_deps: Optional[Set[AssetKey]],
 ) -> Mapping[str, In]:
@@ -284,7 +285,7 @@ def build_asset_ins(
             dagster_type = None
 
         asset_key = asset_key or AssetKey(
-            list(filter(None, [namespace or asset_namespace, input_name]))
+            list(filter(None, [*(namespace or asset_namespace or []), input_name]))
         )
 
         ins[input_name] = In(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -257,7 +257,7 @@ def test_multiple_non_argument_deps():
     def foo():
         pass
 
-    @asset
+    @asset(namespace="namespace")
     def bar():
         pass
 
@@ -265,7 +265,7 @@ def test_multiple_non_argument_deps():
     def baz():
         return 1
 
-    @asset(non_argument_deps={AssetKey("foo"), AssetKey("bar")})
+    @asset(non_argument_deps={AssetKey("foo"), AssetKey(["namespace", "bar"])})
     def qux(baz):
         return baz
 
@@ -281,7 +281,7 @@ def test_multiple_non_argument_deps():
     assert index.get_upstream_outputs("qux", "foo") == [
         OutputHandleSnap("foo", "result"),
     ]
-    assert index.get_upstream_outputs("qux", "bar") == [OutputHandleSnap("bar", "result")]
+    assert index.get_upstream_outputs("qux", "namespace_bar") == [OutputHandleSnap("bar", "result")]
     assert index.get_upstream_outputs("qux", "baz") == [OutputHandleSnap("baz", "result")]
 
     result = job.execute_in_process()

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -158,7 +158,7 @@ def test_asset_key_for_asset_with_namespace():
     @asset(
         ins={"foo": AssetIn(asset_key=AssetKey("asset_foo"))}
     )  # Should fail because asset_foo is defined with namespace, so has asset key ["hello", "asset_foo"]
-    def failing_asset(foo):
+    def failing_asset(foo):  # pylint: disable=unused-argument
         pass
 
     with pytest.raises(

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_assets_job.py
@@ -150,8 +150,8 @@ def test_asset_key_and_inferred():
     assert result.output_for_node("asset_baz") == 7
 
 
-def test_asset_key_for_asset_with_namespace():
-    @asset(namespace="hello")
+def test_asset_key_for_asset_with_namespace_list():
+    @asset(namespace=["hell", "o"])
     def asset_foo():
         return "foo"
 
@@ -165,6 +165,22 @@ def test_asset_key_for_asset_with_namespace():
         DagsterInvalidDefinitionError,
     ):
         build_assets_job("lol", [asset_foo, failing_asset])
+
+    @asset(ins={"foo": AssetIn(asset_key=AssetKey(["hell", "o", "asset_foo"]))})
+    def success_asset(foo):
+        return foo
+
+    job = build_assets_job("lol", [asset_foo, success_asset])
+
+    result = job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("success_asset") == "foo"
+
+
+def test_asset_key_for_asset_with_namespace_str():
+    @asset(namespace="hello")
+    def asset_foo():
+        return "foo"
 
     @asset(ins={"foo": AssetIn(asset_key=AssetKey(["hello", "asset_foo"]))})
     def success_asset(foo):

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -118,12 +118,20 @@ def test_input_asset_key_and_namespace():
             assert arg1
 
 
-def test_input_namespace():
+def test_input_namespace_str():
     @asset(ins={"arg1": AssetIn(namespace="abc")})
     def my_asset(arg1):
         assert arg1
 
     assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey(["abc", "arg1"])
+
+
+def test_input_namespace_list():
+    @asset(ins={"arg1": AssetIn(namespace=["abc", "xyz"])})
+    def my_asset(arg1):
+        assert arg1
+
+    assert my_asset.op.input_defs[0].get_asset_key(None) == AssetKey(["abc", "xyz", "arg1"])
 
 
 def test_input_metadata():


### PR DESCRIPTION
Without this change, asset keys generated using @asset can only have two "segments" at most (namespace, name of function).

We probably want to be more flexible than that.

This preserves the old behavior when users input a single string (so it's backwards compatible).