### PR TITLE
Pass repository location through to GrapheneAssetNode

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -54,7 +54,7 @@ def get_asset_nodes_by_asset_key(graphene_info):
     from ..schema.asset_graph import GrapheneAssetNode
 
     return {
-        external_asset_node.asset_key: GrapheneAssetNode(repository, external_asset_node)
+        external_asset_node.asset_key: GrapheneAssetNode(location, repository, external_asset_node)
         for location in graphene_info.context.repository_locations
         for repository in location.get_repositories().values()
         for external_asset_node in repository.get_external_asset_nodes()
@@ -65,7 +65,7 @@ def get_asset_nodes(graphene_info):
     from ..schema.asset_graph import GrapheneAssetNode
 
     return [
-        GrapheneAssetNode(repository, external_asset_node)
+        GrapheneAssetNode(location, repository, external_asset_node)
         for location in graphene_info.context.repository_locations
         for repository in location.get_repositories().values()
         for external_asset_node in repository.get_external_asset_nodes()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1,6 +1,6 @@
 import graphene
 from dagster import AssetKey, check
-from dagster.core.host_representation import ExternalRepository
+from dagster.core.host_representation import ExternalRepository, RepositoryLocation
 from dagster.core.host_representation.external_data import (
     ExternalAssetNode,
     ExternalStaticPartitionsDefinitionData,
@@ -24,7 +24,17 @@ class GrapheneAssetDependency(graphene.ObjectType):
     inputName = graphene.NonNull(graphene.String)
     asset = graphene.NonNull("dagster_graphql.schema.asset_graph.GrapheneAssetNode")
 
-    def __init__(self, external_repository, input_name, asset_key, materialization_loader=None):
+    def __init__(
+        self,
+        repository_location,
+        external_repository,
+        input_name,
+        asset_key,
+        materialization_loader=None,
+    ):
+        self._repository_location = check.inst_param(
+            repository_location, "repository_location", RepositoryLocation
+        )
         self._external_repository = check.inst_param(
             external_repository, "external_repository", ExternalRepository
         )
@@ -36,6 +46,7 @@ class GrapheneAssetDependency(graphene.ObjectType):
 
     def resolve_asset(self, _graphene_info):
         return GrapheneAssetNode(
+            self._repository_location,
             self._external_repository,
             self._external_repository.get_external_asset_node(self._asset_key),
             self._latest_materialization_loader,
@@ -73,10 +84,16 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def __init__(
         self,
+        repository_location,
         external_repository,
         external_asset_node,
         materialization_loader=None,
     ):
+        self._repository_location = check.inst_param(
+            repository_location,
+            "repository_location",
+            RepositoryLocation,
+        )
         self._external_repository = check.inst_param(
             external_repository, "external_repository", ExternalRepository
         )
@@ -94,19 +111,20 @@ class GrapheneAssetNode(graphene.ObjectType):
             description=external_asset_node.op_description,
         )
 
+    @property
+    def repository_location(self):
+        return self._repository_location
+
+    @property
+    def external_repository(self):
+        return self._external_repository
+
     def get_external_asset_node(self):
         return self._external_asset_node
 
-    def get_external_repository(self):
-        return self._external_repository
-
     def resolve_repository(self, graphene_info):
-        loc = None
-        for location in graphene_info.context.repository_locations:
-            if self._external_repository in location.get_repositories().values():
-                loc = location
         return external.GrapheneRepository(
-            graphene_info.context.instance, self._external_repository, loc
+            graphene_info.context.instance, self._external_repository, self._repository_location
         )
 
     def resolve_dependencies(self, graphene_info):
@@ -119,6 +137,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         )
         return [
             GrapheneAssetDependency(
+                repository_location=self._repository_location,
                 external_repository=self._external_repository,
                 input_name=dep.input_name,
                 asset_key=dep.upstream_asset_key,
@@ -138,6 +157,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         return [
             GrapheneAssetDependency(
+                repository_location=self._repository_location,
                 external_repository=self._external_repository,
                 input_name=dep.input_name,
                 asset_key=dep.downstream_asset_key,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -248,7 +248,7 @@ class GrapheneRepository(graphene.ObjectType):
 
     def resolve_assetNodes(self, _graphene_info):
         return [
-            GrapheneAssetNode(self._repository, external_asset_node)
+            GrapheneAssetNode(self._repository_location, self._repository, external_asset_node)
             for external_asset_node in self._repository.get_external_asset_nodes()
         ]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -434,7 +434,10 @@ class GrapheneDagitQuery(graphene.ObjectType):
             repo = repo_loc.get_repository(repo_sel.repository_name)
             external_asset_nodes = repo.get_external_asset_nodes(pipeline_name)
             results = (
-                [GrapheneAssetNode(repo, asset_node) for asset_node in external_asset_nodes]
+                [
+                    GrapheneAssetNode(repo_loc, repo, asset_node)
+                    for asset_node in external_asset_nodes
+                ]
                 if external_asset_nodes
                 else []
             )
@@ -452,7 +455,8 @@ class GrapheneDagitQuery(graphene.ObjectType):
         )
         return [
             GrapheneAssetNode(
-                node.get_external_repository(),
+                node.repository_location,
+                node.external_repository,
                 node.get_external_asset_node(),
                 materialization_loader=materialization_loader,
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -398,7 +398,7 @@ class ISolidDefinitionMixin:
             for node in ext_repo.get_external_asset_nodes()
             if node.op_name == self.solid_def_name
         ]
-        return [GrapheneAssetNode(ext_repo, node) for node in nodes]
+        return [GrapheneAssetNode(location, ext_repo, node) for node in nodes]
 
 
 class GrapheneSolidDefinition(graphene.ObjectType, ISolidDefinitionMixin):


### PR DESCRIPTION
Summary:
Rather than doing exact matching on an ExternalRepository object to find the right RepositoryLocation object, pass it all the way down through the graphql objects

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.