### PR TITLE
[docs] factor out admonition component

### DIFF
--- a/docs/next/components/Icons.tsx
+++ b/docs/next/components/Icons.tsx
@@ -38,6 +38,15 @@ const CodeIcon = (
   ></path>
 );
 
+const InfoCircleIcon = (
+  <path
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="2"
+    d="M 12 2 C 6.4889971 2 2 6.4889971 2 12 C 2 17.511003 6.4889971 22 12 22 C 17.511003 22 22 17.511003 22 12 C 22 6.4889971 17.511003 2 12 2 z M 12 4 C 16.430123 4 20 7.5698774 20 12 C 20 16.430123 16.430123 20 12 20 C 7.5698774 20 4 16.430123 4 12 C 4 7.5698774 7.5698774 4 12 4 z M 11 7 L 11 9 L 13 9 L 13 7 L 11 7 z M 11 11 L 11 17 L 13 17 L 13 11 L 11 11 z">
+  </path>
+)
+
 const SearchIcon = (
   <path
     strokeLinecap="round"
@@ -92,6 +101,14 @@ const CloudIcon = (
   />
 );
 
+const WarningIcon = (
+  <path
+    fillRule="evenodd"
+    d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+    clipRule="evenodd"
+  />
+);
+
 const Icons = {
   // This should be an append only list. Do not remove an icon here, since
   // an older version of the site coul dbe depending on it.
@@ -105,6 +122,8 @@ const Icons = {
   Users: UsersIcon,
   Sparkles: SparklesIcon,
   Cloud: CloudIcon,
+  InfoCircle: InfoCircleIcon,
+  Warning: WarningIcon,
 };
 
 export default Icons;

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -198,33 +198,70 @@ const LinkGridItem = ({ title, href, children, tags = [] }) => {
   );
 };
 
-const Warning = ({ children }) => {
+const ADMONITION_STYLES = {
+  note: { color: 'blue', icon: Icons.InfoCircle },
+  warning: { color: 'yellow', icon: Icons.Warning },
+}
+
+const Admonition = ({ style, children }) => {
+  const { color, icon } = ADMONITION_STYLES[style];
   return (
-    <div className="bg-yellow-50 border-l-4 border-yellow-400 px-4 my-4">
+    <div className={`bg-${color}-50 border-l-4 border-${color}-400 px-4 my-4`}>
       <div className="flex items-center">
         <div className="flex-shrink-0">
-          {/* Heroicon name: solid/exclamation */}
           <svg
-            className="h-5 w-5 text-yellow-400"
+            className={`h-5 w-5 text-${color}-400`}
             xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
+            viewBox="0 0 25 25"
             fill="currentColor"
             aria-hidden="true"
           >
-            <path
-              fillRule="evenodd"
-              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-              clipRule="evenodd"
-            />
+            {icon}
           </svg>
         </div>
         <div className="ml-3">
-          <p className="text-sm text-yellow-700">{children}</p>
+          <p className={`text-sm text-${color}-700`}>{children}</p>
         </div>
       </div>
     </div>
   );
 };
+
+const Note = ({ children }) => {
+  return <Admonition style="note">{children}</Admonition>;
+};
+
+const Warning = ({ children }) => {
+  return <Admonition style="warning">{children}</Admonition>;
+};
+
+// const Warning = ({ children }) => {
+//   return (
+//     <div className="bg-yellow-50 border-l-4 border-yellow-400 px-4 my-4">
+//       <div className="flex items-center">
+//         <div className="flex-shrink-0">
+//           {/* Heroicon name: solid/exclamation */}
+//           <svg
+//             className="h-5 w-5 text-yellow-400"
+//             xmlns="http://www.w3.org/2000/svg"
+//             viewBox="0 0 20 20"
+//             fill="currentColor"
+//             aria-hidden="true"
+//           >
+//             <path
+//               fillRule="evenodd"
+//               d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+//               clipRule="evenodd"
+//             />
+//           </svg>
+//         </div>
+//         <div className="ml-3">
+//           <p className="text-sm text-yellow-700">{children}</p>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// };
 
 const CodeReferenceLink = ({ filePath, isInline, children }) => {
   const { version } = useVersion();
@@ -352,6 +389,7 @@ export default {
   Cross,
   LinkGrid,
   LinkGridItem,
+  Note,
   Warning,
   CodeReferenceLink,
   InstanceDiagramBox,

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -199,18 +199,18 @@ const LinkGridItem = ({ title, href, children, tags = [] }) => {
 };
 
 const ADMONITION_STYLES = {
-  note: { color: 'blue', icon: Icons.InfoCircle },
-  warning: { color: 'yellow', icon: Icons.Warning },
+  note: { colors: { bg: 'primary-100', borderIcon: 'primary-500', text: 'primary-500'}, icon: Icons.InfoCircle },
+  warning: { colors: { bg: 'yellow-50', borderIcon: 'yellow-400', text: 'yellow-700'}, icon: Icons.Warning },
 }
 
 const Admonition = ({ style, children }) => {
-  const { color, icon } = ADMONITION_STYLES[style];
+  const { colors, icon } = ADMONITION_STYLES[style];
   return (
-    <div className={`bg-${color}-50 border-l-4 border-${color}-400 px-4 my-4`}>
+    <div className={`bg-${colors.bg} border-l-4 border-${colors.borderIcon} px-4 my-4`}>
       <div className="flex items-center">
         <div className="flex-shrink-0">
           <svg
-            className={`h-5 w-5 text-${color}-400`}
+            className={`h-5 w-5 text-${colors.borderIcon}`}
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 25 25"
             fill="currentColor"
@@ -220,7 +220,7 @@ const Admonition = ({ style, children }) => {
           </svg>
         </div>
         <div className="ml-3">
-          <p className={`text-sm text-${color}-700`}>{children}</p>
+          <p className={`text-sm text-${colors.text}`}>{children}</p>
         </div>
       </div>
     </div>

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -235,34 +235,6 @@ const Warning = ({ children }) => {
   return <Admonition style="warning">{children}</Admonition>;
 };
 
-// const Warning = ({ children }) => {
-//   return (
-//     <div className="bg-yellow-50 border-l-4 border-yellow-400 px-4 my-4">
-//       <div className="flex items-center">
-//         <div className="flex-shrink-0">
-//           {/* Heroicon name: solid/exclamation */}
-//           <svg
-//             className="h-5 w-5 text-yellow-400"
-//             xmlns="http://www.w3.org/2000/svg"
-//             viewBox="0 0 20 20"
-//             fill="currentColor"
-//             aria-hidden="true"
-//           >
-//             <path
-//               fillRule="evenodd"
-//               d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-//               clipRule="evenodd"
-//             />
-//           </svg>
-//         </div>
-//         <div className="ml-3">
-//           <p className="text-sm text-yellow-700">{children}</p>
-//         </div>
-//       </div>
-//     </div>
-//   );
-// };
-
 const CodeReferenceLink = ({ filePath, isInline, children }) => {
   const { version } = useVersion();
   const url = `https://github.com/dagster-io/dagster/tree/${version}/${filePath}`;


### PR DESCRIPTION
This includes some modifications/additions to docs MDX components:

- A new (private) component `Admonition` is added that implements common logic for "Admonition"-style components. Previously the only "Admonition"-style component was `Warning`.
- A new "Admonition"-style component `Note` is added that has blue coloring and uses an info circle icon.

The appearance of the old `Warning` component is left unchanged.

Here's an example of the new `Note` component: 
<img width="889" alt="image" src="https://user-images.githubusercontent.com/1531373/153951205-2808280c-22b2-4053-8716-5c41178d8857.png">
