### PR TITLE
Don't carry forward all container definitions

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -74,8 +74,7 @@ def default_ecs_task_definition(
     # and the command will fail
     # https://aws.amazon.com/blogs/opensource/demystifying-entrypoint-cmd-docker/
     container_definitions = task_definition["containerDefinitions"]
-    container_definitions.remove(metadata.container_definition)
-    container_definitions.append(
+    container_definitions = [
         merge_dicts(
             {
                 **metadata.container_definition,
@@ -87,7 +86,7 @@ def default_ecs_task_definition(
             environment_dict,
             secrets_dict,
         )
-    )
+    ]
     task_definition = {
         **task_definition,
         "family": "dagster-run",

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 
 import boto3
 import pytest
-
 from dagster import ExperimentalWarning
 from dagster.core.definitions.reconstructable import ReconstructableRepository
 from dagster.core.test_utils import in_process_test_workspace, instance_for_test
@@ -34,7 +33,8 @@ def task_definition(ecs, image, environment):
     return ecs.register_task_definition(
         family="dagster",
         containerDefinitions=[
-            {"name": "dagster", "image": image, "environment": environment, "entryPoint": ["ls"]}
+            {"name": "dagster", "image": image, "environment": environment, "entryPoint": ["ls"]},
+            {"name": "other", "image": image, "entryPoint": ["ls"]}
         ],
         networkMode="awsvpc",
         memory="512",


### PR DESCRIPTION
When we create a task definition for the job run, we inherit a bunch of
information from the container running running the current process. The
original implementation assumed that this was the lone container running
in the task (or at the very least, that the other containers had no
meaningful side effects).

But if somebody chooses to run a task with both a daemon and a dagit
container (or even a handful of sidecar containers), this behavior would
cause the dagit container to also stand up in the job run task.

This change constrains that behavior to only launch a single container
in the job run task.