### PR TITLE
Change schedule storage and instance methods to drop `job` references

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_jobs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_jobs.py
@@ -7,11 +7,13 @@ from .utils import capture_error
 
 
 @capture_error
-def get_unloadable_job_states_or_error(graphene_info, job_type=None):
+def get_unloadable_instigator_states_or_error(graphene_info, instigator_type=None):
     from ..schema.instigation import GrapheneInstigationState, GrapheneInstigationStates
 
-    check.opt_inst_param(job_type, "job_type", InstigatorType)
-    job_states = graphene_info.context.instance.all_stored_job_state(job_type=job_type)
+    check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
+    job_states = graphene_info.context.instance.all_instigator_state(
+        instigator_type=instigator_type
+    )
     external_jobs = [
         job
         for repository_location in graphene_info.context.repository_locations
@@ -34,7 +36,7 @@ def get_unloadable_job_states_or_error(graphene_info, job_type=None):
 
 
 @capture_error
-def get_job_state_or_error(graphene_info, selector):
+def get_instigator_state_or_error(graphene_info, selector):
     from ..schema.instigation import GrapheneInstigationState
 
     check.inst_param(selector, "selector", InstigationSelector)
@@ -43,17 +45,17 @@ def get_job_state_or_error(graphene_info, selector):
 
     if repository.has_external_sensor(selector.name):
         external_sensor = repository.get_external_sensor(selector.name)
-        stored_state = graphene_info.context.instance.get_job_state(
+        stored_state = graphene_info.context.instance.get_instigator_state(
             external_sensor.get_external_origin_id()
         )
-        job_state = external_sensor.get_current_instigator_state(stored_state)
+        current_state = external_sensor.get_current_instigator_state(stored_state)
     elif repository.has_external_schedule(selector.name):
         external_schedule = repository.get_external_schedule(selector.name)
-        stored_state = graphene_info.context.instance.get_job_state(
+        stored_state = graphene_info.context.instance.get_instigator_state(
             external_schedule.get_external_origin_id()
         )
-        job_state = external_schedule.get_current_instigator_state(stored_state)
+        current_state = external_schedule.get_current_instigator_state(stored_state)
     else:
         check.failed(f"Could not find a definition for {selector.name}")
 
-    return GrapheneInstigationState(job_state=job_state)
+    return GrapheneInstigationState(current_state)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -69,9 +69,9 @@ def get_schedules_or_error(graphene_info, repository_selector):
     external_schedules = repository.get_external_schedules()
     schedule_states_by_name = {
         state.name: state
-        for state in graphene_info.context.instance.all_stored_job_state(
+        for state in graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
-            job_type=InstigatorType.SCHEDULE,
+            instigator_type=InstigatorType.SCHEDULE,
         )
     }
 
@@ -101,7 +101,7 @@ def get_schedules_for_pipeline(graphene_info, pipeline_selector):
         if external_schedule.pipeline_name != pipeline_selector.pipeline_name:
             continue
 
-        schedule_state = graphene_info.context.instance.get_job_state(
+        schedule_state = graphene_info.context.instance.get_instigator_state(
             external_schedule.get_external_origin_id()
         )
         results.append(GrapheneSchedule(external_schedule, schedule_state))
@@ -125,7 +125,7 @@ def get_schedule_or_error(graphene_info, schedule_selector):
             GrapheneScheduleNotFoundError(schedule_name=schedule_selector.schedule_name)
         )
 
-    schedule_state = graphene_info.context.instance.get_job_state(
+    schedule_state = graphene_info.context.instance.get_instigator_state(
         external_schedule.get_external_origin_id()
     )
     return GrapheneSchedule(external_schedule, schedule_state)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -20,9 +20,9 @@ def get_sensors_or_error(graphene_info, repository_selector):
     sensors = repository.get_external_sensors()
     sensor_states_by_name = {
         state.name: state
-        for state in graphene_info.context.instance.all_stored_job_state(
+        for state in graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
-            job_type=InstigatorType.SENSOR,
+            instigator_type=InstigatorType.SENSOR,
         )
     }
     return GrapheneSensors(
@@ -49,7 +49,7 @@ def get_sensor_or_error(graphene_info, selector):
     if not repository.has_external_sensor(selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
     external_sensor = repository.get_external_sensor(selector.sensor_name)
-    sensor_state = graphene_info.context.instance.get_job_state(
+    sensor_state = graphene_info.context.instance.get_instigator_state(
         external_sensor.get_external_origin_id()
     )
 
@@ -70,7 +70,7 @@ def start_sensor(graphene_info, sensor_selector):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(sensor_selector.sensor_name))
     external_sensor = repository.get_external_sensor(sensor_selector.sensor_name)
     graphene_info.context.instance.start_sensor(external_sensor)
-    sensor_state = graphene_info.context.instance.get_job_state(
+    sensor_state = graphene_info.context.instance.get_instigator_state(
         external_sensor.get_external_origin_id()
     )
     return GrapheneSensor(external_sensor, sensor_state)
@@ -91,7 +91,7 @@ def stop_sensor(graphene_info, job_origin_id):
         for job in repository.get_external_sensors()
     }
     instance.stop_sensor(job_origin_id, external_sensors.get(job_origin_id))
-    job_state = graphene_info.context.instance.get_job_state(job_origin_id)
+    job_state = graphene_info.context.instance.get_instigator_state(job_origin_id)
     return GrapheneStopSensorMutationResult(job_state)
 
 
@@ -99,8 +99,8 @@ def stop_sensor(graphene_info, job_origin_id):
 def get_unloadable_sensor_states_or_error(graphene_info):
     from ..schema.instigation import GrapheneInstigationState, GrapheneInstigationStates
 
-    sensor_states = graphene_info.context.instance.all_stored_job_state(
-        job_type=InstigatorType.SENSOR
+    sensor_states = graphene_info.context.instance.all_instigator_state(
+        instigator_type=InstigatorType.SENSOR
     )
     external_sensors = [
         sensor
@@ -141,7 +141,7 @@ def get_sensors_for_pipeline(graphene_info, pipeline_selector):
         ]:
             continue
 
-        sensor_state = graphene_info.context.instance.get_job_state(
+        sensor_state = graphene_info.context.instance.get_instigator_state(
             external_sensor.get_external_origin_id()
         )
         results.append(GrapheneSensor(external_sensor, sensor_state))

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -177,9 +177,10 @@ def get_sensor_next_tick(graphene_info, sensor_state):
     if not sensor_state.is_running:
         return None
 
-    latest_tick = graphene_info.context.instance.get_latest_job_tick(sensor_state.job_origin_id)
-    if not latest_tick:
+    ticks = graphene_info.context.instance.get_ticks(sensor_state.job_origin_id, limit=1)
+    if not ticks:
         return None
+    latest_tick = ticks[0]
 
     next_timestamp = latest_tick.timestamp + external_sensor.min_interval_seconds
     if next_timestamp < get_timestamp_from_utc_datetime(get_current_datetime_in_utc()):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -90,17 +90,17 @@ class RepositoryScopedBatchLoader:
                 fetched[record.pipeline_run.tags.get(SENSOR_NAME_TAG)].append(record)
 
         elif data_type == RepositoryDataType.SCHEDULE_STATES:
-            schedule_states = self._instance.all_stored_job_state(
+            schedule_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
-                job_type=InstigatorType.SCHEDULE,
+                instigator_type=InstigatorType.SCHEDULE,
             )
             for state in schedule_states:
                 fetched[state.name].append(state)
 
         elif data_type == RepositoryDataType.SENSOR_STATES:
-            sensor_states = self._instance.all_stored_job_state(
+            sensor_states = self._instance.all_instigator_state(
                 repository_origin_id=self._repository.get_external_origin_id(),
-                job_type=InstigatorType.SENSOR,
+                instigator_type=InstigatorType.SENSOR,
             )
             for state in sensor_states:
                 fetched[state.name].append(state)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -102,26 +102,26 @@ class GrapheneInstigationTick(graphene.ObjectType):
     class Meta:
         name = "InstigationTick"
 
-    def __init__(self, _, job_tick):
-        self._job_tick = check.inst_param(job_tick, "job_tick", InstigatorTick)
+    def __init__(self, _, tick):
+        self._tick = check.inst_param(tick, "tick", InstigatorTick)
 
         super().__init__(
-            status=job_tick.status,
-            timestamp=job_tick.timestamp,
-            runIds=job_tick.run_ids,
-            error=job_tick.error,
-            skipReason=job_tick.skip_reason,
-            originRunIds=job_tick.origin_run_ids,
+            status=tick.status,
+            timestamp=tick.timestamp,
+            runIds=tick.run_ids,
+            error=tick.error,
+            skipReason=tick.skip_reason,
+            originRunIds=tick.origin_run_ids,
         )
 
     def resolve_id(self, _):
-        return "%s:%s" % (self._job_tick.job_origin_id, self._job_tick.timestamp)
+        return "%s:%s" % (self._tick.job_origin_id, self._tick.timestamp)
 
     def resolve_runs(self, graphene_info):
         from .pipelines.pipeline import GrapheneRun
 
         instance = graphene_info.context.instance
-        run_ids = self._job_tick.origin_run_ids or self._job_tick.run_ids
+        run_ids = self._tick.origin_run_ids or self._tick.run_ids
         if not run_ids:
             return []
 
@@ -345,7 +345,7 @@ class GrapheneInstigationState(graphene.ObjectType):
         return graphene_info.context.instance.get_runs_count(filters=filters)
 
     def resolve_tick(self, graphene_info, timestamp):
-        tick = graphene_info.context.instance.get_job_tick(
+        tick = graphene_info.context.instance.get_tick(
             self._job_state.job_origin_id, timestamp=timestamp
         )
         return GrapheneInstigationTick(graphene_info, tick) if tick else None
@@ -359,7 +359,7 @@ class GrapheneInstigationState(graphene.ObjectType):
         )
         return [
             GrapheneInstigationTick(graphene_info, tick)
-            for tick in graphene_info.context.instance.get_job_ticks(
+            for tick in graphene_info.context.instance.get_ticks(
                 self._job_state.job_origin_id, before=before, after=after, limit=limit
             )
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -13,7 +13,10 @@ from dagster.core.scheduler.instigation import InstigatorType
 from ...implementation.external import fetch_repositories, fetch_repository, fetch_workspace
 from ...implementation.fetch_assets import get_asset, get_asset_node, get_asset_nodes, get_assets
 from ...implementation.fetch_backfills import get_backfill, get_backfills
-from ...implementation.fetch_jobs import get_job_state_or_error, get_unloadable_job_states_or_error
+from ...implementation.fetch_jobs import (
+    get_instigator_state_or_error,
+    get_unloadable_instigator_states_or_error,
+)
 from ...implementation.fetch_partition_sets import get_partition_set, get_partition_sets_or_error
 from ...implementation.fetch_pipelines import (
     get_pipeline_or_error,
@@ -321,15 +324,15 @@ class GrapheneDagitQuery(graphene.ObjectType):
         )
 
     def resolve_instigationStateOrError(self, graphene_info, instigationSelector):
-        return get_job_state_or_error(
+        return get_instigator_state_or_error(
             graphene_info, InstigationSelector.from_graphql_input(instigationSelector)
         )
 
     def resolve_unloadableInstigationStatesOrError(self, graphene_info, **kwargs):
-        job_type = (
+        instigation_type = (
             InstigatorType(kwargs["instigationType"]) if "instigationType" in kwargs else None
         )
-        return get_unloadable_job_states_or_error(graphene_info, job_type)
+        return get_unloadable_instigator_states_or_error(graphene_info, instigation_type)
 
     def resolve_pipelineOrError(self, graphene_info, **kwargs):
         return get_pipeline_or_error(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -417,7 +417,7 @@ def test_get_unloadable_job(graphql_context):
         second=59,
     )
     with pendulum.test(initial_datetime):
-        instance.add_job_state(
+        instance.add_instigator_state(
             InstigatorState(
                 _get_unloadable_schedule_origin("unloadable_running"),
                 InstigatorType.SCHEDULE,
@@ -429,7 +429,7 @@ def test_get_unloadable_job(graphql_context):
             )
         )
 
-        instance.add_job_state(
+        instance.add_instigator_state(
             InstigatorState(
                 _get_unloadable_schedule_origin("unloadable_stopped"),
                 InstigatorType.SCHEDULE,
@@ -512,6 +512,6 @@ def test_repository_batching(graphql_context):
     # batch call to fetch instigator state, instead of separate calls for each schedule (~18
     # distinct schedules in the repo)
     # 1) `get_run_records` is fetched to instantiate GrapheneRun
-    # 2) `all_stored_job_state` is fetched to instantiate GrapheneSchedule
+    # 2) `all_instigator_state` is fetched to instantiate GrapheneSchedule
     assert counts.get("DagsterInstance.get_run_records") == 1
-    assert counts.get("DagsterInstance.all_stored_job_state") == 1
+    assert counts.get("DagsterInstance.all_instigator_state") == 1

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -273,7 +273,7 @@ def test_sensor_next_ticks(graphql_context):
     assert not next_tick
 
     # test default sensor with no tick
-    graphql_context.instance.add_job_state(
+    graphql_context.instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
@@ -329,7 +329,7 @@ def test_sensor_tick_range(graphql_context):
     assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 0
 
     # turn the sensor on
-    graphql_context.instance.add_job_state(
+    graphql_context.instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
@@ -403,6 +403,6 @@ def test_repository_batching(graphql_context):
     # batch call to fetch instigator state, instead of separate calls for each sensor (~5 distinct
     # sensors in the repo)
     # 1) `get_run_records` is fetched to instantiate GrapheneRun
-    # 2) `all_stored_job_state` is fetched to instantiate GrapheneSensor
+    # 2) `all_instigator_state` is fetched to instantiate GrapheneSensor
     assert counts.get("DagsterInstance.get_run_records") == 1
-    assert counts.get("DagsterInstance.all_stored_job_state") == 1
+    assert counts.get("DagsterInstance.all_instigator_state") == 1

--- a/python_modules/dagster/dagster/cli/schedule.py
+++ b/python_modules/dagster/dagster/cli/schedule.py
@@ -27,7 +27,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     debug_info = instance.scheduler_debug_info()
     errors = debug_info.errors
     external_schedules = external_repository.get_external_schedules()
-    schedule_states = instance.all_stored_job_state(
+    schedule_states = instance.all_instigator_state(
         external_repository.get_external_origin_id(), InstigatorType.SCHEDULE
     )
     external_schedules_dict = {s.get_external_origin_id(): s for s in external_schedules}
@@ -183,8 +183,8 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
             repo_schedules = external_repo.get_external_schedules()
             stored_schedules_by_origin_id = {
                 stored_schedule_state.job_origin_id: stored_schedule_state
-                for stored_schedule_state in instance.all_stored_job_state(
-                    external_repo.get_external_origin_id(), job_type=InstigatorType.SCHEDULE
+                for stored_schedule_state in instance.all_instigator_state(
+                    external_repo.get_external_origin_id(), instigator_type=InstigatorType.SCHEDULE
                 )
             }
 
@@ -389,7 +389,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
             repository_name = external_repo.name
 
             if all_running_flag:
-                for schedule_state in instance.all_stored_job_state(
+                for schedule_state in instance.all_instigator_state(
                     external_repo.get_external_origin_id(), InstigatorType.SCHEDULE
                 ):
                     if schedule_state.status == InstigatorStatus.RUNNING:
@@ -412,7 +412,9 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
                 )
             else:
                 external_schedule = external_repo.get_external_schedule(schedule_name)
-                schedule_state = instance.get_job_state(external_schedule.get_external_origin_id())
+                schedule_state = instance.get_instigator_state(
+                    external_schedule.get_external_origin_id()
+                )
                 if schedule_state != None and schedule_state.status != InstigatorStatus.RUNNING:
                     click.UsageError(
                         "Cannot restart a schedule {name} because is not currently running".format(

--- a/python_modules/dagster/dagster/cli/sensor.py
+++ b/python_modules/dagster/dagster/cli/sensor.py
@@ -31,7 +31,7 @@ def sensor_cli():
 
 
 def print_changes(external_repository, instance, print_fn=print, preview=False):
-    sensor_states = instance.all_stored_job_state(
+    sensor_states = instance.all_instigator_state(
         external_repository.get_origin_id(), InstigatorType.SENSOR
     )
     external_sensors = external_repository.get_external_sensors()
@@ -145,8 +145,8 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
             repo_sensors = external_repo.get_external_sensors()
             stored_sensors_by_origin_id = {
                 stored_sensor_state.job_origin_id: stored_sensor_state
-                for stored_sensor_state in instance.all_stored_job_state(
-                    external_repo.get_external_origin_id(), job_type=InstigatorType.SENSOR
+                for stored_sensor_state in instance.all_instigator_state(
+                    external_repo.get_external_origin_id(), instigator_type=InstigatorType.SENSOR
                 )
             }
 
@@ -358,9 +358,9 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
             )
             check_repo_and_scheduler(external_repo, instance)
             external_sensor = external_repo.get_external_sensor(sensor_name)
-            job_state = instance.get_job_state(external_sensor.get_external_origin_id())
+            job_state = instance.get_instigator_state(external_sensor.get_external_origin_id())
             if not job_state:
-                instance.add_job_state(
+                instance.add_instigator_state(
                     InstigatorState(
                         external_sensor.get_external_origin(),
                         InstigatorType.SENSOR,
@@ -371,7 +371,7 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
                     )
                 )
             else:
-                instance.update_job_state(
+                instance.update_instigator_state(
                     job_state.with_data(
                         SensorInstigatorData(
                             last_tick_timestamp=job_state.job_specific_data.last_tick_timestamp,

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1695,7 +1695,7 @@ records = instance.get_event_records(
         errors = []
 
         schedules = []
-        for schedule_state in self.all_instigator_state(job_type=InstigatorType.SCHEDULE):
+        for schedule_state in self.all_instigator_state(instigator_type=InstigatorType.SCHEDULE):
             schedule_info = {
                 schedule_state.job_name: {
                     "status": schedule_state.status.value,

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1695,7 +1695,7 @@ records = instance.get_event_records(
         errors = []
 
         schedules = []
-        for schedule_state in self.all_stored_job_state(job_type=InstigatorType.SCHEDULE):
+        for schedule_state in self.all_instigator_state(job_type=InstigatorType.SCHEDULE):
             schedule_info = {
                 schedule_state.job_name: {
                     "status": schedule_state.status.value,
@@ -1729,10 +1729,10 @@ records = instance.get_event_records(
             "Can only manually start a sensor that does not have its status set in code",
         )
 
-        job_state = self.get_job_state(external_sensor.get_external_origin_id())
+        state = self.get_instigator_state(external_sensor.get_external_origin_id())
 
-        if not job_state:
-            return self.add_job_state(
+        if not state:
+            return self.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -1741,7 +1741,7 @@ records = instance.get_event_records(
                 )
             )
         else:
-            return self.update_job_state(job_state.with_status(InstigatorStatus.RUNNING))
+            return self.update_instigator_state(state.with_status(InstigatorStatus.RUNNING))
 
     def stop_sensor(self, job_origin_id, external_sensor):
         from dagster.core.scheduler.instigation import (
@@ -1751,10 +1751,10 @@ records = instance.get_event_records(
         )
         from dagster.core.definitions.run_request import InstigatorType
 
-        job_state = self.get_job_state(job_origin_id)
+        state = self.get_instigator_state(job_origin_id)
 
-        if not job_state:
-            return self.add_job_state(
+        if not state:
+            return self.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -1763,24 +1763,24 @@ records = instance.get_event_records(
                 )
             )
         else:
-            return self.update_job_state(job_state.with_status(InstigatorStatus.STOPPED))
+            return self.update_instigator_state(state.with_status(InstigatorStatus.STOPPED))
 
     @traced
-    def all_stored_job_state(self, repository_origin_id=None, job_type=None):
-        return self._schedule_storage.all_stored_job_state(repository_origin_id, job_type)
+    def all_instigator_state(self, repository_origin_id=None, instigator_type=None):
+        return self._schedule_storage.all_instigator_state(repository_origin_id, instigator_type)
 
     @traced
-    def get_job_state(self, job_origin_id):
-        return self._schedule_storage.get_job_state(job_origin_id)
+    def get_instigator_state(self, origin_id):
+        return self._schedule_storage.get_instigator_state(origin_id)
 
-    def add_job_state(self, job_state):
-        return self._schedule_storage.add_job_state(job_state)
+    def add_instigator_state(self, state):
+        return self._schedule_storage.add_instigator_state(state)
 
-    def update_job_state(self, job_state):
-        return self._schedule_storage.update_job_state(job_state)
+    def update_instigator_state(self, state):
+        return self._schedule_storage.update_instigator_state(state)
 
-    def delete_job_state(self, job_origin_id):
-        return self._schedule_storage.delete_job_state(job_origin_id)
+    def delete_instigator_state(self, origin_id):
+        return self._schedule_storage.delete_instigator_state(origin_id)
 
     @traced
     def get_tick(self, origin_id, timestamp):

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1783,34 +1783,28 @@ records = instance.get_event_records(
         return self._schedule_storage.delete_job_state(job_origin_id)
 
     @traced
-    def get_job_tick(self, job_origin_id, timestamp):
-        matches = self._schedule_storage.get_job_ticks(
-            job_origin_id, before=timestamp + 1, after=timestamp - 1, limit=1
+    def get_tick(self, origin_id, timestamp):
+        matches = self._schedule_storage.get_ticks(
+            origin_id, before=timestamp + 1, after=timestamp - 1, limit=1
         )
         return matches[0] if len(matches) else None
 
     @traced
-    def get_job_ticks(self, job_origin_id, before=None, after=None, limit=None):
-        return self._schedule_storage.get_job_ticks(
-            job_origin_id, before=before, after=after, limit=limit
-        )
+    def get_ticks(self, origin_id, before=None, after=None, limit=None):
+        return self._schedule_storage.get_ticks(origin_id, before=before, after=after, limit=limit)
+
+    def create_tick(self, tick_data):
+        return self._schedule_storage.create_tick(tick_data)
+
+    def update_tick(self, tick):
+        return self._schedule_storage.update_tick(tick)
 
     @traced
-    def get_latest_job_tick(self, job_origin_id):
-        return self._schedule_storage.get_latest_job_tick(job_origin_id)
+    def get_tick_stats(self, origin_id):
+        return self._schedule_storage.get_tick_stats(origin_id)
 
-    def create_job_tick(self, job_tick_data):
-        return self._schedule_storage.create_job_tick(job_tick_data)
-
-    def update_job_tick(self, tick):
-        return self._schedule_storage.update_job_tick(tick)
-
-    @traced
-    def get_job_tick_stats(self, job_origin_id):
-        return self._schedule_storage.get_job_tick_stats(job_origin_id)
-
-    def purge_job_ticks(self, job_origin_id, tick_status, before):
-        self._schedule_storage.purge_job_ticks(job_origin_id, tick_status, before)
+    def purge_ticks(self, origin_id, tick_status, before):
+        self._schedule_storage.purge_ticks(origin_id, tick_status, before)
 
     def wipe_all_schedules(self):
         if self._scheduler:

--- a/python_modules/dagster/dagster/core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/core/scheduler/instigation.py
@@ -180,6 +180,10 @@ class InstigatorTick(namedtuple("_InstigatorTick", "tick_id job_tick_data")):
         return self._replace(job_tick_data=self.job_tick_data.with_origin_run(origin_run_id))
 
     @property
+    def tick_data(self):
+        return self.job_tick_data
+
+    @property
     def job_origin_id(self):
         return self.job_tick_data.job_origin_id
 
@@ -277,7 +281,7 @@ class TickData(
             failure_count (int): The number of times this tick has failed. If the status is not
                 FAILED, this is the number of previous failures before it reached the current state.
         """
-        _validate_job_tick_args(job_type, status, run_ids, error, skip_reason)
+        _validate_tick_args(job_type, status, run_ids, error, skip_reason)
         return super(TickData, cls).__new__(
             cls,
             check.str_param(job_origin_id, "job_origin_id"),
@@ -287,8 +291,8 @@ class TickData(
             check.float_param(timestamp, "timestamp"),
             check.opt_list_param(run_ids, "run_ids", of_type=str),
             check.opt_list_param(run_keys, "run_keys", of_type=str),
-            error,  # validated in _validate_job_tick_args
-            skip_reason,  # validated in _validate_job_tick_args
+            error,  # validated in _validate_tick_args
+            skip_reason,  # validated in _validate_tick_args
             cursor=check.opt_str_param(cursor, "cursor"),
             origin_run_ids=check.opt_list_param(origin_run_ids, "origin_run_ids", of_type=str),
             failure_count=check.opt_int_param(failure_count, "failure_count", 0),
@@ -358,7 +362,7 @@ register_serdes_tuple_fallbacks({"JobTickData": TickData})
 JobTickData = TickData
 
 
-def _validate_job_tick_args(job_type, status, run_ids=None, error=None, skip_reason=None):
+def _validate_tick_args(job_type, status, run_ids=None, error=None, skip_reason=None):
     check.inst_param(job_type, "job_type", InstigatorType)
     check.inst_param(status, "status", TickStatus)
 

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -57,55 +57,47 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def get_job_ticks(
-        self, job_origin_id: str, before: float = None, after: float = None, limit: int = None
+    def get_ticks(
+        self, origin_id: str, before: float = None, after: float = None, limit: int = None
     ) -> Iterable[InstigatorTick]:
-        """Get the ticks for a given job.
+        """Get the ticks for a given instigator.
 
         Args:
-            job_origin_id (str): The id of the ExternalJob target
+            origin_id (str): The id of the instigator target
         """
 
     @abc.abstractmethod
-    def get_latest_job_tick(self, job_origin_id: str) -> InstigatorTick:
-        """Get the most recent tick for a given job.
+    def create_tick(self, tick_data: TickData):
+        """Add a tick to storage.
 
         Args:
-            job_origin_id (str): The id of the ExternalJob target
+            tick_data (TickData): The tick to add
         """
 
     @abc.abstractmethod
-    def create_job_tick(self, job_tick_data: TickData):
-        """Add a job tick to storage.
+    def update_tick(self, tick: InstigatorTick):
+        """Update a tick already in storage.
 
         Args:
-            job_tick_data (TickData): The job tick to add
+            tick (InstigatorTick): The tick to update
         """
 
     @abc.abstractmethod
-    def update_job_tick(self, tick: InstigatorTick):
-        """Update a job tick already in storage.
+    def purge_ticks(self, origin_id: str, tick_status: TickStatus, before: float):
+        """Wipe ticks for an instigator for a certain status and timestamp.
 
         Args:
-            tick (InstigatorTick): The job tick to update
-        """
-
-    @abc.abstractmethod
-    def purge_job_ticks(self, job_origin_id: str, tick_status: TickStatus, before: float):
-        """Wipe ticks for a job for a certain status and timestamp.
-
-        Args:
-            job_origin_id (str): The id of the ExternalJob target to delete
+            origin_id (str): The id of the instigator target to delete
             tick_status (TickStatus): The tick status to wipe
             before (datetime): All ticks before this datetime will get purged
         """
 
     @abc.abstractmethod
-    def get_job_tick_stats(self, job_origin_id: str):
-        """Get tick stats for a given job.
+    def get_tick_stats(self, origin_id: str):
+        """Get tick stats for a given instigator.
 
         Args:
-            job_origin_id (str): The id of the ExternalJob target
+            origin_id (str): The id of the instigator target
         """
 
     @abc.abstractmethod

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -14,46 +14,46 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """Delete all schedules from storage"""
 
     @abc.abstractmethod
-    def all_stored_job_state(
-        self, repository_origin_id: str = None, job_type: InstigatorType = None
+    def all_instigator_state(
+        self, repository_origin_id: str = None, instigator_type: InstigatorType = None
     ) -> Iterable[InstigatorState]:
         """Return all InstigationStates present in storage
 
         Args:
             repository_origin_id (Optional[str]): The ExternalRepository target id to scope results to
-            job_type (Optional[InstigatorType]): The InstigatorType to scope results to
+            instigator_type (Optional[InstigatorType]): The InstigatorType to scope results to
         """
 
     @abc.abstractmethod
-    def get_job_state(self, job_origin_id: str) -> InstigatorState:
-        """Return the unique job with the given id
+    def get_instigator_state(self, origin_id: str) -> InstigatorState:
+        """Return the instigator state for the given id
 
         Args:
-            job_origin_id (str): The unique job identifier
+            origin_id (str): The unique instigator identifier
         """
 
     @abc.abstractmethod
-    def add_job_state(self, job: InstigatorState):
-        """Add a job to storage.
+    def add_instigator_state(self, state: InstigatorState):
+        """Add an instigator state to storage.
 
         Args:
-            job (InstigatorState): The job to add
+            state (InstigatorState): The state to add
         """
 
     @abc.abstractmethod
-    def update_job_state(self, job: InstigatorState):
-        """Update a job in storage.
+    def update_instigator_state(self, state: InstigatorState):
+        """Update an instigator state in storage.
 
         Args:
-            job (InstigatorState): The job to update
+            state (InstigatorState): The state to update
         """
 
     @abc.abstractmethod
-    def delete_job_state(self, job_origin_id: str):
-        """Delete a job in storage.
+    def delete_instigator_state(self, origin_id: str):
+        """Delete a state in storage.
 
         Args:
-            job_origin_id (str): The id of the ExternalJob target to delete
+            origin_id (str): The id of the instigator target to delete
         """
 
     @abc.abstractmethod

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -130,8 +130,8 @@ class SqlScheduleStorage(ScheduleStorage):
             query = query.limit(limit)
         return query
 
-    def get_ticks(self, job_origin_id, before=None, after=None, limit=None):
-        check.str_param(job_origin_id, "job_origin_id")
+    def get_ticks(self, origin_id, before=None, after=None, limit=None):
+        check.str_param(origin_id, "origin_id")
         check.opt_float_param(before, "before")
         check.opt_float_param(after, "after")
         check.opt_int_param(limit, "limit")
@@ -139,7 +139,7 @@ class SqlScheduleStorage(ScheduleStorage):
         query = (
             db.select([JobTickTable.c.id, JobTickTable.c.tick_body])
             .select_from(JobTickTable)
-            .where(JobTickTable.c.job_origin_id == job_origin_id)
+            .where(JobTickTable.c.job_origin_id == origin_id)
             .order_by(JobTickTable.c.id.desc())
         )
 

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -89,7 +89,7 @@ class SensorLaunchContext:
         self._tick = self._tick.with_run(run_id, run_key)
 
     def _write(self):
-        self._instance.update_job_tick(self._tick)
+        self._instance.update_tick(self._tick)
         if self._tick.status in FULFILLED_TICK_STATES:
             last_run_key = (
                 self._job_state.job_specific_data.last_run_key
@@ -120,7 +120,7 @@ class SensorLaunchContext:
 
         self._write()
 
-        self._instance.purge_job_ticks(
+        self._instance.purge_ticks(
             self._job_state.job_origin_id,
             tick_status=TickStatus.SKIPPED,
             before=pendulum.now("UTC").subtract(days=7).timestamp(),  #  keep the last 7 days
@@ -274,7 +274,7 @@ def execute_sensor_iteration(
             elif _is_under_min_interval(sensor_state, external_sensor, now):
                 continue
 
-            tick = instance.create_job_tick(
+            tick = instance.create_tick(
                 TickData(
                     job_origin_id=sensor_state.job_origin_id,
                     job_name=sensor_state.job_name,

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -98,7 +98,7 @@ class SensorLaunchContext:
             )
             if self._tick.run_keys:
                 last_run_key = self._tick.run_keys[-1]
-            self._instance.update_job_state(
+            self._instance.update_instigator_state(
                 self._job_state.with_data(
                     SensorInstigatorData(
                         last_tick_timestamp=self._tick.timestamp,
@@ -189,7 +189,7 @@ def execute_sensor_iteration(
 
     all_sensor_states = {
         sensor_state.origin.get_id(): sensor_state
-        for sensor_state in instance.all_stored_job_state(job_type=InstigatorType.SENSOR)
+        for sensor_state in instance.all_instigator_state(job_type=InstigatorType.SENSOR)
     }
 
     sensors = {}
@@ -270,7 +270,7 @@ def execute_sensor_iteration(
                     InstigatorStatus.AUTOMATICALLY_RUNNING,
                     SensorInstigatorData(min_interval=external_sensor.min_interval_seconds),
                 )
-                instance.add_job_state(sensor_state)
+                instance.add_instigator_state(sensor_state)
             elif _is_under_min_interval(sensor_state, external_sensor, now):
                 continue
 

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -189,7 +189,7 @@ def execute_sensor_iteration(
 
     all_sensor_states = {
         sensor_state.origin.get_id(): sensor_state
-        for sensor_state in instance.all_instigator_state(job_type=InstigatorType.SENSOR)
+        for sensor_state in instance.all_instigator_state(instigator_type=InstigatorType.SENSOR)
     }
 
     sensors = {}

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -36,7 +36,7 @@ class _ScheduleLaunchContext:
 
     @property
     def failure_count(self) -> int:
-        return self._tick.job_tick_data.failure_count
+        return self._tick.tick_data.failure_count
 
     def update_state(self, status, error=None, **kwargs):
         skip_reason = kwargs.get("skip_reason")
@@ -52,7 +52,7 @@ class _ScheduleLaunchContext:
         self._tick = self._tick.with_run(run_id, run_key)
 
     def _write(self):
-        self._instance.update_job_tick(self._tick)
+        self._instance.update_tick(self._tick)
 
     def __enter__(self):
         return self
@@ -252,7 +252,8 @@ def launch_scheduled_runs_for_schedule(
     check.inst_param(end_datetime_utc, "end_datetime_utc", datetime.datetime)
 
     job_origin_id = external_schedule.get_external_origin_id()
-    latest_tick = instance.get_latest_job_tick(job_origin_id)
+    ticks = instance.get_ticks(job_origin_id, limit=1)
+    latest_tick = ticks[0] if ticks else None
 
     start_timestamp_utc = (
         schedule_state.job_specific_data.start_timestamp if schedule_state else None
@@ -327,7 +328,7 @@ def launch_scheduled_runs_for_schedule(
                     f"Resuming previously interrupted schedule execution at {schedule_time_str}"
                 )
         else:
-            tick = instance.create_job_tick(
+            tick = instance.create_tick(
                 TickData(
                     job_origin_id=external_schedule.get_external_origin_id(),
                     job_name=schedule_name,

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -116,7 +116,7 @@ def launch_scheduled_runs(
 
     all_schedule_states = {
         schedule_state.origin.get_id(): schedule_state
-        for schedule_state in instance.all_stored_job_state(job_type=InstigatorType.SCHEDULE)
+        for schedule_state in instance.all_instigator_state(job_type=InstigatorType.SCHEDULE)
     }
 
     schedules = {}
@@ -145,7 +145,7 @@ def launch_scheduled_runs(
         and schedule_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
     }
     for origin_id in schedule_state_ids_to_delete:
-        instance.schedule_storage.delete_job_state(origin_id)
+        instance.schedule_storage.delete_instigator_state(origin_id)
 
     if log_verbose_checks:
         unloadable_schedule_states = {
@@ -213,7 +213,7 @@ def launch_scheduled_runs(
                         end_datetime_utc.timestamp(),
                     ),
                 )
-                instance.add_job_state(schedule_state)
+                instance.add_instigator_state(schedule_state)
 
             yield from launch_scheduled_runs_for_schedule(
                 instance,

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -116,7 +116,7 @@ def launch_scheduled_runs(
 
     all_schedule_states = {
         schedule_state.origin.get_id(): schedule_state
-        for schedule_state in instance.all_instigator_state(job_type=InstigatorType.SCHEDULE)
+        for schedule_state in instance.all_instigator_state(instigator_type=InstigatorType.SCHEDULE)
     }
 
     schedules = {}

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -84,8 +84,8 @@ class TestScheduleStorage:
         assert storage
 
         schedule = self.build_schedule("my_schedule", "* * * * *")
-        storage.add_job_state(schedule)
-        schedules = storage.all_stored_job_state(
+        storage.add_instigator_state(schedule)
+        schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
             InstigatorType.SCHEDULE,
         )
@@ -103,11 +103,11 @@ class TestScheduleStorage:
         schedule_2 = self.build_schedule("my_schedule_2", "* * * * *")
         schedule_3 = self.build_schedule("my_schedule_3", "* * * * *")
 
-        storage.add_job_state(schedule)
-        storage.add_job_state(schedule_2)
-        storage.add_job_state(schedule_3)
+        storage.add_instigator_state(schedule)
+        storage.add_instigator_state(schedule_2)
+        storage.add_instigator_state(schedule_3)
 
-        schedules = storage.all_stored_job_state(
+        schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
         )
         assert len(schedules) == 3
@@ -120,8 +120,8 @@ class TestScheduleStorage:
         assert storage
 
         state = self.build_schedule("my_schedule", "* * * * *")
-        storage.add_job_state(state)
-        schedule = storage.get_job_state(state.job_origin_id)
+        storage.add_instigator_state(state)
+        schedule = storage.get_instigator_state(state.job_origin_id)
 
         assert schedule.job_name == "my_schedule"
         assert schedule.job_specific_data.start_timestamp == None
@@ -129,8 +129,8 @@ class TestScheduleStorage:
     def test_get_schedule_state_not_found(self, storage):
         assert storage
 
-        storage.add_job_state(self.build_schedule("my_schedule", "* * * * *"))
-        schedule = storage.get_job_state("fake_id")
+        storage.add_instigator_state(self.build_schedule("my_schedule", "* * * * *"))
+        schedule = storage.get_instigator_state("fake_id")
 
         assert schedule is None
 
@@ -138,7 +138,7 @@ class TestScheduleStorage:
         assert storage
 
         schedule = self.build_schedule("my_schedule", "* * * * *")
-        storage.add_job_state(schedule)
+        storage.add_instigator_state(schedule)
 
         now_time = get_current_datetime_in_utc().timestamp()
 
@@ -148,9 +148,9 @@ class TestScheduleStorage:
                 start_timestamp=now_time,
             )
         )
-        storage.update_job_state(new_schedule)
+        storage.update_instigator_state(new_schedule)
 
-        schedules = storage.all_stored_job_state(
+        schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
         )
         assert len(schedules) == 1
@@ -163,9 +163,9 @@ class TestScheduleStorage:
         stopped_schedule = schedule.with_status(InstigatorStatus.STOPPED).with_data(
             ScheduleInstigatorData(schedule.job_specific_data.cron_schedule)
         )
-        storage.update_job_state(stopped_schedule)
+        storage.update_instigator_state(stopped_schedule)
 
-        schedules = storage.all_stored_job_state(
+        schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
         )
         assert len(schedules) == 1
@@ -181,7 +181,7 @@ class TestScheduleStorage:
         schedule = self.build_schedule("my_schedule", "* * * * *")
 
         with pytest.raises(Exception):
-            storage.update_job_state(schedule)
+            storage.update_instigator_state(schedule)
 
     def test_delete_schedule_state(self, storage):
         assert storage
@@ -190,10 +190,10 @@ class TestScheduleStorage:
             pytest.skip("Storage cannot delete")
 
         schedule = self.build_schedule("my_schedule", "* * * * *")
-        storage.add_job_state(schedule)
-        storage.delete_job_state(schedule.job_origin_id)
+        storage.add_instigator_state(schedule)
+        storage.delete_instigator_state(schedule.job_origin_id)
 
-        schedules = storage.all_stored_job_state(
+        schedules = storage.all_instigator_state(
             self.fake_repo_target().get_id(), InstigatorType.SCHEDULE
         )
         assert len(schedules) == 0
@@ -207,16 +207,16 @@ class TestScheduleStorage:
         schedule = self.build_schedule("my_schedule", "* * * * *")
 
         with pytest.raises(Exception):
-            storage.delete_job_state(schedule.job_origin_id)
+            storage.delete_instigator_state(schedule.job_origin_id)
 
     def test_add_schedule_with_same_name(self, storage):
         assert storage
 
         schedule = self.build_schedule("my_schedule", "* * * * *")
-        storage.add_job_state(schedule)
+        storage.add_instigator_state(schedule)
 
         with pytest.raises(Exception):
-            storage.add_job_state(schedule)
+            storage.add_instigator_state(schedule)
 
     def build_schedule_tick(self, current_time, status=TickStatus.STARTED, run_id=None, error=None):
         return TickData(
@@ -343,8 +343,8 @@ class TestScheduleStorage:
     def test_basic_job_storage(self, storage):
         assert storage
         job = self.build_sensor("my_sensor")
-        storage.add_job_state(job)
-        jobs = storage.all_stored_job_state(self.fake_repo_target().get_id())
+        storage.add_instigator_state(job)
+        jobs = storage.all_instigator_state(self.fake_repo_target().get_id())
         assert len(jobs) == 1
 
         job = jobs[0]
@@ -357,43 +357,43 @@ class TestScheduleStorage:
         job_2 = self.build_sensor("my_sensor_2")
         job_3 = self.build_sensor("my_sensor_3")
 
-        storage.add_job_state(job)
-        storage.add_job_state(job_2)
-        storage.add_job_state(job_3)
+        storage.add_instigator_state(job)
+        storage.add_instigator_state(job_2)
+        storage.add_instigator_state(job_3)
 
-        jobs = storage.all_stored_job_state(self.fake_repo_target().get_id())
+        jobs = storage.all_instigator_state(self.fake_repo_target().get_id())
         assert len(jobs) == 3
 
         assert any(s.job_name == "my_sensor" for s in jobs)
         assert any(s.job_name == "my_sensor_2" for s in jobs)
         assert any(s.job_name == "my_sensor_3" for s in jobs)
 
-    def test_get_job_state(self, storage):
+    def test_get_instigator_state(self, storage):
         assert storage
 
         state = self.build_sensor("my_sensor")
-        storage.add_job_state(state)
-        job = storage.get_job_state(state.job_origin_id)
+        storage.add_instigator_state(state)
+        job = storage.get_instigator_state(state.job_origin_id)
 
         assert job.job_name == "my_sensor"
 
-    def test_get_job_state_not_found(self, storage):
+    def test_get_instigator_state_not_found(self, storage):
         assert storage
 
-        storage.add_job_state(self.build_sensor("my_sensor"))
-        job_state = storage.get_job_state("fake_id")
+        storage.add_instigator_state(self.build_sensor("my_sensor"))
+        job_state = storage.get_instigator_state("fake_id")
         assert job_state is None
 
     def test_update_job(self, storage):
         assert storage
 
         job = self.build_sensor("my_sensor")
-        storage.add_job_state(job)
+        storage.add_instigator_state(job)
 
         new_job = job.with_status(InstigatorStatus.RUNNING)
-        storage.update_job_state(new_job)
+        storage.update_instigator_state(new_job)
 
-        jobs = storage.all_stored_job_state(self.fake_repo_target().get_id())
+        jobs = storage.all_instigator_state(self.fake_repo_target().get_id())
         assert len(jobs) == 1
 
         job = jobs[0]
@@ -401,9 +401,9 @@ class TestScheduleStorage:
         assert job.status == InstigatorStatus.RUNNING
 
         stopped_job = job.with_status(InstigatorStatus.STOPPED)
-        storage.update_job_state(stopped_job)
+        storage.update_instigator_state(stopped_job)
 
-        jobs = storage.all_stored_job_state(self.fake_repo_target().get_id())
+        jobs = storage.all_instigator_state(self.fake_repo_target().get_id())
         assert len(jobs) == 1
 
         job = jobs[0]
@@ -416,19 +416,19 @@ class TestScheduleStorage:
         job = self.build_sensor("my_sensor")
 
         with pytest.raises(Exception):
-            storage.update_job_state(job)
+            storage.update_instigator_state(job)
 
-    def test_delete_job_state(self, storage):
+    def test_delete_instigator_state(self, storage):
         assert storage
 
         if not self.can_delete():
             pytest.skip("Storage cannot delete")
 
         job = self.build_sensor("my_sensor")
-        storage.add_job_state(job)
-        storage.delete_job_state(job.job_origin_id)
+        storage.add_instigator_state(job)
+        storage.delete_instigator_state(job.job_origin_id)
 
-        jobs = storage.all_stored_job_state(self.fake_repo_target().get_id())
+        jobs = storage.all_instigator_state(self.fake_repo_target().get_id())
         assert len(jobs) == 0
 
     def test_delete_job_not_found(self, storage):
@@ -440,16 +440,16 @@ class TestScheduleStorage:
         job = self.build_sensor("my_sensor")
 
         with pytest.raises(Exception):
-            storage.delete_job_state(job.job_origin_id)
+            storage.delete_instigator_state(job.job_origin_id)
 
     def test_add_job_with_same_name(self, storage):
         assert storage
 
         job = self.build_sensor("my_sensor")
-        storage.add_job_state(job)
+        storage.add_instigator_state(job)
 
         with pytest.raises(Exception):
-            storage.add_job_state(job)
+            storage.add_instigator_state(job)
 
     def build_sensor_tick(self, current_time, status=TickStatus.STARTED, run_id=None, error=None):
         return TickData(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -78,7 +78,7 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
             )
             launch_process.start()
             launch_process.join(timeout=60)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SKIPPED
             capfd.readouterr()
@@ -96,7 +96,7 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
 
             capfd.readouterr()
 
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
             assert ticks[0].status == TickStatus.STARTED
             assert not int(ticks[0].timestamp) % 2  # skip condition for simple_sensor
@@ -123,7 +123,7 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
 2019-02-27 18:01:03 -0600 - dagster.daemon.SensorDaemon - INFO - Completed launch of run {run.run_id} for simple_sensor"""
             )
 
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 3
             assert ticks[0].status == TickStatus.SUCCESS
 
@@ -164,7 +164,7 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
 
             assert launch_process.exitcode != 0
 
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
 
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.STARTED
@@ -198,7 +198,7 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
                 in captured.out
             )
 
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
             assert ticks[0].status == TickStatus.SUCCESS
 
@@ -247,7 +247,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
 
             assert launch_process.exitcode != 0
 
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
 
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.STARTED
@@ -278,6 +278,6 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
                 in captured.out
             )
 
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
             assert ticks[0].status == TickStatus.SKIPPED

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_failure_recovery.py
@@ -63,7 +63,7 @@ def test_failure_before_run_created(crash_location, crash_signal, capfd):
     ):
         with pendulum.test(frozen_datetime):
             external_sensor = external_repo.get_external_sensor("simple_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -145,7 +145,7 @@ def test_failure_after_run_created_before_run_launched(crash_location, crash_sig
     ):
         with pendulum.test(frozen_datetime):
             external_sensor = external_repo.get_external_sensor("run_key_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -228,7 +228,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, capfd):
     ):
         with pendulum.test(frozen_datetime):
             external_sensor = external_repo.get_external_sensor("run_key_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -372,7 +372,7 @@ def validate_tick(
     expected_run_ids=None,
     expected_error=None,
 ):
-    tick_data = tick.job_tick_data
+    tick_data = tick.tick_data
     assert tick_data.job_origin_id == external_sensor.get_external_origin_id()
     assert tick_data.job_name == external_sensor.name
     assert tick_data.job_type == InstigatorType.SENSOR
@@ -450,13 +450,13 @@ def test_simple_sensor(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -479,7 +479,7 @@ def test_simple_sensor(capfd):
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
             validate_run_started(run)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
 
             expected_datetime = create_pendulum_time(
@@ -534,13 +534,13 @@ def test_bad_load_sensor_repository(capfd):
             )
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(invalid_repo_origin.get_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(invalid_repo_origin.get_id())
             assert len(ticks) == 0
 
             captured = capfd.readouterr()
@@ -578,13 +578,13 @@ def test_bad_load_sensor(capfd):
             )
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(invalid_repo_origin.get_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+            ticks = instance.get_ticks(invalid_repo_origin.get_id())
             assert len(ticks) == 0
 
             captured = capfd.readouterr()
@@ -611,13 +611,13 @@ def test_error_sensor(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -661,12 +661,12 @@ def test_wrong_config_sensor(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
 
             validate_tick(
@@ -685,7 +685,7 @@ def test_wrong_config_sensor(capfd):
 
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
 
             validate_tick(
@@ -725,14 +725,14 @@ def test_launch_failure(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -779,7 +779,7 @@ def test_launch_once(capfd):
                 )
             )
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
@@ -787,7 +787,7 @@ def test_launch_once(capfd):
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -802,7 +802,7 @@ def test_launch_once(capfd):
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
             assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -830,7 +830,7 @@ def test_launch_once(capfd):
         freeze_datetime = freeze_datetime.add(seconds=30)
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
 
             assert len(ticks) == 3
             validate_tick(
@@ -859,11 +859,11 @@ def test_custom_interval_sensor():
                     InstigatorStatus.RUNNING,
                 )
             )
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(ticks[0], external_sensor, freeze_datetime, TickStatus.SKIPPED)
 
@@ -871,7 +871,7 @@ def test_custom_interval_sensor():
 
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             # no additional tick created after 30 seconds
             assert len(ticks) == 1
 
@@ -879,7 +879,7 @@ def test_custom_interval_sensor():
 
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
 
             expected_datetime = create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=1)
@@ -919,13 +919,13 @@ def test_custom_interval_sensor_with_offset(monkeypatch):
 
             # create a tick
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
 
             # calling for another iteration should not generate another tick because time has not
             # advanced
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
 
             # call the sensor_iteration_loop, which should loop, and call the monkeypatched sleep
@@ -940,7 +940,7 @@ def test_custom_interval_sensor_with_offset(monkeypatch):
             )
 
             assert pendulum.now() == freeze_datetime.add(seconds=65)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 2
             assert sum(sleeps) == 65
 
@@ -968,14 +968,14 @@ def test_sensor_start_stop():
             instance.start_sensor(external_sensor)
 
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id)
             assert len(ticks) == 0
 
             evaluate_sensors(instance, workspace)
 
             assert instance.get_runs_count() == 1
             run = instance.get_runs()[0]
-            ticks = instance.get_job_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id)
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -991,7 +991,7 @@ def test_sensor_start_stop():
             evaluate_sensors(instance, workspace)
             # no new ticks, no new runs, we are below the 30 second min interval
             assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id)
             assert len(ticks) == 1
 
             # stop / start
@@ -1001,7 +1001,7 @@ def test_sensor_start_stop():
             evaluate_sensors(instance, workspace)
             # no new ticks, no new runs, we are below the 30 second min interval
             assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id)
             assert len(ticks) == 1
 
             freeze_datetime = freeze_datetime.add(seconds=16)
@@ -1010,7 +1010,7 @@ def test_sensor_start_stop():
             evaluate_sensors(instance, workspace)
             # should have new tick, new run, we are after the 30 second min interval
             assert instance.get_runs_count() == 2
-            ticks = instance.get_job_ticks(external_origin_id)
+            ticks = instance.get_ticks(external_origin_id)
             assert len(ticks) == 2
 
 
@@ -1028,7 +1028,7 @@ def test_large_sensor():
             external_sensor = external_repo.get_external_sensor("large_sensor")
             instance.start_sensor(external_sensor)
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(external_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1055,7 +1055,7 @@ def test_cursor_sensor():
             instance.start_sensor(run_sensor)
             evaluate_sensors(instance, workspace)
 
-            skip_ticks = instance.get_job_ticks(skip_sensor.get_external_origin_id())
+            skip_ticks = instance.get_ticks(skip_sensor.get_external_origin_id())
             assert len(skip_ticks) == 1
             validate_tick(
                 skip_ticks[0],
@@ -1065,7 +1065,7 @@ def test_cursor_sensor():
             )
             assert skip_ticks[0].cursor == "1"
 
-            run_ticks = instance.get_job_ticks(run_sensor.get_external_origin_id())
+            run_ticks = instance.get_ticks(run_sensor.get_external_origin_id())
             assert len(run_ticks) == 1
             validate_tick(
                 run_ticks[0],
@@ -1079,7 +1079,7 @@ def test_cursor_sensor():
         with pendulum.test(freeze_datetime):
             evaluate_sensors(instance, workspace)
 
-            skip_ticks = instance.get_job_ticks(skip_sensor.get_external_origin_id())
+            skip_ticks = instance.get_ticks(skip_sensor.get_external_origin_id())
             assert len(skip_ticks) == 2
             validate_tick(
                 skip_ticks[0],
@@ -1089,7 +1089,7 @@ def test_cursor_sensor():
             )
             assert skip_ticks[0].cursor == "2"
 
-            run_ticks = instance.get_job_ticks(run_sensor.get_external_origin_id())
+            run_ticks = instance.get_ticks(run_sensor.get_external_origin_id())
             assert len(run_ticks) == 2
             validate_tick(
                 run_ticks[0],
@@ -1116,7 +1116,7 @@ def test_asset_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1133,7 +1133,7 @@ def test_asset_sensor():
 
             # should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1163,7 +1163,7 @@ def test_asset_job_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1180,7 +1180,7 @@ def test_asset_job_sensor():
 
             # should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1214,7 +1214,7 @@ def test_asset_sensor_not_triggered_on_observation():
             # observation should not fire the asset sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1231,7 +1231,7 @@ def test_asset_sensor_not_triggered_on_observation():
 
             # materialization should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(foo_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(foo_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1258,7 +1258,7 @@ def test_pipeline_failure_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1288,7 +1288,7 @@ def test_pipeline_failure_sensor():
             # should fire the failure sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1311,7 +1311,7 @@ def test_run_failure_sensor_filtered():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1341,7 +1341,7 @@ def test_run_failure_sensor_filtered():
             # should not fire the failure sensor (filtered to failure job)
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1372,7 +1372,7 @@ def test_run_failure_sensor_filtered():
             # should not fire the failure sensor (filtered to failure job)
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
             assert len(ticks) == 3
             validate_tick(
                 ticks[0],
@@ -1395,7 +1395,7 @@ def test_run_status_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(success_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(success_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1425,7 +1425,7 @@ def test_run_status_sensor():
             # should not fire the success sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(success_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(success_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1452,7 +1452,7 @@ def test_run_status_sensor():
             # should fire the success sensor
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(success_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(success_sensor.get_external_origin_id())
             assert len(ticks) == 3
             validate_tick(
                 ticks[0],
@@ -1513,7 +1513,7 @@ def test_run_status_sensor_interleave(storage_config_fn):
 
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
                 assert len(ticks) == 1
                 validate_tick(
                     ticks[0],
@@ -1556,7 +1556,7 @@ def test_run_status_sensor_interleave(storage_config_fn):
                 # should fire for run 2
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
                 assert len(ticks) == 2
                 validate_tick(
                     ticks[0],
@@ -1580,7 +1580,7 @@ def test_run_status_sensor_interleave(storage_config_fn):
                 # should fire for run 1
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
                 assert len(ticks) == 3
                 validate_tick(
                     ticks[0],
@@ -1609,7 +1609,7 @@ def test_pipeline_failure_sensor_empty_run_records(storage_config_fn):
 
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
                 assert len(ticks) == 1
                 validate_tick(
                     ticks[0],
@@ -1649,7 +1649,7 @@ def test_pipeline_failure_sensor_empty_run_records(storage_config_fn):
                 # shouldn't fire the failure sensor due to the mismatch
                 evaluate_sensors(instance, workspace)
 
-                ticks = instance.get_job_ticks(failure_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(failure_sensor.get_external_origin_id())
                 assert len(ticks) == 2
                 validate_tick(
                     ticks[0],
@@ -1675,7 +1675,7 @@ def test_multi_job_sensor():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1694,7 +1694,7 @@ def test_multi_job_sensor():
 
             # should fire the asset sensor
             evaluate_sensors(instance, workspace)
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 2
             validate_tick(
                 ticks[0],
@@ -1725,7 +1725,7 @@ def test_bad_run_request_untargeted():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1756,7 +1756,7 @@ def test_bad_run_request_mismatch():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1787,7 +1787,7 @@ def test_bad_run_request_unspecified():
 
             evaluate_sensors(instance, workspace)
 
-            ticks = instance.get_job_ticks(job_sensor.get_external_origin_id())
+            ticks = instance.get_ticks(job_sensor.get_external_origin_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1825,8 +1825,8 @@ def test_status_in_code_sensor():
                 never_running_origin = not_running_sensor.get_external_origin()
 
                 assert instance.get_runs_count() == 0
-                assert len(instance.get_job_ticks(always_running_origin.get_id())) == 0
-                assert len(instance.get_job_ticks(never_running_origin.get_id())) == 0
+                assert len(instance.get_ticks(always_running_origin.get_id())) == 0
+                assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
                 assert len(instance.all_stored_job_state()) == 0
 
@@ -1838,7 +1838,7 @@ def test_status_in_code_sensor():
                 instigator_state = instance.get_job_state(always_running_origin.get_id())
                 assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
 
-                ticks = instance.get_job_ticks(running_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(running_sensor.get_external_origin_id())
                 assert len(ticks) == 1
                 validate_tick(
                     ticks[0],
@@ -1847,7 +1847,7 @@ def test_status_in_code_sensor():
                     TickStatus.SKIPPED,
                 )
 
-                assert len(instance.get_job_ticks(never_running_origin.get_id())) == 0
+                assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
             freeze_datetime = freeze_datetime.add(seconds=30)
             with pendulum.test(freeze_datetime):
@@ -1856,7 +1856,7 @@ def test_status_in_code_sensor():
                 assert instance.get_runs_count() == 1
                 run = instance.get_runs()[0]
                 validate_run_started(run)
-                ticks = instance.get_job_ticks(running_sensor.get_external_origin_id())
+                ticks = instance.get_ticks(running_sensor.get_external_origin_id())
                 assert len(ticks) == 2
 
                 expected_datetime = create_pendulum_time(
@@ -1870,4 +1870,4 @@ def test_status_in_code_sensor():
                     [run.run_id],
                 )
 
-                assert len(instance.get_job_ticks(never_running_origin.get_id())) == 0
+                assert len(instance.get_ticks(never_running_origin.get_id())) == 0

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -442,7 +442,7 @@ def test_simple_sensor(capfd):
     ):
         with pendulum.test(freeze_datetime):
             external_sensor = external_repo.get_external_sensor("simple_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -527,7 +527,7 @@ def test_bad_load_sensor_repository(capfd):
                 valid_origin.instigator_name,
             )
 
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     invalid_repo_origin, InstigatorType.SENSOR, InstigatorStatus.RUNNING
                 )
@@ -571,7 +571,7 @@ def test_bad_load_sensor(capfd):
                 "invalid_sensor",
             )
 
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     invalid_repo_origin, InstigatorType.SENSOR, InstigatorStatus.RUNNING
                 )
@@ -603,7 +603,7 @@ def test_error_sensor(capfd):
     ):
         with pendulum.test(freeze_datetime):
             external_sensor = external_repo.get_external_sensor("error_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -653,7 +653,7 @@ def test_wrong_config_sensor(capfd):
     ):
         with pendulum.test(freeze_datetime):
             external_sensor = external_repo.get_external_sensor("wrong_config_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -717,7 +717,7 @@ def test_launch_failure(capfd):
         with pendulum.test(freeze_datetime):
 
             external_sensor = external_repo.get_external_sensor("always_on_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -771,7 +771,7 @@ def test_launch_once(capfd):
         with pendulum.test(freeze_datetime):
 
             external_sensor = external_repo.get_external_sensor("run_key_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -852,7 +852,7 @@ def test_custom_interval_sensor():
     ):
         with pendulum.test(freeze_datetime):
             external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -909,7 +909,7 @@ def test_custom_interval_sensor_with_offset(monkeypatch):
             # 60 second custom interval
             external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
 
-            instance.add_job_state(
+            instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_external_origin(),
                     InstigatorType.SENSOR,
@@ -1828,14 +1828,14 @@ def test_status_in_code_sensor():
                 assert len(instance.get_ticks(always_running_origin.get_id())) == 0
                 assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
-                assert len(instance.all_stored_job_state()) == 0
+                assert len(instance.all_instigator_state()) == 0
 
                 evaluate_sensors(instance, workspace)
 
                 assert instance.get_runs_count() == 0
 
-                assert len(instance.all_stored_job_state()) == 1
-                instigator_state = instance.get_job_state(always_running_origin.get_id())
+                assert len(instance.all_instigator_state()) == 1
+                instigator_state = instance.get_instigator_state(always_running_origin.get_id())
                 assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
 
                 ticks = instance.get_ticks(running_sensor.get_external_origin_id())

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -408,7 +408,7 @@ def test_0_10_0_schedule_wipe():
         assert "job_ticks" in get_sqlite3_tables(db_path)
 
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as upgraded_instance:
-            assert len(upgraded_instance.all_stored_job_state()) == 0
+            assert len(upgraded_instance.all_instigator_state()) == 0
 
 
 def test_0_10_6_add_bulk_actions_table():

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -72,7 +72,7 @@ def test_failure_recovery_before_run_created(instance, external_repo, crash_loca
 
         assert scheduler_process.exitcode != 0
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
 
@@ -96,7 +96,7 @@ def test_failure_recovery_before_run_created(instance, external_repo, crash_loca
             partition_time=create_pendulum_time(2019, 2, 26),
         )
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -132,7 +132,7 @@ def test_failure_recovery_after_run_created(instance, external_repo, crash_locat
 
         assert scheduler_process.exitcode != 0
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
 
@@ -180,7 +180,7 @@ def test_failure_recovery_after_run_created(instance, external_repo, crash_locat
             instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
         )
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -224,7 +224,7 @@ def test_failure_recovery_after_tick_success(instance, external_repo, crash_loca
             instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
         )
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
 
         if crash_signal == get_terminate_signal():
@@ -256,7 +256,7 @@ def test_failure_recovery_after_tick_success(instance, external_repo, crash_loca
             instance.get_runs()[0], initial_datetime, create_pendulum_time(2019, 2, 26)
         )
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -294,7 +294,7 @@ def test_failure_recovery_between_multi_runs(instance, external_repo, crash_loca
         assert instance.get_runs_count() == 1
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
 
     frozen_datetime = frozen_datetime.add(minutes=1)
@@ -308,7 +308,7 @@ def test_failure_recovery_between_multi_runs(instance, external_repo, crash_loca
         assert scheduler_process.exitcode == 0
         assert instance.get_runs_count() == 2
         validate_run_exists(instance.get_runs()[0], initial_datetime)
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1112,7 +1112,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             InstigatorStatus.RUNNING,
             ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
         )
-        instance.add_job_state(unloadable_schedule_state)
+        instance.add_instigator_state(unloadable_schedule_state)
 
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
@@ -1248,7 +1248,7 @@ def test_bad_load_repository(instance, workspace, external_repo, caplog):
             InstigatorStatus.RUNNING,
             ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
         )
-        instance.add_job_state(schedule_state)
+        instance.add_instigator_state(schedule_state)
 
     initial_datetime = freeze_datetime.add(seconds=1)
     with pendulum.test(initial_datetime):
@@ -1287,7 +1287,7 @@ def test_bad_load_schedule(instance, workspace, external_repo, caplog):
             InstigatorStatus.RUNNING,
             ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
         )
-        instance.add_job_state(schedule_state)
+        instance.add_instigator_state(schedule_state)
 
     initial_datetime = freeze_datetime.add(seconds=1)
     with pendulum.test(initial_datetime):
@@ -1367,7 +1367,7 @@ def test_load_repository_location_not_in_workspace(instance, workspace, external
             InstigatorStatus.RUNNING,
             ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
         )
-        instance.add_job_state(schedule_state)
+        instance.add_instigator_state(schedule_state)
 
     initial_datetime = freeze_datetime.add(seconds=1)
     with pendulum.test(initial_datetime):

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -1320,7 +1320,7 @@ def test_error_load_repository_location(instance):
                 InstigatorStatus.RUNNING,
                 ScheduleInstigatorData("0 0 * * *", pendulum.now("UTC").timestamp()),
             )
-            instance.add_job_state(schedule_state)
+            instance.add_instigator_state(schedule_state)
 
         initial_datetime = initial_datetime.add(seconds=1)
         with pendulum.test(initial_datetime):
@@ -1860,16 +1860,16 @@ def test_status_in_code_schedule(instance):
             assert len(instance.get_ticks(always_running_origin.get_id())) == 0
             assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
-            assert len(instance.all_stored_job_state()) == 0
+            assert len(instance.all_instigator_state()) == 0
 
             list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
             # No runs, but the job state is updated to set a checkpoing
             assert instance.get_runs_count() == 0
 
-            assert len(instance.all_stored_job_state()) == 1
+            assert len(instance.all_instigator_state()) == 1
 
-            instigator_state = instance.get_job_state(always_running_origin.get_id())
+            instigator_state = instance.get_instigator_state(always_running_origin.get_id())
 
             assert instigator_state.status == InstigatorStatus.AUTOMATICALLY_RUNNING
             assert (
@@ -1968,7 +1968,7 @@ def test_status_in_code_schedule(instance):
             )
             ticks = instance.get_ticks(always_running_origin.get_id())
             assert len(ticks) == 3
-            assert len(instance.all_stored_job_state()) == 0
+            assert len(instance.all_instigator_state()) == 0
 
 
 def test_change_default_status(instance):
@@ -1998,7 +1998,7 @@ def test_change_default_status(instance):
                 freeze_datetime.timestamp(),
             ),
         )
-        instance.add_job_state(schedule_state)
+        instance.add_instigator_state(schedule_state)
 
         freeze_datetime = freeze_datetime.add(days=2)
         with pendulum.test(freeze_datetime):
@@ -2016,7 +2016,7 @@ def test_change_default_status(instance):
             assert len(ticks) == 0
 
             # AUTOMATICALLY_RUNNING row has been removed from the database
-            instigator_state = instance.get_job_state(never_running_origin.get_id())
+            instigator_state = instance.get_instigator_state(never_running_origin.get_id())
             assert not instigator_state
 
             # schedule can still be manually started
@@ -2030,7 +2030,7 @@ def test_change_default_status(instance):
                     freeze_datetime.timestamp(),
                 ),
             )
-            instance.add_job_state(schedule_state)
+            instance.add_instigator_state(schedule_state)
 
             list(
                 launch_scheduled_runs(

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -457,7 +457,7 @@ def validate_tick(
     expected_failure_count=0,
     expected_skip_reason=None,
 ):
-    tick_data = tick.job_tick_data
+    tick_data = tick.tick_data
     assert tick_data.job_origin_id == external_schedule.get_external_origin_id()
     assert tick_data.job_name == external_schedule.name
     assert tick_data.timestamp == expected_datetime.timestamp()
@@ -528,7 +528,7 @@ def test_simple_schedule(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
         # launch_scheduled_runs does nothing before the first tick
@@ -541,7 +541,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
@@ -556,7 +556,7 @@ def test_simple_schedule(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
@@ -587,7 +587,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -603,7 +603,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -620,7 +620,7 @@ def test_simple_schedule(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
         assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 3
 
@@ -632,7 +632,7 @@ def test_simple_schedule(instance, workspace, external_repo):
         # Check idempotence again
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
 
@@ -645,7 +645,7 @@ def test_old_tick_schedule(instance, workspace, external_repo):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
 
         # Create an old tick from several days ago
-        instance.create_job_tick(
+        instance.create_tick(
             TickData(
                 job_origin_id=external_schedule.get_external_origin_id(),
                 job_name="simple_schedule",
@@ -672,7 +672,7 @@ def test_old_tick_schedule(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 2
 
 
@@ -683,7 +683,7 @@ def test_no_started_schedules(instance, workspace, external_repo):
     list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
     assert instance.get_runs_count() == 0
 
-    ticks = instance.get_job_ticks(schedule_origin.get_id())
+    ticks = instance.get_ticks(schedule_origin.get_id())
     assert len(ticks) == 0
 
 
@@ -710,7 +710,7 @@ def test_schedule_without_timezone(instance):
 
                 assert instance.get_runs_count() == 1
 
-                ticks = instance.get_job_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id())
 
                 assert len(ticks) == 1
 
@@ -735,7 +735,7 @@ def test_schedule_without_timezone(instance):
                 # Verify idempotence
                 list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
                 assert instance.get_runs_count() == 1
-                ticks = instance.get_job_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id())
                 assert len(ticks) == 1
 
 
@@ -749,7 +749,7 @@ def test_bad_env_fn_no_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -766,7 +766,7 @@ def test_bad_env_fn_no_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -784,7 +784,7 @@ def test_bad_env_fn_no_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 2
 
         validate_tick(
@@ -812,7 +812,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -837,7 +837,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -856,7 +856,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -874,7 +874,7 @@ def test_bad_env_fn_with_retries(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 2
 
         validate_tick(
@@ -902,7 +902,7 @@ def test_passes_on_retry(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -922,7 +922,7 @@ def test_passes_on_retry(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -943,7 +943,7 @@ def test_passes_on_retry(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 2
 
         validate_tick(
@@ -973,7 +973,7 @@ def test_bad_should_execute(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -1000,7 +1000,7 @@ def test_skip(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1023,7 +1023,7 @@ def test_wrong_config_schedule(instance, workspace, external_repo):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1058,7 +1058,7 @@ def test_schedule_run_default_config(instance, workspace, external_repo):
             expected_success=True,
         )
 
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
@@ -1125,7 +1125,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             partition_time=create_pendulum_time(2019, 2, 26),
         )
 
-        good_ticks = instance.get_job_ticks(good_origin.get_id())
+        good_ticks = instance.get_ticks(good_origin.get_id())
         assert len(good_ticks) == 1
         validate_tick(
             good_ticks[0],
@@ -1135,7 +1135,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             [run.run_id for run in instance.get_runs()],
         )
 
-        bad_ticks = instance.get_job_ticks(bad_origin.get_id())
+        bad_ticks = instance.get_ticks(bad_origin.get_id())
         assert len(bad_ticks) == 1
 
         assert bad_ticks[0].status == TickStatus.FAILURE
@@ -1145,7 +1145,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             in bad_ticks[0].error.message
         )
 
-        unloadable_ticks = instance.get_job_ticks(unloadable_origin.get_id())
+        unloadable_ticks = instance.get_ticks(unloadable_origin.get_id())
         assert len(unloadable_ticks) == 0
 
     initial_datetime = initial_datetime.add(days=1)
@@ -1167,7 +1167,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             partition_time=create_pendulum_time(2019, 2, 27),
         )
 
-        good_ticks = instance.get_job_ticks(good_origin.get_id())
+        good_ticks = instance.get_ticks(good_origin.get_id())
         assert len(good_ticks) == 2
         validate_tick(
             good_ticks[0],
@@ -1186,7 +1186,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             partition_time=create_pendulum_time(2019, 2, 27),
         )
 
-        bad_ticks = instance.get_job_ticks(bad_origin.get_id())
+        bad_ticks = instance.get_ticks(bad_origin.get_id())
         assert len(bad_ticks) == 2
         validate_tick(
             bad_ticks[0],
@@ -1196,7 +1196,7 @@ def test_bad_schedules_mixed_with_good_schedule(instance, workspace, external_re
             [bad_schedule_runs[0].run_id],
         )
 
-        unloadable_ticks = instance.get_job_ticks(unloadable_origin.get_id())
+        unloadable_ticks = instance.get_ticks(unloadable_origin.get_id())
         assert len(unloadable_ticks) == 0
 
 
@@ -1219,7 +1219,7 @@ def test_run_scheduled_on_time_boundary(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -1256,7 +1256,7 @@ def test_bad_load_repository(instance, workspace, external_repo, caplog):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id())
 
         assert len(ticks) == 0
 
@@ -1295,7 +1295,7 @@ def test_bad_load_schedule(instance, workspace, external_repo, caplog):
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id())
 
         assert len(ticks) == 0
 
@@ -1328,7 +1328,7 @@ def test_error_load_repository_location(instance):
 
             assert instance.get_runs_count() == 0
 
-            ticks = instance.get_job_ticks(fake_origin.get_id())
+            ticks = instance.get_ticks(fake_origin.get_id())
 
             assert len(ticks) == 0
 
@@ -1336,7 +1336,7 @@ def test_error_load_repository_location(instance):
         with pendulum.test(initial_datetime):
             list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
             assert instance.get_runs_count() == 0
-            ticks = instance.get_job_ticks(fake_origin.get_id())
+            ticks = instance.get_ticks(fake_origin.get_id())
             assert len(ticks) == 0
 
 
@@ -1375,7 +1375,7 @@ def test_load_repository_location_not_in_workspace(instance, workspace, external
 
         assert instance.get_runs_count() == 0
 
-        ticks = instance.get_job_ticks(invalid_repo_origin.get_id())
+        ticks = instance.get_ticks(invalid_repo_origin.get_id())
 
         assert len(ticks) == 0
 
@@ -1408,11 +1408,11 @@ def test_multiple_schedules_on_different_time_ranges(instance, workspace, extern
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
-        hourly_ticks = instance.get_job_ticks(external_hourly_schedule.get_external_origin_id())
+        hourly_ticks = instance.get_ticks(external_hourly_schedule.get_external_origin_id())
         assert len(hourly_ticks) == 1
         assert hourly_ticks[0].status == TickStatus.SUCCESS
 
@@ -1422,11 +1422,11 @@ def test_multiple_schedules_on_different_time_ranges(instance, workspace, extern
 
         assert instance.get_runs_count() == 3
 
-        ticks = instance.get_job_ticks(external_schedule.get_external_origin_id())
+        ticks = instance.get_ticks(external_schedule.get_external_origin_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
-        hourly_ticks = instance.get_job_ticks(external_hourly_schedule.get_external_origin_id())
+        hourly_ticks = instance.get_ticks(external_hourly_schedule.get_external_origin_id())
         assert len(hourly_ticks) == 2
         assert len([tick for tick in hourly_ticks if tick.status == TickStatus.SUCCESS]) == 2
 
@@ -1465,7 +1465,7 @@ def test_launch_failure(workspace, external_repo):
                 expected_success=False,
             )
 
-            ticks = instance.get_job_ticks(schedule_origin.get_id())
+            ticks = instance.get_ticks(schedule_origin.get_id())
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],
@@ -1491,7 +1491,7 @@ def test_partitionless_schedule(instance, workspace, external_repo):
 
         wait_for_all_runs_to_start(instance)
 
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -1534,7 +1534,7 @@ def test_max_catchup_runs(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 2
 
         first_datetime = create_pendulum_time(year=2019, month=3, day=4)
@@ -1592,20 +1592,20 @@ def test_multi_runs(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
         # launch_scheduled_runs does nothing before the first tick
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
     with pendulum.test(freeze_datetime):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
@@ -1627,7 +1627,7 @@ def test_multi_runs(instance, workspace, external_repo):
         # Verify idempotence
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -1637,7 +1637,7 @@ def test_multi_runs(instance, workspace, external_repo):
         # Traveling one more day in the future before running results in a tick
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 4
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 2
         assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 2
         runs = instance.get_runs()
@@ -1656,7 +1656,7 @@ def test_multi_runs_missing_run_key(instance, workspace, external_repo):
 
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         validate_tick(
@@ -1694,7 +1694,7 @@ def test_large_schedule(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
 
@@ -1720,7 +1720,7 @@ def test_manual_partition_with_solid_selection(instance, workspace, external_rep
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         run_id = ticks[0].run_ids[0]
 
@@ -1763,7 +1763,7 @@ def test_skip_reason_schedule(instance, workspace, external_repo):
         list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = create_pendulum_time(year=2019, month=2, day=28, tz="UTC")
@@ -1805,7 +1805,7 @@ def test_grpc_server_down(instance):
             for _trial in range(3):
                 list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
                 assert instance.get_runs_count() == 0
-                ticks = instance.get_job_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id())
                 assert len(ticks) == 1
 
                 validate_tick(
@@ -1822,7 +1822,7 @@ def test_grpc_server_down(instance):
             with _grpc_server_external_repo(port) as external_repo:
                 list(launch_scheduled_runs(instance, workspace, logger(), pendulum.now("UTC")))
                 assert instance.get_runs_count() == 1
-                ticks = instance.get_job_ticks(schedule_origin.get_id())
+                ticks = instance.get_ticks(schedule_origin.get_id())
                 assert len(ticks) == 1
 
                 expected_datetime = create_pendulum_time(year=2019, month=2, day=27)
@@ -1857,8 +1857,8 @@ def test_status_in_code_schedule(instance):
             never_running_origin = not_running_schedule.get_external_origin()
 
             assert instance.get_runs_count() == 0
-            assert len(instance.get_job_ticks(always_running_origin.get_id())) == 0
-            assert len(instance.get_job_ticks(never_running_origin.get_id())) == 0
+            assert len(instance.get_ticks(always_running_origin.get_id())) == 0
+            assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
             assert len(instance.all_stored_job_state()) == 0
 
@@ -1877,10 +1877,10 @@ def test_status_in_code_schedule(instance):
                 == pendulum.now("UTC").timestamp()
             )
 
-            ticks = instance.get_job_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id())
             assert len(ticks) == 0
 
-            assert len(instance.get_job_ticks(never_running_origin.get_id())) == 0
+            assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
         freeze_datetime = freeze_datetime.add(seconds=2)
         with pendulum.test(freeze_datetime):
@@ -1895,9 +1895,9 @@ def test_status_in_code_schedule(instance):
 
             assert instance.get_runs_count() == 1
 
-            assert len(instance.get_job_ticks(never_running_origin.get_id())) == 0
+            assert len(instance.get_ticks(never_running_origin.get_id())) == 0
 
-            ticks = instance.get_job_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id())
 
             assert len(ticks) == 1
 
@@ -1929,7 +1929,7 @@ def test_status_in_code_schedule(instance):
                 )
             )
             assert instance.get_runs_count() == 1
-            ticks = instance.get_job_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id())
             assert len(ticks) == 1
             assert ticks[0].status == TickStatus.SUCCESS
 
@@ -1945,7 +1945,7 @@ def test_status_in_code_schedule(instance):
                 )
             )
             assert instance.get_runs_count() == 3
-            ticks = instance.get_job_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id())
             assert len(ticks) == 3
             assert len([tick for tick in ticks if tick.status == TickStatus.SUCCESS]) == 3
 
@@ -1966,7 +1966,7 @@ def test_status_in_code_schedule(instance):
                     pendulum.now("UTC"),
                 )
             )
-            ticks = instance.get_job_ticks(always_running_origin.get_id())
+            ticks = instance.get_ticks(always_running_origin.get_id())
             assert len(ticks) == 3
             assert len(instance.all_stored_job_state()) == 0
 
@@ -2012,7 +2012,7 @@ def test_change_default_status(instance):
                 )
             )
 
-            ticks = instance.get_job_ticks(never_running_origin.get_id())
+            ticks = instance.get_ticks(never_running_origin.get_id())
             assert len(ticks) == 0
 
             # AUTOMATICALLY_RUNNING row has been removed from the database
@@ -2041,7 +2041,7 @@ def test_change_default_status(instance):
                 )
             )
 
-            ticks = instance.get_job_ticks(never_running_origin.get_id())
+            ticks = instance.get_ticks(never_running_origin.get_id())
             assert len(ticks) == 1
             assert len(ticks[0].run_ids) == 1
             assert ticks[0].timestamp == freeze_datetime.timestamp()

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -26,7 +26,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
         list(
@@ -38,7 +38,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
@@ -53,7 +53,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -86,7 +86,7 @@ def test_non_utc_timezone_run(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -109,10 +109,10 @@ def test_differing_timezones(instance, workspace, external_repo):
         instance.start_schedule(external_eastern_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
-        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id())
         assert len(ticks) == 0
 
         list(
@@ -124,10 +124,10 @@ def test_differing_timezones(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
-        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id())
         assert len(ticks) == 0
 
     # Past midnight eastern time, the eastern timezone schedule will run, but not the central timezone
@@ -143,7 +143,7 @@ def test_differing_timezones(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -158,7 +158,7 @@ def test_differing_timezones(instance, workspace, external_repo):
             [run.run_id for run in instance.get_runs()],
         )
 
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
         wait_for_all_runs_to_start(instance)
@@ -183,10 +183,10 @@ def test_differing_timezones(instance, workspace, external_repo):
         )
 
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id())
         assert len(ticks) == 1
 
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -219,11 +219,11 @@ def test_differing_timezones(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 2
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
-        ticks = instance.get_job_ticks(eastern_origin.get_id())
+        ticks = instance.get_ticks(eastern_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -241,7 +241,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
         list(
@@ -253,7 +253,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
             )
         )
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(seconds=2)
@@ -268,7 +268,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
         )
 
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
 
         expected_datetime = to_timezone(
@@ -301,7 +301,7 @@ def test_different_days_in_different_timezones(instance, workspace, external_rep
             )
         )
         assert instance.get_runs_count() == 1
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.SUCCESS
 
@@ -319,7 +319,7 @@ def test_hourly_dst_spring_forward(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(hours=2)
@@ -339,7 +339,7 @@ def test_hourly_dst_spring_forward(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
         expected_datetimes_utc = [
@@ -377,7 +377,7 @@ def test_hourly_dst_spring_forward(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
 
@@ -394,7 +394,7 @@ def test_hourly_dst_fall_back(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(hours=4)
@@ -414,7 +414,7 @@ def test_hourly_dst_fall_back(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 4
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 4
 
         expected_datetimes_utc = [
@@ -465,7 +465,7 @@ def test_hourly_dst_fall_back(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 4
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 4
 
 
@@ -482,7 +482,7 @@ def test_daily_dst_spring_forward(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=2)
@@ -500,7 +500,7 @@ def test_daily_dst_spring_forward(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
         # UTC time changed by one hour after the transition, still running daily at the same
@@ -543,7 +543,7 @@ def test_daily_dst_spring_forward(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
 
@@ -560,7 +560,7 @@ def test_daily_dst_fall_back(instance, workspace, external_repo):
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=2)
@@ -578,7 +578,7 @@ def test_daily_dst_fall_back(instance, workspace, external_repo):
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
         # UTC time changed by one hour after the transition, still running daily at the same
@@ -621,7 +621,7 @@ def test_daily_dst_fall_back(instance, workspace, external_repo):
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
 
@@ -641,7 +641,7 @@ def test_execute_during_dst_transition_spring_forward(instance, workspace, exter
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=3)
@@ -659,7 +659,7 @@ def test_execute_during_dst_transition_spring_forward(instance, workspace, exter
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
         expected_datetimes_utc = [
@@ -709,7 +709,7 @@ def test_execute_during_dst_transition_spring_forward(instance, workspace, exter
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
 
@@ -728,7 +728,7 @@ def test_execute_during_dst_transition_fall_back(instance, workspace, external_r
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 0
 
     freeze_datetime = freeze_datetime.add(days=3)
@@ -746,7 +746,7 @@ def test_execute_during_dst_transition_fall_back(instance, workspace, external_r
         wait_for_all_runs_to_start(instance)
 
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3
 
         expected_datetimes_utc = [
@@ -787,5 +787,5 @@ def test_execute_during_dst_transition_fall_back(instance, workspace, external_r
             )
         )
         assert instance.get_runs_count() == 3
-        ticks = instance.get_job_ticks(schedule_origin.get_id())
+        ticks = instance.get_ticks(schedule_origin.get_id())
         assert len(ticks) == 3

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -175,7 +175,7 @@ def test_0_10_0_schedule_wipe(hostname, conn_string):
             instance.upgrade()
 
         with DagsterInstance.from_config(tempdir) as upgraded_instance:
-            assert len(upgraded_instance.all_stored_job_state()) == 0
+            assert len(upgraded_instance.all_instigator_state()) == 0
 
 
 def test_0_10_6_add_bulk_actions_table(hostname, conn_string):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -199,12 +199,12 @@ def test_skip_autocreate(hostname, conn_string):
             instance.all_asset_keys()
 
         with pytest.raises(db.exc.ProgrammingError):
-            instance.all_stored_job_state()
+            instance.all_instigator_state()
 
     with instance_for_test(overrides=yaml.safe_load(full_pg_config(hostname))) as instance:
         instance.get_runs()
         instance.all_asset_keys()
-        instance.all_stored_job_state()
+        instance.all_instigator_state()
 
     TestPostgresInstance.clean_run_storage(conn_string, should_autocreate_tables=False)
     TestPostgresInstance.clean_event_log_storage(conn_string, should_autocreate_tables=False)


### PR DESCRIPTION
## Summary

To clean up the job => instigator naming collisions, this diff changes the top-level APIs of DagsterInstance and ScheduleStorage to reference `instigator` instead of `job`.  This is a breaking change for anyone who implemented their own storage.

Also, drops `get_latest_job_tick` which could be accomplished by adding a limit to the `get_ticks` call, in order to simplify the API.

The internal compatibility tests should fail, but the companion PR (https://github.com/dagster-io/internal/pull/1093) should address the failures.

## Test Plan
BK
