### PR TITLE
Fix missing partition bars in large partition data-sets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -88,6 +88,8 @@ export const PartitionHealthSummary: React.FC<{
   }
 
   const {spans, keys, indexToPct} = assetData;
+  const highestIndex = spans.map((s) => s.endIdx).reduce((prev, cur) => Math.max(prev, cur), 0);
+
   const selectedSpans = selected
     ? assembleIntoSpans(keys, (key) => selected.includes(key)).filter((s) => s.status)
     : [];
@@ -144,9 +146,9 @@ export const PartitionHealthSummary: React.FC<{
             style={{
               left: indexToPct(s.startIdx),
               width: indexToPct(s.endIdx - s.startIdx + 1),
-              minWidth: 2,
+              minWidth: s.status ? 2 : undefined,
               position: 'absolute',
-              zIndex: s.status === false ? 2 : 1,
+              zIndex: s.startIdx === 0 || s.endIdx === highestIndex ? 3 : s.status ? 2 : 1, //End-caps, then statuses, then missing
               top: 0,
             }}
           >


### PR DESCRIPTION

## Summary
See issue #6502

After tweaking this I created a custom set of spans here (ignore the counts in the screenshots) to test this with just the end-caps being the successful runs in a partition set of 1000. Then also with the 2nd from the end-caps being the only successful runs in a partition set of 1000. See below. 

![Screen Shot 2022-03-02 at 3 06 03 PM](https://user-images.githubusercontent.com/4010391/156450871-7a360c78-bce1-4380-bac6-25623954e870.png)

![Screen Shot 2022-03-02 at 3 05 31 PM](https://user-images.githubusercontent.com/4010391/156450889-8603cfba-fce4-4016-b296-d3e10566358b.png)

Note that in terms of rending the bars, we prefer status over no status (status is given a min-width of 2px), and then if they happen to be colliding (the endcaps usually) we prefer (for z-index) the end-caps, then the bars with a status, and then the gray ones.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.