### PR TITLE
deflake test_retry_policy

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py
@@ -332,11 +332,16 @@ def test_retry_policy():
     """
 
     def _send_int(path):
-        while not os.path.exists(path):
-            time.sleep(0.05)
+        pid = None
+        while True:
+            if os.path.exists(path):
+                with open(path) as f:
+                    pid_str = f.read()
+                    if pid_str:
+                        pid = int(pid_str)
+                        break
 
-        with open(path) as f:
-            pid = int(f.read())
+            time.sleep(0.05)
 
         os.kill(pid, signal.SIGINT)
 


### PR DESCRIPTION
This would fail sporaically when the file existed but the write had not yet been flushed to disk.

## Test Plan

pytest python_modules/dagster/dagster_tests/execution_tests/test_interrupt.py::test_retry_policy --count 100