### PR TITLE
add a blank state message for the asset table

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -97,20 +97,24 @@ export const AssetTable = ({
           </tr>
         </thead>
         <tbody>
-          {pageDisplayPathKeys.map((pathStr, idx) => {
-            return (
-              <AssetEntryRow
-                key={idx}
-                prefixPath={prefixPath}
-                path={JSON.parse(pathStr)}
-                assets={assetGroups[pathStr] || []}
-                isSelected={checkedPaths.has(pathStr)}
-                onToggleChecked={onToggleFactory(pathStr)}
-                onWipe={(assets: Asset[]) => setToWipe(assets.map((asset) => asset.key))}
-                canWipe={canWipeAssets}
-              />
-            );
-          })}
+          {pageDisplayPathKeys.length ? (
+            pageDisplayPathKeys.map((pathStr, idx) => {
+              return (
+                <AssetEntryRow
+                  key={idx}
+                  prefixPath={prefixPath}
+                  path={JSON.parse(pathStr)}
+                  assets={assetGroups[pathStr] || []}
+                  isSelected={checkedPaths.has(pathStr)}
+                  onToggleChecked={onToggleFactory(pathStr)}
+                  onWipe={(assets: Asset[]) => setToWipe(assets.map((asset) => asset.key))}
+                  canWipe={canWipeAssets}
+                />
+              );
+            })
+          ) : (
+            <AssetEmptyRow />
+          )}
         </tbody>
       </Table>
       <AssetWipeDialog
@@ -121,6 +125,18 @@ export const AssetTable = ({
         requery={requery}
       />
     </Box>
+  );
+};
+
+const AssetEmptyRow = () => {
+  return (
+    <tr>
+      <td colSpan={4}>
+        <Box flex={{justifyContent: 'center', alignItems: 'center'}}>
+          <Box margin={{left: 8}}>No assets to display</Box>
+        </Box>
+      </td>
+    </tr>
   );
 };
 


### PR DESCRIPTION
## Summary
The empty state when there are no assets to display looks broken at the moment. 

![Screen Shot 2022-02-24 at 11 48 26 AM](https://user-images.githubusercontent.com/1040172/155596739-80ad4154-3c48-409b-a83f-eef728fd79ca.png)


## Test Plan
Applied filter, saw blank state message
