### PR TITLE
Add optional name parameter to Map ConfigType

### DIFF
--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -154,6 +154,8 @@ class Map(ConfigType):
             The type of keys this map can contain. Must be a scalar type.
         inner_type (type):
             The type of the values that this map type can contain.
+        name (string):
+            Optional name which describes the role of keys in the map.
 
     **Examples:**
 
@@ -164,22 +166,27 @@ class Map(ConfigType):
             return sorted(list(context.op_config.items()))
     """
 
-    def __init__(self, key_type, inner_type):
+    def __init__(self, key_type, inner_type, name=None):
         from .field import resolve_to_config_type
 
         self.key_type = resolve_to_config_type(key_type)
         self.inner_type = resolve_to_config_type(inner_type)
+        self.given_name = name
 
         check.inst_param(self.key_type, "key_type", ConfigType)
         check.inst_param(self.inner_type, "inner_type", ConfigType)
         check.param_invariant(
             self.key_type.kind == ConfigTypeKind.SCALAR, "key_type", "Key type must be a scalar"
         )
+        check.opt_str_param(self.given_name, "name")
 
         super(Map, self).__init__(
-            key="Map.{key_type}.{inner_type}".format(
-                key_type=self.key_type.key, inner_type=self.inner_type.key
+            key="Map.{key_type}.{inner_type}{name_key}".format(
+                key_type=self.key_type.key,
+                inner_type=self.inner_type.key,
+                name_key=f":name: {name}" if name else "",
             ),
+            given_name=name,
             type_params=[self.key_type, self.inner_type],
             kind=ConfigTypeKind.MAP,
         )

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from dagster import check
 from dagster.core.errors import DagsterInvalidConfigDefinitionError
-from zmq import GSSAPI_SERVICE_PRINCIPAL
 
 from .config_type import Array, ConfigType, ConfigTypeKind
 

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -55,6 +55,8 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
         line_break_fn("{")
         with printer.with_indent():
             printer.append("[")
+            if config_type_snap.given_name:
+                printer.append(f"{config_type_snap.given_name}: ")
             _do_print(config_schema_snapshot, config_type_snap.key_type_key, printer)
             printer.append("]: ")
             _do_print(

--- a/python_modules/dagster/dagster/config/type_printer.py
+++ b/python_modules/dagster/dagster/config/type_printer.py
@@ -55,6 +55,7 @@ def _do_print(config_schema_snapshot, config_type_key, printer, with_lines=True)
         line_break_fn("{")
         with printer.with_indent():
             printer.append("[")
+            # In a Map, the given_name stores the optional key_label_name
             if config_type_snap.given_name:
                 printer.append(f"{config_type_snap.given_name}: ")
             _do_print(config_schema_snapshot, config_type_snap.key_type_key, printer)

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -367,7 +367,8 @@ def _construct_map_from_snap(config_type_snap, config_snap_map):
             config_snap_map[config_type_snap.type_param_keys[1]],
             config_snap_map,
         ),
-        name=config_type_snap.given_name,
+        # In a Map, the given_name stores the optional key_label_name
+        key_label_name=config_type_snap.given_name,
     )
 
 

--- a/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/core/snap/pipeline_snapshot.py
@@ -367,6 +367,7 @@ def _construct_map_from_snap(config_type_snap, config_snap_map):
             config_snap_map[config_type_snap.type_param_keys[1]],
             config_snap_map,
         ),
+        name=config_type_snap.given_name,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -1,4 +1,4 @@
-from dagster import Field, Int, Noneable, PipelineDefinition, ScalarUnion, String, solid
+from dagster import Field, Int, Map, Noneable, PipelineDefinition, ScalarUnion, String, solid
 from dagster.config.field import resolve_to_config_type
 from dagster.config.iterate_types import config_schema_snapshot_from_config_type
 from dagster.config.snap import get_recursive_type_keys, snap_from_config_type
@@ -64,6 +64,22 @@ def test_basic_map_type_print():
 }"""
     )
     assert_inner_types({int: int}, int, int)
+
+
+def test_map_name_print():
+    assert (
+        print_config_type_to_string(Map(str, int, name="name"))
+        == """{
+  [name: String]: Int
+}"""
+    )
+
+    assert (
+        print_config_type_to_string(Map(int, float, name="title"))
+        == """{
+  [title: Int]: Float
+}"""
+    )
 
 
 def test_double_map_type_print():

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -68,14 +68,14 @@ def test_basic_map_type_print():
 
 def test_map_name_print():
     assert (
-        print_config_type_to_string(Map(str, int, name="name"))
+        print_config_type_to_string(Map(str, int, key_label_name="name"))
         == """{
   [name: String]: Int
 }"""
     )
 
     assert (
-        print_config_type_to_string(Map(int, float, name="title"))
+        print_config_type_to_string(Map(int, float, key_label_name="title"))
         == """{
   [title: Int]: Float
 }"""

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -167,7 +167,7 @@ def test_basic_map():
 
 
 def test_named_map():
-    map_snap = snap_from_dagster_type(Map(str, float, name="title"))
+    map_snap = snap_from_dagster_type(Map(str, float, key_label_name="title"))
     assert map_snap.key.startswith("Map")
     assert map_snap.given_name == "title"
     child_type_keys = map_snap.get_child_type_keys()

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -166,6 +166,17 @@ def test_basic_map():
     assert child_type_keys[1] == "Int"
 
 
+def test_named_map():
+    map_snap = snap_from_dagster_type(Map(str, float, name="title"))
+    assert map_snap.key.startswith("Map")
+    assert map_snap.given_name == "title"
+    child_type_keys = map_snap.get_child_type_keys()
+    assert child_type_keys
+    assert len(child_type_keys) == 2
+    assert child_type_keys[0] == "String"
+    assert child_type_keys[1] == "Float"
+
+
 def test_basic_map_nested():
     map_snap = snap_from_dagster_type({int: {str: int}})
     assert map_snap.key.startswith("Map")

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -13,7 +13,7 @@ from dagster import (
     pipeline,
     solid,
 )
-from dagster.config.config_type import Array, Enum, EnumValue, Int, Noneable, String
+from dagster.config.config_type import Array, Bool, Enum, EnumValue, Float, Int, Noneable, String
 from dagster.core.snap import (
     DependencyStructureIndex,
     PipelineSnapshot,
@@ -400,7 +400,29 @@ def test_deserialize_solid_def_snaps_map():
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_solid")
     recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Map)
+    assert isinstance(recevied_config_type.key_type, String)
     assert isinstance(recevied_config_type.inner_type, String)
+    _map_has_stable_hashes(
+        recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
+    )
+
+
+def test_deserialize_solid_def_snaps_map_with_name():
+    @solid(config_schema=Field(Map(bool, float, name="title")))
+    def noop_solid(_):
+        pass
+
+    @pipeline
+    def noop_pipeline():
+        noop_solid()
+
+    pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_pipeline)
+    solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_solid")
+    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    assert isinstance(recevied_config_type, Map)
+    assert isinstance(recevied_config_type.key_type, Bool)
+    assert isinstance(recevied_config_type.inner_type, Float)
+    assert recevied_config_type.given_name == "title"
     _map_has_stable_hashes(
         recevied_config_type, pipeline_snapshot.config_schema_snapshot.all_config_snaps_by_key
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -408,7 +408,7 @@ def test_deserialize_solid_def_snaps_map():
 
 
 def test_deserialize_solid_def_snaps_map_with_name():
-    @solid(config_schema=Field(Map(bool, float, name="title")))
+    @solid(config_schema=Field(Map(bool, float, key_label_name="title")))
     def noop_solid(_):
         pass
 


### PR DESCRIPTION
## Summary

Adds an optional `name` parameter to the `Map` config type. Specifying a name provides context as to the role of the keys in the given map, and is rendered in the type printer (and will be rendered in the schema YAML editor):

`Map(str, {"image": str, "python_file": str}, name="location_name")`
```yaml
{
    [location_name: String]: {
        image: String,
        python_file: String
    }
}
```

In the above case, the name indicates that the key specifies a location name.

## Rationale

Without a name field, a map config type can be fairly inscrutable. If the `Map` lives in a `Field`, the field's description could be used to explain the role of the keys and values, but this is not always the case.

The name field helps give concrete meaning to the key type, otherwise all the end user is shown is that it can be any string, or any int, etc.

## Test Plan

New unit tests.