### PR TITLE
Add a check in run execution that the run actually exists, just like in step execution

### DIFF
--- a/python_modules/dagster/dagster/cli/api.py
+++ b/python_modules/dagster/dagster/cli/api.py
@@ -83,6 +83,12 @@ def _execute_run_command_body(
 
     pipeline_run = instance.get_run_by_id(pipeline_run_id)
 
+    check.inst(
+        pipeline_run,
+        PipelineRun,
+        "Pipeline run with id '{}' not found for run execution.".format(pipeline_run_id),
+    )
+
     pid = os.getpid()
     instance.report_engine_event(
         "Started process for run (pid: {pid}).".format(pid=pid),
@@ -169,6 +175,11 @@ def _resume_run_command_body(
             instance, pipeline_run_id
         )
     pipeline_run = instance.get_run_by_id(pipeline_run_id)
+    check.inst(
+        pipeline_run,
+        PipelineRun,
+        "Pipeline run with id '{}' not found for run execution.".format(pipeline_run_id),
+    )
 
     pid = os.getpid()
     instance.report_engine_event(


### PR DESCRIPTION
Summary:
A user reported hitting this: dagster.check.CheckError: Invariant failed. Description: Must include either pipeline_run or pipeline_name and run_id

We can do slightly better in the case where we can't load the run for some reason in the run worker.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.