### PR TITLE
Organize dagster.check module

### DIFF
--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1,5 +1,4 @@
 import inspect
-import sys
 from typing import (
     AbstractSet,
     Any,
@@ -20,6 +19,949 @@ Type = Union[type, Tuple[type, ...]]
 Numeric = Union[int, float]
 T = TypeVar("T")
 
+# This module contains runtime type-checking code used throughout Dagster. It is divided into three
+# sections:
+#
+# - TYPE CHECKS: functions that check the type of a single value
+# - OTHER CHECKS: functions that check conditions other than the type of a single value
+# - ERRORS: error generation code invoked by the check functions
+#
+# TYPE CHECKS is divided into subsections for each type (e.g. bool, list). Each subsection contains
+# multiple functions that implement the same check logic, but differ in how the target value is
+# extracted and how the error message is generated. Call this dimension the "check context". Check
+# contexts are:
+#
+# - Parameter checks (`<type>_param`): Used to type-check the arguments to a function, typically
+#   before any business logic executes.
+# - Element checks (`<type>_elem`): Used to type-check an element of a dictionary under a specific
+#   key.
+# - General checks (`[is_]<type>`): Used to type-check a value in an arbitrary context. When the
+#   function name would conflict with a python built-in, the prefix `is_` is used to disambiguate--
+#   e.g. we have `check.is_list` instead of `check.list`.
+#
+# Using the right check for the calling context ensures an appropriate error message can be generated.
+
+# ###################################################################################################
+# ##### TYPE CHECKS
+# ###################################################################################################
+
+# ########################
+# ##### BOOL
+# ########################
+
+
+def bool_param(obj: Any, param_name: str) -> bool:
+    if not isinstance(obj, bool):
+        raise _param_type_mismatch_exception(obj, bool, param_name)
+    return obj
+
+
+def opt_bool_param(obj: Any, param_name: str, default: bool = None) -> Optional[bool]:
+    if obj is not None and not isinstance(obj, bool):
+        raise _param_type_mismatch_exception(obj, bool, param_name)
+    return default if obj is None else obj
+
+
+def bool_elem(ddict: Dict, key: str) -> bool:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict[key]
+    if not isinstance(value, bool):
+        raise _element_check_error(key, value, ddict, bool)
+    return value
+
+
+# ########################
+# ##### CALLABLE
+# ########################
+
+
+def callable_param(obj: Any, param_name: str) -> Callable:
+    if not callable(obj):
+        raise _not_callable_exception(obj, param_name)
+    return obj
+
+
+def opt_callable_param(obj: Any, param_name: str, default: Callable = None) -> Optional[Callable]:
+    if obj is not None and not callable(obj):
+        raise _not_callable_exception(obj, param_name)
+    return default if obj is None else obj
+
+
+def is_callable(obj: Any, desc: str = None) -> Callable:
+    if not callable(obj):
+        if desc:
+            raise CheckError(
+                "Must be callable. Got {obj}. Description: {desc}".format(obj=repr(obj), desc=desc)
+            )
+        else:
+            raise CheckError(
+                "Must be callable. Got {obj}. Description: {desc}".format(obj=obj, desc=desc)
+            )
+    return obj
+
+
+# ########################
+# ##### DICT
+# ########################
+
+
+def dict_param(
+    obj: Any,
+    param_name: str,
+    key_type: Type = None,
+    value_type: Type = None,
+    additional_message: str = None,
+) -> Dict:
+    """Ensures argument obj is a native Python dictionary, raises an exception if not, and otherwise
+    returns obj.
+    """
+    from dagster.utils import frozendict
+
+    if not isinstance(obj, (frozendict, dict)):
+        raise _param_type_mismatch_exception(
+            obj, (frozendict, dict), param_name, additional_message=additional_message
+        )
+
+    if not (key_type or value_type):
+        return obj
+
+    return _check_key_value_types(obj, key_type, value_type)
+
+
+def opt_dict_param(
+    obj: Any,
+    param_name: str,
+    key_type: Type = None,
+    value_type: Type = None,
+    value_class: Type = None,
+) -> Dict:
+    """Ensures argument obj is either a dictionary or None; if the latter, instantiates an empty
+    dictionary.
+    """
+    from dagster.utils import frozendict
+
+    if obj is not None and not isinstance(obj, (frozendict, dict)):
+        raise _param_type_mismatch_exception(obj, (frozendict, dict), param_name)
+
+    if not obj:
+        return {}
+
+    if value_class:
+        return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
+    return _check_key_value_types(obj, key_type, value_type)
+
+
+def opt_nullable_dict_param(
+    obj: Any,
+    param_name: str,
+    key_type: Type = None,
+    value_type: Type = None,
+    value_class: Type = None,
+) -> Optional[Dict]:
+    """Ensures argument obj is either a dictionary or None;"""
+    from dagster.utils import frozendict
+
+    if obj is not None and not isinstance(obj, (frozendict, dict)):
+        raise _param_type_mismatch_exception(obj, (frozendict, dict), param_name)
+
+    if not obj:
+        return None if obj is None else {}
+
+    if value_class:
+        return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
+    return _check_key_value_types(obj, key_type, value_type)
+
+
+def two_dim_dict_param(
+    obj: Any, param_name: str, key_type: Type = str, value_type: Type = None
+) -> Dict:
+    if not isinstance(obj, dict):
+        raise _param_type_mismatch_exception(obj, dict, param_name)
+
+    return _check_two_dim_key_value_types(obj, key_type, param_name, value_type)
+
+
+def opt_two_dim_dict_param(
+    obj: Any, param_name: str, key_type: Type = str, value_type: Type = None
+) -> Dict:
+    if obj is not None and not isinstance(obj, dict):
+        raise _param_type_mismatch_exception(obj, dict, param_name)
+
+    if not obj:
+        return {}
+
+    return _check_two_dim_key_value_types(obj, key_type, param_name, value_type)
+
+
+def dict_elem(ddict: Dict, key: str) -> Dict:
+    from dagster.utils import frozendict
+
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    if key not in ddict:
+        raise CheckError(f"{key} not present in dictionary {ddict}")
+
+    value = ddict[key]
+    if not isinstance(value, (frozendict, dict)):
+        raise _element_check_error(key, value, ddict, (frozendict, dict))
+    return value
+
+
+def opt_dict_elem(ddict: Dict, key: str) -> Dict:
+    from dagster.utils import frozendict
+
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict.get(key)
+
+    if value is None:
+        return {}
+
+    if not isinstance(value, (frozendict, dict)):
+        raise _element_check_error(key, value, ddict, list)
+
+    return value
+
+
+def is_dict(obj: Any, key_type: Type = None, value_type: Type = None, desc: str = None) -> Dict:
+    from dagster.utils import frozendict
+
+    if not isinstance(obj, (frozendict, dict)):
+        raise _type_mismatch_error(obj, (frozendict, dict), desc)
+
+    if not (key_type or value_type):
+        return obj
+
+    return _check_key_value_types(obj, key_type, value_type)
+
+
+def _check_key_value_types(
+    obj: Any,
+    key_type: Type = None,
+    value_type: Type = None,
+    key_check: Callable = isinstance,
+    value_check: Callable = isinstance,
+) -> Dict:
+    """Ensures argument obj is a dictionary, and enforces that the keys/values conform to the types
+    specified by key_type, value_type.
+    """
+    if not isinstance(obj, dict):
+        raise _type_mismatch_error(obj, dict)
+
+    for key, value in obj.items():
+        if key_type and not key_check(key, key_type):
+            raise CheckError(
+                "Key in dictionary mismatches type. Expected {key_type}. Got {obj_repr}".format(
+                    key_type=repr(key_type), obj_repr=repr(key)
+                )
+            )
+
+        if value_type and not value_check(value, value_type):
+            raise CheckError(
+                "Value in dictionary mismatches expected type for key {key}. Expected value "
+                "of type {vtype}. Got value {value} of type {obj_type}.".format(
+                    vtype=repr(value_type), obj_type=type(value), key=key, value=value
+                )
+            )
+
+    return obj
+
+
+def _check_two_dim_key_value_types(
+    obj: Any, key_type: Type = None, _param_name: str = None, value_type: Type = None
+) -> Dict:
+    _check_key_value_types(obj, key_type, dict)  # check level one
+
+    for level_two_dict in obj.values():
+        _check_key_value_types(level_two_dict, key_type, value_type)  # check level two
+
+    return obj
+
+
+# ########################
+# ##### FLOAT
+# ########################
+
+
+def float_param(obj: Any, param_name: str) -> float:
+    if not isinstance(obj, float):
+        raise _param_type_mismatch_exception(obj, float, param_name)
+    return obj
+
+
+def opt_float_param(obj: Any, param_name: str, default: float = None) -> Optional[float]:
+    if obj is not None and not isinstance(obj, float):
+        raise _param_type_mismatch_exception(obj, float, param_name)
+    return default if obj is None else obj
+
+
+def float_elem(ddict: Dict, key: str) -> float:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict[key]
+    if not isinstance(value, float):
+        raise _element_check_error(key, value, ddict, float)
+    return value
+
+
+def opt_float_elem(ddict: Dict, key: str) -> Optional[float]:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, float):
+        raise _element_check_error(key, value, ddict, float)
+    return value
+
+
+# ########################
+# ##### GENERATOR
+# ########################
+
+
+def generator_param(obj: Any, param_name: str) -> Generator:
+    if not inspect.isgenerator(obj):
+        raise ParameterCheckError(
+            f'Param "{param_name}" is not a generator (return value of function that yields) Got '
+            f"{obj} instead"
+        )
+    return obj
+
+
+def opt_generator_param(obj: Any, param_name: str) -> Optional[Generator]:
+    if obj is not None and not inspect.isgenerator(obj):
+        raise ParameterCheckError(
+            f'Param "{param_name}" is not a generator (return value of function that yields) Got '
+            f"{obj} instead"
+        )
+    return obj
+
+
+def generator(obj: Any) -> Generator:
+    if not inspect.isgenerator(obj):
+        raise ParameterCheckError(
+            f"Not a generator (return value of function that yields) Got {obj} instead"
+        )
+    return obj
+
+
+def opt_generator(obj: Any) -> Optional[Generator]:
+    if obj is not None and not inspect.isgenerator(obj):
+        raise ParameterCheckError(
+            f"Not a generator (return value of function that yields) Got {obj} instead"
+        )
+    return obj
+
+
+# ########################
+# ##### INT
+# ########################
+
+
+def int_param(obj: Any, param_name: str) -> int:
+    if not isinstance(obj, int):
+        raise _param_type_mismatch_exception(obj, int, param_name)
+    return obj
+
+
+def opt_int_param(obj: Any, param_name: str, default: int = None) -> Optional[int]:
+    if obj is not None and not isinstance(obj, int):
+        raise _param_type_mismatch_exception(obj, int, param_name)
+    return default if obj is None else obj
+
+
+def int_value_param(obj: Any, value: int, param_name: str) -> int:
+    if not isinstance(obj, int):
+        raise _param_type_mismatch_exception(obj, int, param_name)
+    if obj != value:
+        raise _param_invariant_exception(param_name, f"Should be equal to {value}")
+
+    return obj
+
+
+def int_elem(ddict: Dict, key: str) -> int:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict[key]
+    if not isinstance(value, int):
+        raise _element_check_error(key, value, ddict, int)
+    return value
+
+
+def opt_int_elem(ddict: Dict, key: str) -> Optional[int]:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise _element_check_error(key, value, ddict, int)
+    return value
+
+
+# ########################
+# ##### INST
+# ########################
+
+# mypy note: Attempting to use the passed type (Type[T] -> T) to infer the output type has
+# issues with abstract classes, so here we count on the incoming object to be typed before
+# this runtime validation check.
+
+
+def inst_param(obj: T, param_name: str, ttype: Type, additional_message: str = None) -> T:
+    if not isinstance(obj, ttype):
+        raise _param_type_mismatch_exception(
+            obj, ttype, param_name, additional_message=additional_message
+        )
+    return obj
+
+
+@overload
+def opt_inst_param(obj: Optional[T], param_name: str, ttype: Type, default: T) -> T:
+    ...
+
+
+@overload
+def opt_inst_param(obj: T, param_name: str, ttype: Type) -> T:
+    ...
+
+
+def opt_inst_param(obj: Any, param_name: str, ttype: Type, default: Any = None) -> Any:
+    if obj is not None and not isinstance(obj, ttype):
+        raise _param_type_mismatch_exception(obj, ttype, param_name)
+    return default if obj is None else obj
+
+
+def inst(obj: T, ttype: Type, desc: str = None) -> T:
+    if not isinstance(obj, ttype):
+        raise _type_mismatch_error(obj, ttype, desc)
+    return obj
+
+
+def opt_inst(obj: T, ttype: Type, desc: str = None, default: Any = None) -> T:
+    if obj is not None and not isinstance(obj, ttype):
+        raise _type_mismatch_error(obj, ttype, desc)
+    return default if obj is None else obj
+
+
+# ########################
+# ##### NOT NONE
+# ########################
+
+
+def not_none_param(obj: Optional[T], param_name: str) -> T:
+    if obj is None:
+        raise _param_invariant_exception(param_name, f"Param {param_name} cannot be none")
+    return obj
+
+
+def not_none(value: Optional[T], desc: str = None) -> T:
+    if value is None:
+        raise ValueError("Expected non-None value: {desc}".format(desc=desc))
+    return value
+
+
+# ########################
+# ##### LIST
+# ########################
+
+
+def list_param(obj_list: Any, param_name: str, of_type: Type = None) -> List:
+    from dagster.utils import frozenlist
+
+    if not isinstance(obj_list, (frozenlist, list)):
+        raise _param_type_mismatch_exception(obj_list, (frozenlist, list), param_name)
+
+    if not of_type:
+        return obj_list
+
+    return _check_list_items(obj_list, of_type)
+
+
+def opt_list_param(obj_list: Any, param_name: str, of_type: Type = None) -> List:
+    """Ensures argument obj_list is a list or None; in the latter case, instantiates an empty list
+    and returns it.
+
+    If the of_type argument is provided, also ensures that list items conform to the type specified
+    by of_type.
+    """
+    from dagster.utils import frozenlist
+
+    if obj_list is not None and not isinstance(obj_list, (frozenlist, list)):
+        raise _param_type_mismatch_exception(obj_list, (frozenlist, list), param_name)
+
+    if not obj_list:
+        return []
+    if not of_type:
+        return obj_list
+
+    return _check_list_items(obj_list, of_type)
+
+
+def opt_nullable_list_param(obj_list: Any, param_name: str, of_type: Type = None) -> Optional[List]:
+    """Ensures argument obj_list is a list or None. Returns None if input is None.
+
+    If the of_type argument is provided, also ensures that list items conform to the type specified
+    by of_type.
+    """
+    from dagster.utils import frozenlist
+
+    if obj_list is not None and not isinstance(obj_list, (frozenlist, list)):
+        raise _param_type_mismatch_exception(obj_list, (frozenlist, list), param_name)
+
+    if not obj_list:
+        return None if obj_list is None else []
+    if not of_type:
+        return obj_list
+
+    return _check_list_items(obj_list, of_type)
+
+
+def list_elem(ddict: Dict, key: str, of_type: Type = None) -> List:  # type: ignore[return]
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+    opt_type_param(of_type, "of_type")
+
+    value = ddict.get(key)
+
+    if isinstance(value, list):
+        if not of_type:
+            return value
+
+        return _check_list_items(value, of_type)
+
+    raise _element_check_error(key, value, ddict, list)
+
+
+def opt_list_elem(ddict: Dict, key: str, of_type: Type = None) -> List:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+    opt_type_param(of_type, "of_type")
+
+    value = ddict.get(key)
+
+    if value is None:
+        return []
+
+    if not isinstance(value, list):
+        raise _element_check_error(key, value, ddict, list)
+
+    if not of_type:
+        return value
+
+    return _check_list_items(value, of_type)
+
+
+def is_list(obj_list: Any, of_type: Type = None, desc: str = None) -> List:
+    if not isinstance(obj_list, list):
+        raise _type_mismatch_error(obj_list, list, desc)
+
+    if not of_type:
+        return obj_list
+
+    return _check_list_items(obj_list, of_type)
+
+
+def _check_list_items(obj_list: Any, of_type: Type) -> List:
+    for obj in obj_list:
+        if not isinstance(obj, of_type):
+            if isinstance(obj, type):
+                additional_message = (
+                    " Did you pass a class where you were expecting an instance of the class?"
+                )
+            else:
+                additional_message = ""
+            raise CheckError(
+                "Member of list mismatches type. Expected {of_type}. Got {obj_repr} of type "
+                "{obj_type}.{additional_message}".format(
+                    of_type=of_type,
+                    obj_repr=repr(obj),
+                    obj_type=type(obj),
+                    additional_message=additional_message,
+                )
+            )
+
+    return obj_list
+
+
+# ########################
+# ##### MATRIX
+# ########################
+
+
+def matrix_param(matrix: Any, param_name: str, of_type: Type = None) -> List[List]:
+    matrix = list_param(matrix, param_name, of_type=list)
+    if not matrix:
+        raise CheckError("You must pass a list of lists. Received an empty list.")
+    for sublist in matrix:
+        sublist = list_param(sublist, "sublist_{}".format(param_name), of_type=of_type)
+        if len(sublist) != len(matrix[0]):
+            raise CheckError("All sublists in matrix must have the same length")
+    return matrix
+
+
+# ########################
+# ##### NUMERIC
+# ########################
+
+
+def numeric_param(obj: Any, param_name: str) -> Numeric:
+    if not isinstance(obj, (int, float)):
+        raise _param_type_mismatch_exception(obj, (int, float), param_name)
+    return obj
+
+
+def opt_numeric_param(obj: Any, param_name: str, default: Numeric = None) -> Optional[Numeric]:
+    if obj is not None and not isinstance(obj, (int, float)):
+        raise _param_type_mismatch_exception(obj, (int, float), param_name)
+    return default if obj is None else obj
+
+
+# ########################
+# ##### SET
+# ########################
+
+
+def set_param(obj_set: Any, param_name: str, of_type: Type = None) -> AbstractSet:
+    if not isinstance(obj_set, (frozenset, set)):
+        raise _param_type_mismatch_exception(obj_set, (frozenset, set), param_name)
+
+    if not of_type:
+        return obj_set
+
+    return _check_set_items(obj_set, of_type)
+
+
+def opt_set_param(obj_set: Any, param_name: str, of_type: Type = None) -> AbstractSet:
+    """Ensures argument obj_set is a set or None; in the latter case, instantiates an empty set
+    and returns it.
+
+    If the of_type argument is provided, also ensures that list items conform to the type specified
+    by of_type.
+    """
+    if obj_set is not None and not isinstance(obj_set, (frozenset, set)):
+        raise _param_type_mismatch_exception(obj_set, (frozenset, set), param_name)
+    if not obj_set:
+        return set()
+    if not of_type:
+        return obj_set
+
+    return _check_set_items(obj_set, of_type)
+
+
+def _check_set_items(obj_set: Any, of_type: Type) -> Set:
+    for obj in obj_set:
+
+        if not isinstance(obj, of_type):
+            if isinstance(obj, type):
+                additional_message = (
+                    " Did you pass a class where you were expecting an instance of the class?"
+                )
+            else:
+                additional_message = ""
+            raise CheckError(
+                "Member of set mismatches type. Expected {of_type}. Got {obj_repr} of type "
+                "{obj_type}.{additional_message}".format(
+                    of_type=of_type,
+                    obj_repr=repr(obj),
+                    obj_type=type(obj),
+                    additional_message=additional_message,
+                )
+            )
+
+    return obj_set
+
+
+# ########################
+# ##### STR
+# ########################
+
+
+def str_param(obj: Any, param_name: str) -> str:
+    if not isinstance(obj, str):
+        raise _param_type_mismatch_exception(obj, str, param_name)
+    return obj
+
+
+@overload
+def opt_str_param(obj: object, param_name: str, default: str) -> str:
+    ...
+
+
+@overload
+def opt_str_param(obj: object, param_name: str) -> Optional[str]:
+    ...
+
+
+def opt_str_param(obj, param_name, default=None):
+    if obj is not None and not isinstance(obj, str):
+        raise _param_type_mismatch_exception(obj, str, param_name)
+    return default if obj is None else obj
+
+
+def opt_nonempty_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
+    if obj is not None and not isinstance(obj, str):
+        raise _param_type_mismatch_exception(obj, str, param_name)
+    return default if obj is None or obj == "" else obj
+
+
+def str_elem(ddict: Dict, key: str) -> str:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict[key]
+    if not isinstance(value, str):
+        raise _element_check_error(key, value, ddict, str)
+    return value
+
+
+def opt_str_elem(ddict: Dict, key: str) -> Optional[str]:
+    dict_param(ddict, "ddict")
+    str_param(key, "key")
+
+    value = ddict.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _element_check_error(key, value, ddict, str)
+    return value
+
+
+# ########################
+# ##### SUBCLASS
+# ########################
+
+
+def subclass_param(obj: Any, param_name: str, superclass: type) -> type:
+    type_param(obj, param_name)
+    if not issubclass(obj, superclass):
+        raise _param_subclass_mismatch_exception(obj, superclass, param_name)
+
+    return obj
+
+
+def opt_subclass_param(obj: Any, param_name: str, superclass: type) -> Optional[type]:
+    opt_type_param(obj, param_name)
+    if obj is not None and not issubclass(obj, superclass):
+        raise _param_subclass_mismatch_exception(obj, superclass, param_name)
+
+    return obj
+
+
+def subclass(obj: Any, superclass: Type, desc: str = None) -> Any:
+    if not issubclass(obj, superclass):
+        raise _type_mismatch_error(obj, superclass, desc)
+
+    return obj
+
+
+# ########################
+# ##### TUPLE
+# ########################
+
+
+def tuple_param(
+    obj: Any, param_name: str, of_type: Type = None, of_shape: Optional[Tuple[Type, ...]] = None
+) -> Tuple:
+    """Ensure param is a tuple and is of a specified type. `of_type` defines a variadic tuple type--
+    `obj` may be of any length, but each element must match the `of_type` argmument. `of_shape`
+    defines a fixed-length tuple type-- each element must match the corresponding element in
+    `of_shape`. Passing both `of_type` and `of_shape` will raise an error.
+    """
+    if not isinstance(obj, tuple):
+        raise _param_type_mismatch_exception(obj, tuple, param_name)
+
+    if of_type is None and of_shape is None:
+        return obj
+
+    if of_type and of_shape:
+        raise CheckError("Must specify exactly one `of_type` or `of_shape`")
+
+    return _check_tuple_items(obj, of_type, of_shape)
+
+
+def opt_tuple_param(
+    obj: Any,
+    param_name: str,
+    default: Tuple = None,
+    of_type: Type = None,
+    of_shape: Optional[Tuple[Type, ...]] = None,
+) -> Optional[Tuple]:
+    """Ensure optional param is a tuple and is of a specified type. `default` is returned if `obj`
+    is None. `of_type` defines a variadic tuple type-- `obj` may be of any length, but each element
+    must match the `of_type` argmument. `of_shape` defines a fixed-length tuple type-- each element
+    must match the corresponding element in `of_shape`. Passing both `of_type` and `of_shape` will
+    raise an error.
+    """
+    if obj is not None and not isinstance(obj, tuple):
+        raise _param_type_mismatch_exception(obj, tuple, param_name)
+
+    if obj is None:
+        return default
+
+    if of_type is None and of_shape is None:
+        return obj
+
+    if of_type and of_shape:
+        raise CheckError("Must specify exactly one `of_type` or `of_shape`")
+
+    return _check_tuple_items(obj, of_type, of_shape)
+
+
+def is_tuple(
+    obj_tuple: Any,
+    of_type: Type = None,
+    of_shape: Optional[Tuple[Type, ...]] = None,
+    desc: str = None,
+) -> Tuple:
+    """Ensure target is a tuple and is of a specified type. `of_type` defines a variadic tuple
+    type-- `obj` may be of any length, but each element must match the `of_type` argmument.
+    `of_shape` defines a fixed-length tuple type-- each element must match the corresponding element
+    in `of_shape`. Passing both `of_type` and `of_shape` will raise an error.
+    """
+    if not isinstance(obj_tuple, tuple):
+        raise _type_mismatch_error(obj_tuple, tuple, desc)
+
+    if of_type is None and of_shape is None:
+        return obj_tuple
+
+    if of_type and of_shape:
+        raise CheckError("Must specify exactly one `of_type` or `of_shape`")
+
+    return _check_tuple_items(obj_tuple, of_type, of_shape)
+
+
+def _check_tuple_items(
+    obj_tuple: Any, of_type: Optional[Type] = None, of_shape: Optional[Tuple[Type, ...]] = None
+) -> Tuple:
+    if of_shape is not None:
+        len_tuple = len(obj_tuple)
+        len_type = len(of_shape)
+        if not len_tuple == len_type:
+            raise CheckError(
+                "Tuple mismatches type: tuple had {len_tuple} members but type had "
+                "{len_type}".format(len_tuple=len_tuple, len_type=len_type)
+            )
+
+        for (i, obj) in enumerate(obj_tuple):
+            of_shape_i = of_shape[i]
+            if not isinstance(obj, of_shape_i):
+                if isinstance(obj, type):
+                    additional_message = (
+                        " Did you pass a class where you were expecting an instance of the class?"
+                    )
+                else:
+                    additional_message = ""
+                raise CheckError(
+                    "Member of tuple mismatches type at index {index}. Expected {of_type}. Got "
+                    "{obj_repr} of type {obj_type}.{additional_message}".format(
+                        index=i,
+                        of_type=of_shape_i,
+                        obj_repr=repr(obj),
+                        obj_type=type(obj),
+                        additional_message=additional_message,
+                    )
+                )
+
+    elif of_type is not None:
+        for (i, obj) in enumerate(obj_tuple):
+            if not isinstance(obj, of_type):
+                if isinstance(obj, type):
+                    additional_message = (
+                        " Did you pass a class where you were expecting an instance of the class?"
+                    )
+                else:
+                    additional_message = ""
+                raise CheckError(
+                    "Member of tuple mismatches type at index {index}. Expected {of_type}. Got "
+                    "{obj_repr} of type {obj_type}.{additional_message}".format(
+                        index=i,
+                        of_type=of_type,
+                        obj_repr=repr(obj),
+                        obj_type=type(obj),
+                        additional_message=additional_message,
+                    )
+                )
+
+    return obj_tuple
+
+
+# ########################
+# ##### TYPE
+# ########################
+
+
+def type_param(obj: Any, param_name: str) -> type:
+    if not isinstance(obj, type):
+        raise _not_type_param_subclass_mismatch_exception(obj, param_name)
+    return obj
+
+
+def opt_type_param(obj: Any, param_name: str, default: type = None) -> Optional[type]:
+    if obj is not None and not isinstance(obj, type):
+        raise _not_type_param_subclass_mismatch_exception(obj, param_name)
+    return obj if obj is not None else default
+
+
+def class_param(obj: Any, param_name: str) -> Union["ParameterCheckError", type]:
+    if not inspect.isclass(obj):
+        return ParameterCheckError(
+            f'Param "{param_name}" is not a class. Got {repr(obj)} which is type {type(obj)}.'
+        )
+    return obj
+
+
+# ###################################################################################################
+# ##### OTHER CHECKS
+# ###################################################################################################
+
+
+def param_invariant(condition: Any, param_name: str, desc: str = None):
+    if not condition:
+        raise _param_invariant_exception(param_name, desc)
+
+
+def invariant(condition: Any, desc: str = None) -> bool:
+    if not condition:
+        if desc:
+            raise CheckError(f"Invariant failed. Description: {desc}")
+        else:
+            raise CheckError("Invariant failed.")
+
+    return True
+
+
+def assert_never(value: NoReturn) -> NoReturn:
+    failed(f"Unhandled value: {value} ({type(value).__name__})")
+
+
+def failed(desc: str) -> NoReturn:  # type: ignore[misc]
+    if not isinstance(desc, str):
+        raise CheckError("desc argument must be a string")
+
+    raise CheckError("Failure condition: {desc}".format(desc=desc))
+
+
+def not_implemented(desc: str) -> NoReturn:
+    if not isinstance(desc, str):
+        raise CheckError("desc argument must be a string")
+
+    raise NotImplementedCheckError(f"Not implemented: {desc}")
+
+
+# ###################################################################################################
+# ##### ERRORS
+# ###################################################################################################
+
 
 class CheckError(Exception):
     pass
@@ -35,6 +977,14 @@ class ElementCheckError(CheckError):
 
 class NotImplementedCheckError(CheckError):
     pass
+
+
+def _element_check_error(key: Any, value: Any, ddict: Dict, ttype: Type) -> ElementCheckError:
+    return ElementCheckError(
+        "Value {value} from key {key} is not a {ttype}. Dict: {ddict}".format(
+            key=key, value=repr(value), ddict=repr(ddict), ttype=repr(ttype)
+        )
+    )
 
 
 def _param_type_mismatch_exception(
@@ -110,840 +1060,3 @@ def _param_invariant_exception(param_name: str, desc: str = None) -> ParameterCh
             param_name=param_name, desc=desc
         )
     )
-
-
-def failed(desc: str) -> NoReturn:  # type: ignore[misc]
-    if not isinstance(desc, str):
-        raise CheckError("desc argument must be a string")
-
-    raise CheckError("Failure condition: {desc}".format(desc=desc))
-
-
-def not_implemented(desc: str) -> NoReturn:
-    if not isinstance(desc, str):
-        raise CheckError("desc argument must be a string")
-
-    raise NotImplementedCheckError(f"Not implemented: {desc}")
-
-
-def inst(obj: T, ttype: Type, desc: str = None) -> T:
-    if not isinstance(obj, ttype):
-        raise _type_mismatch_error(obj, ttype, desc)
-    return obj
-
-
-def opt_inst(obj: T, ttype: Type, desc: str = None, default: Any = None) -> T:
-    if obj is not None and not isinstance(obj, ttype):
-        raise _type_mismatch_error(obj, ttype, desc)
-    return default if obj is None else obj
-
-
-def subclass(obj: Any, superclass: Type, desc: str = None) -> Any:
-    if not issubclass(obj, superclass):
-        raise _type_mismatch_error(obj, superclass, desc)
-
-    return obj
-
-
-def is_callable(obj: Any, desc: str = None) -> Callable:
-    if not callable(obj):
-        if desc:
-            raise CheckError(
-                "Must be callable. Got {obj}. Description: {desc}".format(obj=repr(obj), desc=desc)
-            )
-        else:
-            raise CheckError(
-                "Must be callable. Got {obj}. Description: {desc}".format(obj=obj, desc=desc)
-            )
-    return obj
-
-
-def not_none(value: Optional[T], desc: str = None) -> T:
-    if value is None:
-        raise ValueError("Expected non-None value: {desc}".format(desc=desc))
-    return value
-
-
-def not_none_param(obj: Optional[T], param_name: str) -> T:
-    if obj is None:
-        raise _param_invariant_exception(param_name, f"Param {param_name} cannot be none")
-    return obj
-
-
-def invariant(condition: Any, desc: str = None) -> bool:
-    if not condition:
-        if desc:
-            raise CheckError(f"Invariant failed. Description: {desc}")
-        else:
-            raise CheckError("Invariant failed.")
-
-    return True
-
-
-def param_invariant(condition: Any, param_name: str, desc: str = None):
-    if not condition:
-        raise _param_invariant_exception(param_name, desc)
-
-
-# mypy note: Attempting to use the passed type (Type[T] -> T) to infer the output type has
-# issues with abstract classes, so here we count on the incoming object to be typed before
-# this runtime validation check.
-
-
-def inst_param(obj: T, param_name: str, ttype: Type, additional_message: str = None) -> T:
-    if not isinstance(obj, ttype):
-        raise _param_type_mismatch_exception(
-            obj, ttype, param_name, additional_message=additional_message
-        )
-    return obj
-
-
-@overload
-def opt_inst_param(obj: Optional[T], param_name: str, ttype: Type, default: T) -> T:
-    ...
-
-
-@overload
-def opt_inst_param(obj: T, param_name: str, ttype: Type) -> T:
-    ...
-
-
-def opt_inst_param(obj: Any, param_name: str, ttype: Type, default: Any = None) -> Any:
-    if obj is not None and not isinstance(obj, ttype):
-        raise _param_type_mismatch_exception(obj, ttype, param_name)
-    return default if obj is None else obj
-
-
-def callable_param(obj: Any, param_name: str) -> Callable:
-    if not callable(obj):
-        raise _not_callable_exception(obj, param_name)
-    return obj
-
-
-def opt_callable_param(obj: Any, param_name: str, default: Callable = None) -> Optional[Callable]:
-    if obj is not None and not callable(obj):
-        raise _not_callable_exception(obj, param_name)
-    return default if obj is None else obj
-
-
-def int_param(obj: Any, param_name: str) -> int:
-    if not isinstance(obj, int):
-        raise _param_type_mismatch_exception(obj, int, param_name)
-    return obj
-
-
-def int_value_param(obj: Any, value: int, param_name: str) -> int:
-    if not isinstance(obj, int):
-        raise _param_type_mismatch_exception(obj, int, param_name)
-    if obj != value:
-        raise _param_invariant_exception(param_name, f"Should be equal to {value}")
-
-    return obj
-
-
-def opt_int_param(obj: Any, param_name: str, default: int = None) -> Optional[int]:
-    if obj is not None and not isinstance(obj, int):
-        raise _param_type_mismatch_exception(obj, int, param_name)
-    return default if obj is None else obj
-
-
-def float_param(obj: Any, param_name: str) -> float:
-    if not isinstance(obj, float):
-        raise _param_type_mismatch_exception(obj, float, param_name)
-    return obj
-
-
-def opt_numeric_param(obj: Any, param_name: str, default: Numeric = None) -> Optional[Numeric]:
-    if obj is not None and not isinstance(obj, (int, float)):
-        raise _param_type_mismatch_exception(obj, (int, float), param_name)
-    return default if obj is None else obj
-
-
-def numeric_param(obj: Any, param_name: str) -> Numeric:
-    if not isinstance(obj, (int, float)):
-        raise _param_type_mismatch_exception(obj, (int, float), param_name)
-    return obj
-
-
-def opt_float_param(obj: Any, param_name: str, default: float = None) -> Optional[float]:
-    if obj is not None and not isinstance(obj, float):
-        raise _param_type_mismatch_exception(obj, float, param_name)
-    return default if obj is None else obj
-
-
-def str_param(obj: Any, param_name: str) -> str:
-    if not isinstance(obj, str):
-        raise _param_type_mismatch_exception(obj, str, param_name)
-    return obj
-
-
-@overload
-def opt_str_param(obj: object, param_name: str, default: str) -> str:
-    ...
-
-
-@overload
-def opt_str_param(obj: object, param_name: str) -> Optional[str]:
-    ...
-
-
-def opt_str_param(obj, param_name, default=None):
-    if obj is not None and not isinstance(obj, str):
-        raise _param_type_mismatch_exception(obj, str, param_name)
-    return default if obj is None else obj
-
-
-def opt_nonempty_str_param(obj: Any, param_name: str, default: str = None) -> Optional[str]:
-    if obj is not None and not isinstance(obj, str):
-        raise _param_type_mismatch_exception(obj, str, param_name)
-    return default if obj is None or obj == "" else obj
-
-
-def bool_param(obj: Any, param_name: str) -> bool:
-    if not isinstance(obj, bool):
-        raise _param_type_mismatch_exception(obj, bool, param_name)
-    return obj
-
-
-def opt_bool_param(obj: Any, param_name: str, default: bool = None) -> Optional[bool]:
-    if obj is not None and not isinstance(obj, bool):
-        raise _param_type_mismatch_exception(obj, bool, param_name)
-    return default if obj is None else obj
-
-
-def is_dict(obj: Any, key_type: Type = None, value_type: Type = None, desc: str = None) -> Dict:
-    from dagster.utils import frozendict
-
-    if not isinstance(obj, (frozendict, dict)):
-        raise _type_mismatch_error(obj, (frozendict, dict), desc)
-
-    if not (key_type or value_type):
-        return obj
-
-    return _check_key_value_types(obj, key_type, value_type)
-
-
-def is_list(obj_list: Any, of_type: Type = None, desc: str = None) -> List:
-    if not isinstance(obj_list, list):
-        raise _type_mismatch_error(obj_list, list, desc)
-
-    if not of_type:
-        return obj_list
-
-    return _check_list_items(obj_list, of_type)
-
-
-def is_tuple(
-    obj_tuple: Any,
-    of_type: Type = None,
-    of_shape: Optional[Tuple[Type, ...]] = None,
-    desc: str = None,
-) -> Tuple:
-    """Ensure target is a tuple and is of a specified type. `of_type` defines a variadic tuple
-    type-- `obj` may be of any length, but each element must match the `of_type` argmument.
-    `of_shape` defines a fixed-length tuple type-- each element must match the corresponding element
-    in `of_shape`. Passing both `of_type` and `of_shape` will raise an error.
-    """
-    if not isinstance(obj_tuple, tuple):
-        raise _type_mismatch_error(obj_tuple, tuple, desc)
-
-    if of_type is None and of_shape is None:
-        return obj_tuple
-
-    if of_type and of_shape:
-        raise CheckError("Must specify exactly one `of_type` or `of_shape`")
-
-    return _check_tuple_items(obj_tuple, of_type, of_shape)
-
-
-def list_param(obj_list: Any, param_name: str, of_type: Type = None) -> List:
-    from dagster.utils import frozenlist
-
-    if not isinstance(obj_list, (frozenlist, list)):
-        raise _param_type_mismatch_exception(obj_list, (frozenlist, list), param_name)
-
-    if not of_type:
-        return obj_list
-
-    return _check_list_items(obj_list, of_type)
-
-
-def set_param(obj_set: Any, param_name: str, of_type: Type = None) -> AbstractSet:
-    if not isinstance(obj_set, (frozenset, set)):
-        raise _param_type_mismatch_exception(obj_set, (frozenset, set), param_name)
-
-    if not of_type:
-        return obj_set
-
-    return _check_set_items(obj_set, of_type)
-
-
-def tuple_param(
-    obj: Any, param_name: str, of_type: Type = None, of_shape: Optional[Tuple[Type, ...]] = None
-) -> Tuple:
-    """Ensure param is a tuple and is of a specified type. `of_type` defines a variadic tuple type--
-    `obj` may be of any length, but each element must match the `of_type` argmument. `of_shape`
-    defines a fixed-length tuple type-- each element must match the corresponding element in
-    `of_shape`. Passing both `of_type` and `of_shape` will raise an error.
-    """
-    if not isinstance(obj, tuple):
-        raise _param_type_mismatch_exception(obj, tuple, param_name)
-
-    if of_type is None and of_shape is None:
-        return obj
-
-    if of_type and of_shape:
-        raise CheckError("Must specify exactly one `of_type` or `of_shape`")
-
-    return _check_tuple_items(obj, of_type, of_shape)
-
-
-def matrix_param(matrix: Any, param_name: str, of_type: Type = None) -> List[List]:
-    matrix = list_param(matrix, param_name, of_type=list)
-    if not matrix:
-        raise CheckError("You must pass a list of lists. Received an empty list.")
-    for sublist in matrix:
-        sublist = list_param(sublist, "sublist_{}".format(param_name), of_type=of_type)
-        if len(sublist) != len(matrix[0]):
-            raise CheckError("All sublists in matrix must have the same length")
-    return matrix
-
-
-def opt_tuple_param(
-    obj: Any,
-    param_name: str,
-    default: Tuple = None,
-    of_type: Type = None,
-    of_shape: Optional[Tuple[Type, ...]] = None,
-) -> Optional[Tuple]:
-    """Ensure optional param is a tuple and is of a specified type. `default` is returned if `obj`
-    is None. `of_type` defines a variadic tuple type-- `obj` may be of any length, but each element
-    must match the `of_type` argmument. `of_shape` defines a fixed-length tuple type-- each element
-    must match the corresponding element in `of_shape`. Passing both `of_type` and `of_shape` will
-    raise an error.
-    """
-    if obj is not None and not isinstance(obj, tuple):
-        raise _param_type_mismatch_exception(obj, tuple, param_name)
-
-    if obj is None:
-        return default
-
-    if of_type is None and of_shape is None:
-        return obj
-
-    if of_type and of_shape:
-        raise CheckError("Must specify exactly one `of_type` or `of_shape`")
-
-    return _check_tuple_items(obj, of_type, of_shape)
-
-
-def _check_list_items(obj_list: Any, of_type: Type) -> List:
-    for obj in obj_list:
-        if not isinstance(obj, of_type):
-            if isinstance(obj, type):
-                additional_message = (
-                    " Did you pass a class where you were expecting an instance of the class?"
-                )
-            else:
-                additional_message = ""
-            raise CheckError(
-                "Member of list mismatches type. Expected {of_type}. Got {obj_repr} of type "
-                "{obj_type}.{additional_message}".format(
-                    of_type=of_type,
-                    obj_repr=repr(obj),
-                    obj_type=type(obj),
-                    additional_message=additional_message,
-                )
-            )
-
-    return obj_list
-
-
-def _check_set_items(obj_set: Any, of_type: Type) -> Set:
-    for obj in obj_set:
-
-        if not isinstance(obj, of_type):
-            if isinstance(obj, type):
-                additional_message = (
-                    " Did you pass a class where you were expecting an instance of the class?"
-                )
-            else:
-                additional_message = ""
-            raise CheckError(
-                "Member of set mismatches type. Expected {of_type}. Got {obj_repr} of type "
-                "{obj_type}.{additional_message}".format(
-                    of_type=of_type,
-                    obj_repr=repr(obj),
-                    obj_type=type(obj),
-                    additional_message=additional_message,
-                )
-            )
-
-    return obj_set
-
-
-def _check_tuple_items(
-    obj_tuple: Any, of_type: Optional[Type] = None, of_shape: Optional[Tuple[Type, ...]] = None
-) -> Tuple:
-    if of_shape is not None:
-        len_tuple = len(obj_tuple)
-        len_type = len(of_shape)
-        if not len_tuple == len_type:
-            raise CheckError(
-                "Tuple mismatches type: tuple had {len_tuple} members but type had "
-                "{len_type}".format(len_tuple=len_tuple, len_type=len_type)
-            )
-
-        for (i, obj) in enumerate(obj_tuple):
-            of_shape_i = of_shape[i]
-            if not isinstance(obj, of_shape_i):
-                if isinstance(obj, type):
-                    additional_message = (
-                        " Did you pass a class where you were expecting an instance of the class?"
-                    )
-                else:
-                    additional_message = ""
-                raise CheckError(
-                    "Member of tuple mismatches type at index {index}. Expected {of_type}. Got "
-                    "{obj_repr} of type {obj_type}.{additional_message}".format(
-                        index=i,
-                        of_type=of_shape_i,
-                        obj_repr=repr(obj),
-                        obj_type=type(obj),
-                        additional_message=additional_message,
-                    )
-                )
-
-    elif of_type is not None:
-        for (i, obj) in enumerate(obj_tuple):
-            if not isinstance(obj, of_type):
-                if isinstance(obj, type):
-                    additional_message = (
-                        " Did you pass a class where you were expecting an instance of the class?"
-                    )
-                else:
-                    additional_message = ""
-                raise CheckError(
-                    "Member of tuple mismatches type at index {index}. Expected {of_type}. Got "
-                    "{obj_repr} of type {obj_type}.{additional_message}".format(
-                        index=i,
-                        of_type=of_type,
-                        obj_repr=repr(obj),
-                        obj_type=type(obj),
-                        additional_message=additional_message,
-                    )
-                )
-
-    return obj_tuple
-
-
-def opt_list_param(obj_list: Any, param_name: str, of_type: Type = None) -> List:
-    """Ensures argument obj_list is a list or None; in the latter case, instantiates an empty list
-    and returns it.
-
-    If the of_type argument is provided, also ensures that list items conform to the type specified
-    by of_type.
-    """
-    from dagster.utils import frozenlist
-
-    if obj_list is not None and not isinstance(obj_list, (frozenlist, list)):
-        raise _param_type_mismatch_exception(obj_list, (frozenlist, list), param_name)
-
-    if not obj_list:
-        return []
-    if not of_type:
-        return obj_list
-
-    return _check_list_items(obj_list, of_type)
-
-
-def opt_set_param(obj_set: Any, param_name: str, of_type: Type = None) -> AbstractSet:
-    """Ensures argument obj_set is a set or None; in the latter case, instantiates an empty set
-    and returns it.
-
-    If the of_type argument is provided, also ensures that list items conform to the type specified
-    by of_type.
-    """
-    if obj_set is not None and not isinstance(obj_set, (frozenset, set)):
-        raise _param_type_mismatch_exception(obj_set, (frozenset, set), param_name)
-    if not obj_set:
-        return set()
-    if not of_type:
-        return obj_set
-
-    return _check_set_items(obj_set, of_type)
-
-
-def opt_nullable_list_param(obj_list: Any, param_name: str, of_type: Type = None) -> Optional[List]:
-    """Ensures argument obj_list is a list or None. Returns None if input is None.
-
-    If the of_type argument is provided, also ensures that list items conform to the type specified
-    by of_type.
-    """
-    from dagster.utils import frozenlist
-
-    if obj_list is not None and not isinstance(obj_list, (frozenlist, list)):
-        raise _param_type_mismatch_exception(obj_list, (frozenlist, list), param_name)
-
-    if not obj_list:
-        return None if obj_list is None else []
-    if not of_type:
-        return obj_list
-
-    return _check_list_items(obj_list, of_type)
-
-
-def _check_key_value_types(
-    obj: Any,
-    key_type: Type = None,
-    value_type: Type = None,
-    key_check: Callable = isinstance,
-    value_check: Callable = isinstance,
-) -> Dict:
-    """Ensures argument obj is a dictionary, and enforces that the keys/values conform to the types
-    specified by key_type, value_type.
-    """
-    if not isinstance(obj, dict):
-        raise _type_mismatch_error(obj, dict)
-
-    for key, value in obj.items():
-        if key_type and not key_check(key, key_type):
-            raise CheckError(
-                "Key in dictionary mismatches type. Expected {key_type}. Got {obj_repr}".format(
-                    key_type=repr(key_type), obj_repr=repr(key)
-                )
-            )
-
-        if value_type and not value_check(value, value_type):
-            raise CheckError(
-                "Value in dictionary mismatches expected type for key {key}. Expected value "
-                "of type {vtype}. Got value {value} of type {obj_type}.".format(
-                    vtype=repr(value_type), obj_type=type(value), key=key, value=value
-                )
-            )
-
-    return obj
-
-
-def dict_param(
-    obj: Any,
-    param_name: str,
-    key_type: Type = None,
-    value_type: Type = None,
-    additional_message: str = None,
-) -> Dict:
-    """Ensures argument obj is a native Python dictionary, raises an exception if not, and otherwise
-    returns obj.
-    """
-    from dagster.utils import frozendict
-
-    if not isinstance(obj, (frozendict, dict)):
-        raise _param_type_mismatch_exception(
-            obj, (frozendict, dict), param_name, additional_message=additional_message
-        )
-
-    if not (key_type or value_type):
-        return obj
-
-    return _check_key_value_types(obj, key_type, value_type)
-
-
-def opt_dict_param(
-    obj: Any,
-    param_name: str,
-    key_type: Type = None,
-    value_type: Type = None,
-    value_class: Type = None,
-) -> Dict:
-    """Ensures argument obj is either a dictionary or None; if the latter, instantiates an empty
-    dictionary.
-    """
-    from dagster.utils import frozendict
-
-    if obj is not None and not isinstance(obj, (frozendict, dict)):
-        raise _param_type_mismatch_exception(obj, (frozendict, dict), param_name)
-
-    if not obj:
-        return {}
-
-    if value_class:
-        return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
-    return _check_key_value_types(obj, key_type, value_type)
-
-
-def opt_nullable_dict_param(
-    obj: Any,
-    param_name: str,
-    key_type: Type = None,
-    value_type: Type = None,
-    value_class: Type = None,
-) -> Optional[Dict]:
-    """Ensures argument obj is either a dictionary or None;"""
-    from dagster.utils import frozendict
-
-    if obj is not None and not isinstance(obj, (frozendict, dict)):
-        raise _param_type_mismatch_exception(obj, (frozendict, dict), param_name)
-
-    if not obj:
-        return None if obj is None else {}
-
-    if value_class:
-        return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
-    return _check_key_value_types(obj, key_type, value_type)
-
-
-def _check_two_dim_key_value_types(
-    obj: Any, key_type: Type = None, _param_name: str = None, value_type: Type = None
-) -> Dict:
-    _check_key_value_types(obj, key_type, dict)  # check level one
-
-    for level_two_dict in obj.values():
-        _check_key_value_types(level_two_dict, key_type, value_type)  # check level two
-
-    return obj
-
-
-def two_dim_dict_param(
-    obj: Any, param_name: str, key_type: Type = str, value_type: Type = None
-) -> Dict:
-    if not isinstance(obj, dict):
-        raise _param_type_mismatch_exception(obj, dict, param_name)
-
-    return _check_two_dim_key_value_types(obj, key_type, param_name, value_type)
-
-
-def opt_two_dim_dict_param(
-    obj: Any, param_name: str, key_type: Type = str, value_type: Type = None
-) -> Dict:
-    if obj is not None and not isinstance(obj, dict):
-        raise _param_type_mismatch_exception(obj, dict, param_name)
-
-    if not obj:
-        return {}
-
-    return _check_two_dim_key_value_types(obj, key_type, param_name, value_type)
-
-
-def type_param(obj: Any, param_name: str) -> type:
-    if not isinstance(obj, type):
-        raise _not_type_param_subclass_mismatch_exception(obj, param_name)
-    return obj
-
-
-def opt_type_param(obj: Any, param_name: str, default: type = None) -> Optional[type]:
-    if obj is not None and not isinstance(obj, type):
-        raise _not_type_param_subclass_mismatch_exception(obj, param_name)
-    return obj if obj is not None else default
-
-
-def subclass_param(obj: Any, param_name: str, superclass: type) -> type:
-    type_param(obj, param_name)
-    if not issubclass(obj, superclass):
-        raise _param_subclass_mismatch_exception(obj, superclass, param_name)
-
-    return obj
-
-
-def opt_subclass_param(obj: Any, param_name: str, superclass: type) -> Optional[type]:
-    opt_type_param(obj, param_name)
-    if obj is not None and not issubclass(obj, superclass):
-        raise _param_subclass_mismatch_exception(obj, superclass, param_name)
-
-    return obj
-
-
-def _element_check_error(key: Any, value: Any, ddict: Dict, ttype: Type) -> ElementCheckError:
-    return ElementCheckError(
-        "Value {value} from key {key} is not a {ttype}. Dict: {ddict}".format(
-            key=key, value=repr(value), ddict=repr(ddict), ttype=repr(ttype)
-        )
-    )
-
-
-def generator(obj: Any) -> Generator:
-    if not inspect.isgenerator(obj):
-        raise ParameterCheckError(
-            f"Not a generator (return value of function that yields) Got {obj} instead"
-        )
-    return obj
-
-
-def opt_generator(obj: Any) -> Optional[Generator]:
-    if obj is not None and not inspect.isgenerator(obj):
-        raise ParameterCheckError(
-            f"Not a generator (return value of function that yields) Got {obj} instead"
-        )
-    return obj
-
-
-def generator_param(obj: Any, param_name: str) -> Generator:
-    if not inspect.isgenerator(obj):
-        raise ParameterCheckError(
-            f'Param "{param_name}" is not a generator (return value of function that yields) Got '
-            f"{obj} instead"
-        )
-    return obj
-
-
-def opt_generator_param(obj: Any, param_name: str) -> Optional[Generator]:
-    if obj is not None and not inspect.isgenerator(obj):
-        raise ParameterCheckError(
-            f'Param "{param_name}" is not a generator (return value of function that yields) Got '
-            f"{obj} instead"
-        )
-    return obj
-
-
-def list_elem(ddict: Dict, key: str, of_type: Type = None) -> List:  # type: ignore[return]
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-    opt_type_param(of_type, "of_type")
-
-    value = ddict.get(key)
-
-    if isinstance(value, list):
-        if not of_type:
-            return value
-
-        return _check_list_items(value, of_type)
-
-    raise _element_check_error(key, value, ddict, list)
-
-
-def opt_list_elem(ddict: Dict, key: str, of_type: Type = None) -> List:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-    opt_type_param(of_type, "of_type")
-
-    value = ddict.get(key)
-
-    if value is None:
-        return []
-
-    if not isinstance(value, list):
-        raise _element_check_error(key, value, ddict, list)
-
-    if not of_type:
-        return value
-
-    return _check_list_items(value, of_type)
-
-
-def dict_elem(ddict: Dict, key: str) -> Dict:
-    from dagster.utils import frozendict
-
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    if key not in ddict:
-        raise CheckError(f"{key} not present in dictionary {ddict}")
-
-    value = ddict[key]
-    if not isinstance(value, (frozendict, dict)):
-        raise _element_check_error(key, value, ddict, (frozendict, dict))
-    return value
-
-
-def opt_dict_elem(ddict: Dict, key: str) -> Dict:
-    from dagster.utils import frozendict
-
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict.get(key)
-
-    if value is None:
-        return {}
-
-    if not isinstance(value, (frozendict, dict)):
-        raise _element_check_error(key, value, ddict, list)
-
-    return value
-
-
-def bool_elem(ddict: Dict, key: str) -> bool:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict[key]
-    if not isinstance(value, bool):
-        raise _element_check_error(key, value, ddict, bool)
-    return value
-
-
-def opt_float_elem(ddict: Dict, key: str) -> Optional[float]:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, float):
-        raise _element_check_error(key, value, ddict, float)
-    return value
-
-
-def float_elem(ddict: Dict, key: str) -> float:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict[key]
-    if not isinstance(value, float):
-        raise _element_check_error(key, value, ddict, float)
-    return value
-
-
-def opt_int_elem(ddict: Dict, key: str) -> Optional[int]:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, int):
-        raise _element_check_error(key, value, ddict, int)
-    return value
-
-
-def int_elem(ddict: Dict, key: str) -> int:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict[key]
-    if not isinstance(value, int):
-        raise _element_check_error(key, value, ddict, int)
-    return value
-
-
-def opt_str_elem(ddict: Dict, key: str) -> Optional[str]:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise _element_check_error(key, value, ddict, str)
-    return value
-
-
-def str_elem(ddict: Dict, key: str) -> str:
-    dict_param(ddict, "ddict")
-    str_param(key, "key")
-
-    value = ddict[key]
-    if not isinstance(value, str):
-        raise _element_check_error(key, value, ddict, str)
-    return value
-
-
-def class_param(obj: Any, param_name: str) -> Union[ParameterCheckError, type]:
-    if not inspect.isclass(obj):
-        return ParameterCheckError(
-            f'Param "{param_name}" is not a class. Got {repr(obj)} which is type {type(obj)}.'
-        )
-    return obj
-
-
-def assert_never(value: NoReturn) -> NoReturn:
-    failed(f"Unhandled value: {value} ({type(value).__name__})")


### PR DESCRIPTION
This PR organizes `dagster.check`. It had gotten unwieldy after functions were tacked on over time, making it hard to see exactly what check functions were available at a glance. Logic changes were left out of this, it just moves functions around and adds some explanatory comments. Downstream #6751 contains a few check modifications.
