### PR TITLE
Move bollinger example to AssetGroup and add README

### DIFF
--- a/examples/bollinger/README.md
+++ b/examples/bollinger/README.md
@@ -1,0 +1,15 @@
+## Bollinger example
+
+A small graph of software-defined assets that compute bollinger bands for S&P 500 prices.
+
+### Loading the example into Dagit
+
+    dagit -w workspace.yaml
+
+### Features demonstrated
+
+- Software-defined assets.
+- Dagster types.
+- `dagster-pandera` integration.
+- Custom `IOManager`.
+- Definition-level metadata on assets.

--- a/examples/bollinger/bollinger/__init__.py
+++ b/examples/bollinger/bollinger/__init__.py
@@ -1,21 +1,21 @@
 import warnings
 
-from dagster import ExperimentalWarning, repository
+from bollinger.resources.csv_io_manager import local_csv_io_manager
+from dagster import AssetGroup, ExperimentalWarning, repository
 
 from . import lib
-from .jobs import bollinger_analysis
 
 warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
 
-@repository(name="bollinger")
-def repo():
+@repository
+def bollinger():
     return [
-        bollinger_analysis,
+        AssetGroup.from_package_name(__name__, resource_defs={"io_manager": local_csv_io_manager})
     ]
 
 
 __all__ = [
-    "repo",
+    "bollinger",
     "lib",
 ]

--- a/examples/bollinger/bollinger/assets/bollinger_analysis.py
+++ b/examples/bollinger/bollinger/assets/bollinger_analysis.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-outer-name
-from dagster import asset, build_assets_job
+from dagster import asset
 
 from ..lib import (
     AnomalousEventsDgType,
@@ -36,9 +36,3 @@ def sp500_bollinger_bands(sp500_prices):
 def sp500_anomalous_events(sp500_prices, sp500_bollinger_bands):
     """Anomalous events for the S&P 500 stock prices."""
     return compute_anomalous_events(sp500_prices, sp500_bollinger_bands)
-
-
-bollinger_analysis = build_assets_job(
-    "bollinger_analysis",
-    assets=[sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],
-)

--- a/examples/bollinger/bollinger/jobs/__init__.py
+++ b/examples/bollinger/bollinger/jobs/__init__.py
@@ -1,3 +1,0 @@
-from .bollinger_analysis import bollinger_analysis
-
-__all__ = ["bollinger_analysis"]

--- a/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
+++ b/examples/bollinger/bollinger_tests/jobs_tests/test_bollinger_analysis.py
@@ -1,17 +1,16 @@
-from bollinger.jobs.bollinger_analysis import (
+from bollinger.assets.bollinger_analysis import (
     sp500_anomalous_events,
     sp500_bollinger_bands,
     sp500_prices,
 )
 from bollinger.resources.csv_io_manager import local_csv_io_manager
-from dagster.core.asset_defs import build_assets_job
+from dagster import AssetGroup
 
 
 def test_bollinger_analysis():
-    bollinger_sda = build_assets_job(
-        "bollinger_sda",
+    bollinger_sda = AssetGroup(
         assets=[sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],
         resource_defs={"io_manager": local_csv_io_manager},
     )
-    result = bollinger_sda.execute_in_process()
+    result = bollinger_sda.build_job("test_job").execute_in_process()
     assert result.asset_materializations_for_node


### PR DESCRIPTION
This moves the bollinger example from `build_assets_job` to `AssetGroup`, which is now preferred.

It also adds a README with instructions for loading it into Dagit and a list of the features covered.