### PR TITLE
[dagit] Add "View as op graph" option to instance-wide asset graph

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/InstanceAssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/assets/InstanceAssetGraphExplorer.tsx
@@ -14,6 +14,7 @@ import {AssetGraphQuery_assetNodes} from '../workspace/asset-graph/types/AssetGr
 import {buildRepoPath} from '../workspace/buildRepoAddress';
 
 import {AssetViewModeSwitch} from './AssetViewModeSwitch';
+import {InstanceAssetOpGraphExplorer} from './InstanceAssetOpGraphExplorer';
 import {useAssetView} from './useAssetView';
 
 export const InstanceAssetGraphExplorer: React.FC = () => {
@@ -32,6 +33,8 @@ export const InstanceAssetGraphExplorer: React.FC = () => {
         buildRepoPath(node.repository.name, node.repository.location.name),
       );
   }, [visibleRepos]);
+
+  const [assetRendering, setAssetRendering] = React.useState(true);
 
   return (
     <Box
@@ -56,14 +59,26 @@ export const InstanceAssetGraphExplorer: React.FC = () => {
         />
         <RepoFilterButton />
       </Box>
-      <AssetGraphExplorer
-        options={{preferAssetRendering: true, explodeComposites: true}}
-        filterNodes={filterNodes}
-        explorerPath={explorerPath}
-        onChangeExplorerPath={(path, mode) => {
-          history[mode](instanceAssetsExplorerPathToURL(path));
-        }}
-      />
+      {assetRendering ? (
+        <AssetGraphExplorer
+          options={{preferAssetRendering: assetRendering, explodeComposites: false}}
+          filterNodes={filterNodes}
+          explorerPath={explorerPath}
+          setOptions={(o) => setAssetRendering(o.preferAssetRendering)}
+          onChangeExplorerPath={(path, mode) => {
+            history[mode](instanceAssetsExplorerPathToURL(path));
+          }}
+        />
+      ) : (
+        <InstanceAssetOpGraphExplorer
+          options={{preferAssetRendering: assetRendering, explodeComposites: false}}
+          explorerPath={explorerPath}
+          setOptions={(o) => setAssetRendering(o.preferAssetRendering)}
+          onChangeExplorerPath={(path, mode) => {
+            history[mode](instanceAssetsExplorerPathToURL(path));
+          }}
+        />
+      )}
     </Box>
   );
 };

--- a/js_modules/dagit/packages/core/src/assets/InstanceAssetOpGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/assets/InstanceAssetOpGraphExplorer.tsx
@@ -1,0 +1,90 @@
+import {useQuery} from '@apollo/client';
+import {Spinner} from '@dagster-io/ui';
+import {gql} from 'graphql.macro';
+import {flatten} from 'lodash';
+import * as React from 'react';
+
+import {
+  GraphExplorer,
+  GraphExplorerOptions,
+  GRAPH_EXPLORER_ASSET_NODE_FRAGMENT,
+  GRAPH_EXPLORER_FRAGMENT,
+  GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT,
+} from '../pipelines/GraphExplorer';
+import {ExplorerPath} from '../pipelines/PipelinePathUtils';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+
+import {InstanceAssetOpsQuery} from './types/InstanceAssetOpsQuery';
+
+export const InstanceAssetOpGraphExplorer: React.FC<{
+  explorerPath: ExplorerPath;
+  onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
+  options: GraphExplorerOptions;
+  setOptions: (options: GraphExplorerOptions) => void;
+}> = (props) => {
+  const result = useQuery<InstanceAssetOpsQuery>(INSTANCE_ASSET_OPS_QUERY);
+
+  if (result.data?.repositoriesOrError.__typename !== 'RepositoryConnection') {
+    return <Spinner purpose="page" />;
+  }
+
+  const repos = result.data.repositoriesOrError.nodes;
+  const assetGroupJobs = repos.map((f) => f.assetGroupJob!).filter(Boolean);
+  const handles = flatten(assetGroupJobs.map((job) => job.solidHandles));
+
+  return (
+    <GraphExplorer
+      {...props}
+      isGraph={true}
+      handles={handles}
+      repoAddress={undefined}
+      repoAddressForHandle={(handle) => {
+        const repo = repos.find((r) =>
+          r.assetGroupJob?.solidHandles.some((h) => h.handleID === handle.handleID),
+        )!;
+        return buildRepoAddress(repo.name, repo.location.name);
+      }}
+      pipelineOrGraph={assetGroupJobs[0]}
+    />
+  );
+};
+
+const INSTANCE_ASSET_OPS_QUERY = gql`
+  query InstanceAssetOpsQuery {
+    repositoriesOrError {
+      __typename
+      ... on RepositoryConnection {
+        nodes {
+          id
+          name
+          location {
+            id
+            name
+          }
+          assetGroupJob {
+            id
+            name
+            ...GraphExplorerFragment
+            solidHandles {
+              handleID
+              solid {
+                name
+                definition {
+                  assetNodes {
+                    id
+                    ...GraphExplorerAssetNodeFragment
+                  }
+                }
+              }
+              ...GraphExplorerSolidHandleFragment
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ${GRAPH_EXPLORER_FRAGMENT}
+  ${GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT}
+  ${GRAPH_EXPLORER_ASSET_NODE_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/assets/types/InstanceAssetOpsQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/InstanceAssetOpsQuery.ts
@@ -1,0 +1,1242 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: InstanceAssetOpsQuery
+// ====================================================
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_location {
+  __typename: "RepositoryLocation";
+  id: string;
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_fields[];
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType_recursiveConfigTypes[];
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField {
+  __typename: "ConfigTypeField";
+  configType: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField_configType;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources {
+  __typename: "Resource";
+  name: string;
+  description: string | null;
+  configField: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources_configField | null;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_fields[];
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType_recursiveConfigTypes[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType {
+  __typename: "ArrayConfigType" | "NullableConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType {
+  __typename: "EnumConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType {
+  __typename: "RegularConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  givenName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields {
+  __typename: "ConfigTypeField";
+  name: string;
+  description: string | null;
+  isRequired: boolean;
+  configTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType {
+  __typename: "CompositeConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  fields: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType_fields[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType {
+  __typename: "ScalarUnionConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  scalarTypeKey: string;
+  nonScalarTypeKey: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType {
+  __typename: "MapConfigType";
+  key: string;
+  description: string | null;
+  isSelector: boolean;
+  typeParamKeys: string[];
+  keyLabelName: string | null;
+  recursiveConfigTypes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType_recursiveConfigTypes[];
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ArrayConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_EnumConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_RegularConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_CompositeConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_ScalarUnionConfigType | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType_MapConfigType;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField {
+  __typename: "ConfigTypeField";
+  configType: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField_configType;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers {
+  __typename: "Logger";
+  name: string;
+  description: string | null;
+  configField: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers_configField | null;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes {
+  __typename: "Mode";
+  id: string;
+  name: string;
+  description: string | null;
+  resources: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_resources[];
+  loggers: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes_loggers[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  opName: string | null;
+  assetKey: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_assetNodes_assetKey;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_metadata {
+  __typename: "MetadataItemDefinition";
+  key: string;
+  value: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_inputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_inputDefinitions {
+  __typename: "InputDefinition";
+  name: string;
+  type: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_inputDefinitions_type;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_outputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_outputDefinitions {
+  __typename: "OutputDefinition";
+  name: string;
+  isDynamic: boolean | null;
+  type: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_outputDefinitions_type;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_configField_configType {
+  __typename: "EnumConfigType" | "CompositeConfigType" | "RegularConfigType" | "ArrayConfigType" | "NullableConfigType" | "ScalarUnionConfigType" | "MapConfigType";
+  key: string;
+  description: string | null;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_configField {
+  __typename: "ConfigTypeField";
+  configType: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_configField_configType;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition {
+  __typename: "SolidDefinition";
+  assetNodes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_assetNodes[];
+  name: string;
+  description: string | null;
+  metadata: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_metadata[];
+  inputDefinitions: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_inputDefinitions[];
+  outputDefinitions: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_outputDefinitions[];
+  configField: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition_configField | null;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes_assetKey {
+  __typename: "AssetKey";
+  path: string[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes {
+  __typename: "AssetNode";
+  id: string;
+  opName: string | null;
+  assetKey: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes_assetKey;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_metadata {
+  __typename: "MetadataItemDefinition";
+  key: string;
+  value: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions {
+  __typename: "InputDefinition";
+  name: string;
+  type: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions_type;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions {
+  __typename: "OutputDefinition";
+  name: string;
+  isDynamic: boolean | null;
+  type: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions_type;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput {
+  __typename: "Input";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_definition;
+  solid: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput_solid;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings {
+  __typename: "InputMapping";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_definition;
+  mappedInput: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings_mappedInput;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput {
+  __typename: "Output";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_definition;
+  solid: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput_solid;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings {
+  __typename: "OutputMapping";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_definition;
+  mappedOutput: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings_mappedOutput;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition {
+  __typename: "CompositeSolidDefinition";
+  assetNodes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_assetNodes[];
+  name: string;
+  description: string | null;
+  metadata: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_metadata[];
+  inputDefinitions: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputDefinitions[];
+  outputDefinitions: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputDefinitions[];
+  id: string;
+  inputMappings: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_inputMappings[];
+  outputMappings: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition_outputMappings[];
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition = InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_SolidDefinition | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition_CompositeSolidDefinition;
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_definition {
+  __typename: "InputDefinition";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn_definition_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn_definition {
+  __typename: "OutputDefinition";
+  name: string;
+  type: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn_definition_type;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn {
+  __typename: "Output";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn_definition;
+  solid: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn_solid;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs {
+  __typename: "Input";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_definition;
+  isDynamicCollect: boolean;
+  dependsOn: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs_dependsOn[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_definition {
+  __typename: "OutputDefinition";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy_solid {
+  __typename: "Solid";
+  name: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy_definition_type {
+  __typename: "RegularDagsterType" | "ListDagsterType" | "NullableDagsterType";
+  displayName: string;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy_definition {
+  __typename: "InputDefinition";
+  name: string;
+  type: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy_definition_type;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy {
+  __typename: "Input";
+  solid: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy_solid;
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy_definition;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs {
+  __typename: "Output";
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_definition;
+  dependedBy: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs_dependedBy[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid {
+  __typename: "Solid";
+  name: string;
+  definition: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_definition;
+  isDynamicMapped: boolean;
+  inputs: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_inputs[];
+  outputs: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid_outputs[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles {
+  __typename: "SolidHandle";
+  handleID: string;
+  solid: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles_solid;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob {
+  __typename: "Job";
+  id: string;
+  name: string;
+  description: string | null;
+  modes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_modes[];
+  solidHandles: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob_solidHandles[];
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes {
+  __typename: "Repository";
+  id: string;
+  name: string;
+  location: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_location;
+  assetGroupJob: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes_assetGroupJob | null;
+}
+
+export interface InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection {
+  __typename: "RepositoryConnection";
+  nodes: InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection_nodes[];
+}
+
+export type InstanceAssetOpsQuery_repositoriesOrError = InstanceAssetOpsQuery_repositoriesOrError_PythonError | InstanceAssetOpsQuery_repositoriesOrError_RepositoryConnection;
+
+export interface InstanceAssetOpsQuery {
+  repositoriesOrError: InstanceAssetOpsQuery_repositoriesOrError;
+}

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -85,6 +85,7 @@ type Repository {
   schedules: [Schedule!]!
   sensors: [Sensor!]!
   assetNodes: [AssetNode!]!
+  assetGroupJob: Job
   displayMetadata: [RepositoryMetadata!]!
   inProgressRunsByStep: [InProgressRunsByStep!]!
   latestRunByStep: [RunStatsByStep!]!

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -34,7 +34,8 @@ interface GraphExplorerProps {
   options: GraphExplorerOptions;
   setOptions: (options: GraphExplorerOptions) => void;
   pipelineOrGraph: GraphExplorerFragment;
-  repoAddress?: RepoAddress;
+  repoAddress: RepoAddress | undefined;
+  repoAddressForHandle?: (handle: GraphExplorerSolidHandleFragment) => RepoAddress | undefined;
   handles: GraphExplorerSolidHandleFragment[];
   parentHandle?: GraphExplorerSolidHandleFragment;
   getInvocations?: (definitionName: string) => {handleID: string}[];
@@ -52,6 +53,7 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
     parentHandle,
     setOptions,
     repoAddress,
+    repoAddressForHandle,
     isGraph,
   } = props;
   const [nameMatch, setNameMatch] = React.useState('');
@@ -273,7 +275,11 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
                 getInvocations={getInvocations}
                 onEnterSubgraph={handleEnterCompositeSolid}
                 onClickOp={handleClickOp}
-                repoAddress={repoAddress}
+                repoAddress={
+                  selectedHandle && repoAddressForHandle
+                    ? repoAddressForHandle(selectedHandle)
+                    : repoAddress
+                }
                 isGraph={isGraph}
                 {...qs.parse(location.search || '', {ignoreQueryPrefix: true})}
               />

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -1,5 +1,6 @@
 import graphene
 from dagster import DagsterInstance, check
+from dagster.core.asset_defs.asset_group import AssetGroup
 from dagster.core.host_representation import (
     ExternalRepository,
     GrpcServerRepositoryLocation,
@@ -166,6 +167,7 @@ class GrapheneRepository(graphene.ObjectType):
     schedules = non_null_list(GrapheneSchedule)
     sensors = non_null_list(GrapheneSensor)
     assetNodes = non_null_list(GrapheneAssetNode)
+    assetGroupJob = graphene.Field(GrapheneJob)
     displayMetadata = non_null_list(GrapheneRepositoryMetadata)
     inProgressRunsByStep = non_null_list(GrapheneInProgressRunsByStep)
     latestRunByStep = non_null_list(GrapheneRunStatsByStep)
@@ -234,6 +236,12 @@ class GrapheneRepository(graphene.ObjectType):
             )
             if pipeline.is_job
         ]
+
+    def resolve_assetGroupJob(self, _graphene_info):
+        if self._repository.has_pipeline("__ASSET_GROUP"):
+            job = self._repository.get_full_external_pipeline("__ASSET_GROUP")
+            return GrapheneJob(job, self._batch_loader)
+        return None
 
     def resolve_usedSolid(self, _graphene_info, name):
         return get_solid(self._repository, name)


### PR DESCRIPTION
## Summary
<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/155603821-01eb9a3f-67d5-4c50-bb09-953f55200e6f.png">
<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/155603835-d4209e1f-afe6-4e76-883d-1451f84de718.png">


Few notes about this:
- The op graph relies on the AssetGroup jobs, so you must be using AssetGroup and not make_asset_job.
- The op graph "Types" sidebar is a bit borked because it assumes a single repo's types should be shown.
- The op graph should probably get the slide in/out behavior that the global asset graph has.
- Technically the placement of subgraphs in the rendering may be inconsistent between the two graphs


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.