### PR TITLE
Ensure that only one daemon pod is up at once during helm upgrades

### DIFF
--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -13,6 +13,8 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "dagster.selectorLabels" $ | nindent 6 }}

--- a/python_modules/dagster/dagster/daemon/daemon.py
+++ b/python_modules/dagster/dagster/daemon/daemon.py
@@ -140,9 +140,9 @@ class DagsterDaemon(AbstractContextManager):
             and last_stored_heartbeat
             and last_stored_heartbeat.daemon_id != daemon_uuid
         ):
-            self._logger.warning(
-                "Taking over from another {} daemon process. If this "
-                "message reoccurs, you may have multiple daemons running which is not supported. "
+            self._logger.error(
+                "Another {} daemon is still sending heartbeats. You likely have multiple "
+                "daemon processes running at once, which is not supported. "
                 "Last heartbeat daemon id: {}, "
                 "Current daemon_id: {}".format(
                     daemon_type,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon_health.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon_health.py
@@ -370,7 +370,7 @@ def test_warn_multiple_daemons(capsys):
                     instance, heartbeat_interval_seconds=heartbeat_interval_seconds
                 ):
                     captured = capsys.readouterr()
-                    assert "Taking over from another SENSOR daemon process" not in captured.out
+                    assert "Another SENSOR daemon is still sending heartbeats" not in captured.out
                     break
 
                 if (now - init_time).total_seconds() > 10:
@@ -406,7 +406,7 @@ def test_warn_multiple_daemons(capsys):
 
                 if status.last_heartbeat and status.last_heartbeat.timestamp != last_heartbeat_time:
                     captured = capsys.readouterr()
-                    assert "Taking over from another SENSOR daemon process" not in captured.out
+                    assert "Another SENSOR daemon is still sending heartbeats" not in captured.out
                     break
 
                 if (now - init_time).total_seconds() > 10:
@@ -434,7 +434,7 @@ def test_warn_multiple_daemons(capsys):
                     now = pendulum.now("UTC")
 
                     captured = capsys.readouterr()
-                    if "Taking over from another SENSOR daemon process" in captured.out:
+                    if "Another SENSOR daemon is still sending heartbeats" in captured.out:
                         break
 
                     if (now - init_time).total_seconds() > 60:


### PR DESCRIPTION
Summary:
The default rolling deploy option here causes an undesirable situation where there are two daemons running at the same time. Instead, use the option that spins down the old daemon before spinning up a new one.

Test Plan:
Redeploy to dogfood cluster, watch old daemon spin down before a new daemon spins up, no more 'taking over from another daemon, this should not happen' message

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.