### PR TITLE
restore old metadata name deprecation warnings

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -264,30 +264,25 @@ from dagster.config.source import BoolSource, StringSource, IntSource  # isort:s
 # ##### DEPRECATED ALIASES
 # ########################
 
-# NOTE: Unfortunately we have to declare deprecated aliases twice-- the top
-# level declaration informs pylint that the module contains the attribute (this
-# prevents generating noisy lint errors for users), but the entry in
-# `_DEPRECATED` is required  for us to generate the deprecation warning. Note
-# that the typing.Annotated functionality introduced in Python 3.9 (or
-# available through the `typing-extensions` package) would allow us to avoid
-# the double declaration, e.g.:
-#
-# EventMetadataEntry: Annotated[Type[MetadataEntry], MetadataEntry, "0.15.0"]
+# NOTE: Unfortunately we have to declare deprecated aliases twice-- the
+# TYPE_CHECKING declaration satisfies linters and type checkers, but the entry
+# in `_DEPRECATED` is required  for us to generate the deprecation warning.
 
-EventMetadataEntry: typing.Type[MetadataEntry]
-EventMetadata: typing.Type[MetadataValue]
-TextMetadataEntryData: typing.Type[TextMetadataValue]
-UrlMetadataEntryData: typing.Type[UrlMetadataValue]
-PathMetadataEntryData: typing.Type[PathMetadataValue]
-JsonMetadataEntryData: typing.Type[JsonMetadataValue]
-MarkdownMetadataEntryData: typing.Type[MarkdownMetadataValue]
-PythonArtifactMetadataEntryData: typing.Type[PythonArtifactMetadataValue]
-FloatMetadataEntryData: typing.Type[FloatMetadataValue]
-IntMetadataEntryData: typing.Type[IntMetadataValue]
-DagsterPipelineRunMetadataEntryData: typing.Type[DagsterPipelineRunMetadataValue]
-DagsterAssetMetadataEntryData: typing.Type[DagsterAssetMetadataValue]
-TableMetadataEntryData: typing.Type[TableMetadataValue]
-TableSchemaMetadataEntryData: typing.Type[TableSchemaMetadataValue]
+if typing.TYPE_CHECKING:
+    from dagster.core.definitions import MetadataEntry as EventMetadataEntry
+    from dagster.core.definitions import MetadataValue as EventMetadata
+    from dagster.core.definitions import TextMetadataValue as TextMetadataEntryData
+    from dagster.core.definitions import UrlMetadataValue as UrlMetadataEntryData
+    from dagster.core.definitions import PathMetadataValue as PathMetadataEntryData
+    from dagster.core.definitions import JsonMetadataValue as JsonMetadataEntryData
+    from dagster.core.definitions import MarkdownMetadataValue as MarkdownMetadataEntryData
+    from dagster.core.definitions import PythonArtifactMetadataValue as PythonArtifactMetadataEntryData
+    from dagster.core.definitions import FloatMetadataValue as FloatMetadataEntryData
+    from dagster.core.definitions import IntMetadataValue as IntMetadataEntryData
+    from dagster.core.definitions import DagsterPipelineRunMetadataValue as DagsterPipelineRunMetadataEntryData
+    from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
+    from dagster.core.definitions import TableMetadataValue as TableMetadataEntryData
+    from dagster.core.definitions import TableSchemaMetadataValue as TableSchemaMetadataEntryData
 
 _DEPRECATED = {
     "EventMetadataEntry": ("MetadataEntry", MetadataEntry, "0.15.0"),

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,6 +1,8 @@
 import sys
 import typing
 
+from pep562 import pep562
+
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
 from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Shape
 from dagster.config.config_schema import ConfigSchema
@@ -254,7 +256,6 @@ from dagster.utils.test import (
     execute_solid_within_pipeline,
     execute_solids_within_pipeline,
 )
-from pep562 import pep562
 
 from .version import __version__
 
@@ -270,22 +271,24 @@ from dagster.config.source import BoolSource, StringSource, IntSource  # isort:s
 
 if typing.TYPE_CHECKING:
     # pylint:disable=reimported
+    from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
     from dagster.core.definitions import (
-        MetadataEntry as EventMetadataEntry,
-        MetadataValue as EventMetadata,
-        TextMetadataValue as TextMetadataEntryData,
-        UrlMetadataValue as UrlMetadataEntryData,
-        PathMetadataValue as PathMetadataEntryData,
-        JsonMetadataValue as JsonMetadataEntryData,
-        MarkdownMetadataValue as MarkdownMetadataEntryData,
-        PythonArtifactMetadataValue as PythonArtifactMetadataEntryData,
-        FloatMetadataValue as FloatMetadataEntryData,
-        IntMetadataValue as IntMetadataEntryData,
         DagsterPipelineRunMetadataValue as DagsterPipelineRunMetadataEntryData,
-        DagsterAssetMetadataValue as DagsterAssetMetadataEntryData,
-        TableMetadataValue as TableMetadataEntryData,
-        TableSchemaMetadataValue as TableSchemaMetadataEntryData,
     )
+    from dagster.core.definitions import FloatMetadataValue as FloatMetadataEntryData
+    from dagster.core.definitions import IntMetadataValue as IntMetadataEntryData
+    from dagster.core.definitions import JsonMetadataValue as JsonMetadataEntryData
+    from dagster.core.definitions import MarkdownMetadataValue as MarkdownMetadataEntryData
+    from dagster.core.definitions import MetadataEntry as EventMetadataEntry
+    from dagster.core.definitions import MetadataValue as EventMetadata
+    from dagster.core.definitions import PathMetadataValue as PathMetadataEntryData
+    from dagster.core.definitions import (
+        PythonArtifactMetadataValue as PythonArtifactMetadataEntryData,
+    )
+    from dagster.core.definitions import TableMetadataValue as TableMetadataEntryData
+    from dagster.core.definitions import TableSchemaMetadataValue as TableSchemaMetadataEntryData
+    from dagster.core.definitions import TextMetadataValue as TextMetadataEntryData
+    from dagster.core.definitions import UrlMetadataValue as UrlMetadataEntryData
 
     # pylint:enable=reimported
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -290,33 +290,29 @@ if typing.TYPE_CHECKING:
     # pylint:enable=reimported
 
 _DEPRECATED = {
-    "EventMetadataEntry": ("MetadataEntry", MetadataEntry, "0.15.0"),
-    "EventMetadata": ("MetadataValue", MetadataValue, "0.15.0"),
-    "TextMetadataEntryData": ("TextMetadataValue", TextMetadataValue, "0.15.0"),
-    "UrlMetadataEntryData": ("UrlMetadataValue", UrlMetadataValue, "0.15.0"),
-    "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue, "0.15.0"),
-    "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue, "0.15.0"),
-    "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue, "0.15.0"),
+    "EventMetadataEntry": (MetadataEntry, "0.15.0"),
+    "EventMetadata": (MetadataValue, "0.15.0"),
+    "TextMetadataEntryData": (TextMetadataValue, "0.15.0"),
+    "UrlMetadataEntryData": (UrlMetadataValue, "0.15.0"),
+    "PathMetadataEntryData": (PathMetadataValue, "0.15.0"),
+    "JsonMetadataEntryData": (JsonMetadataValue, "0.15.0"),
+    "MarkdownMetadataEntryData": (MarkdownMetadataValue, "0.15.0"),
     "PythonArtifactMetadataEntryData": (
-        "PythonArtifactMetadataValue",
         PythonArtifactMetadataValue,
         "0.15.0",
     ),
-    "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue, "0.15.0"),
-    "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue, "0.15.0"),
+    "FloatMetadataEntryData": (FloatMetadataValue, "0.15.0"),
+    "IntMetadataEntryData": (IntMetadataValue, "0.15.0"),
     "DagsterPipelineRunMetadataEntryData": (
-        "DagsterPipelineRunMetadataValue",
         DagsterPipelineRunMetadataValue,
         "0.15.0",
     ),
     "DagsterAssetMetadataEntryData": (
-        "DagsterAssetMetadataValue",
         DagsterAssetMetadataValue,
         "0.15.0",
     ),
-    "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue, "0.15.0"),
+    "TableMetadataEntryData": (TableMetadataValue, "0.15.0"),
     "TableSchemaMetadataEntryData": (
-        "TableSchemaMetadataValue",
         TableSchemaMetadataValue,
         "0.15.0",
     ),
@@ -325,9 +321,9 @@ _DEPRECATED = {
 
 def __getattr__(name):
     if name in _DEPRECATED:
-        new_name, value, breaking_version = _DEPRECATED[name]
+        value, breaking_version = _DEPRECATED[name]
         stacklevel = 3 if sys.version_info >= (3, 7) else 4
-        rename_warning(new_name, name, breaking_version, stacklevel=stacklevel)
+        rename_warning(value.__name__, name, breaking_version, stacklevel=stacklevel)
         return value
     else:
         raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -286,6 +286,7 @@ if typing.TYPE_CHECKING:
         TableMetadataValue as TableMetadataEntryData,
         TableSchemaMetadataValue as TableSchemaMetadataEntryData,
     )
+
     # pylint:enable=reimported
 
 _DEPRECATED = {

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import typing
 
 from dagster.builtins import Any, Bool, Float, Int, Nothing, String
 from dagster.config import Enum, EnumValue, Field, Map, Permissive, Selector, Shape
@@ -240,7 +241,7 @@ from dagster.core.types.python_set import Set
 from dagster.core.types.python_tuple import Tuple
 from dagster.utils import file_relative_path
 from dagster.utils.alert import make_email_on_run_failure_sensor
-from dagster.utils.backcompat import ExperimentalWarning
+from dagster.utils.backcompat import ExperimentalWarning, rename_warning
 from dagster.utils.log import get_dagster_logger
 from dagster.utils.partitions import (
     create_offset_partition_selector,
@@ -258,40 +259,92 @@ from .version import __version__
 
 from dagster.config.source import BoolSource, StringSource, IntSource  # isort:skip
 
-# DEPRECATIONS
-# TODO: find a way to add warnings
-EventMetadataEntry = MetadataEntry
-EventMetadata = MetadataValue
-TextMetadataEntryData = TextMetadataValue
-UrlMetadataEntryData = UrlMetadataValue
-PathMetadataEntryData = PathMetadataValue
-JsonMetadataEntryData = JsonMetadataValue
-MarkdownMetadataEntryData = MarkdownMetadataValue
-PythonArtifactMetadataEntryData = PythonArtifactMetadataValue
-FloatMetadataEntryData = FloatMetadataValue
-IntMetadataEntryData = IntMetadataValue
-DagsterPipelineRunMetadataEntryData = DagsterPipelineRunMetadataValue
-DagsterAssetMetadataEntryData = DagsterAssetMetadataValue
-TableMetadataEntryData = TableMetadataValue
-TableSchemaMetadataEntryData = TableSchemaMetadataValue
+# ########################
+# ##### DEPRECATED ALIASES
+# ########################
 
+# NOTE: Unfortunately we have to declare deprecated aliases twice-- the top
+# level declaration informs pylint that the module contains the attribute (this
+# prevents generating noisy lint errors for users), but the entry in
+# `_DEPRECATED` is required  for us to generate the deprecation warning. Note
+# that the typing.Annotated functionality introduced in Python 3.9 (or
+# available through the `typing-extensions` package) would allow us to avoid
+# the double declaration, e.g.:
+#
+# EventMetadataEntry: Annotated[Type[MetadataEntry], MetadataEntry, "0.15.0"]
+
+EventMetadataEntry: typing.Type[MetadataEntry]
+EventMetadata: typing.Type[MetadataValue]
+TextMetadataEntryData: typing.Type[TextMetadataValue]
+UrlMetadataEntryData: typing.Type[UrlMetadataValue]
+PathMetadataEntryData: typing.Type[PathMetadataValue]
+JsonMetadataEntryData: typing.Type[JsonMetadataValue]
+MarkdownMetadataEntryData: typing.Type[MarkdownMetadataValue]
+PythonArtifactMetadataEntryData: typing.Type[PythonArtifactMetadataValue]
+FloatMetadataEntryData: typing.Type[FloatMetadataValue]
+IntMetadataEntryData: typing.Type[IntMetadataValue]
+DagsterPipelineRunMetadataEntryData: typing.Type[DagsterPipelineRunMetadataValue]
+DagsterAssetMetadataEntryData: typing.Type[DagsterAssetMetadataValue]
+TableMetadataEntryData: typing.Type[TableMetadataValue]
+TableSchemaMetadataEntryData: typing.Type[TableSchemaMetadataValue]
+
+_DEPRECATED = {
+    "EventMetadataEntry": ("MetadataEntry", MetadataEntry, "0.15.0"),
+    "EventMetadata": ("MetadataValue", MetadataValue, "0.15.0"),
+    "TextMetadataEntryData": ("TextMetadataValue", TextMetadataValue, "0.15.0"),
+    "UrlMetadataEntryData": ("UrlMetadataValue", UrlMetadataValue, "0.15.0"),
+    "PathMetadataEntryData": ("PathMetadataValue", PathMetadataValue, "0.15.0"),
+    "JsonMetadataEntryData": ("JsonMetadataValue", JsonMetadataValue, "0.15.0"),
+    "MarkdownMetadataEntryData": ("MarkdownMetadataValue", MarkdownMetadataValue, "0.15.0"),
+    "PythonArtifactMetadataEntryData": (
+        "PythonArtifactMetadataValue",
+        PythonArtifactMetadataValue,
+        "0.15.0",
+    ),
+    "FloatMetadataEntryData": ("FloatMetadataValue", FloatMetadataValue, "0.15.0"),
+    "IntMetadataEntryData": ("IntMetadataValue", IntMetadataValue, "0.15.0"),
+    "DagsterPipelineRunMetadataEntryData": (
+        "DagsterPipelineRunMetadataValue",
+        DagsterPipelineRunMetadataValue,
+        "0.15.0",
+    ),
+    "DagsterAssetMetadataEntryData": (
+        "DagsterAssetMetadataValue",
+        DagsterAssetMetadataValue,
+        "0.15.0",
+    ),
+    "TableMetadataEntryData": ("TableMetadataValue", TableMetadataValue, "0.15.0"),
+    "TableSchemaMetadataEntryData": (
+        "TableSchemaMetadataValue",
+        TableSchemaMetadataValue,
+        "0.15.0",
+    ),
+}
+
+
+def __getattr__(name):
+    if name in _DEPRECATED:
+        new_name, value, breaking_version = _DEPRECATED[name]
+        stacklevel = 3 if sys.version_info >= (3, 7) else 4
+        rename_warning(new_name, name, breaking_version, stacklevel=stacklevel)
+        return value
+    else:
+        raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
+
+
+def __dir__():
+    return sorted(list(__all__) + list(_DEPRECATED.keys()))
+
+from pep562 import pep562
+
+# Backports PEP 562, which allows for override of __getattr__ and __dir__, to this module. PEP 562
+# was introduced in Python 3.7, so the `pep562` call here is a no-op for 3.7+.
+# See:
+#  PEP 562: https://www.python.org/dev/peps/pep-0562/
+#  PEP 562 backport package: https://github.com/facelessuser/pep562
+pep562(__name__)
 
 __all__ = [
-    # DEPRECATIONS
-    "EventMetadataEntry",
-    "EventMetadata",
-    "TextMetadataEntryData",
-    "UrlMetadataEntryData",
-    "PathMetadataEntryData",
-    "JsonMetadataEntryData",
-    "MarkdownMetadataEntryData",
-    "PythonArtifactMetadataEntryData",
-    "FloatMetadataEntryData",
-    "IntMetadataEntryData",
-    "DagsterPipelineRunMetadataEntryData",
-    "DagsterAssetMetadataEntryData",
-    "TableMetadataEntryData",
-    "TableSchemaMetadataEntryData",
     # Definition
     "AssetGroup",
     "AssetKey",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -269,20 +269,24 @@ from dagster.config.source import BoolSource, StringSource, IntSource  # isort:s
 # in `_DEPRECATED` is required  for us to generate the deprecation warning.
 
 if typing.TYPE_CHECKING:
-    from dagster.core.definitions import MetadataEntry as EventMetadataEntry
-    from dagster.core.definitions import MetadataValue as EventMetadata
-    from dagster.core.definitions import TextMetadataValue as TextMetadataEntryData
-    from dagster.core.definitions import UrlMetadataValue as UrlMetadataEntryData
-    from dagster.core.definitions import PathMetadataValue as PathMetadataEntryData
-    from dagster.core.definitions import JsonMetadataValue as JsonMetadataEntryData
-    from dagster.core.definitions import MarkdownMetadataValue as MarkdownMetadataEntryData
-    from dagster.core.definitions import PythonArtifactMetadataValue as PythonArtifactMetadataEntryData
-    from dagster.core.definitions import FloatMetadataValue as FloatMetadataEntryData
-    from dagster.core.definitions import IntMetadataValue as IntMetadataEntryData
-    from dagster.core.definitions import DagsterPipelineRunMetadataValue as DagsterPipelineRunMetadataEntryData
-    from dagster.core.definitions import DagsterAssetMetadataValue as DagsterAssetMetadataEntryData
-    from dagster.core.definitions import TableMetadataValue as TableMetadataEntryData
-    from dagster.core.definitions import TableSchemaMetadataValue as TableSchemaMetadataEntryData
+    # pylint:disable=reimported
+    from dagster.core.definitions import (
+        MetadataEntry as EventMetadataEntry,
+        MetadataValue as EventMetadata,
+        TextMetadataValue as TextMetadataEntryData,
+        UrlMetadataValue as UrlMetadataEntryData,
+        PathMetadataValue as PathMetadataEntryData,
+        JsonMetadataValue as JsonMetadataEntryData,
+        MarkdownMetadataValue as MarkdownMetadataEntryData,
+        PythonArtifactMetadataValue as PythonArtifactMetadataEntryData,
+        FloatMetadataValue as FloatMetadataEntryData,
+        IntMetadataValue as IntMetadataEntryData,
+        DagsterPipelineRunMetadataValue as DagsterPipelineRunMetadataEntryData,
+        DagsterAssetMetadataValue as DagsterAssetMetadataEntryData,
+        TableMetadataValue as TableMetadataEntryData,
+        TableSchemaMetadataValue as TableSchemaMetadataEntryData,
+    )
+    # pylint:enable=reimported
 
 _DEPRECATED = {
     "EventMetadataEntry": ("MetadataEntry", MetadataEntry, "0.15.0"),

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -254,6 +254,7 @@ from dagster.utils.test import (
     execute_solid_within_pipeline,
     execute_solids_within_pipeline,
 )
+from pep562 import pep562
 
 from .version import __version__
 
@@ -335,7 +336,6 @@ def __getattr__(name):
 def __dir__():
     return sorted(list(__all__) + list(_DEPRECATED.keys()))
 
-from pep562 import pep562
 
 # Backports PEP 562, which allows for override of __getattr__ and __dir__, to this module. PEP 562
 # was introduced in Python 3.7, so the `pep562` call here is a no-op for 3.7+.

--- a/python_modules/dagster/dagster/core/definitions/policy.py
+++ b/python_modules/dagster/dagster/core/definitions/policy.py
@@ -93,7 +93,7 @@ class RetryPolicy(
 
 def calculate_delay(attempt_num, backoff, jitter, base_delay):
     if backoff is Backoff.EXPONENTIAL:
-        calc_delay = ((2 ** attempt_num) - 1) * base_delay
+        calc_delay = ((2**attempt_num) - 1) * base_delay
     elif backoff is Backoff.LINEAR:
         calc_delay = base_delay * attempt_num
     elif backoff is None:

--- a/python_modules/dagster/dagster/grpc/compile.py
+++ b/python_modules/dagster/dagster/grpc/compile.py
@@ -104,8 +104,9 @@ def protoc(generated_dir: str):
 
     installed_pkgs = {
         # pylint: disable=not-an-iterable
-        pkg.key for pkg in pkg_resources.working_set
-    }  
+        pkg.key
+        for pkg in pkg_resources.working_set
+    }
 
     # Run black if it's available. This is under a conditional because black may not be available in
     # a test environment.

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -4,6 +4,7 @@ import re
 import dagster
 import pytest
 
+
 def test_all():
     dagster_dir = dir(dagster)
     for each in dagster.__all__:
@@ -18,6 +19,6 @@ def test_all():
 
 
 def test_deprecated_imports():
-    with pytest.warns(DeprecationWarning, match=re.escape('"Foo" is deprecated')):
+    with pytest.warns(DeprecationWarning, match=re.escape('"EventMetadataEntry" is deprecated')):
         from dagster import EventMetadataEntry, MetadataEntry
     assert EventMetadataEntry is MetadataEntry

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -1,12 +1,23 @@
 import inspect
+import re
 
 import dagster
-
+import pytest
 
 def test_all():
     dagster_dir = dir(dagster)
     for each in dagster.__all__:
         assert each in dagster_dir
     for exported in dagster_dir:
-        if not exported.startswith("_") and not inspect.ismodule(getattr(dagster, exported)):
+        if (
+            not exported.startswith("_")
+            and not inspect.ismodule(getattr(dagster, exported))
+            and not exported in dagster._DEPRECATED
+        ):
             assert exported in dagster.__all__
+
+
+def test_deprecated_imports():
+    with pytest.warns(DeprecationWarning, match=re.escape('"Foo" is deprecated')):
+        from dagster import EventMetadataEntry, MetadataEntry
+    assert EventMetadataEntry is MetadataEntry

--- a/python_modules/dagster/dagster_tests/general_tests/test_api.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_api.py
@@ -1,8 +1,9 @@
 import inspect
 import re
 
-import dagster
 import pytest
+
+import dagster
 
 
 def test_all():

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
             "grpcio-health-checking>=1.32.0,<1.44.0",
             "packaging>=20.9",
             "pendulum",
+            "pep562",
             "protobuf>=3.13.0",  # ensure version we require is >= that with which we generated the proto code (set in dev-requirements)
             "python-dateutil",
             "pytz",


### PR DESCRIPTION
This restores the deprecation warnings for the use of old metadata class names that were removed immediately prior to 0.14.0 release due to concerns over introducing pylint false positives for users (see: https://dagster.slack.com/archives/G01E8E403T7/p1645067791246379).

The problem was that the deprecation system used a `__getattr__` override to print a warning and return e.g. `TextMetadataValue` on import of `TextMetadataEntryData`. Pylint does not understand `__getattr__`, and because it could not discover `TextMetdataEntryData` through static analysis, raised a E0611 no-name-in-module lint error.

This PR fixes the problem by declaring the deprecated names in an `if TYPE_CHECKING` block. These declarations are identified by pylint as a declaration of the attribute, but `__getattr__` is still invoked to properly raise a warning and return the correct object.