### PR TITLE
Remove @abstractproperty

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -8,10 +8,8 @@ from dagster.core.test_utils import create_test_daemon_workspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
 
-from .graphql_context_test_suite import (  # get_dict_recon_repo,
-    GraphQLContextVariant,
-    make_graphql_context_test_suite,
-)
+from .graphql_context_test_suite import GraphQLContextVariant  # get_dict_recon_repo,
+from .graphql_context_test_suite import make_graphql_context_test_suite
 
 INSTIGATION_QUERY = """
 query JobQuery($instigationSelector: InstigationSelector!) {

--- a/python_modules/dagster/dagster/core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/core/definitions/configurable.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Optional, Union
 
 from dagster import Field, check
@@ -12,7 +12,8 @@ from .definition_config_schema import (
 
 
 class ConfigurableDefinition(ABC):
-    @abstractproperty
+    @property
+    @abstractmethod
     def config_schema(self) -> Optional[IDefinitionConfigSchema]:
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster/core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/node_definition.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Mapping, Sequence
 
 from dagster import check
@@ -45,11 +45,13 @@ class NodeDefinition(NamedConfigurableDefinition):
             else list(map(lambda inp: inp.name, input_defs))
         )
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def node_type_str(self):
         raise NotImplementedError()
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_graph_job_op_node(self) -> bool:
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_base.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_base.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, FrozenSet, List, Optional
 
 from dagster import check
@@ -25,7 +25,8 @@ class IPipeline(ABC):
     def subset_for_execution(self, solid_selection: List[str]) -> "IPipeline":
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def solids_to_execute(self) -> Optional[FrozenSet[str]]:
         pass
 

--- a/python_modules/dagster/dagster/core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/core/execution/context/compute.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 
 from dagster import check
@@ -36,35 +36,43 @@ class AbstractComputeExecutionContext(ABC):  # pylint: disable=no-init
     def get_tag(self, key: str) -> Optional[str]:
         """Implement this method to get a logging tag."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def run_id(self) -> str:
         """The run id for the context."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def solid_def(self) -> SolidDefinition:
         """The solid definition corresponding to the execution step being executed."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def solid(self) -> Node:
         """The solid corresponding to the execution step being executed."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def pipeline_def(self) -> PipelineDefinition:
         """The pipeline being executed."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def pipeline_run(self) -> PipelineRun:
         """The PipelineRun object corresponding to the execution."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def resources(self) -> Any:
         """Resources available in the execution context."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def log(self) -> DagsterLogManager:
         """The log manager available in the execution context."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def solid_config(self) -> Any:
         """The parsed config specific to this solid."""
 

--- a/python_modules/dagster/dagster/core/execution/context/system.py
+++ b/python_modules/dagster/dagster/core/execution/context/system.py
@@ -4,7 +4,7 @@ Not every property on these should be exposed to random Jane or Joe dagster user
 so we have a different layer of objects that encode the explicit public API
 in the user_context module
 """
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -67,7 +67,8 @@ class IPlanContext(ABC):
     The information available via this interface is accessible to the system throughout a run.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def plan_data(self) -> "PlanData":
         raise NotImplementedError()
 
@@ -111,7 +112,8 @@ class IPlanContext(ABC):
     def execution_plan(self):
         return self.plan_data.execution_plan
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def output_capture(self) -> Optional[Dict[StepOutputHandle, Any]]:
         raise NotImplementedError()
 
@@ -163,11 +165,13 @@ class ExecutionData(NamedTuple):
 class IStepContext(IPlanContext):
     """Interface to represent data to be available during either step orchestration or execution."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def step(self) -> ExecutionStep:
         raise NotImplementedError()
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def solid_handle(self) -> "NodeHandle":
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
+++ b/python_modules/dagster/dagster/core/execution/context_creation_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
@@ -181,7 +181,8 @@ class ExecutionContextManager(Generic[TContextType], ABC):
             generator=event_generator, object_cls=self.context_type, require_object=raise_on_error
         )
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def context_type(self) -> Type[TContextType]:
         pass
 

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -1,5 +1,5 @@
 import hashlib
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, NamedTuple, Optional, Set, Union, cast
 
 from dagster import check
@@ -102,11 +102,13 @@ class StepInputSource(ABC):
     def get_input_def(self, pipeline_def: PipelineDefinition) -> InputDefinition:
         return pipeline_def.get_solid(self.solid_handle).input_def_named(self.input_name)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def solid_handle(self) -> NodeHandle:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def input_name(self) -> str:
         pass
 

--- a/python_modules/dagster/dagster/core/executor/base.py
+++ b/python_modules/dagster/dagster/core/executor/base.py
@@ -1,10 +1,10 @@
-import abc
+from abc import abstractmethod, ABC
 
 from dagster.core.execution.retries import RetryMode
 
 
-class Executor(abc.ABC):  # pylint: disable=no-init
-    @abc.abstractmethod
+class Executor(ABC):  # pylint: disable=no-init
+    @abstractmethod
     def execute(self, plan_context, execution_plan):
         """
         For the given context and execution plan, orchestrate a series of sub plan executions in a way that satisfies the whole plan being executed.
@@ -17,7 +17,8 @@ class Executor(abc.ABC):  # pylint: disable=no-init
             A stream of dagster events.
         """
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def retries(self) -> RetryMode:
         """
         Whether retries are enabled or disabled for this instance of the executor.

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/base.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/base.py
@@ -1,4 +1,4 @@
-import abc
+from abc import abstractmethod, ABC
 from typing import Dict, List, Optional
 
 from dagster import DagsterEvent, DagsterInstance, check
@@ -44,19 +44,20 @@ class StepHandlerContext:
         return self._instance
 
 
-class StepHandler(abc.ABC):  # pylint: disable=no-init
-    @abc.abstractproperty
+class StepHandler(ABC):  # pylint: disable=no-init
+    @property
+    @abstractmethod
     def name(self) -> str:
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def launch_step(self, step_handler_context: StepHandlerContext) -> List[DagsterEvent]:
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def check_step_health(self, step_handler_context: StepHandlerContext) -> List[DagsterEvent]:
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def terminate_step(self, step_handler_context: StepHandlerContext) -> List[DagsterEvent]:
         pass

--- a/python_modules/dagster/dagster/core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/core/host_representation/represented.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 from dagster import check
 
@@ -33,11 +33,13 @@ class RepresentedPipeline(ABC):
 
     # Snapshot things
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def computed_pipeline_snapshot_id(self):
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def identifying_pipeline_snapshot_id(self):
         pass
 

--- a/python_modules/dagster/dagster/core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/base.py
@@ -1,5 +1,5 @@
 import warnings
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import (
     Callable,
@@ -195,7 +195,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
     def end_watch(self, run_id: str, handler: Callable):
         """Call this method to stop watching."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_persistent(self) -> bool:
         """bool: Whether the storage is persistent."""
 

--- a/python_modules/dagster/dagster/core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/core/storage/file_manager.py
@@ -2,7 +2,7 @@ import io
 import os
 import shutil
 import uuid
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import BinaryIO, TextIO, Union
 
@@ -31,7 +31,8 @@ class FileHandle(ABC):
     such as S3.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def path_desc(self) -> str:
         """A representation of the file path for display purposes only."""
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/core/storage/output_manager.py
+++ b/python_modules/dagster/dagster/core/storage/output_manager.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 
 from dagster.core.definitions.definition_config_schema import (
     convert_user_facing_definition_config_schema,
@@ -7,7 +7,8 @@ from dagster.core.definitions.resource_definition import ResourceDefinition
 
 
 class IOutputManagerDefinition:
-    @abstractproperty
+    @property
+    @abstractmethod
     def output_config_schema(self):
         """The schema for per-output configuration for outputs that are managed by this
         manager"""

--- a/python_modules/dagster/dagster/core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/core/storage/root_input_manager.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from functools import update_wrapper
 
 from dagster import check
@@ -12,7 +12,8 @@ from dagster.utils.backcompat import experimental
 
 
 class IInputManagerDefinition:
-    @abstractproperty
+    @property
+    @abstractmethod
     def input_config_schema(self):
         """The schema for per-input configuration for inputs that are managed by this
         input manager"""

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -2,7 +2,7 @@ import sys
 import threading
 import time
 import warnings
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
@@ -343,7 +343,8 @@ class IWorkspaceProcessContext(ABC):
     def version(self) -> str:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def location_state_events(self) -> "Subject":
         pass
 
@@ -358,7 +359,8 @@ class IWorkspaceProcessContext(ABC):
     def reload_workspace(self) -> None:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def instance(self):
         pass
 

--- a/python_modules/dagster/dagster/serdes/config_class.py
+++ b/python_modules/dagster/dagster/serdes/config_class.py
@@ -1,5 +1,5 @@
 import importlib
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import NamedTuple
 
 import yaml
@@ -116,7 +116,8 @@ class ConfigurableClass(ABC):
 
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def inst_data(self):
         """
         Subclass must be able to return the inst_data as a property if it has been constructed

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -1,7 +1,8 @@
 from botocore import __version__ as botocore_version
 from botocore.config import Config
-from dagster import check
 from packaging import version
+
+from dagster import check
 
 
 def construct_boto_client_retry_config(max_attempts):


### PR DESCRIPTION
@abstractmethod is deprecated https://docs.python.org/3/library/abc.html#abc.abstractproperty in favor of

@property @abstractmethod

Feels... less clear? Oh well

Same as https://github.com/dagster-io/internal/pull/1256?no-redirect=1