### PR TITLE
dagit-debug fix in-mem daemon heartbeats

### DIFF
--- a/python_modules/dagster/dagster/core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/core/storage/runs/in_memory.py
@@ -335,9 +335,7 @@ class InMemoryRunStorage(RunStorage):
         )
 
     def get_daemon_heartbeats(self) -> Dict[str, DaemonHeartbeat]:
-        raise NotImplementedError(
-            "The dagster daemon lives in a separate process. It cannot use in memory storage."
-        )
+        return {}
 
     def wipe_daemon_heartbeats(self):
         raise NotImplementedError(


### PR DESCRIPTION
This change allows the dagit-debug page to operate with an ephemeral instance without error.

We could change things higher in the stack if this approach is not preferred. 

## Test Plan

dagit-debug