### PR TITLE
Fix bug with single-output with asset key

### DIFF
--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -100,8 +100,7 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
                     node_type=context.solid_def.node_type_str,
                 )
             )
-        metadata = context.get_output_metadata(output_defs[0].name)
-        yield Output(value=result, output_name=output_defs[0].name, metadata=metadata)
+        yield Output(value=result, output_name=output_defs[0].name)
     elif len(output_defs) > 1 and isinstance(result, tuple):
         if len(result) != len(output_defs):
             check.failed(

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
@@ -10,6 +10,8 @@ from dagster import (
     DagsterInstance,
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
+    DynamicOut,
+    DynamicOutput,
     EventMetadataEntry,
     Field,
     IOManagerDefinition,
@@ -879,3 +881,38 @@ def test_context_logging_metadata():
         match="When handling output 'result' of op 'the_op', received a materialization with metadata, while context.add_output_metadata was used within the same call to handle_output. Due to potential conflicts, this is not allowed. Please specify metadata in one place within the `handle_output` function.",
     ):
         build_for_materialization(AssetMaterialization("has_metadata", metadata={"bar": "baz"}))
+
+
+def test_metadata_dynamic_outputs():
+    class DummyIOManager(IOManager):
+        def __init__(self):
+            self.values = {}
+
+        def handle_output(self, context, obj):
+            keys = tuple(context.get_output_identifier())
+            self.values[keys] = obj
+
+            yield EventMetadataEntry.text(label="handle_output", text="I come from handle_output")
+
+        def load_input(self, context):
+            keys = tuple(context.upstream_output.get_output_identifier())
+            return self.values[keys]
+
+    @op(out=DynamicOut(asset_key=AssetKey(["foo"])))
+    def the_op():
+        yield DynamicOutput(1, mapping_key="one", metadata={"one": "blah"})
+        yield DynamicOutput(2, mapping_key="two", metadata={"two": "blah"})
+
+    @graph
+    def the_graph():
+        the_op()
+
+    result = the_graph.execute_in_process(resources={"io_manager": DummyIOManager()})
+    materializations = result.asset_materializations_for_node("the_op")
+    assert len(materializations) == 2
+    for materialization in materializations:
+        assert materialization.metadata_entries[1].label == "handle_output"
+        assert materialization.metadata_entries[1].entry_data.text == "I come from handle_output"
+
+    assert materializations[0].metadata_entries[0].label == "one"
+    assert materializations[1].metadata_entries[0].label == "two"


### PR DESCRIPTION
Metadata entries were getting repeated, because metadata was being added twice.

This also puts under test a few different cases:
- using dynamic outputs with asset keys, which to my knowledge was not previously under test.
- the validity of implicitly constructed asset materializations when using the output metadata logging APIs (from both io manager and op)