### PR TITLE
Add short-circuit in run start time if run failed to start

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -369,6 +369,10 @@ class GrapheneRun(graphene.ObjectType):
         run_record = self._get_run_record(graphene_info.context.instance)
         # If a user has not migrated in 0.13.15, then run_record will not have start_time and end_time. So it will be necessary to fill this data using the run_stats. Since we potentially make this call multiple times, we cache the result.
         if run_record.start_time is None and self._pipeline_run.status in STARTED_STATUSES:
+            # Short-circuit if pipeline failed to start, so it has an end time but no start time
+            if run_record.end_time is not None:
+                return None
+
             if self._run_stats is None or self._run_stats.start_time is None:
                 self._run_stats = graphene_info.context.instance.get_run_stats(self.runId)
             return self._run_stats.start_time


### PR DESCRIPTION
Summary:
If a run fails to start while launching, it gets a FAILURE event but no STARTED event. In that case, it currently falls back to the expensive get_run_stats query. Instead, fall back to the end time as the same as the start time.

Test Plan: 
- Set DefaultRunLauncher to raise an Exception during launch_run
- Add an exception in get_run_stats (the slow call)
- Launch a run (it will fail)
- View the runs page and factory floor page, do not see the exception for the slow method being called


<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.