### PR TITLE
Add sequence and mapping check functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,7 @@
 # W1201, W1202 disable log format warning. False positives (I think)
 # W0707 disable raise-missing-from which we cant use because py2 back compat
 
-disable=C,R,duplicate-code,W0511,W1201,W1202,W0707,no-init,broad-except,bare-except
+disable=C,R,duplicate-code,W0511,W1201,W1202,W0707,no-init,broad-except,bare-except,typecheck
 
 # See: https://github.com/getsentry/responses/issues/74
 [TYPECHECK]

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -809,17 +809,22 @@ def opt_path_param(obj: None, param_name: str, default: Union[str, PathLike]) ->
 
 
 @overload
-def opt_path_param(obj: Union[str, PathLike], param_name: str, default: Union[str, PathLike]) -> str:
+def opt_path_param(
+    obj: Union[str, PathLike], param_name: str, default: Union[str, PathLike]
+) -> str:
     ...
 
 
 def opt_path_param(
-    obj: Optional[Union[str, PathLike]], param_name: str, default: Optional[Union[str, PathLike]] = None
+    obj: Optional[Union[str, PathLike]],
+    param_name: str,
+    default: Optional[Union[str, PathLike]] = None,
 ) -> Optional[Union[str, PathLike]]:
     if obj is None:
         return str(default) if default is not None else None
     else:
         return path_param(obj, param_name)
+
 
 # ########################
 # ##### SEQUENCE
@@ -850,17 +855,20 @@ def opt_sequence_param(
     else:
         return obj
 
+
 @overload
 def opt_nullable_sequence_param(
     obj: None, param_name: str, of_type: Optional[TypeOrTupleOfTypes] = ...
 ) -> None:
     ...
 
+
 @overload
 def opt_nullable_sequence_param(
     obj: Sequence[T], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
 ) -> Sequence[T]:
     ...
+
 
 def opt_nullable_sequence_param(
     obj: Optional[Sequence[T]], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
@@ -869,6 +877,7 @@ def opt_nullable_sequence_param(
         return None
     else:
         return opt_sequence_param(obj, param_name, of_type)
+
 
 # ########################
 # ##### SET

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -850,6 +850,25 @@ def opt_sequence_param(
     else:
         return obj
 
+@overload
+def opt_nullable_sequence_param(
+    obj: None, param_name: str, of_type: Optional[TypeOrTupleOfTypes] = ...
+) -> None:
+    ...
+
+@overload
+def opt_nullable_sequence_param(
+    obj: Sequence[T], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
+) -> Sequence[T]:
+    ...
+
+def opt_nullable_sequence_param(
+    obj: Optional[Sequence[T]], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
+) -> Optional[Sequence[T]]:
+    if obj is None:
+        return None
+    else:
+        return opt_sequence_param(obj, param_name, of_type)
 
 # ########################
 # ##### SET

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -842,7 +842,7 @@ def opt_sequence_param(
     obj: Optional[Sequence[T]], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
 ) -> Sequence[T]:
     if obj is None:
-        return tuple()
+        return []
     elif not isinstance(obj, collections.abc.Sequence):
         raise _param_type_mismatch_exception(obj, (collections.abc.Sequence,), param_name)
     elif of_type is not None:

--- a/python_modules/dagster/dagster/check/__init__.py
+++ b/python_modules/dagster/dagster/check/__init__.py
@@ -1,3 +1,4 @@
+import collections.abc
 import inspect
 from os import PathLike, fspath
 from typing import (
@@ -6,11 +7,15 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     List,
+    Mapping,
     NoReturn,
     Optional,
+    Sequence,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
     overload,
@@ -19,13 +24,14 @@ from typing import (
 TypeOrTupleOfTypes = Union[type, Tuple[type, ...]]
 Numeric = Union[int, float]
 T = TypeVar("T")
+U = TypeVar("U")
 
 # This module contains runtime type-checking code used throughout Dagster. It is divided into three
 # sections:
 #
 # - TYPE CHECKS: functions that check the type of a single value
 # - OTHER CHECKS: functions that check conditions other than the type of a single value
-# - ERRORS: error generation code invoked by the check functions
+# - ERRORS/UTILITY: error generation code and other utility functions invoked by the check functions
 #
 # TYPE CHECKS is divided into subsections for each type (e.g. bool, list). Each subsection contains
 # multiple functions that implement the same check logic, but differ in how the target value is
@@ -187,7 +193,7 @@ def dict_param(
     if not (key_type or value_type):
         return obj
 
-    return _check_key_value_types(obj, key_type, value_type)
+    return _check_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
 def opt_dict_param(
@@ -195,7 +201,6 @@ def opt_dict_param(
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
-    value_class: Optional[TypeOrTupleOfTypes] = None,
 ) -> Dict:
     """Ensures argument obj is either a dictionary or None; if the latter, instantiates an empty
     dictionary.
@@ -208,9 +213,7 @@ def opt_dict_param(
     if not obj:
         return {}
 
-    if value_class:
-        return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
-    return _check_key_value_types(obj, key_type, value_type)
+    return _check_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
 # pyright understands this overload but not mypy
@@ -220,7 +223,6 @@ def opt_nullable_dict_param(  # type: ignore
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = ...,
     value_type: Optional[TypeOrTupleOfTypes] = ...,
-    value_class: Optional[TypeOrTupleOfTypes] = ...,
 ) -> None:
     ...
 
@@ -231,7 +233,6 @@ def opt_nullable_dict_param(
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = ...,
     value_type: Optional[TypeOrTupleOfTypes] = ...,
-    value_class: Optional[TypeOrTupleOfTypes] = ...,
 ) -> Dict:
     ...
 
@@ -241,7 +242,6 @@ def opt_nullable_dict_param(
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = None,
     value_type: Optional[TypeOrTupleOfTypes] = None,
-    value_class: Optional[TypeOrTupleOfTypes] = None,
 ) -> Optional[Dict]:
     """Ensures argument obj is either a dictionary or None."""
     from dagster.utils import frozendict
@@ -252,9 +252,7 @@ def opt_nullable_dict_param(
     if not obj:
         return None if obj is None else {}
 
-    if value_class:
-        return _check_key_value_types(obj, key_type, value_type=value_class, value_check=issubclass)
-    return _check_key_value_types(obj, key_type, value_type)
+    return _check_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
 def two_dim_dict_param(
@@ -266,7 +264,7 @@ def two_dim_dict_param(
     if not isinstance(obj, dict):
         raise _param_type_mismatch_exception(obj, dict, param_name)
 
-    return _check_two_dim_key_value_types(obj, key_type, param_name, value_type)
+    return _check_two_dim_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
 def opt_two_dim_dict_param(
@@ -281,7 +279,7 @@ def opt_two_dim_dict_param(
     if not obj:
         return {}
 
-    return _check_two_dim_key_value_types(obj, key_type, param_name, value_type)
+    return _check_two_dim_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
 def dict_elem(ddict: Dict, key: str) -> Dict:
@@ -330,49 +328,7 @@ def is_dict(
     if not (key_type or value_type):
         return obj
 
-    return _check_key_value_types(obj, key_type, value_type)
-
-
-def _check_key_value_types(
-    obj_dict: Dict,
-    key_type: Optional[TypeOrTupleOfTypes] = None,
-    value_type: Optional[TypeOrTupleOfTypes] = None,
-    key_check: Callable = isinstance,
-    value_check: Callable = isinstance,
-) -> Dict:
-    """Ensures argument obj_dict is a dictionary, and enforces that the keys/values conform to the types
-    specified by key_type, value_type.
-    """
-    if not isinstance(obj_dict, dict):
-        raise _type_mismatch_error(obj_dict, dict, "obj_dict")
-
-    for key, value in obj_dict.items():
-        if key_type and not key_check(key, key_type):
-            raise CheckError(
-                f"Key in dictionary mismatches type. Expected {repr(key_type)}. Got {repr(key)}"
-            )
-
-        if value_type and not value_check(value, value_type):
-            raise CheckError(
-                f"Value in dictionary mismatches expected type for key {key}. Expected value "
-                f"of type {repr(value_type)}. Got value {value} of type {type(value)}."
-            )
-
-    return obj_dict
-
-
-def _check_two_dim_key_value_types(
-    obj_dict: Dict,
-    key_type: Optional[TypeOrTupleOfTypes] = None,
-    _param_name: Optional[str] = None,
-    value_type: Optional[TypeOrTupleOfTypes] = None,
-) -> Dict:
-    _check_key_value_types(obj_dict, key_type, dict)  # check level one
-
-    for level_two_dict in obj_dict.values():
-        _check_key_value_types(level_two_dict, key_type, value_type)  # check level two
-
-    return obj_dict
+    return _check_mapping_entries(obj, key_type, value_type, mapping_type=dict)
 
 
 # ########################
@@ -588,7 +544,7 @@ def list_param(obj: object, param_name: str, of_type: Optional[TypeOrTupleOfType
     if not of_type:
         return obj
 
-    return _check_list_items(obj, of_type)
+    return _check_iterable_items(obj, of_type, "list")
 
 
 def opt_list_param(
@@ -610,7 +566,7 @@ def opt_list_param(
     if not of_type:
         return obj
 
-    return _check_list_items(obj, of_type)
+    return _check_iterable_items(obj, of_type, "list")
 
 
 # pyright understands this overload but not mypy
@@ -625,10 +581,10 @@ def opt_nullable_list_param(  # type: ignore
 
 @overload
 def opt_nullable_list_param(
-    obj: object,
+    obj: List[T],
     param_name: str,
     of_type: Optional[TypeOrTupleOfTypes] = ...,
-) -> List:
+) -> List[T]:
     ...
 
 
@@ -650,7 +606,7 @@ def opt_nullable_list_param(
     if not of_type:
         return obj
 
-    return _check_list_items(obj, of_type)
+    return _check_iterable_items(obj, of_type, "list")
 
 
 def two_dim_list_param(
@@ -677,7 +633,7 @@ def list_elem(ddict: Dict, key: str, of_type: Optional[TypeOrTupleOfTypes] = Non
         if not of_type:
             return value
 
-        return _check_list_items(value, of_type)
+        return _check_iterable_items(value, of_type, "list")
 
     raise _element_check_error(key, value, ddict, list)
 
@@ -698,7 +654,7 @@ def opt_list_elem(ddict: Dict, key: str, of_type: Optional[TypeOrTupleOfTypes] =
     if not of_type:
         return value
 
-    return _check_list_items(value, of_type)
+    return _check_iterable_items(value, of_type, "list")
 
 
 def is_list(
@@ -710,24 +666,79 @@ def is_list(
     if not of_type:
         return obj
 
-    return _check_list_items(obj, of_type)
+    return _check_iterable_items(obj, of_type, "list")
 
 
-def _check_list_items(obj_list: List, of_type: TypeOrTupleOfTypes) -> List:
-    for obj in obj_list:
-        if not isinstance(obj, of_type):
-            if isinstance(obj, type):
-                additional_message = (
-                    " Did you pass a class where you were expecting an instance of the class?"
-                )
-            else:
-                additional_message = ""
-            raise CheckError(
-                f"Member of list mismatches type. Expected {of_type}. Got {repr(obj)} of type "
-                f"{type(obj)}.{additional_message}"
-            )
+# ########################
+# ##### MAPPING
+# ########################
 
-    return obj_list
+
+def mapping_param(
+    obj: Mapping[T, U],
+    param_name: str,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    additional_message: Optional[str] = None,
+) -> Mapping[T, U]:
+    if not isinstance(obj, collections.abc.Mapping):
+        raise _param_type_mismatch_exception(
+            obj, (collections.abc.Mapping,), param_name, additional_message=additional_message
+        )
+
+    if not (key_type or value_type):
+        return obj
+
+    return _check_mapping_entries(obj, key_type, value_type, mapping_type=collections.abc.Mapping)
+
+
+def opt_mapping_param(
+    obj: Optional[Mapping[T, U]],
+    param_name: str,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    additional_message: Optional[str] = None,
+) -> Mapping[T, U]:
+    if obj is None:
+        return dict()
+    else:
+        return mapping_param(obj, param_name, key_type, value_type, additional_message)
+
+
+# pyright understands this overload but not mypy
+@overload
+def opt_nullable_mapping_param(  # type: ignore
+    obj: None,
+    param_name: str,
+    key_type: Optional[TypeOrTupleOfTypes] = ...,
+    value_type: Optional[TypeOrTupleOfTypes] = ...,
+    additional_message: Optional[str] = ...,
+) -> None:
+    ...
+
+
+@overload
+def opt_nullable_mapping_param(
+    obj: Mapping[T, U],
+    param_name: str,
+    key_type: Optional[TypeOrTupleOfTypes] = ...,
+    value_type: Optional[TypeOrTupleOfTypes] = ...,
+    additional_message: Optional[str] = ...,
+) -> Mapping[T, U]:
+    ...
+
+
+def opt_nullable_mapping_param(
+    obj: Optional[Mapping[T, U]],
+    param_name: str,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    additional_message: Optional[str] = None,
+) -> Optional[Mapping[T, U]]:
+    if obj is None:
+        return dict()
+    else:
+        return mapping_param(obj, param_name, key_type, value_type, additional_message)
 
 
 # ########################
@@ -777,6 +788,70 @@ def opt_numeric_param(
 
 
 # ########################
+# ##### PATH
+# ########################
+
+
+def path_param(obj: Union[str, PathLike], param_name: str) -> str:
+    if not isinstance(obj, (str, PathLike)):
+        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
+    return fspath(obj)
+
+
+@overload
+def opt_path_param(obj: None, param_name: str, default: None = ...) -> None:
+    ...
+
+
+@overload
+def opt_path_param(obj: None, param_name: str, default: Union[str, PathLike]) -> str:
+    ...
+
+
+@overload
+def opt_path_param(obj: Union[str, PathLike], param_name: str, default: Union[str, PathLike]) -> str:
+    ...
+
+
+def opt_path_param(
+    obj: Optional[Union[str, PathLike]], param_name: str, default: Optional[Union[str, PathLike]] = None
+) -> Optional[Union[str, PathLike]]:
+    if obj is None:
+        return str(default) if default is not None else None
+    else:
+        return path_param(obj, param_name)
+
+# ########################
+# ##### SEQUENCE
+# ########################
+
+
+def sequence_param(
+    obj: Sequence[T], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
+) -> Sequence[T]:
+    if not isinstance(obj, collections.abc.Sequence):
+        raise _param_type_mismatch_exception(obj, (collections.abc.Sequence,), param_name)
+
+    if not of_type:
+        return obj
+
+    return _check_iterable_items(obj, of_type, "sequence")
+
+
+def opt_sequence_param(
+    obj: Optional[Sequence[T]], param_name: str, of_type: Optional[TypeOrTupleOfTypes] = None
+) -> Sequence[T]:
+    if obj is None:
+        return tuple()
+    elif not isinstance(obj, collections.abc.Sequence):
+        raise _param_type_mismatch_exception(obj, (collections.abc.Sequence,), param_name)
+    elif of_type is not None:
+        return _check_iterable_items(obj, of_type, "sequence")
+    else:
+        return obj
+
+
+# ########################
 # ##### SET
 # ########################
 
@@ -790,7 +865,7 @@ def set_param(
     if not of_type:
         return obj
 
-    return _check_set_items(obj, of_type)
+    return _check_iterable_items(obj, of_type, "set")
 
 
 def opt_set_param(
@@ -809,7 +884,7 @@ def opt_set_param(
     if not of_type:
         return obj
 
-    return _check_set_items(obj, of_type)
+    return _check_iterable_items(obj, of_type, "set")
 
 
 def opt_nullable_set_param(
@@ -828,25 +903,7 @@ def opt_nullable_set_param(
     elif not of_type:
         return obj
 
-    return _check_set_items(obj, of_type)
-
-
-def _check_set_items(obj_set: AbstractSet, of_type: TypeOrTupleOfTypes) -> AbstractSet:
-    for obj in obj_set:
-
-        if not isinstance(obj, of_type):
-            if isinstance(obj, type):
-                additional_message = (
-                    " Did you pass a class where you were expecting an instance of the class?"
-                )
-            else:
-                additional_message = ""
-            raise CheckError(
-                f"Member of set mismatches type. Expected {of_type}. Got {repr(obj)} of type "
-                f"{type(obj)}.{additional_message}"
-            )
-
-    return obj_set
+    return _check_iterable_items(obj, of_type, "set")
 
 
 # ########################
@@ -1035,54 +1092,9 @@ def _check_tuple_items(
                 )
 
     elif of_type is not None:
-        for (i, obj) in enumerate(obj_tuple):
-            if not isinstance(obj, of_type):
-                if isinstance(obj, type):
-                    additional_message = (
-                        " Did you pass a class where you were expecting an instance of the class?"
-                    )
-                else:
-                    additional_message = ""
-                raise CheckError(
-                    f"Member of tuple mismatches type at index {i}. Expected {of_type}. Got "
-                    f"{repr(obj)} of type {type(obj)}.{additional_message}"
-                )
+        _check_iterable_items(obj_tuple, of_type, "tuple")
 
     return obj_tuple
-
-
-# ########################
-# ##### PATH
-# ########################
-
-
-def path_param(obj: object, param_name: str) -> str:
-    if not isinstance(obj, (str, PathLike)):
-        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
-    return fspath(obj)
-
-
-@overload
-def opt_path_param(obj: object, param_name: str, default: Union[str, PathLike]) -> str:
-    ...
-
-
-@overload
-def opt_path_param(obj: object, param_name: str) -> Optional[str]:
-    ...
-
-
-def opt_path_param(
-    obj: object, param_name: str, default: Optional[Union[str, PathLike]] = None
-) -> Optional[str]:
-    if obj is not None and not isinstance(obj, (str, PathLike)):
-        raise _param_type_mismatch_exception(obj, (str, PathLike), param_name)
-    if obj is not None:
-        return fspath(obj)
-
-    if obj is None and default is None:
-        return default
-    return fspath(default)
 
 
 # ###################################################################################################
@@ -1124,7 +1136,7 @@ def not_implemented(desc: str) -> NoReturn:
 
 
 # ###################################################################################################
-# ##### ERRORS
+# ##### ERRORS / UTILITY
 # ###################################################################################################
 
 
@@ -1210,3 +1222,72 @@ def _param_invariant_exception(param_name: str, desc: Optional[str] = None) -> P
     return ParameterCheckError(
         f"Invariant violation for parameter {param_name}. Description: {desc}"
     )
+
+
+V = TypeVar("V", bound=Iterable)
+
+
+def _check_iterable_items(
+    obj_iter: V, of_type: TypeOrTupleOfTypes, collection_name: str = "iterable"
+) -> V:
+    for obj in obj_iter:
+
+        if not isinstance(obj, of_type):
+            if isinstance(obj, type):
+                additional_message = (
+                    " Did you pass a class where you were expecting an instance of the class?"
+                )
+            else:
+                additional_message = ""
+            raise CheckError(
+                f"Member of {collection_name} mismatches type. Expected {of_type}. Got {repr(obj)} of type "
+                f"{type(obj)}.{additional_message}"
+            )
+
+    return obj_iter
+
+
+W = TypeVar("W", bound=Mapping)
+X = TypeVar("X", bound=Mapping)
+
+
+def _check_mapping_entries(
+    obj: W,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    key_check: Callable = isinstance,
+    value_check: Callable = isinstance,
+    mapping_type: Type = collections.abc.Mapping,
+) -> W:
+    """Enforces that the keys/values conform to the types specified by key_type, value_type."""
+    for key, value in obj.items():
+        if key_type and not key_check(key, key_type):
+            raise CheckError(
+                f"Key in {mapping_type.__name__} mismatches type. Expected {repr(key_type)}. Got {repr(key)}"
+            )
+
+        if value_type and not value_check(value, value_type):
+            raise CheckError(
+                f"Value in {mapping_type.__name__} mismatches expected type for key {key}. Expected value "
+                f"of type {repr(value_type)}. Got value {value} of type {type(value)}."
+            )
+
+    return obj
+
+
+def _check_two_dim_mapping_entries(
+    obj: W,
+    key_type: Optional[TypeOrTupleOfTypes] = None,
+    value_type: Optional[TypeOrTupleOfTypes] = None,
+    mapping_type: Type = collections.abc.Mapping,
+) -> W:
+    _check_mapping_entries(
+        obj, key_type, mapping_type, mapping_type=mapping_type
+    )  # check level one
+
+    for inner_mapping in obj.values():
+        _check_mapping_entries(
+            inner_mapping, key_type, value_type, mapping_type=mapping_type
+        )  # check level two
+
+    return obj

--- a/python_modules/dagster/dagster/core/definitions/decorators/op.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/op.py
@@ -49,7 +49,7 @@ class _Op:
         out: Optional[Union[Out, Dict[str, Out]]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
-        self.input_defs = check.opt_nullable_list_param(
+        self.input_defs = check.opt_nullable_sequence_param(
             input_defs, "input_defs", of_type=InputDefinition
         )
         self.output_defs = output_defs

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid.py
@@ -73,7 +73,7 @@ class _Solid:
     ):
         self.name = check.opt_str_param(name, "name")
         self.input_defs = check.opt_list_param(input_defs, "input_defs", InputDefinition)
-        self.output_defs = check.opt_nullable_list_param(
+        self.output_defs = check.opt_nullable_sequence_param(
             output_defs, "output_defs", OutputDefinition
         )
         self.decorator_takes_context = check.bool_param(

--- a/python_modules/dagster/dagster/core/definitions/decorators/solid.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/solid.py
@@ -97,6 +97,7 @@ class _Solid:
         if not self.name:
             self.name = fn.__name__
 
+        output_defs: Sequence[OutputDefinition]
         if self.output_defs is None:
             output_defs = [OutputDefinition.create_from_inferred(infer_output_props(fn))]
         elif len(self.output_defs) == 1:

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1103,7 +1103,7 @@ def test_opt_sequence_param():
     assert check.opt_sequence_param("foo", "sequence_param") == "foo"
     assert check.opt_sequence_param("foo", "sequence_param", of_type=str) == "foo"
 
-    assert check.opt_sequence_param(None, "sequence_param") == tuple()
+    assert check.opt_sequence_param(None, "sequence_param") == []
 
     with pytest.raises(CheckError):
         check.opt_sequence_param(1, "sequence_param", of_type=int)  # type: ignore

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+import collections.abc
 import re
 import sys
 from collections import defaultdict
@@ -15,262 +17,195 @@ from dagster.check import (
 from dagster.utils import frozendict, frozenlist
 
 
-def test_int_param():
-    assert check.int_param(-1, "param_name") == -1
-    assert check.int_param(0, "param_name") == 0
-    assert check.int_param(1, "param_name") == 1
+@contextmanager
+def raises_with_message(exc_type, message_text):
+    with pytest.raises(exc_type) as exc_info:
+        yield
+
+    assert str(exc_info.value) == message_text
+
+
+def is_python_three():
+    return sys.version_info[0] >= 3
+
+
+# ###################################################################################################
+# ##### TYPE CHECKS
+# ###################################################################################################
+
+# ########################
+# ##### BOOL
+# ########################
+
+
+def test_bool_param():
+    assert check.bool_param(True, "b") is True
+    assert check.bool_param(False, "b") is False
 
     with pytest.raises(ParameterCheckError):
-        check.int_param(None, "param_name")
+        check.bool_param(None, "b")
 
     with pytest.raises(ParameterCheckError):
-        check.int_param("s", "param_name")
-
-
-def test_int_value_param():
-    assert check.int_value_param(-1, -1, "param_name") == -1
-    with pytest.raises(ParameterCheckError):
-        check.int_value_param(None, -1, "param_name")
+        check.bool_param(0, "b")
 
     with pytest.raises(ParameterCheckError):
-        check.int_value_param(1, 0, "param_name")
+        check.bool_param("val", "b")
 
 
-def test_opt_int_param():
-    assert check.opt_int_param(-1, "param_name") == -1
-    assert check.opt_int_param(0, "param_name") == 0
-    assert check.opt_int_param(1, "param_name") == 1
-    assert check.opt_int_param(None, "param_name") is None
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_int_param("s", "param_name")
-
-
-def test_float_param():
-    assert check.float_param(-1.0, "param_name") == -1.0
-    assert check.float_param(0.0, "param_name") == 0.0
-    assert check.float_param(1.1, "param_name") == 1.1
+def test_opt_bool_param():
+    assert check.opt_bool_param(True, "b") is True
+    assert check.opt_bool_param(False, "b") is False
+    assert check.opt_bool_param(None, "b") is None
+    assert check.opt_bool_param(None, "b", True) is True
+    assert check.opt_bool_param(None, "b", False) is False
 
     with pytest.raises(ParameterCheckError):
-        check.float_param(None, "param_name")
+        check.opt_bool_param(0, "b")
 
     with pytest.raises(ParameterCheckError):
-        check.float_param("s", "param_name")
+        check.opt_bool_param("val", "b")
+
+
+def test_bool_elem():
+    ddict = {"a_true": True, "a_str": "a", "a_num": 1, "a_none": None}
+
+    assert check.bool_elem(ddict, "a_true") is True
+
+    with pytest.raises(ElementCheckError):
+        check.bool_elem(ddict, "a_none")
+
+    with pytest.raises(ElementCheckError):
+        check.bool_elem(ddict, "a_num")
+
+    with pytest.raises(ElementCheckError):
+        check.bool_elem(ddict, "a_str")
+
+
+# ########################
+# ##### CALLABLE
+# ########################
+
+
+def test_callable_param():
+    lamb = lambda: 1
+    assert check.callable_param(lamb, "lamb") == lamb
 
     with pytest.raises(ParameterCheckError):
-        check.float_param(1, "param_name")
+        check.callable_param(None, "lamb")
 
     with pytest.raises(ParameterCheckError):
-        check.float_param(0, "param_name")
+        check.callable_param(2, "lamb")
 
 
-def test_opt_float_param():
-    assert check.opt_float_param(-1.0, "param_name") == -1.0
-    assert check.opt_float_param(0.0, "param_name") == 0.0
-    assert check.opt_float_param(1.1, "param_name") == 1.1
-    assert check.opt_float_param(None, "param_name") is None
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_float_param("s", "param_name")
-
-
-def test_list_param():
-    assert check.list_param([], "list_param") == []
-    assert check.list_param(frozenlist(), "list_param") == []
-
-    assert check.list_param(["foo"], "list_param", of_type=str) == ["foo"]
+def test_opt_callable_param():
+    lamb = lambda: 1
+    assert check.opt_callable_param(lamb, "lamb") == lamb
+    assert check.opt_callable_param(None, "lamb") is None
+    assert check.opt_callable_param(None, "lamb") is None
+    assert check.opt_callable_param(None, "lamb", default=lamb) == lamb
 
     with pytest.raises(ParameterCheckError):
-        check.list_param(None, "list_param")
+        check.opt_callable_param(2, "lamb")
 
-    with pytest.raises(ParameterCheckError):
-        check.list_param("3u4", "list_param")
+
+def test_is_callable():
+    def fn():
+        pass
+
+    assert check.is_callable(fn) == fn
+    assert check.is_callable(lambda: None)
+    assert check.is_callable(lambda: None, "some desc")
 
     with pytest.raises(CheckError):
-        check.list_param(["foo"], "list_param", of_type=int)
+        check.is_callable(None)
+
+    with pytest.raises(CheckError):
+        check.is_callable(1)
+
+    with pytest.raises(CheckError, match="some other desc"):
+        check.is_callable(1, "some other desc")
 
 
-def test_set_param():
-    assert check.set_param(set(), "set_param") == set()
-    assert check.set_param(frozenset(), "set_param") == set()
-
-    with pytest.raises(ParameterCheckError):
-        check.set_param(None, "set_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.set_param("3u4", "set_param")
-
-    obj_set = {1}
-    assert check.set_param(obj_set, "set_param") == obj_set
-
-    obj_set_two = {1, 1, 2}
-    obj_set_two_deduped = {1, 2}
-    assert check.set_param(obj_set_two, "set_param") == obj_set_two_deduped
-    assert check.set_param(obj_set_two, "set_param", of_type=int) == obj_set_two_deduped
-
-    with pytest.raises(CheckError, match="Did you pass a class"):
-        check.set_param({str}, "set_param", of_type=int)
-
-    with pytest.raises(CheckError, match="Member of set mismatches type"):
-        check.set_param({"foo"}, "set_param", of_type=int)
+# ########################
+# ##### CLASS
+# ########################
 
 
-def test_typed_list_param():
+def test_opt_class_param():
     class Foo:
         pass
 
+    assert check.opt_class_param(int, "foo")
+    assert check.opt_class_param(Foo, "foo")
+
+    assert check.opt_class_param(None, "foo") is None
+    assert check.opt_class_param(None, "foo", Foo) is Foo
+
+    with pytest.raises(CheckError):
+        check.opt_class_param(check, "foo")
+
+    with pytest.raises(CheckError):
+        check.opt_class_param(234, "foo")
+
+    with pytest.raises(CheckError):
+        check.opt_class_param("bar", "foo")
+
+    with pytest.raises(CheckError):
+        check.opt_class_param(Foo(), "foo")
+
+
+def test_class_param():
     class Bar:
         pass
 
-    assert check.list_param([], "list_param", Foo) == []
-    foo_list = [Foo()]
-    assert check.list_param(foo_list, "list_param", Foo) == foo_list
+    assert check.class_param(int, "foo")
+    assert check.class_param(Bar, "foo")
 
     with pytest.raises(CheckError):
-        check.list_param([Bar()], "list_param", Foo)
+        check.class_param(None, "foo")
 
     with pytest.raises(CheckError):
-        check.list_param([None], "list_param", Foo)
-
-
-def test_is_tuple():
-    assert check.is_tuple(()) == ()
+        check.class_param(check, "foo")
 
     with pytest.raises(CheckError):
-        check.is_tuple(None)
+        check.class_param(234, "foo")
 
     with pytest.raises(CheckError):
-        check.is_tuple("3u4")
+        check.class_param("bar", "foo")
 
-    with pytest.raises(CheckError, match="Did you pass a class"):
-        check.is_tuple((str,), of_type=int)
+    with pytest.raises(CheckError):
+        check.class_param(Bar(), "foo")
 
-
-def test_typed_is_tuple():
-    class Foo:
+    class Super:
         pass
 
-    class Bar:
+    class Sub(Super):
         pass
 
-    assert check.is_tuple((), Foo) == ()
-    foo_tuple = (Foo(),)
-    assert check.is_tuple(foo_tuple, Foo) == foo_tuple
-    assert check.is_tuple(foo_tuple, (Foo, Bar))
-
-    with pytest.raises(CheckError):
-        check.is_tuple((Bar(),), Foo)
-
-    with pytest.raises(CheckError):
-        check.is_tuple((None,), Foo)
-
-    assert check.is_tuple((Foo(), Bar()), of_shape=(Foo, Bar))
-
-    with pytest.raises(CheckError):
-        check.is_tuple((Foo(),), of_shape=(Foo, Bar))
-
-    with pytest.raises(CheckError):
-        check.is_tuple((Foo(), Foo()), of_shape=(Foo, Bar))
-
-    with pytest.raises(CheckError):
-        check.is_tuple((Foo(), Foo()), of_shape=(Foo, Foo), of_type=Foo)
-
-
-def test_typed_is_list():
-    class Foo:
+    class Alone:
         pass
 
-    class Bar:
-        pass
-
-    assert check.is_list([], Foo) == []
-    foo_list = [Foo()]
-    assert check.is_list(foo_list, of_type=Foo) == foo_list
-
-    assert check.is_list([Foo(), Bar()], of_type=(Foo, Bar))
+    assert check.class_param(Sub, "foo", superclass=Super)
 
     with pytest.raises(CheckError):
-        check.is_list([Bar()], of_type=Foo)
+        assert check.class_param(Alone, "foo", superclass=Super)
 
     with pytest.raises(CheckError):
-        check.is_list([None], of_type=Foo)
+        assert check.class_param("value", "foo", superclass=Super)
+
+    assert check.opt_class_param(Sub, "foo", superclass=Super)
+    assert check.opt_class_param(None, "foo", superclass=Super) is None
 
     with pytest.raises(CheckError):
-        check.is_list([Foo(), Bar(), ""], of_type=(Foo, Bar))
-
-
-def test_opt_list_param():
-    assert check.opt_list_param(None, "list_param") == []
-    assert check.opt_list_param(None, "list_param", of_type=str) == []
-    assert check.opt_list_param([], "list_param") == []
-    assert check.opt_list_param(frozenlist(), "list_param") == []
-    obj_list = [1]
-    assert check.list_param(obj_list, "list_param") == obj_list
-    assert check.opt_list_param(["foo"], "list_param", of_type=str) == ["foo"]
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_list_param(0, "list_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_list_param("", "list_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_list_param("3u4", "list_param")
+        assert check.opt_class_param(Alone, "foo", superclass=Super)
 
     with pytest.raises(CheckError):
-        check.opt_list_param(["foo"], "list_param", of_type=int)
+        assert check.opt_class_param("value", "foo", superclass=Super)
 
 
-def test_opt_set_param():
-    assert check.opt_set_param(None, "set_param") == set()
-    assert check.opt_set_param(set(), "set_param") == set()
-    assert check.opt_set_param(frozenset(), "set_param") == set()
-    assert check.opt_set_param({3}, "set_param") == {3}
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_set_param(0, "set_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_set_param("", "set_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_set_param("3u4", "set_param")
-
-
-def test_opt_nullable_list_param():
-    assert check.opt_nullable_list_param(None, "list_param") is None
-    assert check.opt_nullable_list_param([], "list_param") == []
-    assert check.opt_nullable_list_param(frozenlist(), "list_param") == []
-    obj_list = [1]
-    assert check.opt_nullable_list_param(obj_list, "list_param") == obj_list
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_nullable_list_param(0, "list_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_nullable_list_param("", "list_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_nullable_list_param("3u4", "list_param")
-
-
-def test_opt_typed_list_param():
-    class Foo:
-        pass
-
-    class Bar:
-        pass
-
-    assert check.opt_list_param(None, "list_param", Foo) == []
-    assert check.opt_list_param([], "list_param", Foo) == []
-    foo_list = [Foo()]
-    assert check.opt_list_param(foo_list, "list_param", Foo) == foo_list
-
-    with pytest.raises(CheckError):
-        check.opt_list_param([Bar()], "list_param", Foo)
-
-    with pytest.raises(CheckError):
-        check.opt_list_param([None], "list_param", Foo)
+# ########################
+# ##### DICT
+# ########################
 
 
 class Wrong:
@@ -358,7 +293,7 @@ def test_opt_dict_param_with_type():
         value_type=(str, int),
     )
 
-    class Wrong:
+    class Wrong:  # pylint: disable=redefined-outer-name
         pass
 
     with pytest.raises(CheckError):
@@ -376,7 +311,7 @@ def test_opt_dict_param_with_type():
     with pytest.raises(CheckError):
         assert check.opt_dict_param(str_to_int, "str_to_int", value_type=Wrong)
 
-    class AlsoWrong:
+    class AlsoWrong:  # pylint: disable=redefined-outer-name
         pass
 
     with pytest.raises(CheckError):
@@ -416,18 +351,6 @@ def test_opt_nullable_dict_param():
     ddict = {"a": 2}
     assert check.opt_nullable_dict_param(ddict, "opt_nullable_dict_param") == ddict
 
-    class Foo:
-        pass
-
-    class Bar(Foo):
-        pass
-
-    ddict_class = {"a": Bar}
-    assert (
-        check.opt_nullable_dict_param(ddict_class, "opt_nullable_dict_param", value_class=Foo)
-        == ddict_class
-    )
-
     with pytest.raises(ParameterCheckError):
         check.opt_nullable_dict_param(1, "opt_nullable_dict_param")
 
@@ -435,196 +358,123 @@ def test_opt_nullable_dict_param():
         check.opt_nullable_dict_param("foo", "opt_nullable_dict_param")
 
 
-def test_str_param():
-    assert check.str_param("a", "str_param") == "a"
-    assert check.str_param("", "str_param") == ""
-    assert check.str_param("a", "unicode_param") == "a"
+def test_opt_two_dim_dict_param():
+    assert check.opt_two_dim_dict_param({}, "foo") == {}
+    assert check.opt_two_dim_dict_param({"key": {}}, "foo")
+    assert check.opt_two_dim_dict_param({"key": {"key2": 2}}, "foo")
+    assert check.opt_two_dim_dict_param(None, "foo") == {}
+
+    with pytest.raises(CheckError):
+        assert check.opt_two_dim_dict_param("str", "foo")
+
+
+def test_two_dim_dict():
+    assert check.two_dim_dict_param({}, "foo") == {}
+    assert check.two_dim_dict_param({"key": {}}, "foo")
+    assert check.two_dim_dict_param({"key": {"key2": 2}}, "foo")
+
+    # make sure default dict passes
+    default_dict = defaultdict(dict)
+    default_dict["key"]["key2"] = 2
+    assert check.two_dim_dict_param(default_dict, "foo")
+
+    with raises_with_message(
+        CheckError, """Param "foo" is not a dict. Got None which is type <class 'NoneType'>."""
+    ):
+        check.two_dim_dict_param(None, "foo")
+
+    with raises_with_message(
+        CheckError,
+        "Value in dict mismatches expected type for key int_value. Expected value "
+        "of type <class 'dict'>. Got value 2 of type <class 'int'>.",
+    ):
+        check.two_dim_dict_param({"int_value": 2}, "foo")
+
+    with raises_with_message(
+        CheckError,
+        "Value in dict mismatches expected type for key level_two_value_mismatch. "
+        "Expected value of type <class 'str'>. Got value 2 of type <class 'int'>.",
+    ):
+        check.two_dim_dict_param(
+            {"level_one_key": {"level_two_value_mismatch": 2}}, "foo", value_type=str
+        )
+
+    with raises_with_message(
+        CheckError,
+        "Key in dict mismatches type. Expected <class 'int'>. Got 'key'"
+        if is_python_three()
+        else "Key in dictionary mismatches type. Expected <type 'int'>. Got 'key'",
+    ):
+        assert check.two_dim_dict_param({"key": {}}, "foo", key_type=int)
+
+    with raises_with_message(
+        CheckError,
+        "Key in dict mismatches type. Expected <class 'int'>. Got 'level_two_key'"
+        if is_python_three()
+        else "Key in dictionary mismatches type. Expected <type 'int'>. Got 'level_two_key'",
+    ):
+        assert check.two_dim_dict_param({1: {"level_two_key": "something"}}, "foo", key_type=int)
+
+
+def test_dict_elem():
+    dict_value = {"blah": "blahblah"}
+    ddict = {"dictkey": dict_value, "stringkey": "A", "nonekey": None}
+
+    assert check.dict_elem(ddict, "dictkey") == dict_value
+
+    with pytest.raises(CheckError):
+        check.dict_elem(ddict, "stringkey")
+
+    with pytest.raises(CheckError):
+        check.dict_elem(ddict, "nonekey")
+
+    with pytest.raises(CheckError):
+        check.dict_elem(ddict, "nonexistantkey")
+
+
+def test_opt_dict_elem():
+    dict_value = {"blah": "blahblah"}
+    ddict = {"dictkey": dict_value, "stringkey": "A", "nonekey": None}
+
+    assert check.opt_dict_elem(ddict, "dictkey") == dict_value
+    assert check.opt_dict_elem(ddict, "nonekey") == {}
+    assert check.opt_dict_elem(ddict, "nonexistantkey") == {}
+
+    with pytest.raises(CheckError):
+        check.opt_dict_elem(ddict, "stringkey")
+
+
+# ########################
+# ##### FLOAT
+# ########################
+
+
+def test_float_param():
+    assert check.float_param(-1.0, "param_name") == -1.0
+    assert check.float_param(0.0, "param_name") == 0.0
+    assert check.float_param(1.1, "param_name") == 1.1
 
     with pytest.raises(ParameterCheckError):
-        check.str_param(None, "str_param")
+        check.float_param(None, "param_name")
 
     with pytest.raises(ParameterCheckError):
-        check.str_param(0, "str_param")
+        check.float_param("s", "param_name")
 
     with pytest.raises(ParameterCheckError):
-        check.str_param(1, "str_param")
-
-
-def test_opt_str_param():
-    assert check.opt_str_param("a", "str_param") == "a"
-    assert check.opt_str_param("", "str_param") == ""
-    assert check.opt_str_param("a", "unicode_param") == "a"
-    assert check.opt_str_param(None, "str_param") is None
-    assert check.opt_str_param(None, "str_param", "foo") == "foo"
+        check.float_param(1, "param_name")
 
     with pytest.raises(ParameterCheckError):
-        check.opt_str_param(0, "str_param")
+        check.float_param(0, "param_name")
+
+
+def test_opt_float_param():
+    assert check.opt_float_param(-1.0, "param_name") == -1.0
+    assert check.opt_float_param(0.0, "param_name") == 0.0
+    assert check.opt_float_param(1.1, "param_name") == 1.1
+    assert check.opt_float_param(None, "param_name") is None
 
     with pytest.raises(ParameterCheckError):
-        check.opt_str_param(1, "str_param")
-
-
-def test_opt_nonempty_str_param():
-    assert check.opt_nonempty_str_param("a", "str_param") == "a"
-    assert check.opt_nonempty_str_param("", "str_param") is None
-    assert check.opt_nonempty_str_param("", "str_param", "foo") == "foo"
-    assert check.opt_nonempty_str_param("a", "unicode_param") == "a"
-    assert check.opt_nonempty_str_param(None, "str_param") is None
-    assert check.opt_nonempty_str_param(None, "str_param", "foo") == "foo"
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_nonempty_str_param(0, "str_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_nonempty_str_param(1, "str_param")
-
-
-def test_path_param():
-    from pathlib import Path
-
-    assert check.path_param("/a/b.csv", "path_param") == "/a/b.csv"
-    assert check.path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
-
-    with pytest.raises(ParameterCheckError):
-        check.path_param(None, "path_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.path_param(0, "path_param")
-
-
-def test_opt_path_param():
-    from pathlib import Path
-
-    assert check.opt_path_param("/a/b.csv", "path_param") == "/a/b.csv"
-    assert check.opt_path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
-    assert check.opt_path_param(None, "path_param") is None
-    assert check.opt_path_param(None, "path_param", "/a/b/c.csv") == "/a/b/c.csv"
-    assert check.opt_path_param(None, "path_param", Path("/a/b/c.csv")) == "/a/b/c.csv"
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_path_param(0, "path_param")
-
-
-def test_bool_param():
-    assert check.bool_param(True, "b") is True
-    assert check.bool_param(False, "b") is False
-
-    with pytest.raises(ParameterCheckError):
-        check.bool_param(None, "b")
-
-    with pytest.raises(ParameterCheckError):
-        check.bool_param(0, "b")
-
-    with pytest.raises(ParameterCheckError):
-        check.bool_param("val", "b")
-
-
-def test_opt_bool_param():
-    assert check.opt_bool_param(True, "b") is True
-    assert check.opt_bool_param(False, "b") is False
-    assert check.opt_bool_param(None, "b") is None
-    assert check.opt_bool_param(None, "b", True) is True
-    assert check.opt_bool_param(None, "b", False) is False
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_bool_param(0, "b")
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_bool_param("val", "b")
-
-
-def test_callable_param():
-    lamb = lambda: 1
-    assert check.callable_param(lamb, "lamb") == lamb
-
-    with pytest.raises(ParameterCheckError):
-        check.callable_param(None, "lamb")
-
-    with pytest.raises(ParameterCheckError):
-        check.callable_param(2, "lamb")
-
-
-def test_opt_callable_param():
-    lamb = lambda: 1
-    assert check.opt_callable_param(lamb, "lamb") == lamb
-    assert check.opt_callable_param(None, "lamb") is None
-    assert check.opt_callable_param(None, "lamb", default=None) is None
-    assert check.opt_callable_param(None, "lamb", default=lamb) == lamb
-
-    with pytest.raises(ParameterCheckError):
-        check.opt_callable_param(2, "lamb")
-
-
-def test_param_invariant():
-    check.param_invariant(True, "some_param")
-    num_to_check = 1
-    check.param_invariant(num_to_check == 1, "some_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.param_invariant(num_to_check == 2, "some_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.param_invariant(False, "some_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.param_invariant(0, "some_param")
-
-    check.param_invariant(1, "some_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.param_invariant("", "some_param")
-
-    check.param_invariant("1kjkjsf", "some_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.param_invariant({}, "some_param")
-
-    check.param_invariant({234: "1kjkjsf"}, "some_param")
-
-    with pytest.raises(ParameterCheckError):
-        check.param_invariant([], "some_param")
-
-    check.param_invariant([234], "some_param")
-
-
-def test_string_elem():
-    ddict = {"a_str": "a", "a_num": 1, "a_none": None}
-
-    assert check.str_elem(ddict, "a_str") == "a"
-
-    with pytest.raises(ElementCheckError):
-        assert check.str_elem(ddict, "a_none")
-
-    with pytest.raises(ElementCheckError):
-        check.str_elem(ddict, "a_num")
-
-
-def test_opt_string_elem():
-    ddict = {"a_str": "a", "a_num": 1, "a_none": None}
-
-    assert check.opt_str_elem(ddict, "a_str") == "a"
-
-    assert check.opt_str_elem(ddict, "a_none") == None
-
-    assert check.opt_str_elem(ddict, "nonexistentkey") == None
-
-    with pytest.raises(ElementCheckError):
-        check.opt_str_elem(ddict, "a_num")
-
-
-def test_bool_elem():
-    ddict = {"a_true": True, "a_str": "a", "a_num": 1, "a_none": None}
-
-    assert check.bool_elem(ddict, "a_true") is True
-
-    with pytest.raises(ElementCheckError):
-        check.bool_elem(ddict, "a_none")
-
-    with pytest.raises(ElementCheckError):
-        check.bool_elem(ddict, "a_num")
-
-    with pytest.raises(ElementCheckError):
-        check.bool_elem(ddict, "a_str")
+        check.opt_float_param("s", "param_name")
 
 
 def test_float_elem():
@@ -664,6 +514,117 @@ def test_opt_float_elem():
         check.opt_float_elem(ddict, "a_str")
 
 
+# ########################
+# ##### GENERATOR
+# ########################
+
+
+def test_generator_param():
+    def _test_gen():
+        yield 1
+
+    assert check.generator_param(_test_gen(), "gen")
+
+    gen = _test_gen()
+    assert check.generator(gen)
+    assert list(gen) == [1]
+    assert check.generator(gen)
+    assert list(gen) == []
+
+    with pytest.raises(ParameterCheckError):
+        assert check.generator_param(list(gen), "gen")
+
+    with pytest.raises(ParameterCheckError):
+        assert check.generator_param(None, "gen")
+
+    with pytest.raises(ParameterCheckError):
+        assert check.generator_param(_test_gen, "gen")
+
+
+def test_opt_generator_param():
+    def _test_gen():
+        yield 1
+
+    assert check.opt_generator_param(_test_gen(), "gen")
+
+    assert check.opt_generator_param(None, "gen") is None
+
+    with pytest.raises(ParameterCheckError):
+        assert check.opt_generator_param(_test_gen, "gen")
+
+
+def test_generator():
+    def _test_gen():
+        yield 1
+
+    assert check.generator(_test_gen())
+
+    gen = _test_gen()
+    assert check.generator(gen)
+
+    with pytest.raises(ParameterCheckError):
+        assert check.generator(list(gen))
+
+    with pytest.raises(ParameterCheckError):
+        assert check.generator(None)
+
+    with pytest.raises(ParameterCheckError):
+        assert check.generator(_test_gen)
+
+
+def test_opt_generator():
+    def _test_gen():
+        yield 1
+
+    assert check.opt_generator(_test_gen())
+
+    gen = _test_gen()
+    assert check.opt_generator(gen)
+    assert check.opt_generator(None) is None
+
+    with pytest.raises(ParameterCheckError):
+        assert check.opt_generator(list(gen))
+
+    with pytest.raises(ParameterCheckError):
+        assert check.opt_generator(_test_gen)
+
+
+# ########################
+# ##### INT
+# ########################
+
+
+def test_int_param():
+    assert check.int_param(-1, "param_name") == -1
+    assert check.int_param(0, "param_name") == 0
+    assert check.int_param(1, "param_name") == 1
+
+    with pytest.raises(ParameterCheckError):
+        check.int_param(None, "param_name")
+
+    with pytest.raises(ParameterCheckError):
+        check.int_param("s", "param_name")
+
+
+def test_int_value_param():
+    assert check.int_value_param(-1, -1, "param_name") == -1
+    with pytest.raises(ParameterCheckError):
+        check.int_value_param(None, -1, "param_name")
+
+    with pytest.raises(ParameterCheckError):
+        check.int_value_param(1, 0, "param_name")
+
+
+def test_opt_int_param():
+    assert check.opt_int_param(-1, "param_name") == -1
+    assert check.opt_int_param(0, "param_name") == 0
+    assert check.opt_int_param(1, "param_name") == 1
+    assert check.opt_int_param(None, "param_name") is None
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_int_param("s", "param_name")
+
+
 def test_int_elem():
     ddict = {"a_bool": True, "a_float": 1.0, "a_int": 1, "a_none": None, "a_str": "a"}
 
@@ -699,35 +660,9 @@ def test_opt_int_elem():
         check.opt_int_elem(ddict, "a_str")
 
 
-def test_invariant():
-    assert check.invariant(True)
-
-    with pytest.raises(CheckError):
-        check.invariant(False)
-
-    with pytest.raises(CheckError, match="Some Unique String"):
-        check.invariant(False, "Some Unique String")
-
-    empty_list = []
-
-    with pytest.raises(CheckError, match="Invariant failed"):
-        check.invariant(empty_list)
-
-
-def test_failed():
-    with pytest.raises(CheckError, match="some desc"):
-        check.failed("some desc")
-
-    with pytest.raises(CheckError, match="must be a string"):
-        check.failed(0)
-
-
-def test_not_implemented():
-    with pytest.raises(NotImplementedCheckError, match="some string"):
-        check.not_implemented("some string")
-
-    with pytest.raises(CheckError, match="desc argument must be a string"):
-        check.not_implemented(None)
+# ########################
+# ##### INST
+# ########################
 
 
 def test_inst():
@@ -821,32 +756,146 @@ def test_opt_inst_param():
         check.inst_param(Baaz(), "obj", (Foo, Bar))
 
 
-def test_dict_elem():
-    dict_value = {"blah": "blahblah"}
-    ddict = {"dictkey": dict_value, "stringkey": "A", "nonekey": None}
-
-    assert check.dict_elem(ddict, "dictkey") == dict_value
-
-    with pytest.raises(CheckError):
-        check.dict_elem(ddict, "stringkey")
-
-    with pytest.raises(CheckError):
-        check.dict_elem(ddict, "nonekey")
-
-    with pytest.raises(CheckError):
-        check.dict_elem(ddict, "nonexistantkey")
+# ########################
+# ##### LIST
+# ########################
 
 
-def test_opt_dict_elem():
-    dict_value = {"blah": "blahblah"}
-    ddict = {"dictkey": dict_value, "stringkey": "A", "nonekey": None}
+def test_list_param():
+    assert check.list_param([], "list_param") == []
+    assert check.list_param(frozenlist(), "list_param") == []
 
-    assert check.opt_dict_elem(ddict, "dictkey") == dict_value
-    assert check.opt_dict_elem(ddict, "nonekey") == {}
-    assert check.opt_dict_elem(ddict, "nonexistantkey") == {}
+    assert check.list_param(["foo"], "list_param", of_type=str) == ["foo"]
+
+    with pytest.raises(ParameterCheckError):
+        check.list_param(None, "list_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.list_param("3u4", "list_param")
 
     with pytest.raises(CheckError):
-        check.opt_dict_elem(ddict, "stringkey")
+        check.list_param(["foo"], "list_param", of_type=int)
+
+
+def test_typed_list_param():
+    class Foo:
+        pass
+
+    class Bar:
+        pass
+
+    assert check.list_param([], "list_param", Foo) == []
+    foo_list = [Foo()]
+    assert check.list_param(foo_list, "list_param", Foo) == foo_list
+
+    with pytest.raises(CheckError):
+        check.list_param([Bar()], "list_param", Foo)
+
+    with pytest.raises(CheckError):
+        check.list_param([None], "list_param", Foo)
+
+
+def test_opt_list_param():
+    assert check.opt_list_param(None, "list_param") == []
+    assert check.opt_list_param(None, "list_param", of_type=str) == []
+    assert check.opt_list_param([], "list_param") == []
+    assert check.opt_list_param(frozenlist(), "list_param") == []
+    obj_list = [1]
+    assert check.list_param(obj_list, "list_param") == obj_list
+    assert check.opt_list_param(["foo"], "list_param", of_type=str) == ["foo"]
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_list_param(0, "list_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_list_param("", "list_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_list_param("3u4", "list_param")
+
+    with pytest.raises(CheckError):
+        check.opt_list_param(["foo"], "list_param", of_type=int)
+
+
+def test_opt_typed_list_param():
+    class Foo:
+        pass
+
+    class Bar:
+        pass
+
+    assert check.opt_list_param(None, "list_param", Foo) == []
+    assert check.opt_list_param([], "list_param", Foo) == []
+    foo_list = [Foo()]
+    assert check.opt_list_param(foo_list, "list_param", Foo) == foo_list
+
+    with pytest.raises(CheckError):
+        check.opt_list_param([Bar()], "list_param", Foo)
+
+    with pytest.raises(CheckError):
+        check.opt_list_param([None], "list_param", Foo)
+
+
+def test_opt_nullable_list_param():
+    assert check.opt_nullable_list_param(None, "list_param") is None
+    assert check.opt_nullable_list_param([], "list_param") == []
+    assert check.opt_nullable_list_param(frozenlist(), "list_param") == []
+    obj_list = [1]
+    assert check.opt_nullable_list_param(obj_list, "list_param") == obj_list
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_nullable_list_param(0, "list_param")  # type: ignore
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_nullable_list_param("", "list_param")  # type: ignore
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_nullable_list_param("3u4", "list_param")  # type: ignore
+
+
+def test_typed_is_list():
+    class Foo:
+        pass
+
+    class Bar:
+        pass
+
+    assert check.is_list([], Foo) == []
+    foo_list = [Foo()]
+    assert check.is_list(foo_list, of_type=Foo) == foo_list
+
+    assert check.is_list([Foo(), Bar()], of_type=(Foo, Bar))
+
+    with pytest.raises(CheckError):
+        check.is_list([Bar()], of_type=Foo)
+
+    with pytest.raises(CheckError):
+        check.is_list([None], of_type=Foo)
+
+    with pytest.raises(CheckError):
+        check.is_list([Foo(), Bar(), ""], of_type=(Foo, Bar))
+
+
+def test_two_dim_list_param():
+    assert check.two_dim_list_param([[1, 2], [2, 3]], "something")
+
+    with pytest.raises(CheckError):
+        assert check.two_dim_list_param(None, "something")
+
+    with pytest.raises(CheckError):
+        assert check.two_dim_list_param([1, 2, 4], "something")
+
+    with pytest.raises(CheckError):
+        assert check.two_dim_list_param([], "something")
+
+    with pytest.raises(CheckError):
+        assert check.two_dim_list_param([[1, 2], 3], "soemthing")
+
+    with pytest.raises(CheckError):
+        assert check.two_dim_list_param([[1, 2], [3.0, 4.1]], "something", of_type=int)
+
+    with pytest.raises(CheckError):
+        assert check.two_dim_list_param([[1, 2], [2, 3, 4]], "something")
 
 
 def test_list_elem():
@@ -885,6 +934,57 @@ def test_opt_list_elem():
         check.opt_list_elem(ddict, "listkey", of_type=int)
 
 
+# ########################
+# ##### MAPPING
+# ########################
+
+
+class SimpleMapping(collections.abc.Mapping):
+    def __init__(self, **kwargs):
+        self._dict = dict()
+        for key, value in kwargs.items():
+            self._dict[key] = value
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+
+MAPPING_TEST_CASES = DICT_TEST_CASES + [
+    (dict(obj=SimpleMapping(x=1), key_type=str, value_type=int), True),
+]
+
+
+@pytest.mark.parametrize("kwargs, should_succeed", MAPPING_TEST_CASES)
+def test_mapping_param(kwargs, should_succeed):
+    if should_succeed:
+        assert check.mapping_param(**kwargs, param_name="name") == kwargs["obj"]
+    else:
+        with pytest.raises(CheckError):
+            check.mapping_param(**kwargs, param_name="name")
+
+
+def test_opt_mapping_param():
+    mapping = SimpleMapping(x=1)
+    assert check.opt_mapping_param(mapping, param_name="name") == mapping
+    assert check.opt_mapping_param(mapping, param_name="name", key_type=str) == mapping
+    assert check.opt_mapping_param(mapping, param_name="name", value_type=int) == mapping
+    assert check.opt_mapping_param(None, param_name="name") == dict()
+
+    with pytest.raises(CheckError):
+        check.opt_mapping_param("foo", param_name="name")  # type: ignore
+
+
+# ########################
+# ##### NOT NONE
+# ########################
+
+
 def test_not_none_param():
     assert check.not_none_param(1, "fine")
     check.not_none_param(0, "zero is fine")
@@ -894,22 +994,201 @@ def test_not_none_param():
         check.not_none_param(None, "none fails")
 
 
-def test_is_callable():
-    def fn():
-        pass
+# ########################
+# ##### PATH
+# ########################
 
-    assert check.is_callable(fn) == fn
-    assert check.is_callable(lambda: None)
-    assert check.is_callable(lambda: None, "some desc")
+
+def test_path_param():
+    from pathlib import Path
+
+    assert check.path_param("/a/b.csv", "path_param") == "/a/b.csv"
+    assert check.path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(None, "path_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.path_param(0, "path_param")
+
+
+def test_opt_path_param():
+    from pathlib import Path
+
+    assert check.opt_path_param("/a/b.csv", "path_param") == "/a/b.csv"
+    assert check.opt_path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
+    assert check.opt_path_param(None, "path_param") is None
+    assert check.opt_path_param(None, "path_param", "/a/b/c.csv") == "/a/b/c.csv"
+    assert check.opt_path_param(None, "path_param", Path("/a/b/c.csv")) == "/a/b/c.csv"
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_path_param(0, "path_param")
+
+
+# ########################
+# ##### SET
+# ########################
+
+
+def test_set_param():
+    assert check.set_param(set(), "set_param") == set()
+    assert check.set_param(frozenset(), "set_param") == set()
+
+    with pytest.raises(ParameterCheckError):
+        check.set_param(None, "set_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.set_param("3u4", "set_param")
+
+    obj_set = {1}
+    assert check.set_param(obj_set, "set_param") == obj_set
+
+    obj_set_two = {1, 1, 2}
+    obj_set_two_deduped = {1, 2}
+    assert check.set_param(obj_set_two, "set_param") == obj_set_two_deduped
+    assert check.set_param(obj_set_two, "set_param", of_type=int) == obj_set_two_deduped
+
+    with pytest.raises(CheckError, match="Did you pass a class"):
+        check.set_param({str}, "set_param", of_type=int)
+
+    with pytest.raises(CheckError, match="Member of set mismatches type"):
+        check.set_param({"foo"}, "set_param", of_type=int)
+
+
+def test_opt_set_param():
+    assert check.opt_set_param(None, "set_param") == set()
+    assert check.opt_set_param(set(), "set_param") == set()
+    assert check.opt_set_param(frozenset(), "set_param") == set()
+    assert check.opt_set_param({3}, "set_param") == {3}
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_set_param(0, "set_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_set_param("", "set_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_set_param("3u4", "set_param")
+
+
+# ########################
+# ##### SEQUENCE
+# ########################
+
+
+def test_sequence_param():
+    assert check.sequence_param([], "sequence_param") == []
+    assert check.sequence_param(tuple(), "sequence_param") == tuple()
+
+    assert check.sequence_param(["foo"], "sequence_param", of_type=str) == ["foo"]
+    assert check.sequence_param("foo", "sequence_param") == "foo"
+    assert check.sequence_param("foo", "sequence_param", of_type=str) == "foo"
+
+    with pytest.raises(ParameterCheckError):
+        check.sequence_param(None, "sequence_param")  # type: ignore
 
     with pytest.raises(CheckError):
-        check.is_callable(None)
+        check.sequence_param(1, "sequence_param", of_type=int)  # type: ignore
 
     with pytest.raises(CheckError):
-        check.is_callable(1)
+        check.sequence_param(["foo"], "sequence_param", of_type=int)
 
-    with pytest.raises(CheckError, match="some other desc"):
-        check.is_callable(1, "some other desc")
+
+def test_opt_sequence_param():
+
+    assert check.opt_sequence_param([], "sequence_param") == []
+    assert check.opt_sequence_param(tuple(), "sequence_param") == tuple()
+
+    assert check.opt_sequence_param(["foo"], "sequence_param", of_type=str) == ["foo"]
+    assert check.opt_sequence_param("foo", "sequence_param") == "foo"
+    assert check.opt_sequence_param("foo", "sequence_param", of_type=str) == "foo"
+
+    assert check.opt_sequence_param(None, "sequence_param") == tuple()
+
+    with pytest.raises(CheckError):
+        check.opt_sequence_param(1, "sequence_param", of_type=int)  # type: ignore
+
+    with pytest.raises(CheckError):
+        check.opt_sequence_param(["foo"], "sequence_param", of_type=int)
+
+
+# ########################
+# ##### STR
+# ########################
+
+
+def test_str_param():
+    assert check.str_param("a", "str_param") == "a"
+    assert check.str_param("", "str_param") == ""
+    assert check.str_param("a", "unicode_param") == "a"
+
+    with pytest.raises(ParameterCheckError):
+        check.str_param(None, "str_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.str_param(0, "str_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.str_param(1, "str_param")
+
+
+def test_opt_str_param():
+    assert check.opt_str_param("a", "str_param") == "a"
+    assert check.opt_str_param("", "str_param") == ""
+    assert check.opt_str_param("a", "unicode_param") == "a"
+    assert check.opt_str_param(None, "str_param") is None
+    assert check.opt_str_param(None, "str_param", "foo") == "foo"
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_str_param(0, "str_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_str_param(1, "str_param")
+
+
+def test_opt_nonempty_str_param():
+    assert check.opt_nonempty_str_param("a", "str_param") == "a"
+    assert check.opt_nonempty_str_param("", "str_param") is None
+    assert check.opt_nonempty_str_param("", "str_param", "foo") == "foo"
+    assert check.opt_nonempty_str_param("a", "unicode_param") == "a"
+    assert check.opt_nonempty_str_param(None, "str_param") is None
+    assert check.opt_nonempty_str_param(None, "str_param", "foo") == "foo"
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_nonempty_str_param(0, "str_param")
+
+    with pytest.raises(ParameterCheckError):
+        check.opt_nonempty_str_param(1, "str_param")
+
+
+def test_string_elem():
+    ddict = {"a_str": "a", "a_num": 1, "a_none": None}
+
+    assert check.str_elem(ddict, "a_str") == "a"
+
+    with pytest.raises(ElementCheckError):
+        assert check.str_elem(ddict, "a_none")
+
+    with pytest.raises(ElementCheckError):
+        check.str_elem(ddict, "a_num")
+
+
+def test_opt_string_elem():
+    ddict = {"a_str": "a", "a_num": 1, "a_none": None}
+
+    assert check.opt_str_elem(ddict, "a_str") == "a"
+
+    assert check.opt_str_elem(ddict, "a_none") == None
+
+    assert check.opt_str_elem(ddict, "nonexistentkey") == None
+
+    with pytest.raises(ElementCheckError):
+        check.opt_str_elem(ddict, "a_num")
+
+
+# ########################
+# ##### TUPLE
+# ########################
 
 
 def test_tuple_param():
@@ -955,28 +1234,6 @@ def test_tuple_param():
         check.is_tuple((3, 4), of_shape=(int, int), of_type=int)
 
 
-def test_two_dim_list_param():
-    assert check.two_dim_list_param([[1, 2], [2, 3]], "something")
-
-    with pytest.raises(CheckError):
-        assert check.two_dim_list_param(None, "something")
-
-    with pytest.raises(CheckError):
-        assert check.two_dim_list_param([1, 2, 4], "something")
-
-    with pytest.raises(CheckError):
-        assert check.two_dim_list_param([], "something")
-
-    with pytest.raises(CheckError):
-        assert check.two_dim_list_param([[1, 2], 3], "soemthing")
-
-    with pytest.raises(CheckError):
-        assert check.two_dim_list_param([[1, 2], [3.0, 4.1]], "something", of_type=int)
-
-    with pytest.raises(CheckError):
-        assert check.two_dim_list_param([[1, 2], [2, 3, 4]], "something")
-
-
 def test_opt_tuple_param():
     assert check.opt_tuple_param((1, 2), "something")
     assert check.opt_tuple_param(None, "something") is None
@@ -1019,227 +1276,112 @@ def test_opt_tuple_param():
         check.is_tuple((3, 4), of_shape=(int, int), of_type=int)
 
 
-def test_opt_class_param():
+def test_is_tuple():
+    assert check.is_tuple(()) == ()
+
+    with pytest.raises(CheckError):
+        check.is_tuple(None)
+
+    with pytest.raises(CheckError):
+        check.is_tuple("3u4")
+
+    with pytest.raises(CheckError, match="Did you pass a class"):
+        check.is_tuple((str,), of_type=int)
+
+
+def test_typed_is_tuple():
     class Foo:
         pass
 
-    assert check.opt_class_param(int, "foo")
-    assert check.opt_class_param(Foo, "foo")
-
-    assert check.opt_class_param(None, "foo") is None
-    assert check.opt_class_param(None, "foo", Foo) is Foo
-
-    with pytest.raises(CheckError):
-        check.opt_class_param(check, "foo")
-
-    with pytest.raises(CheckError):
-        check.opt_class_param(234, "foo")
-
-    with pytest.raises(CheckError):
-        check.opt_class_param("bar", "foo")
-
-    with pytest.raises(CheckError):
-        check.opt_class_param(Foo(), "foo")
-
-
-def test_class_param():
     class Bar:
         pass
 
-    assert check.class_param(int, "foo")
-    assert check.class_param(Bar, "foo")
+    assert check.is_tuple((), Foo) == ()
+    foo_tuple = (Foo(),)
+    assert check.is_tuple(foo_tuple, Foo) == foo_tuple
+    assert check.is_tuple(foo_tuple, (Foo, Bar))
 
     with pytest.raises(CheckError):
-        check.class_param(None, "foo")
+        check.is_tuple((Bar(),), Foo)
 
     with pytest.raises(CheckError):
-        check.class_param(check, "foo")
+        check.is_tuple((None,), Foo)
+
+    assert check.is_tuple((Foo(), Bar()), of_shape=(Foo, Bar))
 
     with pytest.raises(CheckError):
-        check.class_param(234, "foo")
+        check.is_tuple((Foo(),), of_shape=(Foo, Bar))
 
     with pytest.raises(CheckError):
-        check.class_param("bar", "foo")
+        check.is_tuple((Foo(), Foo()), of_shape=(Foo, Bar))
 
     with pytest.raises(CheckError):
-        check.class_param(Bar(), "foo")
-
-    class Super:
-        pass
-
-    class Sub(Super):
-        pass
-
-    class Alone:
-        pass
-
-    assert check.class_param(Sub, "foo", superclass=Super)
-
-    with pytest.raises(CheckError):
-        assert check.class_param(Alone, "foo", superclass=Super)
-
-    with pytest.raises(CheckError):
-        assert check.class_param("value", "foo", superclass=Super)
-
-    assert check.opt_class_param(Sub, "foo", superclass=Super)
-    assert check.opt_class_param(None, "foo", superclass=Super) is None
-
-    with pytest.raises(CheckError):
-        assert check.opt_class_param(Alone, "foo", superclass=Super)
-
-    with pytest.raises(CheckError):
-        assert check.opt_class_param("value", "foo", superclass=Super)
+        check.is_tuple((Foo(), Foo()), of_shape=(Foo, Foo), of_type=Foo)
 
 
-@contextmanager
-def raises_with_message(exc_type, message_text):
-    with pytest.raises(exc_type) as exc_info:
-        yield
-
-    assert str(exc_info.value) == message_text
+# ###################################################################################################
+# ##### OTHER CHECKS
+# ###################################################################################################
 
 
-def is_python_three():
-    return sys.version_info[0] >= 3
-
-
-def test_two_dim_dict():
-    assert check.two_dim_dict_param({}, "foo") == {}
-    assert check.two_dim_dict_param({"key": {}}, "foo")
-    assert check.two_dim_dict_param({"key": {"key2": 2}}, "foo")
-
-    # make sure default dict passes
-    default_dict = defaultdict(dict)
-    default_dict["key"]["key2"] = 2
-    assert check.two_dim_dict_param(default_dict, "foo")
-
-    with raises_with_message(
-        CheckError,
-        """Param "foo" is not a dict. Got None which is type <class 'NoneType'>."""
-        if is_python_three()
-        else """Param "foo" is not a dict. Got None which is type <type 'NoneType'>.""",
-    ):
-        check.two_dim_dict_param(None, "foo")
-
-    with raises_with_message(
-        CheckError,
-        "Value in dictionary mismatches expected type for key int_value. Expected value "
-        "of type <class 'dict'>. Got value 2 of type <class 'int'>."
-        if is_python_three()
-        else "Value in dictionary mismatches expected type for key int_value. Expected value "
-        "of type <type 'dict'>. Got value 2 of type <type 'int'>.",
-    ):
-        check.two_dim_dict_param({"int_value": 2}, "foo")
-
-    with raises_with_message(
-        CheckError,
-        "Value in dictionary mismatches expected type for key level_two_value_mismatch. "
-        "Expected value of type <class 'str'>. Got value 2 of type <class 'int'>."
-        if is_python_three()
-        else "Value in dictionary mismatches expected type for key level_two_value_mismatch. "
-        "Expected value of type (<type 'basestring'>,). Got value 2 of type <type 'int'>.",
-    ):
-        check.two_dim_dict_param(
-            {"level_one_key": {"level_two_value_mismatch": 2}}, "foo", value_type=str
-        )
-
-    with raises_with_message(
-        CheckError,
-        "Key in dictionary mismatches type. Expected <class 'int'>. Got 'key'"
-        if is_python_three()
-        else "Key in dictionary mismatches type. Expected <type 'int'>. Got 'key'",
-    ):
-        assert check.two_dim_dict_param({"key": {}}, "foo", key_type=int)
-
-    with raises_with_message(
-        CheckError,
-        "Key in dictionary mismatches type. Expected <class 'int'>. Got 'level_two_key'"
-        if is_python_three()
-        else "Key in dictionary mismatches type. Expected <type 'int'>. Got 'level_two_key'",
-    ):
-        assert check.two_dim_dict_param({1: {"level_two_key": "something"}}, "foo", key_type=int)
-
-
-def test_opt_two_dim_dict_parm():
-    assert check.opt_two_dim_dict_param({}, "foo") == {}
-    assert check.opt_two_dim_dict_param({"key": {}}, "foo")
-    assert check.opt_two_dim_dict_param({"key": {"key2": 2}}, "foo")
-    assert check.opt_two_dim_dict_param(None, "foo") == {}
-
-    with pytest.raises(CheckError):
-        assert check.opt_two_dim_dict_param("str", "foo")
-
-
-def test_generator_param():
-    def _test_gen():
-        yield 1
-
-    assert check.generator_param(_test_gen(), "gen")
-
-    gen = _test_gen()
-    assert check.generator(gen)
-    assert list(gen) == [1]
-    assert check.generator(gen)
-    assert list(gen) == []
+def test_param_invariant():
+    check.param_invariant(True, "some_param")
+    num_to_check = 1
+    check.param_invariant(num_to_check == 1, "some_param")
 
     with pytest.raises(ParameterCheckError):
-        assert check.generator_param(list(gen), "gen")
+        check.param_invariant(num_to_check == 2, "some_param")
 
     with pytest.raises(ParameterCheckError):
-        assert check.generator_param(None, "gen")
+        check.param_invariant(False, "some_param")
 
     with pytest.raises(ParameterCheckError):
-        assert check.generator_param(_test_gen, "gen")
+        check.param_invariant(0, "some_param")
 
-
-def test_opt_generator_param():
-    def _test_gen():
-        yield 1
-
-    assert check.opt_generator_param(_test_gen(), "gen")
-
-    assert check.opt_generator_param(None, "gen") is None
+    check.param_invariant(1, "some_param")
 
     with pytest.raises(ParameterCheckError):
-        assert check.opt_generator_param(_test_gen, "gen")
+        check.param_invariant("", "some_param")
 
-
-def test_generator():
-    def _test_gen():
-        yield 1
-
-    assert check.generator(_test_gen())
-
-    gen = _test_gen()
-    assert check.generator(gen)
+    check.param_invariant("1kjkjsf", "some_param")
 
     with pytest.raises(ParameterCheckError):
-        assert check.generator(list(gen))
+        check.param_invariant({}, "some_param")
+
+    check.param_invariant({234: "1kjkjsf"}, "some_param")
 
     with pytest.raises(ParameterCheckError):
-        assert check.generator(None)
+        check.param_invariant([], "some_param")
 
-    with pytest.raises(ParameterCheckError):
-        assert check.generator(_test_gen)
-
-
-def test_opt_generator():
-    def _test_gen():
-        yield 1
-
-    assert check.opt_generator(_test_gen())
-
-    gen = _test_gen()
-    assert check.opt_generator(gen)
-    assert check.opt_generator(None) is None
-
-    with pytest.raises(ParameterCheckError):
-        assert check.opt_generator(list(gen))
-
-    with pytest.raises(ParameterCheckError):
-        assert check.opt_generator(_test_gen)
+    check.param_invariant([234], "some_param")
 
 
-def test_internals():
+def test_invariant():
+    assert check.invariant(True)
+
     with pytest.raises(CheckError):
-        check._check_key_value_types(None, str, str)  # pylint: disable=protected-access
+        check.invariant(False)
+
+    with pytest.raises(CheckError, match="Some Unique String"):
+        check.invariant(False, "Some Unique String")
+
+    empty_list = []
+
+    with pytest.raises(CheckError, match="Invariant failed"):
+        check.invariant(empty_list)
+
+
+def test_failed():
+    with pytest.raises(CheckError, match="some desc"):
+        check.failed("some desc")
+
+    with pytest.raises(CheckError, match="must be a string"):
+        check.failed(0)  # type: ignore
+
+
+def test_not_implemented():
+    with pytest.raises(NotImplementedCheckError, match="some string"):
+        check.not_implemented("some string")
+
+    with pytest.raises(CheckError, match="desc argument must be a string"):
+        check.not_implemented(None)  # type: ignore

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1111,22 +1111,24 @@ def test_opt_sequence_param():
     with pytest.raises(CheckError):
         check.opt_sequence_param(["foo"], "sequence_param", of_type=int)
 
+
 def test_opt_nullable_sequence_param():
 
     assert check.opt_nullable_sequence_param([], "sequence_param") == []
     assert check.opt_nullable_sequence_param(tuple(), "sequence_param") == tuple()
 
     assert check.opt_nullable_sequence_param(["foo"], "sequence_param", of_type=str) == ["foo"]
-    assert check.opt_nullable_sequence_param("foo", "sequence_param") == 'foo'
-    assert check.opt_nullable_sequence_param("foo", "sequence_param", of_type=str) == 'foo'
+    assert check.opt_nullable_sequence_param("foo", "sequence_param") == "foo"
+    assert check.opt_nullable_sequence_param("foo", "sequence_param", of_type=str) == "foo"
 
     assert check.opt_nullable_sequence_param(None, "sequence_param") == None
 
     with pytest.raises(CheckError):
-        check.opt_nullable_sequence_param(1, "sequence_param", of_type=int)   # type: ignore
+        check.opt_nullable_sequence_param(1, "sequence_param", of_type=int)  # type: ignore
 
     with pytest.raises(CheckError):
         check.opt_nullable_sequence_param(["foo"], "sequence_param", of_type=int)
+
 
 # ########################
 # ##### STR

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1111,6 +1111,22 @@ def test_opt_sequence_param():
     with pytest.raises(CheckError):
         check.opt_sequence_param(["foo"], "sequence_param", of_type=int)
 
+def test_opt_nullable_sequence_param():
+
+    assert check.opt_nullable_sequence_param([], "sequence_param") == []
+    assert check.opt_nullable_sequence_param(tuple(), "sequence_param") == tuple()
+
+    assert check.opt_nullable_sequence_param(["foo"], "sequence_param", of_type=str) == ["foo"]
+    assert check.opt_nullable_sequence_param("foo", "sequence_param") == 'foo'
+    assert check.opt_nullable_sequence_param("foo", "sequence_param", of_type=str) == 'foo'
+
+    assert check.opt_nullable_sequence_param(None, "sequence_param") == None
+
+    with pytest.raises(CheckError):
+        check.opt_nullable_sequence_param(1, "sequence_param", of_type=int)   # type: ignore
+
+    with pytest.raises(CheckError):
+        check.opt_nullable_sequence_param(["foo"], "sequence_param", of_type=int)
 
 # ########################
 # ##### STR


### PR DESCRIPTION
Adds sequence and mapping functions to `check`. If we are going to use `Sequence`/`Mapping` in type annotations, then the corresponding runtime checks should look for `Sequence`/`Mapping` instead of `list`/`dict`. Otherwise the caller might reasonably pass a tuple etc for a sequence and have it rejected by the runtime list check.
