### PR TITLE
black/isort config tweaks

### DIFF
--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -7,9 +7,8 @@
 [tool.black]
 line-length = 88
 required-version = "22.1.0"
-target_version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 [tool.isort]
 profile = 'black'  # sets line-length to 88
 case_sensitive = true
-skip_gitignore = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ line-length = 100
 required-version = "22.1.0"
 
 # Ensure black's output will be compatible with all listed versions.
-target_version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 # ########################
 # ##### ISORT
@@ -25,6 +25,9 @@ target_version = ['py36', 'py37', 'py38', 'py39', 'py310']
 # [Config option reference]
 #   https://pycqa.github.io/isort/docs/configuration/options.html
 
+# NOTE: File inclusion//exclusion/skip options are set at the invocation site
+# and shouldn't be set in this config file.
+
 [tool.isort]
 
 # Sets a variety of default options for parentheses etc that are compatible with black.
@@ -32,9 +35,6 @@ profile = "black"
 
 # Sorts uppercase imports before lowercase improts.
 case_sensitive=true
-
-# Isort will read skip info from gitignore (including subdirectory gitignores)
-skip_gitignore=true
 
 # profile=black just sets defaults, it won't read our line-length override in black's config
 line_length=100

--- a/python_modules/dagster/dagster/core/executor/base.py
+++ b/python_modules/dagster/dagster/core/executor/base.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 
 from dagster.core.execution.retries import RetryMode
 

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/base.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/base.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
 from dagster import DagsterEvent, DagsterInstance, check

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
                 "pylint==2.6.0",
             ],
             "black": [
-                "black==22.1.0",
+                "black[jupyter]==22.1.0",
             ],
             "isort": [
                 "isort==5.10.1",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -9,6 +9,7 @@ from dagster_dbt.utils import generate_materializations
 
 from dagster import (
     AssetKey,
+    MetadataValue,
     Out,
     Output,
     SolidExecutionContext,
@@ -16,7 +17,6 @@ from dagster import (
     TableSchema,
     check,
     get_dagster_logger,
-    MetadataValue,
 )
 from dagster.core.asset_defs import AssetsDefinition, multi_asset
 


### PR DESCRIPTION
This is a followup to the black/isort update that makes a few tweaks:

- standardized black option casing in pyproject.toml
- makes sure jupyter extras are installed for black in setup.py
- removes `isort` skip_gitignore

The last is warranted as this was apparently causing slowdown for people and we are now specifying all target files/skips on command invocation anyway (with git ls-files).
