### PR TITLE
[dagster-airbyte][examples] fix bug with empty prefix

### DIFF
--- a/examples/modern_data_stack_assets/mds_dbt/models/orders_cleaned.sql
+++ b/examples/modern_data_stack_assets/mds_dbt/models/orders_cleaned.sql
@@ -1,1 +1,6 @@
-select * from {{ source('postgres_replica', 'orders') }}
+select
+        (_airbyte_data->'index')::int as index,
+        (_airbyte_data->'user_id')::int as user_id,
+        TO_TIMESTAMP(_airbyte_data->>'order_time', 'YYYY-MM-DDTHH:MI:SSZ') as order_time,
+        (_airbyte_data->'order_value')::float as order_value
+from {{ source('postgres_replica', 'orders') }}

--- a/examples/modern_data_stack_assets/mds_dbt/models/sources.yml
+++ b/examples/modern_data_stack_assets/mds_dbt/models/sources.yml
@@ -5,5 +5,7 @@ sources:
     database: postgres_replica
     schema: public
     tables:
-      - name: users
       - name: orders
+        identifier: _airbyte_raw_orders
+      - name: users
+        identifier: _airbyte_raw_users

--- a/examples/modern_data_stack_assets/mds_dbt/models/users_augmented.sql
+++ b/examples/modern_data_stack_assets/mds_dbt/models/users_augmented.sql
@@ -1,1 +1,5 @@
-select * from {{ source('postgres_replica', 'users') }}
+select
+        (_airbyte_data->'index')::int as index,
+        (_airbyte_data->'user_id')::int as user_id,
+        (_airbyte_data->'is_bot')::bool as is_bot
+from {{ source('postgres_replica', 'users') }}

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
@@ -6,7 +6,7 @@ from dagster.utils import file_relative_path
 # =========================================================================
 # To get this value, run `python -m modern_data_stack_assets.setup_airbyte`
 # and grab the connection id that it prints
-AIRBYTE_CONNECTION_ID = "your_airbyte_connection_id"
+AIRBYTE_CONNECTION_ID = "ea55748b-22eb-47c5-a9b2-24b30b04add9"
 # =========================================================================
 
 

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
@@ -5,8 +5,8 @@ from dagster.utils import file_relative_path
 
 # =========================================================================
 # To get this value, run `python -m modern_data_stack_assets.setup_airbyte`
-# and grab the connection id that it prints
-AIRBYTE_CONNECTION_ID = "ea55748b-22eb-47c5-a9b2-24b30b04add9"
+# and grab the connection id that it prints at the end
+AIRBYTE_CONNECTION_ID = "your_airbyte_connection_id"
 # =========================================================================
 
 

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -59,6 +59,18 @@ def _create_ab_destination(client: AirbyteResource) -> str:
     if not postgres_definitions:
         raise check.CheckError("Expected at least one Postgres destination definition.")
     destination_definition_id = postgres_definitions[0]["destinationDefinitionId"]
+    import json
+
+    print(
+        json.dumps(
+            client.make_request(
+                "/destination_definition_specifications/get",
+                data={"destinationDefinitionId": destination_definition_id},
+            ),
+            indent=4,
+        )
+    )
+    exit()
 
     # create Postgres destination
     destination_id = client.make_request(
@@ -76,7 +88,7 @@ def _create_ab_destination(client: AirbyteResource) -> str:
 
 def setup_airbyte():
     client = AirbyteResource(host="localhost", port="8000", use_https=False)
-    source_id = _create_ab_source(client)
+    # source_id = _create_ab_source(client)
     destination_id = _create_ab_destination(client)
 
     source_catalog = client.make_request("/sources/discover_schema", data={"sourceId": source_id})[

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -59,18 +59,6 @@ def _create_ab_destination(client: AirbyteResource) -> str:
     if not postgres_definitions:
         raise check.CheckError("Expected at least one Postgres destination definition.")
     destination_definition_id = postgres_definitions[0]["destinationDefinitionId"]
-    import json
-
-    print(
-        json.dumps(
-            client.make_request(
-                "/destination_definition_specifications/get",
-                data={"destinationDefinitionId": destination_definition_id},
-            ),
-            indent=4,
-        )
-    )
-    exit()
 
     # create Postgres destination
     destination_id = client.make_request(
@@ -88,7 +76,7 @@ def _create_ab_destination(client: AirbyteResource) -> str:
 
 def setup_airbyte():
     client = AirbyteResource(host="localhost", port="8000", use_https=False)
-    # source_id = _create_ab_source(client)
+    source_id = _create_ab_source(client)
     destination_id = _create_ab_destination(client)
 
     source_catalog = client.make_request("/sources/discover_schema", data={"sourceId": source_id})[

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -91,6 +91,7 @@ def setup_airbyte():
             "sourceId": source_id,
             "destinationId": destination_id,
             "syncCatalog": source_catalog,
+            "prefix": "",
             "status": "active",
         },
     )["connectionId"]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -74,7 +74,7 @@ class AirbyteResource:
                     url=self.api_base_url + endpoint,
                     headers=headers,
                     json=data,
-                    timeout=5,
+                    timeout=15,
                 )
                 response.raise_for_status()
                 return response.json()

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -33,7 +33,7 @@ def _materialization_for_stream(
 
 
 def generate_materializations(output: AirbyteOutput, asset_key_prefix: List[str]):
-    prefix = output.connection_details.get("prefix", "")
+    prefix = output.connection_details.get("prefix") or ""
     stream_info = {
         prefix + stream["stream"]["name"]: stream
         for stream in output.connection_details.get("syncCatalog", {}).get("streams", [])


### PR DESCRIPTION
When you set up a connector via the UI and don't supply a prefix, the UI will return the empty string as the prefix. However, if you set it up via the API, and do not supply a prefix, you get None, which causes an error.