### PR TITLE
add back mutation tests for sensor/schedules with default status

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
@@ -17,6 +17,8 @@ from dagster import (
     AssetObservation,
     Bool,
     DagsterInstance,
+    DefaultScheduleStatus,
+    DefaultSensorStatus,
     DynamicOutput,
     DynamicOutputDefinition,
     Enum,
@@ -1079,6 +1081,15 @@ def define_schedules():
         return {}
 
     @daily_schedule(
+        pipeline_name="no_config_pipeline",
+        start_date=today_at_midnight().subtract(days=1),
+        execution_time=(datetime.datetime.now() + datetime.timedelta(hours=2)).time(),
+        default_status=DefaultScheduleStatus.RUNNING,
+    )
+    def running_in_code_schedule(_date):
+        return {}
+
+    @daily_schedule(
         pipeline_name="multi_mode_with_loggers",
         start_date=today_at_midnight().subtract(days=1),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=2)).time(),
@@ -1194,6 +1205,7 @@ def define_schedules():
         tags_error_schedule,
         timezone_schedule,
         invalid_config_schedule,
+        running_in_code_schedule,
     ]
 
 
@@ -1260,12 +1272,24 @@ def define_sensors():
             tags={"test": "1234"},
         )
 
+    @sensor(
+        pipeline_name="no_config_pipeline",
+        mode="default",
+        default_status=DefaultSensorStatus.RUNNING,
+    )
+    def running_in_code_sensor(_):
+        return RunRequest(
+            run_key=None,
+            tags={"test": "1234"},
+        )
+
     return [
         always_no_config_sensor,
         once_no_config_sensor,
         never_no_config_sensor,
         multi_no_config_sensor,
         custom_interval_sensor,
+        running_in_code_sensor,
     ]
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_partition_sets.py
@@ -1258,6 +1258,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             },
             {
                 'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
                 'name': 'scheduled_integer_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
@@ -1319,6 +1325,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             {
                 'mode': 'default',
                 'name': 'run_config_error_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             },
@@ -1390,6 +1402,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             },
             {
                 'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
                 'name': 'scheduled_integer_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
@@ -1451,6 +1469,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             {
                 'mode': 'default',
                 'name': 'run_config_error_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             },
@@ -1522,6 +1546,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             },
             {
                 'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
                 'name': 'scheduled_integer_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
@@ -1583,6 +1613,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             {
                 'mode': 'default',
                 'name': 'run_config_error_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             },
@@ -1654,6 +1690,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             },
             {
                 'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
                 'name': 'scheduled_integer_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
@@ -1715,6 +1757,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             {
                 'mode': 'default',
                 'name': 'run_config_error_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             },
@@ -1786,6 +1834,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             },
             {
                 'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
                 'name': 'scheduled_integer_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
@@ -1847,6 +1901,12 @@ snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable
             {
                 'mode': 'default',
                 'name': 'run_config_error_schedule_partitions',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            },
+            {
+                'mode': 'default',
+                'name': 'running_in_code_schedule_partitions',
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             },

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
@@ -326,6 +326,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_in_memory_instance_lazy_r
                 'solidSelection': None
             }
         ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     }
 ]
 
@@ -419,6 +439,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_in_memory_instance_manage
             ],
             'runsCount': 0,
             'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
             'ticks': [
             ]
         },
@@ -532,6 +572,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_in_memory_instance_multi_
                 'solidSelection': None
             }
         ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     }
 ]
 
@@ -625,6 +685,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_lazy_re
             ],
             'runsCount': 0,
             'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
             'ticks': [
             ]
         },
@@ -738,6 +818,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_managed
                 'solidSelection': None
             }
         ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     }
 ]
 
@@ -831,6 +931,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_multi_l
             ],
             'runsCount': 0,
             'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
             'ticks': [
             ]
         },
@@ -944,6 +1064,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
                 'solidSelection': None
             }
         ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     }
 ]
 
@@ -1037,6 +1177,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repo
             ],
             'runsCount': 0,
             'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
             'ticks': [
             ]
         },
@@ -1150,6 +1310,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
                 'solidSelection': None
             }
         ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     }
 ]
 
@@ -1243,6 +1423,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_loc
             ],
             'runsCount': 0,
             'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
             'ticks': [
             ]
         },

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -92,6 +92,20 @@ query getSchedule($scheduleSelector: ScheduleSelector!, $ticksAfter: Float) {
 }
 """
 
+GET_SCHEDULE_STATE_QUERY = """
+query getScheduleState($scheduleSelector: ScheduleSelector!) {
+  scheduleOrError(scheduleSelector: $scheduleSelector) {
+    __typename
+    ... on Schedule {
+      scheduleState {
+        id
+        status
+      }
+    }
+  }
+}
+"""
+
 GET_UNLOADABLE_QUERY = """
 query getUnloadableSchedules {
   unloadableInstigationStatesOrError(instigationType: SCHEDULE) {
@@ -515,3 +529,51 @@ def test_repository_batching(graphql_context):
     # 2) `all_instigator_state` is fetched to instantiate GrapheneSchedule
     assert counts.get("DagsterInstance.get_run_records") == 1
     assert counts.get("DagsterInstance.all_instigator_state") == 1
+
+
+def test_start_schedule_with_default_status(graphql_context):
+    schedule_selector = infer_schedule_selector(graphql_context, "running_in_code_schedule")
+
+    result = execute_dagster_graphql(
+        graphql_context,
+        GET_SCHEDULE_STATE_QUERY,
+        variables={"scheduleSelector": schedule_selector},
+    )
+
+    schedule_origin_id = result.data["scheduleOrError"]["scheduleState"]["id"]
+    assert result.data["scheduleOrError"]["scheduleState"]["status"] == "RUNNING"
+
+    # Start a single schedule
+    start_result = execute_dagster_graphql(
+        graphql_context,
+        START_SCHEDULES_QUERY,
+        variables={"scheduleSelector": schedule_selector},
+    )
+
+    assert (
+        "You have attempted to start schedule running_in_code_schedule, but it is already running"
+        in start_result.data["startSchedule"]["message"]
+    )
+
+    # Stop a single schedule
+    stop_result = execute_dagster_graphql(
+        graphql_context,
+        STOP_SCHEDULES_QUERY,
+        variables={"scheduleOriginId": schedule_origin_id},
+    )
+    assert (
+        stop_result.data["stopRunningSchedule"]["scheduleState"]["status"]
+        == InstigatorStatus.STOPPED.value
+    )
+
+    # Start a single schedule
+    start_result = execute_dagster_graphql(
+        graphql_context,
+        START_SCHEDULES_QUERY,
+        variables={"scheduleSelector": schedule_selector},
+    )
+
+    assert (
+        start_result.data["startSchedule"]["scheduleState"]["status"]
+        == InstigatorStatus.RUNNING.value
+    )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -103,6 +103,20 @@ query SensorQuery($sensorSelector: SensorSelector!) {
 }
 """
 
+GET_SENSOR_STATUS_QUERY = """
+query SensorStateQuery($sensorSelector: SensorSelector!) {
+  sensorOrError(sensorSelector: $sensorSelector) {
+    __typename
+    ... on Sensor {
+      sensorState {
+        id
+        status
+      }
+    }
+  }
+}
+"""
+
 
 GET_SENSOR_TICK_RANGE_QUERY = """
 query SensorQuery($sensorSelector: SensorSelector!, $dayRange: Int, $dayOffset: Int) {
@@ -251,6 +265,46 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
             result.data["stopSensor"]["instigationState"]["status"]
             == InstigatorStatus.STOPPED.value
         )
+
+    def test_start_sensor_with_default_status(self, graphql_context):
+        sensor_selector = infer_sensor_selector(graphql_context, "running_in_code_sensor")
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_SENSOR_STATUS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert result.data["sensorOrError"]["sensorState"]["status"] == "RUNNING"
+        sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
+
+        start_result = execute_dagster_graphql(
+            graphql_context,
+            START_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert (
+            "You have attempted to start sensor running_in_code_sensor, but it is already running"
+            in start_result.data["startSensor"]["message"]
+        )
+
+        stop_result = execute_dagster_graphql(
+            graphql_context,
+            STOP_SENSORS_QUERY,
+            variables={"jobOriginId": sensor_origin_id},
+        )
+
+        assert stop_result.data["stopSensor"]["instigationState"]["status"] == "STOPPED"
+
+        # Now can be restarted
+        start_result = execute_dagster_graphql(
+            graphql_context,
+            START_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert start_result.data["startSensor"]["sensorState"]["status"] == "RUNNING"
 
 
 def test_sensor_next_ticks(graphql_context):


### PR DESCRIPTION
## Summary
Rather than mess up the snapshot tests for the sensor/schedule queries by fetching the unique id field, sets up a specific query just to get this unique field in the mutation tests.


## Test Plan
BK


