### PR TITLE
Upstream/Downstream graph quick fixes

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventsTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventsTable.tsx
@@ -87,7 +87,7 @@ const MetadataEntriesRow: React.FC<{
 }> = React.memo(({group, hasLineage}) => {
   const {latest, timestamp} = group;
   if (!latest) {
-    return <span />;
+    return <tr></tr>;
   }
   const assetLineage = latest.__typename === 'MaterializationEvent' ? latest.assetLineage : [];
 

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -149,8 +149,8 @@ const JobGraphLink: React.FC<{
   return (
     <Link
       to={instanceAssetsExplorerPathToURL({
-        opNames: [token],
-        opsQuery: direction === 'upstream' ? `*${token}` : `${token}*`,
+        opNames: [],
+        opsQuery: direction === 'upstream' ? `*"${token}"` : `"${token}"*`,
       })}
     >
       <Box flex={{gap: 4, alignItems: 'center'}}>


### PR DESCRIPTION
See issues #6833 and #6839.

## Summary
* Quote selection to avoid grabbing downstreams with the same name prefix when viewing upstream graph
* Fix react table unhappy log
* Do not default to selecting the chosen asset, because then rematerialize will only materialize that one asset instead of those downstream.

## Test Plan

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.