### PR TITLE
In run status sensors, snapshot the status that triggered the reaction in the PipelineRunReaction rather than pulling it from the PipelineRun object

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/core/definitions/run_request.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Mapping, NamedTuple, Optional
 
 from dagster import check
-from dagster.core.storage.pipeline_run import PipelineRun
+from dagster.core.storage.pipeline_run import PipelineRun, PipelineRunStatus
 from dagster.serdes.serdes import register_serdes_enum_fallbacks, whitelist_for_serdes
 from dagster.utils.error import SerializableErrorInfo
 
@@ -85,7 +85,11 @@ class RunRequest(
 class PipelineRunReaction(
     NamedTuple(
         "_PipelineRunReaction",
-        [("pipeline_run", Optional[PipelineRun]), ("error", Optional[SerializableErrorInfo])],
+        [
+            ("pipeline_run", Optional[PipelineRun]),
+            ("error", Optional[SerializableErrorInfo]),
+            ("run_status", Optional[PipelineRunStatus]),
+        ],
     )
 ):
     """
@@ -93,15 +97,20 @@ class PipelineRunReaction(
     back to the run.
 
     Attributes:
-        pipeline_run (PipelineRun): The pipeline run that originates this reaction.
+        pipeline_run (Optional[PipelineRun]): The pipeline run that originates this reaction.
         error (Optional[SerializableErrorInfo]): user code execution error.
+        run_status: (Optional[PipelineRunStatus]): The run status that triggered the reaction.
     """
 
     def __new__(
-        cls, pipeline_run: Optional[PipelineRun], error: Optional[SerializableErrorInfo] = None
+        cls,
+        pipeline_run: Optional[PipelineRun],
+        error: Optional[SerializableErrorInfo] = None,
+        run_status: Optional[PipelineRunStatus] = None,
     ):
         return super(PipelineRunReaction, cls).__new__(
             cls,
             pipeline_run=check.opt_inst_param(pipeline_run, "pipeline_run", PipelineRun),
             error=check.opt_inst_param(error, "error", SerializableErrorInfo),
+            run_status=check.opt_inst_param(run_status, "run_status", PipelineRunStatus),
         )

--- a/python_modules/dagster/dagster/core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/run_status_sensor_definition.py
@@ -501,6 +501,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                 # * update cursor and job state
                 yield PipelineRunReaction(
                     pipeline_run=pipeline_run,
+                    run_status=pipeline_run_status,
                     error=serializable_error,
                 )
 

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -372,10 +372,18 @@ def _evaluate_sensor(
                     # we still want to update the cursor, even though the tick failed
                     context.set_should_update_cursor_on_failure(True)
                 else:
+                    # Use status from the PipelineRunReaction object if it is from a new enough
+                    # version (0.14.4) to be set (the status on the PipelineRun object itself
+                    # may have since changed)
+                    status = (
+                        pipeline_run_reaction.run_status.value
+                        if pipeline_run_reaction.run_status
+                        else pipeline_run_reaction.pipeline_run.status.value
+                    )
                     # log to the original pipeline run
                     message = (
                         f'Sensor "{external_sensor.name}" acted on run status '
-                        f"{pipeline_run_reaction.pipeline_run.status.value} of run {origin_run_id}."
+                        f"{status} of run {origin_run_id}."
                     )
                     instance.report_engine_event(
                         message=message, pipeline_run=pipeline_run_reaction.pipeline_run

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -238,6 +238,11 @@ def my_pipeline_success_sensor(context):
     assert isinstance(context.instance, DagsterInstance)
 
 
+@run_status_sensor(pipeline_run_status=PipelineRunStatus.STARTED)
+def my_pipeline_started_sensor(context):
+    assert isinstance(context.instance, DagsterInstance)
+
+
 config_job = config_graph.to_job()
 
 
@@ -293,6 +298,7 @@ def the_repo():
         my_run_failure_sensor_filtered,
         my_run_failure_sensor_that_itself_fails,
         my_pipeline_success_sensor,
+        my_pipeline_started_sensor,
         failure_pipeline,
         failure_job,
         hanging_pipeline,
@@ -1472,7 +1478,7 @@ def test_run_failure_sensor_filtered():
             )
 
 
-def test_run_status_sensor():
+def test_run_status_sensor(capfd):
     freeze_datetime = pendulum.now()
     with instance_with_sensors() as (
         instance,
@@ -1482,6 +1488,9 @@ def test_run_status_sensor():
         with pendulum.test(freeze_datetime):
             success_sensor = external_repo.get_external_sensor("my_pipeline_success_sensor")
             instance.start_sensor(success_sensor)
+
+            started_sensor = external_repo.get_external_sensor("my_pipeline_started_sensor")
+            instance.start_sensor(started_sensor)
 
             evaluate_sensors(instance, workspace)
 
@@ -1512,7 +1521,7 @@ def test_run_status_sensor():
 
         with pendulum.test(freeze_datetime):
 
-            # should not fire the success sensor
+            # should not fire the success sensor, should fire the started sensro
             evaluate_sensors(instance, workspace)
 
             ticks = instance.get_ticks(success_sensor.get_external_origin_id())
@@ -1522,6 +1531,15 @@ def test_run_status_sensor():
                 success_sensor,
                 freeze_datetime,
                 TickStatus.SKIPPED,
+            )
+
+            ticks = instance.get_ticks(started_sensor.get_external_origin_id())
+            assert len(ticks) == 2
+            validate_tick(
+                ticks[0],
+                started_sensor,
+                freeze_datetime,
+                TickStatus.SUCCESS,
             )
 
         with pendulum.test(freeze_datetime):
@@ -1537,9 +1555,11 @@ def test_run_status_sensor():
             assert run.status == PipelineRunStatus.SUCCESS
             freeze_datetime = freeze_datetime.add(seconds=60)
 
+        capfd.readouterr()
+
         with pendulum.test(freeze_datetime):
 
-            # should fire the success sensor
+            # should fire the success sensor and the started sensor
             evaluate_sensors(instance, workspace)
 
             ticks = instance.get_ticks(success_sensor.get_external_origin_id())
@@ -1549,6 +1569,25 @@ def test_run_status_sensor():
                 success_sensor,
                 freeze_datetime,
                 TickStatus.SUCCESS,
+            )
+
+            ticks = instance.get_ticks(started_sensor.get_external_origin_id())
+            assert len(ticks) == 3
+            validate_tick(
+                ticks[0],
+                started_sensor,
+                freeze_datetime,
+                TickStatus.SUCCESS,
+            )
+
+            captured = capfd.readouterr()
+            assert (
+                'Sensor "my_pipeline_started_sensor" acted on run status STARTED of run'
+                in captured.out
+            )
+            assert (
+                'Sensor "my_pipeline_success_sensor" acted on run status SUCCESS of run'
+                in captured.out
             )
 
 


### PR DESCRIPTION
Summary:
A user reported that when jobs change status quickly, a run status sensor that is set to trigger on, say, STARTED, sometimes incorrectly says "acted on run status SUCCEEDED". This resolves that race condition by setting the intended status on the PipelineRunReaction, rather than pulling it from the PipelineRun object itself.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.