### PR TITLE
Adjustments/condensing of dagster.check

### DIFF
--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -15,7 +15,7 @@ from typing import (
     overload,
 )
 
-Type = Union[type, Tuple[type, ...]]
+TypeOrTupleOfTypes = Union[type, Tuple[type, ...]]
 Numeric = Union[int, float]
 T = TypeVar("T")
 
@@ -55,13 +55,16 @@ def bool_param(obj: object, param_name: str) -> bool:
         raise _param_type_mismatch_exception(obj, bool, param_name)
     return obj
 
+
 @overload
 def opt_bool_param(obj: object, param_name: str, default: bool) -> bool:
     ...
 
+
 @overload
 def opt_bool_param(obj: object, param_name: str) -> Optional[bool]:
     ...
+
 
 def opt_bool_param(obj: object, param_name: str, default: Optional[bool] = None) -> Optional[bool]:
     if obj is not None and not isinstance(obj, bool):
@@ -89,15 +92,20 @@ def callable_param(obj: object, param_name: str) -> Callable:
         raise _param_not_callable_exception(obj, param_name)
     return obj
 
+
 @overload
 def opt_callable_param(obj: object, param_name: str, default: Callable) -> Callable:
     ...
+
 
 @overload
 def opt_callable_param(obj: object, param_name: str) -> Optional[Callable]:
     ...
 
-def opt_callable_param(obj: object, param_name: str, default: Optional[Callable] = None) -> Optional[Callable]:
+
+def opt_callable_param(
+    obj: object, param_name: str, default: Optional[Callable] = None
+) -> Optional[Callable]:
     if obj is not None and not callable(obj):
         raise _param_not_callable_exception(obj, param_name)
     return default if obj is None else obj
@@ -106,12 +114,13 @@ def opt_callable_param(obj: object, param_name: str, default: Optional[Callable]
 def is_callable(obj: object, desc: str = None) -> Callable:
     if not callable(obj):
         raise CheckError(f"Must be callable. Got {obj}.{desc and f' Description: {desc}.' or ''}")
-    return obj   # type: ignore
+    return obj  # type: ignore
 
 
 # ########################
 # ##### CLASS
 # ########################
+
 
 def class_param(obj: object, param_name: str, superclass: Optional[type] = None) -> type:
     if not isinstance(obj, type):
@@ -122,15 +131,24 @@ def class_param(obj: object, param_name: str, superclass: Optional[type] = None)
 
     return obj
 
-@overload
-def opt_class_param(obj: object, param_name: str, default: type, superclass: Optional[type] = None) -> type:
-    ...
 
 @overload
-def opt_class_param(obj: object, param_name: str, default: None = ..., superclass: Optional[type] = None) -> Optional[type]:
+def opt_class_param(
+    obj: object, param_name: str, default: type, superclass: Optional[type] = None
+) -> type:
     ...
 
-def opt_class_param(obj: object, param_name: str, default: Optional[type] = None, superclass: Optional[type] = None) -> Optional[type]:
+
+@overload
+def opt_class_param(
+    obj: object, param_name: str, default: None = ..., superclass: Optional[type] = None
+) -> Optional[type]:
+    ...
+
+
+def opt_class_param(
+    obj: object, param_name: str, default: Optional[type] = None, superclass: Optional[type] = None
+) -> Optional[type]:
     if obj is not None and not isinstance(obj, type):
         raise _param_class_mismatch_exception(obj, param_name, superclass, True)
 
@@ -151,8 +169,8 @@ def opt_class_param(obj: object, param_name: str, default: Optional[type] = None
 def dict_param(
     obj: object,
     param_name: str,
-    key_type: Optional[Type] = None,
-    value_type: Optional[Type] = None,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
     additional_message: Optional[str] = None,
 ) -> Dict:
     """Ensures argument obj is a native Python dictionary, raises an exception if not, and otherwise
@@ -174,9 +192,9 @@ def dict_param(
 def opt_dict_param(
     obj: object,
     param_name: str,
-    key_type: Optional[Type] = None,
-    value_type: Optional[Type] = None,
-    value_class: Optional[Type] = None,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    value_class: Optional[TypeOrTupleOfTypes] = None,
 ) -> Dict:
     """Ensures argument obj is either a dictionary or None; if the latter, instantiates an empty
     dictionary.
@@ -193,32 +211,35 @@ def opt_dict_param(
         return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
     return _check_key_value_types(obj, key_type, value_type)
 
+
 @overload
 def opt_nullable_dict_param(
     obj: None,
     param_name: str,
-    key_type: Optional[Type] = ...,
-    value_type: Optional[Type] = ...,
-    value_class: Optional[Type] = ...,
+    key_type: Optional[TypeOrTupleOfTypes] = ...,
+    value_type: Optional[TypeOrTupleOfTypes] = ...,
+    value_class: Optional[TypeOrTupleOfTypes] = ...,
 ) -> None:
     ...
+
 
 @overload
 def opt_nullable_dict_param(
     obj: object,
     param_name: str,
-    key_type: Optional[Type] = ...,
-    value_type: Optional[Type] = ...,
-    value_class: Optional[Type] = ...,
+    key_type: Optional[TypeOrTupleOfTypes] = ...,
+    value_type: Optional[TypeOrTupleOfTypes] = ...,
+    value_class: Optional[TypeOrTupleOfTypes] = ...,
 ) -> Dict:
     ...
+
 
 def opt_nullable_dict_param(
     obj: object,
     param_name: str,
-    key_type: Optional[Type] = None,
-    value_type: Optional[Type] = None,
-    value_class: Optional[Type] = None,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    value_class: Optional[TypeOrTupleOfTypes] = None,
 ) -> Optional[Dict]:
     """Ensures argument obj is either a dictionary or None."""
     from dagster.utils import frozendict
@@ -235,7 +256,10 @@ def opt_nullable_dict_param(
 
 
 def two_dim_dict_param(
-    obj: object, param_name: str, key_type: Type = str, value_type: Optional[Type] = None
+    obj: object,
+    param_name: str,
+    key_type: TypeOrTupleOfTypes = str,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
 ) -> Dict:
     if not isinstance(obj, dict):
         raise _param_type_mismatch_exception(obj, dict, param_name)
@@ -244,7 +268,10 @@ def two_dim_dict_param(
 
 
 def opt_two_dim_dict_param(
-    obj: object, param_name: str, key_type: Type = str, value_type: Optional[Type] = None
+    obj: object,
+    param_name: str,
+    key_type: TypeOrTupleOfTypes = str,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
 ) -> Dict:
     if obj is not None and not isinstance(obj, dict):
         raise _param_type_mismatch_exception(obj, dict, param_name)
@@ -287,7 +314,12 @@ def opt_dict_elem(ddict: Dict, key: str) -> Dict:
     return value
 
 
-def is_dict(obj: object, key_type: Type = None, value_type: Type = None, desc: str = None) -> Dict:
+def is_dict(
+    obj: object,
+    key_type: TypeOrTupleOfTypes = None,
+    value_type: TypeOrTupleOfTypes = None,
+    desc: str = None,
+) -> Dict:
     from dagster.utils import frozendict
 
     if not isinstance(obj, (frozendict, dict)):
@@ -301,8 +333,8 @@ def is_dict(obj: object, key_type: Type = None, value_type: Type = None, desc: s
 
 def _check_key_value_types(
     obj_dict: Dict,
-    key_type: Type = None,
-    value_type: Type = None,
+    key_type: TypeOrTupleOfTypes = None,
+    value_type: TypeOrTupleOfTypes = None,
     key_check: Callable = isinstance,
     value_check: Callable = isinstance,
 ) -> Dict:
@@ -328,7 +360,10 @@ def _check_key_value_types(
 
 
 def _check_two_dim_key_value_types(
-    obj_dict: Dict, key_type: Type = None, _param_name: str = None, value_type: Type = None
+    obj_dict: Dict,
+    key_type: TypeOrTupleOfTypes = None,
+    _param_name: str = None,
+    value_type: TypeOrTupleOfTypes = None,
 ) -> Dict:
     _check_key_value_types(obj_dict, key_type, dict)  # check level one
 
@@ -353,11 +388,15 @@ def float_param(obj: object, param_name: str) -> float:
 def opt_float_param(obj: object, param_name: str, default: float) -> float:
     ...
 
+
 @overload
 def opt_float_param(obj: object, param_name: str) -> Optional[float]:
     ...
 
-def opt_float_param(obj: object, param_name: str, default: Optional[float] = None) -> Optional[float]:
+
+def opt_float_param(
+    obj: object, param_name: str, default: Optional[float] = None
+) -> Optional[float]:
     if obj is not None and not isinstance(obj, float):
         raise _param_type_mismatch_exception(obj, float, param_name)
     return default if obj is None else obj
@@ -439,9 +478,11 @@ def int_param(obj: object, param_name: str) -> int:
 def opt_int_param(obj: object, param_name: str, default: int) -> int:
     ...
 
+
 @overload
 def opt_int_param(obj: object, param_name: str) -> Optional[int]:
     ...
+
 
 def opt_int_param(obj: object, param_name: str, default: Optional[int] = None) -> Optional[int]:
     if obj is not None and not isinstance(obj, int):
@@ -489,7 +530,9 @@ def opt_int_elem(ddict: Dict, key: str) -> Optional[int]:
 # this runtime validation check.
 
 
-def inst_param(obj: T, param_name: str, ttype: Type, additional_message: str = None) -> T:
+def inst_param(
+    obj: T, param_name: str, ttype: TypeOrTupleOfTypes, additional_message: str = None
+) -> T:
     if not isinstance(obj, ttype):
         raise _param_type_mismatch_exception(
             obj, ttype, param_name, additional_message=additional_message
@@ -498,28 +541,32 @@ def inst_param(obj: T, param_name: str, ttype: Type, additional_message: str = N
 
 
 @overload
-def opt_inst_param(obj: Optional[T], param_name: str, ttype: Type, default: T) -> T:
+def opt_inst_param(obj: Optional[T], param_name: str, ttype: TypeOrTupleOfTypes, default: T) -> T:
     ...
 
 
 @overload
-def opt_inst_param(obj: T, param_name: str, ttype: Type) -> T:
+def opt_inst_param(obj: T, param_name: str, ttype: TypeOrTupleOfTypes) -> T:
     ...
 
 
-def opt_inst_param(obj: T, param_name: str, ttype: Type, default: T = None) -> Optional[T]:
+def opt_inst_param(
+    obj: T, param_name: str, ttype: TypeOrTupleOfTypes, default: T = None
+) -> Optional[T]:
     if obj is not None and not isinstance(obj, ttype):
         raise _param_type_mismatch_exception(obj, ttype, param_name)
     return default if obj is None else obj
 
 
-def inst(obj: T, ttype: Type, desc: str = None) -> T:
+def inst(obj: T, ttype: TypeOrTupleOfTypes, desc: str = None) -> T:
     if not isinstance(obj, ttype):
         raise _type_mismatch_error(obj, ttype, desc)
     return obj
 
 
-def opt_inst(obj: T, ttype: Type, desc: str = None, default: Optional[T] = None) -> Optional[T]:
+def opt_inst(
+    obj: T, ttype: TypeOrTupleOfTypes, desc: str = None, default: Optional[T] = None
+) -> Optional[T]:
     if obj is not None and not isinstance(obj, ttype):
         raise _type_mismatch_error(obj, ttype, desc)
     return default if obj is None else obj
@@ -547,7 +594,7 @@ def not_none(value: Optional[T], desc: str = None) -> T:
 # ########################
 
 
-def list_param(obj: object, param_name: str, of_type: Type = None) -> List:
+def list_param(obj: object, param_name: str, of_type: TypeOrTupleOfTypes = None) -> List:
     from dagster.utils import frozenlist
 
     if not isinstance(obj, (frozenlist, list)):
@@ -559,7 +606,7 @@ def list_param(obj: object, param_name: str, of_type: Type = None) -> List:
     return _check_list_items(obj, of_type)
 
 
-def opt_list_param(obj: object, param_name: str, of_type: Type = None) -> List:
+def opt_list_param(obj: object, param_name: str, of_type: TypeOrTupleOfTypes = None) -> List:
     """Ensures argument obj is a list or None; in the latter case, instantiates an empty list
     and returns it.
 
@@ -578,23 +625,28 @@ def opt_list_param(obj: object, param_name: str, of_type: Type = None) -> List:
 
     return _check_list_items(obj, of_type)
 
+
 @overload
 def opt_nullable_list_param(
     obj: None,
     param_name: str,
-    of_type: Optional[Type] = ...,
+    of_type: Optional[TypeOrTupleOfTypes] = ...,
 ) -> None:
     ...
+
 
 @overload
 def opt_nullable_list_param(
     obj: object,
     param_name: str,
-    of_type: Optional[Type] = ...,
+    of_type: Optional[TypeOrTupleOfTypes] = ...,
 ) -> List:
     ...
 
-def opt_nullable_list_param(obj: object, param_name: str, of_type: Optional[Type] = None) -> Optional[List]:
+
+def opt_nullable_list_param(
+    obj: object, param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
+) -> Optional[List]:
     """Ensures argument obj is a list or None. Returns None if input is None.
 
     If the of_type argument is provided, also ensures that list items conform to the type specified
@@ -613,7 +665,9 @@ def opt_nullable_list_param(obj: object, param_name: str, of_type: Optional[Type
     return _check_list_items(obj, of_type)
 
 
-def two_dim_list_param(obj: object, param_name: str, of_type: Optional[Type] = None) -> List[List]:
+def two_dim_list_param(
+    obj: object, param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
+) -> List[List]:
     obj = list_param(obj, param_name, of_type=list)
     if not obj:
         raise CheckError("You must pass a list of lists. Received an empty list.")
@@ -624,7 +678,7 @@ def two_dim_list_param(obj: object, param_name: str, of_type: Optional[Type] = N
     return obj
 
 
-def list_elem(ddict: Dict, key: str, of_type: Optional[Type] = None) -> List:
+def list_elem(ddict: Dict, key: str, of_type: Optional[TypeOrTupleOfTypes] = None) -> List:
     dict_param(ddict, "ddict")
     str_param(key, "key")
     opt_class_param(of_type, "of_type")
@@ -640,7 +694,7 @@ def list_elem(ddict: Dict, key: str, of_type: Optional[Type] = None) -> List:
     raise _element_check_error(key, value, ddict, list)
 
 
-def opt_list_elem(ddict: Dict, key: str, of_type: Optional[Type] = None) -> List:
+def opt_list_elem(ddict: Dict, key: str, of_type: Optional[TypeOrTupleOfTypes] = None) -> List:
     dict_param(ddict, "ddict")
     str_param(key, "key")
     opt_class_param(of_type, "of_type")
@@ -659,7 +713,9 @@ def opt_list_elem(ddict: Dict, key: str, of_type: Optional[Type] = None) -> List
     return _check_list_items(value, of_type)
 
 
-def is_list(obj: object, of_type: Optional[Type] = None, desc: Optional[str] = None) -> List:
+def is_list(
+    obj: object, of_type: Optional[TypeOrTupleOfTypes] = None, desc: Optional[str] = None
+) -> List:
     if not isinstance(obj, list):
         raise _type_mismatch_error(obj, list, desc)
 
@@ -669,7 +725,7 @@ def is_list(obj: object, of_type: Optional[Type] = None, desc: Optional[str] = N
     return _check_list_items(obj, of_type)
 
 
-def _check_list_items(obj_list: List, of_type: Type) -> List:
+def _check_list_items(obj_list: List, of_type: TypeOrTupleOfTypes) -> List:
     for obj in obj_list:
         if not isinstance(obj, of_type):
             if isinstance(obj, type):
@@ -690,20 +746,26 @@ def _check_list_items(obj_list: List, of_type: Type) -> List:
 # ##### NUMERIC
 # ########################
 
+
 def numeric_param(obj: object, param_name: str) -> Numeric:
     if not isinstance(obj, (int, float)):
         raise _param_type_mismatch_exception(obj, (int, float), param_name)
     return obj
 
+
 @overload
 def opt_numeric_param(obj: object, param_name: str, default: Numeric) -> Numeric:
     ...
+
 
 @overload
 def opt_numeric_param(obj: object, param_name: str) -> Optional[Numeric]:
     ...
 
-def opt_numeric_param(obj: object, param_name: str, default: Optional[Numeric] = None) -> Optional[Numeric]:
+
+def opt_numeric_param(
+    obj: object, param_name: str, default: Optional[Numeric] = None
+) -> Optional[Numeric]:
     if obj is not None and not isinstance(obj, (int, float)):
         raise _param_type_mismatch_exception(obj, (int, float), param_name)
     return default if obj is None else obj
@@ -714,7 +776,7 @@ def opt_numeric_param(obj: object, param_name: str, default: Optional[Numeric] =
 # ########################
 
 
-def set_param(obj: object, param_name: str, of_type: Type = None) -> AbstractSet:
+def set_param(obj: object, param_name: str, of_type: TypeOrTupleOfTypes = None) -> AbstractSet:
     if not isinstance(obj, (frozenset, set)):
         raise _param_type_mismatch_exception(obj, (frozenset, set), param_name)
 
@@ -724,7 +786,7 @@ def set_param(obj: object, param_name: str, of_type: Type = None) -> AbstractSet
     return _check_set_items(obj, of_type)
 
 
-def opt_set_param(obj: object, param_name: str, of_type: Type = None) -> AbstractSet:
+def opt_set_param(obj: object, param_name: str, of_type: TypeOrTupleOfTypes = None) -> AbstractSet:
     """Ensures argument obj is a set or None; in the latter case, instantiates an empty set
     and returns it.
 
@@ -741,7 +803,7 @@ def opt_set_param(obj: object, param_name: str, of_type: Type = None) -> Abstrac
     return _check_set_items(obj, of_type)
 
 
-def _check_set_items(obj_set: AbstractSet, of_type: Type) -> AbstractSet:
+def _check_set_items(obj_set: AbstractSet, of_type: TypeOrTupleOfTypes) -> AbstractSet:
     for obj in obj_set:
 
         if not isinstance(obj, of_type):
@@ -786,7 +848,9 @@ def opt_str_param(obj: object, param_name: str, default: Optional[str] = None) -
     return default if obj is None else obj
 
 
-def opt_nonempty_str_param(obj: object, param_name: str, default: Optional[str] = None) -> Optional[str]:
+def opt_nonempty_str_param(
+    obj: object, param_name: str, default: Optional[str] = None
+) -> Optional[str]:
     if obj is not None and not isinstance(obj, str):
         raise _param_type_mismatch_exception(obj, str, param_name)
     return default if obj is None or obj == "" else obj
@@ -820,7 +884,10 @@ def opt_str_elem(ddict: Dict, key: str) -> Optional[str]:
 
 
 def tuple_param(
-    obj: object, param_name: str, of_type: Type = None, of_shape: Optional[Tuple[Type, ...]] = None
+    obj: object,
+    param_name: str,
+    of_type: TypeOrTupleOfTypes = None,
+    of_shape: Optional[Tuple[TypeOrTupleOfTypes, ...]] = None,
 ) -> Tuple:
     """Ensure param is a tuple and is of a specified type. `of_type` defines a variadic tuple type--
     `obj` may be of any length, but each element must match the `of_type` argmument. `of_shape`
@@ -843,8 +910,8 @@ def opt_tuple_param(
     obj: object,
     param_name: str,
     default: Tuple = None,
-    of_type: Type = None,
-    of_shape: Optional[Tuple[Type, ...]] = None,
+    of_type: TypeOrTupleOfTypes = None,
+    of_shape: Optional[Tuple[TypeOrTupleOfTypes, ...]] = None,
 ) -> Optional[Tuple]:
     """Ensure optional param is a tuple and is of a specified type. `default` is returned if `obj`
     is None. `of_type` defines a variadic tuple type-- `obj` may be of any length, but each element
@@ -869,8 +936,8 @@ def opt_tuple_param(
 
 def is_tuple(
     obj: object,
-    of_type: Type = None,
-    of_shape: Optional[Tuple[Type, ...]] = None,
+    of_type: TypeOrTupleOfTypes = None,
+    of_shape: Optional[Tuple[TypeOrTupleOfTypes, ...]] = None,
     desc: str = None,
 ) -> Tuple:
     """Ensure target is a tuple and is of a specified type. `of_type` defines a variadic tuple
@@ -891,15 +958,16 @@ def is_tuple(
 
 
 def _check_tuple_items(
-    obj_tuple: Tuple, of_type: Optional[Type] = None, of_shape: Optional[Tuple[Type, ...]] = None
+    obj_tuple: Tuple,
+    of_type: Optional[TypeOrTupleOfTypes] = None,
+    of_shape: Optional[Tuple[TypeOrTupleOfTypes, ...]] = None,
 ) -> Tuple:
     if of_shape is not None:
         len_tuple = len(obj_tuple)
         len_type = len(of_shape)
         if not len_tuple == len_type:
             raise CheckError(
-                f"Tuple mismatches type: tuple had {len_tuple} members but type had "
-                f"{len_type}"
+                f"Tuple mismatches type: tuple had {len_tuple} members but type had " f"{len_type}"
             )
 
         for (i, obj) in enumerate(obj_tuple):
@@ -1024,16 +1092,18 @@ class NotImplementedCheckError(CheckError):
     pass
 
 
-def _element_check_error(key: object, value: object, ddict: Dict, ttype: Type) -> ElementCheckError:
+def _element_check_error(
+    key: object, value: object, ddict: Dict, ttype: TypeOrTupleOfTypes
+) -> ElementCheckError:
     return ElementCheckError(
         f"Value {repr(value)} from key {key} is not a {repr(ttype)}. Dict: {repr(ddict)}"
     )
 
 
 def _param_type_mismatch_exception(
-    obj: object, ttype: Type, param_name: str, additional_message: str = None
+    obj: object, ttype: TypeOrTupleOfTypes, param_name: str, additional_message: str = None
 ) -> ParameterCheckError:
-    additional_message=" " + additional_message if additional_message else ""
+    additional_message = " " + additional_message if additional_message else ""
     if isinstance(ttype, tuple):
         type_names = sorted([t.__name__ for t in ttype])
         return ParameterCheckError(
@@ -1048,16 +1118,19 @@ def _param_type_mismatch_exception(
 
 
 def _param_class_mismatch_exception(
-        obj: object, param_name: str, superclass: Optional[type], optional: bool,
+    obj: object,
+    param_name: str,
+    superclass: Optional[type],
+    optional: bool,
 ) -> ParameterCheckError:
     opt_clause = optional and "be None or" or ""
-    subclass_clause = superclass and f'that inherits from {superclass.__name__}' or ''
+    subclass_clause = superclass and f"that inherits from {superclass.__name__}" or ""
     return ParameterCheckError(
         f'Param "{param_name}" must {opt_clause}be a class{subclass_clause}. Got {repr(obj)} of type {type(obj)}.'
     )
 
 
-def _type_mismatch_error(obj: object, ttype: Type, desc: str = None) -> CheckError:
+def _type_mismatch_error(obj: object, ttype: TypeOrTupleOfTypes, desc: str = None) -> CheckError:
     type_message = (
         f"not one of {sorted([t.__name__ for t in ttype])}"
         if isinstance(ttype, tuple)

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -580,6 +580,17 @@ def opt_nullable_list_param(obj: object, param_name: str, of_type: Optional[Type
     return _check_list_items(obj, of_type)
 
 
+def two_dim_list_param(obj: object, param_name: str, of_type: Optional[Type] = None) -> List[List]:
+    obj = list_param(obj, param_name, of_type=list)
+    if not obj:
+        raise CheckError("You must pass a list of lists. Received an empty list.")
+    for sublist in obj:
+        sublist = list_param(sublist, "sublist_{}".format(param_name), of_type=of_type)
+        if len(sublist) != len(obj[0]):
+            raise CheckError("All sublists in obj must have the same length")
+    return obj
+
+
 def list_elem(ddict: Dict, key: str, of_type: Optional[Type] = None) -> List:
     dict_param(ddict, "ddict")
     str_param(key, "key")
@@ -645,22 +656,6 @@ def _check_list_items(obj_list: List, of_type: Type) -> List:
             )
 
     return obj_list
-
-
-# ########################
-# ##### MATRIX
-# ########################
-
-
-def matrix_param(matrix: object, param_name: str, of_type: Optional[Type] = None) -> List[List]:
-    matrix = list_param(matrix, param_name, of_type=list)
-    if not matrix:
-        raise CheckError("You must pass a list of lists. Received an empty list.")
-    for sublist in matrix:
-        sublist = list_param(sublist, "sublist_{}".format(param_name), of_type=of_type)
-        if len(sublist) != len(matrix[0]):
-            raise CheckError("All sublists in matrix must have the same length")
-    return matrix
 
 
 # ########################

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -114,7 +114,7 @@ def opt_callable_param(
 def is_callable(obj: object, desc: str = None) -> Callable:
     if not callable(obj):
         raise CheckError(f"Must be callable. Got {obj}.{desc and f' Description: {desc}.' or ''}")
-    return obj  # type: ignore
+    return obj
 
 
 # ########################
@@ -212,8 +212,9 @@ def opt_dict_param(
     return _check_key_value_types(obj, key_type, value_type)
 
 
+# pyright understands this overload but not mypy
 @overload
-def opt_nullable_dict_param(
+def opt_nullable_dict_param(   # type: ignore
     obj: None,
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = ...,
@@ -573,23 +574,6 @@ def opt_inst(
 
 
 # ########################
-# ##### NOT NONE
-# ########################
-
-
-def not_none_param(obj: Optional[T], param_name: str) -> T:
-    if obj is None:
-        raise _param_invariant_exception(param_name, f"Param {param_name} cannot be none")
-    return obj
-
-
-def not_none(value: Optional[T], desc: str = None) -> T:
-    if value is None:
-        raise ValueError(f"Expected non-None value: {desc}")
-    return value
-
-
-# ########################
 # ##### LIST
 # ########################
 
@@ -625,9 +609,9 @@ def opt_list_param(obj: object, param_name: str, of_type: TypeOrTupleOfTypes = N
 
     return _check_list_items(obj, of_type)
 
-
+# pyright understands this overload but not mypy
 @overload
-def opt_nullable_list_param(
+def opt_nullable_list_param(  # type: ignore
     obj: None,
     param_name: str,
     of_type: Optional[TypeOrTupleOfTypes] = ...,
@@ -740,6 +724,23 @@ def _check_list_items(obj_list: List, of_type: TypeOrTupleOfTypes) -> List:
             )
 
     return obj_list
+
+
+# ########################
+# ##### NOT NONE
+# ########################
+
+
+def not_none_param(obj: Optional[T], param_name: str) -> T:
+    if obj is None:
+        raise _param_invariant_exception(param_name, f"Param {param_name} cannot be none")
+    return obj
+
+
+def not_none(value: Optional[T], desc: str = None) -> T:
+    if value is None:
+        raise ValueError(f"Expected non-None value: {desc}")
+    return value
 
 
 # ########################
@@ -1057,7 +1058,7 @@ def assert_never(value: NoReturn) -> NoReturn:
     failed(f"Unhandled value: {value} ({type(value).__name__})")
 
 
-def failed(desc: str) -> NoReturn:  # type: ignore[misc]
+def failed(desc: str) -> NoReturn:
     if not isinstance(desc, str):
         raise CheckError("desc argument must be a string")
 

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1002,38 +1002,6 @@ def _check_tuple_items(
     return obj_tuple
 
 
-# ########################
-# ##### TYPE
-# ########################
-
-
-def type_param(obj: Any, param_name: str) -> type:
-    if not isinstance(obj, type):
-        raise _not_type_param_subclass_mismatch_exception(obj, param_name)
-    return obj
-
-
-def opt_type_param(obj: Any, param_name: str, default: type = None) -> Optional[type]:
-    if obj is not None and not isinstance(obj, type):
-        raise _not_type_param_subclass_mismatch_exception(obj, param_name)
-    return obj if obj is not None else default
-
-
-def class_param(obj: Any, param_name: str) -> Union["ParameterCheckError", type]:
-    if not inspect.isclass(obj):
-        return ParameterCheckError(
-            f'Param "{param_name}" is not a class. Got {repr(obj)} which is type {type(obj)}.'
-    return obj
-
-
-def is_type(obj: object, desc: Optional[str] = None) -> type:
-    if not isinstance(obj, type):
-        raise CheckError(
-            f"Must be a class. Got {obj}.{desc and f' Description: {desc}.' or ''}"
-        )
-    return obj
-
-
 # ###################################################################################################
 # ##### OTHER CHECKS
 # ###################################################################################################

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -214,7 +214,7 @@ def opt_dict_param(
 
 # pyright understands this overload but not mypy
 @overload
-def opt_nullable_dict_param(   # type: ignore
+def opt_nullable_dict_param(  # type: ignore
     obj: None,
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = ...,
@@ -608,6 +608,7 @@ def opt_list_param(obj: object, param_name: str, of_type: TypeOrTupleOfTypes = N
         return obj
 
     return _check_list_items(obj, of_type)
+
 
 # pyright understands this overload but not mypy
 @overload

--- a/python_modules/dagster/dagster/config/config_type.py
+++ b/python_modules/dagster/dagster/config/config_type.py
@@ -394,7 +394,7 @@ ConfigFloatInstance = Float()
 ConfigIntInstance = Int()
 ConfigStringInstance = String()
 
-_CONFIG_MAP: Dict[check.Type, ConfigType] = {
+_CONFIG_MAP: Dict[check.TypeOrTupleOfTypes, ConfigType] = {
     BuiltinEnum.ANY: ConfigAnyInstance,
     BuiltinEnum.BOOL: ConfigBoolInstance,
     BuiltinEnum.FLOAT: ConfigFloatInstance,

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -292,10 +292,10 @@ class AssetObservation(
         elif isinstance(asset_key, str):
             asset_key = AssetKey(parse_asset_key_string(asset_key))
         elif isinstance(asset_key, list):
-            check.is_list(asset_key, of_type=str)
+            check.list_param(asset_key, "asset_key", of_type=str)
             asset_key = AssetKey(asset_key)
         else:
-            check.is_tuple(asset_key, of_type=str)
+            check.tuple_param(asset_key, "asset_key", of_type=str)
             asset_key = AssetKey(asset_key)
 
         metadata = check.opt_dict_param(metadata, "metadata", key_type=str)
@@ -372,10 +372,10 @@ class AssetMaterialization(
         elif isinstance(asset_key, str):
             asset_key = AssetKey(parse_asset_key_string(asset_key))
         elif isinstance(asset_key, list):
-            check.is_list(asset_key, of_type=str)
+            check.list_param(asset_key, "asset_key", of_type=str)
             asset_key = AssetKey(asset_key)
         else:
-            check.is_tuple(asset_key, of_type=str)
+            check.tuple_param(asset_key, "asset_key", of_type=str)
             asset_key = AssetKey(asset_key)
 
         if tags:

--- a/python_modules/dagster/dagster/core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/table.py
@@ -33,7 +33,7 @@ class TableRecord(NamedTuple("TableRecord", [("data", Dict[str, Union[str, int, 
             data,
             "data",
             value_type=(str, float, int, bool, type(None)),
-            desc="Record fields must be one of types: (str, float, int, bool)",
+            additional_message="Record fields must be one of types: (str, float, int, bool)",
         )
         return super(TableRecord, cls).__new__(cls, data=data)
 

--- a/python_modules/dagster/dagster/core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/table.py
@@ -29,8 +29,9 @@ class TableRecord(NamedTuple("TableRecord", [("data", Dict[str, Union[str, int, 
     """
 
     def __new__(cls, **data):
-        check.is_dict(
+        check.dict_param(
             data,
+            "data",
             value_type=(str, float, int, bool, type(None)),
             desc="Record fields must be one of types: (str, float, int, bool)",
         )

--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -176,7 +176,7 @@ def user_code_error_boundary(error_cls, msg_fn, log_manager=None, **kwargs):
 
     """
     check.callable_param(msg_fn, "msg_fn")
-    check.subclass_param(error_cls, "error_cls", DagsterUserCodeExecutionError)
+    check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
 
     with raise_execution_interrupts():
         if log_manager:

--- a/python_modules/dagster/dagster/core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/core/execution/plan/utils.py
@@ -35,7 +35,7 @@ def solid_execution_error_boundary(error_cls, msg_fn, step_context, **kwargs):
     from dagster.core.execution.context.system import StepExecutionContext
 
     check.callable_param(msg_fn, "msg_fn")
-    check.subclass_param(error_cls, "error_cls", DagsterUserCodeExecutionError)
+    check.class_param(error_cls, "error_cls", superclass=DagsterUserCodeExecutionError)
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
     with raise_execution_interrupts():

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1316,7 +1316,7 @@ records = instance.get_event_records(
         from dagster.core.events import EngineEventData, DagsterEvent, DagsterEventType
         from dagster.core.events.log import EventLogEntry
 
-        check.class_param(cls, "cls")
+        check.type_param(cls, "cls")
         check.str_param(message, "message")
         check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun)
         check.opt_str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1316,7 +1316,7 @@ records = instance.get_event_records(
         from dagster.core.events import EngineEventData, DagsterEvent, DagsterEventType
         from dagster.core.events.log import EventLogEntry
 
-        check.class_param(cls, "cls")
+        check.opt_class_param(cls, "cls")
         check.str_param(message, "message")
         check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun)
         check.opt_str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1316,7 +1316,7 @@ records = instance.get_event_records(
         from dagster.core.events import EngineEventData, DagsterEvent, DagsterEventType
         from dagster.core.events.log import EventLogEntry
 
-        check.type_param(cls, "cls")
+        check.class_param(cls, "cls")
         check.str_param(message, "message")
         check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun)
         check.opt_str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -519,7 +519,7 @@ class PythonObjectDagsterType(DagsterType):
             typing_type = t.Union[python_type]  # type: ignore
 
         else:
-            self.python_type = check.type_param(python_type, "python_type")  # type: ignore
+            self.python_type = check.class_param(python_type, "python_type")  # type: ignore
             self.type_str = cast(str, python_type.__name__)
             typing_type = self.python_type  # type: ignore
         name = check.opt_str_param(name, "name", self.type_str)

--- a/python_modules/dagster/dagster/core/types/decorator.py
+++ b/python_modules/dagster/dagster/core/types/decorator.py
@@ -60,7 +60,7 @@ def usable_as_dagster_type(
     """
 
     def _with_args(bare_cls):
-        check.type_param(bare_cls, "bare_cls")
+        check.class_param(bare_cls, "bare_cls")
         new_name = name if name else bare_cls.__name__
 
         make_python_type_usable_as_dagster_type(

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -155,10 +155,10 @@ def whitelist_for_serdes(
         "storage_name can only be used with DefaultNamedTupleSerializer",
     )
     if __cls is not None:  # decorator invoked directly on class
-        check.type_param(__cls, "__cls")
+        check.class_param(__cls, "__cls")
         return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP)(__cls)
     else:  # decorator passed params
-        check.opt_subclass_param(serializer, "serializer", Serializer)
+        check.opt_class_param(serializer, "serializer", superclass=Serializer)
         serializer = cast(Type[Serializer], serializer)
         return _whitelist_for_serdes(
             whitelist_map=_WHITELIST_MAP, serializer=serializer, storage_name=storage_name

--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -155,7 +155,7 @@ def whitelist_for_serdes(
         "storage_name can only be used with DefaultNamedTupleSerializer",
     )
     if __cls is not None:  # decorator invoked directly on class
-        check.class_param(__cls, "__cls")
+        check.type_param(__cls, "__cls")
         return _whitelist_for_serdes(whitelist_map=_WHITELIST_MAP)(__cls)
     else:  # decorator passed params
         check.opt_subclass_param(serializer, "serializer", Serializer)

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -448,7 +448,7 @@ class EventGenerationManager(Generic[GeneratedContext]):
         require_object: Optional[bool] = True,
     ):
         self.generator = check.generator(generator)
-        self.object_cls: Type[GeneratedContext] = check.type_param(object_cls, "object_cls")
+        self.object_cls: Type[GeneratedContext] = check.class_param(object_cls, "object_cls")
         self.require_object = check.bool_param(require_object, "require_object")
         self.object: Optional[GeneratedContext] = None
         self.did_setup = False

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -928,26 +928,26 @@ def test_tuple_param():
         check.is_tuple((3, 4), of_shape=(int, int), of_type=int)
 
 
-def test_matrix_param():
-    assert check.matrix_param([[1, 2], [2, 3]], "something")
+def test_two_dim_list_param():
+    assert check.two_dim_list_param([[1, 2], [2, 3]], "something")
 
     with pytest.raises(CheckError):
-        assert check.matrix_param(None, "something")
+        assert check.two_dim_list_param(None, "something")
 
     with pytest.raises(CheckError):
-        assert check.matrix_param([1, 2, 4], "something")
+        assert check.two_dim_list_param([1, 2, 4], "something")
 
     with pytest.raises(CheckError):
-        assert check.matrix_param([], "something")
+        assert check.two_dim_list_param([], "something")
 
     with pytest.raises(CheckError):
-        assert check.matrix_param([[1, 2], 3], "soemthing")
+        assert check.two_dim_list_param([[1, 2], 3], "soemthing")
 
     with pytest.raises(CheckError):
-        assert check.matrix_param([[1, 2], [3.0, 4.1]], "something", of_type=int)
+        assert check.two_dim_list_param([[1, 2], [3.0, 4.1]], "something", of_type=int)
 
     with pytest.raises(CheckError):
-        assert check.matrix_param([[1, 2], [2, 3, 4]], "something")
+        assert check.two_dim_list_param([[1, 2], [2, 3, 4]], "something")
 
 
 def test_opt_tuple_param():
@@ -992,53 +992,51 @@ def test_opt_tuple_param():
         check.is_tuple((3, 4), of_shape=(int, int), of_type=int)
 
 
-def test_opt_type_param():
+def test_opt_class_param():
     class Foo:
         pass
 
-    assert check.opt_type_param(int, "foo")
-    assert check.opt_type_param(Foo, "foo")
+    assert check.opt_class_param(int, "foo")
+    assert check.opt_class_param(Foo, "foo")
 
-    assert check.opt_type_param(None, "foo") is None
-    assert check.opt_type_param(None, "foo", Foo) is Foo
-
-    with pytest.raises(CheckError):
-        check.opt_type_param(check, "foo")
+    assert check.opt_class_param(None, "foo") is None
+    assert check.opt_class_param(None, "foo", Foo) is Foo
 
     with pytest.raises(CheckError):
-        check.opt_type_param(234, "foo")
+        check.opt_class_param(check, "foo")
 
     with pytest.raises(CheckError):
-        check.opt_type_param("bar", "foo")
+        check.opt_class_param(234, "foo")
 
     with pytest.raises(CheckError):
-        check.opt_type_param(Foo(), "foo")
+        check.opt_class_param("bar", "foo")
+
+    with pytest.raises(CheckError):
+        check.opt_class_param(Foo(), "foo")
 
 
-def test_type_param():
+def test_class_param():
     class Bar:
         pass
 
-    assert check.type_param(int, "foo")
-    assert check.type_param(Bar, "foo")
+    assert check.class_param(int, "foo")
+    assert check.class_param(Bar, "foo")
 
     with pytest.raises(CheckError):
-        check.type_param(None, "foo")
+        check.class_param(None, "foo")
 
     with pytest.raises(CheckError):
-        check.type_param(check, "foo")
+        check.class_param(check, "foo")
 
     with pytest.raises(CheckError):
-        check.type_param(234, "foo")
+        check.class_param(234, "foo")
 
     with pytest.raises(CheckError):
-        check.type_param("bar", "foo")
+        check.class_param("bar", "foo")
 
     with pytest.raises(CheckError):
-        check.type_param(Bar(), "foo")
+        check.class_param(Bar(), "foo")
 
-
-def test_subclass_param():
     class Super:
         pass
 
@@ -1048,22 +1046,22 @@ def test_subclass_param():
     class Alone:
         pass
 
-    assert check.subclass_param(Sub, "foo", Super)
+    assert check.class_param(Sub, "foo", superclass=Super)
 
     with pytest.raises(CheckError):
-        assert check.subclass_param(Alone, "foo", Super)
+        assert check.class_param(Alone, "foo", superclass=Super)
 
     with pytest.raises(CheckError):
-        assert check.subclass_param("value", "foo", Super)
+        assert check.class_param("value", "foo", superclass=Super)
 
-    assert check.opt_subclass_param(Sub, "foo", Super)
-    assert check.opt_subclass_param(None, "foo", Super) is None
-
-    with pytest.raises(CheckError):
-        assert check.opt_subclass_param(Alone, "foo", Super)
+    assert check.opt_class_param(Sub, "foo", superclass=Super)
+    assert check.opt_class_param(None, "foo", superclass=Super) is None
 
     with pytest.raises(CheckError):
-        assert check.opt_subclass_param("value", "foo", Super)
+        assert check.opt_class_param(Alone, "foo", superclass=Super)
+
+    with pytest.raises(CheckError):
+        assert check.opt_class_param("value", "foo", superclass=Super)
 
 
 @contextmanager

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_utils.py
@@ -37,7 +37,7 @@ def test_event_generation_manager():
     with pytest.raises(CheckError, match="Not a generator"):
         EventGenerationManager(None, int)
 
-    with pytest.raises(CheckError, match="was supposed to be a type"):
+    with pytest.raises(CheckError, match="must be a class"):
         EventGenerationManager(basic_generator(), None)
 
     with pytest.raises(CheckError, match="Called `get_object` before `generate_setup_events`"):

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/factory.py
@@ -187,7 +187,7 @@ def _make_airflow_dag(
     dag_description = check.opt_str_param(
         dag_description, "dag_description", _make_dag_description(job_name)
     )
-    check.subclass_param(operator, "operator", BaseOperator)
+    check.class_param(operator, "operator", superclass=BaseOperator)
 
     dag_kwargs = dict(
         {"default_args": DEFAULT_ARGS},
@@ -361,7 +361,7 @@ def make_airflow_dag_for_operator(
         (airflow.models.DAG, List[airflow.models.BaseOperator]): The generated Airflow DAG, and a
         list of its constituent tasks.
     """
-    check.subclass_param(operator, "operator", BaseOperator)
+    check.class_param(operator, "operator", superclass=BaseOperator)
 
     job_name = canonicalize_backcompat_args(
         new_val=job_name,

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -66,7 +66,7 @@ class RedshiftResource(_BaseRedshiftResource):
         """
         check.str_param(query, "query")
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_subclass_param(cursor_factory, "cursor_factory", psycopg2.extensions.cursor)
+        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
         check.opt_callable_param(error_callback, "error_callback")
 
         with self._get_conn() as conn:
@@ -124,7 +124,7 @@ class RedshiftResource(_BaseRedshiftResource):
         """
         check.list_param(queries, "queries", of_type=str)
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_subclass_param(cursor_factory, "cursor_factory", psycopg2.extensions.cursor)
+        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
         check.opt_callable_param(error_callback, "error_callback")
 
         results = []
@@ -174,7 +174,7 @@ class RedshiftResource(_BaseRedshiftResource):
 
     @contextmanager
     def _get_cursor(self, conn, cursor_factory=None):
-        check.opt_subclass_param(cursor_factory, "cursor_factory", psycopg2.extensions.cursor)
+        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
 
         # Could be none, in which case we should respect the connection default. Otherwise
         # explicitly set to true/false.
@@ -217,7 +217,7 @@ class FakeRedshiftResource(_BaseRedshiftResource):
         """
         check.str_param(query, "query")
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_subclass_param(cursor_factory, "cursor_factory", psycopg2.extensions.cursor)
+        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
         check.opt_callable_param(error_callback, "error_callback")
 
         self.log.info("Executing query '{query}'".format(query=query))
@@ -248,7 +248,7 @@ class FakeRedshiftResource(_BaseRedshiftResource):
         """
         check.list_param(queries, "queries", of_type=str)
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_subclass_param(cursor_factory, "cursor_factory", psycopg2.extensions.cursor)
+        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
         check.opt_callable_param(error_callback, "error_callback")
 
         for query in queries:

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -66,7 +66,9 @@ class RedshiftResource(_BaseRedshiftResource):
         """
         check.str_param(query, "query")
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
+        check.opt_class_param(
+            cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor
+        )
         check.opt_callable_param(error_callback, "error_callback")
 
         with self._get_conn() as conn:
@@ -124,7 +126,9 @@ class RedshiftResource(_BaseRedshiftResource):
         """
         check.list_param(queries, "queries", of_type=str)
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
+        check.opt_class_param(
+            cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor
+        )
         check.opt_callable_param(error_callback, "error_callback")
 
         results = []
@@ -174,7 +178,9 @@ class RedshiftResource(_BaseRedshiftResource):
 
     @contextmanager
     def _get_cursor(self, conn, cursor_factory=None):
-        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
+        check.opt_class_param(
+            cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor
+        )
 
         # Could be none, in which case we should respect the connection default. Otherwise
         # explicitly set to true/false.
@@ -217,7 +223,9 @@ class FakeRedshiftResource(_BaseRedshiftResource):
         """
         check.str_param(query, "query")
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
+        check.opt_class_param(
+            cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor
+        )
         check.opt_callable_param(error_callback, "error_callback")
 
         self.log.info("Executing query '{query}'".format(query=query))
@@ -248,7 +256,9 @@ class FakeRedshiftResource(_BaseRedshiftResource):
         """
         check.list_param(queries, "queries", of_type=str)
         check.bool_param(fetch_results, "fetch_results")
-        check.opt_class_param(cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor)
+        check.opt_class_param(
+            cursor_factory, "cursor_factory", superclass=psycopg2.extensions.cursor
+        )
         check.opt_callable_param(error_callback, "error_callback")
 
         for query in queries:


### PR DESCRIPTION
This makes a few adjustments to dagster.check functions and updates callsites appropriately.

- `type_*` checks and `subclass_*` checks condensed into `class_*` checks
- "matrix" check renamed to `two_dim_list` for consistency with existing `two_dim_dict`
- type annotations fixed/improved, in particular several `opt` checks now have overloads that provide more accurate type info
- some cosmetic tweaks (some local vars renamed for consistency, f-strings over `.format`)
- internal type alias `Type` renamed to `TypeOrTupleOfTypes` so that it doesn't clobber `typing.Type`

## Test Plan

Affected tests have been updated.
