### PR TITLE
Order get_ticks by a column that we have an index on in JobTickTable

### DIFF
--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -140,7 +140,7 @@ class SqlScheduleStorage(ScheduleStorage):
             db.select([JobTickTable.c.id, JobTickTable.c.tick_body])
             .select_from(JobTickTable)
             .where(JobTickTable.c.job_origin_id == origin_id)
-            .order_by(JobTickTable.c.id.desc())
+            .order_by(JobTickTable.c.timestamp.desc())
         )
 
         query = self._add_filter_limit(query, before=before, after=after, limit=limit)


### PR DESCRIPTION
Summary:
A user reported a timeout on this query when there are large numbers of ticks. We have an index on job_origin_id + timestamp, but not on job_origin_id + id.

I'm a little confused about what primary keys are good for as indices when there are other filters applied - would like to discuss if https://github.com/dagster-io/internal/pull/1139 is actually sufficient to make a similar query more efficient?

Test Plan: Verify with a postgres query plan that the get_ticks query is now performant

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.