### PR TITLE
Fix add_output_metadata in dynamic output, multi-output case

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/core/definitions/solid_invocation.py
@@ -341,6 +341,10 @@ def _type_check_output(
                 metadata_entries=type_check.metadata_entries,
                 dagster_type=dagster_type,
             )
+
+        context.observe_output(
+            output.output_name, output.mapping_key if isinstance(output, DynamicOutput) else None
+        )
         return output
     else:
         dagster_type = output_def.dagster_type

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -16,6 +16,7 @@ from typing import (
     NamedTuple,
     Optional,
     Set,
+    Union,
     cast,
 )
 
@@ -385,6 +386,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             self._step_output_capture = {}
 
         self._output_metadata: Dict[str, Any] = {}
+        self._seen_outputs: Dict[str, Union[str, Set[str]]] = {}
 
     @property
     def step(self) -> ExecutionStep:
@@ -506,6 +508,19 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         return False
 
+    def observe_output(self, output_name: str, mapping_key: Optional[str] = None) -> None:
+        if mapping_key:
+            if output_name not in self._seen_outputs:
+                self._seen_outputs[output_name] = set()
+            cast(Set[str], self._seen_outputs[output_name]).add(mapping_key)
+        else:
+            self._seen_outputs[output_name] = "seen"
+
+    def has_seen_output(self, output_name: str, mapping_key: Optional[str] = None) -> bool:
+        if mapping_key:
+            return output_name in self._seen_outputs and mapping_key in self._seen_outputs
+        return output_name in self._seen_outputs
+
     def add_output_metadata(
         self,
         metadata: Mapping[str, Any],
@@ -515,6 +530,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         if output_name is None and len(self.solid_def.output_defs) == 1:
             output_def = self.solid_def.output_defs[0]
+            output_name = output_def.name
         elif output_name is None:
             raise DagsterInvariantViolationError(
                 "Attempted to log metadata without providing output_name, but multiple outputs exist. Please provide an output_name to the invocation of `context.add_output_metadata`."
@@ -522,6 +538,15 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         else:
             output_def = self.solid_def.output_def_named(output_name)
 
+        if self.has_seen_output(output_name, mapping_key):
+            output_desc = (
+                f"output '{output_def.name}'"
+                if not mapping_key
+                else f"output '{output_def.name}' with mapping_key '{mapping_key}'"
+            )
+            raise DagsterInvariantViolationError(
+                f"In {self.solid_def.node_type_str} '{self.solid.name}', attempted to log output metadata for {output_desc} which has already been yielded. Metadata must be logged before the output is yielded."
+            )
         if output_def.is_dynamic and not mapping_key:
             raise DagsterInvariantViolationError(
                 f"In {self.solid_def.node_type_str} '{self.solid.name}', attempted to log metadata for dynamic output '{output_def.name}' without providing a mapping key. When logging metadata for a dynamic output, it is necessary to provide a mapping key."
@@ -529,9 +554,10 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
         output_name = output_def.name
         if output_name in self._output_metadata:
-            raise DagsterInvariantViolationError(
-                f"In {self.solid_def.node_type_str} '{self.solid.name}', attempted to log metadata for output '{output_name}' more than once."
-            )
+            if not mapping_key or mapping_key in self._output_metadata[output_name]:
+                raise DagsterInvariantViolationError(
+                    f"In {self.solid_def.node_type_str} '{self.solid.name}', attempted to log metadata for output '{output_name}' more than once."
+                )
         if mapping_key:
             if not output_name in self._output_metadata:
                 self._output_metadata[output_name] = {}

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -518,7 +518,9 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     def has_seen_output(self, output_name: str, mapping_key: Optional[str] = None) -> bool:
         if mapping_key:
-            return output_name in self._seen_outputs and mapping_key in self._seen_outputs
+            return (
+                output_name in self._seen_outputs and mapping_key in self._seen_outputs[output_name]
+            )
         return output_name in self._seen_outputs
 
     def add_output_metadata(

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -9,6 +9,8 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterType,
     DagsterTypeCheckDidNotPass,
+    DynamicOut,
+    DynamicOutput,
     ExpectationResult,
     In,
     Materialization,
@@ -663,3 +665,54 @@ def test_log_metadata_multi_output():
 
     assert first_output_event.event_specific_data.metadata_entries[0].label == "foo"
     assert second_output_event.event_specific_data.metadata_entries[0].label == "bar"
+
+
+def test_log_metadata_after_output():
+    @op
+    def the_op(context):
+        yield Output(1)
+        context.add_output_metadata({"foo": "bar"})
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="In op 'the_op', attempted to log output metadata for output 'result' which has already been yielded. Metadata must be logged before the output is yielded.",
+    ):
+        execute_op_in_graph(the_op)
+
+
+def test_log_metadata_multiple_dynamic_outputs():
+    @op(out={"out1": DynamicOut(), "out2": DynamicOut()})
+    def the_op(context):
+        context.add_output_metadata({"one": "one"}, output_name="out1", mapping_key="one")
+        yield DynamicOutput(value=1, output_name="out1", mapping_key="one")
+        context.add_output_metadata({"two": "two"}, output_name="out1", mapping_key="two")
+        context.add_output_metadata({"three": "three"}, output_name="out2", mapping_key="three")
+        yield DynamicOutput(value=2, output_name="out1", mapping_key="two")
+        yield DynamicOutput(value=3, output_name="out2", mapping_key="three")
+        context.add_output_metadata({"four": "four"}, output_name="out2", mapping_key="four")
+        yield DynamicOutput(value=4, output_name="out2", mapping_key="four")
+
+    result = execute_op_in_graph(the_op)
+    assert result.success
+    events = result.all_node_events
+    output_event_one = events[1]
+    assert output_event_one.event_specific_data.mapping_key == "one"
+    assert output_event_one.event_specific_data.metadata_entries[0].label == "one"
+    output_event_two = events[3]
+    assert output_event_two.event_specific_data.mapping_key == "two"
+    assert output_event_two.event_specific_data.metadata_entries[0].label == "two"
+    output_event_three = events[5]
+    assert output_event_three.event_specific_data.mapping_key == "three"
+    assert output_event_three.event_specific_data.metadata_entries[0].label == "three"
+    output_event_four = events[7]
+    assert output_event_four.event_specific_data.mapping_key == "four"
+    assert output_event_four.event_specific_data.metadata_entries[0].label == "four"
+
+
+def test_log_metadata_after_dynamic_output():
+    @op(out=DynamicOut())
+    def the_op(context):
+        yield DynamicOutput(1, mapping_key="one")
+        context.add_output_metadata({"foo": "bar"}, mapping_key="one")
+
+    execute_op_in_graph(the_op)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -715,4 +715,8 @@ def test_log_metadata_after_dynamic_output():
         yield DynamicOutput(1, mapping_key="one")
         context.add_output_metadata({"foo": "bar"}, mapping_key="one")
 
-    execute_op_in_graph(the_op)
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="In op 'the_op', attempted to log output metadata for output 'result' with mapping_key 'one' which has already been yielded. Metadata must be logged before the output is yielded.",
+    ):
+        execute_op_in_graph(the_op)


### PR DESCRIPTION
This PR greatly expands the test coverage for `add_output_metadata`, and fixes functionality in multi-output and dynamic output cases.
- We previously could not handle the multi-output case, because we needed to destruct the existing output object that is yielded, and construct a new one with the expected metadata. 
- We also didn't properly handle storing of mapping keys in the dynamic case.
- We didn't have explicit invocation APIs around add_output_metadata, this adds.