### PR TITLE
[dagit] Replace black tag tooltips with as-needed, selectable ones

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -1,4 +1,4 @@
-import {Tag, Tooltip} from '@dagster-io/ui';
+import {Tag} from '@dagster-io/ui';
 import * as React from 'react';
 
 export enum DagsterTag {
@@ -33,14 +33,6 @@ export const RunTag = ({tag, onClick}: IRunTagProps) => {
   const onTagClick = () => {
     onClick && onClick(tag);
   };
-
-  if (isDagsterTag) {
-    return (
-      <Tooltip content={`${tag.key}=${tag.value}`} targetTagName="div" placement="top">
-        <Tag isDagsterTag={isDagsterTag} onClick={onTagClick} tag={displayTag} />
-      </Tooltip>
-    );
-  }
 
   return <Tag isDagsterTag={isDagsterTag} onClick={onTagClick} tag={displayTag} />;
 };

--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -13,6 +13,19 @@ interface Props {
   label?: React.ReactNode;
 }
 
+const BaseTagTooltipStyle: React.CSSProperties = {
+  fontSize: 12,
+  lineHeight: '16px',
+  alignItems: 'center',
+  padding: '4px 8px',
+  userSelect: 'text',
+  pointerEvents: 'all',
+  borderRadius: 8,
+  border: 'none',
+  top: -10,
+  left: -13,
+};
+
 export const BaseTag = (props: Props) => {
   const {
     fillColor = ColorsWIP.Gray10,
@@ -25,7 +38,18 @@ export const BaseTag = (props: Props) => {
   return (
     <StyledTag $fillColor={fillColor} $interactive={interactive} $textColor={textColor}>
       {icon || null}
-      {label !== undefined && label !== null ? <span>{label}</span> : null}
+      {label !== undefined && label !== null ? (
+        <span
+          data-tooltip={label}
+          data-tooltip-style={JSON.stringify({
+            ...BaseTagTooltipStyle,
+            backgroundColor: fillColor,
+            color: textColor,
+          })}
+        >
+          {label}
+        </span>
+      ) : null}
       {rightIcon || null}
     </StyledTag>
   );

--- a/js_modules/dagit/packages/ui/src/components/Colors.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Colors.tsx
@@ -20,7 +20,7 @@ export const ColorsWIP = {
   Blue500: 'rgba(79, 67, 221, 1)',
   Blue200: 'rgba(185, 180, 241, 1)',
   Blue100: 'rgba(211, 209,237,1)',
-  Blue50: 'rgba(14, 12, 167, 0.08)',
+  Blue50: 'rgba(236,236,248, 1)',
   Red700: 'rgba(165, 9, 6, 1)',
   Red500: 'rgba(221, 84, 72, 1)',
   Red200: 'rgba(241, 187, 182, 1)',

--- a/js_modules/dagit/packages/ui/src/components/Tag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tag.tsx
@@ -18,7 +18,7 @@ export const Tag = ({tag, onClick, isDagsterTag}: ITagProps) => {
   return (
     <TagButton onClick={onTagClick}>
       <TagWIP intent={isDagsterTag ? 'none' : 'primary'} interactive>
-        {tag.key}: {tag.value}
+        {`${tag.key}: ${tag.value}`}
       </TagWIP>
     </TagButton>
   );


### PR DESCRIPTION
## Summary
Currently, Dagit displays black on-hover tooltips over "dagster tags", defined as any tag starting with `dagster/`. Recently it came up that the `dagster-k8s/config` tags are very long and truncate.

This would be resolved partially by those tags using `dagster/` and not a different prefix (they would get tooltips), but after playing around with it a bit I think the tooltip behavior can still be improved. This PR makes a few small changes:

- Tags only get tooltips if they are being truncated (via our data-tooltip global helper)
- Tag tooltips have selectable text so it's easier to copy paste long JSON blobs to a place you can render them
- Tag toolips are available for both built-in (dagster/) and userland tags. The "dagster/" prefix only changes the color from blue to gray.

![Feb-28-2022 22-24-44](https://user-images.githubusercontent.com/1037212/156104672-99ab3cc5-7a99-4a1a-88dd-37878c306b4f.gif)

This PR stops short of adding a "render this tooltip value as nice JSON" modal, because I think there's some ongoing discussion about whether we should be putting these large values into tags in the first place and maybe we'll move away from that in a future release.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.