### PR TITLE
bump js wait time for docs search reindex

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -50,6 +50,6 @@
     }
   },
   "js_render": true,
-  "js_wait": 3,
+  "js_wait": 5,
   "nb_hits": 9458
 }


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
we've seen search results became off after the indexing script was run in recent releases. it's because the indexing got time out for some pages some times. 
 
i think we can do better than this but just bumping for now..

better could be better error or warning on timeout, or some smarter config that im not aware of and i need to study more about algollia. 



## Test Plan
local indexing is fine



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.