### PR TITLE
[dagster-fivetran] update how we generate the asset key for a given schema, table name pair

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
@@ -42,7 +42,15 @@ def _table_data_to_materialization(
 def generate_materializations(fivetran_output: FivetranOutput, asset_key_prefix: List[str]):
     for schema in fivetran_output.schema_config["schemas"].values():
         schema_name = schema["name_in_destination"]
-        schema_prefix = fivetran_output.connector_details.get("config", {}).get("schema_prefix")
+        schema_prefix = next(
+            item
+            for item in (
+                fivetran_output.connector_details.get("schema"),
+                fivetran_output.connector_details.get("config", {}).get("schema_prefix"),
+                fivetran_output.connector_details.get("config", {}).get("schema"),
+            )
+            if item is not None
+        )
         if schema_prefix:
             schema_name = f"{schema_prefix}_{schema_name}"
         if not schema["enabled"]:


### PR DESCRIPTION
When Fivetran says "name_in_destination", it turns out it doesn't actually mean "name_in_destination".

For many connector types, you need to provide a schema prefix, which is not included in this field (as was originally assumed). There's also not an exact place to find this information (it can be in a few different places depending on the connector type), so this is a best-effort approach to figuring out what the table name actually should be.