### PR TITLE
[Dagit] Fix graph in op sidebar overflowing, asset sidebar missing op name

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetValueGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetValueGraph.tsx
@@ -20,6 +20,7 @@ export interface AssetValueGraphData {
 export const AssetValueGraph: React.FC<{
   label: string;
   width: string;
+  yAxisLabel?: string;
   data: AssetValueGraphData;
   xHover: string | number | null;
   onHoverX: (value: string | number | null) => void;
@@ -86,7 +87,7 @@ export const AssetValueGraph: React.FC<{
               },
             }),
       },
-      y: {id: 'y', display: true, title: {display: true, text: 'Value'}},
+      y: {id: 'y', display: true, title: {display: true, text: props.yAxisLabel || 'Value'}},
     },
     plugins: {
       legend: {

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -79,12 +79,13 @@ export const SidebarOpExecutionGraphs: React.FC<{
   return (
     <>
       <SidebarSection title="Execution Time">
-        <Box flex={{alignItems: 'center', justifyContent: 'center'}} style={{height: 170}}>
+        <Box flex={{alignItems: 'center', justifyContent: 'center'}}>
           {result.loading ? (
             <Spinner purpose="section" />
           ) : (
             <AssetValueGraph
               label="Step Execution Time"
+              yAxisLabel="Seconds"
               width="100%"
               data={executionTime}
               xHover={highlightedStartTime}

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -130,6 +130,7 @@ const Header: React.FC<{assetKey: AssetKey; opName?: string}> = ({assetKey, opNa
         {displayName !== opName ? (
           <Box style={{opacity: 0.5}} flex={{gap: 6, alignItems: 'center'}}>
             <IconWIP name="op" size={16} />
+            {opName}
           </Box>
         ) : undefined}
       </SidebarTitle>


### PR DESCRIPTION
## Summary

- The "Step Execution Time" graph can expand beyond it's bounds because we actually can't limit it's height. (https://github.com/dagster-io/dagster/projects/8. This PR removes the fixed height on the section so the graph does not overflow the section.

- The "Step Execution Time" graph now has a "Seconds" y-axis label

- The asset sidebar now shows the name of the op if the op name is not the same as the asset name. This must have been removed when we merged the 0.14.0 work together.

(Label in gray shown below)

<img width="536" alt="image" src="https://user-images.githubusercontent.com/1037212/155239095-3b2332f4-7592-4d77-9196-cd7e8ff4dfb8.png">


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.