### PR TITLE
Remove experimental from EcsRunLauncher, add missing IAM role

### DIFF
--- a/examples/deploy_ecs/docker-compose.yml
+++ b/examples/deploy_ecs/docker-compose.yml
@@ -72,8 +72,9 @@ services:
             - "ecs:RegisterTaskDefinition"
             - "ecs:RunTask"
             - "ecs:TagResource"
+            - "secretsmanager:DescribeSecret"
             - "secretsmanager:ListSecrets"
-            - "secretsManager:GetSecretValue"
+            - "secretsmanager:GetSecretValue"
           Resource:
             - "*"
         - Effect: "Allow"
@@ -104,7 +105,6 @@ services:
       DAGSTER_POSTGRES_PASSWORD: "postgres_password"
       DAGSTER_POSTGRES_USER: "postgres_user"
       DAGSTER_CURRENT_IMAGE: "$REGISTRY_URL/deploy_ecs/user_code"
-
 
   # This service runs the postgres DB used by dagster for run storage, schedule
   # storage, and event log storage. In a real deployment, you might choose to

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -7,7 +7,6 @@ from dagster.core.events import EngineEventData, EventMetadataEntry
 from dagster.core.launcher.base import LaunchRunContext, RunLauncher
 from dagster.grpc.types import ExecuteRunArgs
 from dagster.serdes import ConfigurableClass
-from dagster.utils.backcompat import experimental
 
 from ..secretsmanager import get_secrets_from_arns, get_tagged_secrets
 from .tasks import default_ecs_task_definition, default_ecs_task_metadata
@@ -15,7 +14,6 @@ from .tasks import default_ecs_task_definition, default_ecs_task_metadata
 Tags = namedtuple("Tags", ["arn", "cluster", "cpu", "memory"])
 
 
-@experimental
 class EcsRunLauncher(RunLauncher, ConfigurableClass):
     def __init__(
         self,


### PR DESCRIPTION
Summary:
- We use this permission in get_secrets_from_arns, be sure its included in the example
- Remove experimental from EcsRunLauncher now that it's been put through its paces more

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.