### PR TITLE
use pipeline run to compute pipeline origin, not the args to the execute_run / execute_step call

### DIFF
--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/base.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_handler/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
 from dagster import DagsterEvent, DagsterInstance, check
+from dagster.core.origin import PipelinePythonOrigin
 from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.grpc.types import ExecuteStepArgs
 
@@ -34,6 +35,10 @@ class StepHandlerContext:
             self._pipeline_run = run
 
         return self._pipeline_run
+
+    @property
+    def pipeline_origin(self) -> PipelinePythonOrigin:
+        return self.pipeline_run.pipeline_code_origin
 
     @property
     def step_tags(self) -> Dict[str, Dict[str, str]]:

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -235,7 +235,7 @@ def create_docker_task(celery_app, **task_kwargs):
         docker_image = (
             docker_config["image"]
             if docker_config.get("image")
-            else execute_step_args.pipeline_origin.repository_origin.container_image
+            else pipeline_run.pipeline_code_origin.repository_origin.container_image
         )
 
         if not docker_image:

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -376,7 +376,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             pod_name,
             component="step_worker",
             labels={
-                "dagster/job": execute_step_args.pipeline_origin.pipeline_name,
+                "dagster/job": pipeline_run.pipeline_code_origin.pipeline_name,
                 "dagster/op": step_key,
             },
         )

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -150,9 +150,7 @@ class DockerStepHandler(StepHandler):
     def launch_step(self, step_handler_context: StepHandlerContext) -> List[DagsterEvent]:
         client = self._get_client()
 
-        step_image = (
-            step_handler_context.execute_step_args.pipeline_origin.repository_origin.container_image
-        )
+        step_image = step_handler_context.pipeline_origin.repository_origin.container_image
 
         if not step_image:
             step_image = self._image
@@ -185,7 +183,7 @@ class DockerStepHandler(StepHandler):
         events = [
             DagsterEvent(
                 event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                 step_key=step_key,
                 message="Launching step in Docker container",
                 event_specific_data=EngineEventData(
@@ -218,7 +216,7 @@ class DockerStepHandler(StepHandler):
             return [
                 DagsterEvent(
                     event_type_value=DagsterEventType.STEP_FAILURE.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                     step_key=step_key,
                     message=f"Error when checking on step container health: {e}",
                     event_specific_data=StepFailureData(
@@ -237,7 +235,7 @@ class DockerStepHandler(StepHandler):
             return [
                 DagsterEvent(
                     event_type_value=DagsterEventType.STEP_FAILURE.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                     step_key=step_key,
                     message=f"Container status is {container.status}. Hit exception attempting to get its return code: {e}",
                     event_specific_data=StepFailureData(
@@ -254,7 +252,7 @@ class DockerStepHandler(StepHandler):
         return [
             DagsterEvent(
                 event_type_value=DagsterEventType.STEP_FAILURE.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                 step_key=step_key,
                 message=f"Container status is {container.status}. Return code is {str(ret_code)}.",
                 event_specific_data=StepFailureData(
@@ -274,7 +272,7 @@ class DockerStepHandler(StepHandler):
         events = [
             DagsterEvent(
                 event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                 step_key=step_key,
                 message="Stopping Docker container for step",
                 event_specific_data=EngineEventData(),
@@ -295,7 +293,7 @@ class DockerStepHandler(StepHandler):
             events.append(
                 DagsterEvent(
                     event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                     step_key=step_key,
                     message=f"Hit error while terminating Docker container:\n{e}",
                     event_specific_data=EngineEventData(),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -174,7 +174,7 @@ class K8sStepHandler(StepHandler):
         job_config = self._job_config
         if not job_config.job_image:
             job_config = job_config.with_image(
-                step_handler_context.execute_step_args.pipeline_origin.repository_origin.container_image
+                step_handler_context.pipeline_origin.repository_origin.container_image
             )
 
         if not job_config.job_image:
@@ -192,7 +192,7 @@ class K8sStepHandler(StepHandler):
             component="step_worker",
             user_defined_k8s_config=user_defined_k8s_config,
             labels={
-                "dagster/job": step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                "dagster/job": step_handler_context.pipeline_origin.pipeline_name,
                 "dagster/op": step_key,
             },
         )
@@ -200,7 +200,7 @@ class K8sStepHandler(StepHandler):
         events.append(
             DagsterEvent(
                 event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                 step_key=step_key,
                 message=f"Executing step {step_key} in Kubernetes job {job_name}",
                 event_specific_data=EngineEventData(
@@ -229,7 +229,7 @@ class K8sStepHandler(StepHandler):
             return [
                 DagsterEvent(
                     event_type_value=DagsterEventType.STEP_FAILURE.value,
-                    pipeline_name=step_handler_context.execute_step_args.pipeline_origin.pipeline_name,
+                    pipeline_name=step_handler_context.pipeline_origin.pipeline_name,
                     step_key=step_key,
                     message=f"Discovered failed Kubernetes job {job_name} for step {step_key}",
                     event_specific_data=StepFailureData(


### PR DESCRIPTION
Summary:
Unclear why this is being passed in when it can be derived directly from the run, and we are already loading the run anywhere that it is used. If back-compat were not a concern I think we could remove the pipeline origin from the call entirely

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.