### PR TITLE
Add dbt-snowflake to hacker-news deps

### DIFF
--- a/examples/hacker_news/setup.py
+++ b/examples/hacker_news/setup.py
@@ -25,6 +25,7 @@ setup(
         "dagster-postgres",
         "dagstermill",
         "dbt-core",
+        "dbt-snowflake",
         "mock",
         # DataFrames were not written to Snowflake, causing errors
         "pandas<1.4.0",

--- a/examples/hacker_news_assets/setup.py
+++ b/examples/hacker_news_assets/setup.py
@@ -24,6 +24,7 @@ setup(
         "dagster-slack",
         "dagster-postgres",
         "dbt-core",
+        "dbt-snowflake",
         "mock",
         # DataFrames were not written to Snowflake, causing errors
         "pandas<1.4.0",


### PR DESCRIPTION
Summary:
My best guess for why https://demo.elementl.dev/instance/runs/6921c459-6d57-4843-9c38-e3145d206935?logKey=hn_dbt_run is failing - switching from depending on dbt to just dbt-core does not seem to have been sufficient.

Test Plan: Run internal integraion tests against this rev, hopefully they will pass

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.