### PR TITLE
Add authenticator field to conn_args

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/configs.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/configs.py
@@ -133,6 +133,12 @@ def define_snowflake_config():
         is_required=False,
     )
 
+    authenticator = Field(
+        StringSource,
+        description="Optional parameter to specify the authentication mechanism to use.",
+        is_required=False,
+    )
+
     return {
         "account": account,
         "user": user,
@@ -153,4 +159,5 @@ def define_snowflake_config():
         "connector": connector,
         "cache_column_metadata": cache_column_metadata,
         "numpy": numpy,
+        "authenticator": authenticator,
     }

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -64,6 +64,7 @@ class SnowflakeConnection:
                     "validate_default_parameters",
                     "paramstyle",
                     "timezone",
+                    "authenticator",
                 )
                 if context.resource_config.get(k) is not None
             }


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
New feature: Some snowflake set up requires setting the "authenticator" parameter manually in setting up connection in Python. The PR is to add this function by simply including authenticator as one of the parameter in setting up the resource.
[Related github issue](https://github.com/dagster-io/dagster/issues/6093)



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.