### PR TITLE
serdes name translation layer

### DIFF
--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -153,7 +153,7 @@ def whitelist_for_serdes(
         check.class_param(__cls, "__cls")
         return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP)(__cls)
     else:  # decorator passed params
-        check.subclass_param(serializer, "serializer", Serializer)
+        check.opt_subclass_param(serializer, "serializer", Serializer)
         serializer = cast(Type[Serializer], serializer)
         return _whitelist_for_serdes(
             whitelist_map=_WHITELIST_MAP, serializer=serializer, storage_name=storage_name

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -50,7 +50,8 @@ EnumEntry = Tuple[Type[Enum], Type["EnumSerializer"]]
 class WhitelistMap(NamedTuple):
     tuples: Dict[str, TupleEntry]
     enums: Dict[str, EnumEntry]
-    names: Dict[str, Dict[str, str]]
+    serialized_names: Dict[str, str]
+    deserialized_names: Dict[str, str]
 
     def register_tuple(
         self,
@@ -90,26 +91,26 @@ class WhitelistMap(NamedTuple):
         return self.enums[name]
 
     def register_serialized_name(self, name: str, serialized_name: str):
-        self.names["serialized"][name] = serialized_name
+        self.serialized_names[name] = serialized_name
 
     def has_serialized_name(self, name: str) -> bool:
-        return name in self.names["serialized"]
+        return name in self.serialized_names
 
     def get_serialized_name(self, name: str) -> str:
-        return self.names["serialized"][name]
+        return self.serialized_names[name]
 
-    def register_deserialized_name(self, name: str, serialized_name: str):
-        self.names["serialized"][name] = serialized_name
+    def register_deserialized_name(self, name: str, deserialized_name: str):
+        self.deserialized_names[name] = deserialized_name
 
     def has_deserialized_name(self, name: str) -> bool:
-        return name in self.names["deserialized"]
+        return name in self.deserialized_names
 
     def get_deserialized_name(self, name: str) -> str:
-        return self.names["deserialized"][name]
+        return self.deserialized_names[name]
 
     @staticmethod
     def create():
-        return WhitelistMap(tuples={}, enums={}, names=dict(serialized={}, deserialized={}))
+        return WhitelistMap(tuples={}, enums={}, serialized_names={}, deserialized_names={})
 
 
 _WHITELIST_MAP = WhitelistMap.create()

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -50,6 +50,7 @@ EnumEntry = Tuple[Type[Enum], Type["EnumSerializer"]]
 class WhitelistMap(NamedTuple):
     tuples: Dict[str, TupleEntry]
     enums: Dict[str, EnumEntry]
+    names: Dict[str, Dict[str, str]]
 
     def register_tuple(
         self,
@@ -88,9 +89,27 @@ class WhitelistMap(NamedTuple):
     def get_enum_entry(self, name: str) -> EnumEntry:
         return self.enums[name]
 
+    def register_serialized_name(self, name: str, serialized_name: str):
+        self.names["serialized"][name] = serialized_name
+
+    def has_serialized_name(self, name: str) -> bool:
+        return name in self.names["serialized"]
+
+    def get_serialized_name(self, name: str) -> str:
+        return self.names["serialized"][name]
+
+    def register_deserialized_name(self, name: str, serialized_name: str):
+        self.names["serialized"][name] = serialized_name
+
+    def has_deserialized_name(self, name: str) -> bool:
+        return name in self.names["deserialized"]
+
+    def get_deserialized_name(self, name: str) -> str:
+        return self.names["deserialized"][name]
+
     @staticmethod
     def create():
-        return WhitelistMap(tuples={}, enums={})
+        return WhitelistMap(tuples={}, enums={}, names=dict(serialized={}, deserialized={}))
 
 
 _WHITELIST_MAP = WhitelistMap.create()
@@ -103,33 +122,47 @@ def whitelist_for_serdes(__cls: Type) -> Type:
 
 @overload
 def whitelist_for_serdes(
-    __cls: None = None, *, serializer: Type["Serializer"]
+    __cls: None = None,
+    *,
+    serializer: Optional[Type["Serializer"]] = ...,
+    storage_name: Optional[str] = ...,
 ) -> Callable[[Type], Type]:
     ...
 
 
 def whitelist_for_serdes(
-    __cls: Optional[Type] = None, *, serializer: Optional[Type["Serializer"]] = None
+    __cls: Optional[Type] = None,
+    *,
+    serializer: Optional[Type["Serializer"]] = None,
+    storage_name: Optional[str] = None,
 ):
     """
-    Decorator to whitelist a named tuple or enum to be serializable.
+    Decorator to whitelist a NamedTuple or enum to be serializable. If a `storage_name` is provided
+    for a NamedTuple, then serialized instances of the NamedTuple will be stored with under the
+    `storage_name` instead of the class name. This is primarily useful for maintaining backwards
+    compatibility. If a serialized object undergoes a name change, then setting `storage_name` to
+    the old name will (a) allow the object to be deserialized by versions of Dagster prior to the
+    name change; (b) allow Dagster to load objects stored using the old name.
 
     @whitelist_for_serdes
     class
 
     """
-
     if __cls is not None:  # decorator invoked directly on class
         check.class_param(__cls, "__cls")
-        return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP, serializer=None)(__cls)
+        return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP)(__cls)
     else:  # decorator passed params
         check.subclass_param(serializer, "serializer", Serializer)
         serializer = cast(Type[Serializer], serializer)
-        return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP, serializer=serializer)
+        return _whitelist_for_serdes(
+            whitelist_map=_WHITELIST_MAP, serializer=serializer, storage_name=storage_name
+        )
 
 
 def _whitelist_for_serdes(
-    whitelist_map: WhitelistMap, serializer: Optional[Type["Serializer"]] = None
+    whitelist_map: WhitelistMap,
+    serializer: Optional[Type["Serializer"]] = None,
+    storage_name: Optional[str] = None,
 ) -> Callable[[type], type]:
     def __whitelist_for_serdes(klass: type) -> type:
         if issubclass(klass, Enum) and (
@@ -144,6 +177,9 @@ def _whitelist_for_serdes(
             whitelist_map.register_tuple(
                 klass.__name__, cast(Type[NamedTuple], klass), serializer, sig_params
             )
+            if storage_name:
+                whitelist_map.register_serialized_name(klass.__name__, storage_name)
+                whitelist_map.register_deserialized_name(storage_name, klass.__name__)
         else:
             raise SerdesUsageError(f"Can not whitelist class {klass} for serializer {serializer}")
 
@@ -278,7 +314,13 @@ class DefaultNamedTupleSerializer(NamedTupleSerializer):
                 continue
             base_dict[key] = pack_inner_value(inner_value, whitelist_map, f"{descent_path}.{key}")
 
-        base_dict["__class__"] = value.__class__.__name__
+        klass_name = value.__class__.__name__
+        base_dict["__class__"] = (
+            whitelist_map.get_serialized_name(klass_name)
+            if whitelist_map.has_serialized_name(klass_name)
+            else klass_name
+        )
+
         return base_dict
 
 
@@ -429,15 +471,25 @@ def unpack_inner_value(val: Any, whitelist_map: WhitelistMap, descent_path: str)
             for idx, item in enumerate(val)
         ]
     if isinstance(val, dict) and val.get("__class__"):
-        klass_name = val.pop("__class__")
-        if not whitelist_map.has_tuple_entry(klass_name):
+        klass_name = cast(str, val.pop("__class__"))
+        lookup_name = (
+            whitelist_map.get_deserialized_name(klass_name)
+            if whitelist_map.has_deserialized_name(klass_name)
+            else klass_name
+        )
+        if not whitelist_map.has_tuple_entry(lookup_name):
+            name_str = (
+                '"klass_name"'
+                if klass_name == lookup_name
+                else f'"{klass_name}" (mapped to: "{lookup_name}")'
+            )
             raise DeserializationError(
-                f'Attempted to deserialize class "{klass_name}" which is not in the whitelist. '
+                f"Attempted to deserialize class {name_str} which is not in the whitelist. "
                 "This error can occur due to version skew, verify processes are running "
                 f"expected versions.{_path_msg(descent_path)}"
             )
 
-        klass, serializer, args_for_class = whitelist_map.get_tuple_entry(klass_name)
+        klass, serializer, args_for_class = whitelist_map.get_tuple_entry(lookup_name)
 
         # Target class being set to none, likely by
         if klass is None:

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -149,6 +149,11 @@ def whitelist_for_serdes(
     class
 
     """
+    check.invariant(
+        not storage_name
+        or (serializer is None or issubclass(serializer, DefaultNamedTupleSerializer)),
+        "storage_name can only be used with DefaultNamedTupleSerializer",
+    )
     if __cls is not None:  # decorator invoked directly on class
         check.class_param(__cls, "__cls")
         return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP)(__cls)

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import NamedTuple, Set
 
 import pytest
+from dagster import seven
 from dagster.check import ParameterCheckError, inst_param, set_param
 from dagster.serdes.errors import DeserializationError, SerdesUsageError, SerializationError
 from dagster.serdes.serdes import (
@@ -685,3 +686,36 @@ def test_namedtuple_backcompat():
     new_thing_deserialized = _deserialize_json(new_thing_serialized, old_map)
     assert isinstance(new_thing_deserialized, OldThing)
     assert new_thing_deserialized.get_id() == old_thing_id
+
+
+def test_namedtuple_name_map():
+
+    wmap = WhitelistMap.create()
+
+    @_whitelist_for_serdes(whitelist_map=wmap)
+    class Thing(NamedTuple):
+        name: str
+
+    wmap.register_serialized_name("Thing", "SerializedThing")
+    thing = Thing("foo")
+
+    thing_serialized = _serialize_dagster_namedtuple(thing, wmap)
+    assert seven.json.loads(thing_serialized)["__class__"] == "SerializedThing"
+
+    with pytest.raises(DeserializationError):
+        _deserialize_json(thing_serialized, wmap)
+
+    wmap.register_deserialized_name("SerializedThing", "Thing")
+    assert _deserialize_json(thing_serialized, wmap) == thing
+
+
+def test_whitelist_storage_name():
+
+    wmap = WhitelistMap.create()
+
+    @_whitelist_for_serdes(whitelist_map=wmap, storage_name="SerializedThing")
+    class Thing(NamedTuple):
+        name: str
+
+    assert wmap.get_serialized_name("Thing") == "SerializedThing"
+    assert wmap.get_deserialized_name("SerializedThing") == "Thing"


### PR DESCRIPTION
This introduces a name translation layer for serdes NamedTuples, i.e. a class named X can be stored under the name Y, and objects stored under Y can be loaded as X.

- When serializing, name conversion is done after resolving the serializer against the whitelist map: given instance of X, "X" is used to look up the serializer, then a storage name X' is resolved for storage under `__class__` in the serialized representation of X.
- When deserializing, name conversion is done before resolving the serializer against the whitelist map: given a serialized obj with `__class__` X, X is first resolved to its "deserialized" name X', then a serializer is looked up on the whitelist map with X'.

This allows renamed classes to be stored under their old names, allowing (a) new Dagster to load old-named objects; (b) old Dagster to load new-named objects.

The motivation for this was to rename Metadata classes in a backward-compatible way with a miniumum of additional complexity (e.g. a bunch of custom serializers).

Probably some of the older serialization shim code can be folded into this layer, but that is not in this PR.

This will not affect any code that does not explicitly make use of this layer.

## Test Plan

Some tests were added (see diff).