### PR TITLE
[dagit] Use a virtualized list in <SuggestWIP /> to fix launchpad partition picker perf

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Suggest.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Suggest.tsx
@@ -1,8 +1,9 @@
 import {InputGroupProps2, IPopoverProps} from '@blueprintjs/core';
 // eslint-disable-next-line no-restricted-imports
-import {Suggest as BlueprintSuggest, SuggestProps} from '@blueprintjs/select';
+import {isCreateNewItem, Suggest as BlueprintSuggest, SuggestProps} from '@blueprintjs/select';
 import deepmerge from 'deepmerge';
 import * as React from 'react';
+import {List} from 'react-virtualized';
 import {createGlobalStyle} from 'styled-components/macro';
 
 import {ColorsWIP} from './Colors';
@@ -49,6 +50,11 @@ export const GlobalSuggestStyle = createGlobalStyle`
   }
 `;
 
+export const MENU_ITEM_HEIGHT = 32;
+
+const MENU_WIDTH = 250; // arbitrary, just looks nice
+const MENU_HEIGHT_MAX = MENU_ITEM_HEIGHT * 7.5;
+
 export const SuggestWIP = <T,>(props: React.PropsWithChildren<SuggestProps<T>>) => {
   const popoverProps: Partial<IPopoverProps> = {
     ...props.popoverProps,
@@ -65,5 +71,30 @@ export const SuggestWIP = <T,>(props: React.PropsWithChildren<SuggestProps<T>>) 
     className: 'dagit-suggest-input',
   };
 
-  return <BlueprintSuggest {...props} inputProps={inputProps} popoverProps={popoverProps} />;
+  return (
+    <BlueprintSuggest<T>
+      {...props}
+      inputProps={inputProps}
+      itemListRenderer={(props) => (
+        <List
+          style={{outline: 'none', marginRight: -5, paddingRight: 5}}
+          rowCount={props.filteredItems.length}
+          scrollToIndex={
+            props.activeItem && !isCreateNewItem(props.activeItem)
+              ? props.filteredItems.indexOf(props.activeItem)
+              : undefined
+          }
+          rowHeight={MENU_ITEM_HEIGHT}
+          rowRenderer={(a) => (
+            <div key={a.index} style={a.style}>
+              {props.renderItem(props.filteredItems[a.index] as T, a.index)}
+            </div>
+          )}
+          width={MENU_WIDTH}
+          height={Math.min(props.filteredItems.length * MENU_ITEM_HEIGHT, MENU_HEIGHT_MAX)}
+        />
+      )}
+      popoverProps={popoverProps}
+    />
+  );
 };


### PR DESCRIPTION
## Summary
I was working on the hacker_news_download demo job which has 10,000 partitions. The whole launchpad page has awful performance because the default Blueprint `<Suggest>` implementation renders all possible suggestions in it's dropdown menu.

I think that if our team chooses a `<Suggest />` input, it's probably because the list of options is long and we want the typeahead feature, and our standard SuggestWIP implementation should be performant. I swapped in a virtualized list per the suggestion in https://github.com/palantir/blueprint/issues/3281 and checked that this 1) looks fine and fixes the performance problems in the 10,000 partition case and 2) works when virtualization isn't required (with only a few partitions)

There are no other uses of SuggestWIP in our codebase at the moment.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.