### PR TITLE
[dagit] New feature flag: collapse the jobs nav by default on instance-scoped pages

### DIFF
--- a/js_modules/dagit/packages/core/src/app/App.tsx
+++ b/js_modules/dagit/packages/core/src/app/App.tsx
@@ -15,22 +15,25 @@ export const App: React.FC = (props) => {
   return (
     <Container>
       <LeftNav />
-      <Main $navOpen={nav.isOpen} onClick={onClickMain}>
+      <Main $navCollapsible={nav.isCollapsible} onClick={onClickMain}>
         {props.children}
       </Main>
     </Container>
   );
 };
 
-const Main = styled.div<{$navOpen: boolean}>`
+const Main = styled.div<{$navCollapsible: boolean}>`
   height: 100%;
-  margin-left: ${LEFT_NAV_WIDTH}px;
-  width: calc(100% - ${LEFT_NAV_WIDTH}px);
 
-  @media (max-width: 1440px) {
+  ${(p) =>
+    p.$navCollapsible
+      ? `
     margin-left: 0;
-    width: 100%;
-  }
+    width: 100%;`
+      : `
+    margin-left: ${LEFT_NAV_WIDTH}px;
+    width: calc(100% - ${LEFT_NAV_WIDTH}px);
+`}
 `;
 
 const Container = styled.div`

--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -97,7 +97,12 @@ export const AppTopNavLogo: React.FC = () => {
         shortcutLabel="."
         shortcutFilter={(e) => e.key === '.'}
       >
-        <NavButton onClick={onToggle} onKeyDown={onKeyDown} ref={navButton}>
+        <NavButton
+          onClick={onToggle}
+          onKeyDown={onKeyDown}
+          ref={navButton}
+          $visible={nav.isCollapsible}
+        >
           <IconWIP name="menu" color={ColorsWIP.White} size={24} />
         </NavButton>
       </ShortcutHandler>
@@ -207,7 +212,7 @@ const LogoContainer = styled.div`
   }
 `;
 
-const NavButton = styled.button`
+const NavButton = styled.button<{$visible: boolean}>`
   border-radius: 20px;
   cursor: pointer;
   margin-left: 4px;
@@ -215,7 +220,7 @@ const NavButton = styled.button`
   padding: 6px;
   border: none;
   background: transparent;
-  display: none;
+  display: ${(p) => (p.$visible ? `block` : 'none')};
 
   ${IconWrapper} {
     transition: background 100ms linear;
@@ -231,9 +236,5 @@ const NavButton = styled.button`
 
   :focus {
     background: ${ColorsWIP.Gray700};
-  }
-
-  @media (max-width: 1440px) {
-    display: block;
   }
 `;

--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -9,6 +9,7 @@ export enum FeatureFlag {
   flagDebugConsoleLogging = 'flagDebugConsoleLogging',
   flagAssetGraph = 'flagAssetGraph',
   flagInstanceOverview = 'flagInstanceOverview',
+  flagCollapseInstancePagesSidebar = 'flagCollapseInstancePagesSidebar',
 }
 
 export const getFeatureFlags: () => FeatureFlag[] = memoize(

--- a/js_modules/dagit/packages/core/src/app/LayoutProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/LayoutProvider.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {useLocation} from 'react-router-dom';
 
+import {useFeatureFlags} from './Flags';
+
 function useMatchMedia(query: string) {
   const match = React.useRef(matchMedia(query));
   const [result, setResult] = React.useState(match.current.matches);
@@ -37,6 +39,7 @@ export const LayoutContext = React.createContext<LayoutContextValue>({
 
 export const LayoutProvider: React.FC = (props) => {
   const [navOpen, setNavOpen] = React.useState(false);
+  const {flagCollapseInstancePagesSidebar} = useFeatureFlags();
   const location = useLocation();
   const isSmallScreen = useMatchMedia('(max-width: 1440px)');
   const isInstancePage = location.pathname.startsWith('/instance');
@@ -49,12 +52,12 @@ export const LayoutProvider: React.FC = (props) => {
     () => ({
       nav: {
         isOpen: navOpen,
-        isCollapsible: isInstancePage || isSmallScreen,
+        isCollapsible: (flagCollapseInstancePagesSidebar && isInstancePage) || isSmallScreen,
         open: () => setNavOpen(true),
         close: () => setNavOpen(false),
       },
     }),
-    [navOpen, isInstancePage, isSmallScreen],
+    [navOpen, isInstancePage, isSmallScreen, flagCollapseInstancePagesSidebar],
   );
   console.log(value);
   return <LayoutContext.Provider value={value}>{props.children}</LayoutContext.Provider>;

--- a/js_modules/dagit/packages/core/src/app/LayoutProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/LayoutProvider.tsx
@@ -1,9 +1,26 @@
 import * as React from 'react';
 import {useLocation} from 'react-router-dom';
 
+function useMatchMedia(query: string) {
+  const match = React.useRef(matchMedia(query));
+  const [result, setResult] = React.useState(match.current.matches);
+
+  React.useEffect(() => {
+    const matcher = match.current;
+    const onChange = () => setResult(matcher.matches);
+    matcher.addEventListener('change', onChange);
+    return () => {
+      matcher.removeEventListener('change', onChange);
+    };
+  }, [query]);
+
+  return result;
+}
+
 type LayoutContextValue = {
   nav: {
     isOpen: boolean;
+    isCollapsible: boolean;
     open: () => void;
     close: () => void;
   };
@@ -12,6 +29,7 @@ type LayoutContextValue = {
 export const LayoutContext = React.createContext<LayoutContextValue>({
   nav: {
     isOpen: false,
+    isCollapsible: false,
     open: () => {},
     close: () => {},
   },
@@ -20,6 +38,8 @@ export const LayoutContext = React.createContext<LayoutContextValue>({
 export const LayoutProvider: React.FC = (props) => {
   const [navOpen, setNavOpen] = React.useState(false);
   const location = useLocation();
+  const isSmallScreen = useMatchMedia('(max-width: 1440px)');
+  const isInstancePage = location.pathname.startsWith('/instance');
 
   React.useEffect(() => {
     setNavOpen(false);
@@ -29,12 +49,13 @@ export const LayoutProvider: React.FC = (props) => {
     () => ({
       nav: {
         isOpen: navOpen,
+        isCollapsible: isInstancePage || isSmallScreen,
         open: () => setNavOpen(true),
         close: () => setNavOpen(false),
       },
     }),
-    [navOpen],
+    [navOpen, isInstancePage, isSmallScreen],
   );
-
+  console.log(value);
   return <LayoutContext.Provider value={value}>{props.children}</LayoutContext.Provider>;
 };

--- a/js_modules/dagit/packages/core/src/app/LayoutProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/LayoutProvider.tsx
@@ -59,6 +59,6 @@ export const LayoutProvider: React.FC = (props) => {
     }),
     [navOpen, isInstancePage, isSmallScreen, flagCollapseInstancePagesSidebar],
   );
-  console.log(value);
+
   return <LayoutContext.Provider value={value}>{props.children}</LayoutContext.Provider>;
 };

--- a/js_modules/dagit/packages/core/src/app/SettingsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/SettingsRoot.tsx
@@ -92,6 +92,16 @@ const SettingsRoot = () => {
                 />
               ),
             },
+            {
+              key: 'Collapse sidebar on instance pages',
+              value: (
+                <Checkbox
+                  format="switch"
+                  checked={flags.includes(FeatureFlag.flagCollapseInstancePagesSidebar)}
+                  onChange={() => toggleFlag(FeatureFlag.flagCollapseInstancePagesSidebar)}
+                />
+              ),
+            },
           ]}
         />
       </Box>

--- a/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNav.tsx
@@ -10,7 +10,7 @@ export const LeftNav = () => {
   const {nav} = React.useContext(LayoutContext);
 
   return (
-    <LeftNavContainer $open={nav.isOpen}>
+    <LeftNavContainer $open={nav.isOpen} $collapsible={nav.isCollapsible}>
       <LeftNavRepositorySection />
     </LeftNavContainer>
   );
@@ -18,7 +18,7 @@ export const LeftNav = () => {
 
 export const LEFT_NAV_WIDTH = 332;
 
-const LeftNavContainer = styled.div<{$open: boolean}>`
+const LeftNavContainer = styled.div<{$open: boolean; $collapsible: boolean}>`
   position: fixed;
   z-index: 2;
   top: 64px;
@@ -33,8 +33,11 @@ const LeftNavContainer = styled.div<{$open: boolean}>`
   background: ${ColorsWIP.Gray100};
   box-shadow: 1px 0px 0px ${ColorsWIP.KeylineGray};
 
-  @media (max-width: 1440px) {
-    transform: translateX(${({$open}) => ($open ? '0' : `-${LEFT_NAV_WIDTH}px`)});
-    transition: transform 150ms ease-in-out;
-  }
+  ${(p) =>
+    p.$collapsible
+      ? `
+        transform: translateX(${p.$open ? '0' : `-${LEFT_NAV_WIDTH}px`});
+        transition: transform 150ms ease-in-out;
+      `
+      : ``}
 `;


### PR DESCRIPTION
## Summary
There's some discussion about this change in @braunjj's latest designs for the global asset graph (https://www.loom.com/share/9326414ea6b14d82a7ab915ebc5b07ae).

On small screens, the left nav already collapses and a hamburger button allows you to show / hide it. This PR extends this behavior on large monitors when you're viewing `/instance/*` pages. 

This means the job list is hidden by default on all instance pages (schedules, sensors, etc), the asset catalog, asset details pages, and run pages. It's a pretty major change and we could scope it more narrowly to just the asset catalog + asset details pages, but I actually like this direction a lot and enjoy having more space for content in the run logs, etc. The left nav actually animates away when you click into a run, for example, so you can sort of see that it just collapsed and is still there.

## Test Plan
Tested with different screen sizes + page layouts.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.