### PR TITLE
[Dagit] Nits and polish based on user feedback

### DIFF
--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {Redirect, Route, Switch, useLocation} from 'react-router-dom';
 
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
+import {__ASSET_GROUP} from '../workspace/asset-graph/Utils';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
 const InstanceRedirect = () => {
@@ -49,10 +50,12 @@ const FinalRedirectOrLoadingRoot = () => {
   }
 
   // If we have exactly one job, route to the job's overview / graph tab
-  const reposWithJob = allRepos.filter((r) => r.repository.pipelines.length > 0);
+  const reposWithJob = allRepos.filter((r) =>
+    r.repository.pipelines.some((p) => p.name !== __ASSET_GROUP),
+  );
   if (reposWithJob.length === 1) {
     const repo = reposWithJob[0];
-    const job = repo.repository.pipelines[0];
+    const job = repo.repository.pipelines.filter((p) => p.name !== __ASSET_GROUP)[0];
     return (
       <Redirect
         to={workspacePipelinePath({

--- a/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/FallthroughRoot.tsx
@@ -49,14 +49,16 @@ const FinalRedirectOrLoadingRoot = () => {
     return <Redirect to="/workspace" />;
   }
 
-  // If we have exactly one job, route to the job's overview / graph tab
-  const reposWithJob = allRepos.filter((r) =>
-    r.repository.pipelines.some((p) => p.name !== __ASSET_GROUP),
-  );
-  if (reposWithJob.length === 1) {
-    const repo = reposWithJob[0];
-    const job = repo.repository.pipelines.filter((p) => p.name !== __ASSET_GROUP)[0];
-    return (
+  const reposWithAJob = allRepos.filter((r) => r.repository.pipelines.length > 0);
+
+  // If we have exactly one job, route to it's overview / graph tab or
+  // to the asset graph if it's an __ASSET_GROUP job.
+  if (reposWithAJob.length === 1 && reposWithAJob[0].repository.pipelines.length === 1) {
+    const repo = reposWithAJob[0];
+    const job = repo.repository.pipelines[0];
+    return job.name === __ASSET_GROUP ? (
+      <Redirect to="/instance/asset-graph" />
+    ) : (
       <Redirect
         to={workspacePipelinePath({
           repoName: repo.repository.name,
@@ -69,7 +71,7 @@ const FinalRedirectOrLoadingRoot = () => {
   }
 
   // If we have more than one job, route to the instance overview
-  if (reposWithJob.length > 1) {
+  if (reposWithAJob.length > 1) {
     return <Redirect to="/instance" />;
   }
 

--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -6,10 +6,11 @@ function twoDigit(v: number) {
   return `${v < 10 ? '0' : ''}${v}`;
 }
 
-function indexesOf(string: string, regex: RegExp) {
+function indexesOf(string: string, search: RegExp | string) {
   const indexes: number[] = [];
+  const regexp = new RegExp(search, 'g');
   let match = null;
-  while ((match = regex.exec(string))) {
+  while ((match = regexp.exec(string))) {
     indexes.push(match.index);
   }
   return indexes;

--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -6,6 +6,29 @@ function twoDigit(v: number) {
   return `${v < 10 ? '0' : ''}${v}`;
 }
 
+function indexesOf(string: string, regex: RegExp) {
+  const indexes: number[] = [];
+  let match = null;
+  while ((match = regex.exec(string))) {
+    indexes.push(match.index);
+  }
+  return indexes;
+}
+
+export const withMiddleTruncation = (text: string, options: {maxLength: number}) => {
+  const overflowLength = text.length - options.maxLength;
+  if (overflowLength <= 0) {
+    return text;
+  }
+  let breakpoint = Math.floor(text.length / 2);
+  const breakpoints = text.includes('__') ? indexesOf(text, /__/g) : indexesOf(text, /[_>\.-]/g);
+  if (breakpoints.length > 0) {
+    breakpoint = breakpoints[Math.floor(breakpoints.length / 2)];
+  }
+
+  return `${text.substring(0, breakpoint - (overflowLength + 1))}…${text.substring(breakpoint)}`;
+};
+
 export const formatElapsedTime = (msec: number) => {
   if (msec < 10000) {
     return `${(msec / 1000).toLocaleString(navigator.language, {

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -39,7 +39,7 @@ export const AssetNodeDefinition: React.FC<{
       <AssetDefinedInMultipleReposNotice assetId={assetNode.id} loadedFromRepo={repoAddress} />
       <Box flex={{direction: 'row'}}>
         <Box
-          style={{flex: 1}}
+          style={{flex: 1, minWidth: 0}}
           flex={{direction: 'column'}}
           border={{side: 'right', width: 1, color: ColorsWIP.KeylineGray}}
         >
@@ -96,7 +96,7 @@ export const AssetNodeDefinition: React.FC<{
           </Box>
           <AssetNodeList items={assetNode.dependedBy} liveDataByNode={liveDataByNode} />
         </Box>
-        <Box style={{flex: 0.5}} flex={{direction: 'column'}}>
+        <Box style={{flex: 0.5, minWidth: 0}} flex={{direction: 'column'}}>
           <Box
             padding={{vertical: 16, horizontal: 24}}
             border={{side: 'bottom', width: 1, color: ColorsWIP.KeylineGray}}
@@ -178,7 +178,7 @@ const DefinitionLocation: React.FC<{
           />
         </Mono>
       ))}
-    {displayNameForAssetKey(assetNode.assetKey) !== assetNode.opName && (
+    {displayNameForAssetKey(assetNode.assetKey) !== assetNode.opName && assetNode.opName && (
       <Box flex={{gap: 6, alignItems: 'center'}}>
         <IconWIP name="op" size={16} />
         <Mono>{assetNode.opName}</Mono>
@@ -186,7 +186,7 @@ const DefinitionLocation: React.FC<{
     )}
 
     {assetNode.jobNames.length === 0 && !assetNode.opName && (
-      <Caption style={{marginTop: 2}}>Foreign Asset</Caption>
+      <Caption style={{lineHeight: '16px', marginTop: 2}}>Source Asset</Caption>
     )}
   </Box>
 );

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -91,7 +91,7 @@ export const AssetsCatalogTable: React.FC<{prefixPath?: string[]}> = ({prefixPat
           ).filter(
             (a) =>
               !searchSeparatorAgnostic ||
-              tokenForAssetKey(a.key).toLowerCase().startsWith(searchSeparatorAgnostic),
+              tokenForAssetKey(a.key).toLowerCase().includes(searchSeparatorAgnostic),
           );
 
           const {displayPathForAsset, displayed, nextCursor, prevCursor} =

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -4,6 +4,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
+import {withMiddleTruncation} from '../app/Util';
 import {repoAddressAsString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
@@ -18,6 +19,11 @@ export const RepositoryLink: React.FC<{
   const {location} = repoAddress;
   const {canReloadRepositoryLocation} = usePermissions();
 
+  const repoAddressTruncated = [
+    withMiddleTruncation(repoAddress.name, {maxLength: 19}),
+    withMiddleTruncation(repoAddress.location, {maxLength: 19}),
+  ].join('@');
+
   return (
     <Box flex={{display: 'inline-flex', direction: 'row', alignItems: 'center'}}>
       {showIcon && <IconWIP name="folder" style={{marginRight: 8}} color={ColorsWIP.Gray400} />}
@@ -25,7 +31,7 @@ export const RepositoryLink: React.FC<{
         to={workspacePathFromAddress(repoAddress)}
         title={repoAddressAsString(repoAddress)}
       >
-        {repoAddressAsString(repoAddress)}
+        {repoAddressTruncated}
       </RepositoryName>
       {canReloadRepositoryLocation && showRefresh ? (
         <ReloadRepositoryLocationButton location={location}>

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -65,7 +65,9 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
       const opNames = [...explorerPath.opNames];
       const retValue = fn(opNames);
       if (retValue !== undefined) {
-        throw new Error('handleAdjustPath function is expected to mutate the array');
+        throw new Error(
+          'handleAdjustPath function is expected to mutate the array and return nothing',
+        );
       }
       onChangeExplorerPath({...explorerPath, opNames}, 'push');
     },
@@ -136,7 +138,9 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
 
   React.useEffect(() => {
     if (invalidSelection || invalidParent) {
-      handleAdjustPath((opNames) => opNames.pop());
+      handleAdjustPath((opNames) => {
+        opNames.pop();
+      });
     }
   }, [handleAdjustPath, invalidSelection, invalidParent]);
 

--- a/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagit/packages/core/src/ui/GraphQueryInput.tsx
@@ -335,7 +335,10 @@ export const GraphQueryInput = React.memo(
                 props.onBlur?.(pendingValue);
               }}
               onKeyDown={onKeyDown}
-              style={{width: props.width || '24vw'}}
+              style={{
+                width: props.width || '24vw',
+                paddingRight: focused && uncomitted ? 55 : '',
+              }}
               className={props.className}
               ref={inputRef}
             />
@@ -439,6 +442,7 @@ const EnterHint = styled.div`
   top: 5px;
   border-radius: 5px;
   border: 1px solid ${ColorsWIP.Gray500};
+  background: ${ColorsWIP.White};
   font-weight: 500;
   font-size: 12px;
   color: ${ColorsWIP.Gray500};

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetGraphExplorer.tsx
@@ -231,7 +231,7 @@ const AssetGraphExplorerWithData: React.FC<
         clicked = {opName: node.definition.opName, jobName: explorerPath.pipelineName};
       } else {
         // The asset's definition was not provided in our query for job.assetNodes. This means
-        // it's in another job or is a foreign asset not defined in the repository at all.
+        // it's in another job or is a source asset not defined in the repository at all.
         clicked = await findAssetInWorkspace(assetKey);
       }
 

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/AssetNode.tsx
@@ -180,9 +180,20 @@ export const AssetNode: React.FC<{
             )}
             {definition.opName && displayName !== definition.opName && (
               <StatsRow>
-                <Box flex={{gap: 4, alignItems: 'flex-end'}} style={{marginLeft: -2}}>
+                <Box
+                  flex={{gap: 4, alignItems: 'flex-end'}}
+                  style={{marginLeft: -2, overflow: 'hidden'}}
+                >
                   <IconWIP name="op" size={16} />
-                  {definition.opName}
+                  <div
+                    style={{
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {definition.opName}
+                  </div>
                 </Box>
               </StatsRow>
             )}
@@ -275,7 +286,7 @@ export const getNodeDimensions = (def: {
   if (def.opName && displayName !== def.opName) {
     height += 25;
   }
-  return {width: Math.max(250, displayName.length * 9.5) + 25, height};
+  return {width: Math.max(250, displayName.length * 8.0) + 25, height};
 };
 
 const BoxColors = {

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -29,7 +29,7 @@ export const LaunchAssetExecutionButton: React.FC<{
 
   let disabledReason = '';
   if (!assets.every((a) => a.opName)) {
-    disabledReason = 'One or more foreign assets are selected and cannot be materialized.';
+    disabledReason = 'One or more source assets are selected and cannot be materialized.';
   }
   if (
     !assets.every(

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/SidebarAssetInfo.tsx
@@ -125,8 +125,15 @@ const Header: React.FC<{assetKey: AssetKey; opName?: string}> = ({assetKey, opNa
 
   return (
     <Box flex={{gap: 4, direction: 'column'}} margin={{left: 24, right: 12, vertical: 16}}>
-      <SidebarTitle style={{marginBottom: 0, display: 'flex', justifyContent: 'space-between'}}>
-        {displayName}
+      <SidebarTitle
+        style={{
+          marginBottom: 0,
+          display: 'flex',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box>{displayName}</Box>
         {displayName !== opName ? (
           <Box style={{opacity: 0.5}} flex={{gap: 6, alignItems: 'center'}}>
             <IconWIP name="op" size={16} />


### PR DESCRIPTION
## Summary
This PR fixes a bunch of small stuff that users have noticed / mentioned recently:

- Clicking Daggy no longer takes you to the hidden __ASSET_GROUP job if you only have one loaded repo. (seems it's often "job zero")
- The Asset Details page no longer overflows off the screen if there are too many upstream/downstream assets
- Dagit no longer crashes if you have an op selected that does not match an asset name and toggle back to the Asset graph with an invalid selection

- The nodes on the Op graph now do middle truncation (possible since they have a fixed width), preferring to break at common separators like __, _, . etc. (https://github.com/dagster-io/dagster/issues/6747)
- The "RepositoryLink" also does middle truncation since we already had an arbitrary maximum width on it and can express that in characters instead.

- The graph query input no longer renders text flowing under the "Enter" hint

- In the Asset Catalog, the search bar now does substring matching instead of prefix matching, so you can match by a subpath more easily. (Pulled from https://github.com/dagster-io/dagster/pull/6783 so we can postpone that one)

Truncation behavior:
<img width="610" alt="Screen Shot 2022-02-24 at 3 49 42 PM" src="https://user-images.githubusercontent.com/1037212/155615666-70645538-f087-4d41-923d-3632c5d807e3.png">
<img width="524" alt="Screen Shot 2022-02-24 at 3 40 17 PM" src="https://user-images.githubusercontent.com/1037212/155615668-a3309b3c-b29e-4fce-9816-3ba8dc8d7cf7.png">



Fixed:
<img width="178" alt="Screen Shot 2022-02-24 at 3 15 06 PM" src="https://user-images.githubusercontent.com/1037212/155615594-dfeef478-d5f8-49f3-9c73-ec4b40bc20ca.png">
<img width="480" alt="Screen Shot 2022-02-24 at 3 09 46 PM" src="https://user-images.githubusercontent.com/1037212/155615601-68c2dac5-671a-466c-a8a9-3f82ba8f94c2.png">
<img width="1840" alt="Screen Shot 2022-02-24 at 3 08 31 PM" src="https://user-images.githubusercontent.com/1037212/155615611-00b26a87-14ef-49d7-8184-d6fc3b8fd81d.png">


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.