### PR TITLE
easy: fix make reindex_search cmd

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,4 +11,4 @@ snapshot:
 	cd next; yarn snapshot; cd ..;
 
 reindex_search:
-	docker run -it --env-file=.env -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper
+	docker run -it --env-file=.env -e "CONFIG=$$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
before:
```
dagster-3.8.6 $ make reindex_search
docker run -it --env-file=.env -e "CONFIG=" algolia/docsearch-scraper
Traceback (most recent call last):
  File "/root/src/config/config_loader.py", line 101, in _load_config
    data = json.loads(config, object_pairs_hook=OrderedDict)
  File "/usr/lib/python3.6/json/__init__.py", line 367, in loads
    return cls(**kw).decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:
...
```


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.