### PR TITLE
make EventLogEntry.message change safe to downgrade

### DIFF
--- a/python_modules/dagster/dagster/serdes/serdes.py
+++ b/python_modules/dagster/dagster/serdes/serdes.py
@@ -497,7 +497,7 @@ def unpack_inner_value(val: Any, whitelist_map: WhitelistMap, descent_path: str)
         )
         if not whitelist_map.has_tuple_entry(lookup_name):
             name_str = (
-                '"klass_name"'
+                f'"{klass_name}"'
                 if klass_name == lookup_name
                 else f'"{klass_name}" (mapped to: "{lookup_name}")'
             )


### PR DESCRIPTION
someone hit a forward compat issue with the removal of EventLogEntry.message that got me concerned about people doing runs on >= 0.14.3 but reading them back out on < 0.14.3 for some reason such as having to downgrade or not applied everywhere yet upgrades. 

Here we put `message: ""` in to the `EventLogEntry` payload so it can deserialize safely in older versions

## Test Plan

added a back compat test and verfieid it failed without the serdes changes