### PR TITLE
[software-defined-assets] metadata implementation for inter asset dependencies

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_composites.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_composites.py
@@ -6,473 +6,454 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestComposites.test_composites[non_launchable_in_memory_instance_multi_location] 1'] = {
-    'pipelineOrError': {
-        '__typename': 'Pipeline',
-        'name': 'composites_pipeline',
-        'solidHandles': [
+snapshots["TestComposites.test_composites[non_launchable_in_memory_instance_multi_location] 1"] = {
+    "pipelineOrError": {
+        "__typename": "Pipeline",
+        "name": "composites_pipeline",
+        "solidHandles": [
             {
-                'handleID': 'add_four',
-                'solid': {
-                    'definition': {
-                        'inputMappings': [
+                "handleID": "add_four",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
                             {
-                                'definition': {
-                                    'name': 'num'
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "adder_1"},
                                 },
-                                'mappedInput': {
-                                    'definition': {
-                                        'name': 'num'
-                                    },
-                                    'solid': {
-                                        'name': 'adder_1'
-                                    }
-                                }
                             }
                         ],
-                        'outputMappings': [
+                        "outputMappings": [
                             {
-                                'definition': {
-                                    'name': 'result'
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "adder_2"},
                                 },
-                                'mappedOutput': {
-                                    'definition': {
-                                        'name': 'result'
-                                    },
-                                    'solid': {
-                                        'name': 'adder_2'
-                                    }
-                                }
                             }
                         ],
-                        'solids': [
-                            {
-                                'name': 'adder_1'
-                            },
-                            {
-                                'name': 'adder_2'
-                            }
-                        ]
+                        "solids": [{"name": "adder_1"}, {"name": "adder_2"}],
                     },
-                    'inputs': [
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "add_four",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "div_four"}}],
                         }
                     ],
-                    'name': 'add_four',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                                {
-                                    'solid': {
-                                        'name': 'div_four'
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
+                },
             },
             {
-                'handleID': 'add_four.adder_1',
-                'solid': {
-                    'definition': {
-                        'inputMappings': [
+                "handleID": "add_four.adder_1",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
                             {
-                                'definition': {
-                                    'name': 'num'
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "adder_1"},
                                 },
-                                'mappedInput': {
-                                    'definition': {
-                                        'name': 'num'
-                                    },
-                                    'solid': {
-                                        'name': 'adder_1'
-                                    }
-                                }
                             }
                         ],
-                        'outputMappings': [
+                        "outputMappings": [
                             {
-                                'definition': {
-                                    'name': 'result'
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "adder_2"},
                                 },
-                                'mappedOutput': {
-                                    'definition': {
-                                        'name': 'result'
-                                    },
-                                    'solid': {
-                                        'name': 'adder_2'
-                                    }
-                                }
                             }
                         ],
-                        'solids': [
-                            {
-                                'name': 'adder_1'
-                            },
-                            {
-                                'name': 'adder_2'
-                            }
-                        ]
+                        "solids": [{"name": "adder_1"}, {"name": "adder_2"}],
                     },
-                    'inputs': [
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "adder_1",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "adder_2"}}],
                         }
                     ],
-                    'name': 'adder_1',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                                {
-                                    'solid': {
-                                        'name': 'adder_2'
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
+                },
             },
             {
-                'handleID': 'add_four.adder_1.adder_1',
-                'solid': {
-                    'definition': {
-                    },
-                    'inputs': [
+                "handleID": "add_four.adder_1.adder_1",
+                "solid": {
+                    "definition": {},
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "adder_1",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "adder_2"}}],
                         }
                     ],
-                    'name': 'adder_1',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                                {
-                                    'solid': {
-                                        'name': 'adder_2'
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
+                },
             },
             {
-                'handleID': 'add_four.adder_1.adder_2',
-                'solid': {
-                    'definition': {
-                    },
-                    'inputs': [
+                "handleID": "add_four.adder_1.adder_2",
+                "solid": {
+                    "definition": {},
+                    "inputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                                {
-                                    'solid': {
-                                        'name': 'adder_1'
-                                    }
-                                }
-                            ]
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "adder_1"}}],
                         }
                     ],
-                    'name': 'adder_2',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                            ]
-                        }
-                    ]
-                }
+                    "name": "adder_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
             },
             {
-                'handleID': 'add_four.adder_2',
-                'solid': {
-                    'definition': {
-                        'inputMappings': [
+                "handleID": "add_four.adder_2",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
                             {
-                                'definition': {
-                                    'name': 'num'
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "adder_1"},
                                 },
-                                'mappedInput': {
-                                    'definition': {
-                                        'name': 'num'
-                                    },
-                                    'solid': {
-                                        'name': 'adder_1'
-                                    }
-                                }
                             }
                         ],
-                        'outputMappings': [
+                        "outputMappings": [
                             {
-                                'definition': {
-                                    'name': 'result'
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "adder_2"},
                                 },
-                                'mappedOutput': {
-                                    'definition': {
-                                        'name': 'result'
-                                    },
-                                    'solid': {
-                                        'name': 'adder_2'
-                                    }
-                                }
                             }
                         ],
-                        'solids': [
-                            {
-                                'name': 'adder_1'
-                            },
-                            {
-                                'name': 'adder_2'
-                            }
-                        ]
+                        "solids": [{"name": "adder_1"}, {"name": "adder_2"}],
                     },
-                    'inputs': [
+                    "inputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                                {
-                                    'solid': {
-                                        'name': 'adder_1'
-                                    }
-                                }
-                            ]
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "adder_1"}}],
                         }
                     ],
-                    'name': 'adder_2',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                            ]
-                        }
-                    ]
-                }
+                    "name": "adder_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
             },
             {
-                'handleID': 'add_four.adder_2.adder_1',
-                'solid': {
-                    'definition': {
-                    },
-                    'inputs': [
+                "handleID": "add_four.adder_2.adder_1",
+                "solid": {
+                    "definition": {},
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "adder_1",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "adder_2"}}],
                         }
                     ],
-                    'name': 'adder_1',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                                {
-                                    'solid': {
-                                        'name': 'adder_2'
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
+                },
             },
             {
-                'handleID': 'add_four.adder_2.adder_2',
-                'solid': {
-                    'definition': {
-                    },
-                    'inputs': [
+                "handleID": "add_four.adder_2.adder_2",
+                "solid": {
+                    "definition": {},
+                    "inputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                                {
-                                    'solid': {
-                                        'name': 'adder_1'
-                                    }
-                                }
-                            ]
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "adder_1"}}],
                         }
                     ],
-                    'name': 'adder_2',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                            ]
-                        }
-                    ]
-                }
+                    "name": "adder_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
             },
             {
-                'handleID': 'div_four',
-                'solid': {
-                    'definition': {
-                        'inputMappings': [
+                "handleID": "div_four",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
                             {
-                                'definition': {
-                                    'name': 'num'
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "div_1"},
                                 },
-                                'mappedInput': {
-                                    'definition': {
-                                        'name': 'num'
-                                    },
-                                    'solid': {
-                                        'name': 'div_1'
-                                    }
-                                }
                             }
                         ],
-                        'outputMappings': [
+                        "outputMappings": [
                             {
-                                'definition': {
-                                    'name': 'result'
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "div_2"},
                                 },
-                                'mappedOutput': {
-                                    'definition': {
-                                        'name': 'result'
-                                    },
-                                    'solid': {
-                                        'name': 'div_2'
-                                    }
-                                }
                             }
                         ],
-                        'solids': [
+                        "solids": [{"name": "div_1"}, {"name": "div_2"}],
+                    },
+                    "inputs": [
+                        {
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "add_four"}}],
+                        }
+                    ],
+                    "name": "div_four",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+            {
+                "handleID": "div_four.div_1",
+                "solid": {
+                    "definition": {},
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "div_1",
+                    "outputs": [
+                        {
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "div_2"}}],
+                        }
+                    ],
+                },
+            },
+            {
+                "handleID": "div_four.div_2",
+                "solid": {
+                    "definition": {},
+                    "inputs": [
+                        {"definition": {"name": "num"}, "dependsOn": [{"solid": {"name": "div_1"}}]}
+                    ],
+                    "name": "div_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+        ],
+    }
+}
+
+snapshots["TestComposites.test_composites[non_launchable_sqlite_instance_managed_grpc_env] 1"] = {
+    "pipelineOrError": {
+        "__typename": "Pipeline",
+        "name": "composites_pipeline",
+        "solidHandles": [
+            {
+                "handleID": "add_four",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
                             {
-                                'name': 'div_1'
-                            },
-                            {
-                                'name': 'div_2'
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "adder_1"},
+                                },
                             }
-                        ]
+                        ],
+                        "outputMappings": [
+                            {
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "adder_2"},
+                                },
+                            }
+                        ],
+                        "solids": [{"name": "adder_1"}, {"name": "adder_2"}],
                     },
-                    'inputs': [
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "add_four",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                                {
-                                    'solid': {
-                                        'name': 'add_four'
-                                    }
-                                }
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "div_four"}}],
                         }
                     ],
-                    'name': 'div_four',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                            ]
-                        }
-                    ]
-                }
+                },
             },
             {
-                'handleID': 'div_four.div_1',
-                'solid': {
-                    'definition': {
+                "handleID": "add_four.adder_1",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
+                            {
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "adder_1"},
+                                },
+                            }
+                        ],
+                        "outputMappings": [
+                            {
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "adder_2"},
+                                },
+                            }
+                        ],
+                        "solids": [{"name": "adder_1"}, {"name": "adder_2"}],
                     },
-                    'inputs': [
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "adder_1",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "adder_2"}}],
                         }
                     ],
-                    'name': 'div_1',
-                    'outputs': [
-                        {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                                {
-                                    'solid': {
-                                        'name': 'div_2'
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
+                },
             },
             {
-                'handleID': 'div_four.div_2',
-                'solid': {
-                    'definition': {
-                    },
-                    'inputs': [
+                "handleID": "add_four.adder_1.adder_1",
+                "solid": {
+                    "definition": {},
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "adder_1",
+                    "outputs": [
                         {
-                            'definition': {
-                                'name': 'num'
-                            },
-                            'dependsOn': [
-                                {
-                                    'solid': {
-                                        'name': 'div_1'
-                                    }
-                                }
-                            ]
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "adder_2"}}],
                         }
                     ],
-                    'name': 'div_2',
-                    'outputs': [
+                },
+            },
+            {
+                "handleID": "add_four.adder_1.adder_2",
+                "solid": {
+                    "definition": {},
+                    "inputs": [
                         {
-                            'definition': {
-                                'name': 'result'
-                            },
-                            'dependedBy': [
-                            ]
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "adder_1"}}],
                         }
-                    ]
-                }
-            }
-        ]
+                    ],
+                    "name": "adder_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+            {
+                "handleID": "add_four.adder_2",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
+                            {
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "adder_1"},
+                                },
+                            }
+                        ],
+                        "outputMappings": [
+                            {
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "adder_2"},
+                                },
+                            }
+                        ],
+                        "solids": [{"name": "adder_1"}, {"name": "adder_2"}],
+                    },
+                    "inputs": [
+                        {
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "adder_1"}}],
+                        }
+                    ],
+                    "name": "adder_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+            {
+                "handleID": "add_four.adder_2.adder_1",
+                "solid": {
+                    "definition": {},
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "adder_1",
+                    "outputs": [
+                        {
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "adder_2"}}],
+                        }
+                    ],
+                },
+            },
+            {
+                "handleID": "add_four.adder_2.adder_2",
+                "solid": {
+                    "definition": {},
+                    "inputs": [
+                        {
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "adder_1"}}],
+                        }
+                    ],
+                    "name": "adder_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+            {
+                "handleID": "div_four",
+                "solid": {
+                    "definition": {
+                        "inputMappings": [
+                            {
+                                "definition": {"name": "num"},
+                                "mappedInput": {
+                                    "definition": {"name": "num"},
+                                    "solid": {"name": "div_1"},
+                                },
+                            }
+                        ],
+                        "outputMappings": [
+                            {
+                                "definition": {"name": "result"},
+                                "mappedOutput": {
+                                    "definition": {"name": "result"},
+                                    "solid": {"name": "div_2"},
+                                },
+                            }
+                        ],
+                        "solids": [{"name": "div_1"}, {"name": "div_2"}],
+                    },
+                    "inputs": [
+                        {
+                            "definition": {"name": "num"},
+                            "dependsOn": [{"solid": {"name": "add_four"}}],
+                        }
+                    ],
+                    "name": "div_four",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+            {
+                "handleID": "div_four.div_1",
+                "solid": {
+                    "definition": {},
+                    "inputs": [{"definition": {"name": "num"}, "dependsOn": []}],
+                    "name": "div_1",
+                    "outputs": [
+                        {
+                            "definition": {"name": "result"},
+                            "dependedBy": [{"solid": {"name": "div_2"}}],
+                        }
+                    ],
+                },
+            },
+            {
+                "handleID": "div_four.div_2",
+                "solid": {
+                    "definition": {},
+                    "inputs": [
+                        {"definition": {"name": "num"}, "dependsOn": [{"solid": {"name": "div_1"}}]}
+                    ],
+                    "name": "div_2",
+                    "outputs": [{"definition": {"name": "result"}, "dependedBy": []}],
+                },
+            },
+        ],
     }
 }

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -134,9 +134,7 @@ class _Asset:
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
 
-        ins_by_input_names: Mapping[str, In] = build_asset_ins(
-            fn, self.namespace, self.ins or {}, self.non_argument_deps
-        )
+        asset_ins = build_asset_ins(fn, self.namespace, self.ins or {}, self.non_argument_deps)
 
         partition_fn: Optional[Callable] = None
         if self.partitions_def:
@@ -156,9 +154,7 @@ class _Asset:
         op = _Op(
             name=asset_name,
             description=self.description,
-            ins={
-                input_name: in_def for input_name, in_def in ins_by_input_names.items()
-            },  # convert Mapping object to dict
+            ins=asset_ins,
             out=out,
             required_resource_keys=self.required_resource_keys,
             tags={"kind": self.compute_kind} if self.compute_kind else None,
@@ -172,13 +168,13 @@ class _Asset:
 
         return AssetsDefinition(
             input_names_by_asset_key={
-                in_def.asset_key: input_name for input_name, in_def in ins_by_input_names.items()
+                in_def.asset_key: input_name for input_name, in_def in asset_ins.items()
             },
             output_names_by_asset_key={out_asset_key: "result"},
             op=op,
             partitions_def=self.partitions_def,
             partition_mappings={
-                ins_by_input_names[input_name].asset_key: partition_mapping
+                asset_ins[input_name].asset_key: partition_mapping
                 for input_name, partition_mapping in self.partition_mappings.items()
             }
             if self.partition_mappings
@@ -232,9 +228,7 @@ def multi_asset(
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:
         asset_name = name or fn.__name__
         asset_ins = build_asset_ins(fn, None, ins or {}, non_argument_deps)
-        asset_outs = build_asset_outs(
-            asset_name, outs, ins_by_input_names, internal_asset_deps or {}
-        )
+        asset_outs = build_asset_outs(asset_name, outs, asset_ins, internal_asset_deps or {})
 
         op = _Op(
             name=asset_name,

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -229,6 +229,49 @@ def multi_asset(
         internal_asset_deps, "internal_asset_deps", key_type=str, value_type=set
     )
 
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
+        asset_name = name or fn.__name__
+        ins_by_input_names: Mapping[str, In] = build_asset_ins(
+            fn, None, ins or {}, non_argument_deps
+        )
+        outs_by_output_names: Mapping[str, Out] = build_asset_outs(
+            asset_name, outs, ins_by_input_names, internal_asset_deps or {}
+        )
+
+        op = _Op(
+            name=asset_name,
+            description=description,
+            ins={
+                input_name: in_def for input_name, in_def in ins_by_input_names.items()
+            },  # convert Mapping object to dict
+            out={
+                output_name: out_def for output_name, out_def in outs_by_output_names.items()
+            },  # convert Mapping object to dict
+            required_resource_keys=required_resource_keys,
+            tags={"kind": compute_kind} if compute_kind else None,
+        )(fn)
+
+        return AssetsDefinition(
+            input_names_by_asset_key={
+                in_def.asset_key: input_name for input_name, in_def in ins_by_input_names.items()
+            },
+            output_names_by_asset_key={
+                out_def.asset_key: output_name  # type: ignore
+                for output_name, out_def in outs_by_output_names.items()
+            },
+            op=op,
+        )
+
+    return inner
+
+
+def build_asset_outs(
+    asset_name: str,
+    outs: Mapping[str, Out],
+    ins: Mapping[str, In],
+    internal_asset_deps: Mapping[str, Set[AssetKey]],
+):
+
     # if an AssetKey is not supplied, create one based off of the out's name
     asset_keys_by_out_name = {
         out_name: out.asset_key if isinstance(out.asset_key, AssetKey) else AssetKey([out_name])
@@ -251,54 +294,25 @@ def multi_asset(
         for out_name, out in outs.items()
     }
 
-    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
-        asset_name = name or fn.__name__
-        ins_by_input_names: Mapping[str, In] = build_asset_ins(
-            fn, None, ins or {}, non_argument_deps
+    # validate that the internal_asset_deps make sense
+    valid_asset_deps = set(in_def.asset_key for in_def in ins.values())
+    valid_asset_deps.update(asset_keys_by_out_name.values())
+    for out_name, asset_keys in internal_asset_deps.items():
+        check.invariant(
+            out_name in outs,
+            f"Invalid out key '{out_name}' supplied to `internal_asset_deps` argument for asset "
+            f"{asset_name}. Must be one of the outs for this multi_asset {list(outs.keys())}.",
+        )
+        invalid_asset_deps = asset_keys.difference(valid_asset_deps)
+        check.invariant(
+            not invalid_asset_deps,
+            f"Invalid asset dependencies: {invalid_asset_deps} specified in `internal_asset_deps` "
+            f"argument for asset '{asset_name}' on key '{out_name}'. Each specified asset key "
+            "must be associated with an input to the asset or produced by this asset. Valid "
+            f"keys: {valid_asset_deps}",
         )
 
-        # validate that the internal_asset_deps make sense
-        if internal_asset_deps:
-            valid_asset_deps = set(in_def.asset_key for in_def in ins_by_input_names.values())
-            valid_asset_deps.update(asset_keys_by_out_name.values())
-            for out_name, asset_keys in internal_asset_deps.items():
-                check.invariant(
-                    out_name in outs,
-                    f"Invalid out key '{out_name}' supplied to `internal_asset_deps` argument for asset "
-                    f"{asset_name}. Must be one of the outs for this multi_asset {list(outs.keys())}.",
-                )
-                invalid_asset_deps = asset_keys.difference(valid_asset_deps)
-                check.invariant(
-                    not invalid_asset_deps,
-                    f"Invalid asset dependencies: {invalid_asset_deps} specified in `internal_asset_deps` "
-                    f"argument for asset '{asset_name}' on key '{out_name}'. Each specified asset key "
-                    "must be associated with an input to the asset or produced by this asset. Valid "
-                    f"keys: {valid_asset_deps}",
-                )
-
-        # for any Outs that do not specify an AssetKey, create one matching the name of the Out
-        op = _Op(
-            name=asset_name,
-            description=description,
-            ins={
-                input_name: in_def for input_name, in_def in ins_by_input_names.items()
-            },  # convert Mapping object to dict
-            out=outs,
-            required_resource_keys=required_resource_keys,
-            tags={"kind": compute_kind} if compute_kind else None,
-        )(fn)
-
-        return AssetsDefinition(
-            input_names_by_asset_key={
-                in_def.asset_key: input_name for input_name, in_def in ins_by_input_names.items()
-            },
-            output_names_by_asset_key={
-                asset_key: out_name for out_name, asset_key in asset_keys_by_out_name.items()
-            },
-            op=op,
-        )
-
-    return inner
+    return outs
 
 
 def build_asset_ins(

--- a/python_modules/dagster/dagster/core/asset_defs/decorators.py
+++ b/python_modules/dagster/dagster/core/asset_defs/decorators.py
@@ -258,22 +258,23 @@ def multi_asset(
         )
 
         # validate that the internal_asset_deps make sense
-        valid_asset_deps = set(in_def.asset_key for in_def in ins_by_input_names.values())
-        valid_asset_deps.update(asset_keys_by_out_name.values())
-        for out_name, asset_keys in internal_asset_deps.items():
-            check.invariant(
-                out_name in outs,
-                f"Invalid out key '{out_name}' supplied to `internal_asset_deps` argument for asset "
-                f"{asset_name}. Must be one of the outs for this multi_asset {list(outs.keys())}.",
-            )
-            invalid_asset_deps = asset_keys.difference(valid_asset_deps)
-            check.invariant(
-                not invalid_asset_deps,
-                f"Invalid asset dependencies: {invalid_asset_deps} specified in `internal_asset_deps` "
-                f"argument for asset '{asset_name}' on key '{out_name}'. Each specified asset key "
-                "must be associated with an input to the asset or produced by this asset. Valid "
-                f"keys: {valid_asset_deps}",
-            )
+        if internal_asset_deps:
+            valid_asset_deps = set(in_def.asset_key for in_def in ins_by_input_names.values())
+            valid_asset_deps.update(asset_keys_by_out_name.values())
+            for out_name, asset_keys in internal_asset_deps.items():
+                check.invariant(
+                    out_name in outs,
+                    f"Invalid out key '{out_name}' supplied to `internal_asset_deps` argument for asset "
+                    f"{asset_name}. Must be one of the outs for this multi_asset {list(outs.keys())}.",
+                )
+                invalid_asset_deps = asset_keys.difference(valid_asset_deps)
+                check.invariant(
+                    not invalid_asset_deps,
+                    f"Invalid asset dependencies: {invalid_asset_deps} specified in `internal_asset_deps` "
+                    f"argument for asset '{asset_name}' on key '{out_name}'. Each specified asset key "
+                    "must be associated with an input to the asset or produced by this asset. Valid "
+                    f"keys: {valid_asset_deps}",
+                )
 
         # for any Outs that do not specify an AssetKey, create one matching the name of the Out
         op = _Op(

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -610,7 +610,7 @@ def external_asset_graph_from_defs(
                 node_defs_by_asset_key[output_asset_key].append((output_def, node_def, pipeline))
 
                 # if no deps specified, assume depends on all inputs and no outputs
-                asset_deps = output_def.metadata.get(ASSET_DEPENDENCY_METADATA_KEY)
+                asset_deps = (output_def.metadata or {}).get(ASSET_DEPENDENCY_METADATA_KEY)
                 if asset_deps is None:
                     asset_deps = node_upstream_asset_keys
 

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -665,8 +665,8 @@ def external_asset_graph_from_defs(
         # temporary workaround to retrieve asset partition definition from job
         partitions_def_data = None
 
-        if output_def and output_def.hardcoded_asset_key:
-            partitions_def = output_def.asset_partitions_def
+        if output_def and output_def._asset_partitions_def:  # pylint: disable=protected-access
+            partitions_def = output_def._asset_partitions_def  # pylint: disable=protected-access
             if partitions_def:
                 if isinstance(partitions_def, TimeWindowPartitionsDefinition):
                     partitions_def_data = external_time_window_partitions_definition_from_def(

--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -11,8 +11,10 @@ from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from dagster import StaticPartitionsDefinition, check
 from dagster.core.asset_defs import ForeignAsset
+from dagster.core.asset_defs.decorators import ASSET_DEPENDENCY_METADATA_KEY
 from dagster.core.definitions import (
     JobDefinition,
+    OutputDefinition,
     PartitionSetDefinition,
     PartitionsDefinition,
     PipelineDefinition,
@@ -458,7 +460,7 @@ class ExternalPartitionExecutionErrorData(
 
 @whitelist_for_serdes
 class ExternalAssetDependency(
-    namedtuple("_ExternalAssetDependency", "upstream_asset_key input_name")
+    namedtuple("_ExternalAssetDependency", "upstream_asset_key input_name output_name")
 ):
     """A definition of a directed edge in the logical asset graph.
 
@@ -466,17 +468,22 @@ class ExternalAssetDependency(
     that depends on it.
     """
 
-    def __new__(cls, upstream_asset_key: AssetKey, input_name: str):
+    def __new__(cls, upstream_asset_key: AssetKey, input_name: str = None, output_name: str = None):
+        check.invariant(
+            (input_name is None) ^ (output_name is None),
+            "Exactly one of `input_name` and `output_name` should be supplied",
+        )
         return super(ExternalAssetDependency, cls).__new__(
             cls,
             upstream_asset_key=upstream_asset_key,
             input_name=input_name,
+            output_name=output_name,
         )
 
 
 @whitelist_for_serdes
 class ExternalAssetDependedBy(
-    namedtuple("_ExternalAssetDependedBy", "downstream_asset_key input_name")
+    namedtuple("_ExternalAssetDependedBy", "downstream_asset_key input_name output_name")
 ):
     """A definition of a directed edge in the logical asset graph.
 
@@ -484,11 +491,18 @@ class ExternalAssetDependedBy(
     asset that it depends on.
     """
 
-    def __new__(cls, downstream_asset_key: AssetKey, input_name: str):
+    def __new__(
+        cls, downstream_asset_key: AssetKey, input_name: str = None, output_name: str = None
+    ):
+        check.invariant(
+            (input_name is None) ^ (output_name is None),
+            "Exactly one of `input_name` and `output_name` should be supplied",
+        )
         return super(ExternalAssetDependedBy, cls).__new__(
             cls,
             downstream_asset_key=downstream_asset_key,
             input_name=input_name,
+            output_name=output_name,
         )
 
 
@@ -496,7 +510,7 @@ class ExternalAssetDependedBy(
 class ExternalAssetNode(
     namedtuple(
         "_ExternalAssetNode",
-        "asset_key dependencies depended_by op_name op_description job_names partitions_def_data",
+        "asset_key dependencies depended_by op_name op_description job_names partitions_def_data output_name output_description",
     )
 ):
     """A definition of a node in the logical asset graph.
@@ -513,6 +527,8 @@ class ExternalAssetNode(
         op_description: Optional[str] = None,
         job_names: Optional[List[str]] = None,
         partitions_def_data: Optional[ExternalPartitionsDefinitionData] = None,
+        output_name: Optional[str] = None,
+        output_description: Optional[str] = None,
     ):
         return super(ExternalAssetNode, cls).__new__(
             cls,
@@ -523,6 +539,8 @@ class ExternalAssetNode(
             op_description=op_description,
             job_names=job_names,
             partitions_def_data=partitions_def_data,
+            output_name=output_name,
+            output_description=output_description,
         )
 
 
@@ -558,40 +576,57 @@ def external_asset_graph_from_defs(
     pipelines: Sequence[PipelineDefinition], foreign_assets_by_key: Mapping[AssetKey, ForeignAsset]
 ) -> Sequence[ExternalAssetNode]:
     node_defs_by_asset_key: Dict[
-        AssetKey, List[Tuple[NodeDefinition, PipelineDefinition]]
+        AssetKey, List[Tuple[OutputDefinition, NodeDefinition, PipelineDefinition]]
     ] = defaultdict(list)
 
-    deps: Dict[AssetKey, Dict[str, ExternalAssetDependency]] = defaultdict(dict)
+    deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
     dep_by: Dict[AssetKey, List[ExternalAssetDependedBy]] = defaultdict(list)
-    all_upstream_asset_keys = set()
+    all_upstream_asset_keys: Set[AssetKey] = set()
 
     for pipeline in pipelines:
         for node_def in pipeline.all_node_defs:
-            node_asset_keys: Set[AssetKey] = set()
+            input_name_by_asset_key = {
+                id.hardcoded_asset_key: id.name
+                for id in node_def.input_defs
+                if id.hardcoded_asset_key is not None
+            }
+
+            output_name_by_asset_key = {
+                od.hardcoded_asset_key: od.name
+                for od in node_def.output_defs
+                if od.hardcoded_asset_key is not None
+            }
+
+            node_upstream_asset_keys = set(
+                filter(None, (id.hardcoded_asset_key for id in node_def.input_defs))
+            )
+            all_upstream_asset_keys.update(node_upstream_asset_keys)
+
             for output_def in node_def.output_defs:
-                asset_key = output_def.hardcoded_asset_key
+                output_asset_key = output_def.hardcoded_asset_key
+                if not output_asset_key:
+                    continue
 
-                if asset_key:
-                    node_asset_keys.add(asset_key)
-                    node_defs_by_asset_key[asset_key].append((node_def, pipeline))
+                node_defs_by_asset_key[output_asset_key].append((output_def, node_def, pipeline))
 
-            for input_def in node_def.input_defs:
-                upstream_asset_key = input_def.hardcoded_asset_key
+                # if no deps specified, assume depends on all inputs and no outputs
+                asset_deps = output_def.metadata.get(ASSET_DEPENDENCY_METADATA_KEY)
+                if asset_deps is None:
+                    asset_deps = node_upstream_asset_keys
 
-                if upstream_asset_key:
-                    all_upstream_asset_keys.add(upstream_asset_key)
-                    for node_asset_key in node_asset_keys:
-                        deps[node_asset_key][input_def.name] = ExternalAssetDependency(
-                            upstream_asset_key=upstream_asset_key,
-                            input_name=input_def.name,
+                for upstream_asset_key in asset_deps:
+                    deps[output_asset_key][upstream_asset_key] = ExternalAssetDependency(
+                        upstream_asset_key=upstream_asset_key,
+                        input_name=input_name_by_asset_key.get(upstream_asset_key),
+                        output_name=output_name_by_asset_key.get(upstream_asset_key),
+                    )
+                    dep_by[upstream_asset_key].append(
+                        ExternalAssetDependedBy(
+                            downstream_asset_key=output_asset_key,
+                            input_name=input_name_by_asset_key.get(upstream_asset_key),
+                            output_name=output_name_by_asset_key.get(upstream_asset_key),
                         )
-                        dep_by[upstream_asset_key].append(
-                            ExternalAssetDependedBy(
-                                downstream_asset_key=node_asset_key,
-                                input_name=input_def.name,
-                            )
-                        )
-
+                    )
     asset_keys_without_definitions = all_upstream_asset_keys.difference(
         node_defs_by_asset_key.keys()
     ).difference(foreign_assets_by_key.keys())
@@ -624,15 +659,14 @@ def external_asset_graph_from_defs(
         )
 
     for asset_key, node_tuple_list in node_defs_by_asset_key.items():
-        node_def = node_tuple_list[0][0]
-        job_names = [node_tuple[1].name for node_tuple in node_tuple_list]
+        output_def, node_def, _ = node_tuple_list[0]
+        job_names = [job_def.name for _, _, job_def in node_tuple_list]
 
         # temporary workaround to retrieve asset partition definition from job
-        output = node_def.output_dict.get("result", None)
         partitions_def_data = None
 
-        if output and output._asset_partitions_def:  # pylint: disable=protected-access
-            partitions_def = output._asset_partitions_def  # pylint: disable=protected-access
+        if output_def and output_def.hardcoded_asset_key:
+            partitions_def = output_def.asset_partitions_def
             if partitions_def:
                 if isinstance(partitions_def, TimeWindowPartitionsDefinition):
                     partitions_def_data = external_time_window_partitions_definition_from_def(
@@ -656,6 +690,8 @@ def external_asset_graph_from_defs(
                 op_description=node_def.description,
                 job_names=job_names,
                 partitions_def_data=partitions_def_data,
+                output_name=output_def.name,
+                output_description=output_def.description,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, Out, DagsterInvariantViolationError
+from dagster import AssetKey, DagsterInvariantViolationError, Out
 from dagster.check import CheckError
 from dagster.core.asset_defs import AssetIn, ForeignAsset, asset, build_assets_job, multi_asset
 from dagster.core.host_representation.external_data import (

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,10 +1,7 @@
-from typing import Dict
-
 import pytest
-from dagster import AssetKey, DagsterInvariantViolationError, In, Out, job, pipeline
-from dagster.core.asset_defs import ForeignAsset
-from dagster.core.decorator_utils import get_function_params
-from dagster.core.definitions.decorators.op import _Op
+from dagster import AssetKey, Out, DagsterInvariantViolationError
+from dagster.check import CheckError
+from dagster.core.asset_defs import AssetIn, ForeignAsset, asset, build_assets_job, multi_asset
 from dagster.core.host_representation.external_data import (
     ExternalAssetDependedBy,
     ExternalAssetDependency,
@@ -16,33 +13,13 @@ from dagster.core.host_representation.external_data import (
 from dagster.serdes import deserialize_json_to_dagster_namedtuple
 
 
-def asset(fn):
-    asset_name = fn.__name__
-
-    ins: Dict[str, In] = {}
-    for input_param in get_function_params(fn):
-        input_param_name = input_param.name
-        asset_key = AssetKey(input_param_name)
-        ins[input_param_name] = In(asset_key=asset_key)
-
-    out = Out(asset_key=AssetKey(asset_name))
-    return _Op(
-        name=asset_name,
-        ins=ins,
-        out=out,
-    )(fn)
-
-
-def test_single_asset_pipeline():
+def test_single_asset_job():
     @asset
     def asset1():
         return 1
 
-    @pipeline
-    def my_graph():
-        asset1()
-
-    external_asset_nodes = external_asset_graph_from_defs([my_graph], foreign_assets_by_key={})
+    assets_job = build_assets_job("assets_job", [asset1])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -51,12 +28,14 @@ def test_single_asset_pipeline():
             depended_by=[],
             op_name="asset1",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         )
     ]
 
 
-def test_two_asset_pipeline():
+def test_two_asset_job():
     @asset
     def asset1():
         return 1
@@ -65,11 +44,8 @@ def test_two_asset_pipeline():
     def asset2(asset1):
         assert asset1 == 1
 
-    @pipeline
-    def my_graph():
-        asset2(asset1())
-
-    external_asset_nodes = external_asset_graph_from_defs([my_graph], foreign_assets_by_key={})
+    assets_job = build_assets_job("assets_job", [asset1, asset2])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -82,7 +58,9 @@ def test_two_asset_pipeline():
             ],
             op_name="asset1",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
@@ -92,12 +70,50 @@ def test_two_asset_pipeline():
             depended_by=[],
             op_name="asset2",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
 
-def test_two_downstream_assets_pipeline():
+def test_input_name_matches_output_name():
+    not_result = ForeignAsset(key=AssetKey("not_result"), description=None)
+
+    @asset(ins={"result": AssetIn(asset_key=AssetKey("not_result"))})
+    def something(result):  # pylint: disable=unused-argument
+        pass
+
+    assets_job = build_assets_job("assets_job", [something], source_assets=[not_result])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey("not_result"),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey("something"), input_name="result"
+                )
+            ],
+            job_names=[],
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey("something"),
+            dependencies=[
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey("not_result"), input_name="result"
+                )
+            ],
+            depended_by=[],
+            op_name="something",
+            output_name="result",
+            job_names=["assets_job"],
+        ),
+    ]
+
+
+def test_two_downstream_assets_job():
     @asset
     def asset1():
         return 1
@@ -110,13 +126,8 @@ def test_two_downstream_assets_pipeline():
     def asset2_b(asset1):
         assert asset1 == 1
 
-    @pipeline
-    def my_graph():
-        r = asset1()
-        asset2_a(r)
-        asset2_b(r)
-
-    external_asset_nodes = external_asset_graph_from_defs([my_graph], foreign_assets_by_key={})
+    assets_job = build_assets_job("assets_job", [asset1, asset2_a, asset2_b])
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -132,7 +143,9 @@ def test_two_downstream_assets_pipeline():
             ],
             op_name="asset1",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2_a"),
@@ -142,7 +155,9 @@ def test_two_downstream_assets_pipeline():
             depended_by=[],
             op_name="asset2_a",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2_b"),
@@ -152,12 +167,14 @@ def test_two_downstream_assets_pipeline():
             depended_by=[],
             op_name="asset2_b",
             op_description=None,
-            job_names=["my_graph"],
+            job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
 
-def test_cross_pipeline_asset_dependency():
+def test_cross_job_asset_dependency():
     @asset
     def asset1():
         return 1
@@ -166,16 +183,10 @@ def test_cross_pipeline_asset_dependency():
     def asset2(asset1):
         assert asset1 == 1
 
-    @pipeline
-    def asset1_graph():
-        asset1()
-
-    @pipeline
-    def asset2_graph():
-        asset2()  # pylint: disable=no-value-for-parameter
-
+    assets_job1 = build_assets_job("assets_job1", [asset1])
+    assets_job2 = build_assets_job("assets_job2", [asset2], source_assets=[asset1])
     external_asset_nodes = external_asset_graph_from_defs(
-        [asset1_graph, asset2_graph], foreign_assets_by_key={}
+        [assets_job1, assets_job2], foreign_assets_by_key={}
     )
 
     assert external_asset_nodes == [
@@ -189,7 +200,9 @@ def test_cross_pipeline_asset_dependency():
             ],
             op_name="asset1",
             op_description=None,
-            job_names=["asset1_graph"],
+            job_names=["assets_job1"],
+            output_name="result",
+            output_description=None,
         ),
         ExternalAssetNode(
             asset_key=AssetKey("asset2"),
@@ -199,7 +212,9 @@ def test_cross_pipeline_asset_dependency():
             depended_by=[],
             op_name="asset2",
             op_description=None,
-            job_names=["asset2_graph"],
+            job_names=["assets_job2"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
@@ -209,17 +224,10 @@ def test_same_asset_in_multiple_pipelines():
     def asset1():
         return 1
 
-    @pipeline
-    def graph1():
-        asset1()
+    job1 = build_assets_job("job1", [asset1])
+    job2 = build_assets_job("job2", [asset1])
 
-    @pipeline
-    def graph2():
-        asset1()
-
-    external_asset_nodes = external_asset_graph_from_defs(
-        [graph1, graph2], foreign_assets_by_key={}
-    )
+    external_asset_nodes = external_asset_graph_from_defs([job1, job2], foreign_assets_by_key={})
 
     assert external_asset_nodes == [
         ExternalAssetNode(
@@ -228,7 +236,218 @@ def test_same_asset_in_multiple_pipelines():
             depended_by=[],
             op_name="asset1",
             op_description=None,
-            job_names=["graph1", "graph2"],
+            job_names=["job1", "job2"],
+            output_name="result",
+            output_description=None,
+        ),
+    ]
+
+
+def test_basic_multi_asset():
+    @multi_asset(
+        outs={
+            f"out{i}": Out(description=f"foo: {i}", asset_key=AssetKey(f"asset{i}"))
+            for i in range(10)
+        }
+    )
+    def assets():
+        pass
+
+    assets_job = build_assets_job("assets_job", [assets])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey(f"asset{i}"),
+            dependencies=[],
+            depended_by=[],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name=f"out{i}",
+            output_description=f"foo: {i}",
+        )
+        for i in range(10)
+    ]
+
+
+def test_inter_op_dependency():
+    @asset
+    def in1():
+        pass
+
+    @asset
+    def in2():
+        pass
+
+    @asset
+    def downstream(only_in, mixed, only_out):  # pylint: disable=unused-argument
+        pass
+
+    @multi_asset(
+        outs={"only_in": Out(), "mixed": Out(), "only_out": Out()},
+        internal_asset_deps={
+            "mixed": {AssetKey("in1"), AssetKey("only_in")},
+            "only_out": {AssetKey("only_in"), AssetKey("mixed")},
+        },
+    )
+    def assets(in1, in2):  # pylint: disable=unused-argument
+        pass
+
+    assets_job = build_assets_job("assets_job", [in1, in2, assets, downstream])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+    # sort so that test is deterministic
+    sorted_nodes = sorted(
+        [
+            node._replace(
+                dependencies=sorted(node.dependencies, key=lambda d: d.upstream_asset_key),
+                depended_by=sorted(node.depended_by, key=lambda d: d.downstream_asset_key),
+            )
+            for node in external_asset_nodes
+        ],
+        key=lambda n: n.asset_key,
+    )
+
+    assert sorted_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey(["downstream"]),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["mixed"]), input_name="mixed"),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_in"]), input_name="only_in"
+                ),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_out"]), input_name="only_out"
+                ),
+            ],
+            depended_by=[],
+            op_name="downstream",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["in1"]),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(downstream_asset_key=AssetKey(["mixed"]), input_name="in1"),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_in"]), input_name="in1"
+                ),
+            ],
+            op_name="in1",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["in2"]),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_in"]), input_name="in2"
+                )
+            ],
+            op_name="in2",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="result",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["mixed"]),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"]), input_name="in1"),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_in"]), output_name="only_in"
+                ),
+            ],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["downstream"]), input_name="mixed"
+                ),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_out"]), output_name="mixed"
+                ),
+            ],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="mixed",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["only_in"]),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in1"]), input_name="in1"),
+                ExternalAssetDependency(upstream_asset_key=AssetKey(["in2"]), input_name="in2"),
+            ],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["downstream"]), input_name="only_in"
+                ),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["mixed"]), output_name="only_in"
+                ),
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["only_out"]), output_name="only_in"
+                ),
+            ],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="only_in",
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey(["only_out"]),
+            dependencies=[
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["mixed"]), output_name="mixed"
+                ),
+                ExternalAssetDependency(
+                    upstream_asset_key=AssetKey(["only_in"]), output_name="only_in"
+                ),
+            ],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey(["downstream"]), input_name="only_out"
+                ),
+            ],
+            op_name="assets",
+            op_description=None,
+            job_names=["assets_job"],
+            output_name="only_out",
+        ),
+    ]
+
+
+def test_source_not_foreign_asset():
+
+    foo = ForeignAsset(key=AssetKey("foo"), description=None)
+
+    @asset
+    def bar(foo):  # pylint: disable=unused-argument
+        pass
+
+    assets_job = build_assets_job("assets_job", [bar], source_assets=[foo])
+
+    external_asset_nodes = external_asset_graph_from_defs([assets_job], foreign_assets_by_key={})
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey("foo"),
+            op_description=None,
+            dependencies=[],
+            depended_by=[ExternalAssetDependedBy(AssetKey("bar"), input_name="foo")],
+            job_names=[],
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey("bar"),
+            op_name="bar",
+            op_description=None,
+            dependencies=[ExternalAssetDependency(AssetKey("foo"), input_name="foo")],
+            depended_by=[],
+            job_names=["assets_job"],
+            output_name="result",
         ),
     ]
 
@@ -265,9 +484,7 @@ def test_used_foreign_asset():
     def foo(bar):
         assert bar
 
-    @job
-    def job1():
-        foo()  # pylint: disable=no-value-for-parameter
+    job1 = build_assets_job("job1", [foo], source_assets=[bar])
 
     external_asset_nodes = external_asset_graph_from_defs(
         [job1], foreign_assets_by_key={AssetKey("bar"): bar}
@@ -291,6 +508,8 @@ def test_used_foreign_asset():
             ],
             depended_by=[],
             job_names=["job1"],
+            output_name="result",
+            output_description=None,
         ),
     ]
 
@@ -302,13 +521,33 @@ def test_foreign_asset_conflicts_with_asset():
     def bar():
         pass
 
-    @job
-    def job1():
-        bar()  # pylint: disable=no-value-for-parameter
+    job1 = build_assets_job("job1", [bar])
 
     with pytest.raises(DagsterInvariantViolationError):
         external_asset_graph_from_defs(
             [job1], foreign_assets_by_key={AssetKey("bar"): bar_foreign_asset}
+        )
+
+
+def test_input_name_or_output_name_dep_by():
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependedBy(
+            downstream_asset_key=AssetKey("bar"), input_name="foo", output_name="foo"
+        )
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependedBy(
+            downstream_asset_key=AssetKey("bar"), input_name=None, output_name=None
+        )
+
+
+def test_input_name_or_output_name_dependency():
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependency(
+            upstream_asset_key=AssetKey("bar"), input_name="foo", output_name="foo"
+        )
+    with pytest.raises(CheckError, match="Exactly one"):
+        ExternalAssetDependency(
+            upstream_asset_key=AssetKey("bar"), input_name=None, output_name=None
         )
 
 


### PR DESCRIPTION
A third crack at this implementation, this time with no user facing changes except for an extra argument to multi_asset :)

Here, we "compile" the asset-level information into the Job/Op layer by stashing it in a particular metadata field, rather than adding a new top level attribute to the OutputDefinition (and adjacent) objects. 