### PR TITLE
ungate run batching

### DIFF
--- a/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sql_event_log.py
@@ -738,12 +738,13 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                 )
                 .group_by(SqlEventLogStorageTable.c.asset_key)
-                .alias('latest_materializations')
+                .alias("latest_materializations")
             )
             backcompat_query = db.select(
                 [SqlEventLogStorageTable.c.asset_key, SqlEventLogStorageTable.c.event]
             ).select_from(
-                latest_event_subquery.join(SqlEventLogStorageTable,
+                latest_event_subquery.join(
+                    SqlEventLogStorageTable,
                     db.and_(
                         SqlEventLogStorageTable.c.asset_key == latest_event_subquery.c.asset_key,
                         SqlEventLogStorageTable.c.timestamp == latest_event_subquery.c.timestamp,

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -121,9 +121,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
 
     @property
     def supports_bucket_queries(self):
-        return (
-            super().supports_bucket_queries and get_sqlite_version() > MINIMUM_SQLITE_BUCKET_VERSION
-        )
+        return get_sqlite_version() > MINIMUM_SQLITE_BUCKET_VERSION
 
     def upgrade(self):
         self._check_for_version_066_migration_and_perform()


### PR DESCRIPTION
We gated some run batching because it was using syntax that wasn't supported by `SQLAlchemy<1.4`.

This PR rewrites the batch query in a backwards compatible way and ungates the run batching.


## Test Plan
BK (with sqlalchemy 1.3 / 1.4)


