### PR TITLE
rename JobHandle => InstigatorHandle

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external.py
+++ b/python_modules/dagster/dagster/core/host_representation/external.py
@@ -20,7 +20,7 @@ from .external_data import (
     ExternalScheduleData,
     ExternalSensorData,
 )
-from .handle import JobHandle, PartitionSetHandle, PipelineHandle, RepositoryHandle
+from .handle import InstigatorHandle, PartitionSetHandle, PipelineHandle, RepositoryHandle
 from .pipeline_index import PipelineIndex
 from .represented import RepresentedPipeline
 
@@ -427,7 +427,7 @@ class ExternalSchedule:
         self._external_schedule_data = check.inst_param(
             external_schedule_data, "external_schedule_data", ExternalScheduleData
         )
-        self._handle = JobHandle(
+        self._handle = InstigatorHandle(
             self._external_schedule_data.name, check.inst_param(handle, "handle", RepositoryHandle)
         )
 
@@ -505,7 +505,7 @@ class ExternalSensor:
         self._external_sensor_data = check.inst_param(
             external_sensor_data, "external_sensor_data", ExternalSensorData
         )
-        self._handle = JobHandle(
+        self._handle = InstigatorHandle(
             self._external_sensor_data.name, check.inst_param(handle, "handle", RepositoryHandle)
         )
 

--- a/python_modules/dagster/dagster/core/host_representation/handle.py
+++ b/python_modules/dagster/dagster/core/host_representation/handle.py
@@ -66,9 +66,9 @@ class PipelineHandle(namedtuple("_PipelineHandle", "pipeline_name repository_han
         return PipelineSelector(self.location_name, self.repository_name, self.pipeline_name, None)
 
 
-class JobHandle(namedtuple("_JobHandle", "job_name repository_handle")):
+class InstigatorHandle(namedtuple("_InstigatorHandle", "instigator_name repository_handle")):
     def __new__(cls, job_name, repository_handle):
-        return super(JobHandle, cls).__new__(
+        return super(InstigatorHandle, cls).__new__(
             cls,
             check.str_param(job_name, "job_name"),
             check.inst_param(repository_handle, "repository_handle", RepositoryHandle),
@@ -83,7 +83,9 @@ class JobHandle(namedtuple("_JobHandle", "job_name repository_handle")):
         return self.repository_handle.location_name
 
     def get_external_origin(self):
-        return self.repository_handle.get_external_origin().get_instigator_origin(self.job_name)
+        return self.repository_handle.get_external_origin().get_instigator_origin(
+            self.instigator_name
+        )
 
 
 class PartitionSetHandle(namedtuple("_PartitionSetHandle", "partition_set_name repository_handle")):


### PR DESCRIPTION
## Summary
Removing the vestigial naming from when generic schedules/sensors were called jobs.



## Test Plan
BK

