### PR TITLE
fix bug with subset selection

### DIFF
--- a/python_modules/dagster/dagster/core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/core/selector/subset_selector.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import TYPE_CHECKING, AbstractSet, Dict, List, NamedTuple
 
 from dagster.core.definitions.dependency import DependencyStructure
@@ -99,7 +99,7 @@ class Traverser:
 
     def _fetch_items(self, item_name, depth, direction):
         dep_graph = self.graph[direction]
-        stack = [item_name]
+        stack = deque([item_name])
         result = set()
         curr_depth = 0
         while stack:
@@ -108,9 +108,9 @@ class Traverser:
                 break
             curr_level_len = len(stack)
             while stack and curr_level_len > 0:
-                curr_item = stack.pop()
+                curr_item = stack.popleft()
+                curr_level_len -= 1
                 for item in dep_graph.get(curr_item, set()):
-                    curr_level_len -= 1
                     if item not in result:
                         stack.append(item)
                         result.add(item)

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -5,8 +5,8 @@ from dagster.core.errors import DagsterExecutionStepNotFoundError, DagsterInvali
 from dagster.core.selector.subset_selector import (
     MAX_NUM,
     Traverser,
-    generate_dep_graph,
     clause_to_subset,
+    generate_dep_graph,
     parse_clause,
     parse_solid_selection,
     parse_step_selection,

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -6,6 +6,7 @@ from dagster.core.selector.subset_selector import (
     MAX_NUM,
     Traverser,
     generate_dep_graph,
+    clause_to_subset,
     parse_clause,
     parse_solid_selection,
     parse_step_selection,
@@ -151,6 +152,42 @@ step_deps = {
     "multiply_two": {"add_nums"},
     "add_one": {"multiply_two"},
 }
+
+
+@pytest.mark.parametrize(
+    "clause,expected_subset",
+    [
+        ("a", "a"),
+        ("b+", "b,c,d"),
+        ("+f", "f,d,e"),
+        ("++f", "f,d,e,c,a,b"),
+        ("+++final", "final,a,d,start,b"),
+        ("b++", "b,c,d,e,f,final"),
+        ("start*", "start,a,d,f,final"),
+    ],
+)
+def test_clause_to_subset(clause, expected_subset):
+    graph = {
+        "upstream": {
+            "start": set(),
+            "a": {"start"},
+            "b": set(),
+            "c": {"b"},
+            "d": {"a", "b"},
+            "e": {"c"},
+            "f": {"e", "d"},
+            "final": {"a", "d"},
+        },
+        "downstream": {
+            "start": {"a"},
+            "b": {"c", "d"},
+            "a": {"final", "d"},
+            "c": {"e"},
+            "d": {"final", "f"},
+            "e": {"f"},
+        },
+    }
+    assert set(clause_to_subset(graph, clause)) == set(expected_subset.split(","))
 
 
 def test_parse_step_selection_single():


### PR DESCRIPTION
I was messing around w/ subset selection for https://github.com/dagster-io/dagster/pull/6723/, and noticed that there would be issues when calculating subsets that were multiple levels deep (but not *).

The basic issue is that the current algorithm figures out what depth it's at by calculating the current length of the stack, then popping off each element of the stack and adding in its parents (or ancestors, depending on the direction).

The result of this should be that after each level, the contents of the stack are replaced with the parents of each element of the stack on the previous level. However, because we're adding to the stack during the loop, and popping from the right, this doesn't happen.