### PR TITLE
reduce the number of calls to fetch run step stats

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+
 from dagster import PipelineDefinition, PipelineRunStatus, check
 from dagster.config.validate import validate_config
 from dagster.core.definitions import create_run_config_schema


### PR DESCRIPTION
## Summary
Getting reports of timeouts on some of the `AssetNodeDefinitionRunsQuery` queries.  It could be that the actual run_step_stats call is just slow for their runs, but it doesn't help that we're fetching this very aggressively for all uncompleted runs, every 5 seconds.

Will send out a separate diff to bump the polling interval.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.