### PR TITLE
[Docs] easy: fix loading shimmer visual padding

### DIFF
--- a/docs/next/components/Shimmer.tsx
+++ b/docs/next/components/Shimmer.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+// Shimmer (skeleton) used as content placeholder while loading
+export function Shimmer() {
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 w-full my-12 h-96 animate-pulse prose max-w-none">
+      <div className="bg-gray-200 px-4 w-48 h-12"></div>
+      <div className="bg-gray-200 mt-12 px-4 w-1/2 h-6"></div>
+      <div className="bg-gray-200 mt-5 px-4 w-2/3 h-6"></div>
+      <div className="bg-gray-200 mt-5 px-4 w-1/3 h-6"></div>
+      <div className="bg-gray-200 mt-5 px-4 w-1/2 h-6"></div>
+    </div>
+  );
+}

--- a/docs/next/pages/[...page].tsx
+++ b/docs/next/pages/[...page].tsx
@@ -24,6 +24,7 @@ import renderToString from "next-mdx-remote/render-to-string";
 import { useRouter } from "next/router";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { Readable } from "stream";
+import { Shimmer } from "components/Shimmer";
 
 const components: MdxRemote.Components = MDXComponents;
 
@@ -229,18 +230,10 @@ function HTMLRenderer({ data }: { data: HTMLData }) {
 export default function MdxPage(props: Props) {
   const router = useRouter();
 
-  // If the page is not yet generated, this will be displayed
+  // If the page is not yet generated, this shimmer/skeleton will be displayed
   // initially until getStaticProps() finishes running
   if (router.isFallback) {
-    return (
-      <div className="w-full my-12 h-96 animate-pulse prose max-w-none">
-        <div className="bg-gray-200 px-4 w-48 h-12"></div>
-        <div className="bg-gray-200 mt-12 px-4 w-1/2 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-2/3 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-1/3 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-1/2 h-6"></div>
-      </div>
-    );
+    return <Shimmer />;
   }
 
   if (props.type == PageType.MDX) {

--- a/docs/next/pages/changelog.tsx
+++ b/docs/next/pages/changelog.tsx
@@ -19,6 +19,7 @@ import renderToString from "next-mdx-remote/render-to-string";
 import { useRouter } from "next/router";
 import { useVersion } from "../util/useVersion";
 import visit from "unist-util-visit";
+import { Shimmer } from "components/Shimmer";
 
 const components: MdxRemote.Components = MDXComponents;
 
@@ -199,18 +200,10 @@ function HTMLRenderer({ data }: { data: HTMLData }) {
 export default function MdxPage(props: Props) {
   const router = useRouter();
 
-  // If the page is not yet generated, this will be displayed
+  // If the page is not yet generated, this shimmer/skeleton will be displayed
   // initially until getStaticProps() finishes running
   if (router.isFallback) {
-    return (
-      <div className="w-full my-12 h-96 animate-pulse prose max-w-none">
-        <div className="bg-gray-200 px-4 w-48 h-12"></div>
-        <div className="bg-gray-200 mt-12 px-4 w-1/2 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-2/3 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-1/3 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-1/2 h-6"></div>
-      </div>
-    );
+    return <Shimmer />;
   }
 
   if (props.type == PageType.MDX) {

--- a/docs/next/pages/migration.tsx
+++ b/docs/next/pages/migration.tsx
@@ -19,6 +19,7 @@ import renderToString from "next-mdx-remote/render-to-string";
 import { useRouter } from "next/router";
 import { useVersion } from "../util/useVersion";
 import visit from "unist-util-visit";
+import { Shimmer } from "components/Shimmer";
 
 const components: MdxRemote.Components = MDXComponents;
 
@@ -199,18 +200,10 @@ function HTMLRenderer({ data }: { data: HTMLData }) {
 export default function MdxPage(props: Props) {
   const router = useRouter();
 
-  // If the page is not yet generated, this will be displayed
+  // If the page is not yet generated, this shimmer/skeleton will be displayed
   // initially until getStaticProps() finishes running
   if (router.isFallback) {
-    return (
-      <div className="w-full my-12 h-96 animate-pulse prose max-w-none">
-        <div className="bg-gray-200 px-4 w-48 h-12"></div>
-        <div className="bg-gray-200 mt-12 px-4 w-1/2 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-2/3 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-1/3 h-6"></div>
-        <div className="bg-gray-200 mt-5 px-4 w-1/2 h-6"></div>
-      </div>
-    );
+    return <Shimmer />;
   }
 
   if (props.type == PageType.MDX) {


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

$title

Padding is `px-4 sm:px-6 lg:px-8`, same as the real content being loaded



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->







Before:
<table>
<tr>
<td><img width="493" alt="Screen Shot 2022-02-01 at 4 38 22 PM" src="https://user-images.githubusercontent.com/2268452/152075892-19596409-8925-47b9-bcfd-3dc9867c154b.png"></td>
<td><img width="1213" alt="Screen Shot 2022-02-01 at 4 38 03 PM" src="https://user-images.githubusercontent.com/2268452/152075894-a33ff842-b75e-40a6-9364-49e3f10b6b71.png"></td>
</tr>
</table>

After:
<table>
<tr>
<td><img width="486" alt="Screen Shot 2022-02-01 at 4 37 18 PM" src="https://user-images.githubusercontent.com/2268452/152075898-6564a076-302e-4804-93e6-d37a83e7fd60.png"></td>
<td><img width="1210" alt="Screen Shot 2022-02-01 at 4 37 39 PM" src="https://user-images.githubusercontent.com/2268452/152075896-3ca08673-b288-4b71-afe4-f94aab09892d.png"></td>
</tr>
</table>



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.