### PR TITLE
remove output from tutorial first example

### DIFF
--- a/docs/content/tutorial/intro-tutorial/single-op-job.mdx
+++ b/docs/content/tutorial/intro-tutorial/single-op-job.mdx
@@ -39,8 +39,6 @@ def hello_cereal():
     lines = response.text.split("\n")
     cereals = [row for row in csv.DictReader(lines)]
     get_dagster_logger().info(f"Found {len(cereals)} cereals")
-
-    return cereals
 ```
 
 In this simple case, our op takes no arguments, and also returns no outputs. Don't worry, we'll soon encounter ops that are much more dynamic.
@@ -65,7 +63,7 @@ Assuming you’ve saved this job as `hello_cereal.py`, you can execute it via an
 
 ### Dagit
 
-To visualize your job (which only has one op) in Dagit, from the directory in which you've saved the job file, just run:
+To visualize your job (which only has one op) in Dagit, just run the following. Make sure you're in the directory in which you've saved the job file:
 
 ```bash
 dagit -f hello_cereal.py

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/single_solid_pipeline/hello_cereal.py
@@ -13,8 +13,6 @@ def hello_cereal():
     cereals = [row for row in csv.DictReader(lines)]
     get_dagster_logger().info(f"Found {len(cereals)} cereals")
 
-    return cereals
-
 
 # end_solid_marker
 

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/basics/test_hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/basics/test_hello_cereal.py
@@ -1,7 +1,4 @@
-from docs_snippets.intro_tutorial.basics.single_solid_pipeline.hello_cereal import (
-    hello_cereal,
-    hello_cereal_job,
-)
+from docs_snippets.intro_tutorial.basics.single_solid_pipeline.hello_cereal import hello_cereal_job
 from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
 
 
@@ -9,8 +6,3 @@ from docs_snippets.intro_tutorial.test_util import patch_cereal_requests
 def test_tutorial_intro_tutorial_hello_world():
     result = hello_cereal_job.execute_in_process()
     assert result.success
-
-
-@patch_cereal_requests
-def test_hello_cereal_solid():
-    assert len(hello_cereal()) == 77


### PR DESCRIPTION
The example contradicts the surrounding text.

I also made a separate minor understandability change.