### PR TITLE
[dagit] Show full asset paths on details pages, tweak filter interactions

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -7,18 +7,14 @@ import styled from 'styled-components/macro';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {RepoAddress} from '../workspace/types';
 
-import {useAssetView} from './useAssetView';
-
 type Props = {assetKey: {path: string[]}; repoAddress: RepoAddress | null} & Partial<
   React.ComponentProps<typeof PageHeader>
 >;
 
 export const AssetPageHeader: React.FC<Props> = ({assetKey, repoAddress, ...extra}) => {
-  const [view] = useAssetView();
-
   const breadcrumbs = React.useMemo(() => {
-    if (assetKey.path.length === 1 || view !== 'directory') {
-      return null;
+    if (assetKey.path.length === 1) {
+      return [{text: assetKey.path[0], href: '/instance/assets'}];
     }
 
     const list: BreadcrumbProps[] = [];
@@ -29,29 +25,22 @@ export const AssetPageHeader: React.FC<Props> = ({assetKey, repoAddress, ...extr
     }, '/instance/assets');
 
     return list;
-  }, [assetKey.path, view]);
+  }, [assetKey.path]);
 
   return (
     <PageHeader
       title={
-        view !== 'directory' || !breadcrumbs ? (
-          <Heading>{assetKey.path[assetKey.path.length - 1]}</Heading>
-        ) : (
-          <Box
-            flex={{alignItems: 'center', gap: 4}}
-            style={{maxWidth: '600px', overflow: 'hidden'}}
-          >
-            <Breadcrumbs
-              items={breadcrumbs}
-              breadcrumbRenderer={({text, href}) => (
-                <Heading>
-                  <BreadcrumbLink to={href || '#'}>{text}</BreadcrumbLink>
-                </Heading>
-              )}
-              currentBreadcrumbRenderer={({text}) => <Heading>{text}</Heading>}
-            />
-          </Box>
-        )
+        <Box flex={{alignItems: 'center', gap: 4}} style={{maxWidth: '600px', overflow: 'hidden'}}>
+          <Breadcrumbs
+            items={breadcrumbs}
+            breadcrumbRenderer={({text, href}) => (
+              <Heading>
+                <BreadcrumbLink to={href || '#'}>{text}</BreadcrumbLink>
+              </Heading>
+            )}
+            currentBreadcrumbRenderer={({text}) => <Heading>{text}</Heading>}
+          />
+        </Box>
       }
       tags={
         repoAddress ? (

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -41,12 +41,18 @@ export const AssetsCatalogTable: React.FC<{prefixPath?: string[]}> = ({prefixPat
 
   const setView = (view: 'flat' | 'graph' | 'directory') => {
     _setView(view);
-    if (view === 'flat' && prefixPath) {
+    if (view === 'flat' && prefixPath.length) {
       history.push('/instance/assets');
     } else if (cursor) {
       setCursor(undefined);
     }
   };
+
+  React.useEffect(() => {
+    if (view === 'flat' && prefixPath.length) {
+      _setView('directory');
+    }
+  }, [view, _setView, prefixPath]);
 
   const assetsQuery = useQuery<AssetCatalogTableQuery>(ASSET_CATALOG_TABLE_QUERY, {
     notifyOnNetworkStatusChange: true,
@@ -112,7 +118,7 @@ export const AssetsCatalogTable: React.FC<{prefixPath?: string[]}> = ({prefixPat
                     <AssetViewModeSwitch view={view} setView={setView} />
                     <RepoFilterButton />
                     <TextInput
-                      value={search}
+                      value={search || ''}
                       style={{width: '30vw', minWidth: 150, maxWidth: 400}}
                       placeholder="Search all asset_keys..."
                       onChange={(e: React.ChangeEvent<any>) => setSearch(e.target.value)}


### PR DESCRIPTION
## Summary
This PR resolves https://github.com/dagster-io/dagster/issues/6412 and changes a few other interactions

- The asset details page now shows the full asset path all the time using the new "display" styling, which happens to match the breadcrumb display (`foo > bar`). Previously in `list` asset catalog mode, it only showed `bar` which I believe was a bug we introduced in the 0.14.0 work.

- Clicking "foo" in the "foo > bar" example now takes you to the asset catalog page and *switches the view mode* to show you all the assets with the foo prefix. Previously in `list` asset catalog mode, these breadcrumbs weren't clickable. I think switching the view mode when you click a breadcrumb might be a good way to introduce people to the feature.

- If you type a search filter into the asset catalog in list mode and click to folder mode, your search filter is now preserved properly.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.