### PR TITLE
Increase truncation threshold on jobs page

### DIFF
--- a/js_modules/dagit/packages/core/src/pipelines/PipelineReference.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineReference.tsx
@@ -13,10 +13,11 @@ export interface Props {
   isJob: boolean;
   snapshotId?: string | null;
   showIcon?: boolean;
+  truncationThreshold?: number;
   size?: 'small' | 'normal';
 }
 
-const TRUNCATION_THRESHOLD = 40;
+const DEFAULT_TRUNCATION_THRESHOLD = 40;
 const TRUNCATION_BUFFER = 5;
 
 export const PipelineReference: React.FC<Props> = ({
@@ -25,11 +26,12 @@ export const PipelineReference: React.FC<Props> = ({
   isJob,
   snapshotId,
   showIcon,
+  truncationThreshold = DEFAULT_TRUNCATION_THRESHOLD,
   size = 'normal',
 }) => {
   const truncatedName =
-    pipelineName.length > TRUNCATION_THRESHOLD
-      ? `${pipelineName.slice(0, TRUNCATION_THRESHOLD - TRUNCATION_BUFFER)}…`
+    truncationThreshold > 0 && pipelineName.length > truncationThreshold
+      ? `${pipelineName.slice(0, truncationThreshold - TRUNCATION_BUFFER)}…`
       : pipelineName;
 
   const pipeline =

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineTable.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineTable.tsx
@@ -48,6 +48,7 @@ export const PipelineTable: React.FC<Props> = (props) => {
                   isJob={pipelineOrJob.isJob}
                   pipelineName={pipelineOrJob.name}
                   pipelineHrefContext={repoAddress}
+                  truncationThreshold={80}
                 />
                 {showRepo ? <Caption>{repoAddressAsString(repoAddress)}</Caption> : null}
                 <Description>{pipelineOrJob.description}</Description>


### PR DESCRIPTION
Summary:
This is related to https://github.com/dagster-io/dagster/pull/6286 - which changed the truncation threshold to jobs to 40 characters. That makes sense on the RunRoot page that prompted the PR, but this component is also used in the jobs page where there is a lot more horizontal space (a user reported that their long job names were now indistinguishable)

That said I'm not sure using a fixed truncation limit in that component makes sense - maybe it should be controlled in CSS in that callsite? When I tried taking out the limit altogether, it didn't seem like there was any limit and the table just expanded undesirably.

Test Plan: Load jobs table with a really ong job, it is no longer being truncated prematurely

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.