### PR TITLE
[dagit] Prevent editor completion hints from being cut off vertically

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditor.tsx
@@ -144,6 +144,11 @@ const CodeMirrorShimStyle = createGlobalStyle`
   .CodeMirror-lint-message.CodeMirror-lint-message-error {
     background: transparent;
   }
+
+  /* Ensure that hints aren't vertically cutoff*/
+  .CodeMirror-hint div {
+    max-height: none !important;
+  }
 `;
 
 const CodeMirrorWhitespaceStyle = createGlobalStyle`


### PR DESCRIPTION
## Summary

Adds a CSS overwrite to the config editor's hints which prevents them from being cut off vertically. This happens in cases where the hint description is more than one line.

**Before:**

![Screen Shot 2022-02-11 at 1 04 23 PM](https://user-images.githubusercontent.com/10215173/153670208-a12c9a27-6530-4298-868d-3270a39f1590.png)

**After:**

![Screen Shot 2022-02-11 at 1 04 00 PM](https://user-images.githubusercontent.com/10215173/153670210-dee550bb-92ad-4fb3-a72a-84fc59a2d409.png)



## Test Plan

Tested locally.