### PR TITLE
RFC: When no @repository is specified, gather all code artifacts and package them together for you instead

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/reconstructable.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstructable.py
@@ -605,7 +605,6 @@ def repository_def_from_target_def(target):
 
     # special case - we can wrap a single pipeline in a repository
     if isinstance(target, (PipelineDefinition, GraphDefinition)):
-        # consider including pipeline name in generated repo name
         return RepositoryDefinition(
             name=get_ephemeral_repository_name(target.name),
             repository_data=CachingRepositoryData.from_list([target]),

--- a/python_modules/dagster/dagster/core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/repository_definition.py
@@ -566,6 +566,7 @@ class CachingRepositoryData(RepositoryData):
         schedules = {}
         sensors = {}
         source_assets = {}
+        asset_group = None
         for definition in repository_definitions:
             if isinstance(definition, PipelineDefinition):
                 if (
@@ -626,6 +627,11 @@ class CachingRepositoryData(RepositoryData):
                 pipelines_or_jobs[coerced.name] = coerced
 
             elif isinstance(definition, AssetGroup):
+                if asset_group:
+                    raise DagsterInvalidDefinitionError(
+                        "Repository can only include one AssetGroup"
+                    )
+
                 asset_group = definition
                 pipelines_or_jobs[asset_group.all_assets_job_name] = build_assets_job(
                     asset_group.all_assets_job_name,

--- a/python_modules/dagster/dagster/core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/core/workspace/autodiscovery.py
@@ -1,12 +1,17 @@
 import inspect
 from collections import namedtuple
+from typing import NamedTuple
 
 from dagster import (
     DagsterInvariantViolationError,
     GraphDefinition,
     JobDefinition,
+    PartitionSetDefinition,
     PipelineDefinition,
     RepositoryDefinition,
+    ScheduleDefinition,
+    SensorDefinition,
+    check,
 )
 from dagster.core.asset_defs import AssetGroup
 from dagster.core.code_pointer import load_python_file, load_python_module
@@ -14,9 +19,13 @@ from dagster.core.code_pointer import load_python_file, load_python_module
 LoadableTarget = namedtuple("LoadableTarget", "attribute target_definition")
 
 
+class EphemeralRepositoryTarget(NamedTuple("EphemeralRepositoryTarget", [])):
+    pass
+
+
 def loadable_targets_from_python_file(python_file, working_directory=None):
     loaded_module = load_python_file(python_file, working_directory)
-    return loadable_targets_from_loaded_module(loaded_module)
+    return _loadable_targets_from_loaded_module(loaded_module)
 
 
 def loadable_targets_from_python_module(module_name, working_directory, remove_from_path_fn=None):
@@ -25,79 +34,59 @@ def loadable_targets_from_python_module(module_name, working_directory, remove_f
         working_directory=working_directory,
         remove_from_path_fn=remove_from_path_fn,
     )
-    return loadable_targets_from_loaded_module(module)
+    return _loadable_targets_from_loaded_module(module)
 
 
 def loadable_targets_from_python_package(package_name, working_directory, remove_from_path_fn=None):
     module = load_python_module(
         package_name, working_directory, remove_from_path_fn=remove_from_path_fn
     )
-    return loadable_targets_from_loaded_module(module)
+    return _loadable_targets_from_loaded_module(module)
 
 
-def loadable_targets_from_loaded_module(module):
+def _loadable_targets_from_loaded_module(module):
     loadable_repos = _loadable_targets_of_type(module, RepositoryDefinition)
     if loadable_repos:
         return loadable_repos
 
+    # Back-compat for ephemeral single-pipeline case
     loadable_pipelines = _loadable_targets_of_type(module, PipelineDefinition)
-    loadable_jobs = _loadable_targets_of_type(module, JobDefinition)
-
     if len(loadable_pipelines) == 1:
         return loadable_pipelines
 
-    elif len(loadable_pipelines) > 1:
-        target_type = "job" if len(loadable_jobs) > 1 else "pipeline"
-        raise DagsterInvariantViolationError(
-            (
-                'No repository and more than one {target_type} found in "{module_name}". If you load '
-                "a file or module directly it must have only one {target_type} "
-                "in scope. Found {target_type}s defined in variables or decorated "
-                "functions: {pipeline_symbols}."
-            ).format(
-                module_name=module.__name__,
-                pipeline_symbols=repr([p.attribute for p in loadable_pipelines]),
-                target_type=target_type,
-            )
-        )
-
+    # Back-compat for ephemeral single-graph case
     loadable_graphs = _loadable_targets_of_type(module, GraphDefinition)
-
     if len(loadable_graphs) == 1:
         return loadable_graphs
 
-    elif len(loadable_graphs) > 1:
-        raise DagsterInvariantViolationError(
-            (
-                'No repository, job, or pipeline, and more than one graph found in "{module_name}". '
-                "If you load a file or module directly it must either have one repository, one "
-                "job, one pipeline, or one graph in scope. Found graphs defined in variables or "
-                "decorated functions: {graph_symbols}."
-            ).format(
-                module_name=module.__name__,
-                graph_symbols=repr([g.attribute for g in loadable_graphs]),
-            )
-        )
-
+    # Back-compat for ephemeral single-asset-group case
     loadable_asset_groups = _loadable_targets_of_type(module, AssetGroup)
     if len(loadable_asset_groups) == 1:
         return loadable_asset_groups
 
-    elif len(loadable_asset_groups) > 1:
-        var_names = repr([a.attribute for a in loadable_asset_groups])
+    loadable_targets = _get_ephemeral_repository_loadable_targets(module)
+
+    if len(loadable_targets) == 0:
         raise DagsterInvariantViolationError(
-            (
-                f'More than one asset collection found in "{module.__name__}". '
-                "If you load a file or module directly it must either have one repository, one "
-                "job, one pipeline, one graph, or one asset collection scope. Found asset "
-                f"collections defined in variables: {var_names}."
+            'No jobs, pipelines, asset collections, or repositories found in "{}".'.format(
+                module.__name__
             )
         )
 
-    raise DagsterInvariantViolationError(
-        'No jobs, pipelines, graphs, asset collections, or repositories found in "{}".'.format(
-            module.__name__
-        )
+    return [EphemeralRepositoryTarget()]
+
+
+def _get_ephemeral_repository_loadable_targets(module):
+    return _loadable_targets_of_type(
+        module,
+        (
+            PipelineDefinition,
+            JobDefinition,
+            PartitionSetDefinition,
+            ScheduleDefinition,
+            SensorDefinition,
+            AssetGroup,
+        ),
     )
 
 
@@ -108,3 +97,17 @@ def _loadable_targets_of_type(module, klass):
             loadable_targets.append(LoadableTarget(name, value))
 
     return loadable_targets
+
+
+def create_ephemeral_repository(module):
+    from dagster.core.definitions.repository_definition import CachingRepositoryData
+
+    # What about caching?????
+    targets = _get_ephemeral_repository_loadable_targets(module)
+    check.invariant(len(targets) > 0, "must have at least one code artifact in a repository")
+    return RepositoryDefinition(
+        name="__repository__",
+        repository_data=CachingRepositoryData.from_list(
+            [target.target_definition for target in targets]
+        ),
+    )

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -217,7 +217,7 @@ class LoadableRepositorySymbol(
         return super(LoadableRepositorySymbol, cls).__new__(
             cls,
             repository_name=check.str_param(repository_name, "repository_name"),
-            attribute=check.str_param(attribute, "attribute"),
+            attribute=check.opt_str_param(attribute, "attribute"),
         )
 
 


### PR DESCRIPTION
Summary:
Inspired by https://threads.com/34418826592 from nick - if we are planning to enforce that each process has a single repository, and are generally planning to de-emphasize the repository as a core organization thing in Dagit, we have the option of not requiring you to write an @repository at all. Instead we could bring in each of the code artifacts in the file/module and package them up into one for you. This might be a bit more familiar to people coming from airflow's auto-geneated DAG approach too.

Whipped this up to explore that direction.

One big thing we would need to figure out is caching - the existing code loading paths rely on the fact that there's a single RepositoryDefinition in code to apply some caching, so creating a new one each time the code is loaded may be undesirable.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.