### PR TITLE
[buildkite] run integration 39 only

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/defines.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/defines.py
@@ -5,14 +5,14 @@ class SupportedPython:
     V3_6 = "3.6.15"
 
 
-SupportedPythons = [
+AllSupportedPythons = [
     SupportedPython.V3_6,
     SupportedPython.V3_7,
     SupportedPython.V3_8,
     SupportedPython.V3_9,
 ]
 
-ExamplePythons = [SupportedPython.V3_8]
+DefaultPythonVersions = [SupportedPython.V3_9]
 
 TOX_MAP = {
     SupportedPython.V3_9: "py39",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -1,7 +1,7 @@
 import os
 from enum import Enum
 
-from .defines import SupportedPythons
+from .defines import AllSupportedPythons
 from .images.versions import INTEGRATION_IMAGE_VERSION, UNIT_IMAGE_VERSION
 
 TIMEOUT_IN_MIN = 20
@@ -87,7 +87,7 @@ class StepBuilder:
         return self
 
     def on_unit_image(self, ver, env=None):
-        if ver not in SupportedPythons:
+        if ver not in AllSupportedPythons:
             raise Exception("Unsupported python version for unit image {ver}".format(ver=ver))
 
         return self.on_python_image(
@@ -98,7 +98,7 @@ class StepBuilder:
         )
 
     def on_integration_image(self, ver, env=None):
-        if ver not in SupportedPythons:
+        if ver not in AllSupportedPythons:
             raise Exception(
                 "Unsupported python version for integration image {ver}".format(ver=ver)
             )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -1,6 +1,6 @@
 import os
 
-from ..defines import GCP_CREDS_LOCAL_FILE, TOX_MAP, ExamplePythons, SupportedPython
+from ..defines import GCP_CREDS_LOCAL_FILE, TOX_MAP, DefaultPythonVersions, SupportedPython
 from ..images.versions import COVERAGE_IMAGE_VERSION
 from ..module_build_spec import ModuleBuildSpec
 from ..step_builder import StepBuilder
@@ -268,42 +268,47 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
         "examples/airline_demo",
         extra_cmds_fn=airline_demo_extra_cmds_fn,
         buildkite_label="airline-demo",
-        supported_pythons=ExamplePythons,
+        supported_pythons=DefaultPythonVersions,
     ),
     ModuleBuildSpec(
         "examples/dbt_example",
         extra_cmds_fn=dbt_example_extra_cmds_fn,
         buildkite_label="dbt_example",
         upload_coverage=False,
-        supported_pythons=ExamplePythons,
+        supported_pythons=DefaultPythonVersions,
     ),
     ModuleBuildSpec(
         "examples/deploy_docker",
         extra_cmds_fn=deploy_docker_example_extra_cmds_fn,
         buildkite_label="deploy_docker_example",
         upload_coverage=False,
-        supported_pythons=ExamplePythons,
+        supported_pythons=DefaultPythonVersions,
     ),
     ModuleBuildSpec(
         "examples/docs_snippets",
         extra_cmds_fn=docs_snippets_extra_cmds_fn,
         buildkite_label="docs_snippets",
         upload_coverage=False,
-        supported_pythons=ExamplePythons,
+        supported_pythons=DefaultPythonVersions,
     ),
     ModuleBuildSpec(
         "examples/hacker_news_assets",
         env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
         buildkite_label="hacker_news_assets",
         upload_coverage=False,
-        supported_pythons=ExamplePythons,
+        supported_pythons=DefaultPythonVersions,
     ),
     ModuleBuildSpec(
         "examples/hacker_news",
         env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
         buildkite_label="hacker_news_example",
         upload_coverage=False,
-        supported_pythons=ExamplePythons,
+        supported_pythons=DefaultPythonVersions,
+    ),
+    ModuleBuildSpec(
+        "examples/airflow_ingest",
+        supported_pythons=[SupportedPython.V3_8],  # run on 3.8
+        upload_coverage=False,
     ),
     ModuleBuildSpec("python_modules/dagit", extra_cmds_fn=dagit_extra_cmds_fn),
     ModuleBuildSpec("python_modules/automation"),
@@ -488,6 +493,7 @@ def examples_tests():
         "deploy_docker",
         "hacker_news",
         "hacker_news_assets",
+        "airflow_ingest",
     ]
 
     examples_root = os.path.join(GIT_REPO_ROOT, "examples")
@@ -501,7 +507,7 @@ def examples_tests():
     tests = []
     for example in examples_packages:
         tests += ModuleBuildSpec(
-            example, upload_coverage=False, supported_pythons=ExamplePythons
+            example, upload_coverage=False, supported_pythons=DefaultPythonVersions
         ).get_tox_build_steps()
     return tests
 

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/integration.py
@@ -3,7 +3,7 @@ import os
 import packaging.version
 import requests
 
-from ..defines import GCP_CREDS_LOCAL_FILE
+from ..defines import GCP_CREDS_LOCAL_FILE, DefaultPythonVersions
 from ..module_build_spec import ModuleBuildSpec
 from ..utils import connect_sibling_docker_container, network_buildkite_container
 from .test_images import publish_test_images, test_image_depends_fn
@@ -168,6 +168,7 @@ def build_steps_integration_suite(
             "BUILDKITE_SECRETS_BUCKET",
             "GOOGLE_APPLICATION_CREDENTIALS",
         ],
+        supported_pythons=DefaultPythonVersions,  # leave version variance to base tests
         upload_coverage=upload_coverage,
         extra_cmds_fn=extra_commands_fn,
         depends_on_fn=test_image_depends_fn,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -3,7 +3,7 @@ import subprocess
 
 import yaml
 
-from .defines import SupportedPython, SupportedPythons
+from .defines import AllSupportedPythons, DefaultPythonVersions
 
 DAGIT_PATH = "js_modules/dagit"
 
@@ -99,12 +99,12 @@ def is_release_branch(branch_name: str):
 
 
 def get_python_versions_for_branch(pr_versions=None):
-    pr_versions = pr_versions if pr_versions != None else [SupportedPython.V3_9]
+    pr_versions = pr_versions if pr_versions != None else DefaultPythonVersions
 
     # Run one representative version on PRs, the full set of python versions on master after
     # landing and on release branches before shipping
     branch_name = os.getenv("BUILDKITE_BRANCH")
     if branch_name == "master" or is_release_branch(branch_name):
-        return SupportedPythons
+        return AllSupportedPythons
     else:
         return pr_versions


### PR DESCRIPTION
Standardize on `3.9` as our default python version as its the one used most by our users.

Update the integration suite to only run on the default version. Thinking here is that any issues due to version variation should be caught by tests in the base suite.

## Test Plan

bk