### PR TITLE
make sure to test tz-aware run sharded cursor

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1304,11 +1304,12 @@ class TestEventLogStorage:
                 storage.store_event(event)
 
             # of_type
+            parsed = pendulum.from_timestamp(run_records[-1].update_timestamp)
             filtered_records = storage.get_event_records(
                 EventRecordsFilter(
                     event_type=DagsterEventType.PIPELINE_SUCCESS,
                     after_cursor=RunShardedEventsCursor(
-                        id=0, run_updated_after=run_records[-1].update_timestamp
+                        id=0, run_updated_after=parsed
                     ),  # events after first run
                 ),
                 ascending=True,

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -1220,11 +1220,7 @@ class TestEventLogStorage:
             DagsterEventType.PIPELINE_SUCCESS
         ]
 
-    def test_get_event_records_sqlite(self, storage):
-        # test for sqlite only because sqlite requires special logic to handle cross-run queries
-        if not isinstance(storage, SqliteEventLogStorage):
-            pytest.skip()
-
+    def test_get_event_records_run_sharded(self, storage):
         asset_key = AssetKey(["path", "to", "asset_one"])
 
         events = []

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/event_log_storage.py
@@ -4,6 +4,7 @@ from collections import Counter
 from contextlib import ExitStack
 
 import mock
+import pendulum
 import pytest
 from dagster import (
     AssetKey,


### PR DESCRIPTION
## Summary
Got cloud error with a tz-aware run sharded cursor.

We didn't have this under test because we were only testing the run-sharded cursor objects against the sqlite event log storage (which is run-sharded).

The semantics of the run-updated-after argument doesn't really apply against cloud storage, but this will at least hit the erroneous datetime operation that a cloud user hit.

## Test Plan
BK - internal should fail
