### PR TITLE
Make parse_run_config_input more defensive

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -144,7 +144,7 @@ class GrapheneRunConfigData(GenericScalar, graphene.Scalar):
 
 
 def parse_run_config_input(run_config):
-    return json.loads(run_config) if isinstance(run_config, str) else run_config
+    return json.loads(run_config) if (run_config and isinstance(run_config, str)) else run_config
 
 
 types = [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_types.py
@@ -155,6 +155,19 @@ class TestConfigTypes(NonLaunchableGraphQLContextTestMatrix):
         assert result.data["isPipelineConfigValid"]["__typename"] == "PipelineConfigValidationValid"
         assert result.data["isPipelineConfigValid"]["pipelineName"] == "csv_hello_world"
 
+    def test_basic_valid_config_empty_string_config(self, graphql_context):
+        result = execute_config_graphql(
+            graphql_context,
+            pipeline_name="csv_hello_world",
+            run_config="",
+            mode="default",
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["isPipelineConfigValid"]["__typename"] == "RunConfigValidationInvalid"
+        assert result.data["isPipelineConfigValid"]["pipelineName"] == "csv_hello_world"
+
     def test_root_field_not_defined(self, graphql_context):
         result = execute_config_graphql(
             graphql_context,


### PR DESCRIPTION
Summary:
Right now if you pass in empty string for runConfigData this codepath will fail with an error. Coerce it to {} instead.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.