### PR TITLE
[dagster-dbt] dbt asset improvements

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -173,7 +173,7 @@ def load_assets_from_dbt_project(
         filter(None, (line.get("unique_id") for line in cli_output.logs))
     )
 
-    dbt_nodes = manifest_json["nodes"]
+    dbt_nodes = {**manifest_json["nodes"], **manifest_json["sources"]}
     return [
         _dbt_nodes_to_assets(
             dbt_nodes,
@@ -216,7 +216,7 @@ def load_assets_from_dbt_manifest(
             default, the asset key will simply be the name of the dbt model.
     """
     check.dict_param(manifest_json, "manifest_json", key_type=str)
-    dbt_nodes = manifest_json["nodes"]
+    dbt_nodes = {**manifest_json["nodes"], **manifest_json["sources"]}
     selected_unique_ids = selected_unique_ids or set(
         unique_id
         for unique_id, node_info in dbt_nodes.items()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -1,13 +1,13 @@
 import json
 import os
 import textwrap
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Set, Tuple, AbstractSet
+from typing import AbstractSet, Any, Callable, Dict, Mapping, Optional, Sequence, Set, Tuple
 
 from dagster import AssetKey, Out, Output, SolidExecutionContext, check, get_dagster_logger
 from dagster.core.asset_defs import AssetsDefinition, multi_asset
-from dagster_dbt.utils import generate_materializations
 from dagster_dbt.cli.types import DbtCliOutput
 from dagster_dbt.cli.utils import execute_cli
+from dagster_dbt.utils import generate_materializations
 
 
 def _load_manifest_for_project(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -76,7 +76,7 @@ def assert_assets_match_project(dbt_assets):
     assets_op = dbt_assets[0].op
     assert assets_op.tags == {"kind": "dbt"}
     assert len(assets_op.input_defs) == 0
-    assert assets_op.output_dict.keys() == {
+    assert set(assets_op.output_dict.keys()) == {
         "sort_by_calories",
         "least_caloric",
         "sort_hot_cereals_by_calories",
@@ -121,7 +121,7 @@ def test_basic(
     assert len(materializations) == 4
 
 
-def test_select(
+def test_select_from_project(
     dbt_seed, conn_string, test_project_dir, dbt_config_dir
 ):  # pylint: disable=unused-argument
 
@@ -146,3 +146,62 @@ def test_select(
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]
     assert len(materializations) == 1
+
+
+def test_select_from_manifest(
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir
+):  # pylint: disable=unused-argument
+
+    manifest_path = file_relative_path(__file__, "sample_manifest.json")
+    with open(manifest_path, "r") as f:
+        manifest_json = json.load(f)
+    dbt_assets = load_assets_from_dbt_manifest(
+        manifest_json, selected_unique_ids={"model.dagster_dbt_test_project.sort_by_calories"}
+    )
+
+    result = build_assets_job(
+        "test_job",
+        dbt_assets,
+        resource_defs={
+            "dbt": dbt_cli_resource.configured(
+                {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir}
+            )
+        },
+    ).execute_in_process()
+
+    assert result.success
+    materializations = [
+        event.event_specific_data.materialization
+        for event in result.events_for_node(dbt_assets[0].op.name)
+        if event.event_type_value == "ASSET_MATERIALIZATION"
+    ]
+    assert len(materializations) == 1
+
+
+def test_node_info_to_asset_key(
+    dbt_seed, conn_string, test_project_dir, dbt_config_dir
+):  # pylint: disable=unused-argument
+    dbt_assets = load_assets_from_dbt_project(
+        test_project_dir,
+        dbt_config_dir,
+        node_info_to_asset_key=lambda node_info: AssetKey(["foo", node_info["name"]]),
+    )
+
+    result = build_assets_job(
+        "test_job",
+        dbt_assets,
+        resource_defs={
+            "dbt": dbt_cli_resource.configured(
+                {"project_dir": test_project_dir, "profiles_dir": dbt_config_dir}
+            )
+        },
+    ).execute_in_process()
+
+    assert result.success
+    materializations = [
+        event.event_specific_data.materialization
+        for event in result.events_for_node(dbt_assets[0].op.name)
+        if event.event_type_value == "ASSET_MATERIALIZATION"
+    ]
+    assert len(materializations) == 4
+    assert materializations[0].asset_key == AssetKey(["foo", "sort_by_calories"])


### PR DESCRIPTION
1. use pre-built function to do the "dbt ls" command, which is nice because it doesn't swallow errors
2. actually respect the "select" command
3. allow users to specify how they want to generate an asset key for each node. this function will also apply to the sources that they get so users can make sure that the sources match up with upstream asset keys if that's relevant