### PR TITLE
add support for filtering ticks by status

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1140,7 +1140,13 @@ type InstigationState {
   runs(limit: Int): [Run!]!
   runsCount: Int!
   tick(timestamp: Float): InstigationTick
-  ticks(dayRange: Int, dayOffset: Int, limit: Int): [InstigationTick!]!
+  ticks(
+    dayRange: Int
+    dayOffset: Int
+    limit: Int
+    cursor: String
+    statuses: [InstigationTickStatus!]
+  ): [InstigationTick!]!
   nextTick: FutureInstigationTick
   runningCount: Int!
 }
@@ -1160,6 +1166,7 @@ union InstigationTypeSpecificData = SensorData | ScheduleData
 type SensorData {
   lastTickTimestamp: Float
   lastRunKey: String
+  lastCursor: String
 }
 
 type ScheduleData {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -2,6 +2,7 @@ import sys
 
 import graphene
 import pendulum
+import warnings
 import yaml
 
 from dagster import check
@@ -377,7 +378,7 @@ class GrapheneInstigationState(graphene.ObjectType):
                 try:
                     before = float(parts[-1])
                 except (ValueError, IndexError):
-                    pass
+                    warnings.warn(f"Invalid cursor for {self.name} ticks: {cursor}")
 
         after = (
             pendulum.now("UTC").subtract(days=dayRange + (dayOffset or 0)).timestamp()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -1,8 +1,8 @@
 import sys
+import warnings
 
 import graphene
 import pendulum
-import warnings
 import yaml
 
 from dagster import check

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1757,8 +1757,10 @@ records = instance.get_event_records(
         return matches[0] if len(matches) else None
 
     @traced
-    def get_ticks(self, origin_id, before=None, after=None, limit=None):
-        return self._schedule_storage.get_ticks(origin_id, before=before, after=after, limit=limit)
+    def get_ticks(self, origin_id, before=None, after=None, limit=None, statuses=None):
+        return self._schedule_storage.get_ticks(
+            origin_id, before=before, after=after, limit=limit, statuses=statuses
+        )
 
     def create_tick(self, tick_data):
         return self._schedule_storage.create_tick(tick_data)

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Iterable
+from typing import Iterable, List, Optional
 
 from dagster.core.definitions.run_request import InstigatorType
 from dagster.core.instance import MayHaveInstanceWeakref
@@ -58,7 +58,12 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
 
     @abc.abstractmethod
     def get_ticks(
-        self, origin_id: str, before: float = None, after: float = None, limit: int = None
+        self,
+        origin_id: str,
+        before: float = None,
+        after: float = None,
+        limit: int = None,
+        statuses: Optional[List[TickStatus]] = None,
     ) -> Iterable[InstigatorTick]:
         """Get the ticks for a given instigator.
 


### PR DESCRIPTION
## Summary
Schedule storage changes required for the new tick-history view of the schedule/sensor page initially showcased in https://github.com/dagster-io/dagster/pull/6861



## Test Plan
BK

