### PR TITLE
switch arg name for metadata value class

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -108,7 +108,6 @@ def normalize_metadata_value(raw_value: RawMetadataValue):
             )
 
     raise DagsterInvalidMetadata(
-        "Could not resolve value to a known type. "
         f"Its type was {type(raw_value)}. Consider wrapping the value with the appropriate "
         "MetadataValue type."
     )
@@ -126,8 +125,8 @@ def package_metadata_value(label: str, raw_value: RawMetadataValue) -> "Metadata
         value = normalize_metadata_value(raw_value)
     except DagsterInvalidMetadata as e:
         raise DagsterInvalidMetadata(
-            f'Could not resolve the metadata value for "{label}" to a known type.'
-        ) from e
+            f'Could not resolve the metadata value for "{label}" to a known type. {e}'
+        ) from None
     return MetadataEntry(label=label, value=value)
 
 

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -740,7 +740,7 @@ class MetadataEntry(
         [
             ("label", str),
             ("description", Optional[str]),
-            ("value", MetadataValue),
+            ("entry_data", MetadataValue),
         ],
     ),
 ):
@@ -764,8 +764,8 @@ class MetadataEntry(
         cls,
         label: str,
         description: Optional[str],
-        value: Optional["MetadataValue"] = None,
         entry_data: Optional["MetadataValue"] = None,
+        value: Optional["MetadataValue"] = None,
     ):
         if description is not None:
             deprecation_warning(
@@ -789,6 +789,11 @@ class MetadataEntry(
             check.opt_str_param(description, "description"),
             check.inst_param(value, "value", MetadataValue),
         )
+
+    @property
+    def value(self):
+        """Alias of `entry_data`."""
+        return self.entry_data
 
     @staticmethod
     @deprecated_metadata_entry_constructor

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import re
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Union, cast
 
 from dagster import check, seven
@@ -724,7 +725,13 @@ def deprecated_metadata_entry_constructor(fn):
         deprecation_warning(
             f"Function `MetadataEntry.{fn.__name__}`",
             "0.15.0",
-            additional_warn_txt="In the future, construct `MetadataEntry` by calling the constructor directly and passing a `MetadataValue`.",
+            additional_warn_txt=re.sub(r'\n\s*', ' ', """
+            As of 0.14.0, the recommended way to supply metadata is to pass a `Dict[str,
+            MetadataValue]` to the `metadata` keyword argument (rather than a `List[MetadataEntry]`
+            to `metadata_entries`. If you need to construct a `MetadataEntry` directly, you should
+            do so using calling the constructor and passing a `MetadataValue`:
+            `MetadataEntry(label="foo", value=MetadataValue.text("bar")",
+            """)
         )
         return fn(*args, **kwargs)
 
@@ -763,7 +770,7 @@ class MetadataEntry(
     def __new__(
         cls,
         label: str,
-        description: Optional[str],
+        description: Optional[str] = None,
         entry_data: Optional["MetadataValue"] = None,
         value: Optional["MetadataValue"] = None,
     ):

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -734,11 +734,10 @@ def deprecated_metadata_entry_constructor(fn):
                 r"\n\s*",
                 " ",
                 """
-            As of 0.14.0, the recommended way to supply metadata is to pass a `Dict[str,
-            MetadataValue]` to the `metadata` keyword argument (rather than a `List[MetadataEntry]`
-            to `metadata_entries`. If you need to construct a `MetadataEntry` directly, you should
-            do so using calling the constructor and passing a `MetadataValue`:
-            `MetadataEntry(label="foo", value=MetadataValue.text("bar")",
+            The recommended way to supply metadata is to pass a `Dict[str,
+            MetadataValue]` to the `metadata` keyword argument. To construct `MetadataEntry`
+            directly, call constructor and pass a `MetadataValue`: `MetadataEntry(label="foo",
+            value=MetadataValue.text("bar")",
             """,
             ),
         )
@@ -749,6 +748,10 @@ def deprecated_metadata_entry_constructor(fn):
 
 # NOTE: This would better be implemented as a generic with `MetadataValue` set as a
 # typevar, but as of 2022-01-25 mypy does not support generics on NamedTuple.
+#
+# NOTE: This currently stores value in the `entry_data` NamedTuple attribute. In the next release,
+# we will change the name of the NamedTuple property to `value`, and need to implement custom
+# serialization so that it continues to be saved as `entry_data` for backcompat purposes.
 @whitelist_for_serdes(storage_name="EventMetadataEntry")
 class MetadataEntry(
     NamedTuple(

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -166,7 +166,8 @@ def test_bad_json_metadata_value():
         execute_pipeline(the_pipeline)
 
     assert str(exc_info.value) == (
-        'Could not resolve the metadata value for "bad" to a JSON serializable value. '
+        'Could not resolve the metadata value for "bad" to a known type. '
+        "Value is a dictionary but is not JSON serializable. "
         "Consider wrapping the value with the appropriate MetadataValue type."
     )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -39,6 +39,14 @@ def solid_events_for_type(result, solid_name, event_type):
     ]
 
 
+def test_metadata_entry_construction():
+    entry_1 = MetadataEntry("foo", value=MetadataValue.text("bar"))
+    entry_2 = MetadataEntry("foo", entry_data=MetadataValue.text("bar"))
+    assert entry_1.value == MetadataValue.text("bar")
+    assert entry_2.value == MetadataValue.text("bar")
+    assert entry_1 == entry_2
+
+
 def test_metadata_asset_materialization():
     @solid(output_defs=[])
     def the_solid(_context):


### PR DESCRIPTION
This adjusts the new `MetadataEntry` class to (temporarily) accept either `value` or `entry_data` for its payload arg. In 0.15.0 will only be `value`.
