### PR TITLE
dagit fix: Launchpad defaults with invalid subset error

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -49,12 +49,9 @@ const LaunchpadSetupAllowedRoot: React.FC<Props> = (props) => {
       if (typeof queryString.mode === 'string') {
         newSession.mode = queryString.mode;
       }
-      if (queryString.solidSelection instanceof Array) {
+      if (queryString.solidSelection instanceof Array && queryString.solidSelection.length > 0) {
         newSession.solidSelection = queryString.solidSelection as string[];
-      } else if (
-        typeof queryString.solidSelection === 'string' &&
-        queryString.solidSelection.length > 0
-      ) {
+      } else if (typeof queryString.solidSelection === 'string' && queryString.solidSelection) {
         newSession.solidSelection = [queryString.solidSelection];
       }
       if (typeof queryString.solidSelectionQuery === 'string') {

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -51,7 +51,10 @@ const LaunchpadSetupAllowedRoot: React.FC<Props> = (props) => {
       }
       if (queryString.solidSelection instanceof Array) {
         newSession.solidSelection = queryString.solidSelection as string[];
-      } else if (typeof queryString.solidSelection === 'string') {
+      } else if (
+        typeof queryString.solidSelection === 'string' &&
+        queryString.solidSelection.length > 0
+      ) {
         newSession.solidSelection = [queryString.solidSelection];
       }
       if (typeof queryString.solidSelectionQuery === 'string') {


### PR DESCRIPTION

## Summary
Resolves https://github.com/dagster-io/dagster/issues/6557
(hoping to get this into the release)

The invalid subset error happens when the launchpad was opened from "Open in Launchpad" (i.e. from `Runs` and `Schedules` pages).

The problem was bc when we setup the launchpad through a path, it parse the null / empty solidSelection into a `[""]` and save that value to the local session.

The fix here is to guard the 0 length string.

## Test Plan
before:

https://user-images.githubusercontent.com/4531914/154174590-a8c59f93-316c-488a-b1e8-d73f8fef3d8e.mov

after:

https://user-images.githubusercontent.com/4531914/154174607-cb855723-d06b-4cf0-af62-5aad82c68c47.mov
