### PR TITLE
Fix deadlock with large output (#6435)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,7 @@
 [settings]
 
 line_length=100
-sections=FUTURE,STDLIB,THIRDPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section = THIRDPARTY
 multi_line_output=3
 case_sensitive=True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,7 @@
 [settings]
 
 line_length=100
-sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,LOCALFOLDER
 default_section = THIRDPARTY
 multi_line_output=3
 case_sensitive=True

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
@@ -26,6 +26,16 @@ def test_execute_file(tmp_file):
         assert retcode == 0
 
 
+def test_execute_file_large_buffered_output(tmp_file):
+    large_string = "0123456789" * (6600)  # bigger than 2**16 buffer
+    with tmp_file(f"echo -n {large_string}") as (tmp_path, tmp_file):
+        output, retcode = execute_script_file(
+            tmp_file, output_logging="BUFFER", log=logging, cwd=tmp_path
+        )
+        assert retcode == 0
+        assert output == large_string
+
+
 def test_env(tmp_file):
     cmd = "echo $TEST_VAR"
     res, retcode = execute(

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
@@ -36,6 +36,16 @@ def test_execute_file_large_buffered_output(tmp_file):
         assert output == large_string
 
 
+def test_execute_file_large_output_no_logging(tmp_file):
+    large_string = "0123456789" * (6600)  # bigger than 2**16 buffer
+    with tmp_file(f"echo -n {large_string}") as (tmp_path, tmp_file):
+        output, retcode = execute_script_file(
+            tmp_file, output_logging="NONE", log=logging, cwd=tmp_path
+        )
+        assert retcode == 0
+        assert output == ""
+
+
 def test_env(tmp_file):
     cmd = "echo $TEST_VAR"
     res, retcode = execute(

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
@@ -46,6 +46,16 @@ def test_execute_file_large_output_no_logging(tmp_file):
         assert output == ""
 
 
+def test_execute_file_large_line_stream_output(tmp_file):
+    large_string = "0123456789" * (100000)  # one giant line > 2**16 buffer
+    with tmp_file(f"echo -n {large_string}") as (tmp_path, tmp_file):
+        output, retcode = execute_script_file(
+            tmp_file, output_logging="STREAM", log=logging, cwd=tmp_path
+        )
+        assert retcode == 0
+        assert output == large_string
+
+
 def test_env(tmp_file):
     cmd = "echo $TEST_VAR"
     res, retcode = execute(


### PR DESCRIPTION
## Summary
As described in #6435, output wasn't properly read with `BUFFER` or `NONE` specified for `output_logging`. This is fixed to properly use `.communicate()`.

## Test Plan
I added tests that deadlock with the initial implementation, but pass with the new implementation.

FWIW, I benchmarked whether it's faster to `"".join(lines)` for stream output or use a `StringIO`.

```python
$ ipython

In [1]: paste
import random
from io import StringIO

def makeline():
    length = random.randrange(20,100)
    return 'a'*length + '\n'

source = [makeline() for i in range(100000)]

def time_join(source):
    lines = []
    for line in source:
        lines.append(line)
    return "".join(lines)

def time_buffer(source):
    io = StringIO()
    for line in source:
        io.write(line)
    return io.getvalue()
## -- End pasted text --

In [2]: %timeit time_join(source)
7.66 ms ± 119 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [3]: %timeit time_buffer(source)
8.49 ms ± 78.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

I also added a test to prove that `STREAM` logging doesn't deadlock even with very long lines.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.

----

A few slight changes in behavior I'll note:

- I moved the validation check of `output_logging` to the beginning of the function. This will now fail before it opens the process.
- I don't capture output from the subprocess at all if `NONE` logging is specified.
- I specify the encoding in the `Popen` constructor so a separate `.decode()` isn't needed. So, this will fail in a different place (sooner) if invalid UTF-8 is output from the subprocess. You may want to consider specifying `errors='replace'` ([docs for codecs error handlers](https://docs.python.org/3/library/codecs.html#error-handlers)) to be more resilient in case of bad data.
- I added `FIRSTPARTY` to the isort config because it was failing without specifying all possible sections.