### PR TITLE
[dagit] Only warn about the backfill daemon when backfills are present

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/types/InstanceWarningQuery.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/InstanceWarningQuery.ts
@@ -42,6 +42,23 @@ export interface InstanceWarningQuery_instance {
   hasInfo: boolean;
 }
 
+export interface InstanceWarningQuery_partitionBackfillsOrError_PythonError {
+  __typename: "PythonError";
+}
+
+export interface InstanceWarningQuery_partitionBackfillsOrError_PartitionBackfills_results {
+  __typename: "PartitionBackfill";
+  backfillId: string;
+}
+
+export interface InstanceWarningQuery_partitionBackfillsOrError_PartitionBackfills {
+  __typename: "PartitionBackfills";
+  results: InstanceWarningQuery_partitionBackfillsOrError_PartitionBackfills_results[];
+}
+
+export type InstanceWarningQuery_partitionBackfillsOrError = InstanceWarningQuery_partitionBackfillsOrError_PythonError | InstanceWarningQuery_partitionBackfillsOrError_PartitionBackfills;
+
 export interface InstanceWarningQuery {
   instance: InstanceWarningQuery_instance;
+  partitionBackfillsOrError: InstanceWarningQuery_partitionBackfillsOrError;
 }


### PR DESCRIPTION

## Summary
This PR makes a few small changes to the way the warning icon next to the Status tab works in Dagit:

- Previously, sensor and schedule warnings were ignored if you had no sensors or schedules defined. Now, these warnings are ignored if you have no sensors/schedules *turned on*.

- The status icon periodically queries for requested backfills and only warns about the backfill daemon if there are backfills in the requested (non-finished, non-cancelled) state.

The result of these two changes is that a new user who runs Dagit for the first time does not see the warning icon in the nav bar.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.