### PR TITLE
RFC: gate sqlite bucketing behavior behind sqlite version checks

### DIFF
--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -15,6 +15,7 @@ from dagster.serdes import (
     whitelist_for_serdes,
 )
 from dagster.serdes.serdes import EnumSerializer, WhitelistMap, register_serdes_enum_fallbacks
+from dagster.utils import merge_dicts
 
 from .tags import (
     BACKFILL_ID_TAG,
@@ -476,6 +477,16 @@ class PipelineRunsFilter(
     @staticmethod
     def for_backfill(backfill_id):
         return PipelineRunsFilter(tags=PipelineRun.tags_for_backfill_id(backfill_id))
+
+    def with_job_name(self, job_name):
+        return PipelineRunsFilter(**self._asdict(), pipeline_name=job_name)
+
+    def with_tags(self, tags):
+        kwargs = self._asdict()
+        if "tags" in kwargs:
+            tags = merge_dicts(kwargs.get("tags"), tags)
+            del kwargs["tags"]
+        return PipelineRunsFilter(**kwargs, tags=tags)
 
 
 class JobBucket(NamedTuple):

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -315,6 +315,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
     def delete_run(self, run_id: str):
         """Remove a run from storage"""
 
+    @property
+    def supports_bucket_queries(self):
+        return True
+
     def migrate(self, print_fn: Callable = None, force_rebuild_all: bool = False):
         """Call this method to run any required data migrations"""
 

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pendulum
 import sqlalchemy as db
@@ -175,7 +175,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
     def _rows_to_runs(self, rows: Iterable[Tuple]) -> List[PipelineRun]:
         return list(map(self._row_to_run, rows))
 
-    def _row_to_run_record(self, row: Tuple) -> RunRecord:
+    def _row_to_run_record(self, row: Any) -> RunRecord:
         return RunRecord(
             storage_id=check.int_param(row["id"], "id"),
             pipeline_run=deserialize_as(check.str_param(row["run_body"], "run_body"), PipelineRun),

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from contextlib import contextmanager
 from urllib.parse import urljoin, urlparse
 

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -16,13 +16,14 @@ from dagster.core.storage.sql import (
 )
 from dagster.core.storage.sqlite import create_db_conn_string, get_sqlite_version
 from dagster.serdes import ConfigurableClass, ConfigurableClassData
+from dagster.seven import IS_WINDOWS
 from dagster.utils import mkdir_p
 from sqlalchemy.pool import NullPool
 
 from ..schema import InstanceInfo, RunStorageSqlMetadata, RunTagsTable, RunsTable
 from ..sql_run_storage import SqlRunStorage
 
-MINIMUM_SQLITE_VERSION = "3.25.0"
+MINIMUM_SQLITE_BUCKET_VERSION = "3.25.0"
 
 
 class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
@@ -52,15 +53,6 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         check.str_param(conn_string, "conn_string")
         self._conn_string = conn_string
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-
-        sqlite_version = get_sqlite_version()
-        if sqlite_version < MINIMUM_SQLITE_VERSION:
-            warnings.warn(
-                "You are using an outdated version of SQLite.  In order to ensure that Dagster "
-                "can efficiently query and write to the database, we recommend upgrading to at "
-                f"least version `3.25.0`.  You are currently using version `{sqlite_version}`."
-            )
-
         super().__init__()
 
     @property
@@ -75,8 +67,8 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return SqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
-    @staticmethod
-    def from_local(base_dir, inst_data=None):
+    @classmethod
+    def from_local(cls, base_dir, inst_data=None):
         check.str_param(base_dir, "base_dir")
         mkdir_p(base_dir)
         conn_string = create_db_conn_string(base_dir, "runs")
@@ -96,7 +88,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
             if "instance_info" not in table_names:
                 InstanceInfo.create(engine)
 
-        run_storage = SqliteRunStorage(conn_string, inst_data)
+        run_storage = cls(conn_string, inst_data)
 
         if should_mark_indexes:
             run_storage.migrate()
@@ -127,6 +119,10 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_downgrade(alembic_config, conn, rev=rev)
+
+    @property
+    def supports_bucket_queries(self):
+        return not IS_WINDOWS and get_sqlite_version() > MINIMUM_SQLITE_BUCKET_VERSION
 
     def upgrade(self):
         self._check_for_version_066_migration_and_perform()

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
@@ -13,6 +13,17 @@ def create_sqlite_run_storage():
 
 
 @contextmanager
+def create_non_bucket_sqlite_run_storage():
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield NonBucketQuerySqliteRunStorage.from_local(tempdir)
+
+
+class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
+    def supports_bucket_query(self):
+        return False
+
+
+@contextmanager
 def create_in_memory_storage():
     yield InMemoryRunStorage()
 
@@ -21,6 +32,15 @@ class TestSqliteImplementation(TestRunStorage):
     __test__ = True
 
     @pytest.fixture(name="storage", params=[create_sqlite_run_storage])
+    def run_storage(self, request):
+        with request.param() as s:
+            yield s
+
+
+class TestNonBucketQuerySqliteImplementation(TestRunStorage):
+    __test__ = True
+
+    @pytest.fixture(name="storage", params=[create_non_bucket_sqlite_run_storage])
     def run_storage(self, request):
         with request.param() as s:
             yield s

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -1234,7 +1234,6 @@ class TestRunStorage:
         assert run_record.end_time is not None
         assert run_record.end_time >= run_record.start_time
 
-    @pytest.mark.skipif(win_py36, reason="Sqlite rank queries not working on windows py36")
     def test_by_job(self, storage):
         def _add_run(job_name, tags=None):
             return storage.add_run(
@@ -1278,7 +1277,6 @@ class TestRunStorage:
         assert runs_by_job.get("b_pipeline").run_id == b_two.run_id
         assert runs_by_job.get("c_pipeline").run_id == c_one.run_id
 
-    @pytest.mark.skipif(win_py36, reason="Sqlite rank queries not working on windows py36")
     def test_by_tag(self, storage):
         def _add_run(job_name, tags=None):
             return storage.add_run(


### PR DESCRIPTION
## Summary
In case we don't want to force users to upgrade their sqlite versions.

This diff adds a flag to the base run storage to see if it supports bucketed queries.  This would return true for sqlite versions below a certain version and windows users.

This diff also adds a sqlite version to the test suite that returns `False` for the flag, to make sure the fallback behavior works. 

## Test Plan
BK

