### PR TITLE
fix helm test to lowercase release names

### DIFF
--- a/helm/dagster/schema/schema/utils/helm_template.py
+++ b/helm/dagster/schema/schema/utils/helm_template.py
@@ -24,7 +24,7 @@ class HelmTemplate:
     subchart_paths: List[str]
     output: Optional[str] = None
     model: Optional[Any] = None
-    name: str = "RELEASE-NAME"
+    name: str = "release-name"
     api_client: ApiClient = ApiClient()
 
     def render(

--- a/helm/dagster/schema/schema_tests/test_celery_queues.py
+++ b/helm/dagster/schema/schema_tests/test_celery_queues.py
@@ -275,8 +275,8 @@ def test_celery_queue_volumes(deployment_template: HelmTemplate):
     rendered_volumes = celery_queue_deployments[0].spec.template.spec.volumes
 
     assert [remove_none_recursively(volume.to_dict()) for volume in rendered_volumes] == [
-        {"config_map": {"name": "RELEASE-NAME-dagster-instance"}, "name": "dagster-instance"},
-        {"config_map": {"name": "RELEASE-NAME-dagster-celery-dagster"}, "name": "dagster-celery"},
+        {"config_map": {"name": "release-name-dagster-instance"}, "name": "dagster-instance"},
+        {"config_map": {"name": "release-name-dagster-celery-dagster"}, "name": "dagster-celery"},
         {"name": "test-volume", "config_map": {"name": "test-volume-configmap"}},
         {
             "name": "test-pvc",

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -92,8 +92,8 @@ def test_dagit_read_only_enabled(deployment_template: HelmTemplate):
         for dagit in dagit_template
     ] == [False, True]
     assert [dagit.metadata.name for dagit in dagit_template] == [
-        "RELEASE-NAME-dagit",
-        "RELEASE-NAME-dagit-read-only",
+        "release-name-dagit",
+        "release-name-dagit-read-only",
     ]
 
     assert [dagit.spec.template.metadata.labels["component"] for dagit in dagit_template] == [
@@ -145,7 +145,7 @@ def test_dagit_service(service_template):
     dagit_template = service_template.render(helm_values)
 
     assert len(dagit_template) == 1
-    assert dagit_template[0].metadata.name == "RELEASE-NAME-dagit"
+    assert dagit_template[0].metadata.name == "release-name-dagit"
 
 
 def test_dagit_service_read_only(service_template):
@@ -154,8 +154,8 @@ def test_dagit_service_read_only(service_template):
 
     assert len(dagit_template) == 2
     assert [dagit.metadata.name for dagit in dagit_template] == [
-        "RELEASE-NAME-dagit",
-        "RELEASE-NAME-dagit-read-only",
+        "release-name-dagit",
+        "release-name-dagit-read-only",
     ]
     assert [dagit.spec.selector["component"] for dagit in dagit_template] == [
         "dagit",

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -262,7 +262,7 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
 
     assert run_launcher_config["config"]["image_pull_policy"] == "Always"
 
-    assert run_launcher_config["config"]["service_account_name"] == "RELEASE-NAME-dagster"
+    assert run_launcher_config["config"]["service_account_name"] == "release-name-dagster"
 
     assert not "fail_pod_on_run_failure" in run_launcher_config["config"]
 


### PR DESCRIPTION
Encountered a bug where the release name has to be lowercase with newer versions of helm.  Ran into this while trying to update our buildkite images.

## Test Plan
Ran against an updated buildkite image with a newer version of helm

