### PR TITLE
[dagit] Add a helper for building instance/runs paths, resolves #6847

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -12,7 +12,6 @@ import {
 } from '@dagster-io/ui';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
-import qs from 'qs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -20,6 +19,7 @@ import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {titleForRun} from '../runs/RunUtils';
+import {runsPathWithFilters} from '../runs/RunsFilterInput';
 import {RepositorySelector} from '../types/globalTypes';
 import {CurrentRunsBanner} from '../workspace/asset-graph/CurrentRunsBanner';
 import {LiveDataForNode} from '../workspace/asset-graph/Utils';
@@ -326,13 +326,11 @@ export const AssetEvents: React.FC<Props> = ({
                 : jobRunsThatDidntMaterializeAsset.jobNames[0]}{' '}
               ran{' '}
               <Link
-                to={`/instance/runs?${
-                  jobRunsThatDidntMaterializeAsset.jobNames.length > 1
-                    ? ''
-                    : qs.stringify({
-                        'q[]': `job:${jobRunsThatDidntMaterializeAsset.jobNames[0]}`,
-                      })
-                }`}
+                to={runsPathWithFilters(
+                  jobRunsThatDidntMaterializeAsset.jobNames.length === 1
+                    ? [{token: 'job', value: jobRunsThatDidntMaterializeAsset.jobNames[0]}]
+                    : [],
+                )}
               >
                 {jobRunsThatDidntMaterializeAsset.count} times
               </Link>{' '}

--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -23,6 +23,7 @@ import {
   IStepMetadata,
   IStepState,
 } from '../runs/RunMetadataProvider';
+import {runsPathWithFilters} from '../runs/RunsFilterInput';
 import {StepSelection} from '../runs/StepSelection';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 
@@ -808,7 +809,11 @@ export const QueuedState = ({runId}: {runId: string}) => (
           icon="arrow_forward"
           title="Run Queued"
           description="This run is queued for execution and will start soon."
-          action={<Link to="/instance/runs?q=status%3AQUEUED">View queued runs</Link>}
+          action={
+            <Link to={runsPathWithFilters([{token: 'status', value: 'QUEUED'}])}>
+              View queued runs
+            </Link>
+          }
         />
       }
       firstInitialPercent={70}

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -38,6 +38,7 @@ import {
   successStatuses,
 } from '../runs/RunStatuses';
 import {DagsterTag} from '../runs/RunTag';
+import {runsPathWithFilters} from '../runs/RunsFilterInput';
 import {TerminationDialog} from '../runs/TerminationDialog';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -281,9 +282,12 @@ const BackfillRow = ({
   const history = useHistory();
   const {canCancelPartitionBackfill, canLaunchPartitionBackfill} = usePermissions();
   const counts = React.useMemo(() => getProgressCounts(backfill), [backfill]);
-  const runsUrl = `/instance/runs?${qs.stringify({
-    q: [stringFromValue([{token: 'tag', value: `dagster/backfill=${backfill.backfillId}`}])],
-  })}`;
+  const runsUrl = runsPathWithFilters([
+    {
+      token: 'tag',
+      value: `dagster/backfill=${backfill.backfillId}`,
+    },
+  ]);
 
   const repoAddress = backfill.partitionSet
     ? buildRepoAddress(

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.stories.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.stories.tsx
@@ -1,9 +1,9 @@
-import {TokenizingFieldValue} from '@dagster-io/ui';
 import {Meta} from '@storybook/react/types-6-0';
 import faker from 'faker';
 import moment from 'moment';
 import * as React from 'react';
 
+import {RunFilterToken} from '../runs/RunsFilterInput';
 import {StorybookProvider} from '../testing/StorybookProvider';
 import {RunStatus, StepEventStatus} from '../types/globalTypes';
 
@@ -34,10 +34,10 @@ interface ISolidHandle {
 // to make them work just filter our sample data.
 function simulateTagFilteringInQuery(
   runs: PartitionSetLoaderRunFragment[],
-  runTags: TokenizingFieldValue[],
+  runFilters: RunFilterToken[],
 ) {
   return runs.filter((r) =>
-    runTags.every((t) => r.tags.some((rt) => `${rt.key}=${rt.value}` === t.value)),
+    runFilters.every((t) => r.tags.some((rt) => `${rt.key}=${rt.value}` === t.value)),
   );
 }
 
@@ -123,7 +123,7 @@ const PipelineMocks = {
 };
 
 export const BasicTestCases = () => {
-  const [runTags, setRunTags] = React.useState<TokenizingFieldValue[]>([]);
+  const [runFilters, setRunFilters] = React.useState<RunFilterToken[]>([]);
   const [stepQuery, setStepQuery] = React.useState('');
   const partitions: {name: string; runs: PartitionSetLoaderRunFragment[]}[] = [];
 
@@ -230,14 +230,14 @@ export const BasicTestCases = () => {
       <PartitionRunMatrix
         pipelineName="TestPipeline"
         repoAddress={{name: 'Test', location: 'TestLocation'}}
-        runTags={runTags}
-        setRunTags={setRunTags}
+        runFilters={runFilters}
+        setRunFilters={setRunFilters}
         stepQuery={stepQuery}
         setStepQuery={setStepQuery}
         partitions={partitions.map((p) => ({
           ...p,
           runsLoaded: true,
-          runs: simulateTagFilteringInQuery(p.runs, runTags),
+          runs: simulateTagFilteringInQuery(p.runs, runFilters),
         }))}
       />
     </StorybookProvider>
@@ -245,7 +245,7 @@ export const BasicTestCases = () => {
 };
 
 export const LargeDataset = () => {
-  const [runTags, setRunTags] = React.useState<TokenizingFieldValue[]>([]);
+  const [runFilters, setRunFilters] = React.useState<RunFilterToken[]>([]);
   const [stepQuery, setStepQuery] = React.useState('');
   const partitions = React.useMemo(() => {
     const results: {name: string; runs: PartitionSetLoaderRunFragment[]}[] = [];
@@ -277,14 +277,14 @@ export const LargeDataset = () => {
       <PartitionRunMatrix
         pipelineName="TestPipeline"
         repoAddress={{name: 'Test', location: 'TestLocation'}}
-        runTags={runTags}
-        setRunTags={setRunTags}
+        runFilters={runFilters}
+        setRunFilters={setRunFilters}
         stepQuery={stepQuery}
         setStepQuery={setStepQuery}
         partitions={partitions.map((p) => ({
           ...p,
           runsLoaded: true,
-          runs: simulateTagFilteringInQuery(p.runs, runTags),
+          runs: simulateTagFilteringInQuery(p.runs, runFilters),
         }))}
       />
     </StorybookProvider>

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunMatrix.tsx
@@ -10,7 +10,6 @@ import {
   MenuLink,
   MenuWIP,
   Popover,
-  TokenizingFieldValue,
   FontFamily,
 } from '@dagster-io/ui';
 import qs from 'qs';
@@ -21,6 +20,7 @@ import {OptionsContainer, OptionsDivider} from '../gantt/VizComponents';
 import {useViewport} from '../gantt/useViewport';
 import {QueryPersistedStateConfig, useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT} from '../pipelines/GraphExplorer';
+import {RunFilterToken} from '../runs/RunsFilterInput';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
@@ -72,16 +72,16 @@ interface PartitionRunMatrixProps {
   pipelineName: string;
   partitions: PartitionRuns[];
   repoAddress: RepoAddress;
-  runTags: TokenizingFieldValue[];
-  setRunTags: (val: TokenizingFieldValue[]) => void;
+  runFilters: RunFilterToken[];
+  setRunFilters: (val: RunFilterToken[]) => void;
   stepQuery: string;
   setStepQuery: (val: string) => void;
 }
 
-const _backfillIdFromTags = (runTags: TokenizingFieldValue[]) => {
-  const [backfillId] = runTags
-    .filter((_) => _.token === 'tag' && _.value.startsWith('dagster/backfill='))
-    .map((_) => _.value.split('=')[1]);
+const _backfillIdFromTags = (runFilters: RunFilterToken[]) => {
+  const [backfillId] = runFilters
+    .filter(({token, value}) => token === 'tag' && value.startsWith('dagster/backfill='))
+    .map(({value}) => value.split('=')[1]);
   return backfillId;
 };
 
@@ -220,15 +220,15 @@ export const PartitionRunMatrix: React.FC<PartitionRunMatrixProps> = (props) => 
             (a, b) => [...a, ...b.runs],
             [] as {tags: {key: string; value: string}[]}[],
           )}
-          onChange={props.setRunTags}
-          tokens={props.runTags}
+          onChange={props.setRunFilters}
+          tokens={props.runFilters}
         />
-        {props.runTags.length && _backfillIdFromTags(props.runTags) ? (
+        {props.runFilters.length && _backfillIdFromTags(props.runFilters) ? (
           <Box flex={{grow: 1}} margin={{left: 12, right: 8}}>
             <PartitionProgress
               pipelineName={props.pipelineName}
               repoAddress={props.repoAddress}
-              backfillId={_backfillIdFromTags(props.runTags)}
+              backfillId={_backfillIdFromTags(props.runFilters)}
             />
           </Box>
         ) : null}

--- a/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionView.tsx
@@ -44,7 +44,7 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
   onChangePartitionSet,
   repoAddress,
 }) => {
-  const [runTags, setRunTags] = useQueryPersistedRunFilters(RunTagsSupportedTokens);
+  const [runFilters, setRunFilters] = useQueryPersistedRunFilters(RunTagsSupportedTokens);
   const [stepQuery = '', setStepQuery] = useQueryPersistedState<string>({queryKey: 'stepQuery'});
   const [showBackfillSetup, setShowBackfillSetup] = React.useState(false);
   const [blockDialog, setBlockDialog] = React.useState(false);
@@ -60,7 +60,7 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
     setPageSize,
   } = useChunkedPartitionsQuery(
     partitionSet.name,
-    runTags,
+    runFilters,
     repoAddress,
     // only query by job name if there is only one partition set
     isJob && partitionSets.length === 1 ? pipelineName : undefined,
@@ -114,7 +114,7 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
             onCancel={() => setShowBackfillSetup(false)}
             onLaunch={(backfillId, stepQuery) => {
               setStepQuery(stepQuery);
-              setRunTags([{token: 'tag', value: `dagster/backfill=${backfillId}`}]);
+              setRunFilters([{token: 'tag', value: `dagster/backfill=${backfillId}`}]);
               setShowBackfillSetup(false);
             }}
             onSubmit={onSubmit}
@@ -155,8 +155,8 @@ export const PartitionView: React.FC<PartitionViewProps> = ({
           partitions={partitions}
           pipelineName={pipelineName}
           repoAddress={repoAddress}
-          runTags={runTags}
-          setRunTags={setRunTags}
+          runFilters={runFilters}
+          setRunFilters={setRunFilters}
           stepQuery={stepQuery}
           setStepQuery={setStepQuery}
         />

--- a/js_modules/dagit/packages/core/src/partitions/RunTagsTokenizingField.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/RunTagsTokenizingField.tsx
@@ -1,18 +1,13 @@
-import {
-  TokenizingField,
-  TokenizingFieldValue,
-  stringFromValue,
-  tokenizedValuesFromString,
-} from '@dagster-io/ui';
+import {TokenizingField, stringFromValue, tokenizedValuesFromString} from '@dagster-io/ui';
 import uniq from 'lodash/uniq';
 import * as React from 'react';
 
-import {RunFilterTokenType} from '../runs/RunsFilterInput';
+import {RunFilterToken, RunFilterTokenType} from '../runs/RunsFilterInput';
 
 interface RunTagsTokenizingFieldProps {
   runs: {tags: {key: string; value: string}[]}[];
-  tokens: TokenizingFieldValue[];
-  onChange: (tokens: TokenizingFieldValue[]) => void;
+  tokens: RunFilterToken[];
+  onChange: (tokens: RunFilterToken[]) => void;
 }
 
 // BG TODO: This should most likely be folded into RunsFilterInput, but that component loads autocompletions
@@ -40,7 +35,7 @@ export const RunTagsTokenizingField: React.FC<RunTagsTokenizingFieldProps> = ({
     <TokenizingField
       small
       values={search}
-      onChange={onChange}
+      onChange={(values) => onChange(values as RunFilterToken[])}
       placeholder="Filter partition runs..."
       suggestionProviders={suggestions}
       loading={false}

--- a/js_modules/dagit/packages/core/src/partitions/useChunkedPartitionsQuery.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useChunkedPartitionsQuery.tsx
@@ -1,11 +1,11 @@
 import {gql, useApolloClient, ApolloClient} from '@apollo/client';
-import {TokenizingFieldValue} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
 import {QueryPersistedStateConfig, useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {DagsterTag} from '../runs/RunTag';
+import {RunFilterToken} from '../runs/RunsFilterInput';
 import {RunStatus} from '../types/globalTypes';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -68,7 +68,7 @@ const InitialDataState: DataState = {
  */
 export function useChunkedPartitionsQuery(
   partitionSetName: string,
-  runsFilter: TokenizingFieldValue[],
+  runsFilter: RunFilterToken[],
   repoAddress: RepoAddress,
   jobName?: string,
 ) {

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -1,14 +1,5 @@
 import {gql} from '@apollo/client';
-import {
-  Box,
-  Checkbox,
-  ColorsWIP,
-  IconWIP,
-  NonIdealState,
-  Table,
-  Mono,
-  TokenizingFieldValue,
-} from '@dagster-io/ui';
+import {Box, Checkbox, ColorsWIP, IconWIP, NonIdealState, Table, Mono} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -33,11 +24,12 @@ import {canceledStatuses, queuedStatuses} from './RunStatuses';
 import {RunStepKeysAssetList} from './RunStepKeysAssetList';
 import {RunTags} from './RunTags';
 import {RunElapsed, RunTime, RUN_TIME_FRAGMENT, titleForRun} from './RunUtils';
+import {RunFilterToken} from './RunsFilterInput';
 import {RunTableRunFragment} from './types/RunTableRunFragment';
 
 interface RunTableProps {
   runs: RunTableRunFragment[];
-  onSetFilter: (search: TokenizingFieldValue[]) => void;
+  onSetFilter: (search: RunFilterToken[]) => void;
   nonIdealState?: React.ReactNode;
   actionBarComponents?: React.ReactNode;
   highlightedIds?: string[];
@@ -180,7 +172,7 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
 const RunRow: React.FC<{
   run: RunTableRunFragment;
   canTerminateOrDelete: boolean;
-  onSetFilter: (search: TokenizingFieldValue[]) => void;
+  onSetFilter: (search: RunFilterToken[]) => void;
   checked?: boolean;
   onToggleChecked?: (values: {checked: boolean; shiftKey: boolean}) => void;
   additionalColumns?: React.ReactNode[];

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -1,7 +1,8 @@
-import {Box, TokenizingFieldValue} from '@dagster-io/ui';
+import {Box} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {RunTag} from './RunTag';
+import {RunFilterToken} from './RunsFilterInput';
 
 interface RunTagType {
   key: string;
@@ -11,7 +12,7 @@ interface RunTagType {
 export const RunTags: React.FC<{
   tags: RunTagType[];
   mode: string | null;
-  onSetFilter?: (search: TokenizingFieldValue[]) => void;
+  onSetFilter?: (search: RunFilterToken[]) => void;
 }> = React.memo(({tags, onSetFilter, mode}) => {
   if (!tags.length) {
     return null;

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -6,6 +6,7 @@ import {
   tokensAsStringArray,
   tokenizedValuesFromStringArray,
 } from '@dagster-io/ui';
+import qs from 'qs';
 import * as React from 'react';
 
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -20,6 +21,11 @@ import {
 type PipelineRunTags = RunsSearchSpaceQuery_pipelineRunTags[];
 
 export type RunFilterTokenType = 'id' | 'status' | 'pipeline' | 'job' | 'snapshotId' | 'tag';
+
+export type RunFilterToken = {
+  token?: RunFilterTokenType;
+  value: string;
+};
 
 const RUN_PROVIDERS_EMPTY = [
   {
@@ -57,7 +63,7 @@ const RUN_PROVIDERS_EMPTY = [
  * be provided (eg pipeline:, which is not relevant within pipeline scoped views.)
  */
 export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[]) {
-  return useQueryPersistedState<TokenizingFieldValue[]>(
+  return useQueryPersistedState<RunFilterToken[]>(
     React.useMemo(
       () => ({
         encode: (tokens) => ({q: tokensAsStringArray(tokens), cursor: undefined}),
@@ -65,11 +71,18 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
           tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY).filter(
             (t) =>
               !t.token || !enabledFilters || enabledFilters.includes(t.token as RunFilterTokenType),
-          ),
+          ) as RunFilterToken[],
       }),
       [enabledFilters],
     ),
   );
+}
+
+export function runsPathWithFilters(filterTokens: RunFilterToken[]) {
+  return `/instance/runs?${qs.stringify(
+    {q: tokensAsStringArray(filterTokens)},
+    {arrayFormat: 'brackets'},
+  )}`;
 }
 
 export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
@@ -164,8 +177,8 @@ function searchSuggestionsForRuns(
 
 interface RunsFilterInputProps {
   loading?: boolean;
-  tokens: TokenizingFieldValue[];
-  onChange: (tokens: TokenizingFieldValue[]) => void;
+  tokens: RunFilterToken[];
+  onChange: (tokens: RunFilterToken[]) => void;
   enabledFilters?: RunFilterTokenType[];
 }
 
@@ -212,7 +225,7 @@ export const RunsFilterInput: React.FC<RunsFilterInputProps> = ({
   return (
     <TokenizingField
       values={search}
-      onChange={onChange}
+      onChange={(values) => onChange(values as RunFilterToken[])}
       onFocus={onFocus}
       suggestionProviders={suggestions}
       suggestionProvidersFilter={suggestionProvidersFilter}

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -92,7 +92,7 @@ export const RunsRoot = () => {
 
   const setStatusFilter = (statuses: RunStatus[]) => {
     const tokensMinusStatus = filterTokens.filter((token) => token.token !== 'status');
-    const statusTokens = statuses.map((status) => ({token: 'status', value: status}));
+    const statusTokens = statuses.map((status) => ({token: 'status' as const, value: status}));
     setFilterTokens([...statusTokens, ...tokensMinusStatus]);
     setShowScheduled(false);
   };

--- a/js_modules/dagit/packages/ui/src/components/NonIdealState.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/NonIdealState.stories.tsx
@@ -17,7 +17,7 @@ export const Default = () => {
       <NonIdealState
         icon="star"
         title="This run is currently queued."
-        action={<a href="/instance/runs?q=status%3AQUEUED">View queued runs</a>}
+        action={<a href="/instance/runs?q[]=status%3AQUEUED">View queued runs</a>}
       />
       <NonIdealState
         icon="warning"


### PR DESCRIPTION
## Summary
https://github.com/dagster-io/dagster/issues/6847

The `/instance/runs?q=status:queued` URLs shifted to a brackets array syntax (`/instance/runs?q[]=status:queued`)  recently, and we had a few stray callsites still using the old syntax.

It's a bit tricky to build these URLs and we were doing it inconsistently so I added a helper that is colocated with the parser. 

I also realized that we were using a `{token: string, value: string}` in a lot of places that referenced run filters, and narrowed it to a type that specifies the valid token options.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.