### PR TITLE
report skipped steps in multiprocess executor

### DIFF
--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -1334,13 +1334,20 @@ class EngineEventData(
 
     @staticmethod
     def multiprocess(
-        pid: int, step_keys_to_execute: Optional[List[str]] = None
+        pid: int,
+        step_keys_to_execute: Optional[List[str]] = None,
+        step_keys_to_skip: Optional[List[str]] = None,
     ) -> "EngineEventData":
         return EngineEventData(
             metadata_entries=[EventMetadataEntry.text(str(pid), "pid")]
             + (
                 [EventMetadataEntry.text(str(step_keys_to_execute), "step_keys")]
                 if step_keys_to_execute
+                else []
+            )
+            + (
+                [EventMetadataEntry.text(str(step_keys_to_skip), "skipped_step_keys")]
+                if step_keys_to_skip
                 else []
             )
         )

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -668,6 +668,13 @@ class ExecutionPlan(
     def step_keys_to_execute(self) -> List[str]:
         return [handle.to_key() for handle in self.step_handles_to_execute]
 
+    @property
+    def step_keys_to_skip(self) -> List[str]:
+        return list(
+            set(handle.to_key() for handle in self.step_dict.keys())
+            - set(self.step_keys_to_execute)
+        )
+
     def get_step_output(self, step_output_handle: StepOutputHandle) -> StepOutput:
         check.inst_param(step_output_handle, "step_output_handle", StepOutputHandle)
         return _get_step_output(self.step_dict_by_key, step_output_handle)

--- a/python_modules/dagster/dagster/core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/core/executor/multiprocess.py
@@ -108,7 +108,9 @@ class MultiprocessExecutor(Executor):
                 pid=os.getpid()
             ),
             event_specific_data=EngineEventData.multiprocess(
-                os.getpid(), step_keys_to_execute=execution_plan.step_keys_to_execute
+                os.getpid(),
+                step_keys_to_execute=execution_plan.step_keys_to_execute,
+                step_keys_to_skip=execution_plan.step_keys_to_skip,
             ),
         )
 


### PR DESCRIPTION
When using memoization, this makes it a little more clear what's going on.