### PR TITLE
Reduce error to warning for run monitoring not supported

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -200,14 +200,14 @@ class TestNonResumeRunLauncher(RunLauncher, ConfigurableClass):
         return True
 
 
-def test_run_monitoring():
-    with pytest.raises(CheckError):
-        with instance_for_test(
-            overrides={
-                "run_monitoring": {"enabled": True},
-            }
-        ):
-            pass
+def test_run_monitoring(capsys):
+    with instance_for_test(
+        overrides={
+            "run_monitoring": {"enabled": True},
+        }
+    ) as instance:
+        # not supported by default run launcher
+        assert not instance.run_monitoring_enabled
 
     settings = {"enabled": True}
     with instance_for_test(


### PR DESCRIPTION
Instead of erroring, just warn when run monitoring is enabled and the launcher doesn't support it. This will ease the transition to enabling monitoring by default for any custom run launchers that don't support it