### PR TITLE
Allow PathMetadataValue to accept os.PathLike input

### DIFF
--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1,3 +1,5 @@
+from os import fspath, PathLike
+
 import inspect
 from typing import (
     AbstractSet,
@@ -873,6 +875,24 @@ def opt_str_param(obj: object, param_name: str, default: Optional[str] = None) -
     if obj is not None and not isinstance(obj, str):
         raise _param_type_mismatch_exception(obj, str, param_name)
     return default if obj is None else obj
+
+
+def path_param(obj: object, param_name: str) -> str:
+    try:
+        return fspath(obj)
+    except TypeError:
+        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+
+
+def opt_path_param(
+    obj: object, param_name: str, default: Optional[Union[str, PathLike]] = None
+) -> Optional[str]:
+    try:
+        return fspath(obj)
+    except TypeError:
+        if obj is not None:
+            raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+        return default
 
 
 def opt_nonempty_str_param(

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1058,10 +1058,9 @@ def _check_tuple_items(
 
 
 def path_param(obj: object, param_name: str) -> str:
-    try:
-        return fspath(obj)
-    except TypeError:
+    if not isinstance(obj, (str, PathLike)):
         raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+    return fspath(obj)
 
 
 @overload
@@ -1077,16 +1076,14 @@ def opt_path_param(obj: object, param_name: str) -> Optional[str]:
 def opt_path_param(
     obj: object, param_name: str, default: Optional[Union[str, PathLike]] = None
 ) -> Optional[str]:
-    try:
+    if obj is not None and not isinstance(obj, (str, PathLike)):
+        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+    if obj is not None:
         return fspath(obj)
-    except TypeError:
-        if obj is not None:
-            raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
 
-        if obj is None and default is None:
-            return default
-
-        return fspath(default)
+    if obj is None and default is None:
+        return default
+    return fspath(default)
 
 
 # ###################################################################################################

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1,6 +1,5 @@
-from os import fspath, PathLike
-
 import inspect
+from os import PathLike, fspath
 from typing import (
     AbstractSet,
     Any,

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -877,24 +877,6 @@ def opt_str_param(obj: object, param_name: str, default: Optional[str] = None) -
     return default if obj is None else obj
 
 
-def path_param(obj: object, param_name: str) -> str:
-    try:
-        return fspath(obj)
-    except TypeError:
-        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
-
-
-def opt_path_param(
-    obj: object, param_name: str, default: Optional[Union[str, PathLike]] = None
-) -> Optional[str]:
-    try:
-        return fspath(obj)
-    except TypeError:
-        if obj is not None:
-            raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
-        return default
-
-
 def opt_nonempty_str_param(
     obj: object, param_name: str, default: Optional[str] = None
 ) -> Optional[str]:
@@ -1068,6 +1050,43 @@ def _check_tuple_items(
                 )
 
     return obj_tuple
+
+
+# ########################
+# ##### PATH
+# ########################
+
+
+def path_param(obj: object, param_name: str) -> str:
+    try:
+        return fspath(obj)
+    except TypeError:
+        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+
+
+@overload
+def opt_path_param(obj: object, param_name: str, default: Union[str, PathLike]) -> str:
+    ...
+
+
+@overload
+def opt_path_param(obj: object, param_name: str) -> Optional[str]:
+    ...
+
+
+def opt_path_param(
+    obj: object, param_name: str, default: Optional[Union[str, PathLike]] = None
+) -> Optional[str]:
+    try:
+        return fspath(obj)
+    except TypeError:
+        if obj is not None:
+            raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+
+        if obj is None and default is None:
+            return default
+
+        return fspath(default)
 
 
 # ###################################################################################################

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -107,6 +107,9 @@ def normalize_metadata_value(raw_value: RawMetadataValue):
                 "Consider wrapping the value with the appropriate MetadataValue type."
             )
 
+    if isinstance(value, os.PathLike):
+        return MetadataEntry.path(value, label)
+
     raise DagsterInvalidMetadata(
         f"Its type was {type(raw_value)}. Consider wrapping the value with the appropriate "
         "MetadataValue type."

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -496,12 +496,12 @@ class UrlMetadataValue(  # type: ignore
 
 @whitelist_for_serdes(storage_name="PathMetadataEntryData")
 class PathMetadataValue(  # type: ignore
-    NamedTuple("_PathMetadataValue", [("path", Optional[Union[str, os.PathLike]])]), MetadataValue
+    NamedTuple("_PathMetadataValue", [("path", Optional[str])]), MetadataValue
 ):
     """Container class for path metadata entry data.
 
     Args:
-        path (Optional[str]): The path as a string.
+        path (Optional[str]): The path as a string or conforming to os.PathLike.
     """
 
     def __new__(cls, path: Optional[Union[str, os.PathLike]]):

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -107,8 +107,8 @@ def normalize_metadata_value(raw_value: RawMetadataValue):
                 "Consider wrapping the value with the appropriate MetadataValue type."
             )
 
-    if isinstance(value, os.PathLike):
-        return MetadataEntry.path(value, label)
+    if isinstance(raw_value, os.PathLike):
+        return MetadataValue.path(raw_value)
 
     raise DagsterInvalidMetadata(
         f"Its type was {type(raw_value)}. Consider wrapping the value with the appropriate "

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -199,7 +199,7 @@ class MetadataValue:
         return UrlMetadataValue(url)
 
     @staticmethod
-    def path(path: str) -> "PathMetadataValue":
+    def path(path: Union[str, os.PathLike]) -> "PathMetadataValue":
         """Static constructor for a metadata value wrapping a path as
         :py:class:`PathMetadataValue`. For example:
 
@@ -496,13 +496,7 @@ class UrlMetadataValue(  # type: ignore
 
 @whitelist_for_serdes(storage_name="PathMetadataEntryData")
 class PathMetadataValue(  # type: ignore
-    NamedTuple(
-        "_PathMetadataValue",
-        [
-            ("path", Optional[str]),
-        ],
-    ),
-    MetadataValue,
+    NamedTuple("_PathMetadataValue", [("path", Optional[Union[str, os.PathLike]])]), MetadataValue
 ):
     """Container class for path metadata entry data.
 
@@ -510,9 +504,9 @@ class PathMetadataValue(  # type: ignore
         path (Optional[str]): The path as a string.
     """
 
-    def __new__(cls, path: Optional[str]):
+    def __new__(cls, path: Optional[Union[str, os.PathLike]]):
         return super(PathMetadataValue, cls).__new__(
-            cls, check.opt_str_param(path, "path", default="")
+            cls, check.opt_path_param(path, "path", default="")
         )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from dagster import (
@@ -7,6 +9,7 @@ from dagster import (
     FloatMetadataValue,
     IntMetadataValue,
     MetadataValue,
+    PathMetadataValue,
     PythonArtifactMetadataValue,
     TextMetadataValue,
     UrlMetadataValue,
@@ -57,6 +60,7 @@ def test_metadata_asset_materialization():
                 "int": 22,
                 "url": MetadataValue.url("http://fake.com"),
                 "float": 0.1,
+                "path": MetadataValue.path(Path("/a/b.csv")),
                 "python": MetadataValue.python_artifact(MetadataValue),
             },
         )
@@ -75,7 +79,7 @@ def test_metadata_asset_materialization():
     )
     assert len(materialization_events) == 1
     materialization = materialization_events[0].event_specific_data.materialization
-    assert len(materialization.metadata_entries) == 5
+    assert len(materialization.metadata_entries) == 6
     entry_map = {
         entry.label: entry.entry_data.__class__ for entry in materialization.metadata_entries
     }
@@ -83,6 +87,7 @@ def test_metadata_asset_materialization():
     assert entry_map["int"] == IntMetadataValue
     assert entry_map["url"] == UrlMetadataValue
     assert entry_map["float"] == FloatMetadataValue
+    assert entry_map["path"] == PathMetadataValue
     assert entry_map["python"] == PythonArtifactMetadataValue
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -163,6 +163,16 @@ def test_parse_invalid_metadata():
     assert entries[0].entry_data == TextMetadataValue("[object] (unserializable)")
 
 
+def test_parse_path_metadata():
+
+    metadata = {"path": Path("/a/b.csv")}
+
+    entries = normalize_metadata(metadata, [])
+    assert len(entries) == 1
+    assert entries[0].label == "path"
+    assert entries[0].entry_data == PathMetadataValue("/a/b.csv")
+
+
 def test_bad_json_metadata_value():
     @solid(output_defs=[])
     def the_solid(context):

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -464,6 +464,35 @@ def test_opt_str_param():
         check.opt_str_param(1, "str_param")
 
 
+def test_path_param():
+    from pathlib import Path
+
+    assert check.path_param("/a/b.csv", "path_param") == "/a/b.csv"
+    assert check.path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(None, "path_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(0, "path_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(1, "path_param")
+
+
+def test_opt_path_param():
+    from pathlib import Path
+
+    assert check.opt_path_param("/a/b.csv", "path_param") == "/a/b.csv"
+    assert check.opt_path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_path_param(0, "path_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_path_param(1, "path_param")
+
+
 def test_opt_nonempty_str_param():
     assert check.opt_nonempty_str_param("a", "str_param") == "a"
     assert check.opt_nonempty_str_param("", "str_param") is None

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -464,35 +464,6 @@ def test_opt_str_param():
         check.opt_str_param(1, "str_param")
 
 
-def test_path_param():
-    from pathlib import Path
-
-    assert check.path_param("/a/b.csv", "path_param") == "/a/b.csv"
-    assert check.path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
-
-    with pytest.raises(ParameterCheckError):
-        check.path_param(None, "path_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.path_param(0, "path_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.path_param(1, "path_param")
-
-
-def test_opt_path_param():
-    from pathlib import Path
-
-    assert check.opt_path_param("/a/b.csv", "path_param") == "/a/b.csv"
-    assert check.opt_path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_path_param(0, "path_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_path_param(1, "path_param")
-
-
 def test_opt_nonempty_str_param():
     assert check.opt_nonempty_str_param("a", "str_param") == "a"
     assert check.opt_nonempty_str_param("", "str_param") is None
@@ -506,6 +477,32 @@ def test_opt_nonempty_str_param():
 
     with pytest.raises(ParameterCheckError):
         check.opt_nonempty_str_param(1, "str_param")
+
+
+def test_path_param():
+    from pathlib import Path
+
+    assert check.path_param("/a/b.csv", "path_param") == "/a/b.csv"
+    assert check.path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(None, "path_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(0, "path_param")
+
+
+def test_opt_path_param():
+    from pathlib import Path
+
+    assert check.opt_path_param("/a/b.csv", "path_param") == "/a/b.csv"
+    assert check.opt_path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
+    assert check.opt_path_param(None, "path_param") is None
+    assert check.opt_path_param(None, "path_param", "/a/b/c.csv") == "/a/b/c.csv"
+    assert check.opt_path_param(None, "path_param", Path("/a/b/c.csv")) == "/a/b/c.csv"
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_path_param(0, "path_param")
 
 
 def test_bool_param():


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

This expands `MetadataValue.path()` and `PathMetadataValue` to be able to accept [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) objects in addition to strings.

Closes #6916

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

I've added two tests for `checks.path_param()` and `checks.opt_path_param()` that checks if `pathlib.Path` objects can be used and converted into strings in addition to string inputs.

I also added a test for `MetadataValue.Path` to see if it can take a `pathlib.Path`.

I tested on Python 3.8.12 in a new Conda environment and dependencies installed by `make dev_install`.

<summary>pip list</summary>
<details>

```sh
➜ python -m pip list
Package                     Version     Editable project location
--------------------------- ----------- -----------------------------------------------------------------------------------
agate                       1.6.1
aiohttp                     3.8.1
aiosignal                   1.2.0
airline-demo                dev         /Users/akerney/Geek/dagster/examples/airline_demo
alembic                     1.6.5
altair                      4.2.0
amqp                        5.0.9
aniso8601                   7.0.0
ansiwrap                    0.8.4
anyio                       3.5.0
appnope                     0.1.2
argon2-cffi                 21.3.0
argon2-cffi-bindings        21.2.0
asgiref                     3.5.0
asn1crypto                  1.4.0
astroid                     2.4.2
asttokens                   2.0.5
async-timeout               4.0.2
attrs                       21.4.0
autoflake                   1.4
automation                  0.0.1       /Users/akerney/Geek/dagster/python_modules/automation
azure-core                  1.23.0
azure-storage-blob          12.9.0
azure-storage-file-datalake 12.5.0
Babel                       2.9.1
backcall                    0.2.0
backports.zoneinfo          0.2.1
bcrypt                      3.2.0
beautifulsoup4              4.10.0
billiard                    3.6.4.0
black                       22.1.0
bleach                      4.1.0
bokeh                       2.4.2
boto3                       1.21.12
botocore                    1.24.12
cachetools                  5.0.0
celery                      5.2.3
certifi                     2021.10.8
cffi                        1.15.0
chardet                     4.0.0
charset-normalizer          2.0.12
click                       8.0.4
click-didyoumean            0.3.0
click-plugins               1.1.1
click-repl                  0.2.0
cloudpickle                 2.0.0
coloredlogs                 14.0
coverage                    5.3
croniter                    1.3.4
cryptography                36.0.1
cycler                      0.11.0
dagit                       dev         /Users/akerney/Geek/dagster/python_modules/dagit
dagster                     dev         /Users/akerney/Geek/dagster/python_modules/dagster
dagster-airbyte             dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-airbyte
dagster-airflow             dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-airflow
dagster-aws                 dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-aws
dagster-azure               dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-azure
dagster-celery              dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-celery
dagster-celery-docker       dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-celery-docker
dagster-celery-k8s          dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-celery-k8s
dagster-dask                dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-dask
dagster-databricks          dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-databricks
dagster-datadog             dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-datadog
dagster-dbt                 dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-dbt
dagster-docker              dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-docker
dagster-fivetran            dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-fivetran
dagster-gcp                 dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-gcp
dagster-ge                  dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-ge
dagster-github              dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-github
dagster-graphql             dev         /Users/akerney/Geek/dagster/python_modules/dagster-graphql
dagster-helm                0.0.1       /Users/akerney/Geek/dagster/helm/dagster/schema
dagster-k8s                 dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-k8s
dagster-k8s-test-infra      0.0.0       /Users/akerney/Geek/dagster/integration_tests/python_modules/dagster-k8s-test-infra
dagster-msteams             dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-msteams
dagster-mysql               dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-mysql
dagster-pagerduty           dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-pagerduty
dagster-pandas              dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-pandas
dagster-papertrail          dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-papertrail
dagster-postgres            dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-postgres
dagster-prometheus          dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-prometheus
dagster-pyspark             dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-pyspark
dagster-shell               dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-shell
dagster-slack               dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-slack
dagster-snowflake           dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-snowflake
dagster-spark               dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-spark
dagster-ssh                 dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-ssh
dagster-test                dev         /Users/akerney/Geek/dagster/python_modules/dagster-test
dagster-twilio              dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagster-twilio
dagstermill                 dev         /Users/akerney/Geek/dagster/python_modules/libraries/dagstermill
dask                        2022.2.1
dask-jobqueue               0.7.3
dask-kubernetes             2022.1.0
dask-yarn                   0.9
databricks-api              0.7.0
databricks-cli              0.16.4
datadog                     0.44.0
DataProperty                0.54.2
debugpy                     1.5.1
decorator                   5.1.1
defusedxml                  0.7.1
descartes                   1.1.0
distributed                 2022.2.1
docker                      5.0.3
docker-image-py             0.1.12
docstring-parser            0.13
docutils                    0.18.1
entrypoints                 0.4
execnet                     1.9.0
executing                   0.8.3
fastdiff                    0.3.0
filelock                    3.6.0
flake8                      4.0.1
freezegun                   1.2.0
frozenlist                  1.3.0
fsspec                      2022.2.0
gevent                      21.12.0
gevent-websocket            0.10.1
google-api-core             2.6.0
google-api-python-client    1.12.10
google-auth                 2.6.0
google-auth-httplib2        0.1.0
google-cloud-bigquery       2.34.1
google-cloud-core           2.2.2
google-cloud-storage        2.1.0
google-crc32c               1.3.0
google-resumable-media      2.3.1
googleapis-common-protos    1.55.0
gql                         2.0.0
graphene                    2.1.9
graphql-core                2.3.2
graphql-relay               2.0.1
graphviz                    0.19.1
great-expectations          0.13.14
greenlet                    1.1.2
grpcio                      1.44.0
grpcio-health-checking      1.43.0
grpcio-status               1.44.0
grpcio-tools                1.32.0
h11                         0.13.0
HeapDict                    1.0.1
httplib2                    0.20.4
httptools                   0.3.0
humanfriendly               10.0
idna                        3.3
importlib-metadata          4.11.2
importlib-resources         5.4.0
iniconfig                   1.1.1
ipykernel                   6.9.1
ipython                     8.1.1
ipython-genutils            0.2.0
ipywidgets                  7.6.5
isodate                     0.6.1
isort                       5.10.1
jedi                        0.18.1
Jinja2                      2.11.3
jmespath                    0.10.0
jsonpatch                   1.32
jsonpointer                 2.2
jsonschema                  4.4.0
jupyter-client              7.1.2
jupyter-core                4.9.2
jupyterlab-widgets          1.0.2
keras                       2.8.0
kiwisolver                  1.3.2
kombu                       5.2.3
kubernetes                  21.7.0
kubernetes-asyncio          19.15.1
lazy-object-proxy           1.4.3
leather                     0.3.4
locket                      0.2.1
Mako                        1.1.6
MarkupSafe                  2.0.1
matplotlib                  3.4.2
matplotlib-inline           0.1.3
mbstrdecoder                1.1.0
mccabe                      0.6.1
mistune                     0.8.4
mock                        3.0.5
moto                        3.0.5
msgpack                     1.0.3
msrest                      0.6.21
multidict                   6.0.2
mypy                        0.931
mypy-extensions             0.4.3
mysql-connector-python      8.0.28
nbclient                    0.5.11
nbconvert                   5.6.1
nbformat                    5.1.3
nest-asyncio                1.5.4
notebook                    6.4.8
numpy                       1.19.5
oauth2client                4.1.3
oauthlib                    3.2.0
objgraph                    3.5.0
oscrypto                    1.2.1
packaging                   21.3
pandas                      1.4.1
pandocfilters               1.5.0
papermill                   2.3.4
paramiko                    2.9.2
parsedatetime               2.6
parso                       0.8.3
partd                       1.2.0
path                        16.4.0
pathspec                    0.9.0
pathvalidate                2.5.0
pendulum                    2.1.2
pep562                      1.1
pexpect                     4.8.0
pickleshare                 0.7.5
Pillow                      9.0.1
pip                         22.0.3
pkginfo                     1.8.2
platformdirs                2.5.1
pluggy                      0.13.1
prometheus-client           0.13.1
promise                     2.3
prompt-toolkit              3.0.28
proto-plus                  1.19.6
protobuf                    3.13.0
psutil                      5.9.0
psycopg2-binary             2.9.3
ptyprocess                  0.7.0
pure-eval                   0.2.2
py                          1.11.0
py4j                        0.10.9.3
pyarrow                     7.0.0
pyasn1                      0.4.8
pyasn1-modules              0.2.8
pycodestyle                 2.8.0
pycparser                   2.21
pycryptodomex               3.14.1
pydantic                    1.9.0
pyflakes                    2.4.0
Pygments                    2.11.2
PyJWT                       2.3.0
pylint                      2.6.0
PyNaCl                      1.5.0
pyOpenSSL                   21.0.0
pyparsing                   2.4.7
pypd                        1.1.0
pyrsistent                  0.18.1
pyspark                     3.2.1
pytablereader               0.31.3
pytest                      6.1.1
pytest-cov                  2.10.1
pytest-dependency           0.5.1
pytest-forked               1.4.0
pytest-mock                 3.3.1
pytest-rerunfailures        10.0
pytest-runner               5.2
pytest-xdist                2.1.0
python-dateutil             2.8.2
python-dotenv               0.19.2
python-editor               1.0.4
python-slugify              6.1.1
pytimeparse                 1.1.8
pytz                        2021.3
pytz-deprecation-shim       0.1.0.post0
pytzdata                    2020.1
PyYAML                      6.0
pyzmq                       22.3.0
readme-renderer             32.0
regex                       2022.3.2
requests                    2.27.1
requests-mock               1.9.3
requests-oauthlib           1.3.1
requests-toolbelt           0.9.1
responses                   0.10.16
rsa                         4.8
ruamel.yaml                 0.17.21
ruamel.yaml.clib            0.2.6
Rx                          1.6.1
s3transfer                  0.5.2
scipy                       1.8.0
scrapbook                   0.5.0
seaborn                     0.11.2
Send2Trash                  1.8.0
setuptools                  59.6.0
six                         1.16.0
skein                       0.8.1
slack-sdk                   3.15.2
snapshottest                0.6.0
sniffio                     1.2.0
snowflake-connector-python  2.7.4
sortedcontainers            2.4.0
soupsieve                   2.3.1
SQLAlchemy                  1.4.31
sqlalchemy-redshift         0.8.9
SQLAlchemy-Utils            0.33.8
sshtunnel                   0.4.0
stack-data                  0.2.0
starlette                   0.18.0
tabledata                   1.3.0
tabulate                    0.8.9
tblib                       1.7.0
tenacity                    8.0.1
termcolor                   1.1.0
terminado                   0.13.2
testpath                    0.6.0
text-unidecode              1.3
textwrap3                   0.9.2
tokenize-rt                 4.2.1
toml                        0.10.2
tomli                       2.0.1
toolz                       0.11.2
toposort                    1.7
tornado                     6.1
tox                         3.14.2
tox-pip-version             0.0.7
tqdm                        4.48.0
traitlets                   5.1.1
twilio                      7.7.0
twine                       1.15.0
typepy                      1.3.0
types-croniter              1.0.7
types-mock                  4.0.11
types-pkg-resources         0.1.3
types-python-dateutil       2.8.9
types-pytz                  2021.3.5
types-PyYAML                6.0.4
types-requests              2.27.11
types-tabulate              0.8.5
types-urllib3               1.26.10
typing-compat               0.1.0
typing_extensions           4.1.1
tzdata                      2021.5
tzlocal                     4.1
uritemplate                 3.0.1
urllib3                     1.26.8
uvicorn                     0.17.5
uvloop                      0.16.0
vine                        5.0.0
virtualenv                  16.5.0
wasmer                      1.1.0
wasmer_compiler_cranelift   1.1.0
watchdog                    2.1.6
watchgod                    0.7
wcwidth                     0.2.5
webencodings                0.5.1
websocket-client            1.3.1
websockets                  10.2
Werkzeug                    2.0.3
wheel                       0.33.6
widgetsnbextension          3.5.2
wrapt                       1.13.3
xmltodict                   0.12.0
yamllint                    1.26.3
yarl                        1.7.2
zict                        2.1.0
zipp                        3.7.0
zope.event                  4.5.0
zope.interface              5.4.0
```

</details>

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.