### PR TITLE
Clear out 'dependsOn' when creating a default ECS task definition

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -73,7 +73,6 @@ def default_ecs_task_definition(
     # entryPoint and containerOverrides are specified, they're concatenated
     # and the command will fail
     # https://aws.amazon.com/blogs/opensource/demystifying-entrypoint-cmd-docker/
-    container_definitions = task_definition["containerDefinitions"]
     container_definitions = [
         merge_dicts(
             {
@@ -82,6 +81,7 @@ def default_ecs_task_definition(
                 "image": image,
                 "entryPoint": [],
                 "command": command if command else [],
+                "dependsOn": [],  # Remove any other container dependencies as well
             },
             environment_dict,
             secrets_dict,

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -34,8 +34,23 @@ def task_definition(ecs, image, environment):
     return ecs.register_task_definition(
         family="dagster",
         containerDefinitions=[
-            {"name": "dagster", "image": image, "environment": environment, "entryPoint": ["ls"]},
-            {"name": "other", "image": image, "entryPoint": ["ls"]},
+            {
+                "name": "dagster",
+                "image": image,
+                "environment": environment,
+                "entryPoint": ["ls"],
+                "dependsOn": [
+                    {
+                        "containerName": "other",
+                        "condition": "SUCCESS",
+                    },
+                ],
+            },
+            {
+                "name": "other",
+                "image": image,
+                "entryPoint": ["ls"],
+            },
         ],
         networkMode="awsvpc",
         memory="512",

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -42,6 +42,7 @@ def test_default_launcher(
     assert container_definition["name"] == "run"
     assert container_definition["image"] == image
     assert not container_definition.get("entryPoint")
+    assert not container_definition.get("dependsOn")
     # But other stuff is inhereted from the parent task definition
     assert container_definition["environment"] == environment
 


### PR DESCRIPTION
Summary:
https://github.com/dagster-io/dagster/pull/6850/files made it so that we no longer include by default the containers that are included in the task definition. My guess from https://github.com/dagster-io/dagster/issues/6926 is that some users have a task definition with multiple containers *and* container dependencies, so taking out the containers left these dangling container

Test Plan: Create a task definition with two containers and a dependsOn in it, use it to launch an ECS run using the deploy_ecs example

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.