### PR TITLE
Add a `container_context` field to RepositoryPythonOrigin that can be used for additional container-specific metadata

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -113,12 +113,13 @@ def build_and_tag_test_image(tag):
     return subprocess.check_output(["./build.sh", base_python, tag], cwd=get_test_repo_path())
 
 
-def get_test_project_recon_pipeline(pipeline_name, container_image=None):
+def get_test_project_recon_pipeline(pipeline_name, container_image=None, container_context=None):
     return ReOriginatedReconstructablePipelineForTest(
         ReconstructableRepository.for_file(
             file_relative_path(__file__, "test_pipelines/repo.py"),
             "define_demo_execution_repo",
             container_image=container_image,
+            container_context=container_context,
         ).get_reconstructable_pipeline(pipeline_name)
     )
 
@@ -154,17 +155,15 @@ class ReOriginatedReconstructablePipelineForTest(ReconstructablePipeline):
                 ),
                 container_image=self.repository.container_image,
                 entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
+                container_context=self.repository.container_context,
             ),
         )
 
 
 class ReOriginatedExternalPipelineForTest(ExternalPipeline):
-    def __init__(
-        self,
-        external_pipeline,
-        container_image=None,
-    ):
+    def __init__(self, external_pipeline, container_image=None, container_context=None):
         self._container_image = container_image
+        self._container_context = container_context
         super(ReOriginatedExternalPipelineForTest, self).__init__(
             external_pipeline.external_pipeline_data,
             external_pipeline.repository_handle,
@@ -188,6 +187,7 @@ class ReOriginatedExternalPipelineForTest(ExternalPipeline):
                 ),
                 container_image=self._container_image,
                 entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
+                container_context=self._container_context,
             ),
         )
 

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -6,6 +6,7 @@ from dagster import check
 from dagster.core.definitions import IPipeline, JobDefinition, PipelineDefinition
 from dagster.core.definitions.pipeline_base import InMemoryPipeline
 from dagster.core.definitions.pipeline_definition import PipelineSubsetDefinition
+from dagster.core.definitions.reconstruct import ReconstructablePipeline
 from dagster.core.errors import DagsterExecutionInterruptedError, DagsterInvariantViolationError
 from dagster.core.events import DagsterEvent, EngineEventData
 from dagster.core.execution.context.system import PlanOrchestrationContext
@@ -429,6 +430,9 @@ def _logged_execute_pipeline(
         solid_selection=solid_selection,
         solids_to_execute=solids_to_execute,
         tags=tags,
+        pipeline_code_origin=(
+            pipeline.get_python_origin() if isinstance(pipeline, ReconstructablePipeline) else None
+        ),
     )
 
     return execute_run(

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -182,6 +182,7 @@ def step_context_to_step_run_ref(
                     container_image=recon_pipeline.repository.container_image,
                     executable_path=recon_pipeline.repository.executable_path,
                     entry_point=recon_pipeline.repository.entry_point,
+                    container_context=recon_pipeline.repository.container_context,
                 ),
                 pipeline_name=recon_pipeline.pipeline_name,
                 solids_to_execute=recon_pipeline.solids_to_execute,

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -235,6 +235,10 @@ class RepositoryLocation(AbstractContextManager):
         pass
 
     @property
+    def container_context(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    @property
     @abstractmethod
     def entry_point(self) -> Optional[List[str]]:
         pass
@@ -256,6 +260,7 @@ class RepositoryLocation(AbstractContextManager):
             code_pointer=code_pointer,
             container_image=self.container_image,
             entry_point=self.entry_point,
+            container_context=self.container_context,
         )
 
 

--- a/python_modules/dagster/dagster/utils/__init__.py
+++ b/python_modules/dagster/dagster/utils/__init__.py
@@ -191,6 +191,9 @@ class frozendict(dict):
     setdefault = __readonly__
     del __readonly__
 
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))
+
 
 class frozenlist(list):
     def __readonly__(self, *args, **kwargs):

--- a/python_modules/dagster/dagster/utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/utils/hosted_user_process.py
@@ -32,6 +32,7 @@ def recon_repository_from_origin(origin):
         origin.container_image,
         origin.executable_path,
         origin.entry_point,
+        origin.container_context,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_reconstructable.py
@@ -158,6 +158,7 @@ def test_reconstruct_from_origin():
             ),
             container_image="my_image",
             entry_point=DEFAULT_DAGSTER_ENTRY_POINT,
+            container_context={"docker": {"registry": "my_reg"}},
         ),
     )
 
@@ -167,3 +168,4 @@ def test_reconstruct_from_origin():
     assert recon_pipeline.repository.pointer == origin.repository_origin.code_pointer
     assert recon_pipeline.repository.container_image == origin.repository_origin.container_image
     assert recon_pipeline.repository.executable_path == origin.repository_origin.executable_path
+    assert recon_pipeline.repository.container_context == origin.repository_origin.container_context

--- a/python_modules/libraries/dagster-docker/dagster_docker/container_context.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/container_context.py
@@ -1,0 +1,146 @@
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
+
+from dagster import Array, Field, Permissive, StringSource, check
+from dagster.config.validate import process_config
+from dagster.core.errors import DagsterInvalidConfigError
+from dagster.core.storage.pipeline_run import PipelineRun
+from dagster.utils import merge_dicts
+
+if TYPE_CHECKING:
+    from . import DockerRunLauncher
+
+DOCKER_CONTAINER_CONTEXT_SCHEMA = {
+    "registry": Field(
+        {
+            "url": Field(StringSource),
+            "username": Field(StringSource),
+            "password": Field(StringSource),
+        },
+        is_required=False,
+        description="Information for using a non local/public docker registry",
+    ),
+    "env_vars": Field(
+        [str],
+        is_required=False,
+        description="The list of environment variables names to include in the docker container. "
+        "Each can be of the form KEY=VALUE or just KEY (in which case the value will be pulled "
+        "from the local environment)",
+    ),
+    "container_kwargs": Field(
+        Permissive(),
+        is_required=False,
+        description="key-value pairs that can be passed into containers.create. See "
+        "https://docker-py.readthedocs.io/en/stable/containers.html for the full list "
+        "of available options.",
+    ),
+    "networks": Field(
+        Array(StringSource),
+        is_required=False,
+        description="Names of the networks to which to connect the launched container at creation time",
+    ),
+}
+
+
+class DockerContainerContext(
+    NamedTuple(
+        "_DockerContainerContext",
+        [
+            ("registry", Optional[Dict[str, str]]),
+            ("env_vars", List[str]),
+            ("networks", List[str]),
+            ("container_kwargs", Dict[str, Any]),
+        ],
+    )
+):
+    """Encapsulates the configuration that can be applied to a Docker container running
+    Dagster code. Can be set at the instance level (via config in the `DockerRunLauncher`),
+    repository location level, and at the individual step level (for runs using the
+    `docker_executor` to run each op in its own container). Config at each of these lower levels is
+    merged in with any config set at a higher level, following the policy laid out in the
+    merge() method below.
+    """
+
+    def __new__(
+        cls,
+        registry: Optional[Dict[str, str]] = None,
+        env_vars: Optional[List[str]] = None,
+        networks: Optional[List[str]] = None,
+        container_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        return super(DockerContainerContext, cls).__new__(
+            cls,
+            registry=check.dict_param(registry, "registry") if registry != None else None,
+            env_vars=check.opt_list_param(env_vars, "env_vars", of_type=str),
+            networks=check.opt_list_param(networks, "networks", of_type=str),
+            container_kwargs=check.opt_dict_param(container_kwargs, "container_kwargs"),
+        )
+
+    def merge(self, other: "DockerContainerContext"):
+        # Combines config set at a higher level with overrides/additions that are set at a lower
+        # level. For example, a certain set of config set in the `DockerRunLauncher`` can be
+        # combined with config set at the step level in the `docker_executor`.
+        # Lists of env vars and secrets are appended, the registry is replaced, and the
+        # `container_kwargs` field does a shallow merge so that different kwargs can be combined
+        # or replaced without replacing the full set of arguments.
+        return DockerContainerContext(
+            registry=other.registry if other.registry != None else self.registry,
+            env_vars=self.env_vars + other.env_vars,
+            networks=self.networks + other.networks,
+            container_kwargs=merge_dicts(other.container_kwargs, self.container_kwargs),
+        )
+
+    @staticmethod
+    def create_for_run(pipeline_run: PipelineRun, run_launcher: Optional["DockerRunLauncher"]):
+
+        context = DockerContainerContext()
+
+        # First apply the instance / run_launcher-level context
+        if run_launcher:
+            context = context.merge(
+                DockerContainerContext(
+                    registry=run_launcher.registry,
+                    env_vars=run_launcher.env_vars,
+                    networks=run_launcher.networks,
+                    container_kwargs=run_launcher.container_kwargs,
+                )
+            )
+
+        run_container_context = (
+            pipeline_run.pipeline_code_origin.repository_origin.container_context
+            if pipeline_run.pipeline_code_origin
+            else None
+        )
+
+        if not run_container_context:
+            return context
+
+        return context.merge(DockerContainerContext.create_from_config(run_container_context))
+
+    @staticmethod
+    def create_from_config(run_container_context):
+        run_docker_container_context = (
+            run_container_context.get("docker", {}) if run_container_context else {}
+        )
+
+        if not run_docker_container_context:
+            return DockerContainerContext()
+
+        processed_container_context = process_config(
+            DOCKER_CONTAINER_CONTEXT_SCHEMA, run_docker_container_context
+        )
+
+        if not processed_container_context.success:
+            raise DagsterInvalidConfigError(
+                "Errors while parsing Docker container context",
+                processed_container_context.errors,
+                run_docker_container_context,
+            )
+
+        processed_context_value = processed_container_context.value
+
+        return DockerContainerContext(
+            registry=processed_context_value.get("registry"),
+            env_vars=processed_context_value.get("env_vars", []),
+            networks=processed_context_value.get("networks", []),
+            container_kwargs=processed_context_value.get("container_kwargs"),
+        )

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -1,5 +1,3 @@
-import os
-
 import docker
 from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
 
@@ -15,6 +13,9 @@ from dagster.core.storage.pipeline_run import PipelineRun
 from dagster.core.storage.tags import DOCKER_IMAGE_TAG
 from dagster.grpc.types import ExecuteRunArgs, ResumeRunArgs
 from dagster.serdes import ConfigurableClass
+
+from .container_context import DockerContainerContext
+from .utils import parse_env_var
 
 DOCKER_CONTAINER_ID_TAG = "docker/container_id"
 
@@ -64,13 +65,16 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
     def from_config_value(inst_data, config_value):
         return DockerRunLauncher(inst_data=inst_data, **config_value)
 
-    def _get_client(self):
+    def get_container_context(self, pipeline_run: PipelineRun) -> DockerContainerContext:
+        return DockerContainerContext.create_for_run(pipeline_run, self)
+
+    def _get_client(self, container_context: DockerContainerContext):
         client = docker.client.from_env()
-        if self.registry:
+        if container_context.registry:
             client.login(
-                registry=self.registry["url"],
-                username=self.registry["username"],
-                password=self.registry["password"],
+                registry=container_context.registry["url"],
+                username=container_context.registry["username"],
+                password=container_context.registry["password"],
             )
         return client
 
@@ -87,11 +91,10 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
         return docker_image
 
     def _launch_container_with_command(self, run, docker_image, command):
-        docker_env = (
-            {env_name: os.getenv(env_name) for env_name in self.env_vars} if self.env_vars else {}
-        )
+        container_context = self.get_container_context(run)
+        docker_env = dict([parse_env_var(env_var) for env_var in container_context.env_vars])
 
-        client = self._get_client()
+        client = self._get_client(container_context)
 
         try:
             container = client.containers.create(
@@ -99,8 +102,8 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
                 command=command,
                 detach=True,
                 environment=docker_env,
-                network=self.networks[0] if len(self.networks) else None,
-                **self.container_kwargs,
+                network=container_context.networks[0] if len(container_context.networks) else None,
+                **container_context.container_kwargs,
             )
 
         except docker.errors.ImageNotFound:
@@ -110,12 +113,12 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
                 command=command,
                 detach=True,
                 environment=docker_env,
-                network=self.networks[0] if len(self.networks) else None,
-                **self.container_kwargs,
+                network=container_context.networks[0] if len(container_context.networks) else None,
+                **container_context.container_kwargs,
             )
 
-        if len(self.networks) > 1:
-            for network_name in self.networks[1:]:
+        if len(container_context.networks) > 1:
+            for network_name in container_context.networks[1:]:
                 network = client.networks.get(network_name)
                 network.connect(container)
 
@@ -174,8 +177,10 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
         if not container_id:
             return None
 
+        container_context = self.get_container_context(run)
+
         try:
-            return self._get_client().containers.get(container_id)
+            return self._get_client(container_context).containers.get(container_id)
         except Exception:
             return None
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/utils.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/utils.py
@@ -1,45 +1,28 @@
+import os
+from typing import Tuple
+
 from docker_image import reference
 
-from dagster import Array, Field, Permissive, StringSource, check
+from dagster import Field, StringSource, check
+from dagster.utils import merge_dicts
 
-DOCKER_CONFIG_SCHEMA = {
-    "image": Field(
-        StringSource,
-        is_required=False,
-        description="The docker image to be used if the repository does not specify one.",
-    ),
-    "registry": Field(
-        {
-            "url": Field(StringSource),
-            "username": Field(StringSource),
-            "password": Field(StringSource),
-        },
-        is_required=False,
-        description="Information for using a non local/public docker registry",
-    ),
-    "env_vars": Field(
-        [str],
-        is_required=False,
-        description="The list of environment variables names to forward to the docker container",
-    ),
-    "network": Field(
-        StringSource,
-        is_required=False,
-        description="Name of the network to which to connect the launched container at creation time",
-    ),
-    "networks": Field(
-        Array(StringSource),
-        is_required=False,
-        description="Names of the networks to which to connect the launched container at creation time",
-    ),
-    "container_kwargs": Field(
-        Permissive(),
-        is_required=False,
-        description="key-value pairs that can be passed into containers.create. See "
-        "https://docker-py.readthedocs.io/en/stable/containers.html for the full list "
-        "of available options.",
-    ),
-}
+from .container_context import DOCKER_CONTAINER_CONTEXT_SCHEMA
+
+DOCKER_CONFIG_SCHEMA = merge_dicts(
+    {
+        "image": Field(
+            StringSource,
+            is_required=False,
+            description="The docker image to be used if the repository does not specify one.",
+        ),
+        "network": Field(
+            StringSource,
+            is_required=False,
+            description="Name of the network to which to connect the launched container at creation time",
+        ),
+    },
+    DOCKER_CONTAINER_CONTEXT_SCHEMA,
+)
 
 
 def validate_docker_config(network, networks, container_kwargs):
@@ -54,12 +37,12 @@ def validate_docker_config(network, networks, container_kwargs):
 
         if "environment" in container_kwargs:
             raise Exception(
-                "'environment' cannot be used in 'container_kwargs'. Use the 'environment' config key instead."
+                "'environment' cannot be used in 'container_kwargs'. Use the 'env_vars' config key instead."
             )
 
         if "network" in container_kwargs:
             raise Exception(
-                "'network' cannot be used in 'container_kwargs'. Use the 'network' config key instead."
+                "'network' cannot be used in 'container_kwargs'. Use the 'networks' config key instead."
             )
 
 
@@ -73,3 +56,11 @@ def validate_docker_image(docker_image):
                 docker_image=docker_image
             )
         ) from e
+
+
+def parse_env_var(env_var_str: str) -> Tuple[str, str]:
+    if "=" in env_var_str:
+        split = env_var_str.split("=")
+        return (split[0], split[1])
+    else:
+        return (env_var_str, os.getenv(env_var_str))

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -339,6 +339,28 @@ def test_launch_docker_image_multiple_networks():
     _test_launch(docker_image, launcher_config)
 
 
+def test_launch_docker_config_on_container_context():
+    docker_image = get_test_project_docker_image()
+    launcher_config = {}
+    _test_launch(
+        docker_image,
+        launcher_config,
+        container_image=docker_image,
+        container_context={
+            "docker": {
+                "env_vars": [
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY",
+                ],
+                "networks": [
+                    "container:test-postgres-db-docker",
+                    "postgres",
+                ],
+            }
+        },
+    )
+
+
 def test_cant_combine_network_and_networks():
     docker_image = get_test_project_docker_image()
     launcher_config = {
@@ -379,7 +401,9 @@ def test_terminate():
     _test_launch(docker_image, launcher_config, terminate=True)
 
 
-def _test_launch(docker_image, launcher_config, terminate=False):
+def _test_launch(
+    docker_image, launcher_config, terminate=False, container_image=None, container_context=None
+):
     if IS_BUILDKITE:
         launcher_config["registry"] = get_buildkite_registry_config()
     else:
@@ -401,8 +425,12 @@ def _test_launch(docker_image, launcher_config, terminate=False):
             }
         }
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_s3")
-        with get_test_project_workspace_and_external_pipeline(instance, "demo_pipeline_s3") as (
+        recon_pipeline = get_test_project_recon_pipeline(
+            "demo_pipeline_s3", container_image=container_image, container_context=container_context
+        )
+        with get_test_project_workspace_and_external_pipeline(
+            instance, "demo_pipeline_s3", container_image=container_image
+        ) as (
             workspace,
             orig_pipeline,
         ):
@@ -412,7 +440,7 @@ def _test_launch(docker_image, launcher_config, terminate=False):
                 pipeline_def=recon_pipeline.get_definition(),
                 run_config=run_config,
                 external_pipeline_origin=external_pipeline.get_external_origin(),
-                pipeline_code_origin=external_pipeline.get_python_origin(),
+                pipeline_code_origin=recon_pipeline.get_python_origin(),
             )
 
             instance.launch_run(run.run_id, workspace)

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -90,6 +90,83 @@ def test_image_on_pipeline():
             assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
 
 
+def test_container_context_on_pipeline():
+    docker_image = get_test_project_docker_image()
+
+    launcher_config = {}
+
+    if IS_BUILDKITE:
+        launcher_config["registry"] = get_buildkite_registry_config()
+    else:
+        find_local_test_image(docker_image)
+
+    executor_config = {
+        "execution": {"docker": {"config": {}}},
+    }
+
+    run_config = merge_dicts(
+        merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
+        executor_config,
+    )
+
+    with docker_postgres_instance(
+        overrides={
+            "run_launcher": {
+                "class": "DockerRunLauncher",
+                "module": "dagster_docker",
+                "config": launcher_config,
+            }
+        }
+    ) as instance:
+        recon_pipeline = get_test_project_recon_pipeline(
+            "demo_pipeline_docker",
+            docker_image,
+            container_context={
+                "docker": {
+                    "env_vars": [
+                        "AWS_ACCESS_KEY_ID",
+                        "AWS_SECRET_ACCESS_KEY",
+                    ],
+                    "networks": ["container:test-postgres-db-docker"],
+                    "container_kwargs": {
+                        "auto_remove": True,
+                        "volumes": ["/var/run/docker.sock:/var/run/docker.sock"],
+                    },
+                }
+            },
+        )
+        with get_test_project_workspace_and_external_pipeline(
+            instance, "demo_pipeline_docker", container_image=docker_image
+        ) as (
+            workspace,
+            orig_pipeline,
+        ):
+            external_pipeline = ReOriginatedExternalPipelineForTest(
+                orig_pipeline, container_image=docker_image
+            )
+
+            run = instance.create_run_for_pipeline(
+                pipeline_def=recon_pipeline.get_definition(),
+                run_config=run_config,
+                external_pipeline_origin=external_pipeline.get_external_origin(),
+                pipeline_code_origin=recon_pipeline.get_python_origin(),
+            )
+
+            instance.launch_run(run.run_id, workspace)
+
+            poll_for_finished_run(instance, run.run_id, timeout=60)
+
+            for log in instance.all_logs(run.run_id):
+                print(log)  # pylint: disable=print-call
+
+            assert instance.get_run_by_id(run.run_id).status == PipelineRunStatus.SUCCESS
+
+
 def test_recovery():
     docker_image = get_test_project_docker_image()
 


### PR DESCRIPTION
Summary:
This dict then ends up on the run, which can then be accessed within the run launcher and the executor to incorporate per-location config into the resulting containers.

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.