### PR TITLE
[dagit] Remove step execution time graph + stepStats fan-out from Asset view

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -317,6 +317,16 @@ const AssetMaterializationGraphs: React.FC<{
           flexDirection: 'column',
         }}
       >
+        {graphedLabels.length === 0 && (
+          <Box padding={{horizontal: 24, top: 64}}>
+            <NonIdealState
+              icon="linear_scale"
+              title="No numeric metadata"
+              description="Include numeric metadata entries in your materializations and observations to see data graphed by time / partition."
+            />
+          </Box>
+        )}
+
         {[...graphedLabels].sort().map((label) => (
           <Box
             key={label}
@@ -435,10 +445,6 @@ const extractNumericData = (datapoints: AssetEventGroup[], xAxis: 'time' | 'part
 
       append(label, {x, y});
     }
-
-    // Add step execution time as a custom dataset
-    const {startTime, endTime} = latest?.stepStats || {};
-    append(LABEL_STEP_EXECUTION_TIME, {x, y: endTime && startTime ? endTime - startTime : NaN});
   }
 
   for (const serie of Object.values(series)) {
@@ -507,10 +513,6 @@ const ASSET_EVENTS_QUERY = gql`
     runId
     timestamp
     stepKey
-    stepStats {
-      endTime
-      startTime
-    }
     label
     description
     metadataEntries {

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -40,8 +40,6 @@ interface Props {
   assetHasDefinedPartitions: boolean;
 }
 
-const LABEL_STEP_EXECUTION_TIME = 'Step Execution Time';
-
 /**
  * If the asset has a defined partition space, we load all materializations in the
  * last 100 partitions. This ensures that if you run a huge backfill of old partitions,

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -320,7 +320,7 @@ const AssetMaterializationGraphs: React.FC<{
             <NonIdealState
               icon="linear_scale"
               title="No numeric metadata"
-              description="Include numeric metadata entries in your materializations and observations to see data graphed by time / partition."
+              description={`Include numeric metadata entries in your materializations and observations to see data graphed by ${props.xAxis}.`}
             />
           </Box>
         )}

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -154,10 +154,6 @@ export const LATEST_MATERIALIZATION_METADATA_FRAGMENT = gql`
     runId
     timestamp
     stepKey
-    stepStats {
-      endTime
-      startTime
-    }
     metadataEntries {
       ...MetadataEntryFragment
     }

--- a/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetEventsQuery.ts
@@ -170,12 +170,6 @@ export interface AssetEventsQuery_assetOrError_Asset_assetMaterializations_runOr
 
 export type AssetEventsQuery_assetOrError_Asset_assetMaterializations_runOrError = AssetEventsQuery_assetOrError_Asset_assetMaterializations_runOrError_RunNotFoundError | AssetEventsQuery_assetOrError_Asset_assetMaterializations_runOrError_Run;
 
-export interface AssetEventsQuery_assetOrError_Asset_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface AssetEventsQuery_assetOrError_Asset_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -279,7 +273,6 @@ export interface AssetEventsQuery_assetOrError_Asset_assetMaterializations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetEventsQuery_assetOrError_Asset_assetMaterializations_stepStats;
   label: string;
   description: string | null;
   metadataEntries: AssetEventsQuery_assetOrError_Asset_assetMaterializations_metadataEntries[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationFragment.ts
@@ -33,12 +33,6 @@ export interface AssetMaterializationFragment_runOrError_Run {
 
 export type AssetMaterializationFragment_runOrError = AssetMaterializationFragment_runOrError_RunNotFoundError | AssetMaterializationFragment_runOrError_Run;
 
-export interface AssetMaterializationFragment_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface AssetMaterializationFragment_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -142,7 +136,6 @@ export interface AssetMaterializationFragment {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetMaterializationFragment_stepStats;
   label: string;
   description: string | null;
   metadataEntries: AssetMaterializationFragment_metadataEntries[];

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinitionFragment.ts
@@ -57,13 +57,6 @@ export interface AssetNodeDefinitionFragment_assetMaterializations_runOrError_Ru
 
 export type AssetNodeDefinitionFragment_assetMaterializations_runOrError = AssetNodeDefinitionFragment_assetMaterializations_runOrError_RunNotFoundError | AssetNodeDefinitionFragment_assetMaterializations_runOrError_Run;
 
-export interface AssetNodeDefinitionFragment_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
-
 export interface AssetNodeDefinitionFragment_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -160,6 +153,13 @@ export interface AssetNodeDefinitionFragment_assetMaterializations_assetLineage 
   partitions: string[];
 }
 
+export interface AssetNodeDefinitionFragment_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetNodeDefinitionFragment_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -167,9 +167,9 @@ export interface AssetNodeDefinitionFragment_assetMaterializations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetNodeDefinitionFragment_assetMaterializations_stepStats;
   metadataEntries: AssetNodeDefinitionFragment_assetMaterializations_metadataEntries[];
   assetLineage: AssetNodeDefinitionFragment_assetMaterializations_assetLineage[];
+  stepStats: AssetNodeDefinitionFragment_assetMaterializations_stepStats;
 }
 
 export interface AssetNodeDefinitionFragment_dependencies_asset_jobs {
@@ -219,13 +219,6 @@ export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializa
 }
 
 export type AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_runOrError = AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_runOrError_RunNotFoundError | AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_runOrError_Run;
-
-export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
 
 export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
@@ -323,6 +316,13 @@ export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializa
   partitions: string[];
 }
 
+export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -330,9 +330,9 @@ export interface AssetNodeDefinitionFragment_dependencies_asset_assetMaterializa
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_stepStats;
   metadataEntries: AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_metadataEntries[];
   assetLineage: AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_assetLineage[];
+  stepStats: AssetNodeDefinitionFragment_dependencies_asset_assetMaterializations_stepStats;
 }
 
 export interface AssetNodeDefinitionFragment_dependencies_asset {
@@ -399,13 +399,6 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializati
 }
 
 export type AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_runOrError = AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_runOrError_RunNotFoundError | AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_runOrError_Run;
-
-export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
 
 export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
@@ -503,6 +496,13 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializati
   partitions: string[];
 }
 
+export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -510,9 +510,9 @@ export interface AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializati
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_stepStats;
   metadataEntries: AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_metadataEntries[];
   assetLineage: AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_assetLineage[];
+  stepStats: AssetNodeDefinitionFragment_dependedBy_asset_assetMaterializations_stepStats;
 }
 
 export interface AssetNodeDefinitionFragment_dependedBy_asset {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -71,13 +71,6 @@ export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations_
 
 export type AssetQuery_assetOrError_Asset_definition_assetMaterializations_runOrError = AssetQuery_assetOrError_Asset_definition_assetMaterializations_runOrError_RunNotFoundError | AssetQuery_assetOrError_Asset_definition_assetMaterializations_runOrError_Run;
 
-export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
-
 export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -174,6 +167,13 @@ export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations_
   partitions: string[];
 }
 
+export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -181,9 +181,9 @@ export interface AssetQuery_assetOrError_Asset_definition_assetMaterializations 
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetQuery_assetOrError_Asset_definition_assetMaterializations_stepStats;
   metadataEntries: AssetQuery_assetOrError_Asset_definition_assetMaterializations_metadataEntries[];
   assetLineage: AssetQuery_assetOrError_Asset_definition_assetMaterializations_assetLineage[];
+  stepStats: AssetQuery_assetOrError_Asset_definition_assetMaterializations_stepStats;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_jobs {
@@ -233,13 +233,6 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_ass
 }
 
 export type AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_runOrError = AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_runOrError_RunNotFoundError | AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_runOrError_Run;
-
-export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
 
 export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
@@ -337,6 +330,13 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_ass
   partitions: string[];
 }
 
+export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -344,9 +344,9 @@ export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset_ass
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_stepStats;
   metadataEntries: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_metadataEntries[];
   assetLineage: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_assetLineage[];
+  stepStats: AssetQuery_assetOrError_Asset_definition_dependencies_asset_assetMaterializations_stepStats;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_dependencies_asset {
@@ -413,13 +413,6 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_asset
 }
 
 export type AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_runOrError = AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_runOrError_RunNotFoundError | AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_runOrError_Run;
-
-export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
 
 export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
@@ -517,6 +510,13 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_asset
   partitions: string[];
 }
 
+export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -524,9 +524,9 @@ export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset_asset
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_stepStats;
   metadataEntries: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_metadataEntries[];
   assetLineage: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_assetLineage[];
+  stepStats: AssetQuery_assetOrError_Asset_definition_dependedBy_asset_assetMaterializations_stepStats;
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_dependedBy_asset {

--- a/js_modules/dagit/packages/core/src/assets/types/LatestMaterializationMetadataFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LatestMaterializationMetadataFragment.ts
@@ -30,12 +30,6 @@ export interface LatestMaterializationMetadataFragment_runOrError_Run {
 
 export type LatestMaterializationMetadataFragment_runOrError = LatestMaterializationMetadataFragment_runOrError_RunNotFoundError | LatestMaterializationMetadataFragment_runOrError_Run;
 
-export interface LatestMaterializationMetadataFragment_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-}
-
 export interface LatestMaterializationMetadataFragment_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -139,7 +133,6 @@ export interface LatestMaterializationMetadataFragment {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: LatestMaterializationMetadataFragment_stepStats;
   metadataEntries: LatestMaterializationMetadataFragment_metadataEntries[];
   assetLineage: LatestMaterializationMetadataFragment_assetLineage[];
 }

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphLiveQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetGraphLiveQuery.ts
@@ -63,13 +63,6 @@ export interface AssetGraphLiveQuery_assetNodes_assetMaterializations_runOrError
 
 export type AssetGraphLiveQuery_assetNodes_assetMaterializations_runOrError = AssetGraphLiveQuery_assetNodes_assetMaterializations_runOrError_RunNotFoundError | AssetGraphLiveQuery_assetNodes_assetMaterializations_runOrError_Run;
 
-export interface AssetGraphLiveQuery_assetNodes_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
-
 export interface AssetGraphLiveQuery_assetNodes_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -166,6 +159,13 @@ export interface AssetGraphLiveQuery_assetNodes_assetMaterializations_assetLinea
   partitions: string[];
 }
 
+export interface AssetGraphLiveQuery_assetNodes_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetGraphLiveQuery_assetNodes_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -173,9 +173,9 @@ export interface AssetGraphLiveQuery_assetNodes_assetMaterializations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetGraphLiveQuery_assetNodes_assetMaterializations_stepStats;
   metadataEntries: AssetGraphLiveQuery_assetNodes_assetMaterializations_metadataEntries[];
   assetLineage: AssetGraphLiveQuery_assetNodes_assetMaterializations_assetLineage[];
+  stepStats: AssetGraphLiveQuery_assetNodes_assetMaterializations_stepStats;
 }
 
 export interface AssetGraphLiveQuery_assetNodes {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetNodeLiveFragment.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetNodeLiveFragment.ts
@@ -33,13 +33,6 @@ export interface AssetNodeLiveFragment_assetMaterializations_runOrError_Run {
 
 export type AssetNodeLiveFragment_assetMaterializations_runOrError = AssetNodeLiveFragment_assetMaterializations_runOrError_RunNotFoundError | AssetNodeLiveFragment_assetMaterializations_runOrError_Run;
 
-export interface AssetNodeLiveFragment_assetMaterializations_stepStats {
-  __typename: "RunStepStats";
-  endTime: number | null;
-  startTime: number | null;
-  stepKey: string;
-}
-
 export interface AssetNodeLiveFragment_assetMaterializations_metadataEntries_EventTableSchemaMetadataEntry {
   __typename: "EventTableSchemaMetadataEntry" | "EventTableMetadataEntry";
   label: string;
@@ -136,6 +129,13 @@ export interface AssetNodeLiveFragment_assetMaterializations_assetLineage {
   partitions: string[];
 }
 
+export interface AssetNodeLiveFragment_assetMaterializations_stepStats {
+  __typename: "RunStepStats";
+  stepKey: string;
+  startTime: number | null;
+  endTime: number | null;
+}
+
 export interface AssetNodeLiveFragment_assetMaterializations {
   __typename: "MaterializationEvent";
   partition: string | null;
@@ -143,9 +143,9 @@ export interface AssetNodeLiveFragment_assetMaterializations {
   runId: string;
   timestamp: string;
   stepKey: string | null;
-  stepStats: AssetNodeLiveFragment_assetMaterializations_stepStats;
   metadataEntries: AssetNodeLiveFragment_assetMaterializations_metadataEntries[];
   assetLineage: AssetNodeLiveFragment_assetMaterializations_assetLineage[];
+  stepStats: AssetNodeLiveFragment_assetMaterializations_stepStats;
 }
 
 export interface AssetNodeLiveFragment {


### PR DESCRIPTION
https://github.com/dagster-io/dagster/issues/6459

## Summary
Per our discussions, the use of `stepStats` causes database query fan-out and is a big part of why the materializations section of the asset page is so slow.

This PR removes the step execution time graph shown on this page. It also adds an empty state when no numeric metadata entries are present, since the right area can now be blank.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.