### PR TITLE
[Docs] Make /changelog page mobile friendly

### DIFF
--- a/docs/next/tailwind.config.js
+++ b/docs/next/tailwind.config.js
@@ -81,6 +81,7 @@ module.exports = {
                 "colors.gray.900",
                 defaultTheme.colors.gray[900]
               ),
+              overflowWrap: "break-word",
             },
             "code::before": {
               content: '""',
@@ -107,6 +108,7 @@ module.exports = {
               color: theme("colors.primary.900"),
               transition: ".3s all",
               textDecoration: "none",
+              overflowWrap: "break-word",
             },
             "a:hover": {
               textDecoration: "underline",


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

Add `overflow-wrap: break-word` to `<a>` and `<code>` elements to make them respect container width.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Before:
<table>
<tr>
<td><img width="485" alt="before 1" src="https://user-images.githubusercontent.com/2268452/152066796-a34385d4-e2b8-46cf-8b35-f6719c2b06a0.png"></td>
<td><img width="460" alt="before 2" src="https://user-images.githubusercontent.com/2268452/152066793-a210f9c6-d32f-492e-b13a-cfcd9e6954c5.png"></td>
<td><img width="465" alt="before 3" src="https://user-images.githubusercontent.com/2268452/152066788-5389617a-db2c-4d90-a855-3b2f5429f321.png"></td>
</tr>
</table>

After:
<table>
<tr>
<td><img width="469" alt="after 1" src="https://user-images.githubusercontent.com/2268452/152067127-0e3f9476-44dd-427a-9cb4-951b947d3930.png"></td>
<td><img width="467" alt="after 2" src="https://user-images.githubusercontent.com/2268452/152067121-7253ca5d-0d9e-4397-9c6e-82e66c5f8c42.png"></td>
<td><img width="474" alt="after 3" src="https://user-images.githubusercontent.com/2268452/152067125-80598702-4833-4eb5-9139-67da31f5ab2a.png"></td>
</tr>
</table>

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.