### PR TITLE
Only run Bk on all python versions on master/release branches

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -1,7 +1,8 @@
 from collections import namedtuple
 
-from .defines import TOX_MAP, SupportedPython, SupportedPythons
+from .defines import TOX_MAP, SupportedPython
 from .step_builder import StepBuilder
+from .utils import get_python_versions_for_branch
 
 MYPY_EXCLUDES = [
     "python_modules/dagit",
@@ -79,7 +80,7 @@ class ModuleBuildSpec(
             cls,
             directory,
             env_vars or [],
-            supported_pythons or SupportedPythons,
+            supported_pythons or get_python_versions_for_branch(),
             extra_cmds_fn,
             depends_on_fn,
             tox_file,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -1,21 +1,23 @@
 import os
 
-from ..defines import (
-    GCP_CREDS_LOCAL_FILE,
-    TOX_MAP,
-    ExamplePythons,
-    SupportedPython,
-    SupportedPythons,
-)
+from ..defines import GCP_CREDS_LOCAL_FILE, TOX_MAP, ExamplePythons, SupportedPython
 from ..images.versions import COVERAGE_IMAGE_VERSION
 from ..module_build_spec import ModuleBuildSpec
 from ..step_builder import StepBuilder
-from ..utils import check_for_release, connect_sibling_docker_container, network_buildkite_container
+from ..utils import (
+    check_for_release,
+    connect_sibling_docker_container,
+    get_python_versions_for_branch,
+    is_release_branch,
+    network_buildkite_container,
+)
 from .docs import docs_steps
 from .helm import helm_steps
 from .test_images import core_test_image_depends_fn, publish_test_images, test_image_depends_fn
 
 GIT_REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..")
+
+branch_name = os.getenv("BUILDKITE_BRANCH")
 
 
 def airflow_extra_cmds_fn(version):
@@ -355,11 +357,15 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
     ModuleBuildSpec(
         "python_modules/libraries/dagster-airflow",
         # omit python 3.9 until we add support
-        supported_pythons=[
-            SupportedPython.V3_6,
-            SupportedPython.V3_7,
-            SupportedPython.V3_8,
-        ],
+        supported_pythons=(
+            [
+                SupportedPython.V3_6,
+                SupportedPython.V3_7,
+                SupportedPython.V3_8,
+            ]
+            if (branch_name == "master" or is_release_branch(branch_name))
+            else [SupportedPython.V3_8]
+        ),
         env_vars=[
             "AIRFLOW_HOME",
             "AWS_ACCOUNT_ID",
@@ -506,7 +512,7 @@ def pipenv_smoke_tests():
         .run(*smoke_test_steps)
         .on_unit_image(version)
         .build()
-        for version in SupportedPythons
+        for version in get_python_versions_for_branch()
     ]
 
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/test_images.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/test_images.py
@@ -1,6 +1,7 @@
-from ..defines import TOX_MAP, SupportedPython, SupportedPythons
+from ..defines import TOX_MAP, SupportedPython
 from ..images.versions import TEST_IMAGE_BUILDER_VERSION, UNIT_IMAGE_VERSION
 from ..step_builder import StepBuilder
+from ..utils import get_python_versions_for_branch
 
 
 def publish_test_images():
@@ -8,7 +9,9 @@ def publish_test_images():
     the dagster-k8s tests
     """
     tests = []
-    for version in SupportedPythons:
+    for version in get_python_versions_for_branch(
+        pr_versions=[SupportedPython.V3_8, SupportedPython.V3_9]
+    ):
         key = _test_image_step(version)
         tests.append(
             StepBuilder(f":docker: test-image {version}", key=key)

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -3,6 +3,8 @@ import subprocess
 
 import yaml
 
+from .defines import SupportedPython, SupportedPythons
+
 DAGIT_PATH = "js_modules/dagit"
 
 
@@ -94,3 +96,15 @@ def connect_sibling_docker_container(network_name, container_name, env_variable)
 
 def is_release_branch(branch_name: str):
     return branch_name.startswith("release-")
+
+
+def get_python_versions_for_branch(pr_versions=None):
+    pr_versions = pr_versions if pr_versions != None else [SupportedPython.V3_9]
+
+    # Run one representative version on PRs, the full set of python versions on master after
+    # landing and on release branches before shipping
+    branch_name = os.getenv("BUILDKITE_BRANCH")
+    if branch_name == "master" or is_release_branch(branch_name):
+        return SupportedPythons
+    else:
+        return pr_versions


### PR DESCRIPTION
Summary:
Adding 3.9 (and soon 3.10) is good, but the sheer number of BK steps running on every PR is getting pretty overwhelming and hard to parse, and actual version differences are quite rare in my experience (to the point where I'd personally be fine waiting to see them in master). There's probably a cost control benefit here as well, but that wasn't the main reason I was inspired to send this out.

None of this is held strongly.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.