### PR TITLE
bump polling to relieve expensive run_step_stats queries

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -72,7 +72,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
       },
     },
     notifyOnNetworkStatusChange: true,
-    pollInterval: 5 * 1000,
+    pollInterval: 15 * 1000,
   });
 
   let liveDataByNode: LiveData = {};


### PR DESCRIPTION
## Summary
Makes for a much worse demo, but does increase the interval for some of our most expensive queries.


## Test Plan
Inspection


