### PR TITLE
[dagit] Add small toggles to Asset Details graphs, consolidate localStorage-backed state

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import {getJSONForKey} from '../hooks/useStateWithStorage';
+
 // Internal LocalStorage data format and mutation helpers
 
 export interface IStorageData {
@@ -114,18 +116,6 @@ function getKey(namespace: string) {
   return `dagit.v2.${namespace}`;
 }
 
-export function getJSONForKey(key: string) {
-  try {
-    const jsonString = window.localStorage.getItem(key);
-    if (jsonString) {
-      return JSON.parse(jsonString);
-    }
-  } catch (err) {
-    // noop
-  }
-  return undefined;
-}
-
 function getStorageDataForNamespace(namespace: string, initial: Partial<IExecutionSession> = {}) {
   if (_data && _dataNamespace === namespace) {
     return _data;
@@ -163,7 +153,7 @@ current localStorage namespace in memory (in _data above) and React keeps a simp
 version flag it can use to trigger a re-render after changes are saved, so changing
 namespaces changes the returned data immediately.
 */
-export function useStorage(
+export function useExecutionSessionStorage(
   repositoryName: string,
   pipelineName: string,
   initial: Partial<IExecutionSession> = {},

--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -1,7 +1,7 @@
 import memoize from 'lodash/memoize';
 import * as React from 'react';
 
-import {getJSONForKey} from './LocalStorage';
+import {getJSONForKey} from '../hooks/useStateWithStorage';
 
 const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 

--- a/js_modules/dagit/packages/core/src/app/time/TimezoneContext.tsx
+++ b/js_modules/dagit/packages/core/src/app/time/TimezoneContext.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
 
+import {useStateWithStorage} from '../../hooks/useStateWithStorage';
+
 const TimezoneStorageKey = 'TimezonePreference';
 
-type Value = [string, (next: string) => void];
+export const TimezoneContext = React.createContext<
+  [string, React.Dispatch<React.SetStateAction<string | undefined>>]
+>(['UTC', () => '']);
 
-export const TimezoneContext = React.createContext<Value>(['UTC', () => {}]);
+const validateTimezone = (saved: string | undefined) =>
+  typeof saved === 'string' ? saved : 'Automatic';
 
 export const TimezoneProvider: React.FC = (props) => {
-  const [value, setValue] = React.useState(
-    () => window.localStorage.getItem(TimezoneStorageKey) || 'Automatic',
-  );
+  const state = useStateWithStorage(TimezoneStorageKey, validateTimezone);
 
-  const onChange = React.useCallback((tz: string) => {
-    window.localStorage.setItem(TimezoneStorageKey, tz);
-    setValue(tz);
-  }, []);
-
-  const provided: Value = React.useMemo(() => [value, onChange], [value, onChange]);
-
-  return <TimezoneContext.Provider value={provided}>{props.children}</TimezoneContext.Provider>;
+  return <TimezoneContext.Provider value={state}>{props.children}</TimezoneContext.Provider>;
 };

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -8,6 +8,7 @@ import {
   Caption,
   Subheading,
   Warning,
+  Checkbox,
 } from '@dagster-io/ui';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
@@ -15,6 +16,7 @@ import qs from 'qs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {titleForRun} from '../runs/RunUtils';
@@ -387,6 +389,8 @@ export const AssetEvents: React.FC<Props> = ({
   );
 };
 
+const validateHiddenGraphsState = (json: string[]) => (Array.isArray(json) ? json : []);
+
 const AssetMaterializationGraphs: React.FC<{
   groups: AssetEventGroup[];
   xAxis: 'partition' | 'time';
@@ -399,7 +403,21 @@ const AssetMaterializationGraphs: React.FC<{
   }, [props.groups]);
 
   const graphDataByMetadataLabel = extractNumericData(reversed, props.xAxis);
-  const [graphedLabels] = React.useState(() => Object.keys(graphDataByMetadataLabel).slice(0, 4));
+  const graphLabels = Object.keys(graphDataByMetadataLabel).slice(0, 20).sort();
+
+  const [collapsedLabels, setCollapsedLabels] = useStateWithStorage(
+    'hidden-graphs',
+    validateHiddenGraphsState,
+  );
+
+  const toggleCollapsed = React.useCallback(
+    (label: string) => {
+      setCollapsedLabels((current = []) =>
+        current.includes(label) ? current.filter((c) => c !== label) : [...current, label],
+      );
+    },
+    [setCollapsedLabels],
+  );
 
   return (
     <>
@@ -411,37 +429,52 @@ const AssetMaterializationGraphs: React.FC<{
           flexDirection: 'column',
         }}
       >
-        {[...graphedLabels].sort().map((label) => (
+        {graphLabels.map((label) => (
           <Box
             key={label}
             style={{width: '100%'}}
             border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
           >
             {props.asSidebarSection ? (
-              <Box padding={{horizontal: 24, top: 8}}>
+              <Box padding={{horizontal: 24, top: 8}} flex={{justifyContent: 'space-between'}}>
                 <Caption style={{fontWeight: 700}}>{label}</Caption>
+                <Checkbox
+                  format="switch"
+                  checked={!collapsedLabels.includes(label)}
+                  onChange={() => toggleCollapsed(label)}
+                  size="small"
+                />
               </Box>
             ) : (
               <Box
                 padding={{horizontal: 24, vertical: 16}}
                 border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
+                flex={{justifyContent: 'space-between'}}
               >
                 <Subheading>{label}</Subheading>
+                <Checkbox
+                  format="switch"
+                  checked={!collapsedLabels.includes(label)}
+                  onChange={() => toggleCollapsed(label)}
+                  size="small"
+                />
               </Box>
             )}
-            <Box padding={{horizontal: 24, vertical: 16}}>
-              <AssetValueGraph
-                label={label}
-                width="100%"
-                data={graphDataByMetadataLabel[label]}
-                xHover={xHover}
-                onHoverX={(x) => x !== xHover && setXHover(x)}
-              />
-            </Box>
+            {!collapsedLabels.includes(label) ? (
+              <Box padding={{horizontal: 24, vertical: 16}}>
+                <AssetValueGraph
+                  label={label}
+                  width="100%"
+                  data={graphDataByMetadataLabel[label]}
+                  xHover={xHover}
+                  onHoverX={(x) => x !== xHover && setXHover(x)}
+                />
+              </Box>
+            ) : undefined}
           </Box>
         ))}
       </div>
-      {graphedLabels.length === 0 ? (
+      {graphLabels.length === 0 ? (
         <Box padding={{horizontal: 24, top: 64}}>
           <NonIdealState
             shrinkable

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -143,7 +143,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
             style={{height: 390}}
             flex={{direction: 'row', justifyContent: 'center', alignItems: 'center'}}
           >
-            <Spinner purpose="section" />
+            <Spinner purpose="page" />
           </Box>
         ) : params.asOf ? (
           <Box

--- a/js_modules/dagit/packages/core/src/assets/useAssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/useAssetView.tsx
@@ -1,24 +1,14 @@
-import * as React from 'react';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
 const ASSET_VIEW_KEY = 'AssetViewPreference';
 
 type View = 'flat' | 'directory' | 'graph';
 
-type Output = [View, (update: View) => void];
+const validateSavedAssetView = (storedValue: any) =>
+  storedValue === 'flat' || storedValue === 'directory' || storedValue === 'graph'
+    ? storedValue
+    : 'flat';
 
 export const useAssetView = () => {
-  const [view, setView] = React.useState<View>(() => {
-    const storedValue = window.localStorage.getItem(ASSET_VIEW_KEY);
-    if (storedValue === 'flat' || storedValue === 'directory' || storedValue === 'graph') {
-      return storedValue;
-    }
-    return 'flat';
-  });
-
-  const onChange = React.useCallback((update: View) => {
-    window.localStorage.setItem(ASSET_VIEW_KEY, update);
-    setView(update);
-  }, []);
-
-  return React.useMemo(() => [view, onChange], [view, onChange]) as Output;
+  return useStateWithStorage<View>(ASSET_VIEW_KEY, validateSavedAssetView);
 };

--- a/js_modules/dagit/packages/core/src/gantt/useGanttChartMode.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/useGanttChartMode.tsx
@@ -1,28 +1,16 @@
-import * as React from 'react';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
 import {GanttChartMode} from './Constants';
 
 const GANTT_CHART_MODE_KEY = 'GanttChartModePreference';
 
-type Output = [GanttChartMode, (update: GanttChartMode) => void];
+const validateSavedMode = (storedValue: string) =>
+  storedValue === GanttChartMode.FLAT ||
+  storedValue === GanttChartMode.WATERFALL ||
+  storedValue === GanttChartMode.WATERFALL_TIMED
+    ? storedValue
+    : GanttChartMode.WATERFALL_TIMED;
 
 export const useGanttChartMode = () => {
-  const [mode, setMode] = React.useState<GanttChartMode>(() => {
-    const storedValue = window.localStorage.getItem(GANTT_CHART_MODE_KEY);
-    if (
-      storedValue === GanttChartMode.FLAT ||
-      storedValue === GanttChartMode.WATERFALL ||
-      storedValue === GanttChartMode.WATERFALL_TIMED
-    ) {
-      return storedValue;
-    }
-    return GanttChartMode.WATERFALL_TIMED;
-  });
-
-  const onChange = React.useCallback((update: GanttChartMode) => {
-    window.localStorage.setItem(GANTT_CHART_MODE_KEY, update);
-    setMode(update);
-  }, []);
-
-  return React.useMemo(() => [mode, onChange], [mode, onChange]) as Output;
+  return useStateWithStorage(GANTT_CHART_MODE_KEY, validateSavedMode);
 };

--- a/js_modules/dagit/packages/core/src/hooks/useStateWithStorage.tsx
+++ b/js_modules/dagit/packages/core/src/hooks/useStateWithStorage.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export function getJSONForKey(key: string) {
+  let stored = undefined;
+  try {
+    stored = window.localStorage.getItem(key);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (err) {
+    if (typeof stored === 'string') {
+      // With useStateWithStorage, some values like timezone are moving from `UTC` to `"UTC"`
+      // in LocalStorage. To read the old values, pass through raw string values. We can
+      // remove this a few months after 0.14.1 is released.
+      return stored;
+    }
+    return undefined;
+  }
+}
+
+export function useStateWithStorage<T>(key: string, validate: (json: any) => T) {
+  const [version, setVersion] = React.useState(0);
+
+  // Note: This hook doesn't keep the loaded data in state -- instead it uses a version bit and
+  // a ref to load the value from localStorage when the `key` changes or when the `version` changes.
+  // This allows us to immediately return the saved value for `key` in the same render.
+
+  const state = React.useMemo(() => {
+    return validate(getJSONForKey(key));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [validate, key, version]);
+
+  const setState = React.useCallback(
+    (input: React.SetStateAction<T>) => {
+      const next = input instanceof Function ? input(validate(getJSONForKey(key))) : input;
+      if (next === undefined) {
+        window.localStorage.removeItem(key);
+      } else {
+        window.localStorage.setItem(key, JSON.stringify(next));
+      }
+      setVersion((v) => v + 1);
+      return next;
+    },
+    [validate, key],
+  );
+
+  const value = React.useMemo(() => [state, setState], [state, setState]);
+  return value as [T, React.Dispatch<React.SetStateAction<T | undefined>>];
+}

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -17,7 +17,7 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {IExecutionSession} from '../app/LocalStorage';
+import {IExecutionSession} from '../app/ExecutionSessionStorage';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -20,8 +20,8 @@ import {
   IExecutionSessionChanges,
   PipelineRunTag,
   SessionBase,
-  useStorage,
-} from '../app/LocalStorage';
+  useExecutionSessionStorage,
+} from '../app/ExecutionSessionStorage';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {ConfigEditor} from '../configeditor/ConfigEditor';
@@ -163,7 +163,11 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
     return {};
   }, [isJob, partitionSets.results, presets]);
 
-  const [data, onSave] = useStorage(repoAddress.name || '', pipeline.name, initialDataForMode);
+  const [data, onSave] = useExecutionSessionStorage(
+    repoAddress.name || '',
+    pipeline.name,
+    initialDataForMode,
+  );
 
   const currentSession = data.sessions[data.current];
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupRoot.tsx
@@ -2,7 +2,11 @@ import qs from 'qs';
 import * as React from 'react';
 import {Redirect, useParams} from 'react-router-dom';
 
-import {IExecutionSession, applyCreateSession, useStorage} from '../app/LocalStorage';
+import {
+  IExecutionSession,
+  applyCreateSession,
+  useExecutionSessionStorage,
+} from '../app/ExecutionSessionStorage';
 import {usePermissions} from '../app/Permissions';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
 import {useJobTitle} from '../pipelines/useJobTitle';
@@ -37,7 +41,7 @@ const LaunchpadSetupAllowedRoot: React.FC<Props> = (props) => {
 
   useJobTitle(explorerPath, isJob);
 
-  const [data, onSave] = useStorage(repoAddress.name, pipelineName);
+  const [data, onSave] = useExecutionSessionStorage(repoAddress.name, pipelineName);
   const queryString = qs.parse(window.location.search, {ignoreQueryPrefix: true});
 
   React.useEffect(() => {

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadTabs.tsx
@@ -8,7 +8,7 @@ import {
   applyRemoveSession,
   applySelectSession,
   IStorageData,
-} from '../app/LocalStorage';
+} from '../app/ExecutionSessionStorage';
 
 interface ExecutationTabProps {
   canRemove?: boolean;

--- a/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
@@ -13,7 +13,7 @@ import {
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {PipelineRunTag} from '../app/LocalStorage';
+import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {RunTag} from '../runs/RunTag';
 

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -3,7 +3,7 @@ import {Intent} from '@blueprintjs/core';
 import * as React from 'react';
 
 import {SharedToaster} from '../app/DomUtils';
-import {useInvalidateConfigsForRepo} from '../app/LocalStorage';
+import {useInvalidateConfigsForRepo} from '../app/ExecutionSessionStorage';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
 import {RepositoryLocationLoadStatus} from '../types/globalTypes';

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -19,8 +19,8 @@ import styled from 'styled-components/macro';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {SharedToaster} from '../app/DomUtils';
+import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {filterByQuery} from '../app/GraphQueryImpl';
-import {PipelineRunTag} from '../app/LocalStorage';
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {GanttChartMode} from '../gantt/GanttChart';
 import {buildLayout} from '../gantt/GanttChartLayout';

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarComponents.tsx
@@ -3,6 +3,8 @@ import {ColorsWIP, IconWIP, FontFamily} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
 interface ISidebarSectionProps {
   title: string;
   collapsedByDefault?: boolean;
@@ -10,22 +12,13 @@ interface ISidebarSectionProps {
 
 export const SidebarSection: React.FC<ISidebarSectionProps> = (props) => {
   const {title, collapsedByDefault, children} = props;
-  const storageKey = `sidebar-${title}`;
-
-  const [open, setOpen] = React.useState(() => {
-    const stored = window.localStorage.getItem(storageKey);
-    if (stored === 'true' || stored === 'false') {
-      return stored === 'true';
-    }
-    return !collapsedByDefault;
-  });
+  const [open, setOpen] = useStateWithStorage<boolean>(`sidebar-${title}`, (storedValue) =>
+    storedValue === true || storedValue === false ? storedValue : !collapsedByDefault,
+  );
 
   const onToggle = React.useCallback(() => {
-    setOpen((current) => {
-      window.localStorage.setItem(storageKey, `${!current}`);
-      return !current;
-    });
-  }, [storageKey]);
+    setOpen((o) => !o);
+  }, [setOpen]);
 
   return (
     <>

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
@@ -2,7 +2,7 @@ import {ColorsWIP} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {getJSONForKey} from '../app/LocalStorage';
+import {getJSONForKey} from '../hooks/useStateWithStorage';
 
 const ColumnWidthsStorageKey = 'ColumnWidths';
 const ColumnWidths = Object.assign(

--- a/js_modules/dagit/packages/core/src/workspace/useReloadWorkspace.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/useReloadWorkspace.tsx
@@ -2,7 +2,7 @@ import {gql, useApolloClient, useMutation} from '@apollo/client';
 import * as React from 'react';
 
 import {SharedToaster} from '../app/DomUtils';
-import {useInvalidateConfigsForRepo} from '../app/LocalStorage';
+import {useInvalidateConfigsForRepo} from '../app/ExecutionSessionStorage';
 import {PYTHON_ERROR_FRAGMENT, UNAUTHORIZED_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 
 import {


### PR DESCRIPTION

## Summary
This PR adds a small switch to the right of each graph on the asset details page, restoring behavior from 0.13.x allowing them to be toggled on and off.

The state is persisted based on the metadata label, so hiding "Boring Datapoint" for asset 1 also hides it for asset 2.

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/1037212/155230148-1177c7e7-91e9-4db8-aa0e-5fea259e4490.png">

This PR also consolidates places in Dagit we've implemented "useState, but with local storage for remembering selection" into a single hook. Have been meaning to do this for a while. This hook should probably get more advanced at some point - it does not currently sync if you useStateWithStorage in 2+ places with the same key on the same page.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.