### PR TITLE
revert stray dagster[lint] for BK mypy

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -162,7 +162,6 @@ class ModuleBuildSpec(
                 StepBuilder(f":mypy: {package}")
                 .run(
                     "pip install -e python_modules/dagster[mypy]",
-                    "mkdir -p .mypy_cache",
                     # mypy raises an error for missing stubs. We try to specify them in
                     # dependencies, but inclusion of `--install-types
                     # --non-interactive` will cause mypy to automatically download any missing ones.

--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -161,7 +161,7 @@ class ModuleBuildSpec(
             tests.append(
                 StepBuilder(f":mypy: {package}")
                 .run(
-                    "pip install -e python_modules/dagster[lint]",
+                    "pip install -e python_modules/dagster[mypy]",
                     "mkdir -p .mypy_cache",
                     # mypy raises an error for missing stubs. We try to specify them in
                     # dependencies, but inclusion of `--install-types


### PR DESCRIPTION
This fixes a BK mypy change that made it into the black/isort update. I don't think it's actually been affecting anything (mypy checks still seem to have been running fine).
