### PR TITLE
Mirror Asset Observation events into Index Shard

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -184,6 +184,9 @@ class SqlEventLogStorage(EventLogStorage):
             and event.dagster_event.is_step_materialization
             and event.dagster_event.asset_key
         ):
+            # Currently, only materializations are stored in the asset catalog.
+            # We will store observations after adding a column migration to
+            # store latest asset observation timestamp in the asset key table.
             self.store_asset(event)
 
     def get_logs_for_run_by_log_id(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -410,7 +410,7 @@ def test_get_asset_keys(asset_aware_context):
 
 @asset_test
 def test_get_observation(asset_aware_context):
-    a = AssetKey(["a"])
+    a = AssetKey(["key_a"])
 
     @op
     def gen_op():

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_assets.py
@@ -6,7 +6,9 @@ import pytest
 from dagster import (
     AssetKey,
     AssetMaterialization,
+    AssetObservation,
     DagsterEventType,
+    EventRecordsFilter,
     Field,
     Output,
     execute_pipeline,
@@ -404,6 +406,33 @@ def test_get_asset_keys(asset_aware_context):
             '["b", "y"]',
             '["b", "z"]',
         ]
+
+
+@asset_test
+def test_get_observation(asset_aware_context):
+    a = AssetKey(["a"])
+
+    @op
+    def gen_op():
+        yield AssetObservation(asset_key=a, metadata={"foo": "bar"})
+        yield Output(1)
+
+    @job
+    def gen_everything():
+        gen_op()
+
+    with asset_aware_context() as ctx:
+        instance, event_log_storage = ctx
+        gen_everything.execute_in_process(instance=instance)
+
+        records = instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_OBSERVATION,
+                asset_key=a,
+            )
+        )
+
+        assert len(records) == 1
 
 
 def _materialization_event_record(run_id, asset_key):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -158,6 +158,9 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             and event.dagster_event.is_step_materialization
             and event.dagster_event.asset_key
         ):
+            # Currently, only materializations are stored in the asset catalog.
+            # We will store observations after adding a column migration to
+            # store latest asset observation timestamp in the asset key table.
             self.store_asset(event)
 
     def store_asset(self, event):


### PR DESCRIPTION
In SQLite, asset observations are currently stored in the run sharded event log storage. This PR modifies storage to store asset observations in the cross run index database.