### PR TITLE
gate bucketing queries on sqlalchemy version

### DIFF
--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -69,6 +69,9 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     @property
     def supports_bucket_queries(self):
+        # This is a temporary stopgap until we can either pin SQLAlchemy==1.4.0 (blocked by airflow
+        # compat issues) or switch the bucketing query to use backwards-compatible syntax (that
+        # avoids calling `.subquery` on a select statement).
         return db.__version__ >= "1.4.0"
 
     def fetchall(self, query):

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -69,7 +69,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     @property
     def supports_bucket_queries(self):
-        # This is a temporary stopgap until we can either pin SQLAlchemy==1.4.0 (blocked by airflow
+        # This is a temporary stopgap until we can either pin SQLAlchemy>=1.4.0 (blocked by airflow
         # compat issues) or switch the bucketing query to use backwards-compatible syntax (that
         # avoids calling `.subquery` on a select statement).
         return db.__version__ >= "1.4.0"

--- a/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sql_run_storage.py
@@ -67,6 +67,10 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         out-of-date instance of the storage up to date.
         """
 
+    @property
+    def supports_bucket_queries(self):
+        return db.__version__ >= "1.4.0"
+
     def fetchall(self, query):
         with self.connect() as conn:
             result_proxy = conn.execute(query)

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -121,7 +121,10 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
 
     @property
     def supports_bucket_queries(self):
-        return get_sqlite_version() > MINIMUM_SQLITE_BUCKET_VERSION
+        return (
+            super().supports_bucket_queries and
+            get_sqlite_version() > MINIMUM_SQLITE_BUCKET_VERSION
+        )
 
     def upgrade(self):
         self._check_for_version_066_migration_and_perform()


### PR DESCRIPTION
## Summary
Downgrading to `SQLAlchemy==1.3.23` caused our bucketing query syntax to throw errors.

This diff gates the bucketing queries to SQLAlchemy >= 1.4.0.   This is a temporary stopgap until we can resolve with a pin / or with backwards-compatible query syntax.



## Test Plan
Manually downgraded SQLAlchemy, saw that batch was disabled.

