### PR TITLE
add fallback error state for snapshot types

### DIFF
--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
@@ -13,6 +13,7 @@ import {RepoAddress} from '../workspace/types';
 
 import {TypeList, TYPE_LIST_FRAGMENT} from './TypeList';
 import {TypeListContainerQuery} from './types/TypeListContainerQuery';
+import {Box, NonIdealState} from '../../../ui/src';
 
 interface ITypeListContainerProps {
   explorerPath: ExplorerPath;
@@ -29,7 +30,9 @@ export const TypeListContainer: React.FunctionComponent<ITypeListContainerProps>
   const pipelineSelector = React.useMemo(() => {
     if (!repoAddress) {
       const reposWithMatch = findRepoContainingPipeline(options, pipelineName, snapshotId);
-      return buildPipelineSelector(optionToRepoAddress(reposWithMatch[0]), pipelineName);
+      return reposWithMatch.length
+        ? buildPipelineSelector(optionToRepoAddress(reposWithMatch[0]), pipelineName)
+        : null;
     }
     return buildPipelineSelector(repoAddress, pipelineName);
   }, [options, pipelineName, repoAddress, snapshotId]);
@@ -37,7 +40,16 @@ export const TypeListContainer: React.FunctionComponent<ITypeListContainerProps>
   const queryResult = useQuery<TypeListContainerQuery>(TYPE_LIST_CONTAINER_QUERY, {
     fetchPolicy: 'cache-and-network',
     variables: {pipelineSelector},
+    skip: !pipelineSelector,
   });
+
+  if (!pipelineSelector) {
+    return (
+      <Box margin={48}>
+        <NonIdealState icon="error" title="Could not fetch types for snapshot" />
+      </Box>
+    );
+  }
 
   return (
     <Loading queryResult={queryResult}>

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
@@ -1,4 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
+import {Box, NonIdealState} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
@@ -13,7 +14,6 @@ import {RepoAddress} from '../workspace/types';
 
 import {TypeList, TYPE_LIST_FRAGMENT} from './TypeList';
 import {TypeListContainerQuery} from './types/TypeListContainerQuery';
-import {Box, NonIdealState} from '../../../ui/src';
 
 interface ITypeListContainerProps {
   explorerPath: ExplorerPath;


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
## Summary
Was previously erroring out (blank screen). 

Now:
<img width="1648" alt="Screen Shot 2022-02-17 at 10 48 03 AM" src="https://user-images.githubusercontent.com/1040172/154518082-8f9608cb-9e22-4e13-a7ee-dd707be4e834.png">


## Test Plan
clicked on `Types` link in sidenav for snapshot explorer page


