### PR TITLE
update error message when output can't be pickled by fs_io_manager

### DIFF
--- a/python_modules/dagster/dagster/core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_io_manager.py
@@ -122,7 +122,7 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
         with open(filepath, self.write_mode) as write_obj:
             try:
                 pickle.dump(obj, write_obj, PICKLE_PROTOCOL)
-            except Exception as e:
+            except (AttributeError, RecursionError, ImportError, pickle.PicklingError):
                 executor = context.step_context.pipeline_def.mode_definitions[0].executor_defs[0]
 
                 raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_io_manager.py
@@ -126,6 +126,8 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
                 executor = context.step_context.pipeline_def.mode_definitions[0].executor_defs[0]
 
                 if isinstance(e, RecursionError):
+                    # if obj can't be pickled because of RecursionError then __str__() will also
+                    # throw a RecursionError
                     obj_repr = f"{obj.__class__} exceeds recursion limit and"
                 else:
                     obj_repr = obj.__str__()

--- a/python_modules/dagster/dagster/core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_io_manager.py
@@ -136,7 +136,7 @@ class PickledObjectFilesystemIOManager(MemoizableIOManager):
                     f"Object {obj_repr} is not picklable. You are currently using the "
                     f"fs_io_manager and the {executor.name}. You will need to use a different "
                     "io manager to continue using this output. For example, you can use the "
-                    "mem_io_manager with an in process executor.\n"
+                    "mem_io_manager with the in_process_executor.\n"
                     "For more information on io managers, visit "
                     "https://docs.dagster.io/concepts/io-management/io-managers \n"
                     "For more information on executors, vist "

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -103,6 +103,7 @@ def test_fs_io_manager_memoization():
             assert result.success
             assert len(recorder) == 1
 
+
 def test_fs_io_manager_unpicklable():
     @op
     def unpicklable_output():
@@ -133,5 +134,3 @@ def test_fs_io_manager_unpicklable():
                 "https://docs.dagster.io/deployment/executors#overview"
             ):
                 my_job.execute_in_process(instance=instance)
-
-            # assert False

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_fs_io_manager.py
@@ -1,8 +1,8 @@
 import os
 import pickle
 import tempfile
-import pytest
 
+import pytest
 from dagster import ModeDefinition, execute_pipeline, graph, op, pipeline, solid
 from dagster.core.definitions.version_strategy import VersionStrategy
 from dagster.core.errors import DagsterInvariantViolationError
@@ -105,7 +105,8 @@ def test_fs_io_manager_memoization():
 
 
 # lamdba functions can't be pickled (pickle.PicklingError)
-l = lambda x: x*x
+l = lambda x: x * x
+
 
 def test_fs_io_manager_unpicklable():
     @op
@@ -113,6 +114,7 @@ def test_fs_io_manager_unpicklable():
         # locally defined functions can't be pickled (AttributeError)
         def local_func():
             return 1
+
         return local_func
 
     @op
@@ -149,21 +151,19 @@ def test_fs_io_manager_unpicklable():
 
             local_func_job = local_func_graph.to_job(resource_defs={"io_manager": io_manager})
             with pytest.raises(
-                DagsterInvariantViolationError,
-                match=r"Object .* is not picklable. .*"
+                DagsterInvariantViolationError, match=r"Object .* is not picklable. .*"
             ):
                 local_func_job.execute_in_process(instance=instance)
 
             lambda_job = lambda_graph.to_job(resource_defs={"io_manager": io_manager})
             with pytest.raises(
-                DagsterInvariantViolationError,
-                match=r"Object .* is not picklable. .*"
+                DagsterInvariantViolationError, match=r"Object .* is not picklable. .*"
             ):
                 lambda_job.execute_in_process(instance=instance)
 
             recursion_job = recursion_limit_graph.to_job(resource_defs={"io_manager": io_manager})
             with pytest.raises(
                 DagsterInvariantViolationError,
-                match=r"Object .* exceeds recursion limit and is not picklable. .*"
+                match=r"Object .* exceeds recursion limit and is not picklable. .*",
             ):
                 recursion_job.execute_in_process(instance=instance)


### PR DESCRIPTION
Catches when an output can't be pickled by the fs_io_manager and raises a more helpful error message (#5551)

Pickle is a bit ambiguous about what Exceptions could be thrown by pickle.dumps()
From the docs `pickle.PicklingError` will be thrown when an object is unpicklable, `RecursionError` will be thrown when trying to pickle recursive structures that exceed the python recursion limit. For `AttributeError` and `ImportError` the docs state:
"""
Note that functions (built-in and user-defined) are pickled by "fully qualified" name reference, not by value. This means that only the function name is pickled, along with the name of the module the function is defined in. Neither the function's code, nor any of its function attributes are pickled. Thus the defining module must be importable in the unpickling environment, and the module must contain the named object, otherwise an exception will be raised. [3]

[3] The exception raised will likely be an ImportError or an AttributeError but it could be something else.
"""

This leaves it open that another error could be thrown if an object isn't pickleable 

This PR manages `AttributeError` `ImportError` `RecursionError` and `pickle.PicklingError` but if one of the "something else" exceptions is thrown by pickle, the original error will be raised to the user. 

Unfortunately, `pickle` doesn't provide a function to check if an object is picklable. the library `dill` does, but `dill` is capable of pickling more types of objects than `pickle` and can only tell us if `dill` can pickle the object. So first checking if `dill` says an object is picklable wouldn't help us if we then use `pickle.dumps()`. 

Definitely open to suggestions on other ways to  handle this error 