### PR TITLE
Metadata argument deprecation layer

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -719,7 +719,7 @@ def deprecated_metadata_entry_constructor(fn):
         deprecation_warning(
             f"Function `MetadataEntry.{fn.__name__}`",
             "0.15.0",
-            additional_warn_txt="In the future use `MetadataValue` and the `metadata` keyword argument instead.",
+            additional_warn_txt="In the future, construct `MetadataEntry` by calling the constructor directly and passing a `MetadataValue`.",
         )
         return fn(*args, **kwargs)
 

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -758,9 +758,8 @@ class MetadataEntry(
     def __new__(cls, label: str, description: Optional[str], entry_data: "MetadataValue"):
         if description is not None:
             deprecation_warning(
-                f'The "description" attribute on "MetadataEntry"',
+                'The "description" attribute on "MetadataEntry"',
                 "0.15.0",
-                additional_warn_txt='In the future, no descriptions will be accepted on "MetadataEntry" objects.',
             )
         return super(MetadataEntry, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -1,12 +1,13 @@
+import functools
 import os
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Union, cast
 
 from dagster import check, seven
 from dagster.core.errors import DagsterInvalidMetadata
 from dagster.serdes import whitelist_for_serdes
-from dagster.utils.backcompat import experimental, experimental_class_warning
+from dagster.utils.backcompat import deprecation_warning, experimental, experimental_class_warning
 
-from .table import TableColumn, TableColumnConstraints, TableConstraints, TableRecord, TableSchema
+from .table import TableColumn, TableRecord, TableSchema
 
 if TYPE_CHECKING:
     from dagster.core.definitions.events import AssetKey
@@ -42,6 +43,12 @@ def normalize_metadata(
         )
 
     if metadata_entries:
+        deprecation_warning(
+            "Argument `metadata_entries`",
+            "0.15.0",
+            additional_warn_txt="Use argument `metadata` instead. The `MetadataEntry` `description` attribute is also deprecated-- argument `metadata` takes a label: value dictionary.",
+            stacklevel=4,  # to get the caller of `normalize_metadata`
+        )
         return check.list_param(
             metadata_entries, "metadata_entries", (MetadataEntry, PartitionMetadataEntry)
         )
@@ -49,14 +56,19 @@ def normalize_metadata(
     # This is a stopgap measure to deal with unsupported metadata values, which occur when we try
     # to convert arbitrary metadata (on e.g. OutputDefinition) to a MetadataValue, which is required
     # for serialization. This will cause unsupported values to be silently replaced with a
-    # string placeholder-- eventually we should probably standardize the metadata system across
-    # dagster.
+    # string placeholder.
     elif allow_invalid:
         metadata_entries = []
         for k, v in metadata.items():
             try:
                 metadata_entries.append(package_metadata_value(k, v))
             except DagsterInvalidMetadata:
+                deprecation_warning(
+                    "Support for arbitrary metadata values",
+                    "0.15.0",
+                    additional_warn_txt=f"In the future, all user-supplied metadata values must be one of {RawMetadataValue}",
+                    stacklevel=4,  # to get the caller of `normalize_metadata`
+                )
                 metadata_entries.append(
                     MetadataEntry.text(f"[{v.__class__.__name__}] (unserializable)", k)
                 )
@@ -74,8 +86,7 @@ def package_metadata_value(label: str, value: RawMetadataValue) -> "MetadataEntr
     if isinstance(value, (MetadataEntry, PartitionMetadataEntry)):
         raise DagsterInvalidMetadata(
             f"Expected a metadata value, found an instance of {value.__class__.__name__}. Consider "
-            "instead using a MetadataValue wrapper for the value, or using the `metadata_entries` "
-            "parameter to pass in a List[MetadataEntry|PartitionMetadataEntry]."
+            "instead using a MetadataValue wrapper for the value."
         )
 
     if isinstance(value, MetadataValue):
@@ -701,6 +712,20 @@ class TableSchemaMetadataValue(
 # ##### METADATA ENTRY
 # ########################
 
+
+def deprecated_metadata_entry_constructor(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        deprecation_warning(
+            f"Function `MetadataEntry.{fn.__name__}`",
+            "0.15.0",
+            additional_warn_txt="In the future use `MetadataValue` and the `metadata` keyword argument instead.",
+        )
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
 # NOTE: This would better be implemented as a generic with `MetadataValue` set as a
 # typevar, but as of 2022-01-25 mypy does not support generics on NamedTuple.
 @whitelist_for_serdes(storage_name="EventMetadataEntry")
@@ -739,6 +764,7 @@ class MetadataEntry(
         )
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def text(text: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
         """Static constructor for a metadata entry containing text as
         :py:class:`TextMetadataValue`. For example:
@@ -762,6 +788,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, TextMetadataValue(text))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def url(url: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
         """Static constructor for a metadata entry containing a URL as
         :py:class:`UrlMetadataValue`. For example:
@@ -787,6 +814,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, UrlMetadataValue(url))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def path(path: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
         """Static constructor for a metadata entry containing a path as
         :py:class:`PathMetadataValue`. For example:
@@ -808,6 +836,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, PathMetadataValue(path))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def fspath(
         path: Optional[str], label: Optional[str] = None, description: Optional[str] = None
     ) -> "MetadataEntry":
@@ -836,6 +865,7 @@ class MetadataEntry(
         return MetadataEntry.path(path, label, description)
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def json(
         data: Optional[Dict[str, Any]],
         label: str,
@@ -866,6 +896,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, JsonMetadataValue(data))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def md(md_str: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
         """Static constructor for a metadata entry containing markdown data as
         :py:class:`MarkdownMetadataValue`. For example:
@@ -887,6 +918,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, MarkdownMetadataValue(md_str))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def python_artifact(
         python_artifact: Callable[..., Any], label: str, description: Optional[str] = None
     ) -> "MetadataEntry":
@@ -898,6 +930,7 @@ class MetadataEntry(
         )
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def float(
         value: Optional[float], label: str, description: Optional[str] = None
     ) -> "MetadataEntry":
@@ -922,6 +955,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, FloatMetadataValue(value))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def int(value: Optional[int], label: str, description: Optional[str] = None) -> "MetadataEntry":
         """Static constructor for a metadata entry containing int as
         :py:class:`IntMetadataValue`. For example:
@@ -944,11 +978,13 @@ class MetadataEntry(
         return MetadataEntry(label, description, IntMetadataValue(value))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def pipeline_run(run_id: str, label: str, description: Optional[str] = None) -> "MetadataEntry":
         check.str_param(run_id, "run_id")
         return MetadataEntry(label, description, DagsterPipelineRunMetadataValue(run_id))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     def asset(
         asset_key: "AssetKey", label: str, description: Optional[str] = None
     ) -> "MetadataEntry":
@@ -979,6 +1015,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, DagsterAssetMetadataValue(asset_key))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     @experimental
     def table(
         records: List[TableRecord],
@@ -1040,6 +1077,7 @@ class MetadataEntry(
         return MetadataEntry(label, description, TableMetadataValue(records, schema))
 
     @staticmethod
+    @deprecated_metadata_entry_constructor
     @experimental
     def table_schema(
         schema: TableSchema, label: str, description: Optional[str] = None

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -7,7 +7,7 @@ from dagster.core.errors import DagsterInvalidMetadata
 from dagster.serdes import whitelist_for_serdes
 from dagster.utils.backcompat import deprecation_warning, experimental, experimental_class_warning
 
-from .table import TableColumn, TableRecord, TableSchema
+from .table import TableColumn, TableColumnConstraints, TableConstraints, TableRecord, TableSchema
 
 if TYPE_CHECKING:
     from dagster.core.definitions.events import AssetKey
@@ -44,7 +44,7 @@ def normalize_metadata(
 
     if metadata_entries:
         deprecation_warning(
-            "Argument `metadata_entries`",
+            'Argument "metadata_entries"',
             "0.15.0",
             additional_warn_txt="Use argument `metadata` instead. The `MetadataEntry` `description` attribute is also deprecated-- argument `metadata` takes a label: value dictionary.",
             stacklevel=4,  # to get the caller of `normalize_metadata`
@@ -756,6 +756,12 @@ class MetadataEntry(
     """
 
     def __new__(cls, label: str, description: Optional[str], entry_data: "MetadataValue"):
+        if description is not None:
+            deprecation_warning(
+                f'The "description" attribute on "MetadataEntry"',
+                "0.15.0",
+                additional_warn_txt='In the future, no descriptions will be accepted on "MetadataEntry" objects.',
+            )
         return super(MetadataEntry, cls).__new__(
             cls,
             check.str_param(label, "label"),

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -1,5 +1,6 @@
-import pytest
 import warnings
+
+import pytest
 from dagster import (
     DependencyDefinition,
     InputDefinition,
@@ -578,7 +579,9 @@ def test_tag_not_invoked():
         execute_pipeline(_my_pipeline)
 
     user_warnings = [warning for warning in record if isinstance(warning.message, UserWarning)]
-    assert len(user_warnings) == 1  # We should only raise one warning because solids have same name.
+    assert (
+        len(user_warnings) == 1
+    )  # We should only raise one warning because solids have same name.
 
     with pytest.warns(
         UserWarning,
@@ -606,6 +609,7 @@ def test_with_hooks_invoked():
 
         execute_pipeline(_my_pipeline)
 
+
 @event_list_hook(required_resource_keys=set())
 def a_hook(_context, _):
     return HookExecutionResult("a_hook")
@@ -629,7 +633,9 @@ def test_with_hooks_not_invoked():
 
     # Note not returning out of the pipe causes warning count to go up to 2
     user_warnings = [warning for warning in record if isinstance(warning.message, UserWarning)]
-    assert len(user_warnings) == 1  # We should only raise one warning because solids have same name.
+    assert (
+        len(user_warnings) == 1
+    )  # We should only raise one warning because solids have same name.
 
     with pytest.warns(
         UserWarning,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_composition.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 from dagster import (
     DependencyDefinition,
     InputDefinition,
@@ -548,15 +549,15 @@ def test_alias_not_invoked():
 
 def test_tag_invoked():
 
-    with pytest.warns(None) as record:
+    # See: https://docs.pytest.org/en/7.0.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UserWarning)
 
         @pipeline
         def _my_pipeline():
             single_input_solid.tag({})()
 
         execute_pipeline(_my_pipeline)
-
-    assert len(record) == 0
 
 
 def test_tag_not_invoked():
@@ -576,7 +577,8 @@ def test_tag_not_invoked():
 
         execute_pipeline(_my_pipeline)
 
-    assert len(record) == 1  # We should only raise one warning because solids have same name.
+    user_warnings = [warning for warning in record if isinstance(warning.message, UserWarning)]
+    assert len(user_warnings) == 1  # We should only raise one warning because solids have same name.
 
     with pytest.warns(
         UserWarning,
@@ -595,16 +597,14 @@ def test_tag_not_invoked():
 
 def test_with_hooks_invoked():
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UserWarning)
 
         @pipeline
         def _my_pipeline():
             single_input_solid.with_hooks(set())()
 
         execute_pipeline(_my_pipeline)
-
-    assert len(record) == 0
-
 
 @event_list_hook(required_resource_keys=set())
 def a_hook(_context, _):
@@ -628,7 +628,8 @@ def test_with_hooks_not_invoked():
         execute_pipeline(_my_pipeline)
 
     # Note not returning out of the pipe causes warning count to go up to 2
-    assert len(record) == 1  # We should only raise one warning because solids have same name.
+    user_warnings = [warning for warning in record if isinstance(warning.message, UserWarning)]
+    assert len(user_warnings) == 1  # We should only raise one warning because solids have same name.
 
     with pytest.warns(
         UserWarning,

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -1,8 +1,16 @@
 # This file strictly contains tests for deprecation warnings. It can serve as a central record of
 # deprecations for the current version.
 
+import re
 import dagster
 import pytest
+from dagster.core.definitions.events import Output
+from dagster.core.definitions.input import InputDefinition
+
+# ########################
+# ##### METADATA IMPORTS
+# ########################
+
 from dagster.core.definitions.metadata import (
     DagsterAssetMetadataValue,
     DagsterPipelineRunMetadataValue,
@@ -19,6 +27,8 @@ from dagster.core.definitions.metadata import (
     TextMetadataValue,
     UrlMetadataValue,
 )
+from dagster.core.definitions.output import OutputDefinition
+from dagster.core.types.dagster_type import DagsterType
 
 # ########################
 # ##### METADATA IMPORTS
@@ -50,10 +60,38 @@ METADATA_DEPRECATIONS = {
 def metadata_entry_class_name(request):
     return request.param
 
-
-def test_deprecated_metadata_classes(metadata_entry_class_name):
+def test_metadata_classes(metadata_entry_class_name):
     with pytest.warns(DeprecationWarning):
-        assert (
-            getattr(dagster, metadata_entry_class_name)
-            == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
-        )
+        assert getattr(dagster, metadata_entry_class_name) == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
+
+# ########################
+# ##### METADATA ARGUMENTS
+# ########################
+
+
+def test_metadata_entries():
+
+    metadata_entry = MetadataEntry("foo", None, MetadataValue.text("bar"))
+
+    # We use `Output` as a stand-in for all events here, they all follow the same pattern of calling
+    # `normalize_metadata`.
+    with pytest.warns(DeprecationWarning, match=re.escape('"metadata_entries" is deprecated')):
+        Output("foo", "bar", metadata_entries=[metadata_entry])
+
+    with pytest.warns(DeprecationWarning, match=re.escape('"metadata_entries" is deprecated')):
+        DagsterType(lambda _, __: True, "foo", metadata_entries=[metadata_entry])
+
+
+def test_arbitrary_metadata():
+
+    with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
+         OutputDefinition(metadata={"foo": object()})
+
+    with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
+        InputDefinition(metadata={"foo": object()})
+
+
+def test_metadata_entry_description():
+
+    with pytest.warns(DeprecationWarning, match=re.escape('"description" attribute')):
+        MetadataEntry("foo", "bar", MetadataValue.text("baz"))

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -2,15 +2,11 @@
 # deprecations for the current version.
 
 import re
+
 import dagster
 import pytest
 from dagster.core.definitions.events import Output
 from dagster.core.definitions.input import InputDefinition
-
-# ########################
-# ##### METADATA IMPORTS
-# ########################
-
 from dagster.core.definitions.metadata import (
     DagsterAssetMetadataValue,
     DagsterPipelineRunMetadataValue,
@@ -60,9 +56,14 @@ METADATA_DEPRECATIONS = {
 def metadata_entry_class_name(request):
     return request.param
 
+
 def test_metadata_classes(metadata_entry_class_name):
     with pytest.warns(DeprecationWarning):
-        assert getattr(dagster, metadata_entry_class_name) == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
+        assert (
+            getattr(dagster, metadata_entry_class_name)
+            == METADATA_DEPRECATIONS[metadata_entry_class_name][1]
+        )
+
 
 # ########################
 # ##### METADATA ARGUMENTS
@@ -85,7 +86,7 @@ def test_metadata_entries():
 def test_arbitrary_metadata():
 
     with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
-         OutputDefinition(metadata={"foo": object()})
+        OutputDefinition(metadata={"foo": object()})
 
     with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
         InputDefinition(metadata={"foo": object()})


### PR DESCRIPTION
Adds deprecation warnings for:

- Specification of metadata as `metadata_entries` by users
- Direct construction of `metadata_entries` by way of `MetadataEntry` static methods.
- Passage of arbitrary (unserializable) metadata values in any context.

## Test Plan

Will add some tests to make sure warnings are emitted.




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
