### PR TITLE
fix: query heartbeats db once

### DIFF
--- a/python_modules/dagster/dagster/daemon/controller.py
+++ b/python_modules/dagster/dagster/daemon/controller.py
@@ -362,6 +362,7 @@ def get_daemon_statuses(
     )
 
     daemon_statuses_by_type = {}
+    heartbeats = instance.get_daemon_heartbeats()
 
     for daemon_type in daemon_types:
         # check if daemon is not required
@@ -371,7 +372,6 @@ def get_daemon_statuses(
             )
         else:
             # check if daemon has a heartbeat
-            heartbeats = instance.get_daemon_heartbeats()
             if daemon_type not in heartbeats:
                 daemon_statuses_by_type[daemon_type] = DaemonStatus(
                     daemon_type=daemon_type, required=True, healthy=False, last_heartbeat=None


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Query requests per second still weren't going down after the batch change. Because I wasn't actually batching.. fix that.


## Test Plan
datadog




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
