### PR TITLE
[docs infra] speed up vercel build with ISR

### DIFF
--- a/docs/next/pages/[...page].tsx
+++ b/docs/next/pages/[...page].tsx
@@ -393,7 +393,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
           githubLink,
         },
       },
-      revalidate: 60, // In seconds; This enables Incremental Static Regeneration
+      revalidate: 600, // In seconds; This enables Incremental Static Regeneration
     };
   } catch (err) {
     console.error(err);

--- a/docs/next/pages/[...page].tsx
+++ b/docs/next/pages/[...page].tsx
@@ -11,7 +11,7 @@ import Link from "../components/Link";
 import { MdxRemote } from "next-mdx-remote/types";
 import { NextSeo } from "next-seo";
 import SidebarNavigation, { getItems } from "components/mdx/SidebarNavigation";
-import { allPaths } from "util/useNavigation";
+import { latestAllPaths } from "util/useNavigation";
 import { promises as fs } from "fs";
 import generateToc from "mdast-util-toc";
 import hydrate from "next-mdx-remote/hydrate";
@@ -393,7 +393,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
           githubLink,
         },
       },
-      revalidate: 10, // In seconds
+      revalidate: 60, // In seconds; This enables Incremental Static Regeneration
     };
   } catch (err) {
     console.error(err);
@@ -405,7 +405,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 export function getStaticPaths({}) {
   return {
-    paths: allPaths(),
+    paths: latestAllPaths(), // only generate pages of latest version at build time
     fallback: true,
   };
 }

--- a/docs/next/util/useNavigation.ts
+++ b/docs/next/util/useNavigation.ts
@@ -1,5 +1,5 @@
 import masterNavigation from "../../content/_navigation.json";
-import { useVersion } from "./useVersion";
+import { useVersion, latestVersion } from "./useVersion";
 import versionedNavigation from "../.versioned_content/_versioned_navigation.json";
 
 export function flatten(yx: any) {
@@ -26,8 +26,8 @@ export const useNavigation = () => {
 };
 
 export const latestAllPaths = () => {
-  // Master
-  return flatten(masterNavigation)
+  // latest version
+  return flatten(versionedNavigation[latestVersion])
     .filter((n: { path: any }) => n.path)
     .map(({ path }) => path.split("/").splice(1))
     .map((page: string[]) => {

--- a/docs/next/util/useVersion.ts
+++ b/docs/next/util/useVersion.ts
@@ -7,7 +7,7 @@ const defaultVersion =
   process.env.NODE_ENV === "production"
     ? ALL_VERSIONS[ALL_VERSIONS.length - 1]
     : "master";
-const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
+export const latestVersion = ALL_VERSIONS[ALL_VERSIONS.length - 1];
 
 export function normalizeVersionPath(
   asPath: string,


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Start using [Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration) to speed up build time. What it does is to only build a small part of the site (latest version) at the build time and generate the rest on the server side.

Pros: reduce build time from 30-40 mins to 2-3 mins.
Cons: it could slow down the site perf for master and older versions.


## Test Plan
- build time: 
  * now: ~2m https://vercel.com/elementl/dagster/Ly3DHNJJZzmmruHkxJNAmjC61G5S
  * status quo: ~30m https://vercel.com/elementl/dagster/5wm3hjG9PsAngSwb3t3SsPoTaF4m
- run time: the loading time for latest version (the default version users will be on) isn't affected because we build static pages for that version, the older versions do get affected because they will be generated on the sever side instead of being pre-built.  The following measurement isn't scientific at all (i only curl'ed the page once) but i feel it's fine to proceed because 1) the downside isn't too bad 2) most users are looking at the default version.
  * now: https://gist.github.com/yuhan/284d9d1370df2f6cd711feba4f1a6544#file-gistfile1-txt-L30 
  * status quo: https://gist.github.com/yuhan/0fc7d6a336c18daee29e55bcb04a9d17