### PR TITLE
[dagster-dbt] better dbt 1.0 compat

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -155,6 +155,11 @@ class DbtCliResource(DbtResource):
             DbtCliOutput: An instance of :class:`DbtCliOutput<dagster_dbt.DbtCliOutput>` containing
                 parsed log output as well as the contents of run_results.json (if applicable).
         """
+        if data and schema:
+            # do not include these arguments if both are True, as these are deprecated in later
+            # versions of dbt, and for older versions the functionality is the same regardless of
+            # if both are set or neither are set.
+            return self.cli("test", models=models, exclude=exclude, **kwargs)
         return self.cli("test", models=models, exclude=exclude, data=data, schema=schema, **kwargs)
 
     def seed(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -4,6 +4,7 @@ import subprocess
 from typing import Any, Dict
 
 from dagster import check
+from dagster.core.utils import coerce_valid_log_level
 
 from ..errors import (
     DagsterDbtCliFatalRuntimeError,
@@ -63,7 +64,7 @@ def execute_cli(
     logs = []
     output = []
 
-    process = subprocess.Popen(command_list, stdout=subprocess.PIPE)
+    process = subprocess.Popen(command_list, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     for raw_line in process.stdout or []:
         line = raw_line.decode("utf-8")
         output.append(line)
@@ -73,11 +74,10 @@ def execute_cli(
             log.info(line.rstrip())
         else:
             logs.append(json_line)
-            level = json_line.get("levelname", "").lower()
-            if hasattr(log, level):
-                getattr(log, level)(json_line.get("message", ""))
-            else:
-                log.info(line.rstrip())
+            level = coerce_valid_log_level(
+                json_line.get("levelname", json_line.get("level", "info"))
+            )
+            log.log(level, json_line.get("message", json_line.get("msg", line.rstrip())))
 
     process.wait()
     return_code = process.returncode

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
@@ -77,6 +77,8 @@ def test_test(
     context = get_dbt_solid_context(test_project_dir, dbt_config_dir)
     dbt_result = my_dbt_solid(context)
     assert len(dbt_result.result["results"]) == 15
+    assert "data" not in dbt_result.command
+    assert "schema" not in dbt_result.command
 
 
 def test_basic_run(


### PR DESCRIPTION
two changes:

1. the "data" and "schema" args are deprecated in dbt 1.0. by default, the test() function on the resource would supply both of these flags to the test command (because supplying both of these flags had identical behavior to supplying neither of them). This meant that if you tried to run the test command in 1.0, it would always fail unless you explicitly set these values to false. This change changes the default to not including those flags at all if they're both true, which should preserve back compat while fixing the 1.0+ experience.

2. I noticed that the log output when using dbt 1.0 was mangled. turns out it's because they use different field names in their json log output ("msg" instead of "message" and "level" instead of "levelname"). This code now accepts either format.