### PR TITLE
add bucket query supported flag, gate in loader

### DIFF
--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1105,7 +1105,7 @@ class DagsterInstance:
 
     @property
     def supports_bucket_queries(self):
-        self._run_storage.supports_bucket_queries
+        return self._run_storage.supports_bucket_queries
 
     def wipe(self):
         self._run_storage.wipe()

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1103,6 +1103,10 @@ class DagsterInstance:
             filters, limit, order_by, ascending, cursor, bucket_by
         )
 
+    @property
+    def supports_bucket_queries(self):
+        self._run_storage.supports_bucket_queries
+
     def wipe(self):
         self._run_storage.wipe()
         self._event_storage.wipe()

--- a/python_modules/dagster/dagster/core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/core/storage/runs/base.py
@@ -315,6 +315,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
     def delete_run(self, run_id: str):
         """Remove a run from storage"""
 
+    @property
+    def supports_bucket_queries(self):
+        return True
+
     def migrate(self, print_fn: Callable = None, force_rebuild_all: bool = False):
         """Call this method to run any required data migrations"""
 

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -241,6 +241,9 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     def _bucket_rank_column(self, bucket_by, order_by, ascending):
         check.inst_param(bucket_by, "bucket_by", (JobBucket, TagBucket))
+        check.invariant(
+            self.supports_bucket_queries, "Bucket queries are not supported by this storage layer"
+        )
         sorting_column = getattr(RunsTable.c, order_by) if order_by else RunsTable.c.id
         direction = db.asc if ascending else db.desc
         bucket_column = (

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from contextlib import contextmanager
 from urllib.parse import urljoin, urlparse
 
@@ -16,13 +15,14 @@ from dagster.core.storage.sql import (
 )
 from dagster.core.storage.sqlite import create_db_conn_string, get_sqlite_version
 from dagster.serdes import ConfigurableClass, ConfigurableClassData
+from dagster.seven import IS_WINDOWS
 from dagster.utils import mkdir_p
 from sqlalchemy.pool import NullPool
 
 from ..schema import InstanceInfo, RunStorageSqlMetadata, RunTagsTable, RunsTable
 from ..sql_run_storage import SqlRunStorage
 
-MINIMUM_SQLITE_VERSION = "3.25.0"
+MINIMUM_SQLITE_BUCKET_VERSION = "3.25.0"
 
 
 class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
@@ -52,15 +52,6 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         check.str_param(conn_string, "conn_string")
         self._conn_string = conn_string
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-
-        sqlite_version = get_sqlite_version()
-        if sqlite_version < MINIMUM_SQLITE_VERSION:
-            warnings.warn(
-                "You are using an outdated version of SQLite.  In order to ensure that Dagster "
-                "can efficiently query and write to the database, we recommend upgrading to at "
-                f"least version `3.25.0`.  You are currently using version `{sqlite_version}`."
-            )
-
         super().__init__()
 
     @property
@@ -75,8 +66,8 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return SqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
-    @staticmethod
-    def from_local(base_dir, inst_data=None):
+    @classmethod
+    def from_local(cls, base_dir, inst_data=None):
         check.str_param(base_dir, "base_dir")
         mkdir_p(base_dir)
         conn_string = create_db_conn_string(base_dir, "runs")
@@ -96,7 +87,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
             if "instance_info" not in table_names:
                 InstanceInfo.create(engine)
 
-        run_storage = SqliteRunStorage(conn_string, inst_data)
+        run_storage = cls(conn_string, inst_data)
 
         if should_mark_indexes:
             run_storage.migrate()
@@ -127,6 +118,10 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_downgrade(alembic_config, conn, rev=rev)
+
+    @property
+    def supports_bucket_queries(self):
+        return get_sqlite_version() > MINIMUM_SQLITE_BUCKET_VERSION
 
     def upgrade(self):
         self._check_for_version_066_migration_and_perform()

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -15,7 +15,6 @@ from dagster.core.storage.sql import (
 )
 from dagster.core.storage.sqlite import create_db_conn_string, get_sqlite_version
 from dagster.serdes import ConfigurableClass, ConfigurableClassData
-from dagster.seven import IS_WINDOWS
 from dagster.utils import mkdir_p
 from sqlalchemy.pool import NullPool
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
@@ -13,6 +13,17 @@ def create_sqlite_run_storage():
 
 
 @contextmanager
+def create_non_bucket_sqlite_run_storage():
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield NonBucketQuerySqliteRunStorage.from_local(tempdir)
+
+
+class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
+    def supports_bucket_query(self):
+        return False
+
+
+@contextmanager
 def create_in_memory_storage():
     yield InMemoryRunStorage()
 
@@ -21,6 +32,15 @@ class TestSqliteImplementation(TestRunStorage):
     __test__ = True
 
     @pytest.fixture(name="storage", params=[create_sqlite_run_storage])
+    def run_storage(self, request):
+        with request.param() as s:
+            yield s
+
+
+class TestNonBucketQuerySqliteImplementation(TestRunStorage):
+    __test__ = True
+
+    @pytest.fixture(name="storage", params=[create_non_bucket_sqlite_run_storage])
     def run_storage(self, request):
         with request.param() as s:
             yield s

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/utils/run_storage.py
@@ -1234,8 +1234,10 @@ class TestRunStorage:
         assert run_record.end_time is not None
         assert run_record.end_time >= run_record.start_time
 
-    @pytest.mark.skipif(win_py36, reason="Sqlite rank queries not working on windows py36")
     def test_by_job(self, storage):
+        if not storage.supports_bucket_queries:
+            pytest.skip("storage cannot bucket")
+
         def _add_run(job_name, tags=None):
             return storage.add_run(
                 TestRunStorage.build_run(
@@ -1278,8 +1280,10 @@ class TestRunStorage:
         assert runs_by_job.get("b_pipeline").run_id == b_two.run_id
         assert runs_by_job.get("c_pipeline").run_id == c_one.run_id
 
-    @pytest.mark.skipif(win_py36, reason="Sqlite rank queries not working on windows py36")
     def test_by_tag(self, storage):
+        if not storage.supports_bucket_queries:
+            pytest.skip("storage cannot bucket")
+
         def _add_run(job_name, tags=None):
             return storage.add_run(
                 TestRunStorage.build_run(


### PR DESCRIPTION
## Summary

Alternative diff to https://github.com/dagster-io/dagster/pull/6613, where instead of abstracting everything away in the storage layer, we just assert that bucket queries are supported and expose a flag for callers to check


## Test Plan
BK
