### PR TITLE
point top-level workspace to latest toys

### DIFF
--- a/workspace.yaml
+++ b/workspace.yaml
@@ -1,3 +1,2 @@
 load_from:
-  - python_module: dagster_test.toys.repo
-  - python_module: dagster_test.toys.graph_job_repos
+  - python_module: dagster_test.graph_job_op_toys.repo


### PR DESCRIPTION
It's a little unclear to me that it makes sense to have this workspace.yaml at the top level, but as long as we do, it should point to our most up-to-date toys.

I tested with `dagit -w workspace.yaml` from the repo root.