### PR TITLE
screenshot-capture fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -153,9 +153,8 @@ pip install selenium
 ```
 
 Install Selenium's chrome driver:
-- Download chromedriver from [here](https://chromedriver.chromium.org/downloads).
-- Add it to /usr/local/bin
-- Run `xattr -d com.apple.quarantine /usr/local/bin/chromedriver` (gross)
+- `brew install chromedriver` OR download chromedriver from [here](https://chromedriver.chromium.org/downloads)) and manually add to /usr/local/bin
+- You may need to run `xattr -d com.apple.quarantine /usr/local/bin/chromedriver` (gross)
 
 #### Capturing a screenshot
 

--- a/docs/screenshot_capture/capture-screenshot.py
+++ b/docs/screenshot_capture/capture-screenshot.py
@@ -21,7 +21,7 @@ from selenium import webdriver
 
 def load_screenshot_specs():
     with open("./docs/screenshot_capture/screenshots.yaml", "r") as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 
 
 def capture_screenshots(screenshot_specs: Sequence[Mapping[str, str]]):


### PR DESCRIPTION
this is a small fix for the screenshot script:

- my python was complaining that the `yaml.load` call was missing a loader arg, using `safe_load` fixed it
- `brew install chromedriver` worked for me and I didn't need to run `xattr`, so updated the instructions
