### PR TITLE
dagster-pandera-remove-py36-testing

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -434,6 +434,18 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
     ModuleBuildSpec("python_modules/libraries/dagster-mlflow", upload_coverage=False),
     ModuleBuildSpec("python_modules/libraries/dagster-mysql", extra_cmds_fn=mysql_extra_cmds_fn),
     ModuleBuildSpec(
+        "python_modules/libraries/dagster-pandera",
+        supported_pythons=(
+            [
+                SupportedPython.V3_7,
+                SupportedPython.V3_8,
+                SupportedPython.V3_9,
+            ]
+            if (branch_name == "master" or is_release_branch(branch_name))
+            else [SupportedPython.V3_9]
+        ),
+    ),
+    ModuleBuildSpec(
         "python_modules/libraries/dagster-postgres", extra_cmds_fn=postgres_extra_cmds_fn
     ),
     ModuleBuildSpec(

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -24,9 +24,9 @@ if __name__ == "__main__":
         description=("Integration layer for dagster and pandera."),
         url="https://github.com/dagster-io/dagster",
         classifiers=[
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent",
         ],

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,37,36}-{unix,windows},pylint
+envlist = py{39,38,37}-{unix,windows},pylint
 
 [testenv]
 pip_version = pip==21.3.1


### PR DESCRIPTION
Remove py36 test from dagster-pandera, it requires 3.7+.
