### PR TITLE
Misc helm chart startup/liveness/readiness probe improvements

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -91,9 +91,13 @@ spec:
             failureThreshold:
               {{- toYaml $deployment.livenessProbe.failureThreshold | nindent 14 }}
             {{- end }}
-          {{- else}}
+          {{- else }}
           livenessProbe: {{ $deployment.livenessProbe | toYaml | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if $deployment.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $deployment.readinessProbe | nindent 12 }}
         {{- end }}
         {{- if $deployment.startupProbe }}
         {{- if $deployment.startupProbe.enabled }}

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -74,7 +74,7 @@ class Daemon(BaseModel):
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
-    livenessProbe: kubernetes.LivenessProbe
+    livenessProbe: Optional[kubernetes.LivenessProbe]
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
     runMonitoring: Dict[str, Any]

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -81,6 +81,10 @@ spec:
           livenessProbe:
             {{- toYaml .Values.dagsterDaemon.livenessProbe | nindent 12 }}
           {{- end }}
+          {{- if .Values.dagsterDaemon.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dagsterDaemon.readinessProbe | nindent 12 }}
+          {{- end }}
           {{- if .Values.dagsterDaemon.startupProbe.enabled}}
           {{- $startupProbe := omit .Values.dagsterDaemon.startupProbe "enabled" }}
           startupProbe:

--- a/helm/dagster/templates/helpers/_deployment-dagit.tpl
+++ b/helm/dagster/templates/helpers/_deployment-dagit.tpl
@@ -99,6 +99,10 @@ spec:
           livenessProbe:
             {{- toYaml .Values.dagit.livenessProbe | nindent 12 }}
         {{- end }}
+        {{- if .Values.dagit.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dagit.readinessProbe | nindent 12 }}
+        {{- end }}
         {{- if .Values.dagit.startupProbe.enabled}}
           {{- $startupProbe := omit .Values.dagit.startupProbe "enabled" }}
           startupProbe:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2174,7 +2174,15 @@
                     "$ref": "#/definitions/Resources"
                 },
                 "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
+                    "title": "LivenessProbe",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LivenessProbe"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"
@@ -2201,7 +2209,6 @@
                 "podSecurityContext",
                 "securityContext",
                 "resources",
-                "livenessProbe",
                 "startupProbe",
                 "annotations",
                 "runMonitoring"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -115,16 +115,23 @@ dagit:
     httpGet:
       path: "/dagit_info"
       port: 80
-    # initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 3
     successThreshold: 1
     failureThreshold: 3
-  # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
+
+  # Readiness probe that always succeeds - workaround for
+  # https://github.com/kubernetes/kubernetes/issues/95140 causing
+  # redeploys to take longer than needed when a startupProbe but no readinessProbe is defined
+  readinessProbe:
+    exec:
+      command:
+        - "echo"
+        - "READY"
+
+  # Startup probe is used at pod startup. Once it has succeeded,
   # then liveness probe takes over. Current delay is 2 min (10 sec * 12) but can be increased based
   # on workspace load times.
-  # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-  # `initialDelaySeconds: 60` under `livenessProbe`
   startupProbe:
     enabled: true
     httpGet:
@@ -319,10 +326,17 @@ dagster-user-deployments:
         successThreshold: 1
         failureThreshold: 3
 
-      # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
+      # Readiness probe that always succeeds - workaround for
+      # https://github.com/kubernetes/kubernetes/issues/95140 causing
+      # redeploys to take longer than needed when a startupProbe but no readinessProbe is defined
+      readinessProbe:
+        exec:
+          command:
+            - "echo"
+            - "READY"
+
+      # Startup probe is used at pod startup. Once it has succeeded,
       # then liveness probe takes over.
-      # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-      # `initialDelaySeconds: 60` under `livenessProbe`
       startupProbe:
         enabled: true
         # If `startupProbe` has no `exec` field, then the following default will be used:
@@ -774,14 +788,11 @@ flower:
   livenessProbe:
     tcpSocket:
       port: "flower"
-    # initialDelaySeconds: 60
     periodSeconds: 20
     failureThreshold: 3
 
-  # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
+  # Startup probe is used at pod startup. Once it has succeeded,
   # then liveness probe takes over.
-  # If on kubernetes < v1.16, then comment out `startupProbe` lines and comment in
-  # `initialDelaySeconds: 60` under `livenessProbe`
   startupProbe:
     tcpSocket:
       port: "flower"
@@ -988,21 +999,22 @@ dagsterDaemon:
   securityContext: {}
   resources: {}
 
-  livenessProbe:
+  # The daemon pod will automatically shut itself down if a thread hangs, so by default
+  # no liveness probe is implemented for the daemon.
+  livenessProbe: ~
+
+  # Readiness probe that always succeeds - workaround for
+  # https://github.com/kubernetes/kubernetes/issues/95140 causing
+  # redeploys to take longer than needed when a startupProbe but no readinessProbe is defined
+  readinessProbe:
     exec:
       command:
-        - "dagster-daemon"
-        - "liveness-check"
-    # initialDelaySeconds: 60
-    periodSeconds: 30
-    failureThreshold: 3
-    timeoutSeconds: 3
+        - "echo"
+        - "READY"
 
-  # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
+  # Startup probe is used at pod startup. Once it has succeeded,
   # then liveness probe takes over. Current delay is 2 min (10 sec * 12) but can be increased based
   # on workspace load times.
-  # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-  # `initialDelaySeconds: 60` under `livenessProbe`
   startupProbe:
     enabled: true
     exec:


### PR DESCRIPTION
Summary:
- Insert a dummy readiness probe so that re-deployments don't take >60 seconds to be ready even after they pass the startup probe (see https://github.com/kubernetes/kubernetes/issues/95140)
- Disable daemon liveness check since it implements its own liveness check within the daemon process
- Remove specific mentions of <1.16 now that that version isn't even mentioned in EKS docs anymore

Open to pushback if the 'readiness probe that always succeeds' workaround is too magical (given that the impact is relatively minor)

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.