### PR TITLE
[dagit] Add error handling to Asset "Rematerialize Partitions" modal

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetJobPartitionSetsQuery.ts
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/types/AssetJobPartitionSetsQuery.ts
@@ -8,7 +8,12 @@
 // ====================================================
 
 export interface AssetJobPartitionSetsQuery_partitionSetsOrError_PipelineNotFoundError {
-  __typename: "PipelineNotFoundError" | "PythonError";
+  __typename: "PipelineNotFoundError";
+}
+
+export interface AssetJobPartitionSetsQuery_partitionSetsOrError_PythonError {
+  __typename: "PythonError";
+  message: string;
 }
 
 export interface AssetJobPartitionSetsQuery_partitionSetsOrError_PartitionSets_results {
@@ -24,7 +29,7 @@ export interface AssetJobPartitionSetsQuery_partitionSetsOrError_PartitionSets {
   results: AssetJobPartitionSetsQuery_partitionSetsOrError_PartitionSets_results[];
 }
 
-export type AssetJobPartitionSetsQuery_partitionSetsOrError = AssetJobPartitionSetsQuery_partitionSetsOrError_PipelineNotFoundError | AssetJobPartitionSetsQuery_partitionSetsOrError_PartitionSets;
+export type AssetJobPartitionSetsQuery_partitionSetsOrError = AssetJobPartitionSetsQuery_partitionSetsOrError_PipelineNotFoundError | AssetJobPartitionSetsQuery_partitionSetsOrError_PythonError | AssetJobPartitionSetsQuery_partitionSetsOrError_PartitionSets;
 
 export interface AssetJobPartitionSetsQuery {
   partitionSetsOrError: AssetJobPartitionSetsQuery_partitionSetsOrError;


### PR DESCRIPTION

## Summary
Hey gang! This should address the client-side portion of the issue in #6953. We weren't handling errors scaffolding config when launching single-partition asset rematerializations. Rather than displaying the error, Dagit would just launch the run without any configuration.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.