### PR TITLE
display non-sda assets in asset catalog

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -177,14 +177,18 @@ const AssetEntryRow: React.FC<{
       <td>
         {asset ? (
           <Box flex={{gap: 8, alignItems: 'center'}}>
-            <Link
-              to={instanceAssetsExplorerPathToURL({
-                opsQuery: `++"${tokenForAssetKey({path})}"++`,
-                opNames: [tokenForAssetKey({path})],
-              })}
-            >
-              <ButtonWIP disabled={!asset.definition?.opName}>View in Asset Graph</ButtonWIP>
-            </Link>
+            {asset.definition?.opName ? (
+              <Link
+                to={instanceAssetsExplorerPathToURL({
+                  opsQuery: `++"${tokenForAssetKey({path})}"++`,
+                  opNames: [tokenForAssetKey({path})],
+                })}
+              >
+                <ButtonWIP>View in Asset Graph</ButtonWIP>
+              </Link>
+            ) : (
+              <ButtonWIP disabled={true}>View in Asset Graph</ButtonWIP>
+            )}
             <Popover
               position="bottom-right"
               content={

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -230,7 +230,7 @@ const filterAssetsToRepos = (assets: Asset[], visibleRepos: DagsterRepoOption[])
   );
   return assets.filter(
     (a) =>
-      a.definition &&
+      !a.definition ||
       visibleRepoHashes.includes(
         buildRepoPath(a.definition.repository.name, a.definition.repository.location.name),
       ),


### PR DESCRIPTION
## Summary
The filtering logic was a bit off.  Also, disabled the graph link button in the table for non-SDA assets



## Test Plan
Added subset of repositories, saw non-SDA assets in the catalog.



