### PR TITLE
metadata deprecation layer

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -253,31 +253,32 @@ from .version import __version__
 from dagster.config.source import BoolSource, StringSource, IntSource  # isort:skip
 
 _DEPRECATED = {
-    "EventMetadataEntry": ("MetadataEntry", MetadataEntry),
-    "EventMetadata": ("MetadataValue", MetadataValue),
-    "TextMetadataEntryData": ("TextMetadataValue", TextMetadataValue),
-    "UrlMetadataEntryData": ("UrlMetadataValue", UrlMetadataValue),
-    "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue),
-    "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue),
-    "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue),
-    "PythonArtifactMetadataEntryData": ("PythonArtifactMetadataValue", PythonArtifactMetadataValue),
-    "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue),
-    "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue),
+    "EventMetadataEntry": ("MetadataEntry", MetadataEntry, "0.15.0"),
+    "EventMetadata": ("MetadataValue", MetadataValue, "0.15.0"),
+    "TextMetadataEntryData": ("TextMetadataValue", TextMetadataValue, "0.15.0"),
+    "UrlMetadataEntryData": ("UrlMetadataValue", UrlMetadataValue, "0.15.0"),
+    "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue, "0.15.0"),
+    "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue, "0.15.0"),
+    "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue, "0.15.0"),
+    "PythonArtifactMetadataEntryData": ("PythonArtifactMetadataValue", PythonArtifactMetadataValue, "0.15.0"),
+    "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue, "0.15.0"),
+    "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue, "0.15.0"),
     "DagsterPipelineRunMetadataEntryData": (
         "DagsterPipelineRunMetadataValue",
         DagsterPipelineRunMetadataValue,
+        "0.15.0",
     ),
-    "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue),
-    "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue),
-    "TableSchemaMetadataEntryData": ("TableSchemaMetadataValue", TableSchemaMetadataValue),
+    "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue, "0.15.0"),
+    "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue, "0.15.0"),
+    "TableSchemaMetadataEntryData": ("TableSchemaMetadataValue", TableSchemaMetadataValue, "0.15.0"),
 }
 
 
 def __getattr__(name):
     if name in _DEPRECATED:
-        new_name, value = _DEPRECATED[name]
+        new_name, value, breaking_version = _DEPRECATED[name]
         stacklevel = 3 if sys.version_info >= (3, 7) else 4
-        rename_warning(new_name, name, "0.15.0", stacklevel=stacklevel)
+        rename_warning(new_name, name, breaking_version, stacklevel=stacklevel)
         return value
     else:
         raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -260,7 +260,11 @@ _DEPRECATED = {
     "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue, "0.15.0"),
     "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue, "0.15.0"),
     "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue, "0.15.0"),
-    "PythonArtifactMetadataEntryData": ("PythonArtifactMetadataValue", PythonArtifactMetadataValue, "0.15.0"),
+    "PythonArtifactMetadataEntryData": (
+        "PythonArtifactMetadataValue",
+        PythonArtifactMetadataValue,
+        "0.15.0",
+    ),
     "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue, "0.15.0"),
     "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue, "0.15.0"),
     "DagsterPipelineRunMetadataEntryData": (
@@ -268,9 +272,17 @@ _DEPRECATED = {
         DagsterPipelineRunMetadataValue,
         "0.15.0",
     ),
-    "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue, "0.15.0"),
+    "DagsterAssetMetadataEntryData": (
+        "DagsterAssetMetadataValue",
+        DagsterAssetMetadataValue,
+        "0.15.0",
+    ),
     "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue, "0.15.0"),
-    "TableSchemaMetadataEntryData": ("TableSchemaMetadataValue", TableSchemaMetadataValue, "0.15.0"),
+    "TableSchemaMetadataEntryData": (
+        "TableSchemaMetadataValue",
+        TableSchemaMetadataValue,
+        "0.15.0",
+    ),
 }
 
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,7 +1,5 @@
 import sys
 
-from pep562 import pep562
-
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
 from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Shape
 from dagster.config.config_schema import ConfigSchema
@@ -248,6 +246,7 @@ from dagster.utils.test import (
     execute_solid_within_pipeline,
     execute_solids_within_pipeline,
 )
+from pep562 import pep562
 
 from .version import __version__
 
@@ -264,20 +263,25 @@ _DEPRECATED = {
     "PythonArtifactMetadataEntryData": ("PythonArtifactMetadataValue", PythonArtifactMetadataValue),
     "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue),
     "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue),
-    "DagsterPipelineRunMetadataEntryData": ("DagsterPipelineRunMetadataValue", DagsterPipelineRunMetadataValue),
+    "DagsterPipelineRunMetadataEntryData": (
+        "DagsterPipelineRunMetadataValue",
+        DagsterPipelineRunMetadataValue,
+    ),
     "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue),
     "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue),
     "TableSchemaMetadataEntryData": ("TableSchemaMetadataValue", TableSchemaMetadataValue),
 }
 
+
 def __getattr__(name):
     if name in _DEPRECATED:
         new_name, value = _DEPRECATED[name]
         stacklevel = 3 if sys.version_info >= (3, 7) else 4
-        rename_warning(new_name, name, '0.15.0', stacklevel=stacklevel)
+        rename_warning(new_name, name, "0.15.0", stacklevel=stacklevel)
         return value
     else:
         raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
+
 
 def __dir__():
     return sorted(list(__all__) + list(_DEPRECATED.keys()))

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,3 +1,7 @@
+import sys
+
+from pep562 import pep562
+
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
 from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Shape
 from dagster.config.config_schema import ConfigSchema
@@ -231,7 +235,7 @@ from dagster.core.types.python_set import Set
 from dagster.core.types.python_tuple import Tuple
 from dagster.utils import file_relative_path
 from dagster.utils.alert import make_email_on_run_failure_sensor
-from dagster.utils.backcompat import ExperimentalWarning
+from dagster.utils.backcompat import ExperimentalWarning, rename_warning
 from dagster.utils.log import get_dagster_logger
 from dagster.utils.partitions import (
     create_offset_partition_selector,
@@ -248,6 +252,43 @@ from dagster.utils.test import (
 from .version import __version__
 
 from dagster.config.source import BoolSource, StringSource, IntSource  # isort:skip
+
+_DEPRECATED = {
+    "EventMetadataEntry": ("MetadataEntry", MetadataEntry),
+    "EventMetadata": ("MetadataValue", MetadataValue),
+    "TextMetadataEntryData": ("TextMetadataValue", TextMetadataValue),
+    "UrlMetadataEntryData": ("UrlMetadataValue", UrlMetadataValue),
+    "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue),
+    "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue),
+    "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue),
+    "PythonArtifactMetadataEntryData": ("PythonArtifactMetadataValue", PythonArtifactMetadataValue),
+    "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue),
+    "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue),
+    "DagsterPipelineRunMetadataEntryData": ("DagsterPipelineRunMetadataValue", DagsterPipelineRunMetadataValue),
+    "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue),
+    "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue),
+    "TableSchemaMetadataEntryData": ("TableSchemaMetadataValue", TableSchemaMetadataValue),
+}
+
+def __getattr__(name):
+    if name in _DEPRECATED:
+        new_name, value = _DEPRECATED[name]
+        stacklevel = 3 if sys.version_info >= (3, 7) else 4
+        rename_warning(new_name, name, '0.15.0', stacklevel=stacklevel)
+        return value
+    else:
+        raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
+
+def __dir__():
+    return sorted(list(__all__) + list(_DEPRECATED.keys()))
+
+
+# Backports PEP 562, which allows for override of __getattr__ and __dir__, to this module. PEP 562
+# was introduced in Python 3.7, so the `pep562` call here is a no-op for 3.7+.
+# See:
+#  PEP 562: https://www.python.org/dev/peps/pep-0562/
+#  PEP 562 backport package: https://github.com/facelessuser/pep562
+pep562(__name__)
 
 __all__ = [
     # Definition

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -1,6 +1,8 @@
 import inspect
+import re
 
 import dagster
+import pytest
 
 
 def test_all():
@@ -18,7 +20,8 @@ def test_all():
 
 def test_deprecated_imports(mocker):
     Bar = object()
-    mocker.patch("dagster._DEPRECATED", {"Foo": ("Bar", Bar)})
-    from dagster import Foo  # pylint: disable=no-name-in-module
+    mocker.patch("dagster._DEPRECATED", {"Foo": ("Bar", Bar, "0.0.0")})
+    with pytest.warns(DeprecationWarning, match=re.escape('"Foo" is deprecated')):
+        from dagster import Foo  # pylint: disable=no-name-in-module
 
     assert Foo is Bar

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -8,5 +8,9 @@ def test_all():
     for each in dagster.__all__:
         assert each in dagster_dir
     for exported in dagster_dir:
-        if not exported.startswith("_") and not inspect.ismodule(getattr(dagster, exported)):
+        if (
+            not exported.startswith("_")
+            and not inspect.ismodule(getattr(dagster, exported))
+            and not exported in dagster._DEPRECATED
+        ):
             assert exported in dagster.__all__

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -14,3 +14,11 @@ def test_all():
             and not exported in dagster._DEPRECATED
         ):
             assert exported in dagster.__all__
+
+
+def test_deprecated_imports(mocker):
+    Bar = object()
+    mocker.patch("dagster._DEPRECATED", {"Foo": ("Bar", Bar)})
+    from dagster import Foo  # pylint: disable=no-name-in-module
+
+    assert Foo is Bar

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -3,11 +3,6 @@
 
 import dagster
 import pytest
-
-# ########################
-# ##### METADATA IMPORTS
-# ########################
-
 from dagster.core.definitions.metadata import (
     DagsterAssetMetadataValue,
     DagsterPipelineRunMetadataValue,
@@ -24,6 +19,11 @@ from dagster.core.definitions.metadata import (
     TextMetadataValue,
     UrlMetadataValue,
 )
+
+# ########################
+# ##### METADATA IMPORTS
+# ########################
+
 
 
 METADATA_DEPRECATIONS = {
@@ -51,6 +51,10 @@ METADATA_DEPRECATIONS = {
 def metadata_entry_class_name(request):
     return request.param
 
+
 def test_deprecated_metadata_classes(metadata_entry_class_name):
     with pytest.warns(DeprecationWarning):
-        assert getattr(dagster, metadata_entry_class_name) == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
+        assert (
+            getattr(dagster, metadata_entry_class_name)
+            == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
+        )

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -1,8 +1,12 @@
 # This file strictly contains tests for deprecation warnings. It can serve as a central record of
 # deprecations for the current version.
 
+import re
+
 import dagster
 import pytest
+from dagster.core.definitions.events import Output
+from dagster.core.definitions.input import InputDefinition
 from dagster.core.definitions.metadata import (
     DagsterAssetMetadataValue,
     DagsterPipelineRunMetadataValue,
@@ -19,6 +23,8 @@ from dagster.core.definitions.metadata import (
     TextMetadataValue,
     UrlMetadataValue,
 )
+from dagster.core.definitions.output import OutputDefinition
+from dagster.core.types.dagster_type import DagsterType
 
 # ########################
 # ##### METADATA IMPORTS
@@ -51,9 +57,42 @@ def metadata_entry_class_name(request):
     return request.param
 
 
-def test_deprecated_metadata_classes(metadata_entry_class_name):
+def test_metadata_classes(metadata_entry_class_name):
     with pytest.warns(DeprecationWarning):
         assert (
             getattr(dagster, metadata_entry_class_name)
             == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
         )
+
+
+# ########################
+# ##### METADATA ARGUMENTS
+# ########################
+
+
+def test_metadata_entries():
+
+    metadata_entry = MetadataEntry("foo", None, MetadataValue.text("bar"))
+
+    # We use `Output` as a stand-in for all events here, they all follow the same pattern of calling
+    # `normalize_metadata`.
+    with pytest.warns(DeprecationWarning, match=re.escape('"metadata_entries" is deprecated')):
+        Output("foo", "bar", metadata_entries=[metadata_entry])
+
+    with pytest.warns(DeprecationWarning, match=re.escape('"metadata_entries" is deprecated')):
+        DagsterType(lambda _, __: True, "foo", metadata_entries=[metadata_entry])
+
+
+def test_arbitrary_metadata():
+
+    with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
+        OutputDefinition(metadata={"foo": object()})
+
+    with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
+        InputDefinition(metadata={"foo": object()})
+
+
+def test_metadata_entry_description():
+
+    with pytest.warns(DeprecationWarning, match=re.escape('"description" attribute')):
+        MetadataEntry("foo", "bar", MetadataValue.text("baz"))

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -25,7 +25,6 @@ from dagster.core.definitions.metadata import (
 # ########################
 
 
-
 METADATA_DEPRECATIONS = {
     "EventMetadataEntry": ("MetadataEntry", MetadataEntry),
     "EventMetadata": ("MetadataValue", MetadataValue),

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -1,0 +1,56 @@
+# This file strictly contains tests for deprecation warnings. It can serve as a central record of
+# deprecations for the current version.
+
+import dagster
+import pytest
+
+# ########################
+# ##### METADATA IMPORTS
+# ########################
+
+from dagster.core.definitions.metadata import (
+    DagsterAssetMetadataValue,
+    DagsterPipelineRunMetadataValue,
+    FloatMetadataValue,
+    IntMetadataValue,
+    JsonMetadataValue,
+    MarkdownMetadataValue,
+    MetadataEntry,
+    MetadataValue,
+    PathMetadataValue,
+    PythonArtifactMetadataValue,
+    TableMetadataValue,
+    TableSchemaMetadataValue,
+    TextMetadataValue,
+    UrlMetadataValue,
+)
+
+
+METADATA_DEPRECATIONS = {
+    "EventMetadataEntry": ("MetadataEntry", MetadataEntry),
+    "EventMetadata": ("MetadataValue", MetadataValue),
+    "TextMetadataEntryData": ("TextMetadataValue", TextMetadataValue),
+    "UrlMetadataEntryData": ("UrlMetadataValue", UrlMetadataValue),
+    "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue),
+    "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue),
+    "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue),
+    "PythonArtifactMetadataEntryData": ("PythonArtifactMetadataValue", PythonArtifactMetadataValue),
+    "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue),
+    "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue),
+    "DagsterPipelineRunMetadataEntryData": (
+        "DagsterPipelineRunMetadataValue",
+        DagsterPipelineRunMetadataValue,
+    ),
+    "DagsterAssetMetadataEntryData": ("DagsterAssetMetadataValue", DagsterAssetMetadataValue),
+    "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue),
+    "TableSchemaMetadataEntryData": ("TableSchemaMetadataValue", TableSchemaMetadataValue),
+}
+
+
+@pytest.fixture(params=METADATA_DEPRECATIONS.keys())
+def metadata_entry_class_name(request):
+    return request.param
+
+def test_deprecated_metadata_classes(metadata_entry_class_name):
+    with pytest.warns(DeprecationWarning):
+        assert getattr(dagster, metadata_entry_class_name) == METADATA_DEPRECATIONS[metadata_entry_class_name][1]

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -72,6 +72,7 @@ if __name__ == "__main__":
             "grpcio-health-checking>=1.32.0",
             "packaging>=20.9",
             "pendulum",
+            "pep562",
             "protobuf>=3.13.0",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
             "python-dateutil",
             "pytz",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -1,5 +1,5 @@
 import responses
-from dagster import EventMetadataEntry, build_assets_job, build_init_resource_context
+from dagster import MetadataEntry, build_assets_job, build_init_resource_context
 from dagster_airbyte import AirbyteState, airbyte_resource, build_airbyte_assets
 
 
@@ -127,14 +127,14 @@ def test_assets():
     ]
     assert len(materializations) == 3
     assert (
-        EventMetadataEntry.text("a,b", "columns")
+        MetadataEntry.text("a,b", "columns")
         in materializations[0].event_specific_data.materialization.metadata_entries
     )
     assert (
-        EventMetadataEntry.int(1234, "bytesEmitted")
+        MetadataEntry.int(1234, "bytesEmitted")
         in materializations[0].event_specific_data.materialization.metadata_entries
     )
     assert (
-        EventMetadataEntry.int(4321, "recordsCommitted")
+        MetadataEntry.int(4321, "recordsCommitted")
         in materializations[0].event_specific_data.materialization.metadata_entries
     )


### PR DESCRIPTION
Multiple deprecation strategies are possible. The one I went with here is to use a backport of PEP 562, which is integrated into Python 3.7 and allows you to override getattr and dir. This is used to intercept imports from dagster. We could try something else though.
