### PR TITLE
Adds pez popover as requested in #6470

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -449,6 +449,7 @@ const JobSection = (props: JobSectionProps) => {
         <tbody>
           {jobs.map(({job, repoAddress, runs, schedules, sensors}) => {
             const jobKey = makeJobKey(repoAddress, job.name);
+            const repoAddressString = repoAddressAsString(repoAddress);
             return (
               <tr key={jobKey}>
                 <td>
@@ -469,12 +470,12 @@ const JobSection = (props: JobSectionProps) => {
                         {!job.isJob ? <LegacyPipelineTag /> : null}
                       </Box>
                       <Body color={ColorsWIP.Gray400} style={{fontFamily: FontFamily.monospace}}>
-                        {repoAddressAsString(repoAddress)}
+                        {repoAddressString}
                       </Body>
                     </Box>
                     {runs ? (
                       <Box margin={{top: 4}}>
-                        <RunStatusPezList fade runs={runs} />
+                        <RunStatusPezList fade runs={runs} repoAddress={repoAddressString} />
                       </Box>
                     ) : null}
                   </Box>

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.stories.tsx
@@ -7,6 +7,8 @@ import {StorybookProvider} from '../testing/StorybookProvider';
 import {RunStatus} from '../types/globalTypes';
 
 import {RunStatusPez, RunStatusPezList} from './RunStatusPez';
+import {generateRuns} from './RunTimeline.stories';
+import {RunTimeFragment} from './types/RunTimeFragment';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -41,35 +43,57 @@ export const Colors = () => {
 };
 
 export const List = () => {
+  const tenDaysAgo = React.useMemo(() => Date.now() - 10 * 24 * 60 * 60 * 1000, []);
+  const now = React.useMemo(() => Date.now(), []);
+
+  const wrapToFragment = (
+    inp: {
+      id: string;
+      status: RunStatus;
+      startTime: number;
+      endTime: number;
+    }[],
+  ): RunTimeFragment[] =>
+    inp.map((r) => ({...r, runId: r.id, updateTime: null, __typename: 'Run'}));
+
+  const fakeRepo = 'a_repo.py';
   const fakeId = React.useCallback(() => faker.datatype.uuid(), []);
-  const randomList = React.useCallback(
-    (count) =>
-      [...new Array(count)].map(() => {
-        const rand = Math.random();
-        const runId = fakeId();
-        if (rand < 0.7) {
-          return {runId, status: RunStatus.SUCCESS};
-        }
-        return {runId, status: RunStatus.FAILURE};
-      }),
-    [fakeId],
-  );
 
   return (
     <StorybookProvider apolloProps={{mocks}}>
       <Box flex={{direction: 'column', gap: 8}}>
-        <RunStatusPezList fade runs={randomList(10)} />
         <RunStatusPezList
+          repoAddress={fakeRepo}
           fade
-          runs={[...randomList(9), {runId: fakeId(), status: RunStatus.STARTING}]}
+          runs={wrapToFragment(generateRuns(10, [tenDaysAgo, now]))}
         />
         <RunStatusPezList
+          repoAddress={fakeRepo}
+          fade
+          runs={wrapToFragment(generateRuns(9, [tenDaysAgo, now])).map((f) => ({
+            ...f,
+            status: RunStatus.STARTED,
+          }))}
+        />
+        <RunStatusPezList
+          repoAddress={fakeRepo}
           fade
           runs={[
-            ...randomList(7),
-            {runId: fakeId(), status: RunStatus.STARTING},
-            {runId: fakeId(), status: RunStatus.STARTING},
-            {runId: fakeId(), status: RunStatus.STARTING},
+            ...wrapToFragment(generateRuns(7, [tenDaysAgo, now])),
+            ...[...new Array(3)]
+              .map((_, idx) => {
+                const id = fakeId();
+                return {
+                  __typename: 'Run' as const,
+                  id,
+                  runId: id,
+                  status: RunStatus.STARTING,
+                  startTime: Date.now() - (idx + 1) * 60 * 60 * 1000,
+                  endTime: Date.now() - idx * 60 * 60 * 1000,
+                  updateTime: null,
+                };
+              })
+              .reverse(), //Latest first
           ]}
         />
       </Box>

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -1,10 +1,14 @@
-import {Box, ColorsWIP, Popover} from '@dagster-io/ui';
+import {Box, ColorsWIP, FontFamily, Mono, Popover} from '@dagster-io/ui';
 import * as React from 'react';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {SectionHeader} from '../pipelines/SidebarComponents';
 import {RunStatus} from '../types/globalTypes';
 
-import {RunStats} from './RunStats';
+import {RunStatusIndicator} from './RunStatusDots';
+import {RunTime, titleForRun} from './RunUtils';
+import {RunTimeFragment} from './types/RunTimeFragment';
 
 const RUN_STATUS_COLORS = {
   QUEUED: ColorsWIP.Blue500,
@@ -37,7 +41,8 @@ export const RunStatusPez = (props: Props) => {
 
 interface ListProps {
   fade: boolean;
-  runs: {runId: string; status: RunStatus}[];
+  repoAddress: string;
+  runs: RunTimeFragment[];
 }
 
 export const RunStatusPezList = (props: ListProps) => {
@@ -52,7 +57,11 @@ export const RunStatusPezList = (props: ListProps) => {
           key={run.runId}
           position="bottom"
           interactionKind="hover"
-          content={<RunStats runId={run.runId} />}
+          content={
+            <div>
+              <RunStatusOverlay run={run} repoAddr={props.repoAddress} />
+            </div>
+          }
           hoverOpenDelay={100}
         >
           <RunStatusPez
@@ -66,6 +75,56 @@ export const RunStatusPezList = (props: ListProps) => {
     </Box>
   );
 };
+
+interface OverlayProps {
+  run: RunTimeFragment;
+  repoAddr: string;
+}
+
+const RunStatusOverlay = (props: OverlayProps) => {
+  return (
+    <OverlayContainer>
+      <OverlayTitle>{props.repoAddr}</OverlayTitle>
+      <RunRow>
+        <RunStatusIndicator status={props.run.status} />
+        <Link to={`/instance/runs/${props.run.runId}`}>
+          <Mono>{titleForRun(props.run)}</Mono>
+        </Link>
+        <HorizontalSpace />
+        <RunTime run={props.run} />
+      </RunRow>
+    </OverlayContainer>
+  );
+};
+
+const OverlayContainer = styled.div`
+  padding: 4px;
+  font-size: 12px;
+  width: 250px;
+`;
+
+const HorizontalSpace = styled.div`
+  flex: 1;
+`;
+
+const OverlayTitle = styled(SectionHeader)`
+  padding: 8px;
+  box-shadow: inset 0 -1px ${ColorsWIP.KeylineGray};
+  max-width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  min-width: 0px;
+`;
+
+const RunRow = styled.div`
+  align-items: center;
+  padding: 8px;
+  font-family: ${FontFamily.monospace};
+  font-size: 14px;
+  line-height: 20px;
+  display: flex;
+  gap: 8px;
+`;
 
 const Pez = styled.div<{$color: string; $opacity: number}>`
   background-color: ${({$color}) => $color};

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: RunTimeline,
 } as Meta;
 
-const generateRuns = (runCount: number, range: [number, number]) => {
+export const generateRuns = (runCount: number, range: [number, number]) => {
   const [start, end] = range;
   const now = Date.now();
   return [...new Array(6)]


### PR DESCRIPTION
## Summary
See #6470, just the popover that was requested there, to show the run status, linked run id, the time of the run in the popover instead of the stats list. 

![Screen Shot 2022-03-02 at 12 02 57 PM](https://user-images.githubusercontent.com/4010391/156421214-b43bbb55-e462-476b-b29a-b87c8f9ce126.png)

## Test Plan

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.