### PR TITLE
[sql event log] order by id instead of timestamp

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -634,13 +634,9 @@ class SqlEventLogStorage(EventLogStorage):
             query = query.limit(limit)
 
         if ascending:
-            query = query.order_by(
-                SqlEventLogStorageTable.c.timestamp.asc(), SqlEventLogStorageTable.c.id.asc()
-            )
+            query = query.order_by(SqlEventLogStorageTable.c.id.asc())
         else:
-            query = query.order_by(
-                SqlEventLogStorageTable.c.timestamp.desc(), SqlEventLogStorageTable.c.id.desc()
-            )
+            query = query.order_by(SqlEventLogStorageTable.c.id.desc())
 
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()


### PR DESCRIPTION
just use the autoincrement id for ordering events

## Test Plan

existing tests