### PR TITLE
Revert isort Makefile config to use git ls-files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,19 +31,21 @@ check_black:
 	-black --check --fast \
     examples/docs_snippets
 
+# NOTE: We use `git ls-files` instead of isort's built-in recursive discovery
+# because it is much faster. 
 isort:
 	isort \
     --skip=examples/docs_snippets --skip=snapshots \
-    examples integration_tests helm python_modules .buildkite
+		`git ls-files {.buildkite,examples,integration_tests,helm,python_modules}/**/*.py`
 	isort \
-    examples/docs_snippets
+    `git ls-files examples/docs_snippets/**/*.py`
 
 check_isort:
 	-isort --check \
     --skip=examples/docs_snippets --skip=snapshots \
-    examples integration_tests helm python_modules .buildkite
+		`git ls-files {.buildkite,examples,integration_tests,helm,python_modules}/**/*.py`
 	-isort --check \
-    examples/docs_snippets
+    `git ls-files examples/docs_snippets/**/*.py`
 
 yamllint:
 	yamllint -c .yamllint.yaml --strict `git ls-files 'helm/**/*.yml' 'helm/**/*.yaml' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'`

--- a/Makefile
+++ b/Makefile
@@ -31,21 +31,26 @@ check_black:
 	-black --check --fast \
     examples/docs_snippets
 
+
 # NOTE: We use `git ls-files` instead of isort's built-in recursive discovery
-# because it is much faster. 
+# because it is much faster. Note that we also need to skip files with `git
+# ls-files` (the `:!:` directives are exclued patterns). Even isort
+# `--skip`/`--filter-files` is very slow.
 isort:
 	isort \
-    --skip=examples/docs_snippets --skip=snapshots \
-		`git ls-files {.buildkite,examples,integration_tests,helm,python_modules}/**/*.py`
+    `git ls-files {.buildkite,examples,integration_tests,helm,python_modules}'/**/*.py' \
+      ':!:examples/docs_snippets' \
+      ':!:snapshots'`
 	isort \
-    `git ls-files examples/docs_snippets/**/*.py`
+   `git ls-files 'examples/docs_snippets/**/*.py'`
 
 check_isort:
 	-isort --check \
-    --skip=examples/docs_snippets --skip=snapshots \
-		`git ls-files {.buildkite,examples,integration_tests,helm,python_modules}/**/*.py`
+    `git ls-files {.buildkite,examples,integration_tests,helm,python_modules}'/**/*.py' \
+      ':!:examples/docs_snippets' \
+      ':!:snapshots'`
 	-isort --check \
-    `git ls-files examples/docs_snippets/**/*.py`
+    `git ls-files 'examples/docs_snippets/**/*.py'`
 
 yamllint:
 	yamllint -c .yamllint.yaml --strict `git ls-files 'helm/**/*.yml' 'helm/**/*.yaml' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml'`

--- a/python_modules/dagster/dagster/api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/api/snapshot_repository.py
@@ -5,10 +5,8 @@ from dagster.core.host_representation.external_data import ExternalRepositoryDat
 from dagster.serdes import deserialize_as
 
 if TYPE_CHECKING:
+    from dagster.core.host_representation import RepositoryLocation
     from dagster.grpc.client import DagsterGrpcClient
-    from dagster.core.host_representation import (
-        RepositoryLocation,
-    )
 
 
 def sync_get_streaming_external_repositories_data_grpc(

--- a/python_modules/dagster/dagster/api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/api/snapshot_sensor.py
@@ -9,8 +9,8 @@ from dagster.grpc.types import SensorExecutionArgs
 from dagster.serdes import deserialize_as
 
 if TYPE_CHECKING:
-    from dagster.grpc.client import DagsterGrpcClient
     from dagster.core.instance import DagsterInstance
+    from dagster.grpc.client import DagsterGrpcClient
 
 
 def sync_get_external_sensor_execution_data_ephemeral_grpc(


### PR DESCRIPTION
git ls-files is a lot faster than `isort` Python-based file discovery/filtering introduced with #6714, so this PR brings back git ls-files.
