### PR TITLE
fix makefile issue with check_black/check_isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ black:
     examples/docs_snippets
 
 check_black:
-	-black --check --fast \
+	black --check --fast \
     --extend-exclude="examples/docs_snippets|snapshots" \
     examples integration_tests helm python_modules .buildkite
-	-black --check --fast \
+	black --check --fast \
     examples/docs_snippets
 
 
@@ -45,11 +45,11 @@ isort:
    `git ls-files 'examples/docs_snippets/*.py'`
 
 check_isort:
-	-isort --check \
+	isort --check \
     `git ls-files '.buildkite/*.py' 'examples/*.py' 'integration_tests/*.py' 'helm/*.py' 'python_modules/*.py' \
       ':!:examples/docs_snippets' \
       ':!:snapshots'`
-	-isort --check \
+	isort --check \
     `git ls-files 'examples/docs_snippets/*.py'`
 
 yamllint:

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ isort:
    `git ls-files 'examples/docs_snippets/*.py'`
 
 check_isort:
-	isort --check --diff -vv \
+	isort --check \
     `git ls-files '.buildkite/*.py' 'examples/*.py' 'integration_tests/*.py' 'helm/*.py' 'python_modules/*.py' \
       ':!:examples/docs_snippets' \
       ':!:snapshots'`
-	isort --check --diff \
+	isort --check \
     `git ls-files 'examples/docs_snippets/*.py'`
 
 yamllint:

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ isort:
    `git ls-files 'examples/docs_snippets/*.py'`
 
 check_isort:
-	isort --check --show-config -vv \
+	isort --check --diff -vv \
     `git ls-files '.buildkite/*.py' 'examples/*.py' 'integration_tests/*.py' 'helm/*.py' 'python_modules/*.py' \
       ':!:examples/docs_snippets' \
       ':!:snapshots'`
-	isort --check --show-config \
+	isort --check --diff \
     `git ls-files 'examples/docs_snippets/*.py'`
 
 yamllint:

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ isort:
    `git ls-files 'examples/docs_snippets/*.py'`
 
 check_isort:
-	isort --check \
+	isort --check --settings-path pyproject.toml \
     `git ls-files '.buildkite/*.py' 'examples/*.py' 'integration_tests/*.py' 'helm/*.py' 'python_modules/*.py' \
       ':!:examples/docs_snippets' \
       ':!:snapshots'`
-	isort --check \
+	isort --check --settings-path examples/docs_snippets/pyproject.toml \
     `git ls-files 'examples/docs_snippets/*.py'`
 
 yamllint:

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ isort:
    `git ls-files 'examples/docs_snippets/*.py'`
 
 check_isort:
-	isort --check -v --settings-path pyproject.toml \
+	isort --check --show-config -vv \
     `git ls-files '.buildkite/*.py' 'examples/*.py' 'integration_tests/*.py' 'helm/*.py' 'python_modules/*.py' \
       ':!:examples/docs_snippets' \
       ':!:snapshots'`
-	isort --check --settings-path examples/docs_snippets/pyproject.toml \
+	isort --check --show-config \
     `git ls-files 'examples/docs_snippets/*.py'`
 
 yamllint:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ isort:
    `git ls-files 'examples/docs_snippets/*.py'`
 
 check_isort:
-	isort --check --settings-path pyproject.toml \
+	isort --check -v --settings-path pyproject.toml \
     `git ls-files '.buildkite/*.py' 'examples/*.py' 'integration_tests/*.py' 'helm/*.py' 'python_modules/*.py' \
       ':!:examples/docs_snippets' \
       ':!:snapshots'`

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -177,8 +177,9 @@ By default, materializing an asset will pickle it to a local file named "my_asse
 To apply an IO manager to a set of assets, you can include it with them in an <PyObject object="AssetGroup" />.
 
 ```python file=/concepts/assets/asset_io_manager.py startafter=start_marker endbefore=end_marker
-from dagster import AssetGroup, asset
 from dagster_aws.s3 import s3_pickle_asset_io_manager, s3_resource
+
+from dagster import AssetGroup, asset
 
 
 @asset
@@ -204,8 +205,9 @@ When `upstream_asset` is materialized, the value `[1, 2, 3]` will be will be pic
 Different assets can have different IO managers:
 
 ```python file=/concepts/assets/asset_different_io_managers.py startafter=start_marker endbefore=end_marker
-from dagster import AssetGroup, asset, fs_asset_io_manager
 from dagster_aws.s3 import s3_pickle_asset_io_manager, s3_resource
+
+from dagster import AssetGroup, asset, fs_asset_io_manager
 
 
 @asset(io_manager_key="s3_io_manager")
@@ -233,8 +235,9 @@ When `upstream_asset` is materialized, the value `[1, 2, 3]` will be will be pic
 The same assets can be bound to different resources and IO managers in different environments. For example, for local development, you might want to store assets on your local filesystem while, in production, you might want to store the assets in S3.
 
 ```python file=/concepts/assets/asset_io_manager_prod_local.py startafter=start_marker endbefore=end_marker
-from dagster import AssetGroup, asset, fs_asset_io_manager
 from dagster_aws.s3 import s3_pickle_asset_io_manager, s3_resource
+
+from dagster import AssetGroup, asset, fs_asset_io_manager
 
 
 @asset

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -90,8 +90,9 @@ Not all the outputs in a job should necessarily be stored the same way. Maybe so
 To select the IOManager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting IO managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
 
 ```python file=/concepts/io_management/io_manager_per_output.py startafter=start_marker endbefore=end_marker
-from dagster import Out, fs_io_manager, job, op
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+from dagster import Out, fs_io_manager, job, op
 
 
 @op(out=Out(io_manager_key="fs"))

--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -141,9 +141,10 @@ To enable parallel computation (e.g., with the multiprocessing or Dagster celery
 You'll first need to need to use <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/> as your IO Manager or customize your own persistent io managers (see [example](/concepts/io-management/io-managers#defining-an-io-manager)).
 
 ```python file=/deploying/aws/io_manager.py
-from dagster import Int, Out, job, op
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import s3_resource
+
+from dagster import Int, Out, job, op
 
 
 @op(out=Out(Int))

--- a/docs/content/deployment/guides/celery.mdx
+++ b/docs/content/deployment/guides/celery.mdx
@@ -20,8 +20,9 @@ The dagster-celery executor compiles a job and its associated configuration into
 Let's construct a very parallel toy job that uses the Celery executor.
 
 ```python file=/deploying/celery_job.py
-from dagster import job, op
 from dagster_celery import celery_executor
+
+from dagster import job, op
 
 
 @op

--- a/docs/content/deployment/guides/dask.mdx
+++ b/docs/content/deployment/guides/dask.mdx
@@ -26,8 +26,9 @@ First, run `pip install dagster-dask`.
 Then, create a job with the dask executor:
 
 ```python file=/deploying/dask_hello_world.py startafter=start_local_job_marker endbefore=end_local_job_marker
-from dagster import job, op
 from dagster_dask import dask_executor
+
+from dagster import job, op
 
 
 @op
@@ -58,10 +59,11 @@ If you want to use a Dask cluster for distributed execution, you will first need
 You'll also need an IO manager that uses persistent shared storage, which should be attached to the job along with any resources on which it depends. Here, we use the <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/>:
 
 ```python file=/deploying/dask_hello_world_distributed.py startafter=start_distributed_job_marker endbefore=end_distributed_job_marker
-from dagster import job, op
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import s3_resource
 from dagster_dask import dask_executor
+
+from dagster import job, op
 
 
 @op

--- a/docs/content/deployment/guides/gcp.mdx
+++ b/docs/content/deployment/guides/gcp.mdx
@@ -63,9 +63,10 @@ You'll probably also want to configure a GCS bucket to store op outputs via pers
 You'll first need to need to create a job using <PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager"/> as its IO Manager (or [define a custom IO Manager](/concepts/io-management/io-managers#defining-an-io-manager)):
 
 ```python file=/deploying/gcp/gcp_job.py
-from dagster import job
 from dagster_gcp.gcs.io_manager import gcs_pickle_io_manager
 from dagster_gcp.gcs.resources import gcs_resource
+
+from dagster import job
 
 
 @job(

--- a/docs/content/guides/dagster/dagster_type_factories.mdx
+++ b/docs/content/guides/dagster/dagster_type_factories.mdx
@@ -68,6 +68,7 @@ The first thing we want to do is visualize the distribution of trip lengths. We 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 from dagster import AssetMaterialization, job, op
 
 
@@ -162,6 +163,7 @@ Fortunately, it's easy to write a factory function that will wrap any Pandera sc
 ```python file=/guides/dagster/dagster_type_factories/factory.py
 import pandas as pd
 import pandera as pa
+
 from dagster import DagsterType, TypeCheck
 
 
@@ -208,6 +210,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pandera as pa
+
 from dagster import AssetMaterialization, In, Out, job, op
 from dagster.config.field import Field
 

--- a/docs/content/guides/dagster/re-execution.mdx
+++ b/docs/content/guides/dagster/re-execution.mdx
@@ -82,7 +82,6 @@ Again, let's revist the job `unreliable_job`, which has a op named `unreliable`.
 
 ```python file=/guides/dagster/reexecution/reexecution_api.py endbefore=end_initial_execution_marker
 from dagster import DagsterInstance, reexecute_pipeline
-
 from docs_snippets.guides.dagster.reexecution.unreliable_job import unreliable_job
 
 instance = DagsterInstance.ephemeral()

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -22,6 +22,7 @@ You can compile Dagster jobs into DAGs that can be understood by Airflow. Each o
 import csv
 
 import requests
+
 from dagster import job, op
 
 

--- a/docs/content/integrations/dagstermill.mdx
+++ b/docs/content/integrations/dagstermill.mdx
@@ -40,6 +40,7 @@ We can simply turn a notebook into an op using <PyObject module="dagstermill" ob
 
 ```python file=/legacy/data_science/iris_classify.py
 import dagstermill as dm
+
 from dagster import job
 from dagster.utils import script_relative_path
 
@@ -96,9 +97,9 @@ We'll illustrate this process by adding a non-notebook op to our job, which will
 
 ```python literalinclude showLines emphasize-lines=2,10,16 caption=iris_classify_2.py file=/legacy/data_science/iris_classify_2.py
 import dagstermill as dm
+
 from dagster import InputDefinition, job
 from dagster.utils import script_relative_path
-
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(
@@ -223,9 +224,9 @@ For instance, suppose we want to make the number of clusters (the \_k\_ in k-mea
 
 ```python literalinclude showLines emphasize-lines=10-12 caption=iris_classify_3.py file=/legacy/data_science/iris_classify_3.py
 import dagstermill as dm
+
 from dagster import Field, InputDefinition, Int, job
 from dagster.utils import script_relative_path
-
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(

--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -87,8 +87,9 @@ Note that you can pass in any keyword to these functions that you wish, and they
 One common way to use this integration is to have the a step in your job run all of the models in a dbt project. For this case, the easiest method is to configure the resource so it knows where your dbt project is, and import the `dbt_run_op` to use in your job.
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_run endbefore=end_marker_dbt_cli_run dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+from dagster import job
 
 my_dbt_resource = dbt_cli_resource.configured(
     {"project_dir": "path/to/dbt/project"}
@@ -110,8 +111,9 @@ Note that in both cases, the `models` option takes in a list of strings. The str
 If you know what models you want to select ahead of time, you might prefer specifying this while configuring your resource. Because you aren't specifying any specific arguments at runtime, you can use the prebuilt `dbt_run_op`, instead of writing your own.
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_run_specific_models_preconfig endbefore=end_marker_dbt_cli_run_specific_models_preconfig dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+from dagster import job
 
 my_dbt_resource = dbt_cli_resource.configured(
     {"project_dir": "path/to/dbt/project", "models": ["tag:staging"]}
@@ -142,8 +144,9 @@ def run_models(context, some_condition: bool):
 Dagster supports creating [multiple jobs from the same graph](/concepts/ops-jobs-graphs/jobs-graphs#from-a-graph). dbt has a similar concept, [profiles](https://docs.getdbt.com/dbt-cli/configure-your-profile). You might want to run a dev version of your graph that targets the development-specific dbt profile, and then have a prod version that runs using the prod dbt profile. This example shows how to accomplish this.
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_profile_modes endbefore=end_marker_dbt_cli_profile_modes dedent=4
-from dagster import graph
 from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+from dagster import graph
 
 @graph
 def my_dbt():
@@ -173,8 +176,9 @@ Sometimes, you'll want to run multiple different dbt commands in the same job. T
 One common use case would be to first run `dbt run` to update all of your models, and then run `dbt test` to check that they all are working as expected, seen below.
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_run_after_another_op endbefore=end_marker_dbt_cli_run_after_another_op dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource, dbt_run_op, dbt_test_op
+
+from dagster import job
 
 my_dbt_resource = dbt_cli_resource.configured(
     {"project_dir": "path/to/dbt/project"}
@@ -212,8 +216,9 @@ For convenience during local development, you may also use `dagster_dbt.local_db
 All of the prebuilt dbt ops in this library are compatible with the `dbt_rpc_resource` (which sends requests and then exists immediately) and the `dbt_rpc_sync_resource` (which sends requests and waits for the task to complete). Therefore, we can use the same ops as in the CLI examples as long as we provide the correct resource to the job.
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_run endbefore=end_marker_dbt_rpc_run dedent=4
-from dagster import job
 from dagster_dbt import dbt_run_op
+
+from dagster import job
 
 @job(resource_defs={"dbt": my_remote_rpc})
 def my_dbt_job():
@@ -225,8 +230,9 @@ def my_dbt_job():
 This is similar to having `"params": {"models": "tag:staging"}` in your dbt RPC request body.
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_run_specific_models endbefore=end_marker_dbt_rpc_run_specific_models dedent=4
-from dagster import job, op
 from dagster_dbt import dbt_rpc_resource
+
+from dagster import job, op
 
 my_remote_rpc = dbt_rpc_resource.configured({"host": "80.80.80.80", "port": 8080})
 
@@ -244,8 +250,9 @@ Note that the job above will NOT wait until the dbt RPC server has finished exec
 #### Running a dbt project and polling the RPC server until it has finished executing
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_rpc_run_and_wait endbefore=end_marker_dbt_rpc_run_and_wait dedent=4
-from dagster import job, op
 from dagster_dbt import dbt_rpc_sync_resource
+
+from dagster import job, op
 
 my_remote_sync_rpc = dbt_rpc_sync_resource.configured(
     {"host": "80.80.80.80", "port": 8080}
@@ -269,8 +276,9 @@ For full documentation on all available config, [visit the API docs for dagster-
 `dagster_dbt` is configured to automatically create [Asset Materializations](/concepts/assets/asset-materializations) for each of your dbt models when you run the `run` command (via either the CLI or over RPC). These materializations are populated with metadata that is automatically parsed from the dbt response. The available metadata differs between dbt versions. If there's anything you would like to add to these materializations, you can explicitly invoke the underlying <PyObject module='dagster_dbt.utils' object='generate_materializations'/> utility function, and modify each of the resulting materializations like so:
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_asset_mats endbefore=end_marker_dbt_asset_mats dedent=4
-from dagster import op
 from dagster_dbt.utils import generate_materializations
+
+from dagster import op
 
 @op(required_resource_keys={"dbt"})
 def dbt_run_with_custom_assets(context):
@@ -287,8 +295,9 @@ def dbt_run_with_custom_assets(context):
 **dbt CLI: Set the dbt profile and target to load**
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_config_profile_and_target endbefore=end_marker_dbt_cli_config_profile_and_target dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource
+
+from dagster import job
 
 config = {"profile": PROFILE_NAME, "target": TARGET_NAME}
 
@@ -300,8 +309,9 @@ def my_job():
 **dbt CLI: Set the path to the dbt executable**
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_config_executable endbefore=end_marker_dbt_cli_config_executable dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource
+
+from dagster import job
 
 config = {"dbt_executable": "path/to/dbt/executable"}
 
@@ -313,8 +323,9 @@ def my_job():
 **dbt CLI: Select specific models to run**
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_config_select_models endbefore=end_marker_dbt_cli_config_select_models dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource
+
+from dagster import job
 
 config = {"models": ["my_dbt_model+", "path.to.models", "tag:nightly"]}
 
@@ -328,8 +339,9 @@ For more details, [visit the official documentation on dbt's node selection synt
 **dbt CLI: Exclude specific models**
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_config_exclude_models endbefore=end_marker_dbt_cli_config_exclude_models dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource
+
+from dagster import job
 
 config = {"exclude": ["my_dbt_model+", "path.to.models", "tag:nightly"]}
 
@@ -343,8 +355,9 @@ For more details, [visit the official documentation on dbt's node selection synt
 **dbt CLI: Set key-values for dbt vars**
 
 ```python file=/integrations/dbt.py startafter=start_marker_dbt_cli_config_vars endbefore=end_marker_dbt_cli_config_vars dedent=4
-from dagster import job
 from dagster_dbt import dbt_cli_resource
+
+from dagster import job
 
 config = {"vars": {"key": "value"}}
 

--- a/docs/content/integrations/pandera.mdx
+++ b/docs/content/integrations/pandera.mdx
@@ -23,9 +23,10 @@ import random
 
 import pandas as pd
 import pandera as pa
-from dagster import Out, job, op
 from dagster_pandera import pandera_schema_to_dagster_type
 from pandera.typing import Series
+
+from dagster import Out, job, op
 
 APPLE_STOCK_PRICES = {
     "name": ["AAPL", "AAPL", "AAPL", "AAPL", "AAPL"],

--- a/docs/content/tutorial/advanced-tutorial/configuring-ops.mdx
+++ b/docs/content/tutorial/advanced-tutorial/configuring-ops.mdx
@@ -37,6 +37,7 @@ Let's rebuild a job we've seen before, but this time using our newly parameteriz
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 
@@ -141,6 +142,7 @@ Dagster allows specifying a "config schema" on any configurable object to help c
 import csv
 
 import requests
+
 from dagster import op
 
 

--- a/docs/content/tutorial/advanced-tutorial/scheduling.mdx
+++ b/docs/content/tutorial/advanced-tutorial/scheduling.mdx
@@ -18,6 +18,7 @@ import csv
 from datetime import datetime
 
 import requests
+
 from dagster import get_dagster_logger, job, op, repository, schedule
 
 

--- a/docs/content/tutorial/intro-tutorial/connecting-ops.mdx
+++ b/docs/content/tutorial/intro-tutorial/connecting-ops.mdx
@@ -30,6 +30,7 @@ This will allow us to re-run the code that finds the sugariest cereal without re
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 
@@ -85,6 +86,7 @@ Ops don't need to be wired together serially. The output of one op can be consum
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_different_io_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_different_io_managers.py
@@ -1,7 +1,8 @@
 # pylint: disable=redefined-outer-name
 # start_marker
-from dagster import AssetGroup, asset, fs_asset_io_manager
 from dagster_aws.s3 import s3_pickle_asset_io_manager, s3_resource
+
+from dagster import AssetGroup, asset, fs_asset_io_manager
 
 
 @asset(io_manager_key="s3_io_manager")

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
@@ -1,7 +1,8 @@
 # pylint: disable=redefined-outer-name
 # start_marker
-from dagster import AssetGroup, asset
 from dagster_aws.s3 import s3_pickle_asset_io_manager, s3_resource
+
+from dagster import AssetGroup, asset
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager_prod_local.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager_prod_local.py
@@ -1,7 +1,8 @@
 # pylint: disable=redefined-outer-name
 # start_marker
-from dagster import AssetGroup, asset, fs_asset_io_manager
 from dagster_aws.s3 import s3_pickle_asset_io_manager, s3_resource
+
+from dagster import AssetGroup, asset, fs_asset_io_manager
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
@@ -1,6 +1,7 @@
 # start_marker
-from dagster import Out, fs_io_manager, job, op
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+from dagster import Out, fs_io_manager, job, op
 
 
 @op(out=Out(io_manager_key="fs"))

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+
 from dagster import (
     AssetMaterialization,
     InputContext,

--- a/examples/docs_snippets/docs_snippets/concepts/logging/logging_jobs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/logging_jobs.py
@@ -1,6 +1,7 @@
+from dagster_aws.cloudwatch.loggers import cloudwatch_logger
+
 from dagster import graph, op, repository
 from dagster.loggers import colored_console_logger
-from dagster_aws.cloudwatch.loggers import cloudwatch_logger
 
 
 # start_logging_mode_marker_0

--- a/examples/docs_snippets/docs_snippets/concepts/solids_pipelines/solids.py
+++ b/examples/docs_snippets/docs_snippets/concepts/solids_pipelines/solids.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-argument
 
 import requests
+
 from dagster import DagsterType, In, Nothing, Out, op
 
 

--- a/examples/docs_snippets/docs_snippets/deploying/aws/io_manager.py
+++ b/examples/docs_snippets/docs_snippets/deploying/aws/io_manager.py
@@ -1,6 +1,7 @@
-from dagster import Int, Out, job, op
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import s3_resource
+
+from dagster import Int, Out, job, op
 
 
 @op(out=Out(Int))

--- a/examples/docs_snippets/docs_snippets/deploying/celery_job.py
+++ b/examples/docs_snippets/docs_snippets/deploying/celery_job.py
@@ -1,5 +1,6 @@
-from dagster import job, op
 from dagster_celery import celery_executor
+
+from dagster import job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/deploying/dask_hello_world.py
+++ b/examples/docs_snippets/docs_snippets/deploying/dask_hello_world.py
@@ -1,7 +1,8 @@
 # start_local_job_marker
 
-from dagster import job, op
 from dagster_dask import dask_executor
+
+from dagster import job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/deploying/dask_hello_world_distributed.py
+++ b/examples/docs_snippets/docs_snippets/deploying/dask_hello_world_distributed.py
@@ -1,9 +1,10 @@
 # start_distributed_job_marker
 
-from dagster import job, op
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import s3_resource
 from dagster_dask import dask_executor
+
+from dagster import job, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/deploying/gcp/gcp_job.py
+++ b/examples/docs_snippets/docs_snippets/deploying/gcp/gcp_job.py
@@ -1,6 +1,7 @@
-from dagster import job
 from dagster_gcp.gcs.io_manager import gcs_pickle_io_manager
 from dagster_gcp.gcs.resources import gcs_resource
+
+from dagster import job
 
 
 @job(

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/factory.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/factory.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pandera as pa
+
 from dagster import DagsterType, TypeCheck
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_1.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 from dagster import AssetMaterialization, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/job_2.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pandera as pa
+
 from dagster import AssetMaterialization, In, Out, job, op
 from dagster.config.field import Field
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/reexecution/reexecution_api.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/reexecution/reexecution_api.py
@@ -1,5 +1,4 @@
 from dagster import DagsterInstance, reexecute_pipeline
-
 from docs_snippets.guides.dagster.reexecution.unreliable_job import unreliable_job
 
 instance = DagsterInstance.ephemeral()

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/hello_cereal.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import job, op
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt.py
@@ -3,8 +3,9 @@
 
 def scope_dbt_asset_mats():
     # start_marker_dbt_asset_mats
-    from dagster import op
     from dagster_dbt.utils import generate_materializations
+
+    from dagster import op
 
     @op(required_resource_keys={"dbt"})
     def dbt_run_with_custom_assets(context):
@@ -35,8 +36,9 @@ def scope_dbt_cli_resource_config():
 
 def scope_dbt_cli_run():
     # start_marker_dbt_cli_run_preconfig
-    from dagster import job
     from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+    from dagster import job
 
     my_dbt_resource = dbt_cli_resource.configured(
         {"project_dir": "path/to/dbt/project"}
@@ -51,8 +53,9 @@ def scope_dbt_cli_run():
 
 def scope_dbt_cli_run_specific_models():
     # start_marker_dbt_cli_run_specific_models_preconfig
-    from dagster import job
     from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+    from dagster import job
 
     my_dbt_resource = dbt_cli_resource.configured(
         {"project_dir": "path/to/dbt/project", "models": ["tag:staging"]}
@@ -81,8 +84,9 @@ def scope_dbt_cli_run_specific_models_runtime():
 
 def scope_dbt_cli_profile_modes():
     # start_marker_dbt_cli_profile_modes
-    from dagster import graph
     from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+    from dagster import graph
 
     @graph
     def my_dbt():
@@ -109,8 +113,9 @@ def scope_dbt_cli_profile_modes():
 
 def scope_dbt_cli_run_after_another_op():
     # start_marker_dbt_cli_run_after_another_op
-    from dagster import job
     from dagster_dbt import dbt_cli_resource, dbt_run_op, dbt_test_op
+
+    from dagster import job
 
     my_dbt_resource = dbt_cli_resource.configured(
         {"project_dir": "path/to/dbt/project"}
@@ -137,8 +142,9 @@ def scope_dbt_rpc_run():
     my_remote_rpc = dbt_rpc_resource.configured({"host": "80.80.80.80", "port": 8080})
 
     # start_marker_dbt_rpc_run
-    from dagster import job
     from dagster_dbt import dbt_run_op
+
+    from dagster import job
 
     @job(resource_defs={"dbt": my_remote_rpc})
     def my_dbt_job():
@@ -150,8 +156,9 @@ def scope_dbt_rpc_run():
 def scope_dbt_rpc_run_specific_models():
 
     # start_marker_dbt_rpc_run_specific_models
-    from dagster import job, op
     from dagster_dbt import dbt_rpc_resource
+
+    from dagster import job, op
 
     my_remote_rpc = dbt_rpc_resource.configured({"host": "80.80.80.80", "port": 8080})
 
@@ -168,8 +175,9 @@ def scope_dbt_rpc_run_specific_models():
 
 def scope_dbt_rpc_run_and_wait():
     # start_marker_dbt_rpc_run_and_wait
-    from dagster import job, op
     from dagster_dbt import dbt_rpc_sync_resource
+
+    from dagster import job, op
 
     my_remote_sync_rpc = dbt_rpc_sync_resource.configured(
         {"host": "80.80.80.80", "port": 8080}
@@ -190,8 +198,9 @@ def scope_dbt_cli_config_profile_and_target():
     PROFILE_NAME, TARGET_NAME = "", ""
 
     # start_marker_dbt_cli_config_profile_and_target
-    from dagster import job
     from dagster_dbt import dbt_cli_resource
+
+    from dagster import job
 
     config = {"profile": PROFILE_NAME, "target": TARGET_NAME}
 
@@ -204,8 +213,9 @@ def scope_dbt_cli_config_profile_and_target():
 
 def scope_dbt_cli_config_executable():
     # start_marker_dbt_cli_config_executable
-    from dagster import job
     from dagster_dbt import dbt_cli_resource
+
+    from dagster import job
 
     config = {"dbt_executable": "path/to/dbt/executable"}
 
@@ -218,8 +228,9 @@ def scope_dbt_cli_config_executable():
 
 def scope_dbt_cli_config_select_models():
     # start_marker_dbt_cli_config_select_models
-    from dagster import job
     from dagster_dbt import dbt_cli_resource
+
+    from dagster import job
 
     config = {"models": ["my_dbt_model+", "path.to.models", "tag:nightly"]}
 
@@ -232,8 +243,9 @@ def scope_dbt_cli_config_select_models():
 
 def scope_dbt_cli_config_exclude_models():
     # start_marker_dbt_cli_config_exclude_models
-    from dagster import job
     from dagster_dbt import dbt_cli_resource
+
+    from dagster import job
 
     config = {"exclude": ["my_dbt_model+", "path.to.models", "tag:nightly"]}
 
@@ -246,8 +258,9 @@ def scope_dbt_cli_config_exclude_models():
 
 def scope_dbt_cli_config_vars():
     # start_marker_dbt_cli_config_vars
-    from dagster import job
     from dagster_dbt import dbt_cli_resource
+
+    from dagster import job
 
     config = {"vars": {"key": "value"}}
 
@@ -269,8 +282,9 @@ def scope_dbt_rpc_resource_example():
 
 def scope_dbt_run_disable_assets():
     # start_marker_dbt_rpc_config_disable_assets
-    from dagster import job
     from dagster_dbt import dbt_cli_resource, dbt_run_op
+
+    from dagster import job
 
     dbt_run_no_assets = dbt_run_op.configured(
         {"yield_materializations": False}, name="dbt_run_no_assets"

--- a/examples/docs_snippets/docs_snippets/integrations/pandera/example.py
+++ b/examples/docs_snippets/docs_snippets/integrations/pandera/example.py
@@ -2,9 +2,10 @@ import random
 
 import pandas as pd
 import pandera as pa
-from dagster import Out, job, op
 from dagster_pandera import pandera_schema_to_dagster_type
 from pandera.typing import Series
+
+from dagster import Out, job, op
 
 APPLE_STOCK_PRICES = {
     "name": ["AAPL", "AAPL", "AAPL", "AAPL", "AAPL"],

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/configuring_ops/config_schema.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/configuring_ops/config_schema.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/configuring_ops/configurable_job.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/configuring_ops/configurable_job.py
@@ -2,6 +2,7 @@
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/configuring_ops/download_csv.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/configuring_ops/download_csv.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/pipelines/modes.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/pipelines/modes.py
@@ -8,6 +8,7 @@ from typing import Any
 import requests
 import sqlalchemy
 import sqlalchemy.ext.declarative
+
 from dagster import Field, String, graph, op, repository, resource
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/pipelines/presets.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/pipelines/presets.py
@@ -8,6 +8,7 @@ from typing import Any
 import requests
 import sqlalchemy
 import sqlalchemy.ext.declarative
+
 from dagster import (
     Field,
     String,

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/pipelines/resources.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/pipelines/resources.py
@@ -3,6 +3,7 @@ import sqlite3
 from copy import deepcopy
 
 import requests
+
 from dagster import Field, String, job, op, resource
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/repositories/hello_cereal.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/repositories/hello_cereal.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import job, op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/scheduling/scheduler.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/advanced/scheduling/scheduler.py
@@ -3,6 +3,7 @@ import csv
 from datetime import datetime
 
 import requests
+
 from dagster import get_dagster_logger, job, op, repository, schedule
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/airflow.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/airflow.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import pipeline, solid
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_solids/complex_pipeline.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_solids/complex_pipeline.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_solids/serial_pipeline.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_solids/serial_pipeline.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import DagsterType, In, Out, get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types_2.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/custom_types_2.py
@@ -1,4 +1,5 @@
 import requests
+
 from dagster import DagsterType, In, Out, get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/inputs_typed.py
+++ b/examples/docs_snippets/docs_snippets/intro_tutorial/basics/e04_quality/inputs_typed.py
@@ -1,6 +1,7 @@
 import csv
 
 import requests
+
 from dagster import get_dagster_logger, job, op
 
 

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-from dagster import Out, job, op
-from dagster.utils import script_relative_path
 from dagster_pandas import PandasColumn, create_dagster_pandas_dataframe_type
 from pandas import DataFrame, read_csv
+
+from dagster import Out, job, op
+from dagster.utils import script_relative_path
 
 # start_core_trip_marker_0
 TripDataFrame = create_dagster_pandas_dataframe_type(

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from dagster import Out, job, op
-from dagster.utils import script_relative_path
 from dagster_pandas import PandasColumn, create_dagster_pandas_dataframe_type
 from dagster_pandas.constraints import (
     ColumnConstraint,
@@ -9,6 +7,9 @@ from dagster_pandas.constraints import (
     ColumnDTypeInSetConstraint,
 )
 from pandas import DataFrame, read_csv
+
+from dagster import Out, job, op
+from dagster.utils import script_relative_path
 
 
 # start_custom_col

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-from dagster import Out, job, op
-from dagster.utils import script_relative_path
 from dagster_pandas import RowCountConstraint, create_dagster_pandas_dataframe_type
 from pandas import DataFrame, read_csv
+
+from dagster import Out, job, op
+from dagster.utils import script_relative_path
 
 # start_create_type
 ShapeConstrainedTripDataFrame = create_dagster_pandas_dataframe_type(

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-from dagster import Out, job, op
-from dagster.utils import script_relative_path
 from dagster_pandas import create_dagster_pandas_dataframe_type
 from pandas import DataFrame, read_csv
+
+from dagster import Out, job, op
+from dagster.utils import script_relative_path
 
 
 # start_summary

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify.py
@@ -1,4 +1,5 @@
 import dagstermill as dm
+
 from dagster import job
 from dagster.utils import script_relative_path
 

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_2.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_2.py
@@ -1,7 +1,7 @@
 import dagstermill as dm
+
 from dagster import InputDefinition, job
 from dagster.utils import script_relative_path
-
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(

--- a/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_3.py
+++ b/examples/docs_snippets/docs_snippets/legacy/data_science/iris_classify_3.py
@@ -1,7 +1,7 @@
 import dagstermill as dm
+
 from dagster import Field, InputDefinition, Int, job
 from dagster.utils import script_relative_path
-
 from docs_snippets.legacy.data_science.download_file import download_file
 
 k_means_iris = dm.define_dagstermill_op(

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_io_managers.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_io_managers.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from dagster import ModeDefinition, execute_pipeline, io_manager, pipeline, solid
 
+from dagster import ModeDefinition, execute_pipeline, io_manager, pipeline, solid
 from docs_snippets.concepts.assets.materialization_io_managers import (
     PandasCsvIOManager,
     PandasCsvIOManagerWithAsset,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_ops.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_ops.py
@@ -1,5 +1,4 @@
 from dagster import build_op_context
-
 from docs_snippets.concepts.assets.materialization_ops import (
     my_asset_key_materialization_op,
     my_asset_op,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observation_ops.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observation_ops.py
@@ -1,5 +1,4 @@
 from dagster import build_op_context
-
 from docs_snippets.concepts.assets.observations import (
     observation_op,
     observes_dataset_op,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_configured_example.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_configured_example.py
@@ -1,7 +1,7 @@
 import yaml
+
 from dagster import graph, op
 from dagster.utils import file_relative_path
-
 from docs_snippets.concepts.configuration.config_map_example import unsigned_s3_session
 from docs_snippets.concepts.configuration.configured_example import (
     east_unsigned_s3_session,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_configured_op_example.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_configured_op_example.py
@@ -1,5 +1,4 @@
 from dagster import build_op_context
-
 from docs_snippets.concepts.configuration.configured_op_example import (
     another_configured_example,
     configured_example,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_execute_with_config.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_execute_with_config.py
@@ -1,6 +1,6 @@
 import pytest
-from dagster import DagsterInvalidConfigError
 
+from dagster import DagsterInvalidConfigError
 from docs_snippets.concepts.configuration.execute_with_config import (
     execute_with_bad_config,
     execute_with_config,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_run_config.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/configuration_tests/test_run_config.py
@@ -1,6 +1,6 @@
 import yaml
-from dagster.utils import file_relative_path
 
+from dagster.utils import file_relative_path
 from docs_snippets.concepts.configuration.make_values_resource_any import basic_result
 from docs_snippets.concepts.configuration.make_values_resource_config_schema import (
     different_values_job,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_builtin.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_builtin.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
-from dagster.utils import file_relative_path
 
+from dagster.utils import file_relative_path
 from docs_snippets.concepts.logging.builtin_logger import demo_job, demo_job_error
 from docs_snippets.concepts.logging.logging_jobs import local_logs, prod_logs
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_custom.py
@@ -1,6 +1,6 @@
 import yaml
-from dagster.utils import file_relative_path
 
+from dagster.utils import file_relative_path
 from docs_snippets.concepts.logging.custom_logger import (
     demo_job,
     test_init_json_console_logger,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_python_capture.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/logging_tests/test_python_capture.py
@@ -1,5 +1,4 @@
 from dagster.core.test_utils import instance_for_test
-
 from docs_snippets.concepts.logging.python_logger import (
     scope_logged_job,
     scope_logged_job2,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_schedules.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_schedules.py
@@ -1,5 +1,4 @@
 from dagster import ScheduleDefinition
-
 from docs_snippets.concepts.partitions_schedules_sensors.schedules.schedule_examples import (  # pylint: disable=unused-import
     test_configurable_job_schedule,
 )

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
@@ -1,5 +1,4 @@
 from dagster import job, op, repository
-
 from docs_snippets.concepts.partitions_schedules_sensors.sensors.sensor_alert import (
     email_on_run_failure,
     my_slack_on_run_failure,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_workspace.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_workspace.py
@@ -1,7 +1,6 @@
 from dagster import DagsterInstance
 from dagster.core.workspace.load import load_workspace_process_context_from_yaml_paths
 from dagster.utils import file_relative_path
-
 from docs_snippets.concepts.repositories_workspaces.hello_world_repository import (
     hello_world_job,
     hello_world_repository,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_resources.py
@@ -1,5 +1,4 @@
 from dagster import build_init_resource_context, build_op_context
-
 from docs_snippets.concepts.resources.resources import (
     cereal_fetcher,
     connect,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_composite_solids.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_composite_solids.py
@@ -1,7 +1,7 @@
 import yaml
+
 from dagster import job
 from dagster.utils import file_relative_path
-
 from docs_snippets.concepts.solids_pipelines.composite_solids import (
     all_together_nested,
     subgraph_config_job,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_hooks.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_hooks.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from dagster import DagsterEventType, ResourceDefinition, job, op
-
 from docs_snippets.concepts.solids_pipelines.op_hooks import (
     a,
     notif_all,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_op_events.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_op_events.py
@@ -1,6 +1,6 @@
 import pytest
-from dagster import Failure, graph
 
+from dagster import Failure, graph
 from docs_snippets.concepts.solids_pipelines.op_events import (
     my_asset_op,
     my_expectation_op,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_solids.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/solids_pipelines_tests/test_solids.py
@@ -1,5 +1,4 @@
 from dagster import OpDefinition, build_op_context
-
 from docs_snippets.concepts.solids_pipelines.solids import (
     context_op,
     my_configurable_op,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/types_tests/test_types.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/types_tests/test_types.py
@@ -1,6 +1,6 @@
 import pytest
-from dagster import DagsterTypeCheckDidNotPass
 
+from dagster import DagsterTypeCheckDidNotPass
 from docs_snippets.concepts.types.types import test_dagster_type
 
 

--- a/examples/docs_snippets/docs_snippets_tests/conftest.py
+++ b/examples/docs_snippets/docs_snippets_tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dagster import file_relative_path
 
 

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_concurrency_limits.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_concurrency_limits.py
@@ -2,7 +2,6 @@ import os
 
 from dagster.core.instance.ref import InstanceRef
 from dagster.core.run_coordinator import QueuedRunCoordinator
-
 from docs_snippets.deploying.concurrency_limits.concurrency_limits import (  # pylint: disable=import-error
     important_pipeline,
     less_important_schedule,

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_dask.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_dask.py
@@ -1,5 +1,4 @@
 from dagster.core.test_utils import instance_for_test
-
 from docs_snippets.deploying.dask_hello_world import (  # pylint: disable=import-error
     local_dask_job,
 )

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_k8s_config_tag.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_k8s_config_tag.py
@@ -13,7 +13,9 @@ def test_k8s_tag_job():
         dagster_home="/opt/dagster/dagster_home",
         instance_config_map="test",
     )
-    job = construct_dagster_k8s_job(cfg, [], "job123", user_defined_k8s_config=user_defined_cfg)
+    job = construct_dagster_k8s_job(
+        cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
+    )
 
     assert job.to_dict()["spec"]["template"]["spec"]["containers"][0]["resources"] == {
         "requests": {"cpu": "250m", "memory": "64Mi"},
@@ -30,7 +32,9 @@ def test_k8s_tag_op():
         dagster_home="/opt/dagster/dagster_home",
         instance_config_map="test",
     )
-    job = construct_dagster_k8s_job(cfg, [], "job123", user_defined_k8s_config=user_defined_cfg)
+    job = construct_dagster_k8s_job(
+        cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
+    )
 
     assert job.to_dict()["spec"]["template"]["spec"]["containers"][0]["resources"] == {
         "requests": {"cpu": "200m", "memory": "32Mi"},

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_type_factories_tests/test_pandas_dagster_types_examples.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_type_factories_tests/test_pandas_dagster_types_examples.py
@@ -2,10 +2,10 @@ import os
 import shutil
 
 import pytest
-from dagster import check_dagster_type
-from dagster.core.errors import DagsterTypeCheckDidNotPass
 
 import docs_snippets.guides.dagster.dagster_type_factories as example_root
+from dagster import check_dagster_type
+from dagster.core.errors import DagsterTypeCheckDidNotPass
 from docs_snippets.guides.dagster.dagster_type_factories.job_1 import (
     generate_trip_distribution_plot as job_1,
 )

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/graph_job_op_tests/test_graph_job_op_examples.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/graph_job_op_tests/test_graph_job_op_examples.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from dagster import build_schedule_context, execute_pipeline
-
 from docs_snippets.guides.dagster.graph_job_op import (
     composite_solid,
     composite_solid_ins_out,

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/versioning_memoization_tests/test_jobs.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/versioning_memoization_tests/test_jobs.py
@@ -1,5 +1,4 @@
 from dagster.core.test_utils import instance_for_test
-
 from docs_snippets.guides.dagster.versioning_memoization import memoization_enabled_job
 
 

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/advanced/test_repos.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/advanced/test_repos.py
@@ -1,5 +1,4 @@
 from dagster.utils import pushd, script_relative_path
-
 from docs_snippets.intro_tutorial.advanced.repositories.repos import (
     hello_cereal_repository,
 )

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/advanced/test_warehouse.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/advanced/test_warehouse.py
@@ -2,7 +2,6 @@ import csv
 import os
 
 from dagster.utils import script_relative_path
-
 from docs_snippets.intro_tutorial.advanced.pipelines.modes import (
     SqlAlchemyPostgresWarehouse as sapw1,
 )

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/basics/test_types.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/basics/test_types.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 from dagster import execute_solid
 from dagster.utils import script_relative_path
-
 from docs_snippets.intro_tutorial.basics.e04_quality.custom_types_2 import (
     sort_by_calories,
 )

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/conftest.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from dagster.utils import file_relative_path
 from dagster.utils.test.postgres_instance import TestPostgresInstance
 

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_cli_invocations.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_cli_invocations.py
@@ -4,12 +4,13 @@ import runpy
 import pytest
 from click.testing import CliRunner
 from dagit.app import create_app_from_workspace_process_context
+from starlette.testclient import TestClient
+
 from dagster.cli.pipeline import pipeline_execute_command
 from dagster.cli.workspace import get_workspace_process_context_from_kwargs
 from dagster.core.instance import DagsterInstance
 from dagster.core.test_utils import instance_for_test
 from dagster.utils import check_script, pushd, script_relative_path
-from starlette.testclient import TestClient
 
 PIPELINES_OR_ERROR_QUERY = """
 {

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
@@ -2,6 +2,7 @@ import typing
 
 import pytest
 import yaml
+
 from dagster import (
     AssetMaterialization,
     DagsterType,

--- a/examples/docs_snippets/docs_snippets_tests/legacy_tests/data_science_tests/test_pipelines.py
+++ b/examples/docs_snippets/docs_snippets_tests/legacy_tests/data_science_tests/test_pipelines.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import pytest
+
 from dagster import execute_pipeline, file_relative_path
 from dagster.core.definitions.reconstructable import ReconstructablePipeline
 from dagster.core.test_utils import instance_for_test

--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -10,5 +10,6 @@ required-version = "22.1.0"
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 [tool.isort]
+known_first_party = ['dagster']
 profile = 'black'  # sets line-length to 88
 case_sensitive = true

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/constants.py
@@ -11,7 +11,7 @@ AIRBYTE_CONNECTION_ID = "your_airbyte_connection_id"
 
 
 def model_func(x, a, b):
-    return a * np.exp(b * (x / 10 ** 18 - 1.6095))
+    return a * np.exp(b * (x / 10**18 - 1.6095))
 
 
 PG_SOURCE_CONFIG = {

--- a/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
+++ b/examples/modern_data_stack_assets/modern_data_stack_assets/setup_airbyte.py
@@ -6,12 +6,12 @@ import random
 
 import numpy as np
 import pandas as pd
-from dagster import check
-from dagster_postgres.utils import get_conn_string
 from dagster_airbyte import AirbyteResource
+from dagster_postgres.utils import get_conn_string
 
-from .constants import PG_SOURCE_CONFIG, PG_DESTINATION_CONFIG
+from dagster import check
 
+from .constants import PG_DESTINATION_CONFIG, PG_SOURCE_CONFIG
 
 # configures the number of records for each table
 N_USERS = 100
@@ -104,8 +104,8 @@ def _random_dates():
     start = pd.to_datetime("2021-01-01")
     end = pd.to_datetime("2022-01-01")
 
-    start_u = start.value // 10 ** 9
-    end_u = end.value // 10 ** 9
+    start_u = start.value // 10**9
+    end_u = end.value // 10**9
 
     dist = np.random.standard_exponential(size=N_ORDERS) / 10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 [tool.isort]
 
+# Ensures isort classifies imports from `dagster` as first-party in all environments. Without this
+# there can be differences between buildkite and local dev.
+known_first_party = ['dagster']
+
 # Sets a variety of default options for parentheses etc that are compatible with black.
 profile = "black"
 

--- a/python_modules/dagster/dagster/core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/sensor_definition.py
@@ -30,8 +30,8 @@ from ..decorator_utils import get_function_params
 from .events import AssetKey
 from .graph_definition import GraphDefinition
 from .job_definition import JobDefinition
-from .pipeline_definition import PipelineDefinition
 from .mode import DEFAULT_MODE_NAME
+from .pipeline_definition import PipelineDefinition
 from .run_request import PipelineRunReaction, RunRequest, SkipReason
 from .target import DirectTarget, RepoRelativeTarget
 from .utils import check_valid_name

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dagster.check import CheckError
 from dagster.seven.compat.pendulum import create_pendulum_time
 from dagster.utils.schedules import schedule_execution_time_iterator


### PR DESCRIPTION
Commands prefixed with `-` caused non-zero exit code to be ignored, allowing non-black/isort compliant code into master, this fixes that.
