### PR TITLE
no longer allow foreign assets directly on repositories

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/decorators/repository.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/repository.py
@@ -23,7 +23,7 @@ class _Repository:
         self.description = check.opt_str_param(description, "description")
 
     def __call__(self, fn: Callable[[], Any]) -> RepositoryDefinition:
-        from dagster.core.asset_defs import ForeignAsset, AssetCollection
+        from dagster.core.asset_defs import AssetCollection
 
         check.callable_param(fn, "fn")
 
@@ -52,7 +52,6 @@ class _Repository:
                     or isinstance(definition, ScheduleDefinition)
                     or isinstance(definition, SensorDefinition)
                     or isinstance(definition, GraphDefinition)
-                    or isinstance(definition, ForeignAsset)
                     or isinstance(definition, AssetCollection)
                 ):
                     bad_definitions.append((i, type(definition)))
@@ -66,7 +65,7 @@ class _Repository:
                 raise DagsterInvalidDefinitionError(
                     "Bad return value from repository construction function: all elements of list "
                     "must be of type JobDefinition, GraphDefinition, PipelineDefinition, "
-                    "PartitionSetDefinition, ScheduleDefinition, SensorDefinition, or ForeignAsset. "
+                    "PartitionSetDefinition, ScheduleDefinition, or SensorDefinition. "
                     f"Got {bad_definitions_str}."
                 )
             repository_data = CachingRepositoryData.from_list(repository_definitions)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_repository_definition.py
@@ -3,9 +3,11 @@ from collections import defaultdict
 
 import pytest
 from dagster import (
+    AssetCollection,
     AssetKey,
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
+    ForeignAsset,
     PipelineDefinition,
     SensorDefinition,
     SolidDefinition,
@@ -22,7 +24,6 @@ from dagster import (
     sensor,
     solid,
 )
-from dagster.core.asset_defs import ForeignAsset
 from dagster.core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 
 
@@ -568,6 +569,6 @@ def test_foreign_assets():
 
     @repository
     def my_repo():
-        return [foo, bar]
+        return [AssetCollection(assets=[], source_assets=[foo, bar])]
 
     assert my_repo.foreign_assets_by_key == {AssetKey("foo"): foo, AssetKey("bar"): bar}


### PR DESCRIPTION
Now that they can go on asset collections, there's no need to allow them directly on repositories.