### PR TITLE
pin markupsafe

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -62,6 +62,8 @@ if __name__ == "__main__":
             "contextvars; python_version < '3.7'",
             # https://github.com/dagster-io/dagster/issues/4167
             "Jinja2<3.0",
+            # https://github.com/pallets/markupsafe/issues/286
+            "markupsafe<2.1",
             "PyYAML>=5.1",
             # core (not explicitly expressed atm)
             # alembic 1.6.3 broke our migrations: https://github.com/sqlalchemy/alembic/issues/848


### PR DESCRIPTION

## Summary

- pin `markupsafe <2.1.0`, which removes a deprecated name used by jinja2 
  - https://github.com/conda-forge/dagster-feedstock/pull/184  
- this is a packaging/dependency fix... presumably be resolved, 
- applied downstream to 0.14.0 here:
  - https://github.com/conda-forge/dagster-feedstock/pull/184

```
import: 'dagster.cli'
Traceback (most recent call last):
  File "~/test_tmp/run_test.py", line 11, in <module>
    import dagster.cli
  File "~/_tmp/lib/python3.7/site-packages/dagster/cli/__init__.py", line 13, in <module>
    from .new_project import new_project_cli
  File "~/_tmp/lib/python3.7/site-packages/dagster/cli/new_project.py", line 4, in <module>
    from dagster.generate import generate_new_project
  File "~/_tmp/lib/python3.7/site-packages/dagster/generate/__init__.py", line 1, in <module>
    from .generate import generate_new_project
  File "~/_tmp/lib/python3.7/site-packages/dagster/generate/generate.py", line 4, in <module>
    import jinja2
  File "~/_tmp/lib/python3.7/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "~/_tmp/lib/python3.7/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "~/_tmp/lib/python3.7/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "~/_tmp/lib/python3.7/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (~/_tmp/lib/python3.7/site-packages/markupsafe/__init__.py)

```

## Test Plan

`pip install dagster` and `import dagster` should work

## Checklist
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.