### PR TITLE
autodiscover asset collections within modules

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/reconstructable.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstructable.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from .repository_definition import RepositoryDefinition
     from .pipeline_definition import PipelineDefinition
     from .graph_definition import GraphDefinition
+    from dagster.core.asset_defs.asset_collection import AssetCollection
 
 
 def get_ephemeral_repository_name(pipeline_name: str) -> str:
@@ -511,13 +512,16 @@ def _check_is_loadable(definition):
     from .pipeline_definition import PipelineDefinition
     from .repository_definition import RepositoryDefinition
     from .graph_definition import GraphDefinition
+    from dagster.core.asset_defs import AssetCollection
 
-    if not isinstance(definition, (PipelineDefinition, RepositoryDefinition, GraphDefinition)):
+    if not isinstance(
+        definition, (PipelineDefinition, RepositoryDefinition, GraphDefinition, AssetCollection)
+    ):
         raise DagsterInvariantViolationError(
             (
-                "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, or a "
-                "RepositoryDefinition. Got {definition}."
-            ).format(definition=repr(definition))
+                "Loadable attributes must be either a JobDefinition, GraphDefinition, "
+                f"PipelineDefinition, AssetCollection, or RepositoryDefinition. Got {repr(definition)}."
+            )
         )
     return definition
 
@@ -544,9 +548,10 @@ def def_from_pointer(
     from .pipeline_definition import PipelineDefinition
     from .repository_definition import RepositoryDefinition
     from .graph_definition import GraphDefinition
+    from dagster.core.asset_defs.asset_collection import AssetCollection
 
     if isinstance(
-        target, (PipelineDefinition, RepositoryDefinition, GraphDefinition)
+        target, (PipelineDefinition, RepositoryDefinition, GraphDefinition, AssetCollection)
     ) or not callable(target):
         return _check_is_loadable(target)
 
@@ -581,7 +586,9 @@ def pipeline_def_from_pointer(pointer: CodePointer) -> "PipelineDefinition":
 @overload
 # NOTE: mypy can't handle these overloads but pyright can
 def repository_def_from_target_def(  # type: ignore
-    target: Union["RepositoryDefinition", "PipelineDefinition", "GraphDefinition"]
+    target: Union[
+        "RepositoryDefinition", "PipelineDefinition", "GraphDefinition", "AssetCollection"
+    ]
 ) -> "RepositoryDefinition":
     ...
 
@@ -595,6 +602,7 @@ def repository_def_from_target_def(target):
     from .pipeline_definition import PipelineDefinition
     from .graph_definition import GraphDefinition
     from .repository_definition import CachingRepositoryData, RepositoryDefinition
+    from dagster.core.asset_defs.asset_collection import AssetCollection
 
     # special case - we can wrap a single pipeline in a repository
     if isinstance(target, (PipelineDefinition, GraphDefinition)):
@@ -602,6 +610,10 @@ def repository_def_from_target_def(target):
         return RepositoryDefinition(
             name=get_ephemeral_repository_name(target.name),
             repository_data=CachingRepositoryData.from_list([target]),
+        )
+    elif isinstance(target, AssetCollection):
+        return RepositoryDefinition(
+            name="__repository__", repository_data=CachingRepositoryData.from_list([target])
         )
     elif isinstance(target, RepositoryDefinition):
         return target

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -382,8 +382,8 @@ def test_attribute_is_wrong_thing():
         with pytest.raises(
             DagsterInvariantViolationError,
             match=re.escape(
-                "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, or a "
-                "RepositoryDefinition. Got 123."
+                "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, "
+                "AssetCollection, or RepositoryDefinition. Got 123."
             ),
         ):
             execute_execute_command(
@@ -403,8 +403,8 @@ def test_attribute_fn_returns_wrong_thing():
         with pytest.raises(
             DagsterInvariantViolationError,
             match=re.escape(
-                "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, or a "
-                "RepositoryDefinition."
+                "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, "
+                "AssetCollection, or RepositoryDefinition."
             ),
         ):
             execute_execute_command(

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/double_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/double_asset_collection.py
@@ -1,0 +1,16 @@
+from dagster import asset
+from dagster.core.asset_defs.asset_collection import AssetCollection
+
+
+@asset
+def asset1():
+    pass
+
+
+@asset
+def asset2():
+    pass
+
+
+ac1 = AssetCollection([asset1])
+ac2 = AssetCollection([asset2])

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/single_asset_collection.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/single_asset_collection.py
@@ -1,0 +1,15 @@
+from dagster import asset
+from dagster.core.asset_defs.asset_collection import AssetCollection
+
+
+@asset
+def asset1():
+    pass
+
+
+@asset
+def asset2():
+    pass
+
+
+my_asset_collection = AssetCollection([asset1, asset2])

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -93,11 +93,42 @@ def test_double_graph():
     )
 
 
+def test_single_asset_collection():
+    path = file_relative_path(__file__, "single_asset_collection.py")
+    loadable_targets = loadable_targets_from_python_file(path)
+
+    assert len(loadable_targets) == 1
+    symbol = loadable_targets[0].attribute
+    assert symbol == "my_asset_collection"
+
+    repo_def = repository_def_from_pointer(CodePointer.from_python_file(path, symbol, None))
+
+    isinstance(repo_def, RepositoryDefinition)
+    the_job = repo_def.get_job("__ASSET_COLLECTION")
+    assert len(the_job.graph.node_defs) == 2
+
+
+def test_double_asset_collection():
+    path = file_relative_path(__file__, "double_asset_collection.py")
+    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+        loadable_targets_from_python_file(path)
+
+    assert str(exc_info.value) == (
+        'More than one asset collection found in "double_asset_collection". '
+        "If you load a file or module directly it must either have one repository, one "
+        "job, one pipeline, one graph, or one asset collection scope. Found asset "
+        "collections defined in variables: ['ac1', 'ac2']."
+    )
+
+
 def test_no_loadable_targets():
     with pytest.raises(DagsterInvariantViolationError) as exc_info:
         loadable_targets_from_python_file(file_relative_path(__file__, "nada.py"))
 
-    assert str(exc_info.value) == 'No jobs, pipelines, graphs, or repositories found in "nada".'
+    assert (
+        str(exc_info.value)
+        == 'No jobs, pipelines, graphs, asset collections, or repositories found in "nada".'
+    )
 
 
 def test_single_repository_in_module():

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
@@ -94,8 +94,8 @@ def test_bad_target():
     with pytest.raises(
         DagsterInvariantViolationError,
         match=re.escape(
-            "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, or a "
-            "RepositoryDefinition. Got None."
+            "Loadable attributes must be either a JobDefinition, GraphDefinition, PipelineDefinition, "
+            "AssetCollection, or RepositoryDefinition. Got None."
         ),
     ):
         reconstructable(not_the_pipeline)


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->


Enables pointing dagit at a Python module that contains a single `AssetCollection`, as well as repository locations that point to Python modules that contain a single `AssetCollection`.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

`dagit -f`



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.