### PR TITLE
Allow noneable secrets_tag that doesn't hit secretsmanager

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -2,11 +2,12 @@ from collections import namedtuple
 
 import boto3
 from botocore.exceptions import ClientError
-from dagster import Array, Field, StringSource, check
+from dagster import Array, Field, Noneable, StringSource, check
 from dagster.core.events import EngineEventData, EventMetadataEntry
 from dagster.core.launcher.base import LaunchRunContext, RunLauncher
 from dagster.grpc.types import ExecuteRunArgs
 from dagster.serdes import ConfigurableClass
+from dagster.utils import merge_dicts
 
 from ..secretsmanager import get_secrets_from_arns, get_tagged_secrets
 from .tasks import default_ecs_task_definition, default_ecs_task_metadata
@@ -81,7 +82,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                 ),
             ),
             "secrets_tag": Field(
-                StringSource,
+                Noneable(StringSource),
                 is_required=False,
                 default_value="dagster",
                 description=(
@@ -234,10 +235,14 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             metadata,
             image,
             self.container_name,
-            secrets={
-                **get_tagged_secrets(self.secrets_manager, self.secrets_tag),
-                **get_secrets_from_arns(self.secrets_manager, self.secrets),
-            },
+            secrets=merge_dicts(
+                (
+                    get_tagged_secrets(self.secrets_manager, self.secrets_tag)
+                    if self.secrets_tag
+                    else {}
+                ),
+                get_secrets_from_arns(self.secrets_manager, self.secrets),
+            ),
         )
 
     def _task_metadata(self):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 from collections import namedtuple
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,6 +53,13 @@ def instance(instance_cm, configured_secret):
         yield dagster_instance
 
 
+@pytest.fixture
+def instance_empty_secrets_tag(instance_cm, configured_secret):
+    config = {"secrets_tag": None}
+    with instance_cm(config) as dagster_instance:
+        yield dagster_instance
+
+
 def test_secrets(
     ecs, secrets_manager, instance, workspace, run, tagged_secret, other_secret, configured_secret
 ):
@@ -75,3 +83,31 @@ def test_secrets(
 
     # But no other secrets
     assert len(secrets) == 2
+
+
+def test_empty_secrets(
+    ecs, secrets_manager, instance_empty_secrets_tag, workspace, pipeline, external_pipeline
+):
+    initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+
+    run = instance_empty_secrets_tag.create_run_for_pipeline(
+        pipeline,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )
+
+    m = MagicMock()
+    with patch.object(instance_empty_secrets_tag.run_launcher, "secrets_manager", new=m):
+        instance_empty_secrets_tag.launch_run(run.run_id, workspace)
+        m.get_paginator.assert_not_called()
+        m.describe_secret.assert_not_called()
+
+    # A new task definition is created
+    task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    assert len(task_definitions) == len(initial_task_definitions) + 1
+    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    task_definition = task_definition["taskDefinition"]
+
+    # No secrets
+    assert "secrets" not in task_definition["containerDefinitions"][0]


### PR DESCRIPTION
Summary:
A user reported they don't have access to secrets_manager. Defaulting to a 'dagster' tag is probably fine, but should include a way for them to set the tag to empty if they want zero secret manager calls.

Test Plan: Bk

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.