### PR TITLE
Fix S3FakeSession's put_object to accept bytes

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/s3_fake_resource.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/s3_fake_resource.py
@@ -38,7 +38,12 @@ class S3FakeSession:
 
     def put_object(self, Bucket, Key, Body, *args, **kwargs):
         self.mock_extras.put_object(*args, **kwargs)
-        self.buckets[Bucket][Key] = Body.read()
+        if isinstance(Body, io.IOBase):
+            self.buckets[Bucket][Key] = Body.read()
+        elif isinstance(Body, str):
+            self.buckets[Bucket][Key] = Body.encode()
+        else:
+            self.buckets[Bucket][Key] = Body
 
     def get_object(self, Bucket, Key, *args, **kwargs):
         if not self.has_object(Bucket, Key):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_fake_resource.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_fake_resource.py
@@ -1,0 +1,20 @@
+from dagster_aws.s3 import create_s3_fake_resource
+
+
+def test_put_object(tmp_path):
+    s3 = create_s3_fake_resource()
+
+    s3.put_object(Bucket="test", Key="string", Body="a string")
+    assert s3.get_object(Bucket="test", Key="string")["Body"].read() == b"a string"
+
+    s3.put_object(Bucket="test", Key="bytes", Body=b"some bytes")
+    assert s3.get_object(Bucket="test", Key="bytes")["Body"].read() == b"some bytes"
+
+    path = tmp_path / "foo.txt"
+    path.write_text("a seekable file-like object")
+    with open(path, "rb") as f:
+        s3.put_object(Bucket="test", Key="seekable file-like object", Body=f)
+    assert (
+        s3.get_object(Bucket="test", Key="seekable file-like object")["Body"].read()
+        == b"a seekable file-like object"
+    )


### PR DESCRIPTION
Our implementation of `S3FakeSession` doesn't match the actual S3 API.
Specifically, `Body` expects "bytes or seekable file-like object" but
our implementation always calls `.read()`:

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object

This change narrowly fixes the reported issue to make the object work
marginally more like the real S3 implementation.

But before we merge this, we might want to alternatively consider
deprecating `create_s3_fake_resource` entirely or giving it some
additional attention.

Some arguments in favor of either of those other two approaches:

- The implementation is only a small subset of what you can do with an
  actual `s3_resource` which passes through an actual boto3 client.
- The implementation isn't under test so it's not clear that the subest
  of implemented methods work correctly.
- Despite the name, `create_s3_fake_resource` doesn't create a resource;
  you can only use it in conjunction with
  `ResourceDefinition.hardcoded_resource()`.
- There exist better, more complete S3 fakes (particularly
  https://github.com/spulec/moto) which are less likely to drift from
  the real implementation than our own.