### PR TITLE
batch run fetches in sensor daemon

### DIFF
--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import time
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional
 
 import pendulum
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_run_storage.py
@@ -21,8 +21,13 @@ def create_non_bucket_sqlite_run_storage():
 
 
 class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
-    def supports_bucket_query(self):
+    @property
+    def supports_bucket_queries(self):
         return False
+
+    @staticmethod
+    def from_config_value(inst_data, config_value):
+        return NonBucketQuerySqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
 
 @contextmanager

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_sensor_run.py
@@ -866,6 +866,116 @@ def test_launch_once(capfd):
             )
 
 
+@contextmanager
+def instance_with_sensors_no_run_bucketing():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with instance_with_sensors(
+            overrides={
+                "run_storage": {
+                    "module": "dagster_tests.core_tests.storage_tests.test_run_storage",
+                    "class": "NonBucketQuerySqliteRunStorage",
+                    "config": {"base_dir": temp_dir},
+                },
+            }
+        ) as (
+            instance,
+            workspace,
+            external_repo,
+        ):
+            yield instance, workspace, external_repo
+
+
+def test_launch_once_unbatched(capfd):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+    with instance_with_sensors_no_run_bucketing() as (
+        instance,
+        workspace,
+        external_repo,
+    ):
+        with pendulum.test(freeze_datetime):
+
+            external_sensor = external_repo.get_external_sensor("run_key_sensor")
+            instance.add_instigator_state(
+                InstigatorState(
+                    external_sensor.get_external_origin(),
+                    InstigatorType.SENSOR,
+                    InstigatorStatus.RUNNING,
+                )
+            )
+            assert instance.get_runs_count() == 0
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            assert len(ticks) == 0
+
+            evaluate_sensors(instance, workspace)
+            wait_for_all_runs_to_start(instance)
+
+            assert instance.get_runs_count() == 1
+            run = instance.get_runs()[0]
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            assert len(ticks) == 1
+            validate_tick(
+                ticks[0],
+                external_sensor,
+                freeze_datetime,
+                TickStatus.SUCCESS,
+                expected_run_ids=[run.run_id],
+            )
+
+        # run again (after 30 seconds), to ensure that the run key maintains idempotence
+        freeze_datetime = freeze_datetime.add(seconds=30)
+        with pendulum.test(freeze_datetime):
+            evaluate_sensors(instance, workspace)
+            assert instance.get_runs_count() == 1
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+            assert len(ticks) == 2
+            validate_tick(
+                ticks[0],
+                external_sensor,
+                freeze_datetime,
+                TickStatus.SKIPPED,
+            )
+            captured = capfd.readouterr()
+            assert (
+                'Skipping 1 run for sensor run_key_sensor already completed with run keys: ["only_once"]'
+                in captured.out
+            )
+
+            launched_run = instance.get_runs()[0]
+
+            # Manually create a new run with the same tags
+            execute_pipeline(
+                the_pipeline,
+                run_config=launched_run.run_config,
+                tags=launched_run.tags,
+                instance=instance,
+            )
+
+            # Sensor loop still executes
+        freeze_datetime = freeze_datetime.add(seconds=30)
+        with pendulum.test(freeze_datetime):
+            evaluate_sensors(instance, workspace)
+            ticks = instance.get_ticks(external_sensor.get_external_origin_id())
+
+            assert len(ticks) == 3
+            validate_tick(
+                ticks[0],
+                external_sensor,
+                freeze_datetime,
+                TickStatus.SKIPPED,
+            )
+
+
 def test_custom_interval_sensor():
     freeze_datetime = to_timezone(
         create_pendulum_time(year=2019, month=2, day=28, tz="UTC"), "US/Central"


### PR DESCRIPTION
## Summary

In order to not do a bunch of DB fetches in a for loop, this PR changes the sensor daemon to fetch the run keys in a batched call.

## Test Plan
BK


