### PR TITLE
add tick batching to schedule storage

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['TestAssetAwareEventLog.test_all_asset_keys[asset_aware_instance_in_process_env] 1'] = {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['TestAssetAwareEventLog.test_all_asset_keys[asset_aware_instance_in_process_env] 1'] = {
@@ -408,6 +409,48 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_la
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_asset_op[asset_aware_instance_in_process_env] 1'] = {
+    'assetOrError': {
+        'definition': {
+            'op': {
+                'description': None,
+                'inputDefinitions': [
+                    {
+                        'name': 'asset_one'
+                    }
+                ],
+                'name': 'asset_two',
+                'outputDefinitions': [
+                    {
+                        'name': 'result'
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        'definition': {
+            'op': {
+                'description': None,
+                'inputDefinitions': [
+                    {
+                        'name': 'asset_one'
+                    }
+                ],
+                'name': 'asset_two',
+                'outputDefinitions': [
+                    {
+                        'name': 'result'
+                    }
+                ]
+            }
+        }
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[asset_aware_instance_in_process_env] 1'] = {
     'assetOrError': {
         'assetMaterializations': [
@@ -564,5 +607,41 @@ snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization
                 'partition': 'partition_1'
             }
         ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_op_assets[asset_aware_instance_in_process_env] 1'] = {
+    'repositoryOrError': {
+        'usedSolid': {
+            'definition': {
+                'assetNodes': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'asset_two'
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_op_assets[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'repositoryOrError': {
+        'usedSolid': {
+            'definition': {
+                'assetNodes': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'asset_two'
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
 }

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1752,7 +1752,7 @@ records = instance.get_event_records(
 
     @property
     def supports_batch_tick_queries(self):
-        return self._schedule_storage.supports_batch_queries
+        return self._schedule_storage and self._schedule_storage.supports_batch_queries
 
     def get_batch_ticks(
         self,
@@ -1760,6 +1760,8 @@ records = instance.get_event_records(
         limit: Optional[int] = None,
         statuses: Optional[Sequence["TickStatus"]] = None,
     ) -> Mapping[str, Iterable["InstigatorTick"]]:
+        if not self._schedule_storage:
+            return {}
         return self._schedule_storage.get_batch_ticks(origin_ids, limit, statuses)
 
     @traced

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
     from dagster.core.launcher import RunLauncher
     from dagster.core.run_coordinator import RunCoordinator
     from dagster.core.scheduler import Scheduler
+    from dagster.core.scheduler.instigation import InstigatorTick, TickStatus
     from dagster.core.snap import ExecutionPlanSnapshot, PipelineSnapshot
     from dagster.core.storage.compute_log_manager import ComputeLogManager
     from dagster.core.storage.event_log import EventLogStorage
@@ -1757,8 +1758,8 @@ records = instance.get_event_records(
         self,
         origin_ids: Sequence[str],
         limit: Optional[int] = None,
-        statuses: Optional[Sequence[TickStatus]] = None,
-    ) -> Mapping[str, Iterable[InstigatorTick]]:
+        statuses: Optional[Sequence["TickStatus"]] = None,
+    ) -> Mapping[str, Iterable["InstigatorTick"]]:
         return self._schedule_storage.get_batch_ticks(origin_ids, limit, statuses)
 
     @traced

--- a/python_modules/dagster/dagster/core/instance/__init__.py
+++ b/python_modules/dagster/dagster/core/instance/__init__.py
@@ -1749,6 +1749,18 @@ records = instance.get_event_records(
     def delete_instigator_state(self, origin_id):
         return self._schedule_storage.delete_instigator_state(origin_id)
 
+    @property
+    def supports_batch_tick_queries(self):
+        return self._schedule_storage.supports_batch_queries
+
+    def get_batch_ticks(
+        self,
+        origin_ids: Sequence[str],
+        limit: Optional[int] = None,
+        statuses: Optional[Sequence[TickStatus]] = None,
+    ) -> Mapping[str, Iterable[InstigatorTick]]:
+        return self._schedule_storage.get_batch_ticks(origin_ids, limit, statuses)
+
     @traced
     def get_tick(self, origin_id, timestamp):
         matches = self._schedule_storage.get_ticks(

--- a/python_modules/dagster/dagster/core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Mapping, Optional, Sequence
 
 from dagster.core.definitions.run_request import InstigatorType
 from dagster.core.instance import MayHaveInstanceWeakref
@@ -55,6 +55,18 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         Args:
             origin_id (str): The id of the instigator target to delete
         """
+
+    @property
+    def supports_batch_queries(self):
+        return False
+
+    def get_batch_ticks(
+        self,
+        origin_ids: Sequence[str],
+        limit: Optional[int] = None,
+        statuses: Optional[Sequence[TickStatus]] = None,
+    ) -> Mapping[str, Iterable[InstigatorTick]]:
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def get_ticks(

--- a/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sql_schedule_storage.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Iterable, Mapping, Optional, Sequence
+from typing import Iterable, Mapping, Optional, Sequence, cast
 
 import sqlalchemy as db
 
@@ -189,7 +189,7 @@ class SqlScheduleStorage(ScheduleStorage):
         for row in rows:
             tick_id = row[0]
             origin_id = row[1]
-            tick_data = deserialize_json_to_dagster_namedtuple(row[2])
+            tick_data = cast(TickData, deserialize_json_to_dagster_namedtuple(row[2]))
             results[origin_id].append(InstigatorTick(tick_id, tick_data))
         return results
 

--- a/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -11,12 +11,14 @@ from dagster.core.storage.sql import (
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
-from dagster.core.storage.sqlite import create_db_conn_string
+from dagster.core.storage.sqlite import create_db_conn_string, get_sqlite_version
 from dagster.serdes import ConfigurableClass, ConfigurableClassData
 from dagster.utils import mkdir_p
 
 from ..schema import ScheduleStorageSqlMetadata
 from ..sql_schedule_storage import SqlScheduleStorage
+
+MINIMUM_SQLITE_BATCH_VERSION = "3.25.0"
 
 
 class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
@@ -71,6 +73,10 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                 yield conn
         finally:
             conn.close()
+
+    @property
+    def supports_batch_queries(self):
+        return get_sqlite_version() > MINIMUM_SQLITE_BATCH_VERSION
 
     def upgrade(self):
         alembic_config = get_alembic_config(__file__)

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -627,13 +627,13 @@ class TestScheduleStorage:
         if not storage.supports_batch_queries:
             pytest.skip("storage cannot batch")
 
-        a = storage.create_tick(
+        _a = storage.create_tick(
             self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_one")
         )
         b = storage.create_tick(
             self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_one")
         )
-        c = storage.create_tick(
+        _c = storage.create_tick(
             self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_two")
         )
         d = storage.create_tick(

--- a/python_modules/dagster/dagster/utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/utils/test/schedule_storage.py
@@ -451,10 +451,12 @@ class TestScheduleStorage:
         with pytest.raises(Exception):
             storage.add_instigator_state(state)
 
-    def build_sensor_tick(self, current_time, status=TickStatus.STARTED, run_id=None, error=None):
+    def build_sensor_tick(
+        self, current_time, status=TickStatus.STARTED, run_id=None, error=None, name="my_sensor"
+    ):
         return TickData(
-            "my_sensor",
-            "my_sensor",
+            name,
+            name,
             InstigatorType.SENSOR,
             status,
             current_time,
@@ -620,3 +622,26 @@ class TestScheduleStorage:
             "my_sensor", statuses=[TickStatus.STARTED, TickStatus.SUCCESS, TickStatus.FAILURE]
         )
         assert len(non_skips) == 3
+
+    def test_ticks_batched(self, storage):
+        if not storage.supports_batch_queries:
+            pytest.skip("storage cannot batch")
+
+        a = storage.create_tick(
+            self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_one")
+        )
+        b = storage.create_tick(
+            self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_one")
+        )
+        c = storage.create_tick(
+            self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_two")
+        )
+        d = storage.create_tick(
+            self.build_sensor_tick(time.time(), status=TickStatus.SUCCESS, name="sensor_two")
+        )
+
+        ticks_by_origin = storage.get_batch_ticks(["sensor_one", "sensor_two"], limit=1)
+        assert set(ticks_by_origin.keys()) == {"sensor_one", "sensor_two"}
+        assert len(ticks_by_origin["sensor_one"]) == 1
+        assert ticks_by_origin["sensor_one"][0].tick_id == b.tick_id
+        assert ticks_by_origin["sensor_two"][0].tick_id == d.tick_id


### PR DESCRIPTION
## Summary

Created instance / schedule storage calls to add a method to batch fetch ticks.

Alternatively, could just change the signature of `get_ticks` to take in a sequence of origin ids, but this seemed a little cleaner.

## Test Plan
BK
