### PR TITLE
bump the db statement default timeout in dagit

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -28,7 +28,7 @@ def create_dagit_cli():
 DEFAULT_DAGIT_HOST = "127.0.0.1"
 DEFAULT_DAGIT_PORT = 3000
 
-DEFAULT_DB_STATEMENT_TIMEOUT = 5000  # 5 sec
+DEFAULT_DB_STATEMENT_TIMEOUT = 10000  # 10 sec
 
 
 @click.command(


### PR DESCRIPTION
## Summary
With batched queries, it looks like we're hitting the statement timeout more frequently.

Bumps the default timeout to 10s.

## Test Plan
inspection


