### PR TITLE
[azure] target 3.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,7 @@ parameters:
   - name: py3_versions
     type: object
     default:
-      - "3.6"
-      - "3.7"
+      - "3.9"
   - name: py3_env_suffixes
     type: object
     default:


### PR DESCRIPTION
target just our most common python version in our windows test

the azure pipeline catches platform issues, so i don't think version variation is high utility given we run the gamut in BK 

## Test Plan

run in azure