### PR TITLE
Support the same Secrets config syntax as ECS

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -120,16 +120,19 @@ run_launcher:
 
 Any secret tagged with `my-tag-name` will be included in the environment.
 
-Additionally, you can pass specific secret ARNs:
+Additionally, you can pass specific secrets using the [same structure as the ECS API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html):
 
 ```yaml
 run_launcher:
   module: "dagster_aws.ecs"
   class: "EcsRunLauncher"
   config:
-    secrets_tag: "my-tag-name"
-    secrets:
-      - "arn:aws:secretsmanager:us-east-1:1234567890:secret:MY_SECRET"
+    - name: "MY_API_TOKEN"
+      valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO/token
+    - name: "MY_PASSWORD"
+      valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO/password
+  ]
+}
 ```
 
 Any secret tagged with `my-tag-name` will be included in the environment. `MY_SECRET` will also be included in the environment.

--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -128,9 +128,9 @@ run_launcher:
   class: "EcsRunLauncher"
   config:
     - name: "MY_API_TOKEN"
-      valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO/token
+      valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::
     - name: "MY_PASSWORD"
-      valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO/password
+      valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::
   ]
 }
 ```

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import namedtuple
 
 import boto3
@@ -37,6 +38,12 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
 
         self.secrets = secrets or []
         if all(isinstance(secret, str) for secret in self.secrets):
+            warnings.warn(
+                "Setting secrets as a list of ARNs is deprecated. "
+                "Secrets should instead follow the same structure as the ECS API: "
+                "https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html",
+                DeprecationWarning,
+            )
             self.secrets = get_secrets_from_arns(self.secrets_manager, self.secrets)
         else:
             self.secrets = {secret["name"]: secret["valueFrom"] for secret in self.secrets}

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
@@ -47,25 +47,31 @@ def configured_secret(secrets_manager):
 
 
 @pytest.fixture
-def instance(instance_cm, configured_secret):
-    config = {"secrets": [configured_secret.arn]}
-    with instance_cm(config) as dagster_instance:
-        yield dagster_instance
+def launch_run(pipeline, external_pipeline, workspace):
+    def _launch_run(instance):
+        run = instance.create_run_for_pipeline(
+            pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        instance.launch_run(run.run_id, workspace)
 
-
-@pytest.fixture
-def instance_empty_secrets_tag(instance_cm, configured_secret):
-    config = {"secrets_tag": None}
-    with instance_cm(config) as dagster_instance:
-        yield dagster_instance
+    return _launch_run
 
 
 def test_secrets(
-    ecs, secrets_manager, instance, workspace, run, tagged_secret, other_secret, configured_secret
+    ecs,
+    secrets_manager,
+    instance_cm,
+    launch_run,
+    tagged_secret,
+    other_secret,
+    configured_secret,
 ):
     initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
 
-    instance.launch_run(run.run_id, workspace)
+    with instance_cm({"secrets": [configured_secret.arn]}) as instance:
+        launch_run(instance)
 
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
@@ -86,19 +92,18 @@ def test_secrets(
 
 
 def test_empty_secrets(
-    ecs, secrets_manager, instance_empty_secrets_tag, workspace, pipeline, external_pipeline
+    ecs,
+    secrets_manager,
+    instance_cm,
+    launch_run,
 ):
     initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
 
-    run = instance_empty_secrets_tag.create_run_for_pipeline(
-        pipeline,
-        external_pipeline_origin=external_pipeline.get_external_origin(),
-        pipeline_code_origin=external_pipeline.get_python_origin(),
-    )
+    with instance_cm({"secrets_tag": None}) as instance:
+        m = MagicMock()
+        with patch.object(instance.run_launcher, "secrets_manager", new=m):
+            launch_run(instance)
 
-    m = MagicMock()
-    with patch.object(instance_empty_secrets_tag.run_launcher, "secrets_manager", new=m):
-        instance_empty_secrets_tag.launch_run(run.run_id, workspace)
         m.get_paginator.assert_not_called()
         m.describe_secret.assert_not_called()
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_secrets.py
@@ -115,8 +115,9 @@ def test_secrets_backcompat(
 ):
     initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
 
-    with instance_cm({"secrets": [configured_secret.arn]}) as instance:
-        launch_run(instance)
+    with pytest.warns(DeprecationWarning, match="Setting secrets as a list of ARNs is deprecated"):
+        with instance_cm({"secrets": [configured_secret.arn]}) as instance:
+            launch_run(instance)
 
     # A new task definition is created
     task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]


### PR DESCRIPTION
Previously, we exposed a simplified configuration syntax as an
array of strings:

```
{
  "secrets": [
    "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO",
    "arn:aws:secretsmanager:us-east-1:123456789012:secret:BAR",
  ]
}
```

We'd then transform this simplified configuration into the structure the
AWS API expects:

```
{
  "secrets": [
    {
      "name": "FOO",
      "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO",
    },
    {
      "name": "BAR",
      "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:BAR",
    },
  ]
}
```

While this simplification made for terser Dagster config, it lost the
expressiveness afforded to us by the ECS API. With it, we cannot:

- choose our own name for the environment variable
- source the value from a key inside a JSON secret

This change changes Dagster's ECS secrets config to expect the same
structure as the ECS API. Consequently, we now support configuration
like:

```
{
  "secrets": [
    {
      "name": "MY_API_TOKEN",
      "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::",
    },
  ]
}
```

To maintain backward compatibility, we'll continue to accept the old
array of strings.