### PR TITLE
[jobless assets 2/n] AssetCollection.build_job

### DIFF
--- a/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
@@ -46,7 +46,10 @@ class AssetCollection(
 
         if "root_manager" in resource_defs:
             raise DagsterInvalidDefinitionError(
-                "Resource dictionary included resource with key 'root_manager', which is a reserved resource keyword in Dagster. Please change this key, and then change all places that require this key to a new value."
+                "Resource dictionary included resource with key 'root_manager', "
+                "which is a reserved resource keyword in Dagster. Please change "
+                "this key, and then change all places that require this key to "
+                "a new value."
             )
         # In the case of collisions, merge_dicts takes values from the dictionary latest in the list, so we place the user provided resource defs after the defaults.
         resource_defs = merge_dicts(
@@ -102,7 +105,7 @@ class AssetCollection(
             resolved_op_selection_dict = parse_op_selection(mega_job_def, op_selection)
 
             included_assets = []
-            excluded_assets = list(self.source_assets)
+            excluded_assets: List[Union[AssetsDefinition, ForeignAsset]] = list(self.source_assets)
 
             op_names = set(list(resolved_op_selection_dict.keys()))
 
@@ -113,6 +116,8 @@ class AssetCollection(
                     excluded_assets.append(asset)
         else:
             included_assets = cast(List[AssetsDefinition], self.assets)
+            # Call to list(...) serves as a copy constructor, so that we don't
+            # accidentally add to the original list
             excluded_assets = list(self.source_assets)
 
         return build_assets_job(
@@ -125,7 +130,7 @@ class AssetCollection(
             tags=tags,
         )
 
-    def _parse_asset_selection(self, selection, job_name) -> List[str]:
+    def _parse_asset_selection(self, selection: Union[str, List[str]], job_name: str) -> List[str]:
         """Convert selection over asset key to selection over ops"""
 
         asset_keys_to_ops: Dict[str, List[OpDefinition]] = {}
@@ -163,7 +168,10 @@ class AssetCollection(
             parts = token_matching.groups() if token_matching is not None else None
             if parts is None:
                 raise DagsterInvalidDefinitionError(
-                    f"When attempting to create job '{job_name}', the clause {clause} within the asset key selection was invalid. Please review the selection syntax here (imagine there is a link here to the docs)."
+                    f"When attempting to create job '{job_name}', the clause "
+                    f"{clause} within the asset key selection was invalid. Please "
+                    "review the selection syntax here (imagine there is a link "
+                    "here to the docs)."
                 )
             upstream_part, key_str, downstream_part = parts
             if key_str in source_asset_keys:

--- a/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
@@ -1,20 +1,16 @@
-<<<<<<< HEAD
-from typing import Mapping, NamedTuple, Optional, Sequence
-=======
 import re
-from typing import Dict, List, NamedTuple, Optional, Union
->>>>>>> Add AssetCollection.build_job API with selection over asset keys
+from typing import List, Mapping, NamedTuple, Optional, Sequence, Union
 
 from dagster import check
 from dagster.utils import merge_dicts
 
 from ..definitions.executor_definition import ExecutorDefinition
-from ..definitions.graph_definition import GraphDefinition
-from ..definitions.job_definition import JobDefinition
+from ..definitions.job_definition import JobDefinition, get_subselected_graph_definition
+from ..definitions.mode import ModeDefinition
 from ..definitions.resource_definition import ResourceDefinition
 from ..errors import DagsterInvalidDefinitionError
 from .asset import AssetsDefinition
-from .assets_job import build_root_manager, build_source_assets_by_key
+from .assets_job import build_assets_job, build_root_manager, build_source_assets_by_key
 from .source_asset import SourceAsset
 
 
@@ -80,34 +76,115 @@ class AssetCollection(
         name: str,
         asset_key_selection: Optional[Union[str, List[str]]] = None,
         executor_def: Optional[ExecutorDefinition] = None,
+        description: Optional[str] = None,
     ) -> JobDefinition:
-        op_selection = self._parse_asset_selection(asset_key_selection)
+        from dagster.core.selector.subset_selector import parse_op_selection, OpSelectionData
 
-    def _parse_asset_selection(self, asset_key_selection):
+        check.str_param(name, "name")
+
+        if not isinstance(asset_key_selection, str):
+            asset_key_selection = check.opt_list_param(
+                asset_key_selection, "asset_key_selection", of_type=str
+            )
+        executor_def = check.opt_inst_param(executor_def, "executor_def", ExecutorDefinition)
+        description = check.opt_str_param(description, "description")
+
+        mega_job_def = build_assets_job(
+            name=name,
+            assets=self.assets,
+            source_assets=self.source_assets,
+            resource_defs=self.resource_defs,
+            executor_def=self.executor_def,
+        )
+
+        orig_mode_def = mega_job_def.get_mode_definition()
+        mode_def = ModeDefinition(
+            resource_defs=orig_mode_def.resource_defs,
+            logger_defs=orig_mode_def.loggers,
+            executor_defs=[executor_def or orig_mode_def.executor_defs[0]],
+        )
+
+        if asset_key_selection:
+            op_selection = self._parse_asset_selection(asset_key_selection, job_name=name)
+            resolved_op_selection_dict = parse_op_selection(mega_job_def, op_selection)
+
+            op_selection_data: Optional[OpSelectionData] = OpSelectionData(
+                op_selection=op_selection,
+                resolved_op_selection=set(
+                    resolved_op_selection_dict.keys()
+                ),  # equivalent to solids_to_execute. currently only gets top level nodes.
+                parent_job_def=mega_job_def,  # used by pipeline snapshot lineage
+            )
+
+            graph = get_subselected_graph_definition(mega_job_def.graph, resolved_op_selection_dict)
+        else:
+            op_selection_data = None
+            graph = mega_job_def.graph
+
+        job_def = JobDefinition(
+            name=name,
+            description=description,
+            mode_def=mode_def,
+            preset_defs=mega_job_def.preset_defs,
+            tags=mega_job_def.tags,
+            hook_defs=mega_job_def.hook_defs,
+            op_retry_policy=mega_job_def._solid_retry_policy,  # pylint: disable=protected-access
+            graph_def=graph,
+            version_strategy=mega_job_def.version_strategy,
+            _op_selection_data=op_selection_data,
+        )
+        return job_def
+
+    def _parse_asset_selection(self, asset_key_selection, job_name):
         """Convert selection over asset key to selection over ops"""
-        from dagster.core.selector.subset_selector import parse_clause
 
-        asset_keys = set()
-        for asset in self.assets:
-            asset_keys_for_asset = [
-                ".".join([piece for piece in asset_key.path]) for asset_key in asset.asset_keys
-            ]
-            asset_keys = asset_keys.union(set(asset_keys_for_asset))
+        asset_keys_to_ops = dict()
 
         if isinstance(asset_key_selection, str):
             asset_key_selection = [asset_key_selection]
 
         if len(asset_key_selection) == 1 and asset_key_selection[0] == "*":
-            return [asset_key_selection]
+            return asset_key_selection
+
+        source_asset_keys = set()
+        for asset in self.assets:
+            # Assume that if a user subselects a source asset, that they want to re-load all inputs that may result from that source asset.
+            for asset_key in asset.asset_keys:
+                asset_key_as_str = ".".join([piece for piece in asset_key.path])
+                if not asset_key_as_str in asset_keys_to_ops:
+                    asset_keys_to_ops[asset_key_as_str] = []
+                asset_keys_to_ops[asset_key_as_str].append(asset.op)
+
+        for asset in self.source_assets:
+            asset_key_as_str = ".".join([piece for piece in asset.key.path])
+            source_asset_keys.add(asset_key_as_str)
+
+        op_selection = []
 
         for clause in asset_key_selection:
-            parts = parse_clause(clause)
+            token_matching = re.compile(r"^(\*?\+*)?([.\w\d\[\]?_-]+)(\+*\*?)?$").search(
+                clause.strip()
+            )
+            # return None if query is invalid
+            parts = token_matching.groups() if token_matching is not None else None
             if parts is None:
-                raise DagsterInvalidDefinitionError("Subset failed")
-            up_depth, item_name, down_depth = parts
-            if item_name not in asset_keys:
-                raise DagsterInvalidDefinitionError("Subset failed")
-            up_depth
+                raise DagsterInvalidDefinitionError(
+                    f"When attempting to create job '{job_name}', the clause {clause} within the asset key selection was invalid. Please review the selection syntax here (imagine there is a link here to the docs)."
+                )
+            upstream_part, asset_key, downstream_part = parts
+            if asset_key in source_asset_keys:
+                raise DagsterInvalidDefinitionError(
+                    f"When attempting to create job '{job_name}', the clause '{clause}' selects asset_key '{asset_key}', which comes from a source asset. Source assets can't be materialized, and therefore can't be subsetted into a job. Please choose a subset on asset keys that are materializable - that is, included on assets within the collection. Valid assets: {list(asset_keys_to_ops.keys())}"
+                )
+            if asset_key not in asset_keys_to_ops:
+                raise DagsterInvalidDefinitionError(
+                    f"When attempting to create job '{job_name}', the clause '{clause}' within the asset key selection did not match any asset keys. Present asset keys: {list(asset_keys_to_ops.keys())}"
+                )
+            for op in asset_keys_to_ops[asset_key]:
+
+                op_clause = f"{upstream_part}{op.name}{downstream_part}"
+                op_selection.append(op_clause)
+        return op_selection
 
 
 def _validate_resource_reqs_for_asset_collection(

--- a/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
@@ -108,7 +108,7 @@ class AssetCollection(
             resolved_op_selection_dict = parse_op_selection(mega_job_def, op_selection)
 
             included_assets = []
-            excluded_assets: List[Union[AssetsDefinition, ForeignAsset]] = list(self.source_assets)
+            excluded_assets: List[Union[AssetsDefinition, SourceAsset]] = list(self.source_assets)
 
             op_names = set(list(resolved_op_selection_dict.keys()))
 
@@ -159,7 +159,7 @@ class AssetCollection(
                 asset_keys_to_ops[asset_key_as_str].append(asset.op)
 
         for asset in self.source_assets:
-            if isinstance(asset, ForeignAsset):
+            if isinstance(asset, SourceAsset):
                 asset_key_as_str = ".".join([piece for piece in asset.key.path])
                 source_asset_keys.add(asset_key_as_str)
             else:

--- a/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
+++ b/python_modules/dagster/dagster/core/asset_defs/asset_collection.py
@@ -74,7 +74,7 @@ class AssetCollection(
     def build_job(
         self,
         name: str,
-        asset_key_selection: Optional[Union[str, List[str]]] = None,
+        selection: Optional[Union[str, List[str]]] = None,
         executor_def: Optional[ExecutorDefinition] = None,
         description: Optional[str] = None,
     ) -> JobDefinition:
@@ -82,10 +82,8 @@ class AssetCollection(
 
         check.str_param(name, "name")
 
-        if not isinstance(asset_key_selection, str):
-            asset_key_selection = check.opt_list_param(
-                asset_key_selection, "asset_key_selection", of_type=str
-            )
+        if not isinstance(selection, str):
+            selection = check.opt_list_param(selection, "selection", of_type=str)
         executor_def = check.opt_inst_param(executor_def, "executor_def", ExecutorDefinition)
         description = check.opt_str_param(description, "description")
 
@@ -104,8 +102,8 @@ class AssetCollection(
             executor_defs=[executor_def or orig_mode_def.executor_defs[0]],
         )
 
-        if asset_key_selection:
-            op_selection = self._parse_asset_selection(asset_key_selection, job_name=name)
+        if selection:
+            op_selection = self._parse_asset_selection(selection, job_name=name)
             resolved_op_selection_dict = parse_op_selection(mega_job_def, op_selection)
 
             op_selection_data: Optional[OpSelectionData] = OpSelectionData(
@@ -135,16 +133,16 @@ class AssetCollection(
         )
         return job_def
 
-    def _parse_asset_selection(self, asset_key_selection, job_name):
+    def _parse_asset_selection(self, selection, job_name):
         """Convert selection over asset key to selection over ops"""
 
         asset_keys_to_ops = dict()
 
-        if isinstance(asset_key_selection, str):
-            asset_key_selection = [asset_key_selection]
+        if isinstance(selection, str):
+            selection = [selection]
 
-        if len(asset_key_selection) == 1 and asset_key_selection[0] == "*":
-            return asset_key_selection
+        if len(selection) == 1 and selection[0] == "*":
+            return selection
 
         source_asset_keys = set()
         for asset in self.assets:
@@ -161,7 +159,7 @@ class AssetCollection(
 
         op_selection = []
 
-        for clause in asset_key_selection:
+        for clause in selection:
             token_matching = re.compile(r"^(\*?\+*)?([.\w\d\[\]?_-]+)(\+*\*?)?$").search(
                 clause.strip()
             )

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -210,7 +210,7 @@ class JobDefinition(PipelineDefinition):
 
         resolved_op_selection_dict = parse_op_selection(self, op_selection)
 
-        sub_graph = _get_subselected_graph_definition(self.graph, resolved_op_selection_dict)
+        sub_graph = get_subselected_graph_definition(self.graph, resolved_op_selection_dict)
 
         return JobDefinition(
             name=self.name,
@@ -310,7 +310,7 @@ def _dep_key_of(node: Node) -> NodeInvocation:
     )
 
 
-def _get_subselected_graph_definition(
+def get_subselected_graph_definition(
     graph: GraphDefinition,
     resolved_op_selection_dict: Dict,
     parent_handle: Optional[NodeHandle] = None,
@@ -330,7 +330,7 @@ def _get_subselected_graph_definition(
 
         # rebuild graph if any nodes inside the graph are selected
         if node.is_graph and resolved_op_selection_dict[node.name] is not LeafNodeSelection:
-            definition = _get_subselected_graph_definition(
+            definition = get_subselected_graph_definition(
                 node.definition,
                 resolved_op_selection_dict[node.name],
                 parent_handle=node_handle,

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
@@ -141,7 +141,9 @@ def test_asset_collection_requires_root_manager():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"Output 'result' with AssetKey 'AssetKey\(\['asset_foo'\]\)' requires io manager 'blah' but was not provided on asset collection. Provided resources: \['io_manager', 'root_manager'\]",
+        match=r"Output 'result' with AssetKey 'AssetKey\(\['asset_foo'\]\)' "
+        r"requires io manager 'blah' but was not provided on asset collection. "
+        r"Provided resources: \['io_manager', 'root_manager'\]",
     ):
         AssetCollection([asset_foo])
 
@@ -153,7 +155,9 @@ def test_resource_override():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Resource dictionary included resource with key 'root_manager', which is a reserved resource keyword in Dagster. Please change this key, and then change all places that require this key to a new value.",
+        match="Resource dictionary included resource with key 'root_manager', "
+        "which is a reserved resource keyword in Dagster. Please change this "
+        "key, and then change all places that require this key to a new value.",
     ):
         AssetCollection([], resource_defs={"root_manager": the_resource})
 
@@ -285,12 +289,17 @@ def test_asset_collection_build_subset_job():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"When attempting to create job 'bad_subset', the clause 'doesnt_exist' within the asset key selection did not match any asset keys. Present asset keys: \['start_asset', 'o1', 'o2', 'follows_o1', 'follows_o2'\]",
+        match=r"When attempting to create job 'bad_subset', the clause "
+        r"'doesnt_exist' within the asset key selection did not match any asset "
+        r"keys. Present asset keys: \['start_asset', 'o1', 'o2', 'follows_o1', 'follows_o2'\]",
     ):
         collection.build_job(name="bad_subset", selection="doesnt_exist")
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match=r"When attempting to create job 'bad_query_arguments', the clause follows_o1= within the asset key selection was invalid. Please review the selection syntax here \(imagine there is a link here to the docs\).",
+        match=r"When attempting to create job 'bad_query_arguments', the clause "
+        r"follows_o1= within the asset key selection was invalid. Please "
+        r"review the selection syntax here "
+        r"\(imagine there is a link here to the docs\).",
     ):
         collection.build_job(name="bad_query_arguments", selection="follows_o1=")

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
@@ -3,13 +3,14 @@ from dagster import (
     AssetKey,
     DagsterInvalidDefinitionError,
     IOManager,
+    Out,
     in_process_executor,
     io_manager,
     mem_io_manager,
     repository,
     resource,
 )
-from dagster.core.asset_defs import AssetCollection, AssetIn, SourceAsset, asset
+from dagster.core.asset_defs import AssetCollection, AssetIn, SourceAsset, asset, multi_asset
 
 
 def test_asset_collection_from_list():
@@ -164,3 +165,81 @@ def test_resource_override():
     assert (  # pylint: disable=comparison-with-callable
         asset_collection_underlying_job.resource_defs["io_manager"] == mem_io_manager
     )
+
+
+def test_asset_collection_build_subset_job():
+    @asset
+    def start_asset():
+        return "foo"
+
+    @multi_asset(outs={"o1": Out(asset_key=AssetKey("o1")), "o2": Out(asset_key=AssetKey("o2"))})
+    def middle_asset(start_asset):
+        return (start_asset, start_asset)
+
+    @asset
+    def follows_o1(o1):
+        return o1
+
+    @asset
+    def follows_o2(o2):
+        return o2
+
+    collection = AssetCollection([start_asset, middle_asset, follows_o1, follows_o2])
+
+    full_job = collection.build_job("full", asset_key_selection="*")
+    result = full_job.execute_in_process()
+    assert result.success
+    assert result.output_for_node("follows_o1") == "foo"
+    assert result.output_for_node("follows_o2") == "foo"
+
+    test_single = collection.build_job(name="test_single", asset_key_selection="follows_o2")
+    assert len(test_single.all_node_defs) == 1
+    assert test_single.all_node_defs[0].name == "follows_o2"
+
+    test_up_star = collection.build_job(name="test_up_star", asset_key_selection="*follows_o2")
+    assert len(test_up_star.all_node_defs) == 3
+    assert set([node.name for node in test_up_star.all_node_defs]) == {
+        "follows_o2",
+        "middle_asset",
+        "start_asset",
+    }
+
+    test_down_star = collection.build_job(name="test_down_star", asset_key_selection="start_asset*")
+    assert len(test_down_star.all_node_defs) == 4
+    assert set([node.name for node in test_down_star.all_node_defs]) == {
+        "follows_o2",
+        "middle_asset",
+        "start_asset",
+        "follows_o1",
+    }
+
+    test_both_plus = collection.build_job(name="test_both_plus", asset_key_selection="+o1+")
+    assert len(test_both_plus.all_node_defs) == 4
+    assert set([node.name for node in test_both_plus.all_node_defs]) == {
+        "follows_o1",
+        "follows_o2",
+        "middle_asset",
+        "start_asset",
+    }
+
+    test_selection_with_overlap = collection.build_job(
+        name="test_multi_asset_multi_selection", asset_key_selection=["o1", "o2+"]
+    )
+    assert len(test_selection_with_overlap.all_node_defs) == 3
+    assert set([node.name for node in test_selection_with_overlap.all_node_defs]) == {
+        "follows_o1",
+        "follows_o2",
+        "middle_asset",
+    }
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=r"When attempting to create job 'bad_subset', the clause 'doesnt_exist' within the asset key selection did not match any asset keys. Present asset keys: \['start_asset', 'o1', 'o2', 'follows_o1', 'follows_o2'\]",
+    ):
+        collection.build_job(name="bad_subset", asset_key_selection="doesnt_exist")
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=r"When attempting to create job 'bad_query_arguments', the clause follows_o1= within the asset key selection was invalid. Please review the selection syntax here \(imagine there is a link here to the docs\).",
+    ):
+        collection.build_job(name="bad_query_arguments", asset_key_selection="follows_o1=")

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
@@ -258,7 +258,7 @@ def test_asset_collection_build_subset_job():
     assert result.success
     assert result.output_for_node("follows_o2") == "foo"
 
-    test_both_plus = collection.build_job(name="test_both_plus", selection="+o1+")
+    test_both_plus = collection.build_job(name="test_both_plus", selection=["+o1+", "o2"])
 
     assert len(test_both_plus.all_node_defs) == 4
     assert set([node.name for node in test_both_plus.all_node_defs]) == {
@@ -303,3 +303,15 @@ def test_asset_collection_build_subset_job():
         r"\(imagine there is a link here to the docs\).",
     ):
         collection.build_job(name="bad_query_arguments", selection="follows_o1=")
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=r"When building job 'test_subselect_only_one_key', the asset "
+        r"'middle_asset' contains asset keys \['o1', 'o2'\], but attempted to "
+        r"select only \['o1'\]. Selecting only some of the asset keys for a "
+        r"particular asset is not yet supported behavior. Please select all "
+        r"asset keys produced by a given asset when subsetting.",
+    ):
+        test_subselect_one_asset_key = collection.build_job(
+            name="test_subselect_only_one_key", selection="o1"
+        )

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
@@ -298,9 +298,9 @@ def test_asset_collection_build_subset_job():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=r"When attempting to create job 'bad_query_arguments', the clause "
-        r"follows_o1= within the asset key selection was invalid. Please "
-        r"review the selection syntax here "
-        r"\(imagine there is a link here to the docs\).",
+        r"follows_o1= within the asset key selection was invalid. Please review "
+        r"the selection syntax here: "
+        r"https://docs.dagster.io/concepts/ops-jobs-graphs/job-execution#op-selection-syntax.",
     ):
         collection.build_job(name="bad_query_arguments", selection="follows_o1=")
 
@@ -312,6 +312,4 @@ def test_asset_collection_build_subset_job():
         r"particular asset is not yet supported behavior. Please select all "
         r"asset keys produced by a given asset when subsetting.",
     ):
-        test_subselect_one_asset_key = collection.build_job(
-            name="test_subselect_only_one_key", selection="o1"
-        )
+        collection.build_job(name="test_subselect_only_one_key", selection="o1")

--- a/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_defs_tests/test_asset_collection.py
@@ -186,17 +186,17 @@ def test_asset_collection_build_subset_job():
 
     collection = AssetCollection([start_asset, middle_asset, follows_o1, follows_o2])
 
-    full_job = collection.build_job("full", asset_key_selection="*")
+    full_job = collection.build_job("full", selection="*")
     result = full_job.execute_in_process()
     assert result.success
     assert result.output_for_node("follows_o1") == "foo"
     assert result.output_for_node("follows_o2") == "foo"
 
-    test_single = collection.build_job(name="test_single", asset_key_selection="follows_o2")
+    test_single = collection.build_job(name="test_single", selection="follows_o2")
     assert len(test_single.all_node_defs) == 1
     assert test_single.all_node_defs[0].name == "follows_o2"
 
-    test_up_star = collection.build_job(name="test_up_star", asset_key_selection="*follows_o2")
+    test_up_star = collection.build_job(name="test_up_star", selection="*follows_o2")
     assert len(test_up_star.all_node_defs) == 3
     assert set([node.name for node in test_up_star.all_node_defs]) == {
         "follows_o2",
@@ -204,7 +204,7 @@ def test_asset_collection_build_subset_job():
         "start_asset",
     }
 
-    test_down_star = collection.build_job(name="test_down_star", asset_key_selection="start_asset*")
+    test_down_star = collection.build_job(name="test_down_star", selection="start_asset*")
     assert len(test_down_star.all_node_defs) == 4
     assert set([node.name for node in test_down_star.all_node_defs]) == {
         "follows_o2",
@@ -213,7 +213,7 @@ def test_asset_collection_build_subset_job():
         "follows_o1",
     }
 
-    test_both_plus = collection.build_job(name="test_both_plus", asset_key_selection="+o1+")
+    test_both_plus = collection.build_job(name="test_both_plus", selection="+o1+")
     assert len(test_both_plus.all_node_defs) == 4
     assert set([node.name for node in test_both_plus.all_node_defs]) == {
         "follows_o1",
@@ -223,7 +223,7 @@ def test_asset_collection_build_subset_job():
     }
 
     test_selection_with_overlap = collection.build_job(
-        name="test_multi_asset_multi_selection", asset_key_selection=["o1", "o2+"]
+        name="test_multi_asset_multi_selection", selection=["o1", "o2+"]
     )
     assert len(test_selection_with_overlap.all_node_defs) == 3
     assert set([node.name for node in test_selection_with_overlap.all_node_defs]) == {
@@ -236,10 +236,10 @@ def test_asset_collection_build_subset_job():
         DagsterInvalidDefinitionError,
         match=r"When attempting to create job 'bad_subset', the clause 'doesnt_exist' within the asset key selection did not match any asset keys. Present asset keys: \['start_asset', 'o1', 'o2', 'follows_o1', 'follows_o2'\]",
     ):
-        collection.build_job(name="bad_subset", asset_key_selection="doesnt_exist")
+        collection.build_job(name="bad_subset", selection="doesnt_exist")
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=r"When attempting to create job 'bad_query_arguments', the clause follows_o1= within the asset key selection was invalid. Please review the selection syntax here \(imagine there is a link here to the docs\).",
     ):
-        collection.build_job(name="bad_query_arguments", asset_key_selection="follows_o1=")
+        collection.build_job(name="bad_query_arguments", selection="follows_o1=")


### PR DESCRIPTION
This PR adds an API to build a job from an asset collection. I think the main interesting piece here is the translation from asset key selection to op selection.

Jobs constructed from an asset collection don't specify their own resources, instead inheriting them from the AssetCollection.
These jobs can specify a subset over asset keys, which we translate into an op selection. I think it brings up an interesting question of whether there should be an asset key subselection option for the launchpad when executing an asset job.
In terms of the selection algorithm itself; the main decisions are:
- if you select an asset key from a multi asset, that translates to selecting the comparative op. This should net out correctly.
- If you select an asset key from a source asset, we error. You are only able to select asset keys that can be materialized. However, it would make sense to be able to select things up and downstream of a source asset. So maybe we should allow this?