### PR TITLE
[dagit] Small nits, add a notice to the asset graph explaining that non-SDAs are hidden

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -109,6 +109,7 @@ function useRecentRunWarnings(
 ) {
   const {data} = useQuery<LastRunQuery, LastRunQueryVariables>(LAST_RUNS_QUERY, {
     skip: !repositorySelector,
+    pollInterval: 15 * 1000,
     variables: {
       repositorySelector: repositorySelector!,
     },
@@ -131,13 +132,14 @@ function useRecentRunWarnings(
 
     const assetName = opName;
     const jobRunsThatDidntMaterializeAsset = jobRunsCounts.find((jrc) => jrc.stepKey === assetName);
-    const latestRunForStepKey = latestRuns.find((lr) => lr.stepKey === assetName);
+    const latestRunForStepKey = latestRuns.find((lr) => lr.stepKey === assetName)?.run;
 
     const runWhichFailedToMaterialize =
       !jobRunsThatDidntMaterializeAsset &&
       latestRunForStepKey &&
-      (!grouped.length || grouped[0].latest?.runId !== latestRunForStepKey.run?.id)
-        ? latestRunForStepKey.run
+      latestRunForStepKey.status === 'FAILURE' &&
+      (!grouped.length || grouped[0].latest?.runId !== latestRunForStepKey?.id)
+        ? latestRunForStepKey
         : undefined;
 
     return {jobRunsThatDidntMaterializeAsset, runWhichFailedToMaterialize};

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -103,7 +103,13 @@ export const AssetNodeDefinition: React.FC<{
           >
             <Subheading>Type</Subheading>
           </Box>
-          {assetType ? <DagsterTypeSummary type={assetType} /> : 'No type data provided.'}
+          {assetType ? (
+            <DagsterTypeSummary type={assetType} />
+          ) : (
+            <Box padding={{vertical: 16, horizontal: 24}}>
+              <Description description="No type data provided." />
+            </Box>
+          )}
           {assetMetadata.length > 0 && (
             <>
               <Box

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -240,10 +240,10 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
 
           {solids.length === 0 ? (
             <EmptyDAGNotice nodeType="op" isGraph={isGraph} />
-          ) : Object.keys(queryResultOps.all).length === 0 ? (
-            <EntirelyFilteredDAGNotice nodeType="op" />
           ) : queryResultOps.applyingEmptyDefault ? (
             <LargeDAGNotice nodeType="op" />
+          ) : Object.keys(queryResultOps.all).length === 0 ? (
+            <EntirelyFilteredDAGNotice nodeType="op" />
           ) : undefined}
 
           <PipelineGraphContainer

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -296,10 +296,10 @@ const AssetGraphExplorerWithData: React.FC<
         <>
           {graphQueryItems.length === 0 ? (
             <EmptyDAGNotice nodeType="asset" isGraph />
-          ) : Object.keys(assetGraphData.nodes).length === 0 ? (
-            <EntirelyFilteredDAGNotice nodeType="asset" />
           ) : applyingEmptyDefault ? (
             <LargeDAGNotice nodeType="asset" />
+          ) : Object.keys(assetGraphData.nodes).length === 0 ? (
+            <EntirelyFilteredDAGNotice nodeType="asset" />
           ) : undefined}
           <SVGViewport
             ref={(r) => (viewportEl.current = r || undefined)}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/OmittedAssetsNotice.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/OmittedAssetsNotice.tsx
@@ -1,0 +1,57 @@
+import {gql, useQuery} from '@apollo/client';
+import {isEqual} from 'lodash';
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import {ColorsWIP, IconWIP} from '../../../../ui/src';
+import {AssetKey} from '../../assets/types';
+
+import {OmittedAssetCountQuery} from './types/OmittedAssetCountQuery';
+
+export const OmittedAssetsNotice: React.FC<{assetKeys: AssetKey[]}> = ({assetKeys}) => {
+  const result = useQuery<OmittedAssetCountQuery>(OMITTED_ASSET_COUNT_QUERY);
+  const allAssetKeys =
+    (result.data?.assetsOrError.__typename === 'AssetConnection' &&
+      result.data.assetsOrError.nodes) ||
+    [];
+  if (allAssetKeys.length === 0) {
+    return <span />;
+  }
+
+  const assetKeysJSONs = assetKeys.map((key) => JSON.stringify(key));
+  const missing = allAssetKeys.filter((a) => !assetKeysJSONs.includes(JSON.stringify(a.key)))
+    .length;
+
+  return (
+    <Container>
+      <IconWIP name="warning" size={16} color={ColorsWIP.Yellow500} />
+      {`${missing} asset${missing > 1 ? 's have' : ' has'} no definition`}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  background: ${ColorsWIP.Yellow50};
+  border-radius: 8px;
+  color: ${ColorsWIP.Yellow700};
+  align-items: center;
+  display: flex;
+  padding: 4px 8px;
+  gap: 4px;
+`;
+
+const OMITTED_ASSET_COUNT_QUERY = gql`
+  query OmittedAssetCountQuery {
+    assetsOrError {
+      __typename
+      ... on AssetConnection {
+        nodes {
+          id
+          key {
+            path
+          }
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/OmittedAssetsNotice.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/OmittedAssetsNotice.tsx
@@ -1,9 +1,8 @@
 import {gql, useQuery} from '@apollo/client';
-import {isEqual} from 'lodash';
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import {ColorsWIP, IconWIP} from '../../../../ui/src';
+import {ColorsWIP} from '../../../../ui/src';
 import {AssetKey} from '../../assets/types';
 
 import {OmittedAssetCountQuery} from './types/OmittedAssetCountQuery';
@@ -22,18 +21,16 @@ export const OmittedAssetsNotice: React.FC<{assetKeys: AssetKey[]}> = ({assetKey
   const missing = allAssetKeys.filter((a) => !assetKeysJSONs.includes(JSON.stringify(a.key)))
     .length;
 
-  return (
-    <Container>
-      <IconWIP name="warning" size={16} color={ColorsWIP.Yellow500} />
-      {`${missing} asset${missing > 1 ? 's have' : ' has'} no definition`}
-    </Container>
-  );
+  if (missing === 0) {
+    return <span />;
+  }
+  return <Container>Only software-defined assets are shown</Container>;
 };
 
 const Container = styled.div`
-  background: ${ColorsWIP.Yellow50};
+  background: ${ColorsWIP.Gray100};
   border-radius: 8px;
-  color: ${ColorsWIP.Yellow700};
+  color: ${ColorsWIP.Gray500};
   align-items: center;
   display: flex;
   padding: 4px 8px;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/OmittedAssetsNotice.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/OmittedAssetsNotice.tsx
@@ -9,19 +9,20 @@ import {OmittedAssetCountQuery} from './types/OmittedAssetCountQuery';
 
 export const OmittedAssetsNotice: React.FC<{assetKeys: AssetKey[]}> = ({assetKeys}) => {
   const result = useQuery<OmittedAssetCountQuery>(OMITTED_ASSET_COUNT_QUERY);
-  const allAssetKeys =
+  const allMaterializationKeys =
     (result.data?.assetsOrError.__typename === 'AssetConnection' &&
       result.data.assetsOrError.nodes) ||
     [];
-  if (allAssetKeys.length === 0) {
+  if (allMaterializationKeys.length === 0) {
     return <span />;
   }
 
   const assetKeysJSONs = assetKeys.map((key) => JSON.stringify(key));
-  const missing = allAssetKeys.filter((a) => !assetKeysJSONs.includes(JSON.stringify(a.key)))
-    .length;
+  const materializationsNotShown = allMaterializationKeys.filter(
+    (a) => !assetKeysJSONs.includes(JSON.stringify(a.key)),
+  ).length;
 
-  if (missing === 0) {
+  if (materializationsNotShown === 0) {
     return <span />;
   }
   return <Container>Only software-defined assets are shown</Container>;

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/OmittedAssetCountQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/OmittedAssetCountQuery.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: OmittedAssetCountQuery
+// ====================================================
+
+export interface OmittedAssetCountQuery_assetsOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface OmittedAssetCountQuery_assetsOrError_AssetConnection_nodes_key {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface OmittedAssetCountQuery_assetsOrError_AssetConnection_nodes {
+  __typename: "Asset";
+  id: string;
+  key: OmittedAssetCountQuery_assetsOrError_AssetConnection_nodes_key;
+}
+
+export interface OmittedAssetCountQuery_assetsOrError_AssetConnection {
+  __typename: "AssetConnection";
+  nodes: OmittedAssetCountQuery_assetsOrError_AssetConnection_nodes[];
+}
+
+export type OmittedAssetCountQuery_assetsOrError = OmittedAssetCountQuery_assetsOrError_PythonError | OmittedAssetCountQuery_assetsOrError_AssetConnection;
+
+export interface OmittedAssetCountQuery {
+  assetsOrError: OmittedAssetCountQuery_assetsOrError;
+}


### PR DESCRIPTION
## Summary

This PR makes a few small changes:
- Add a refresh interval to the asset view's new "recent job failed" notice
- Make sure this notice doesn't appear in the time between a run existing and it emitting the materialization (got into this state by testing with a `sleep` in my asset definition)
- Add a banner that appears in the global graph if materializations are being omitted
- Fix padding on the "No type definition" state in the asset view
- Fix "Type a subset, this is a large graph" notice not appearing because of an order of operations error.

In the global asset graph, this UI appears if there are materializations with asset keys that do not match SDAs (eg: if there are items shown in the other tabs that are not shown in the graph)

![image](https://user-images.githubusercontent.com/1037212/154370213-d893cfb7-4dfb-473f-86f9-de4946051274.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.