### PR TITLE
Rename step jobs 'dagster-step' in k8s and docker

### DIFF
--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -172,11 +172,11 @@ If you do not use a Kubernetes distribution that supports the [TTL Controller](h
 
 Delete dagster [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) older than one day
 
-    kubectl get job | grep -e dagster-run -e dagster-job | awk 'match($4,/[0-9]+d/) {print $1}' | xargs kubectl delete job
+    kubectl get job | grep -e dagster-run -e dagster-step | awk 'match($4,/[0-9]+d/) {print $1}' | xargs kubectl delete job
 
 Delete completed [Pods](https://kubernetes.io/docs/concepts/workloads/pods/) older than one day
 
-    kubectl get pod | grep -e dagster-run -e dagster-job | awk 'match($3,/Completed/) {print $0}' | awk 'match($5,/[0-9]+d/) {print $1}' | xargs kubectl delete pod
+    kubectl get pod | grep -e dagster-run -e dagster-step | awk 'match($3,/Completed/) {print $0}' | awk 'match($5,/[0-9]+d/) {print $1}' | xargs kubectl delete pod
 
 ## Conclusion
 

--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm-advanced.mdx
@@ -161,7 +161,7 @@ The Helm chart can be configured to use this architecture by configuring the `ru
 
 Users can configure multiple Celery queues (for example, one celery queue for each resource the user would like to limit) and multiple Celery workers per queue via the `runLauncher.config.celeryK8sRunLauncher.workerQueues` section of `values.yaml`.
 
-The Celery workers poll for new Celery tasks and execute each task in order of receipt or priority. The Celery task largely consists of launching an ephemeral Kubernetes step job to execute that step.
+The Celery workers poll for new Celery tasks and execute each task in order of receipt or priority. The Celery task largely consists of launching an ephemeral Kubernetes step worker to execute that step.
 
 ### Daemon
 
@@ -173,9 +173,9 @@ The run worker is still responsible for traversing the execution plan, but now u
 
 All jobs being executed on an instance that uses the `CeleryK8sRunLauncher` must have the `celery_k8s_job_executor` set in the `executor_def` field.
 
-### Step Job
+### Step Worker
 
-The step job is responsible for executing a single step, writing the structured events to the database. The Celery worker polls for the step job completion.
+The step worker is responsible for executing a single step, writing the structured events to the database. The Celery worker polls for the step worker completion.
 
 ### Flower
 
@@ -225,11 +225,11 @@ You can introspect the jobs that were launched with `kubectl`:
 
     $ kubectl get jobs
     NAME                                               COMPLETIONS   DURATION   AGE
-    dagster-job-9f5c92d1216f636e0d33877560818840       1/1           5s         12s
-    dagster-job-a1063317b9aac91f42ca9eacec551b6f       1/1           12s        34s
+    dagster-step-9f5c92d1216f636e0d33877560818840       1/1           5s         12s
+    dagster-step-a1063317b9aac91f42ca9eacec551b6f       1/1           12s        34s
     dagster-run-fb6822e5-bf43-476f-9e6c-6f9896cf3fb8   1/1           37s        37s
 
-`dagster-job-` entries correspond to step jobs and `dagster-run-` entries correspond to run workers.
+`dagster-step-` entries correspond to step workers and `dagster-run-` entries correspond to run workers.
 
 Within Dagit, you can watch the job as it executes.
 

--- a/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
+++ b/integration_tests/test_suites/k8s-integration-test-suite/test_executor.py
@@ -169,7 +169,7 @@ def test_k8s_executor_combine_configs(
     )
 
     step_job_key = get_k8s_job_name(run_id, "count_letters")
-    step_job_name = f"dagster-job-{step_job_key}"
+    step_job_name = f"dagster-step-{step_job_key}"
 
     step_pods = get_pods_in_job(
         job_name=step_job_name, namespace=helm_namespace_for_k8s_run_launcher

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -360,11 +360,11 @@ def create_k8s_job_task(celery_app, **task_kwargs):
 
         if retry_state.get_attempt_count(step_key):
             attempt_number = retry_state.get_attempt_count(step_key)
-            job_name = "dagster-job-%s-%d" % (k8s_name_key, attempt_number)
-            pod_name = "dagster-job-%s-%d" % (k8s_name_key, attempt_number)
+            job_name = "dagster-step-%s-%d" % (k8s_name_key, attempt_number)
+            pod_name = "dagster-step-%s-%d" % (k8s_name_key, attempt_number)
         else:
-            job_name = "dagster-job-%s" % (k8s_name_key)
-            pod_name = "dagster-job-%s" % (k8s_name_key)
+            job_name = "dagster-step-%s" % (k8s_name_key)
+            pod_name = "dagster-step-%s" % (k8s_name_key)
 
         args = execute_step_args.get_command_args()
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -128,7 +128,7 @@ class DockerStepHandler(StepHandler):
         return client
 
     def _get_container_name(self, run_id, step_key):
-        return f"dagster-job-{hash_str(run_id + step_key)}"
+        return f"dagster-step-{hash_str(run_id + step_key)}"
 
     def _create_step_container(self, client, step_image, execute_step_args):
         return client.containers.create(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -154,9 +154,9 @@ class K8sStepHandler(StepHandler):
         if step_handler_context.execute_step_args.known_state:
             retry_state = step_handler_context.execute_step_args.known_state.get_retry_state()
             if retry_state.get_attempt_count(step_key):
-                return "dagster-job-%s-%d" % (name_key, retry_state.get_attempt_count(step_key))
+                return "dagster-step-%s-%d" % (name_key, retry_state.get_attempt_count(step_key))
 
-        return "dagster-job-%s" % (name_key)
+        return "dagster-step-%s" % (name_key)
 
     def launch_step(self, step_handler_context: StepHandlerContext):
         events = []

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -21,7 +21,7 @@ from dagster.utils import frozentags, merge_dicts
 from .models import k8s_model_from_dict, k8s_snake_case_dict
 from .utils import sanitize_k8s_label
 
-# To retry step job, users should raise RetryRequested() so that the dagster system is aware of the
+# To retry step worker, users should raise RetryRequested() so that the dagster system is aware of the
 # retry. As an example, see retry_pipeline in dagster_test.test_project.test_pipelines.repo
 # To override this config, user can specify UserDefinedDagsterK8sConfig.
 DEFAULT_K8S_JOB_BACKOFF_LIMIT = 0


### PR DESCRIPTION
Post JOG, `dagster-job` is a confusing name for step jobs.