### PR TITLE
Add missing k8s config field to run launcher type

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -304,6 +304,7 @@ class DagsterK8sJobConfig(
                 ),
                 "load_incluster_config": Field(bool, is_required=False, default_value=True),
                 "kubeconfig_file": Field(Noneable(str), is_required=False, default_value=None),
+                "fail_pod_on_run_failure": Field(bool, is_required=False),
             },
             DagsterK8sJobConfig.config_type_job(),
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -201,6 +201,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         return self._labels
 
     @property
+    def fail_pod_on_run_failure(self):
+        return self._fail_pod_on_run_failure
+
+    @property
     def _batch_api(self):
         return self._fixed_batch_api if self._fixed_batch_api else kubernetes.client.BatchV1Api()
 


### PR DESCRIPTION
Summary:
This was a hole in test coverage - verified that it works if you construct the K8sRunLauncher explicitly, but not if you construct it from config. Fill in the hole.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.