### PR TITLE
enable vixie-style cron strings

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -38,7 +38,7 @@ You define a schedule by constructing a <PyObject object="ScheduleDefinition" />
 
 ### A basic schedule
 
-Here's a simple schedule that runs a job every day, at midnight. The `cron_schedule` accepts standard [cron expressions](https://en.wikipedia.org/wiki/Cron).
+Here's a simple schedule that runs a job every day, at midnight. The `cron_schedule` accepts standard [cron expressions](https://en.wikipedia.org/wiki/Cron). It also accepts `"@hourly"`, `"@daily"`, `"@weekly"`, and `"@monthly"` if your `croniter` dependency's version is >= 1.0.12.
 
 ```python file=concepts/partitions_schedules_sensors/schedules/schedules.py startafter=start_basic_schedule endbefore=end_basic_schedule
 @job

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -210,8 +210,7 @@ class ScheduleDefinition:
 
         if not is_valid_cron_string(self._cron_schedule):
             raise DagsterInvalidDefinitionError(
-                f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''.  "
-                "Dagster recognizes cron expressions consisting of 5 space-separated fields."
+                f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''."
             )
 
         if job is not None:

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -210,7 +210,9 @@ class ScheduleDefinition:
 
         if not is_valid_cron_string(self._cron_schedule):
             raise DagsterInvalidDefinitionError(
-                f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''."
+                f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''. "
+                "Dagster recognizes standard cron expressions consisting of 5 fields, as well as "
+                "certain non-standard keyword expressions (e.g. `@hourly`, `@daily`, etc.)."
             )
 
         if job is not None:

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -211,8 +211,7 @@ class ScheduleDefinition:
         if not is_valid_cron_string(self._cron_schedule):
             raise DagsterInvalidDefinitionError(
                 f"Found invalid cron schedule '{self._cron_schedule}' for schedule '{name}''. "
-                "Dagster recognizes standard cron expressions consisting of 5 fields, as well as "
-                "certain non-standard keyword expressions (e.g. `@hourly`, `@daily`, etc.)."
+                "Dagster recognizes standard cron expressions consisting of 5 fields."
             )
 
         if job is not None:

--- a/python_modules/dagster/dagster/utils/schedules.py
+++ b/python_modules/dagster/dagster/utils/schedules.py
@@ -8,10 +8,15 @@ from croniter import croniter
 from dagster import check
 from dagster.seven.compat.pendulum import to_timezone
 
+OPTIMIZED_KEYWORD_CRON_SCHEDULES = set(["@monthly", "@weekly", "@daily", "@hourly"])
+
 
 def is_valid_cron_string(cron_string: str) -> bool:
     # dagster only recognizes standard cron strings that contains 5 parts
-    return croniter.is_valid(cron_string) and len(cron_string.split(" ")) == 5
+    if not croniter.is_valid(cron_string):
+        return False
+    expanded, _ = croniter.expand(cron_string)
+    return len(expanded) == 5
 
 
 def schedule_execution_time_iterator(
@@ -32,26 +37,31 @@ def schedule_execution_time_iterator(
 
     check.invariant(is_valid_cron_string(cron_schedule))
 
-    is_numeric = [part.isnumeric() for part in cron_parts]
+    cron_parts, _ = croniter.expand(cron_schedule)
+
+    is_numeric = [len(part) == 1 and part[0] != "*" for part in cron_parts]
+    is_wildcard = [len(part) == 1 and part[0] == "*" for part in cron_parts]
 
     delta_fn = None
+    should_hour_change = False
 
     # Special-case common intervals (hourly/daily/weekly/monthly) since croniter iteration can be
     # much slower than adding a fixed interval
-    if cron_schedule.endswith(" * *") and all(is_numeric[0:3]):  # monthly
+    if all(is_numeric[0:3]) and all(is_wildcard[3:]):  # monthly
         delta_fn = lambda d, num: d.add(months=num)
         should_hour_change = False
-    elif (
-        all(is_numeric[0:2]) and is_numeric[4] and cron_parts[2] == "*" and cron_parts[3] == "*"
-    ):  # weekly
+    elif all(is_numeric[0:2]) and is_numeric[4] and all(is_wildcard[2:4]):  # weekly
         delta_fn = lambda d, num: d.add(weeks=num)
         should_hour_change = False
-    elif all(is_numeric[0:2]) and cron_schedule.endswith(" * * *"):  # daily
+    elif all(is_numeric[0:2]) and all(is_wildcard[2:]):  # daily
         delta_fn = lambda d, num: d.add(days=num)
         should_hour_change = False
-    elif is_numeric[0] and cron_schedule.endswith(" * * * *"):  # hourly
+    elif is_numeric[0] and all(is_wildcard[1:]):  # hourly
         delta_fn = lambda d, num: d.add(hours=num)
         should_hour_change = True
+    else:
+        delta_fn = None
+        should_hour_change = None
 
     if delta_fn:
         # Use pendulums for intervals when possible

--- a/python_modules/dagster/dagster/utils/schedules.py
+++ b/python_modules/dagster/dagster/utils/schedules.py
@@ -8,8 +8,6 @@ from croniter import croniter
 from dagster import check
 from dagster.seven.compat.pendulum import to_timezone
 
-OPTIMIZED_KEYWORD_CRON_SCHEDULES = set(["@monthly", "@weekly", "@daily", "@hourly"])
-
 
 def is_valid_cron_string(cron_string: str) -> bool:
     # dagster only recognizes standard cron strings that contains 5 parts

--- a/python_modules/dagster/dagster/utils/schedules.py
+++ b/python_modules/dagster/dagster/utils/schedules.py
@@ -33,8 +33,6 @@ def schedule_execution_time_iterator(
     # and matches the cron schedule
     next_date = date_iter.get_prev(datetime.datetime)
 
-    cron_parts = cron_schedule.split(" ")
-
     check.invariant(is_valid_cron_string(cron_schedule))
 
     cron_parts, _ = croniter.expand(cron_schedule)
@@ -61,7 +59,7 @@ def schedule_execution_time_iterator(
         should_hour_change = True
     else:
         delta_fn = None
-        should_hour_change = None
+        should_hour_change = False
 
     if delta_fn:
         # Use pendulums for intervals when possible

--- a/python_modules/dagster/dagster/utils/schedules.py
+++ b/python_modules/dagster/dagster/utils/schedules.py
@@ -10,10 +10,10 @@ from dagster.seven.compat.pendulum import to_timezone
 
 
 def is_valid_cron_string(cron_string: str) -> bool:
-    # dagster only recognizes standard cron strings that contains 5 parts
     if not croniter.is_valid(cron_string):
         return False
     expanded, _ = croniter.expand(cron_string)
+    # dagster only recognizes cron strings that resolve to 5 parts (e.g. not seconds resolution)
     return len(expanded) == 5
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -735,7 +735,7 @@ def test_schedule_decorators_bad():
 
     with pytest.raises(DagsterInvalidDefinitionError, match="invalid cron schedule"):
 
-        @schedule(cron_schedule="@daily", pipeline_name="foo_pipeline")
+        @schedule(cron_schedule="* * * * * *", pipeline_name="foo_pipeline")
         def bad_cron_string_three(context):
             return {}
 
@@ -995,3 +995,26 @@ def test_request_based_schedule_generator_no_context():
     assert len(requests) == 1
     assert requests[0].run_config == FOO_CONFIG
     assert requests[0].tags.get("foo") == "FOO"
+
+
+def test_vixie_cronstring_schedule():
+    context_without_time = build_schedule_context()
+    start_date = datetime(year=2019, month=1, day=1)
+
+    @op
+    def foo_op(context):
+        pass
+
+    @job
+    def foo_job():
+        foo_op()
+
+    @schedule(cron_schedule="@daily", job=foo_job)
+    def foo_schedule():
+        yield RunRequest(run_key=None, run_config={}, tags={"foo": "FOO"})
+
+    # evaluate tick
+    execution_data = foo_schedule.evaluate_tick(context_without_time)
+    assert execution_data.run_requests
+    assert len(execution_data.run_requests) == 1
+    assert execution_data.run_requests[0].tags.get("foo") == "FOO"

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -1,3 +1,5 @@
+import pytest
+from dagster.check import CheckError
 from dagster.seven.compat.pendulum import create_pendulum_time
 from dagster.utils.schedules import schedule_execution_time_iterator
 
@@ -23,3 +25,63 @@ def test_cron_schedule_advances_past_dst():
             year=2021, month=10, day=3, hour=4, tz="Australia/Sydney"
         ).timestamp()
     )
+
+
+def test_vixie_cronstring_schedule():
+    start_time = create_pendulum_time(
+        year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"
+    )
+
+    time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@hourly", "US/Pacific")
+    for _i in range(6):
+        # 2:00, 3:00, 4:00, 5:00, 6:00, 7:00
+        next_time = next(time_iter)
+    assert (
+        next_time.timestamp()
+        == create_pendulum_time(year=2022, month=2, day=21, hour=7, tz="US/Pacific").timestamp()
+    )
+
+    time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@daily", "US/Pacific")
+    for _i in range(6):
+        # 2/22, 2/23, 2/24, 2/25, 2/26, 2/27
+        next_time = next(time_iter)
+    assert (
+        next_time.timestamp()
+        == create_pendulum_time(year=2022, month=2, day=27, tz="US/Pacific").timestamp()
+    )
+
+    time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@weekly", "US/Pacific")
+    for _i in range(6):
+        # 2/27, 3/6, 3/13, 3/20, 3/27, 4/3
+        next_time = next(time_iter)
+    assert (
+        next_time.timestamp()
+        == create_pendulum_time(year=2022, month=4, day=3, tz="US/Pacific").timestamp()
+    )
+
+    time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@monthly", "US/Pacific")
+    for _i in range(6):
+        # 3/1, 4/1, 5/1, 6/1, 7/1, 8/1
+        next_time = next(time_iter)
+    assert (
+        next_time.timestamp()
+        == create_pendulum_time(year=2022, month=8, day=1, tz="US/Pacific").timestamp()
+    )
+
+    time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@yearly", "US/Pacific")
+    for _i in range(6):
+        # 1/1/2023, 1/1/2024, 1/1/2025, 1/1/2026, 1/1/2027, 1/1/2028
+        next_time = next(time_iter)
+    assert (
+        next_time.timestamp()
+        == create_pendulum_time(year=2028, month=1, day=1, tz="US/Pacific").timestamp()
+    )
+
+
+def test_invalid_cron_string():
+    start_time = create_pendulum_time(
+        year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"
+    )
+
+    with pytest.raises(CheckError):
+        next(schedule_execution_time_iterator(start_time.timestamp(), "* * * * * *", "US/Pacific"))

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
             # alembic 1.6.3 broke our migrations: https://github.com/sqlalchemy/alembic/issues/848
             # alembic 1.7.0 is a breaking change
             "alembic>=1.2.1,!=1.6.3,<1.7.0",
-            "croniter>=0.3.34",
+            "croniter>=1.0.12",
             "grpcio>=1.32.0",  # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
             "grpcio-health-checking>=1.32.0,<1.44.0",
             "packaging>=20.9",

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
             # alembic 1.6.3 broke our migrations: https://github.com/sqlalchemy/alembic/issues/848
             # alembic 1.7.0 is a breaking change
             "alembic>=1.2.1,!=1.6.3,<1.7.0",
-            "croniter>=1.0.12",
+            "croniter>=0.3.34",
             "grpcio>=1.32.0",  # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
             "grpcio-health-checking>=1.32.0,<1.44.0",
             "packaging>=20.9",


### PR DESCRIPTION
We disallowed a class of cron strings that are valid from `croniter`'s point of view (e.g. `@daily`), because `schedule_execution_time_iterator` would barf when trying to do it's special-cased perf optimizations.

This PR re-enables that might by using `croniter`'s `expand` method to parse the cron schedule structure (instead of using split).

## Test Plan
BK
