### PR TITLE
fix: use run status to determine success for an in-process result

### DIFF
--- a/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/core/execution/execute_in_process_result.py
@@ -37,7 +37,7 @@ class ExecuteInProcessResult:
     @property
     def success(self) -> bool:
         """bool: Whether execution was successful."""
-        return all([not event.is_failure for event in self._event_list])
+        return self._dagster_run.is_success
 
     @property
     def all_node_events(self) -> List[DagsterEvent]:

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
@@ -279,3 +279,29 @@ def test_asset_observation():
     assert result.asset_observations_for_node("my_op") == [
         AssetObservation(asset_key=AssetKey(["abc"]))
     ]
+
+
+def test_dagster_run():
+    @op
+    def success_op():
+        return True
+
+    @job
+    def my_success_job():
+        success_op()
+
+    result = my_success_job.execute_in_process()
+    assert result.success
+    assert result.dagster_run.is_success
+
+    @op
+    def fail_op():
+        raise Exception
+
+    @job
+    def my_failure_job():
+        fail_op()
+
+    result = my_failure_job.execute_in_process(raise_on_error=False)
+    assert not result.success
+    assert not result.dagster_run.is_success


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Ran into this in internal - I expected the run from the execution result to have the correct run status, but it was returning `NOT_STARTED`. 

Just for consistency, put the correct status on the run.


## Test Plan
pytest
