### PR TITLE
Make pipeline_name, solid_selection, and mode explicitly deprecated

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -225,7 +225,6 @@ class ScheduleDefinition:
                 'Using "pipeline_name", "mode", or "solid_selection"',
                 breaking_version="1.0",
                 additional_warn_txt="Pass a constructed job to argument `job` instead.",
-                # stacklevel=4,  # to get the caller of `normalize_metadata`
             )
             self._target = RepoRelativeTarget(
                 pipeline_name=check.str_param(pipeline_name, "pipeline_name"),

--- a/python_modules/dagster/dagster/core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/schedule_definition.py
@@ -11,6 +11,7 @@ from dagster.seven import funcsigs
 
 from ...serdes import whitelist_for_serdes
 from ...utils import ensure_gen, merge_dicts
+from ...utils.backcompat import deprecation_warning
 from ...utils.schedules import is_valid_cron_string
 from ..decorator_utils import get_function_params
 from ..errors import (
@@ -145,7 +146,8 @@ class ScheduleDefinition:
             "_schedule".
         cron_schedule (str): A valid cron string specifying when the schedule will run, e.g.,
             '45 23 * * 6' for a schedule that runs at 11:45 PM every Saturday.
-        pipeline_name (Optional[str]): (legacy) The name of the pipeline to execute when the schedule runs.
+        pipeline_name (Optional[str]): DEPRECATED. The name of the pipeline to execute when the schedule runs.
+            Prefer to pass a contructed job to the job parameter instead.
         execution_fn (Callable[ScheduleEvaluationContext]): The core evaluation function for the
             schedule, which is run at an interval to determine whether a run should be launched or
             not. Takes a :py:class:`~dagster.ScheduleEvaluationContext`.
@@ -164,9 +166,11 @@ class ScheduleDefinition:
             function that generates tags to attach to the schedules runs. Takes a
             :py:class:`~dagster.ScheduleEvaluationContext` and returns a dictionary of tags (string
             key-value pairs). You may set only one of ``tags``, ``tags_fn``, and ``execution_fn``.
-        solid_selection (Optional[List[str]]): A list of solid subselection (including single
+        solid_selection (Optional[List[str]]): DEPRECATED A list of solid subselection (including single
             solid names) to execute when the schedule runs. e.g. ``['*some_solid+', 'other_solid']``
-        mode (Optional[str]): (legacy) The mode to apply when executing this schedule. (default: 'default')
+            Prefer to pass a contructed job to the job parameter instead.
+        mode (Optional[str]): DEPRECATED The mode to apply when executing this schedule. (default: 'default')
+            Prefer to pass a contructed job to the job parameter instead.
         should_execute (Optional[Callable[[ScheduleEvaluationContext], bool]]): A function that runs
             at schedule execution time to determine whether a schedule should execute or skip. Takes
             a :py:class:`~dagster.ScheduleEvaluationContext` and returns a boolean (``True`` if the
@@ -217,6 +221,12 @@ class ScheduleDefinition:
         if job is not None:
             self._target: Union[DirectTarget, RepoRelativeTarget] = DirectTarget(job)
         else:
+            deprecation_warning(
+                'Using "pipeline_name", "mode", or "solid_selection"',
+                breaking_version="1.0",
+                additional_warn_txt="Pass a constructed job to argument `job` instead.",
+                # stacklevel=4,  # to get the caller of `normalize_metadata`
+            )
             self._target = RepoRelativeTarget(
                 pipeline_name=check.str_param(pipeline_name, "pipeline_name"),
                 mode=check.opt_str_param(mode, "mode") or DEFAULT_MODE_NAME,


### PR DESCRIPTION
## Summary

pipeline_name, solid_selection, and mode refer to deprecated pre-CRAG apis. ScheduleDefinitions should get jobs instead. This updates documentation to indicate that and creates a deprecation warning if you use those arguments.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Ran test and saw:

```
dagster_tests/core_tests/definitions_tests/test_schedule.py::test_default_name
  /Users/schrockn/code/dagster/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_schedule.py:8: DeprecationWarning: Using "pipeline_name", "mode", or "solid_selection" is deprecated and will be removed in 1.0. Pass a constructed job to argument `job` instead.
    schedule = ScheduleDefinition(pipeline_name="my_pipeline", cron_schedule="0 0 * * *")
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.