### PR TITLE
Add config schema to a bunch of API docs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -143,10 +143,6 @@ Run launcher
 
 .. autoclass:: DefaultRunLauncher
 
-.. currentmodule:: dagster_graphql.launcher
-
-See also: :py:class:`dagster_k8s.K8sRunLauncher`.
-
 ----
 
 Run coordinator
@@ -156,7 +152,8 @@ Run coordinator
 
 .. autoclass:: DefaultRunCoordinator
 
-.. autoclass:: QueuedRunCoordinator
+.. autoconfigurable:: QueuedRunCoordinator
+  :annotation: RunCoordinator
 
 ----
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-celery-k8s.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-celery-k8s.rst
@@ -6,7 +6,8 @@ APIs
 
 .. currentmodule:: dagster_celery_k8s
 
-.. autoclass:: CeleryK8sRunLauncher
+.. autoconfigurable:: CeleryK8sRunLauncher
+  :annotation: RunLauncher
 
 .. autoconfigurable:: celery_k8s_job_executor
   :annotation: ExecutorDefinition

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-docker.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-docker.rst
@@ -6,7 +6,8 @@ APIs
 
 .. currentmodule:: dagster_docker
 
-.. autoclass:: DockerRunLauncher
+.. autoconfigurable:: DockerRunLauncher
+  :annotation: RunLauncher
 
 .. autoconfigurable:: docker_executor
   :annotation: ExecutorDefinition

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-k8s.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-k8s.rst
@@ -11,7 +11,8 @@ APIs
 ----
 .. currentmodule:: dagster_k8s
 
-.. autoclass:: K8sRunLauncher
+.. autoconfigurable:: K8sRunLauncher
+  :annotation: RunLauncher
 
 .. autoconfigurable:: k8s_job_executor
   :annotation: ExecutorDefinition

--- a/docs/sphinx/sections/api/apidocs/schedules-sensors.rst
+++ b/docs/sphinx/sections/api/apidocs/schedules-sensors.rst
@@ -18,7 +18,8 @@ Schedules
 
 .. currentmodule:: dagster.core.scheduler
 
-.. autoclass:: DagsterDaemonScheduler
+.. autoconfigurable:: DagsterDaemonScheduler
+  :annotation: Scheduler
 
 Partitioned Schedules
 =====================

--- a/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
@@ -25,8 +25,8 @@ class RunQueueConfig(
 
 class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
     """
-    Sends runs to the dequeuer process via the run storage. Requires the external process to be
-    alive for runs to be launched.
+    Enqueues runs via the run storage, to be deqeueued by the Dagster Daemon process. Requires
+    the Dagster Daemon process to be alive in order for runs to be launched.
     """
 
     def __init__(
@@ -67,7 +67,11 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
     @classmethod
     def config_type(cls):
         return {
-            "max_concurrent_runs": Field(config=IntSource, is_required=False),
+            "max_concurrent_runs": Field(
+                config=IntSource,
+                is_required=False,
+                description="The maximum number of runs that are allowed to be in progress at once",
+            ),
             "tag_concurrency_limits": Field(
                 config=Noneable(
                     Array(
@@ -87,8 +91,18 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
                     )
                 ),
                 is_required=False,
+                description="A set of limits that are applied to runs with particular tags. "
+                "If a value is set, the limit is applied to only that key-value pair. "
+                "If no value is set, the limit is applied across all values of that key. "
+                "If the value is set to a dict with `applyLimitPerUniqueValue: true`, the limit "
+                "will apply to the number of unique values for that key.",
             ),
-            "dequeue_interval_seconds": Field(config=IntSource, is_required=False),
+            "dequeue_interval_seconds": Field(
+                config=IntSource,
+                is_required=False,
+                description="The interval in seconds at which the Dagster Daemon "
+                "should periodically check the run queue for new runs to launch.",
+            ),
         }
 
     @classmethod

--- a/python_modules/dagster/dagster/core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/core/scheduler/scheduler.py
@@ -237,20 +237,6 @@ class DagsterDaemonScheduler(Scheduler, ConfigurableClass):
     """Default scheduler implementation that submits runs from the `dagster-daemon`
     long-lived process. Periodically checks each running schedule for execution times that don't
     have runs yet and launches them.
-
-    Args:
-        max_catchup_runs (int): For partitioned schedules, controls the maximum number of past
-            partitions for each schedule that will be considered when looking for missing
-            runs (defaults to 5). Generally this parameter will only come into play if the scheduler
-            falls behind or launches after experiencing downtime. This parameter will not be checked for
-            schedules without partition sets (for example, schedules created using the @schedule
-            decorator) - only the most recent execution time will be considered for those schedules.
-
-            Note that no matter what this value is, the scheduler will never launch a run from a time
-            before the schedule was turned on (even if the start_date on the schedule is earlier) - if
-            you want to launch runs for earlier partitions, launch a backfill.
-        max_tick_retries (int): For each schedule tick that raises an error, how many times to retry
-            that tick (defaults to 0).
     """
 
     def __init__(
@@ -269,8 +255,28 @@ class DagsterDaemonScheduler(Scheduler, ConfigurableClass):
     @classmethod
     def config_type(cls):
         return {
-            "max_catchup_runs": Field(IntSource, is_required=False),
-            "max_tick_retries": Field(IntSource, is_required=False),
+            "max_catchup_runs": Field(
+                IntSource,
+                is_required=False,
+                default_value=DEFAULT_MAX_CATCHUP_RUNS,
+                description="""For partitioned schedules, controls the maximum number of past
+            partitions for each schedule that will be considered when looking for missing
+            runs . Generally this parameter will only come into play if the scheduler
+            falls behind or launches after experiencing downtime. This parameter will not be checked for
+            schedules without partition sets (for example, schedules created using the @schedule
+            decorator) - only the most recent execution time will be considered for those schedules.
+
+            Note that no matter what this value is, the scheduler will never launch a run from a time
+            before the schedule was turned on (even if the start_date on the schedule is earlier) - if
+            you want to launch runs for earlier partitions, launch a backfill.
+            """,
+            ),
+            "max_tick_retries": Field(
+                IntSource,
+                default_value=0,
+                is_required=False,
+                description="For each schedule tick that raises an error, how many times to retry that tick",
+            ),
         }
 
     @staticmethod

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -37,7 +37,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
            and each step execution spawns a step execution Kubernetes Job. See the implementation
            defined in :py:func:`dagster_celery_k8.executor.create_k8s_job_task`.
 
-    You may configure a Dagster instance to use this RunLauncher by adding a section to your
+    You can configure a Dagster instance to use this RunLauncher by adding a section to your
     ``dagster.yaml`` like the following:
 
     .. code-block:: yaml
@@ -52,59 +52,6 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             broker: "some_celery_broker_url"
             backend: "some_celery_backend_url"
 
-    As always when using a :py:class:`~dagster.serdes.ConfigurableClass`, the values
-    under the ``config`` key of this YAML block will be passed to the constructor. The full list
-    of acceptable values is given below by the constructor args.
-
-    Args:
-        instance_config_map (str): The ``name`` of an existing Volume to mount into the pod in
-            order to provide a ConfigMap for the Dagster instance. This Volume should contain a
-            ``dagster.yaml`` with appropriate values for run storage, event log storage, etc.
-        dagster_home (str): The location of DAGSTER_HOME in the Job container; this is where the
-            ``dagster.yaml`` file will be mounted from the instance ConfigMap specified above.
-        postgres_password_secret (str): The name of the Kubernetes Secret where the postgres
-            password can be retrieved. Will be mounted and supplied as an environment variable to
-            the Job Pod.
-        load_incluster_config (Optional[bool]):  Set this value if you are running the launcher
-            within a k8s cluster. If ``True``, we assume the launcher is running within the target
-            cluster and load config using ``kubernetes.config.load_incluster_config``. Otherwise,
-            we will use the k8s config specified in ``kubeconfig_file`` (using
-            ``kubernetes.config.load_kube_config``) or fall back to the default kubeconfig. Default:
-            ``True``.
-        kubeconfig_file (Optional[str]): The kubeconfig file from which to load config. Defaults to
-            None (using the default kubeconfig).
-        broker (Optional[str]): The URL of the Celery broker.
-        backend (Optional[str]): The URL of the Celery backend.
-        include (List[str]): List of includes for the Celery workers
-        config_source: (Optional[dict]): Additional settings for the Celery app.
-        retries: (Optional[dict]): Default retry configuration for Celery tasks.
-        env_config_maps (Optional[List[str]]): A list of custom ConfigMapEnvSource names from which to
-            draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
-            https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container
-        env_secrets (Optional[List[str]]): A list of custom Secret names from which to
-            draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
-            https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
-        volume_mounts (Optional[List[Permissive]]): A list of volume mounts to include in the job's
-            container. Default: ``[]``. See:
-            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
-        volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
-            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
-        service_account_name (Optional[str]): The name of the Kubernetes service account under which to run
-            the Job. Defaults to "default"
-        image_pull_secrets (Optional[List[Dict[str, str]]]): Optionally, a list of dicts, each of
-            which corresponds to a Kubernetes ``LocalObjectReference`` (e.g.,
-            ``{'name': 'myRegistryName'}``). This allows you to specify the ```imagePullSecrets`` on
-            a pod basis. Typically, these will be provided through the service account, when needed,
-            and you will not need to pass this argument. See:
-            https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-            and https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podspec-v1-core.
-        image_pull_policy (Optional[str]): Allows the image pull policy to be overridden, e.g. to
-            facilitate local testing with `kind <https://kind.sigs.k8s.io/>`_. Default:
-            ``"IfNotPresent"``. See: https://kubernetes.io/docs/concepts/containers/images/#updating-images.
-        labels (Optional[Dict[str, str]]): Additional labels that should be included in the Job's Pod. See:
-            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-        fail_pod_on_run_failure (Optional[bool): Whether the launched Kubernetes Jobs and Pods
-            should fail if the Dagster run fails. Default: False
     """
 
     def __init__(

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -19,22 +19,7 @@ DOCKER_CONTAINER_ID_TAG = "docker/container_id"
 
 
 class DockerRunLauncher(RunLauncher, ConfigurableClass):
-    """Launches runs in a Docker container.
-
-    Args:
-        image (Optional[str]): The docker image to be used if the repository does not specify one.
-        registry (Optional[Dict[str, str]]): Information for using a non-local docker registry.
-            If set, should include ``url``, ``username``, and ``password`` keys.
-        env_vars (Optional[List[str]]): The list of environment variables names to forward to the
-            docker container.
-        network (Optional[str]): Name of the network this container to which to connect the
-            launched container at creation time. DEPRECATED, prefer networks
-        networks (Optional[List[str]]): List of networks to which to connect the
-            launched container at creation time.
-        container_kwargs(Optional[Dict[str, Any]]): Additional kwargs to pass into
-            containers.create. See https://docker-py.readthedocs.io/en/stable/containers.html
-            for the full list of available options.
-    """
+    """Launches runs in a Docker container."""
 
     def __init__(
         self,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -302,9 +302,27 @@ class DagsterK8sJobConfig(
                     "``dagster.yaml`` file will be mounted from the instance ConfigMap specified here. "
                     "Defaults to /opt/dagster/dagster_home.",
                 ),
-                "load_incluster_config": Field(bool, is_required=False, default_value=True),
-                "kubeconfig_file": Field(Noneable(str), is_required=False, default_value=None),
-                "fail_pod_on_run_failure": Field(bool, is_required=False),
+                "load_incluster_config": Field(
+                    bool,
+                    is_required=False,
+                    default_value=True,
+                    description="""Set this value if you are running the launcher
+            within a k8s cluster. If ``True``, we assume the launcher is running within the target
+            cluster and load config using ``kubernetes.config.load_incluster_config``. Otherwise,
+            we will use the k8s config specified in ``kubeconfig_file`` (using
+            ``kubernetes.config.load_kube_config``) or fall back to the default kubeconfig.""",
+                ),
+                "kubeconfig_file": Field(
+                    Noneable(str),
+                    is_required=False,
+                    default_value=None,
+                    description="The kubeconfig file from which to load config. Defaults to using the default kubeconfig.",
+                ),
+                "fail_pod_on_run_failure": Field(
+                    bool,
+                    is_required=False,
+                    description="Whether the launched Kubernetes Jobs and Pods should fail if the Dagster run fails",
+                ),
             },
             DagsterK8sJobConfig.config_type_job(),
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -27,78 +27,20 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
     Encapsulates each run in a separate, isolated invocation of ``dagster-graphql``.
 
-    You may configure a Dagster instance to use this RunLauncher by adding a section to your
+    You can configure a Dagster instance to use this RunLauncher by adding a section to your
     ``dagster.yaml`` like the following:
 
     .. code-block:: yaml
 
         run_launcher:
-            module: dagster_k8s.launcher
-            class: K8sRunLauncher
-            config:
-                service_account_name: your_service_account
-                job_image: my_project/dagster_image:latest
-                instance_config_map: dagster-instance
-                postgres_password_secret: dagster-postgresql-secret
+          module: dagster_k8s.launcher
+          class: K8sRunLauncher
+          config:
+            service_account_name: your_service_account
+            job_image: my_project/dagster_image:latest
+            instance_config_map: dagster-instance
+            postgres_password_secret: dagster-postgresql-secret
 
-    As always when using a :py:class:`~dagster.serdes.ConfigurableClass`, the values
-    under the ``config`` key of this YAML block will be passed to the constructor. The full list
-    of acceptable values is given below by the constructor args.
-
-    Args:
-        service_account_name (str): The name of the Kubernetes service account under which to run
-            the Job. Defaults to "default"
-        job_image (Optional[str]): The ``name`` of the image to use for the Job's Dagster container.
-            This image will be run with the command
-            ``dagster api execute_run``.
-            When using user code deployments, the image should not be specified.
-        instance_config_map (str): The ``name`` of an existing Volume to mount into the pod in
-            order to provide a ConfigMap for the Dagster instance. This Volume should contain a
-            ``dagster.yaml`` with appropriate values for run storage, event log storage, etc.
-        postgres_password_secret (Optional[str]): The name of the Kubernetes Secret where the postgres
-            password can be retrieved. Will be mounted and supplied as an environment variable to
-            the Job Pod.
-        dagster_home (str): The location of DAGSTER_HOME in the Job container; this is where the
-            ``dagster.yaml`` file will be mounted from the instance ConfigMap specified above.
-        load_incluster_config (Optional[bool]):  Set this value if you are running the launcher
-            within a k8s cluster. If ``True``, we assume the launcher is running within the target
-            cluster and load config using ``kubernetes.config.load_incluster_config``. Otherwise,
-            we will use the k8s config specified in ``kubeconfig_file`` (using
-            ``kubernetes.config.load_kube_config``) or fall back to the default kubeconfig. Default:
-            ``True``.
-        kubeconfig_file (Optional[str]): The kubeconfig file from which to load config. Defaults to
-            None (using the default kubeconfig).
-        image_pull_secrets (Optional[List[Dict[str, str]]]): Optionally, a list of dicts, each of
-            which corresponds to a Kubernetes ``LocalObjectReference`` (e.g.,
-            ``{'name': 'myRegistryName'}``). This allows you to specify the ```imagePullSecrets`` on
-            a pod basis. Typically, these will be provided through the service account, when needed,
-            and you will not need to pass this argument.
-            See:
-            https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-            and https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podspec-v1-core.
-        image_pull_policy (Optional[str]): Allows the image pull policy to be overridden, e.g. to
-            facilitate local testing with `kind <https://kind.sigs.k8s.io/>`_. Default:
-            ``"IfNotPresent"``. See: https://kubernetes.io/docs/concepts/containers/images/#updating-images.
-        job_namespace (Optional[str]): The namespace into which to launch new jobs. Note that any
-            other Kubernetes resources the Job requires (such as the service account) must be
-            present in this namespace. Default: ``"default"``
-        env_config_maps (Optional[List[str]]): A list of custom ConfigMapEnvSource names from which to
-            draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
-            https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container
-        env_secrets (Optional[List[str]]): A list of custom Secret names from which to
-            draw environment variables (using ``envFrom``) for the Job. Default: ``[]``. See:
-            https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
-        env_vars (Optional[List[str]]): A list of environment variables to inject into the Job.
-            Default: ``[]``. See: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
-        volume_mounts (Optional[List[Permissive]]): A list of volume mounts to include in the job's
-            container. Default: ``[]``. See:
-            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volumemount-v1-core
-        volumes (Optional[List[Permissive]]): A list of volumes to include in the Job's Pod. Default: ``[]``. See:
-            https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#volume-v1-core
-        labels (Optional[Dict[str, str]]): Additional labels that should be included in the Job's Pod. See:
-            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-        fail_pod_on_run_failure (Optional[bool): Whether the launched Kubernetes Jobs and Pods
-            should fail if the Dagster run fails. Default: False
     """
 
     def __init__(


### PR DESCRIPTION
Summary:
Take advantage of owen's recent change that lets you expose config schema on run launchers, run coordinators, and the scheduler class on the instance.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.