### PR TITLE
replace custom materialization batch loading with loader object

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1,6 +1,5 @@
 import graphene
 from dagster import AssetKey, check
-from dagster.core.events.log import EventLogEntry
 from dagster.core.host_representation import ExternalRepository
 from dagster.core.host_representation.external_data import (
     ExternalAssetNode,


### PR DESCRIPTION
## Summary
Instead of adding custom args at every level of asset node resolver, this PR creates a BatchMaterializationLoader, which fetches the latest materialization for a set of asset keys.



## Test Plan
BK

