### PR TITLE
[dagster-aws] Fix bug when logging records from pyspark_step_launcher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -373,10 +373,9 @@ class EmrPySparkStepLauncher(StepLauncher):
         records = parse_hadoop_log4j_records(stderr_log)
         for record in records:
             if record.level:
-                log._log(  # pylint: disable=protected-access
-                    record.level,
-                    "".join(["Spark Driver stderr: ", record.logger, ": ", record.message]),
-                    {},
+                log.log(
+                    level=record.level,
+                    msg="".join(["Spark Driver stderr: ", record.logger, ": ", record.message]),
                 )
             else:
                 log.debug(f"Spark Driver stderr: {record.message}")


### PR DESCRIPTION
the private _log() function does not coerce string log levels (e.g. "INFO" to the expected integers), while the public one does.

slack ref: https://dagster.slack.com/archives/C01U954MEER/p1645123233173829?thread_ts=1645109562.129699&cid=C01U954MEER