### PR TITLE
Use an @schedule rather than a ScheduleDefinition in running schedule example

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -133,9 +133,9 @@ Hourly schedules will be unaffected by daylight savings time transitions - the s
 In order for a schedule to run, it must be started. You can start or stop the schedule in Dagit, or with the `dagster schedule start` and `dagster schedule stop` commands. You can also start your schedule by setting the default status to `DefaultScheduleStatus.RUNNING` in code:
 
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_running_in_code endbefore=end_running_in_code
-my_running_schedule = ScheduleDefinition(
-    job=my_job, cron_schedule="0 9 * * *", default_status=DefaultScheduleStatus.RUNNING
-)
+@schedule(job=my_job, cron_schedule="0 0 * * *", default_status=DefaultScheduleStatus.RUNNING)
+def my_running_schedule(context: ScheduleEvaluationContext):
+    return {}
 ```
 
 If you manually start or stop a schedule in Dagit, that will override any default status that is set in code.

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -50,8 +50,11 @@ my_timezone_schedule = ScheduleDefinition(
 # end_timezone
 
 # start_running_in_code
-my_running_schedule = ScheduleDefinition(
-    job=my_job, cron_schedule="0 9 * * *", default_status=DefaultScheduleStatus.RUNNING
-)
+
+
+@schedule(job=my_job, cron_schedule="0 0 * * *", default_status=DefaultScheduleStatus.RUNNING)
+def my_running_schedule(context: ScheduleEvaluationContext):
+    return {}
+
 
 # end_running_in_code


### PR DESCRIPTION
Summary:
Realized while copying this for the release notes that a better example would use the decorator vs. creating a ScheduleDefinition.

Test Plan: View docs

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.