### PR TITLE
[oss telemetry] Get rid of telemetry version

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -263,7 +263,6 @@ def test_dagit_logs(_, caplog):
                         "python_version",
                         "run_storage_id",
                         "metadata",
-                        "version",
                         "dagster_version",
                         "os_desc",
                         "os_platform",

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -47,7 +47,6 @@ DAEMON_ALIVE = "daemon_alive"
 SCHEDULED_RUN_CREATED = "scheduled_run_created"
 SENSOR_RUN_CREATED = "sensor_run_created"
 BACKFILL_RUN_CREATED = "backfill_run_created"
-TELEMETRY_VERSION = "0.2"
 OS_DESC = platform.platform()
 OS_PLATFORM = platform.system()
 
@@ -138,7 +137,6 @@ class TelemetryEntry(
             ("instance_id", str),
             ("metadata", Dict[str, str]),
             ("python_version", str),
-            ("version", str),
             ("dagster_version", str),
             ("os_desc", str),
             ("os_platform", str),
@@ -196,7 +194,6 @@ class TelemetryEntry(
             instance_id=instance_id,
             python_version=get_python_version(),
             metadata=metadata,
-            version=TELEMETRY_VERSION,
             dagster_version=dagster_module_version,
             os_desc=OS_DESC,
             os_platform=OS_PLATFORM,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -26,7 +26,6 @@ EXPECTED_KEYS = set(
         "run_storage_id",
         "python_version",
         "metadata",
-        "version",
         "os_desc",
         "os_platform",
         "dagster_version",


### PR DESCRIPTION
We currently use telemetry version to tell us what the valid columns to expect from a given row of telemetry data. However, we can do the same thing with dagster version, which wouldn't require us to manually bump a number in the code base (prone to human error).