### PR TITLE
deprecate asset key fns

### DIFF
--- a/docs/content/concepts/assets/asset-materializations.mdx
+++ b/docs/content/concepts/assets/asset-materializations.mdx
@@ -190,9 +190,7 @@ If you specified any metadata entries on the <PyObject object="Output" /> event 
 
 ### Linking assets to an Output Definition <Experimental />
 
-For cases where you are storing your asset within the body of an op, the easiest way of linking an asset to an op output is with the `asset_key` parameter on the relevant <PyObject object="OutputDefinition"/> in your op.
-
-You can define a constant <PyObject object="AssetKey"/> that identifies the asset you are linking.
+For cases where you are storing your asset within the body of an op, the easiest way of linking an asset to an op output is with the `asset_key` parameter on the relevant <PyObject object="OutputDefinition"/> in your op. To do this, you may define a constant <PyObject object="AssetKey"/> that identifies the asset you are linking.
 
 ```python file=/concepts/assets/materialization_ops.py startafter=start_output_def_mat_op_0 endbefore=end_output_def_mat_op_0
 from dagster import op, Output, Out, AssetKey

--- a/docs/content/concepts/assets/asset-materializations.mdx
+++ b/docs/content/concepts/assets/asset-materializations.mdx
@@ -71,10 +71,10 @@ We should now see a materialization event in the event log when we execute a job
 -->
 
 <Image
-  alt="asset-materialization"
-  src="/images/concepts/assets/asset-materialization.png"
-  width={3808}
-  height={2414}
+alt="asset-materialization"
+src="/images/concepts/assets/asset-materialization.png"
+width={3808}
+height={2414}
 />
 
 ### Yielding an AssetMaterialization from an IOManager
@@ -300,8 +300,8 @@ This feature is still in its early stages, but for now, this lineage information
 -->
 
 <Image
-  alt="asset-lineage"
-  src="/images/concepts/assets/asset-lineage.png"
-  width={1607}
-  height={1031}
+alt="asset-lineage"
+src="/images/concepts/assets/asset-lineage.png"
+width={1607}
+height={1031}
 />

--- a/docs/content/concepts/assets/asset-materializations.mdx
+++ b/docs/content/concepts/assets/asset-materializations.mdx
@@ -71,10 +71,10 @@ We should now see a materialization event in the event log when we execute a job
 -->
 
 <Image
-alt="asset-materialization"
-src="/images/concepts/assets/asset-materialization.png"
-width={3808}
-height={2414}
+  alt="asset-materialization"
+  src="/images/concepts/assets/asset-materialization.png"
+  width={3808}
+  height={2414}
 />
 
 ### Yielding an AssetMaterialization from an IOManager
@@ -192,7 +192,7 @@ If you specified any metadata entries on the <PyObject object="Output" /> event 
 
 For cases where you are storing your asset within the body of an op, the easiest way of linking an asset to an op output is with the `asset_key` parameter on the relevant <PyObject object="OutputDefinition"/> in your op.
 
-This parameter can be one of two things. For simple cases, where an op will always be writing to the same asset, you can define a constant <PyObject object="AssetKey"/> that identifies the asset you are linking.
+You can define a constant <PyObject object="AssetKey"/> that identifies the asset you are linking.
 
 ```python file=/concepts/assets/materialization_ops.py startafter=start_output_def_mat_op_0 endbefore=end_output_def_mat_op_0
 from dagster import op, Output, Out, AssetKey
@@ -200,24 +200,6 @@ from dagster import op, Output, Out, AssetKey
 
 @op(out=Out(asset_key=AssetKey("my_dataset")))
 def my_constant_asset_op(context):
-    df = read_df()
-    persist_to_storage(df)
-    yield Output(df)
-```
-
-For cases where the asset that you want to link to an output might change based on some context in the job (such as the job name), you can pass in a function that takes <PyObject object="OutputContext"/> and returns an <PyObject object="AssetKey"/>.
-
-```python file=/concepts/assets/materialization_ops.py startafter=start_output_def_mat_op_1 endbefore=end_output_def_mat_op_1
-from dagster import op, OutputContext, Out, Output
-
-
-def get_asset_key(context: OutputContext):
-    job_name = context.step_context.job_name
-    return AssetKey(f"my_dataset_{job_name}")
-
-
-@op(out=Out(asset_key=get_asset_key))
-def my_variable_asset_op(context):
     df = read_df()
     persist_to_storage(df)
     yield Output(df)
@@ -320,8 +302,8 @@ This feature is still in its early stages, but for now, this lineage information
 -->
 
 <Image
-alt="asset-lineage"
-src="/images/concepts/assets/asset-lineage.png"
-width={1607}
-height={1031}
+  alt="asset-lineage"
+  src="/images/concepts/assets/asset-lineage.png"
+  width={1607}
+  height={1031}
 />

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import namedtuple
 from typing import (
     TYPE_CHECKING,
@@ -57,8 +58,7 @@ class OutputDefinition:
             For example, users can provide a file path if the data object will be stored in a
             filesystem, or provide information of a database table when it is going to load the data
             into the table.
-        asset_key (Optional[Union[AssetKey, OutputContext -> AssetKey]]): (Experimental) An AssetKey
-            (or function that produces an AssetKey from the OutputContext) which should be associated
+        asset_key (Optional[AssetKey]]): (Experimental) An AssetKey which should be associated
             with this OutputDefinition. Used for tracking lineage information through Dagster.
         asset_partitions (Optional[Union[Set[str], OutputContext -> Set[str]]]): (Experimental) A
             set of partitions of the given asset_key (or a function that produces this list of
@@ -100,7 +100,12 @@ class OutputDefinition:
         if asset_key:
             experimental_arg_warning("asset_key", "OutputDefinition.__init__")
 
-        if not callable(asset_key):
+        if callable(asset_key):
+            warnings.warn(
+                "Passing a function as the `asset_key` argument to `Out` or `OutputDefinition` is "
+                "deprecated behavior and will be removed in version 0.15.0."
+            )
+        else:
             check.opt_inst_param(asset_key, "asset_key", AssetKey)
 
         self._asset_key = asset_key
@@ -367,8 +372,7 @@ class Out(
             For example, users can provide a file path if the data object will be stored in a
             filesystem, or provide information of a database table when it is going to load the data
             into the table.
-        asset_key (Optional[Union[AssetKey, OutputContext -> AssetKey]]): (Experimental) An AssetKey
-            (or function that produces an AssetKey from the OutputContext) which should be associated
+        asset_key (Optional[AssetKey]): (Experimental) An AssetKey which should be associated
             with this Out. Used for tracking lineage information through Dagster.
         asset_partitions (Optional[Union[Set[str], OutputContext -> Set[str]]]): (Experimental) A
             set of partitions of the given asset_key (or a function that produces this list of


### PR DESCRIPTION
we used to allow users to specify functions instead of constants for asset keys attached to outputs. this is not a direction we want to continue in, and has very limited usage, so we'd like to remove this capability in the future (and not tell people about it for now)