### PR TITLE
namedtuple to NamedTuple (1st batch)

### DIFF
--- a/python_modules/automation/automation/docker/dagster_docker.py
+++ b/python_modules/automation/automation/docker/dagster_docker.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from collections import namedtuple
+from typing import Any, Callable, NamedTuple, Optional
 
 import yaml
 from dagster import check
@@ -25,7 +25,9 @@ def do_nothing(_cwd):
     yield
 
 
-class DagsterDockerImage(namedtuple("_DagsterDockerImage", "image build_cm path")):
+class DagsterDockerImage(
+    NamedTuple("_DagsterDockerImage", [("image", str), ("build_cm", Callable), ("path", str)])
+):
     """Represents a Dagster image.
 
     Properties:
@@ -35,7 +37,7 @@ class DagsterDockerImage(namedtuple("_DagsterDockerImage", "image build_cm path"
         path (Optional(str)): The path to the image's path. Defaults to docker/images/<IMAGE NAME>
     """
 
-    def __new__(cls, image, build_cm=do_nothing, path=None):
+    def __new__(cls, image: str, build_cm: Callable = do_nothing, path: Optional[str] = None):
         return super(DagsterDockerImage, cls).__new__(
             cls,
             check.str_param(image, "image"),

--- a/python_modules/automation/automation/docker/dagster_docker.py
+++ b/python_modules/automation/automation/docker/dagster_docker.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Callable, NamedTuple, Optional
 
 import yaml
 from dagster import check

--- a/python_modules/dagster/dagster/config/snap.py
+++ b/python_modules/dagster/dagster/config/snap.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from typing import Any, Dict, List, NamedTuple, Optional, Set, cast
 
 from dagster import check
@@ -196,8 +195,10 @@ class ConfigTypeSnap(
 
 
 @whitelist_for_serdes
-class ConfigEnumValueSnap(namedtuple("_ConfigEnumValueSnap", "value description")):
-    def __new__(cls, value, description):
+class ConfigEnumValueSnap(
+    NamedTuple("_ConfigEnumValueSnap", [("value", str), ("description", Optional[str])])
+):
+    def __new__(cls, value: str, description: Optional[str]):
         return super(ConfigEnumValueSnap, cls).__new__(
             cls,
             value=check.str_param(value, "value"),

--- a/python_modules/dagster/dagster/core/assets.py
+++ b/python_modules/dagster/dagster/core/assets.py
@@ -1,17 +1,17 @@
-from collections import namedtuple
+from typing import NamedTuple, Optional
 
 from dagster import check
 from dagster.serdes import deserialize_json_to_dagster_namedtuple, whitelist_for_serdes
 
 
 @whitelist_for_serdes
-class AssetDetails(namedtuple("_AssetDetails", "last_wipe_timestamp")):
+class AssetDetails(NamedTuple("_AssetDetails", [("last_wipe_timestamp", Optional[float])])):
     """
     Set of asset fields that do not change with every materialization.  These are generally updated
     on some non-materialization action (e.g. wipe)
     """
 
-    def __new__(cls, last_wipe_timestamp=None):
+    def __new__(cls, last_wipe_timestamp: Optional[float] = None):
         check.opt_float_param(last_wipe_timestamp, "last_wipe_timestamp")
         return super(AssetDetails, cls).__new__(cls, last_wipe_timestamp)
 

--- a/python_modules/dagster/dagster/core/debug.py
+++ b/python_modules/dagster/dagster/core/debug.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from typing import List, NamedTuple
 
 from dagster import check
 from dagster.core.events.log import EventLogEntry
@@ -9,18 +9,24 @@ from dagster.serdes import serialize_dagster_namedtuple, whitelist_for_serdes
 
 @whitelist_for_serdes
 class DebugRunPayload(
-    namedtuple(
+    NamedTuple(
         "_DebugRunPayload",
-        "version pipeline_run event_list pipeline_snapshot execution_plan_snapshot",
+        [
+            ("version", str),
+            ("pipeline_run", PipelineRun),
+            ("event_list", List[EventLogEntry]),
+            ("pipeline_snapshot", PipelineSnapshot),
+            ("execution_plan_snapshot", ExecutionPlanSnapshot),
+        ],
     )
 ):
     def __new__(
         cls,
-        version,
-        pipeline_run,
-        event_list,
-        pipeline_snapshot,
-        execution_plan_snapshot,
+        version: str,
+        pipeline_run: PipelineRun,
+        event_list: List[EventLogEntry],
+        pipeline_snapshot: PipelineSnapshot,
+        execution_plan_snapshot: ExecutionPlanSnapshot,
     ):
         return super(DebugRunPayload, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/core/definitions/dependency.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -262,7 +262,8 @@ class NodeHandleSerializer(DefaultNamedTupleSerializer):
 @whitelist_for_serdes(serializer=NodeHandleSerializer)
 class NodeHandle(
     # mypy does not yet support recursive types
-    namedtuple("_NodeHandle", "name parent")
+    # NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["NodeHandle"])])
+    NamedTuple("_NodeHandle", [("name", str), ("parent", Any)])
 ):
     """
     A structured object to identify nodes in the potentially recursive graph structure.

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -804,32 +804,25 @@ def _validate_in_mappings(
         solid_input_handle = SolidInputHandle(target_solid, target_input)
 
         if mapping.maps_to_fan_in:
+            maps_to = cast(FanInInputPointer, mapping.maps_to)
             if not dependency_structure.has_fan_in_deps(solid_input_handle):
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} '{name}' input mapping target "
-                    '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" (index {mapping.maps_to.fan_in_index} of fan-in) '
-                    "is not a MultiDependencyDefinition.".format(
-                        name=name, mapping=mapping, class_name=class_name
-                    )
+                    f"In {class_name} '{name}' input mapping target "
+                    f'"{maps_to.solid_name}.{maps_to.input_name}" (index {maps_to.fan_in_index} of fan-in) '
+                    f"is not a MultiDependencyDefinition."
                 )
             inner_deps = dependency_structure.get_fan_in_deps(solid_input_handle)
-            if (mapping.maps_to.fan_in_index >= len(inner_deps)) or (
-                inner_deps[mapping.maps_to.fan_in_index] is not MappedInputPlaceholder
+            if (maps_to.fan_in_index >= len(inner_deps)) or (
+                inner_deps[maps_to.fan_in_index] is not MappedInputPlaceholder
             ):
                 raise DagsterInvalidDefinitionError(
-                    "In {class_name} '{name}' input mapping target "
-                    '"{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}" index {mapping.maps_to.fan_in_index} in '
-                    "the MultiDependencyDefinition is not a MappedInputPlaceholder".format(
-                        name=name, mapping=mapping, class_name=class_name
-                    )
+                    f"In {class_name} '{name}' input mapping target "
+                    f'"{maps_to.solid_name}.{maps_to.input_name}" index {maps_to.fan_in_index} in '
+                    f"the MultiDependencyDefinition is not a MappedInputPlaceholder"
                 )
-            mapping_keys.add(
-                "{mapping.maps_to.solid_name}.{mapping.maps_to.input_name}.{mapping.maps_to.fan_in_index}".format(
-                    mapping=mapping
-                )
-            )
+            mapping_keys.add(f"{maps_to.solid_name}.{maps_to.input_name}.{maps_to.fan_in_index}")
             target_type = target_input.dagster_type.get_inner_type_for_fan_in()
-            fan_in_msg = " (index {} of fan-in)".format(mapping.maps_to.fan_in_index)
+            fan_in_msg = " (index {} of fan-in)".format(maps_to.fan_in_index)
         else:
             if dependency_structure.has_deps(solid_input_handle):
                 raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/core/definitions/hook_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/hook_definition.py
@@ -1,5 +1,4 @@
-from collections import namedtuple
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, NamedTuple, Optional
 
 from dagster import check
 
@@ -12,7 +11,15 @@ if TYPE_CHECKING:
 
 
 class HookDefinition(
-    namedtuple("_HookDefinition", "name hook_fn required_resource_keys decorated_fn")
+    NamedTuple(
+        "_HookDefinition",
+        [
+            ("name", str),
+            ("hook_fn", Callable),
+            ("required_resource_keys", AbstractSet[str]),
+            ("decorated_fn", Callable),
+        ],
+    )
 ):
     """Define a hook which can be triggered during a op execution (e.g. a callback on the step
     execution failure event during a op execution).
@@ -38,7 +45,7 @@ class HookDefinition(
             required_resource_keys=frozenset(
                 check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
             ),
-            decorated_fn=check.opt_callable_param(decorated_fn, "decorated_fn"),
+            decorated_fn=check.callable_param(decorated_fn, "decorated_fn"),
         )
 
     def __call__(self, *args, **kwargs):

--- a/python_modules/dagster/dagster/core/definitions/input.py
+++ b/python_modules/dagster/dagster/core/definitions/input.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import NamedTuple, Optional, Set
+from typing import NamedTuple, Optional, Set, Union
 
 from dagster import check
 from dagster.core.definitions.events import AssetKey
@@ -286,8 +286,8 @@ def _checked_inferred_type(inferred: InferredInputProps) -> DagsterType:
     return resolved_type
 
 
-class InputPointer(namedtuple("_InputPointer", "solid_name input_name")):
-    def __new__(cls, solid_name, input_name):
+class InputPointer(NamedTuple("_InputPointer", [("solid_name", str), ("input_name", str)])):
+    def __new__(cls, solid_name: str, input_name: str):
         return super(InputPointer, cls).__new__(
             cls,
             check.str_param(solid_name, "solid_name"),
@@ -295,8 +295,12 @@ class InputPointer(namedtuple("_InputPointer", "solid_name input_name")):
         )
 
 
-class FanInInputPointer(namedtuple("_FanInInputPointer", "solid_name input_name fan_in_index")):
-    def __new__(cls, solid_name, input_name, fan_in_index):
+class FanInInputPointer(
+    NamedTuple(
+        "_FanInInputPointer", [("solid_name", str), ("input_name", str), ("fan_in_index", int)]
+    )
+):
+    def __new__(cls, solid_name: str, input_name: str, fan_in_index: int):
         return super(FanInInputPointer, cls).__new__(
             cls,
             check.str_param(solid_name, "solid_name"),
@@ -305,7 +309,12 @@ class FanInInputPointer(namedtuple("_FanInInputPointer", "solid_name input_name 
         )
 
 
-class InputMapping(namedtuple("_InputMapping", "definition maps_to")):
+class InputMapping(
+    NamedTuple(
+        "_InputMapping",
+        [("definition", InputDefinition), ("maps_to", Union[InputPointer, FanInInputPointer])],
+    )
+):
     """Defines an input mapping for a composite solid.
 
     Args:
@@ -314,7 +323,7 @@ class InputMapping(namedtuple("_InputMapping", "definition maps_to")):
         input_name (str): The name of the input to the child solid onto which to map the input.
     """
 
-    def __new__(cls, definition, maps_to):
+    def __new__(cls, definition: InputDefinition, maps_to: Union[InputPointer, FanInInputPointer]):
         return super(InputMapping, cls).__new__(
             cls,
             check.inst_param(definition, "definition", InputDefinition),

--- a/python_modules/dagster/dagster/core/definitions/output.py
+++ b/python_modules/dagster/dagster/core/definitions/output.py
@@ -1,5 +1,4 @@
 import warnings
-from collections import namedtuple
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -309,8 +308,8 @@ class DynamicOutputDefinition(OutputDefinition):
         return True
 
 
-class OutputPointer(namedtuple("_OutputPointer", "solid_name output_name")):
-    def __new__(cls, solid_name, output_name=None):
+class OutputPointer(NamedTuple("_OutputPointer", [("solid_name", str), ("output_name", str)])):
+    def __new__(cls, solid_name: str, output_name: Optional[str] = None):
         return super(OutputPointer, cls).__new__(
             cls,
             check.str_param(solid_name, "solid_name"),
@@ -318,7 +317,9 @@ class OutputPointer(namedtuple("_OutputPointer", "solid_name output_name")):
         )
 
 
-class OutputMapping(namedtuple("_OutputMapping", "definition maps_from")):
+class OutputMapping(
+    NamedTuple("_OutputMapping", [("definition", OutputDefinition), ("maps_from", OutputPointer)])
+):
     """Defines an output mapping for a composite solid.
 
     Args:
@@ -327,7 +328,7 @@ class OutputMapping(namedtuple("_OutputMapping", "definition maps_from")):
         output_name (str): The name of the child solid's output from which to map the output.
     """
 
-    def __new__(cls, definition, maps_from):
+    def __new__(cls, definition: OutputDefinition, maps_from: OutputPointer):
         return super(OutputMapping, cls).__new__(
             cls,
             check.inst_param(definition, "definition", OutputDefinition),

--- a/python_modules/dagster/dagster/core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/resource_definition.py
@@ -7,6 +7,8 @@ from typing import (
     Callable,
     Dict,
     List,
+    Mapping,
+    NamedTuple,
     Optional,
     Union,
     cast,
@@ -335,7 +337,10 @@ class IContainsGenerator:
 
 
 class ScopedResourcesBuilder(
-    namedtuple("ScopedResourcesBuilder", "resource_instance_dict contains_generator")
+    NamedTuple(
+        "ScopedResourcesBuilder",
+        [("resource_instance_dict", Mapping[str, object]), ("contains_generator", bool)],
+    )
 ):
     """There are concepts in the codebase (e.g. ops, system storage) that receive
     only the resources that they have specified in required_resource_keys.
@@ -344,8 +349,8 @@ class ScopedResourcesBuilder(
 
     def __new__(
         cls,
-        resource_instance_dict: Optional[Dict[str, Any]] = None,
-        contains_generator: Optional[bool] = False,
+        resource_instance_dict: Optional[Mapping[str, object]] = None,
+        contains_generator: bool = False,
     ):
         return super(ScopedResourcesBuilder, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/core/definitions/run_request.py
@@ -1,5 +1,5 @@
-from collections import namedtuple
 from enum import Enum
+from typing import Any, Mapping, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.storage.pipeline_run import PipelineRun
@@ -19,7 +19,7 @@ JobType = InstigatorType
 
 
 @whitelist_for_serdes
-class SkipReason(namedtuple("_SkipReason", "skip_message")):
+class SkipReason(NamedTuple("_SkipReason", [("skip_message", Optional[str])])):
     """
     Represents a skipped evaluation, where no runs are requested. May contain a message to indicate
     why no runs were requested.
@@ -29,7 +29,7 @@ class SkipReason(namedtuple("_SkipReason", "skip_message")):
             in no requested runs.
     """
 
-    def __new__(cls, skip_message=None):
+    def __new__(cls, skip_message: Optional[str] = None):
         return super(SkipReason, cls).__new__(
             cls,
             skip_message=check.opt_str_param(skip_message, "skip_message"),
@@ -37,7 +37,17 @@ class SkipReason(namedtuple("_SkipReason", "skip_message")):
 
 
 @whitelist_for_serdes
-class RunRequest(namedtuple("_RunRequest", "run_key run_config tags job_name")):
+class RunRequest(
+    NamedTuple(
+        "_RunRequest",
+        [
+            ("run_key", Optional[str]),
+            ("run_config", Mapping[str, Any]),
+            ("tags", Mapping[str, str]),
+            ("job_name", Optional[str]),
+        ],
+    )
+):
     """
     Represents all the information required to launch a single run.  Must be returned by a
     SensorDefinition or ScheduleDefinition's evaluation function for a run to be launched.
@@ -55,18 +65,29 @@ class RunRequest(namedtuple("_RunRequest", "run_key run_config tags job_name")):
             Required for sensors that target multiple jobs.
     """
 
-    def __new__(cls, run_key, run_config=None, tags=None, job_name=None):
+    def __new__(
+        cls,
+        run_key: Optional[str],
+        run_config: Mapping[str, Any] = None,
+        tags: Mapping[str, str] = None,
+        job_name: Optional[str] = None,
+    ):
         return super(RunRequest, cls).__new__(
             cls,
             run_key=check.opt_str_param(run_key, "run_key"),
-            run_config=check.opt_dict_param(run_config, "run_config"),
-            tags=check.opt_dict_param(tags, "tags"),
+            run_config=check.opt_dict_param(run_config, "run_config", key_type=str),
+            tags=check.opt_dict_param(tags, "tags", key_type=str, value_type=str),
             job_name=check.opt_str_param(job_name, "job_name"),
         )
 
 
 @whitelist_for_serdes
-class PipelineRunReaction(namedtuple("_PipelineRunReaction", "pipeline_run error")):
+class PipelineRunReaction(
+    NamedTuple(
+        "_PipelineRunReaction",
+        [("pipeline_run", Optional[PipelineRun]), ("error", Optional[SerializableErrorInfo])],
+    )
+):
     """
     Represents a request that reacts to an existing pipeline run. If success, it will report logs
     back to the run.
@@ -76,7 +97,9 @@ class PipelineRunReaction(namedtuple("_PipelineRunReaction", "pipeline_run error
         error (Optional[SerializableErrorInfo]): user code execution error.
     """
 
-    def __new__(cls, pipeline_run, error=None):
+    def __new__(
+        cls, pipeline_run: Optional[PipelineRun], error: Optional[SerializableErrorInfo] = None
+    ):
         return super(PipelineRunReaction, cls).__new__(
             cls,
             pipeline_run=check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun),

--- a/python_modules/dagster/dagster/core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/core/execution/context/hook.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, Optional, Set, Union
+from typing import AbstractSet, Any, Dict, Optional, Set, Union
 
 from dagster import check
 
@@ -116,7 +116,7 @@ class HookContext:
         return self._step_execution_context.mode_def
 
     @property
-    def required_resource_keys(self) -> Set[str]:
+    def required_resource_keys(self) -> AbstractSet[str]:
         return self._required_resource_keys
 
     @property
@@ -360,7 +360,7 @@ class BoundHookContext(HookContext):
         return self._mode_def
 
     @property
-    def required_resource_keys(self) -> Set[str]:
+    def required_resource_keys(self) -> AbstractSet[str]:
         return self._hook_def.required_resource_keys
 
     @property

--- a/python_modules/dagster/dagster/core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/core/storage/runs/migration.py
@@ -50,7 +50,7 @@ def chunked_run_iterator(storage, print_fn=None, chunk_size=RUN_CHUNK_SIZE):
                 yield run
 
             if progress:
-                progress.update(len(chunk))
+                progress.update(len(chunk))  # pylint: disable=no-member
 
 
 def chunked_run_records_iterator(storage, print_fn=None, chunk_size=RUN_CHUNK_SIZE):
@@ -73,7 +73,7 @@ def chunked_run_records_iterator(storage, print_fn=None, chunk_size=RUN_CHUNK_SI
                 yield run
 
             if progress:
-                progress.update(len(chunk))
+                progress.update(len(chunk))  # pylint: disable=no-member
 
 
 def migrate_run_partition(storage, print_fn=None):


### PR DESCRIPTION
This is batch 1 of dagster-wide `namedtuple` > `NamedTuple` (i.e. typed version) conversion. Carrying this out using an experimental interactive refactoring tool that reads `check` calls to infer type annotations, updates the code accordingly, and allows user to edit the result to handle edge cases. `namedtuple > NamedTuple` is a pilot case but this can be used wherever we have unannotated functions that include `check` calls.

There are a few assorted other changes, which were required to pass `mypy` after adding the annotations.
