### PR TITLE
Enable run monitoring by default in k8s, but don't resume by default

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -944,14 +944,13 @@ dagsterDaemon:
   # marked as failed. If a run had started but then the run worker crashed, the daemon will attempt
   # to resume the run with a new run worker.
   runMonitoring:
-    enabled: false
+    enabled: true
     # Timeout for runs to start (avoids runs hanging in STARTED)
     startTimeoutSeconds: 180
     # How often to check on in progress runs
     pollIntervalSeconds: 120
-    # Max number of times to attempt to resume a run with a new run worker. Defaults to 3 if the the
-    # run launcher supports resuming runs, otherwise defaults to 0.
-    maxResumeRunAttempts: ~
+    # Max number of times to attempt to resume a run with a new run worker
+    maxResumeRunAttempts: 0
 
   # Additional environment variables to set.
   # A Kubernetes ConfigMap will be created with these environment variables. See:


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.