### PR TITLE
Default helm chart to enable the QueuedRunCoordinator

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -916,7 +916,7 @@ dagsterDaemon:
   heartbeatTolerance: 300
 
   runCoordinator:
-    enabled: false
+    enabled: true
 
     # Type can be one of [
     #   QueuedRunCoordinator,
@@ -924,10 +924,12 @@ dagsterDaemon:
     #  ]
     type: QueuedRunCoordinator
     config:
+      # https://docs.dagster.io/deployment/run-coordinator#limiting-run-concurrency
       queuedRunCoordinator:
-        maxConcurrentRuns: ~
+        maxConcurrentRuns: 10
         tagConcurrencyLimits: []
-        dequeueIntervalSeconds: ~
+        # How often to check for runs to launch
+        dequeueIntervalSeconds: 5
 
     ##  Uncomment this configuration if the CustomRunCoordinator is selected.
     ##  Using this setting requires a custom Daemon image that defines the user specified

--- a/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/core/run_coordinator/queued_run_coordinator.py
@@ -37,6 +37,8 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
         inst_data=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
+
+        # NOTE: If changing these defaults, also update the Helm values
         self._max_concurrent_runs = check.opt_int_param(
             max_concurrent_runs, "max_concurrent_runs", 10
         )


### PR DESCRIPTION
For 0.14.0

A @alangenfeld pointed out, either choice here has the potential to surprise users. Enabling it means they can hit the 10 run default limit, while disabling it means they can accidentally overwhelm their cluster (though it's probably possible for 10 runs to do this to a small cluster anyway).

My take is that we're better at surfacing (and therefore making it easier for users to fix) that runs are stuck in the queue (you'll see it on the runs page, with a link to the queue configuration) versus surfacing that your cluster is getting overwhelmed.