### PR TITLE
add explicit warning for minimum sqlite version

### DIFF
--- a/python_modules/dagster/dagster/core/storage/sqlite.py
+++ b/python_modules/dagster/dagster/core/storage/sqlite.py
@@ -40,3 +40,7 @@ def create_db_conn_string(base_dir, db_name):
     path_components = os.path.abspath(base_dir).split(os.sep)
     db_file = "{}.db".format(db_name)
     return "sqlite:///{}".format("/".join(path_components + [db_file]))
+
+
+def get_sqlite_version():
+    return str(sqlite3.sqlite_version)


### PR DESCRIPTION
## Summary
This diff explicitly warns on dagster initialization when the sqlite installation is outdated (and cannot perform certain batch queries).


## Test Plan
Forced sqlite version, saw warning.
