### PR TITLE
[Helm] remove liveness and startup probes, add readiness

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -66,6 +66,35 @@ spec:
                 optional: true
             {{- end }}
           resources: {{ $deployment.resources | toYaml | nindent 12 }}
+        {{- if $deployment.readinessProbe }}
+          {{- if not $deployment.readinessProbe.exec }}
+          readinessProbe:
+            exec:
+              command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
+            {{- if hasKey $deployment.readinessProbe "initialDelaySeconds" }}
+            initialDelaySeconds:
+              {{- toYaml $deployment.readinessProbe.initialDelaySeconds | nindent 14 }}
+            {{- end }}
+            {{- if hasKey $deployment.readinessProbe "periodSeconds" }}
+            periodSeconds:
+              {{- toYaml $deployment.readinessProbe.periodSeconds | nindent 14 }}
+            {{- end }}
+            {{- if hasKey $deployment.readinessProbe "timeoutSeconds" }}
+            timeoutSeconds:
+              {{- toYaml $deployment.readinessProbe.timeoutSeconds | nindent 14 }}
+            {{- end }}
+            {{- if hasKey $deployment.readinessProbe "successThreshold" }}
+            successThreshold:
+              {{- toYaml $deployment.readinessProbe.successThreshold | nindent 14 }}
+            {{- end }}
+            {{- if hasKey $deployment.readinessProbe "failureThreshold" }}
+            failureThreshold:
+              {{- toYaml $deployment.readinessProbe.failureThreshold | nindent 14 }}
+            {{- end }}
+          {{- else}}
+          readinessProbe: {{ $deployment.readinessProbe | toYaml | nindent 12 }}
+          {{- end }}
+        {{- end }}
         {{- if $deployment.livenessProbe }}
           {{- if not $deployment.livenessProbe.exec }}
           livenessProbe:

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -146,6 +146,12 @@
             "properties": {},
             "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
         },
+        "ReadinessProbe": {
+            "title": "ReadinessProbe",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+        },
         "StartupProbe": {
             "title": "StartupProbe",
             "type": "object",
@@ -236,6 +242,9 @@
                 },
                 "livenessProbe": {
                     "$ref": "#/definitions/LivenessProbe"
+                },
+                "readinessProbe": {
+                    "$ref": "#/definitions/ReadinessProbe"
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -101,33 +101,22 @@ deployments:
     securityContext: {}
     resources: {}
     labels: {}
-    # Liveness Probe and Startup Probe are optional. For more configuration docs, see:
+    # Readiness probe detects when the pod is ready to serve requests.
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
-    # Note that Startup Probe is only available as a kubernetes v1.16+ feature.
-    livenessProbe:
-      # If `livenessProbe` has no `exec` field, then the following default will be used:
+    readinessProbe:
+      # If `readinessProbe` has no `exec` field, then the following default will be used:
       # exec:
       #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
-      # initialDelaySeconds: 60
       periodSeconds: 20
       timeoutSeconds: 3
       successThreshold: 1
       failureThreshold: 3
 
-    # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
-    # then liveness probe takes over.
-    # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-    # `initialDelaySeconds: 60` under `livenessProbe`
+    # As of 0.14.0, liveness probes are disabled by default. If you want to enable them, it's recommended to also
+    # enable startup probes.
+    livenessProbe: {}
     startupProbe:
-      enabled: true
-      # If `startupProbe` has no `exec` field, then the following default will be used:
-      # exec:
-      #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
-      initialDelaySeconds: 0
-      periodSeconds: 10
-      timeoutSeconds: 3
-      successThreshold: 1
-      failureThreshold: 3
+      enabled: false
 
     service:
       annotations: {}

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -77,6 +77,7 @@ class Daemon(BaseModel):
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
     livenessProbe: kubernetes.LivenessProbe
+    readinessProbe: kubernetes.ReadinessProbe
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
     runMonitoring: Dict[str, Any]

--- a/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
@@ -31,6 +31,7 @@ class Dagit(BaseModel):
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
+    readinessProbe: kubernetes.ReadinessProbe
     livenessProbe: kubernetes.LivenessProbe
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -21,6 +21,7 @@ class UserDeployment(BaseModel):
     securityContext: Optional[kubernetes.SecurityContext]
     resources: Optional[kubernetes.Resources]
     livenessProbe: Optional[kubernetes.LivenessProbe]
+    readinessProbe: Optional[kubernetes.ReadinessProbe]
     startupProbe: Optional[kubernetes.StartupProbe]
     labels: Optional[Dict[str, str]]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]

--- a/helm/dagster/schema/schema/charts/utils/kubernetes.py
+++ b/helm/dagster/schema/schema/charts/utils/kubernetes.py
@@ -112,6 +112,11 @@ class LivenessProbe(BaseModel):
         schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Probe")}
 
 
+class ReadinessProbe(BaseModel):
+    class Config:
+        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Probe")}
+
+
 class StartupProbe(BaseModel):
     enabled: bool = True
 

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -72,6 +72,21 @@ def test_startup_probe_enabled(deployment_template: HelmTemplate, enabled: bool)
     assert (container.startup_probe is not None) == enabled
 
 
+def test_readiness_probe(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(dagit=Dagit.construct())
+
+    dagit = deployment_template.render(helm_values)
+    assert len(dagit) == 1
+    dagit = dagit[0]
+
+    assert len(dagit.spec.template.spec.containers) == 1
+    container = dagit.spec.template.spec.containers[0]
+
+    assert container.startup_probe is None
+    assert container.liveness_probe is None
+    assert container.readiness_probe is not None
+
+
 def test_dagit_read_only_disabled(deployment_template: HelmTemplate):
     helm_values = DagsterHelmValues.construct()
 

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -390,6 +390,46 @@ def test_startup_probe_enabled(template: HelmTemplate, enabled: bool):
     assert (container.startup_probe is not None) == enabled
 
 
+def test_readiness_probes(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.readinessProbe = kubernetes.ReadinessProbe.construct(timeout_seconds=3)
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    assert container.startup_probe is None
+    assert container.startup_probe is None
+    assert container.readiness_probe is not None
+
+
+def test_readiness_probes_subchart(subchart_template: HelmTemplate):
+    deployment = create_simple_user_deployment(
+        "foo",
+    )
+    deployment.readinessProbe = kubernetes.ReadinessProbe.construct(timeout_seconds=3)
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = subchart_template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    assert container.startup_probe is None
+    assert container.startup_probe is None
+    assert container.readiness_probe is not None
+
+
 def test_startup_probe_exec(template: HelmTemplate):
     deployment = create_simple_user_deployment("foo")
     deployment.startupProbe = kubernetes.StartupProbe.construct(

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -108,6 +108,10 @@ spec:
           livenessProbe:
             {{- toYaml .Values.dagsterDaemon.livenessProbe | nindent 12 }}
           {{- end }}
+          {{- if .Values.dagsterDaemon.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dagsterDaemon.readinessProbe | nindent 12 }}
+          {{- end }}
           {{- if .Values.dagsterDaemon.startupProbe.enabled}}
           {{- $startupProbe := omit .Values.dagsterDaemon.startupProbe "enabled" }}
           startupProbe:

--- a/helm/dagster/templates/helpers/_deployment-dagit.tpl
+++ b/helm/dagster/templates/helpers/_deployment-dagit.tpl
@@ -103,6 +103,10 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.dagit.resources | nindent 12 }}
+        {{- if .Values.dagit.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dagit.readinessProbe | nindent 12 }}
+        {{- end }}
         {{- if .Values.dagit.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.dagit.livenessProbe | nindent 12 }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -255,6 +255,12 @@
             "type": "object",
             "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         },
+        "ReadinessProbe": {
+            "title": "ReadinessProbe",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.15.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+        },
         "LivenessProbe": {
             "title": "LivenessProbe",
             "type": "object",
@@ -343,6 +349,9 @@
                 "resources": {
                     "$ref": "#/definitions/Resources"
                 },
+                "readinessProbe": {
+                    "$ref": "#/definitions/ReadinessProbe"
+                },
                 "livenessProbe": {
                     "$ref": "#/definitions/LivenessProbe"
                 },
@@ -384,6 +393,7 @@
                 "podSecurityContext",
                 "securityContext",
                 "resources",
+                "readinessProbe",
                 "livenessProbe",
                 "startupProbe",
                 "annotations",
@@ -468,6 +478,9 @@
                 },
                 "livenessProbe": {
                     "$ref": "#/definitions/LivenessProbe"
+                },
+                "readinessProbe": {
+                    "$ref": "#/definitions/ReadinessProbe"
                 },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"
@@ -2206,6 +2219,9 @@
                 "livenessProbe": {
                     "$ref": "#/definitions/LivenessProbe"
                 },
+                "readinessProbe": {
+                    "$ref": "#/definitions/ReadinessProbe"
+                },
                 "startupProbe": {
                     "$ref": "#/definitions/StartupProbe"
                 },
@@ -2234,6 +2250,7 @@
                 "securityContext",
                 "resources",
                 "livenessProbe",
+                "readinessProbe",
                 "startupProbe",
                 "annotations",
                 "runMonitoring"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -125,32 +125,22 @@ dagit:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-  # Liveness probe detects when to restart dagit.
+  # Readiness probe detects when the pod is ready to serve requests.
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
-  livenessProbe:
+  readinessProbe:
     httpGet:
       path: "/dagit_info"
       port: 80
-    # initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 3
     successThreshold: 1
     failureThreshold: 3
-  # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
-  # then liveness probe takes over. Current delay is 2 min (10 sec * 12) but can be increased based
-  # on workspace load times.
-  # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-  # `initialDelaySeconds: 60` under `livenessProbe`
+
+  # As of 0.14.0, liveness probes are disabled by default. If you want to enable them, it's recommended to also
+  # enable startup probes.
+  livenessProbe: {}
   startupProbe:
-    enabled: true
-    httpGet:
-      path: "/dagit_info"
-      port: 80
-    initialDelaySeconds: 1
-    periodSeconds: 10
-    timeoutSeconds: 3
-    successThreshold: 1
-    failureThreshold: 12
+    enabled: false
 
 ####################################################################################################
 # Compute Log Manager: Configuration for the compute log manager
@@ -322,33 +312,22 @@ dagster-user-deployments:
       podSecurityContext: {}
       securityContext: {}
       resources: {}
-      # Liveness Probe and Startup Probe are optional. For more configuration docs, see:
+      # Readiness probe detects when the pod is ready to serve requests.
       # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
-      # Note that Startup Probe is only available as a kubernetes v1.16+ feature.
-      livenessProbe:
-        # If `livenessProbe` has no `exec` field, then the following default will be used:
+      readinessProbe:
+        # If `readinessProbe` has no `exec` field, then the following default will be used:
         # exec:
         #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
-        initialDelaySeconds: 0
         periodSeconds: 20
         timeoutSeconds: 3
         successThreshold: 1
         failureThreshold: 3
 
-      # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
-      # then liveness probe takes over.
-      # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-      # `initialDelaySeconds: 60` under `livenessProbe`
+      # As of 0.14.0, liveness probes are disabled by default. If you want to enable them, it's recommended to also
+      # enable startup probes.
+      livenessProbe: {}
       startupProbe:
-        enabled: true
-        # If `startupProbe` has no `exec` field, then the following default will be used:
-        # exec:
-        #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
-        initialDelaySeconds: 0
-        periodSeconds: 10
-        timeoutSeconds: 3
-        successThreshold: 1
-        failureThreshold: 3
+        enabled: false
 
       service:
         annotations: {}
@@ -1020,30 +999,11 @@ dagsterDaemon:
   securityContext: {}
   resources: {}
 
-  livenessProbe:
-    exec:
-      command:
-        - "dagster-daemon"
-        - "liveness-check"
-    # initialDelaySeconds: 60
-    periodSeconds: 30
-    failureThreshold: 3
-    timeoutSeconds: 3
-
-  # Startup probe (available in kubernetes v1.16+) is used at pod startup. Once it has succeeded,
-  # then liveness probe takes over. Current delay is 2 min (10 sec * 12) but can be increased based
-  # on workspace load times.
-  # If on kubernetes < v1.16, then disable `startupProbe` and comment in
-  # `initialDelaySeconds: 60` under `livenessProbe`
-  startupProbe:
-    enabled: true
-    exec:
-      command:
-        - "dagster-daemon"
-        - "liveness-check"
-    periodSeconds: 10
-    failureThreshold: 12
-    timeoutSeconds: 3
+  # As of 0.14.0, liveness probes are disabled by default. If you want to enable them, it's recommended to also
+  # enable startup probes.
+  livenessProbe: {}
+  readinessProbe: {}
+  startupProbe: {}
 
 ####################################################################################################
 # busybox: Configuration for the busybox image used to check connections

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -615,16 +615,6 @@ def helm_chart_for_k8s_run_launcher(
                 "runMonitoring": {"enabled": True, "pollIntervalSeconds": 5}
                 if run_monitoring
                 else {},
-                "startupProbe": {
-                    "periodSeconds": 10,
-                    "failureThreshold": 12,
-                    "timeoutSeconds": 12,
-                },
-                "livenessProbe": {
-                    "periodSeconds": 30,
-                    "failureThreshold": 12,
-                    "timeoutSeconds": 12,
-                },
             },
             "imagePullSecrets": [{"name": TEST_IMAGE_PULL_SECRET_NAME}],
         },
@@ -776,16 +766,6 @@ def _base_helm_config(docker_image):
             "env": {"TEST_SET_ENV_VAR": "test_dagit_env_var"},
             "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
             "envSecrets": [{"name": TEST_SECRET_NAME}],
-            "livenessProbe": {
-                "httpGet": {"path": "/dagit_info", "port": 80},
-                "periodSeconds": 20,
-                "failureThreshold": 3,
-            },
-            "startupProbe": {
-                "httpGet": {"path": "/dagit_info", "port": 80},
-                "failureThreshold": 6,
-                "periodSeconds": 10,
-            },
             "annotations": {"dagster-integration-tests": "dagit-pod-annotation"},
             "service": {"annotations": {"dagster-integration-tests": "dagit-svc-annotation"}},
         },
@@ -872,16 +852,6 @@ def _base_helm_config(docker_image):
             "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
             "envSecrets": [{"name": TEST_SECRET_NAME}],
             "annotations": {"dagster-integration-tests": "daemon-pod-annotation"},
-            "startupProbe": {
-                "periodSeconds": 10,
-                "failureThreshold": 12,
-                "timeoutSeconds": 12,
-            },
-            "livenessProbe": {
-                "periodSeconds": 30,
-                "failureThreshold": 12,
-                "timeoutSeconds": 12,
-            },
             "runMonitoring": {
                 "enabled": True,
                 "pollIntervalSeconds": 5,
@@ -913,16 +883,6 @@ def helm_chart_for_daemon(namespace, docker_image, should_cleanup=True):
                 "envConfigMaps": [{"name": TEST_CONFIGMAP_NAME}],
                 "envSecrets": [{"name": TEST_SECRET_NAME}],
                 "annotations": {"dagster-integration-tests": "daemon-pod-annotation"},
-                "startupProbe": {
-                    "periodSeconds": 10,
-                    "failureThreshold": 12,
-                    "timeoutSeconds": 12,
-                },
-                "livenessProbe": {
-                    "periodSeconds": 30,
-                    "failureThreshold": 12,
-                    "timeoutSeconds": 12,
-                },
             },
         },
     )


### PR DESCRIPTION
For 0.14.0

Remove the default liveness and startup probes from Dagit, user deployments, and the daemon. Replace them on dagit and user deployments with readiness probes. Leave the daemon with no probes.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

Why?
- https://blog.colinbreck.com/kubernetes-liveness-and-readiness-probes-how-to-avoid-shooting-yourself-in-the-foot/
- We've heard from users and observed ourselves that the liveness probes on dagit can fail under load, meaning we kill the pod. Headshotting dagit while it's falling behind on requests is counter productive. 
- Readiness probes don't cause the pod to restart, but they stop sending new traffic until the pod recovers. They also help the k8s api server manage rolling upgrades (don't tear down old pods until the new ones are ready)
- The daemon's liveness probe made a DB call. This violated best practices of not having external dependencies on the checks
- Since we're removing the livenessProbes, we can also remove the startupProbe. Readiness probes don't need one bc they don't kill the container

Risks
- if a process becomes wedged, it will no longer be automatically restarted. The fact that we have been running Cloud with only readiness probes brings me some ease. If a user has an issue, they can easily add back the livenessProbes (maybe we should leave them commented?)

Backcompat
- currently this breaks values.yamls that partially specified liveness probes (e.g. just changing the timeout), because we're no longer providing defaults for the rest of the probe. The error message isn't great, e.g.: `Error: INSTALLATION FAILED: Deployment.apps "dagster-daemon" is invalid: spec.template.spec.containers[0].livenessProbe: Required value: must specify a handler type` but I'm not sure about the other options. We could leave the defaults specified and add a new `enabled: false` field to livenessProbes, but that does leave those users with livenessProbe specs in their values.yamls that aren't actually taking effect, so maybe there's an advantage to calling attention to it? 

Should also solve https://github.com/dagster-io/dagster/pull/6437