### PR TITLE
Add AssetOut and AssetOutputDefinition

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -6,6 +6,8 @@ from dagster.core.definitions import (
     AssetKey,
     AssetMaterialization,
     AssetObservation,
+    AssetOut,
+    AssetOutputDefinition,
     AssetSensorDefinition,
     CompositeSolidDefinition,
     ConfigMapping,

--- a/python_modules/dagster/dagster/core/asset_defs/assets_job.py
+++ b/python_modules/dagster/dagster/core/asset_defs/assets_job.py
@@ -13,7 +13,7 @@ from dagster.core.definitions.executor_definition import ExecutorDefinition
 from dagster.core.definitions.graph_definition import GraphDefinition
 from dagster.core.definitions.job_definition import JobDefinition
 from dagster.core.definitions.op_definition import OpDefinition
-from dagster.core.definitions.output import Out, OutputDefinition
+from dagster.core.definitions.output import AssetOut, OutputDefinition
 from dagster.core.definitions.partition import PartitionedConfig, PartitionsDefinition
 from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.resource_definition import ResourceDefinition
@@ -236,7 +236,7 @@ def build_root_manager(
         source_asset_key = cast(AssetKey, input_context.asset_key)
         source_asset = source_assets_by_key[source_asset_key]
 
-        @op(out={source_asset_key.path[-1]: Out(asset_key=source_asset_key)})
+        @op(out={source_asset_key.path[-1]: AssetOut(asset_key=source_asset_key)})
         def _op():
             pass
 

--- a/python_modules/dagster/dagster/core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/__init__.py
@@ -79,6 +79,8 @@ from .logger_definition import LoggerDefinition, build_init_logger_context, logg
 from .mode import ModeDefinition
 from .op_definition import OpDefinition
 from .output import (
+    AssetOut,
+    AssetOutputDefinition,
     DynamicOut,
     DynamicOutputDefinition,
     GraphOut,

--- a/python_modules/dagster/dagster/core/definitions/decorators/op.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -35,7 +35,7 @@ class _Op:
         decorator_takes_context: Optional[bool] = True,
         retry_policy: Optional[RetryPolicy] = None,
         ins: Optional[Dict[str, In]] = None,
-        out: Optional[Union[Out, Dict[str, Out]]] = None,
+        out: Optional[Union[Out, Mapping[str, Out]]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.input_defs = check.opt_nullable_list_param(
@@ -126,7 +126,7 @@ class _Op:
 
 
 def _resolve_output_defs_from_outs(
-    inferred_out: InferredOutputProps, out: Optional[Union[Out, dict]]
+    inferred_out: InferredOutputProps, out: Optional[Union[Out, Mapping[str, Out]]]
 ) -> Optional[List[OutputDefinition]]:
     if out is None:
         return None

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -1,7 +1,7 @@
 import re
 import warnings
 from enum import Enum
-from typing import AbstractSet, Any, Dict, List, NamedTuple, Optional, Tuple, Union, cast
+from typing import AbstractSet, Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union, cast
 
 from dagster import check, seven
 from dagster.core.errors import DagsterInvalidAssetKey
@@ -34,7 +34,7 @@ def parse_asset_key_string(s: str) -> List[str]:
 
 
 @whitelist_for_serdes
-class AssetKey(NamedTuple("_AssetKey", [("path", Union[Tuple[str, ...], List[str]])])):
+class AssetKey(NamedTuple("_AssetKey", [("path", Union[Tuple[str, ...], Sequence[str]])])):
     """Object representing the structure of an asset key.  Takes in a sanitized string, list of
     strings, or tuple of strings.
 
@@ -70,7 +70,7 @@ class AssetKey(NamedTuple("_AssetKey", [("path", Union[Tuple[str, ...], List[str
             represent the hierarchical structure of the asset_key.
     """
 
-    def __new__(cls, path: Optional[Union[str, List[str], Tuple[str, ...]]] = None):
+    def __new__(cls, path: Optional[Union[str, Sequence[str], Tuple[str, ...]]] = None):
         if isinstance(path, str):
             path = [path]
         elif isinstance(path, list):

--- a/python_modules/dagster/dagster/core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/op_definition.py
@@ -20,4 +20,4 @@ class OpDefinition(SolidDefinition):
 
     @property
     def outs(self) -> Dict[str, Out]:
-        return {output_def.name: Out.from_definition(output_def) for output_def in self.output_defs}
+        return {output_def.name: output_def.to_out() for output_def in self.output_defs}

--- a/python_modules/dagster/dagster/core/execution/context/output.py
+++ b/python_modules/dagster/dagster/core/execution/context/output.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 from dagster import check
 from dagster.core.definitions.events import AssetKey
 from dagster.core.definitions.op_definition import OpDefinition
+from dagster.core.definitions.output import AssetOutputDefinition
 from dagster.core.definitions.partition_key_range import PartitionKeyRange
 from dagster.core.definitions.solid_definition import SolidDefinition
 from dagster.core.definitions.time_window_partitions import (
@@ -233,10 +234,10 @@ class OutputContext:
         matching_output_defs = [
             output_def
             for output_def in cast(SolidDefinition, self._solid_def).output_defs
-            if output_def.name == self.name
+            if output_def.name == self.name and isinstance(output_def, AssetOutputDefinition)
         ]
         check.invariant(len(matching_output_defs) == 1)
-        return matching_output_defs[0].get_asset_key(self)
+        return matching_output_defs[0].asset_key
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster/core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_step.py
@@ -7,6 +7,7 @@ from dagster.core.definitions import (
     AssetKey,
     AssetMaterialization,
     AssetObservation,
+    AssetOutputDefinition,
     ExpectationResult,
     Materialization,
     Output,
@@ -396,17 +397,17 @@ def _asset_key_and_partitions_for_output(
 
     manager_asset_key = output_manager.get_output_asset_key(output_context)
 
-    if output_def.is_asset:
+    if isinstance(output_def, AssetOutputDefinition):
         if manager_asset_key is not None:
             solid_def = cast(SolidDefinition, output_context.solid_def)
             raise DagsterInvariantViolationError(
-                f'Both the OutputDefinition and the IOManager of output "{output_def.name}" on '
-                f'solid "{solid_def.name}" associate it with an asset. Either remove '
-                "the asset_key parameter on the OutputDefinition or use an IOManager that does not "
-                "specify an AssetKey in its get_output_asset_key() function."
+                f'The output "{output_def.name}" on op "{solid_def.name}" is an AssetOutputDefinition, '
+                "but the io_manager also associates it with an asset. Either convert this output "
+                "to a regular OutputDefinition or use an IOManager that does not specify an AssetKey "
+                "in its get_output_asset_key() function."
             )
         return (
-            output_def.get_asset_key(output_context),
+            output_def.asset_key,
             output_def.get_asset_partitions(output_context) or set(),
         )
     elif manager_asset_key:

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -334,7 +334,7 @@ class FromStepOutput(
             ).output_def_named(upstream_output.name)
             lineage_info = _get_asset_lineage_from_fns(
                 load_context.upstream_output,
-                output_def.get_asset_key,
+                lambda _: output_def.asset_key,
                 output_def.get_asset_partitions,
             )
             return [lineage_info] if lineage_info else []

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -12,7 +12,9 @@ from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple
 from dagster import StaticPartitionsDefinition, check
 from dagster.core.asset_defs import ForeignAsset
 from dagster.core.definitions import (
+    AssetOutputDefinition,
     JobDefinition,
+    OutputDefinition,
     PartitionSetDefinition,
     PartitionsDefinition,
     PipelineDefinition,
@@ -458,7 +460,7 @@ class ExternalPartitionExecutionErrorData(
 
 @whitelist_for_serdes
 class ExternalAssetDependency(
-    namedtuple("_ExternalAssetDependency", "upstream_asset_key input_name")
+    namedtuple("_ExternalAssetDependency", "upstream_asset_key input_name output_name")
 ):
     """A definition of a directed edge in the logical asset graph.
 
@@ -466,17 +468,22 @@ class ExternalAssetDependency(
     that depends on it.
     """
 
-    def __new__(cls, upstream_asset_key: AssetKey, input_name: str):
+    def __new__(cls, upstream_asset_key: AssetKey, input_name: str = None, output_name: str = None):
+        check.invariant(
+            (input_name is None) ^ (output_name is None),
+            "Exactly one of `input_name` and `output_name` should be supplied",
+        )
         return super(ExternalAssetDependency, cls).__new__(
             cls,
             upstream_asset_key=upstream_asset_key,
             input_name=input_name,
+            output_name=output_name,
         )
 
 
 @whitelist_for_serdes
 class ExternalAssetDependedBy(
-    namedtuple("_ExternalAssetDependedBy", "downstream_asset_key input_name")
+    namedtuple("_ExternalAssetDependedBy", "downstream_asset_key input_name output_name")
 ):
     """A definition of a directed edge in the logical asset graph.
 
@@ -484,11 +491,18 @@ class ExternalAssetDependedBy(
     asset that it depends on.
     """
 
-    def __new__(cls, downstream_asset_key: AssetKey, input_name: str):
+    def __new__(
+        cls, downstream_asset_key: AssetKey, input_name: str = None, output_name: str = None
+    ):
+        check.invariant(
+            (input_name is None) ^ (output_name is None),
+            "Exactly one of `input_name` and `output_name` should be supplied",
+        )
         return super(ExternalAssetDependedBy, cls).__new__(
             cls,
             downstream_asset_key=downstream_asset_key,
             input_name=input_name,
+            output_name=output_name,
         )
 
 
@@ -496,7 +510,7 @@ class ExternalAssetDependedBy(
 class ExternalAssetNode(
     namedtuple(
         "_ExternalAssetNode",
-        "asset_key dependencies depended_by op_name op_description job_names partitions_def_data",
+        "asset_key dependencies depended_by op_name op_description job_names partitions_def_data output_name output_description",
     )
 ):
     """A definition of a node in the logical asset graph.
@@ -513,6 +527,8 @@ class ExternalAssetNode(
         op_description: Optional[str] = None,
         job_names: Optional[List[str]] = None,
         partitions_def_data: Optional[ExternalPartitionsDefinitionData] = None,
+        output_name: Optional[str] = None,
+        output_description: Optional[str] = None,
     ):
         return super(ExternalAssetNode, cls).__new__(
             cls,
@@ -523,6 +539,8 @@ class ExternalAssetNode(
             op_description=op_description,
             job_names=job_names,
             partitions_def_data=partitions_def_data,
+            output_name=output_name,
+            output_description=output_description,
         )
 
 
@@ -558,40 +576,58 @@ def external_asset_graph_from_defs(
     pipelines: Sequence[PipelineDefinition], foreign_assets_by_key: Mapping[AssetKey, ForeignAsset]
 ) -> Sequence[ExternalAssetNode]:
     node_defs_by_asset_key: Dict[
-        AssetKey, List[Tuple[NodeDefinition, PipelineDefinition]]
+        AssetKey, List[Tuple[OutputDefinition, NodeDefinition, PipelineDefinition]]
     ] = defaultdict(list)
 
-    deps: Dict[AssetKey, Dict[str, ExternalAssetDependency]] = defaultdict(dict)
+    deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
     dep_by: Dict[AssetKey, List[ExternalAssetDependedBy]] = defaultdict(list)
-    all_upstream_asset_keys = set()
+    all_upstream_asset_keys: Set[AssetKey] = set()
 
     for pipeline in pipelines:
         for node_def in pipeline.all_node_defs:
-            node_asset_keys: Set[AssetKey] = set()
+            input_name_by_asset_key = {
+                id.hardcoded_asset_key: id.name
+                for id in node_def.input_defs
+                if id.hardcoded_asset_key is not None
+            }
+
+            output_name_by_asset_key = {
+                od.asset_key: od.name
+                for od in node_def.output_defs
+                if isinstance(od, AssetOutputDefinition)
+            }
+
+            node_upstream_asset_keys = set(
+                filter(None, (id.hardcoded_asset_key for id in node_def.input_defs))
+            )
+            all_upstream_asset_keys.update(node_upstream_asset_keys)
+
             for output_def in node_def.output_defs:
-                asset_key = output_def.hardcoded_asset_key
+                if not isinstance(output_def, AssetOutputDefinition):
+                    continue
 
-                if asset_key:
-                    node_asset_keys.add(asset_key)
-                    node_defs_by_asset_key[asset_key].append((node_def, pipeline))
+                node_defs_by_asset_key[output_def.asset_key].append(
+                    (output_def, node_def, pipeline)
+                )
 
-            for input_def in node_def.input_defs:
-                upstream_asset_key = input_def.hardcoded_asset_key
+                # if no deps specified, assume depends on all inputs and no outputs
+                asset_deps = output_def.dependencies
+                if asset_deps is None:
+                    asset_deps = node_upstream_asset_keys
 
-                if upstream_asset_key:
-                    all_upstream_asset_keys.add(upstream_asset_key)
-                    for node_asset_key in node_asset_keys:
-                        deps[node_asset_key][input_def.name] = ExternalAssetDependency(
-                            upstream_asset_key=upstream_asset_key,
-                            input_name=input_def.name,
+                for upstream_asset_key in asset_deps:
+                    deps[output_def.asset_key][upstream_asset_key] = ExternalAssetDependency(
+                        upstream_asset_key=upstream_asset_key,
+                        input_name=input_name_by_asset_key.get(upstream_asset_key),
+                        output_name=output_name_by_asset_key.get(upstream_asset_key),
+                    )
+                    dep_by[upstream_asset_key].append(
+                        ExternalAssetDependedBy(
+                            downstream_asset_key=output_def.asset_key,
+                            input_name=input_name_by_asset_key.get(upstream_asset_key),
+                            output_name=output_name_by_asset_key.get(upstream_asset_key),
                         )
-                        dep_by[upstream_asset_key].append(
-                            ExternalAssetDependedBy(
-                                downstream_asset_key=node_asset_key,
-                                input_name=input_def.name,
-                            )
-                        )
-
+                    )
     asset_keys_without_definitions = all_upstream_asset_keys.difference(
         node_defs_by_asset_key.keys()
     ).difference(foreign_assets_by_key.keys())
@@ -624,15 +660,14 @@ def external_asset_graph_from_defs(
         )
 
     for asset_key, node_tuple_list in node_defs_by_asset_key.items():
-        node_def = node_tuple_list[0][0]
-        job_names = [node_tuple[1].name for node_tuple in node_tuple_list]
+        output_def, node_def, _ = node_tuple_list[0]
+        job_names = [job_def.name for _, _, job_def in node_tuple_list]
 
         # temporary workaround to retrieve asset partition definition from job
-        output = node_def.output_dict.get("result", None)
         partitions_def_data = None
 
-        if output and output._asset_partitions_def:  # pylint: disable=protected-access
-            partitions_def = output._asset_partitions_def  # pylint: disable=protected-access
+        if isinstance(output_def, AssetOutputDefinition):
+            partitions_def = output_def.asset_partitions_def
             if partitions_def:
                 if isinstance(partitions_def, TimeWindowPartitionsDefinition):
                     partitions_def_data = external_time_window_partitions_definition_from_def(
@@ -656,6 +691,8 @@ def external_asset_graph_from_defs(
                 op_description=node_def.description,
                 job_names=job_names,
                 partitions_def_data=partitions_def_data,
+                output_name=output_def.name,
+                output_description=output_def.description,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_decorators.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, DagsterInvalidDefinitionError, Out, Output, String, check
+from dagster import AssetKey, AssetOut, DagsterInvalidDefinitionError, Output, String, check
 from dagster.core.asset_defs import AssetIn, AssetsDefinition, asset, multi_asset
 
 
@@ -33,7 +33,7 @@ def test_asset_with_compute_kind():
 
 
 def test_multi_asset_with_compute_kind():
-    @multi_asset(outs={"o1": Out(asset_key=AssetKey("o1"))}, compute_kind="sql")
+    @multi_asset(outs={"o1": AssetOut(asset_key=AssetKey("o1"))}, compute_kind="sql")
     def my_asset(arg1):
         return arg1
 
@@ -43,8 +43,8 @@ def test_multi_asset_with_compute_kind():
 def test_multi_asset_out_name_diff_from_asset_key():
     @multi_asset(
         outs={
-            "my_out_name": Out(asset_key=AssetKey("my_asset_name")),
-            "my_other_out_name": Out(asset_key=AssetKey("my_other_asset")),
+            "my_out_name": AssetOut(asset_key=AssetKey("my_asset_name")),
+            "my_other_out_name": AssetOut(asset_key=AssetKey("my_other_asset")),
         }
     )
     def my_asset():
@@ -52,15 +52,6 @@ def test_multi_asset_out_name_diff_from_asset_key():
         yield Output(2, "my_other_out_name")
 
     assert my_asset.asset_keys == {AssetKey("my_asset_name"), AssetKey("my_other_asset")}
-
-
-def test_multi_asset_infer_from_empty_asset_key():
-    @multi_asset(outs={"my_out_name": Out(), "my_other_out_name": Out()})
-    def my_asset():
-        yield Output(1, "my_out_name")
-        yield Output(2, "my_other_out_name")
-
-    assert my_asset.asset_keys == {AssetKey("my_out_name"), AssetKey("my_other_out_name")}
 
 
 def test_asset_with_dagster_type():

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,10 +1,7 @@
-from typing import Dict
-
 import pytest
-from dagster import AssetKey, DagsterInvariantViolationError, In, Out, job, pipeline
-from dagster.core.asset_defs import ForeignAsset
-from dagster.core.decorator_utils import get_function_params
-from dagster.core.definitions.decorators.op import _Op
+from dagster import AssetKey, AssetOut, DagsterInvariantViolationError
+from dagster.check import CheckError
+from dagster.core.asset_defs import AssetIn, ForeignAsset, asset, build_assets_job, multi_asset
 from dagster.core.host_representation.external_data import (
     ExternalAssetDependedBy,
     ExternalAssetDependency,
@@ -16,33 +13,13 @@ from dagster.core.host_representation.external_data import (
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 
 
-def asset(fn):
-    asset_name = fn.__name__
-
-    ins: Dict[str, In] = {}
-    for input_param in get_function_params(fn):
-        input_param_name = input_param.name
-        asset_key = AssetKey(input_param_name)
-        ins[input_param_name] = In(asset_key=asset_key)
-
-    out = Out(asset_key=AssetKey(asset_name))
-    return _Op(
-        name=asset_name,
-        ins=ins,
-        out=out,
-    )(fn)
-
-
-def test_single_asset_pipeline():
+def test_single_asset_job():
     @asset
     def asset1():
         return 1
 
-    @pipeline
-    def my_graph():
-        asset1()
-
-    external_asset_nodes = external_asset_graph_from_defs([my_graph], foreign_assets_by_key={})
+    assets_job = build_assets_job("assets_job", [asset1])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -51,12 +28,14 @@ def test_single_asset_pipeline():
             depended_by=[],
             op_name="asset1",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         )
     ]
 
 
-def test_two_asset_pipeline():
+def test_two_asset_job():
     @asset
     def asset1():
         return 1
@@ -65,11 +44,8 @@ def test_two_asset_pipeline():
     def asset2(asset1):
         assert asset1 == 1
 
-    @pipeline
-    def my_graph():
-        asset2(asset1())
-
-    external_asset_nodes = external_asset_graph_from_defs([my_graph], foreign_assets_by_key={})
+    assets_job = build_assets_job("assets_job", [asset1, asset2])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -82,7 +58,9 @@ def test_two_asset_pipeline():
             ],
             op_name="asset1",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
@@ -92,12 +70,50 @@ def test_two_asset_pipeline():
             depended_by=[],
             op_name="asset2",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
 
-def test_two_downstream_assets_pipeline():
+def test_input_name_matches_output_name():
+    not_result = ForeignAsset(key=AssetKey("not_result"), description=None)
+
+    @asset(ins={"result": AssetIn(asset_key=AssetKey("not_result"))})
+    def something(result):  # pylint: disable=unused-argument
+        pass
+
+    assets_job = build_assets_job("assets_job", [something], source_assets=[not_result])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey("not_result"),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey("something"), input_name="result"
+                )
+            ],
+            job_names=[],
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey("something"),
+            dependencies=[
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey("not_result"), input_name="result"
+                )
+            ],
+            depended_by=[],
+            op_name="something",
+            output_name="result",
+            job_names=["assets_job"],
+        ),
+    ]
+
+
+def test_two_downstream_assets_job():
     @asset
     def asset1():
         return 1
@@ -110,13 +126,8 @@ def test_two_downstream_assets_pipeline():
     def asset2_b(asset1):
         assert asset1 == 1
 
-    @pipeline
-    def my_graph():
-        r = asset1()
-        asset2_a(r)
-        asset2_b(r)
-
-    external_asset_nodes = external_asset_graph_from_defs([my_graph], foreign_assets_by_key={})
+    assets_job = build_assets_job("assets_job", [asset1, asset2_a, asset2_b])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -132,7 +143,9 @@ def test_two_downstream_assets_pipeline():
             ],
             op_name="asset1",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2_a"),
@@ -142,7 +155,9 @@ def test_two_downstream_assets_pipeline():
             depended_by=[],
             op_name="asset2_a",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2_b"),
@@ -152,12 +167,14 @@ def test_two_downstream_assets_pipeline():
             depended_by=[],
             op_name="asset2_b",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
 
-def test_cross_pipeline_asset_dependency():
+def test_cross_job_asset_dependency():
     @asset
     def asset1():
         return 1
@@ -166,16 +183,10 @@ def test_cross_pipeline_asset_dependency():
     def asset2(asset1):
         assert asset1 == 1
 
-    @pipeline
-    def asset1_graph():
-        asset1()
-
-    @pipeline
-    def asset2_graph():
-        asset2()  # pylint: disable=no-value-for-parameter
-
+    assets_job1 = build_assets_job("assets_job1", [asset1])
+    assets_job2 = build_assets_job("assets_job2", [asset2], source_assets=[asset1])
     external_asset_nodes = external_asset_graph_from_defs(
-        [asset1_graph, asset2_graph], foreign_assets_by_key={}
+        [assets_job1, assets_job2], foreign_assets_by_key={}
     )
 
     assert external_asset_nodes == [
@@ -189,7 +200,9 @@ def test_cross_pipeline_asset_dependency():
             ],
             op_name="asset1",
             op_description=None,
-            job_names=["asset1_graph"],
+            job_names=["assets_job1"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
@@ -199,7 +212,9 @@ def test_cross_pipeline_asset_dependency():
             depended_by=[],
             op_name="asset2",
             op_description=None,
-            job_names=["asset2_graph"],
+            job_names=["assets_job2"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
@@ -209,17 +224,10 @@ def test_same_asset_in_multiple_pipelines():
     def asset1():
         return 1
 
-    @pipeline
-    def graph1():
-        asset1()
+    job1 = build_assets_job("job1", [asset1])
+    job2 = build_assets_job("job2", [asset1])
 
-    @pipeline
-    def graph2():
-        asset1()
-
-    external_asset_nodes = external_asset_graph_from_defs(
-        [graph1, graph2], foreign_assets_by_key={}
-    )
+    external_asset_nodes = external_asset_graph_from_defs([job1, job2], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -228,7 +236,218 @@ def test_same_asset_in_multiple_pipelines():
             depended_by=[],
             op_name="asset1",
             op_description=None,
-            job_names=["graph1", "graph2"],
+            job_names=["job1", "job2"],
+            output_name="result",
+            output_description=None,
+        ),
+    ]
+
+
+def test_basic_multi_asset():
+    @multi_asset(
+        outs={
+            f"out{i}": AssetOut(description=f"foo: {i}", asset_key=AssetKey(f"asset{i}"))
+            for i in range(10)
+        }
+    )
+    def assets():
+        pass
+
+    assets_job = build_assets_job("assets_job", [assets])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey(f"asset{i}"),
+            dependencies=[],
+            depended_by=[],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name=f"out{i}",
+            output_description=f"foo: {i}",
+        )
+        for i in range(10)
+    ]
+
+
+def test_inter_op_dependency():
+    @asset
+    def in1():
+        pass
+
+    @asset
+    def in2():
+        pass
+
+    @asset
+    def downstream(only_in, mixed, only_out):  # pylint: disable=unused-argument
+        pass
+
+    @multi_asset(
+        outs={
+            "only_in": AssetOut("only_in"),
+            "mixed": AssetOut("mixed", dependencies=[AssetKey("in1"), AssetKey("only_in")]),
+            "only_out": AssetOut("only_out", dependencies=[AssetKey("only_in"), AssetKey("mixed")]),
+        }
+    )
+    def assets(in1, in2):  # pylint: disable=unused-argument
+        pass
+
+    assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+    # sort so that test is deterministic
+    sorted_nodes = sorted(
+        [
+            node._replace(
+                dependencies=sorted(node.dependencies, key=lambda d: d.upstream_asset_key),
+                depended_by=sorted(node.depended_by, key=lambda d: d.downstream_asset_key),
+            )
+            for node in external_asset_nodes
+        ],
+        key=lambda n: n.asset_key,
+    )
+
+    assert sorted_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey(["downstream"]),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"]), input_name="mixed"),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_in"]), input_name="only_in"
+                ),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_out"]), input_name="only_out"
+                ),
+            ],
+            depended_by=[],
+            op_name="downstream",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["in1"]),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"]), input_name="in1"),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_in"]), input_name="in1"
+                ),
+            ],
+            op_name="in1",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["in2"]),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_in"]), input_name="in2"
+                )
+            ],
+            op_name="in2",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["mixed"]),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"]), input_name="in1"),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_in"]), output_name="only_in"
+                ),
+            ],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["downstream"]), input_name="mixed"
+                ),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_out"]), output_name="mixed"
+                ),
+            ],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="mixed",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["only_in"]),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"]), input_name="in1"),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in2"]), input_name="in2"),
+            ],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["downstream"]), input_name="only_in"
+                ),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["mixed"]), output_name="only_in"
+                ),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_out"]), output_name="only_in"
+                ),
+            ],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="only_in",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["only_out"]),
+            dependencies=[
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["mixed"]), output_name="mixed"
+                ),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_in"]), output_name="only_in"
+                ),
+            ],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["downstream"]), input_name="only_out"
+                ),
+            ],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="only_out",
+        ),
+    ]
+
+
+def test_source_not_foreign_asset():
+
+    foo = ForeignAsset(key=AssetKey("foo"), description=None)
+
+    @asset
+    def bar(foo):  # pylint: disable=unused-argument
+        pass
+
+    assets_job = build_assets_job("assets_job", [bar], source_assets=[foo])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey("foo"),
+            op_description=None,
+            dependencies=[],
+            depended_by=[ExternalAssetDependedBy(AssetKey("bar"), input_name="foo")],
+            job_names=[],
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey("bar"),
+            op_name="bar",
+            op_description=None,
+            dependencies=[ExternalAssetDependency(AssetKey("foo"), input_name="foo")],
+            depended_by=[],
+            job_names=["assets_job"],
+            output_name="result",
         ),
     ]
 
@@ -265,9 +484,7 @@ def test_used_foreign_asset():
     def foo(bar):
         assert bar
 
-    @job
-    def job1():
-        foo()  # pylint: disable=no-value-for-parameter
+    job1 = build_assets_job("job1", [foo], source_assets=[bar])
 
     external_asset_nodes = external_asset_graph_from_defs(
         [job1], foreign_assets_by_key={AssetKey("bar"): bar}
@@ -291,6 +508,8 @@ def test_used_foreign_asset():
             ],
             depended_by=[],
             job_names=["job1"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
@@ -302,13 +521,33 @@ def test_foreign_asset_conflicts_with_asset():
     def bar():
         pass
 
-    @job
-    def job1():
-        bar()  # pylint: disable=no-value-for-parameter
+    job1 = build_assets_job("job1", [bar])
 
     with pytest.raises(DagsterInvariantViolationError):
         external_asset_graph_from_defs(
             [job1], foreign_assets_by_key={AssetKey("bar"): bar_foreign_asset}
+        )
+
+
+def test_input_name_or_output_name_dep_by():
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependedBy(
+            downstream_asset_key=AssetKey("bar"), input_name="foo", output_name="foo"
+        )
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependedBy(
+            downstream_asset_key=AssetKey("bar"), input_name=None, output_name=None
+        )
+
+
+def test_input_name_or_output_name_dependency():
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependency(
+            upstream_asset_key=AssetKey("bar"), input_name="foo", output_name="foo"
+        )
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependency(
+            upstream_asset_key=AssetKey("bar"), input_name=None, output_name=None
         )
 
 


### PR DESCRIPTION
This implements a bunch of the changes we were talking about in past conversations.

1. removes any asset-related parameters to Out/OutputDefinition
2. creates a new subclass of Out/OutputDefinition (AssetOut/AssetOutputDefinition) which accept these parameters
3. removes ability for the asset_key parameter to be a function of the output context (must be a static AssetKey)
4. removes the ability for the asset_partitions_fn to be a static set (must be a function of the output context)
5. adds ability for AssetOuts to explicitly define the other AssetKeys that they depend on (must be a subset of the asset keys define on the Inputs/Outputs of its op).

To keep the changes a little more under control, this diff does not attempt similar changes on the In/InputDefinition side of things.

This passes all the same tests as the (now abandoned) pr: https://github.com/dagster-io/dagster/pull/6307