### PR TITLE
[dagster-airbyte] [dagster-fivetran] ingest asset defs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-airbyte.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-airbyte.rst
@@ -19,3 +19,8 @@ Resources
 
 .. autoclass:: AirbyteResource
     :members:
+
+Assets
+======
+
+.. autofunction:: build_airbyte_assets

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-fivetran.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-fivetran.rst
@@ -19,3 +19,8 @@ Resources
 
 .. autoclass:: FivetranResource
     :members:
+
+Assets
+======
+
+.. autofunction:: build_fivetran_assets

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/__init__.py
@@ -1,5 +1,6 @@
 from dagster.core.utils import check_dagster_package_version
 
+from .asset_defs import build_airbyte_assets
 from .ops import airbyte_sync_op
 from .resources import AirbyteResource, AirbyteState, airbyte_resource
 from .types import AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
-from dagster import Output, Out, AssetKey, check
-from dagster.core.asset_defs import AssetsDefinition, multi_asset
 
+from dagster import AssetKey, Out, Output, check
+from dagster.core.asset_defs import AssetsDefinition, multi_asset
 from dagster_airbyte.utils import generate_materializations
 
 
@@ -28,8 +28,12 @@ def build_airbyte_assets(
     @multi_asset(
         name=f"airbyte_sync_{connection_id[:5]}",
         outs={
-            table_name: Out(asset_key=AssetKey(asset_key_prefix + [table_name]))
-            for table_name in destination_tables
+            table: Out(
+                asset_key=AssetKey(
+                    asset_key_prefix + [table],
+                )
+            )
+            for table in destination_tables
         },
         required_resource_keys={"airbyte"},
         compute_kind="airbyte",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -1,0 +1,52 @@
+from typing import List, Optional
+from dagster import Output, Out, AssetKey, check
+from dagster.core.asset_defs import AssetsDefinition, multi_asset
+
+from dagster_airbyte.utils import generate_materializations
+
+
+def build_airbyte_assets(
+    connection_id: str,
+    destination_tables: List[str],
+    asset_key_prefix: Optional[List[str]] = None,
+) -> List[AssetsDefinition]:
+    """
+    Builds a set of assets representing the tables created by an Airbyte sync operation.
+
+    Args:
+        connection_id (str): The Airbyte Connection ID that this op will sync. You can retrieve this
+            value from the "Connections" tab of a given connector in the Airbyte UI.
+        destination_tables (List[str]): The names of the tables that you want to be represented
+            in the Dagster asset graph for this sync. This will generally map to the name of the
+            stream in Airbyte, unless a stream prefix has been specified in Airbyte.
+        asset_key_prefix (Optional[List[str]]): A prefix for the asset keys inside this asset.
+            If left blank, assets will have a key of `AssetKey([table_name])`.
+    """
+
+    asset_key_prefix = check.opt_list_param(asset_key_prefix, "asset_key_prefix", of_type=str)
+
+    @multi_asset(
+        name=f"airbyte_sync_{connection_id[:5]}",
+        outs={
+            table_name: Out(asset_key=AssetKey(asset_key_prefix + [table_name]))
+            for table_name in destination_tables
+        },
+        required_resource_keys={"airbyte"},
+        compute_kind="airbyte",
+    )
+    def _assets(context):
+        ab_output = context.resources.airbyte.sync_and_poll(connection_id=connection_id)
+        for materialization in generate_materializations(ab_output, asset_key_prefix):
+            table_name = materialization.asset_key.path[-1]
+            if table_name in destination_tables:
+                yield Output(
+                    value=None,
+                    output_name=table_name,
+                    metadata={
+                        entry.label: entry.entry_data for entry in materialization.metadata_entries
+                    },
+                )
+            else:
+                yield materialization
+
+    return [_assets]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -2,9 +2,11 @@ from typing import List, Optional
 
 from dagster import AssetKey, Out, Output, check
 from dagster.core.asset_defs import AssetsDefinition, multi_asset
+from dagster.utils.backcompat import experimental
 from dagster_airbyte.utils import generate_materializations
 
 
+@experimental
 def build_airbyte_assets(
     connection_id: str,
     destination_tables: List[str],

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -1,0 +1,146 @@
+import responses
+from dagster import build_init_resource_context, build_assets_job, EventMetadataEntry
+from dagster_airbyte import (
+    AirbyteOutput,
+    airbyte_resource,
+    airbyte_sync_op,
+    build_airbyte_assets,
+    AirbyteState,
+)
+
+
+@responses.activate
+def test_assets():
+
+    ab_resource = airbyte_resource(
+        build_init_resource_context(
+            config={
+                "host": "some_host",
+                "port": "8000",
+            }
+        )
+    )
+    ab_assets = build_airbyte_assets("12345", ["foo", "bar"], asset_key_prefix=["some", "prefix"])
+
+    assert len(ab_assets[0].op.output_defs) == 2
+
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/get",
+        json={
+            "name": "xyz",
+            "syncCatalog": {
+                "streams": [
+                    {
+                        "stream": {
+                            "name": "foo",
+                            "jsonSchema": {
+                                "properties": {"a": {"type": "str"}, "b": {"type": "int"}}
+                            },
+                        },
+                        "config": {"selected": True},
+                    },
+                    {
+                        "stream": {
+                            "name": "bar",
+                            "jsonSchema": {
+                                "properties": {
+                                    "c": {"type": "str"},
+                                }
+                            },
+                        },
+                        "config": {"selected": True},
+                    },
+                    {
+                        "stream": {
+                            "name": "baz",
+                            "jsonSchema": {
+                                "properties": {
+                                    "d": {"type": "str"},
+                                }
+                            },
+                        },
+                        "config": {"selected": True},
+                    },
+                ]
+            },
+        },
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/connections/sync",
+        json={"job": {"id": 1}},
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/jobs/get",
+        json={
+            "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
+            "attempts": [
+                {
+                    "attempt": {
+                        "streamStats": [
+                            {
+                                "streamName": "foo",
+                                "stats": {
+                                    "bytesEmitted": 1234,
+                                    "recordsCommitted": 4321,
+                                },
+                            },
+                            {
+                                "streamName": "bar",
+                                "stats": {
+                                    "bytesEmitted": 1234,
+                                    "recordsCommitted": 4321,
+                                },
+                            },
+                            {
+                                "streamName": "baz",
+                                "stats": {
+                                    "bytesEmitted": 1111,
+                                    "recordsCommitted": 1111,
+                                },
+                            },
+                        ]
+                    }
+                }
+            ],
+        },
+        status=200,
+    )
+
+    ab_job = build_assets_job(
+        "ab_job",
+        ab_assets,
+        resource_defs={
+            "airbyte": airbyte_resource.configured(
+                {
+                    "host": "some_host",
+                    "port": "8000",
+                }
+            )
+        },
+    )
+
+    res = ab_job.execute_in_process()
+
+    materializations = [
+        event
+        for event in res.events_for_node("airbyte_sync_12345")
+        if event.event_type_value == "ASSET_MATERIALIZATION"
+    ]
+    assert len(materializations) == 3
+    assert (
+        EventMetadataEntry.text("a,b", "columns")
+        in materializations[0].event_specific_data.materialization.metadata_entries
+    )
+    assert (
+        EventMetadataEntry.int(1234, "bytesEmitted")
+        in materializations[0].event_specific_data.materialization.metadata_entries
+    )
+    assert (
+        EventMetadataEntry.int(4321, "recordsCommitted")
+        in materializations[0].event_specific_data.materialization.metadata_entries
+    )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -1,12 +1,6 @@
 import responses
-from dagster import build_init_resource_context, build_assets_job, EventMetadataEntry
-from dagster_airbyte import (
-    AirbyteOutput,
-    airbyte_resource,
-    airbyte_sync_op,
-    build_airbyte_assets,
-    AirbyteState,
-)
+from dagster import EventMetadataEntry, build_assets_job, build_init_resource_context
+from dagster_airbyte import AirbyteState, airbyte_resource, build_airbyte_assets
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -1,5 +1,6 @@
 from dagster.core.utils import check_dagster_package_version
 
+from .asset_defs import build_fivetran_assets
 from .ops import fivetran_sync_op
 from .resources import FivetranResource, fivetran_resource
 from .types import FivetranOutput

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from dagster import AssetKey, AssetsDefinition, Out, Output, multi_asset
+from dagster import AssetKey, AssetsDefinition, Out, Output, multi_asset, check
 from dagster.utils.backcompat import experimental
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL
 from dagster_fivetran.utils import generate_materializations
@@ -9,15 +9,15 @@ from dagster_fivetran.utils import generate_materializations
 @experimental
 def build_fivetran_assets(
     connector_id: str,
-    asset_keys: List[AssetKey],
-    name: Optional[str] = None,
+    destination_tables: List[str],
     poll_interval: float = DEFAULT_POLL_INTERVAL,
     poll_timeout: Optional[float] = None,
     io_manager_key: Optional[str] = None,
-) -> AssetsDefinition:
+    asset_key_prefix: List[str] = None,
+) -> List[AssetsDefinition]:
 
     """
-    Create a @multi_asset for a given Fivetran connector.
+    Build a set of assets for a given Fivetran connector.
 
     Returns an AssetsDefintion which connects the specified ``asset_keys`` to the computation that
     will update them. Internally, executes a Fivetran sync for a given ``connector_id``, and
@@ -28,19 +28,14 @@ def build_fivetran_assets(
     Args:
         connector_id (str): The Fivetran Connector ID that this op will sync. You can retrieve this
             value from the "Setup" tab of a given connector in the Fivetran UI.
-        asset_keys (List[AssetKey]): The set of asset keys that Dagster will expect this asset to produce.
-            These should be of the form ``AssetKey([<schema_name>, <table_name>])`` where
-            ``<schema_name>`` and ``<table_name>`` represent the location of the tables in the
-            Fivetran destination. Any AssetKey listed here MUST be sync'd every time this computation
-            is executed, otherwise an exception will be raised. Additional tables that are updated
-            during the sync but not listed here will be recorded with runtime AssetMaterialization
-            events. The set of tables that are sync'd by Fivetran but are not explicitly set in the
-            asset_keys argument may change over time as the Fivetran connector is updated.
-        name (Optional[str]): A name for the underlying computation.
+        destination_tables (List[str]): `schema_name.table_name` for each table that you want to be
+            represented in the Dagster asset graph for this connection.
         poll_interval (float): The time (in seconds) that will be waited between successive polls.
         poll_timeout (Optional[float]): The maximum time that will waited before this operation is
             timed out. By default, this will never time out.
         io_manager_key (Optional[str]): The io_manager to be used to handle each of these assets.
+        asset_key_prefix (Optional[List[str]]): A prefix for the asset keys inside this asset.
+            If left blank, assets will have a key of `AssetKey([schema_name, table_name])`.
 
     Examples:
 
@@ -58,8 +53,9 @@ def build_fivetran_assets(
             }
         )
 
-        fivetran_assets = build_fivetran_assets(connector_id="foobar", asset_keys=[
-            AssetKey(["schema1", "table1"]), AssetKey(["schema2", "table2"])
+        fivetran_assets = build_fivetran_assets(
+            connector_id="foobar",
+            table_names=["schema1.table1", "schema2.table2"],
         ])
 
         my_fivetran_job = build_assets_job(
@@ -70,11 +66,17 @@ def build_fivetran_assets(
 
     """
 
+    asset_key_prefix = check.opt_list_param(asset_key_prefix, "asset_key_prefix", of_type=str)
+
+    tracked_asset_keys = {
+        AssetKey(asset_key_prefix + table.split(".")) for table in destination_tables
+    }
+
     @multi_asset(
-        name=name or f"fivetran_sync_{connector_id}",
+        name=f"fivetran_sync_{connector_id}",
         outs={
             "_".join(key.path): Out(io_manager_key=io_manager_key, asset_key=key)
-            for key in asset_keys
+            for key in tracked_asset_keys
         },
         required_resource_keys={"fivetran"},
     )
@@ -84,16 +86,20 @@ def build_fivetran_assets(
             poll_interval=poll_interval,
             poll_timeout=poll_timeout,
         )
-        for materialization in generate_materializations(fivetran_output, asset_key_prefix=[]):
+        for materialization in generate_materializations(
+            fivetran_output, asset_key_prefix=asset_key_prefix
+        ):
             # scan through all tables actually created, if it was expected then emit an Output.
             # otherwise, emit a runtime AssetMaterialization
-            if materialization.asset_key in asset_keys:
+            if materialization.asset_key in tracked_asset_keys:
                 yield Output(
                     value=None,
                     output_name="_".join(materialization.asset_key.path),
-                    metadata_entries=materialization.metadata_entries,
+                    metadata={
+                        entry.label: entry.entry_data for entry in materialization.metadata_entries
+                    },
                 )
             else:
                 yield materialization
 
-    return _assets
+    return [_assets]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from dagster import AssetKey, AssetsDefinition, Out, Output, multi_asset, check
+from dagster import AssetKey, AssetsDefinition, Out, Output, check, multi_asset
 from dagster.utils.backcompat import experimental
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL
 from dagster_fivetran.utils import generate_materializations

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
@@ -41,6 +41,9 @@ def _table_data_to_materialization(
 def generate_materializations(fivetran_output: FivetranOutput, asset_key_prefix: List[str]):
     for schema in fivetran_output.schema_config["schemas"].values():
         schema_name = schema["name_in_destination"]
+        schema_prefix = fivetran_output.connector_details.get("config", {}).get("schema_prefix")
+        if schema_prefix:
+            schema_name = f"{schema_prefix}_{schema_name}"
         if not schema["enabled"]:
             continue
         for table_data in schema["tables"].values():


### PR DESCRIPTION
basically just ports over the modifications we've made to the fivetran asset stuff after experimenting w/ purina, and creates an equivalent asset def thing for airbyte.