### PR TITLE
[dagster-airbyte] dagster airbyte integration improvements

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -97,5 +97,9 @@ def airbyte_sync_op(context):
         )
     yield Output(
         airbyte_output,
-        metadata={**airbyte_output.job_details["attempts"][-1]["attempt"]["totalStats"]},
+        metadata={
+            **airbyte_output.job_details.get("attempts", [{}])[-1]
+            .get("attempt", {})
+            .get("totalStats", {})
+        },
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -1,6 +1,7 @@
-from dagster import Field, In, Noneable, Nothing, Out, Output, op
+from dagster import Field, In, Noneable, Nothing, Out, Output, op, Bool, Array
 from dagster_airbyte.resources import DEFAULT_POLL_INTERVAL_SECONDS
 from dagster_airbyte.types import AirbyteOutput
+from dagster_airbyte.utils import generate_materializations
 
 
 @op(
@@ -30,6 +31,22 @@ from dagster_airbyte.types import AirbyteOutput
             default_value=None,
             description="The maximum time that will waited before this operation is timed out. By "
             "default, this will never time out.",
+        ),
+        "yield_materializations": Field(
+            config=Bool,
+            default_value=True,
+            description=(
+                "If True, materializations corresponding to the results of the Airbyte sync will "
+                "be yielded when the op executes."
+            ),
+        ),
+        "asset_key_prefix": Field(
+            config=Array(str),
+            default_value=["airbyte"],
+            description=(
+                "If provided and yield_materializations is True, these components will be used to "
+                "prefix the generated asset keys."
+            ),
         ),
     },
     tags={"kind": "airbyte"},
@@ -74,4 +91,11 @@ def airbyte_sync_op(context):
         poll_interval=context.op_config["poll_interval"],
         poll_timeout=context.op_config["poll_timeout"],
     )
-    yield Output(airbyte_output)
+    if context.op_config["yield_materializations"]:
+        yield from generate_materializations(
+            airbyte_output, asset_key_prefix=context.op_config["asset_key_prefix"]
+        )
+    yield Output(
+        airbyte_output,
+        metadata={**airbyte_output.job_details["attempts"][-1]["attempt"]["totalStats"]},
+    )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -1,4 +1,4 @@
-from dagster import Field, In, Noneable, Nothing, Out, Output, op, Bool, Array
+from dagster import Array, Bool, Field, In, Noneable, Nothing, Out, Output, op
 from dagster_airbyte.resources import DEFAULT_POLL_INTERVAL_SECONDS
 from dagster_airbyte.types import AirbyteOutput
 from dagster_airbyte.utils import generate_materializations

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -130,7 +130,7 @@ class AirbyteResource:
             time.sleep(poll_interval)
             job_details = self.get_job_status(job_id)
             cur_attempt = len(job_details.get("attempts", []))
-            # spit out the Airbyte log info
+            # spit out the available Airbyte log info
             if cur_attempt:
                 log_lines = (
                     job_details["attempts"][logged_attempts].get("logs", {}).get("logLines", [])
@@ -138,7 +138,9 @@ class AirbyteResource:
 
                 for line in log_lines[logged_lines:]:
                     sys.stdout.write(line + "\n")
+                    sys.stdout.flush()
                 logged_lines = len(log_lines)
+
                 # if there's a next attempt, this one will have no more log messages
                 if logged_attempts < cur_attempt - 1:
                     logged_lines = 0

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -73,6 +73,7 @@ class AirbyteResource:
                     url=self.api_base_url + endpoint,
                     headers=headers,
                     json=data,
+                    timeout=5,
                 )
                 response.raise_for_status()
                 return response.json()

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 import time
 from typing import Any, Dict, Optional
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -9,6 +9,7 @@ class AirbyteOutput(
         "_AirbyteOutput",
         [
             ("job_details", Dict[str, Any]),
+            ("connection_details", Dict[str, Any]),
         ],
     )
 ):
@@ -17,6 +18,9 @@ class AirbyteOutput(
 
     Attributes:
         job_details (Dict[str, Any]):
-            The raw Airbyte API response containing the details of the sync'd connector. For info
+            The raw Airbyte API response containing the details of the initiated job. For info
             on the schema of this dictionary, see: https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/jobs/get
+        connection_details (Dict[str, Any]):
+            The raw Airbyte API response containing the details of the sync'd connector. For info
+            on the schema of this dictionary, see: https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/get
     """

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -1,7 +1,7 @@
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
-from dagster import EventMetadata, AssetMaterialization
-from dagster.core.definitions.event_metadata.table import TableSchema, TableColumn
+from dagster import AssetMaterialization, EventMetadata
+from dagster.core.definitions.event_metadata.table import TableColumn, TableSchema
 from dagster_airbyte.types import AirbyteOutput
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -1,0 +1,48 @@
+from typing import Dict, Any, List
+
+from dagster import EventMetadata, AssetMaterialization
+from dagster.core.definitions.event_metadata.table import TableSchema, TableColumn
+from dagster_airbyte.types import AirbyteOutput
+
+
+def _materialization_for_stream(
+    name: str,
+    stream_info: Dict[str, Any],
+    stream_stats: Dict[str, Any],
+    asset_key_prefix: List[str],
+) -> AssetMaterialization:
+
+    return AssetMaterialization(
+        asset_key=asset_key_prefix + [name],
+        metadata={
+            "schema": EventMetadata.table_schema(
+                TableSchema(
+                    columns=[
+                        TableColumn(name=name, type=str(info["type"]))
+                        for name, info in stream_info["stream"]["jsonSchema"]["properties"].items()
+                    ]
+                )
+            ),
+            **{k: v for k, v in stream_stats.items() if v is not None},
+        },
+    )
+
+
+def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]):
+    prefix = output.connection_details["prefix"]
+    stream_info = {
+        prefix + stream["stream"]["name"]: stream
+        for stream in output.connection_details["syncCatalog"]["streams"]
+        if stream["config"]["selected"]
+    }
+
+    stream_stats = output.job_details["attempts"][-1]["attempt"]["streamStats"]
+    print(stream_info)
+    for stats in stream_stats:
+        name = stats["streamName"]
+        yield _materialization_for_stream(
+            name,
+            stream_info[name],
+            stats["stats"],
+            asset_key_prefix=asset_key_prefix,
+        )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -23,6 +23,9 @@ def _materialization_for_stream(
                     ]
                 )
             ),
+            "columns": ",".join(
+                name for name in stream_info["stream"]["jsonSchema"]["properties"].keys()
+            ),
             **{k: v for k, v in stream_stats.items() if v is not None},
         },
     )
@@ -37,7 +40,6 @@ def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]
     }
 
     stream_stats = output.job_details["attempts"][-1]["attempt"]["streamStats"]
-    print(stream_info)
     for stats in stream_stats:
         name = stats["streamName"]
         yield _materialization_for_stream(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -32,19 +32,21 @@ def _materialization_for_stream(
 
 
 def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]):
-    prefix = output.connection_details["prefix"]
+    prefix = output.connection_details.get("prefix", "")
     stream_info = {
         prefix + stream["stream"]["name"]: stream
-        for stream in output.connection_details["syncCatalog"]["streams"]
-        if stream["config"]["selected"]
+        for stream in output.connection_details.get("syncCatalog", {}).get("streams", [])
+        if stream.get("config", {}).get("selected")
     }
 
-    stream_stats = output.job_details["attempts"][-1]["attempt"]["streamStats"]
+    stream_stats = (
+        output.job_details.get("attempts", [{}])[-1].get("attempt", {}).get("streamStats", [])
+    )
     for stats in stream_stats:
         name = stats["streamName"]
         yield _materialization_for_stream(
             name,
             stream_info[name],
-            stats["stats"],
+            stats.get("stats", {}),
             asset_key_prefix=asset_key_prefix,
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_ops.py
@@ -35,11 +35,13 @@ def test_airbyte_sync_op():
 
     with responses.RequestsMock() as rsps:
 
+        rsps.add(rsps.POST, f"{ab_url}/connections/get", json={"name": "some_connection"})
         rsps.add(rsps.POST, f"{ab_url}/connections/sync", json={"job": {"id": 1}})
         rsps.add(rsps.POST, f"{ab_url}/jobs/get", json={"job": {"id": 1, "status": "running"}})
         rsps.add(rsps.POST, f"{ab_url}/jobs/get", json={"job": {"id": 1, "status": "succeeded"}})
 
         result = airbyte_sync_job.execute_in_process()
         assert result.output_for_node("airbyte_sync_op") == AirbyteOutput(
-            job_details={"id": 1, "status": "succeeded"},
+            job_details={"job": {"id": 1, "status": "succeeded"}},
+            connection_details={"name": "some_connection"},
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -17,12 +17,6 @@ def test_trigger_connection():
     )
     responses.add(
         method=responses.POST,
-        url=ab_resource.api_base_url + "/connections/get",
-        json={},
-        status=200,
-    )
-    responses.add(
-        method=responses.POST,
         url=ab_resource.api_base_url + "/connections/sync",
         json={"job": {"id": 1}},
         status=200,
@@ -33,12 +27,7 @@ def test_trigger_connection():
 
 def test_trigger_connection_fail():
     ab_resource = airbyte_resource(
-        build_init_resource_context(
-            config={"host": "some_host", "port": "8000", "request_max_retries": 2}
-        )
-    )
-    responses.add(
-        method=responses.POST, url=ab_resource.api_base_url + "/connections/sync", status=500
+        build_init_resource_context(config={"host": "some_host", "port": "8000"})
     )
     with pytest.raises(Failure, match="Exceeded max number of retries"):
         ab_resource.sync_and_poll("some_connection")

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -1,6 +1,6 @@
 import pytest
 import responses
-from dagster import Failure, build_init_resource_context, EventMetadataEntry
+from dagster import EventMetadataEntry, Failure, build_init_resource_context
 from dagster_airbyte import AirbyteOutput, AirbyteState, airbyte_resource
 from dagster_airbyte.utils import generate_materializations
 


### PR DESCRIPTION
adds two new features:

1. logs from Airbyte are spit out to stdout so that they show up in the compute logs pane (honestly, we should probably be doing this for the dbt integration as well because it doesn't mangle the colors).
2. generate asset materializations for the tables that get sync'd

still needs tests