### PR TITLE
[dagit] Avoid copying definition-time tags into launchpad state

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/TagEditor.tsx
@@ -26,10 +26,8 @@ interface ITagEditorProps {
 }
 
 interface ITagContainerProps {
-  tags: {
-    fromDefinition?: PipelineRunTag[];
-    fromSession?: PipelineRunTag[];
-  };
+  tagsFromDefinition?: PipelineRunTag[];
+  tagsFromSession: PipelineRunTag[];
   onRequestEdit: () => void;
 }
 
@@ -43,6 +41,14 @@ export const TagEditor: React.FC<ITagEditorProps> = ({
   const [editState, setEditState] = React.useState(() =>
     tagsFromSession.length ? tagsFromSession : [{key: '', value: ''}],
   );
+
+  // Reset the edit state when you close and re-open the modal, or when
+  // tagsFromSession change while the modal is closed.
+  React.useEffect(() => {
+    if (!open) {
+      setEditState(tagsFromSession.length ? tagsFromSession : [{key: '', value: ''}]);
+    }
+  }, [tagsFromSession, open]);
 
   const toSave: PipelineRunTag[] = editState
     .map((tag: PipelineRunTag) => ({
@@ -176,26 +182,31 @@ export const TagEditor: React.FC<ITagEditorProps> = ({
   );
 };
 
-export const TagContainer = ({tags, onRequestEdit}: ITagContainerProps) => {
-  const {fromDefinition = [], fromSession = []} = tags;
+export const TagContainer = ({
+  tagsFromSession,
+  tagsFromDefinition,
+  onRequestEdit,
+}: ITagContainerProps) => {
   return (
     <Container>
       <TagList>
-        {fromDefinition.map((tag, idx) => {
-          const {key} = tag;
-          const anyOverride = fromSession.some((sessionTag) => sessionTag.key === key);
-          if (anyOverride) {
-            return (
-              <Tooltip key={key} content="Overriden by custom tag value" placement="top">
-                <span style={{opacity: 0.2}}>
-                  <RunTag tag={tag} key={idx} />
-                </span>
-              </Tooltip>
-            );
-          }
-          return <RunTag tag={tag} key={idx} />;
-        })}
-        {fromSession.map((tag, idx) => (
+        {tagsFromDefinition
+          ? tagsFromDefinition.map((tag, idx) => {
+              const {key} = tag;
+              const anyOverride = tagsFromSession.some((sessionTag) => sessionTag.key === key);
+              if (anyOverride) {
+                return (
+                  <Tooltip key={key} content="Overriden by custom tag value" placement="top">
+                    <span style={{opacity: 0.2}}>
+                      <RunTag tag={tag} key={idx} />
+                    </span>
+                  </Tooltip>
+                );
+              }
+              return <RunTag tag={tag} key={idx} />;
+            })
+          : undefined}
+        {tagsFromSession.map((tag, idx) => (
           <RunTag tag={tag} key={idx} />
         ))}
       </TagList>

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -407,10 +407,7 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
           <strong>Tags</strong>
           {tags.length ? (
             <div style={{border: `1px solid ${ColorsWIP.Gray300}`, borderRadius: 8, padding: 3}}>
-              <TagContainer
-                tags={{fromSession: tags}}
-                onRequestEdit={() => setTagEditorOpen(true)}
-              />
+              <TagContainer tagsFromSession={tags} onRequestEdit={() => setTagEditorOpen(true)} />
             </div>
           ) : (
             <div>


### PR DESCRIPTION
## Summary
This is based on a Slack discussion here: https://dagster.slack.com/archives/G01FK61V7PD/p1645628402449029 and resolves two problems:

1) When you choose a partition / preset in the launchpad, Dagit was copying the "definition-time tags" from the pipeline into state. This doesn't serve much of a purpose because we do not allow these tags to be removed, only overridden, and if you make changes to your job definition, your changes are not reflected until you reselect the same partition from the dropdown again. We now merge these in at the last minute when you click "Launch"

2) The "Edit Tags" modal was capturing the current session tags into state for editing, but not resetting back to the parent prop when the modal was closed / re-opened. This caused the modal to show incorrect data if you switched launchpad tabs or reselected a partition.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.