### PR TITLE
Stop building duplicate downstream asset dependencies (#7001)

### DIFF
--- a/python_modules/dagster/dagster/core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/core/host_representation/external_data.py
@@ -768,7 +768,7 @@ def external_asset_graph_from_defs(
     ] = defaultdict(list)
 
     deps: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependency]] = defaultdict(dict)
-    dep_by: Dict[AssetKey, List[ExternalAssetDependedBy]] = defaultdict(list)
+    dep_by: Dict[AssetKey, Dict[AssetKey, ExternalAssetDependedBy]] = defaultdict(dict)
     all_upstream_asset_keys: Set[AssetKey] = set()
 
     for pipeline in pipelines:
@@ -808,12 +808,10 @@ def external_asset_graph_from_defs(
                         input_name=input_name_by_asset_key.get(upstream_asset_key),
                         output_name=output_name_by_asset_key.get(upstream_asset_key),
                     )
-                    dep_by[upstream_asset_key].append(
-                        ExternalAssetDependedBy(
-                            downstream_asset_key=output_asset_key,
-                            input_name=input_name_by_asset_key.get(upstream_asset_key),
-                            output_name=output_name_by_asset_key.get(upstream_asset_key),
-                        )
+                    dep_by[upstream_asset_key][output_asset_key] = ExternalAssetDependedBy(
+                        downstream_asset_key=output_asset_key,
+                        input_name=input_name_by_asset_key.get(upstream_asset_key),
+                        output_name=output_name_by_asset_key.get(upstream_asset_key),
                     )
     asset_keys_without_definitions = all_upstream_asset_keys.difference(
         node_defs_by_asset_key.keys()
@@ -823,7 +821,7 @@ def external_asset_graph_from_defs(
         ExternalAssetNode(
             asset_key=asset_key,
             dependencies=list(deps[asset_key].values()),
-            depended_by=dep_by[asset_key],
+            depended_by=list(dep_by[asset_key].values()),
             job_names=[],
         )
         for asset_key in asset_keys_without_definitions
@@ -840,7 +838,7 @@ def external_asset_graph_from_defs(
             ExternalAssetNode(
                 asset_key=source_asset.key,
                 dependencies=list(deps[source_asset.key].values()),
-                depended_by=dep_by[source_asset.key],
+                depended_by=list(dep_by[source_asset.key].values()),
                 job_names=[],
                 op_description=source_asset.description,
             )
@@ -873,7 +871,7 @@ def external_asset_graph_from_defs(
             ExternalAssetNode(
                 asset_key=asset_key,
                 dependencies=list(deps[asset_key].values()),
-                depended_by=dep_by[asset_key],
+                depended_by=list(dep_by[asset_key].values()),
                 op_name=node_def.name,
                 op_description=node_def.description,
                 job_names=job_names,

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dagster import AssetKey, DagsterInvariantViolationError, Out
+from dagster import AssetGroup, AssetKey, DagsterInvariantViolationError, Out
 from dagster.check import CheckError
 from dagster.core.asset_defs import AssetIn, SourceAsset, asset, build_assets_job, multi_asset
 from dagster.core.host_representation.external_data import (
@@ -72,6 +72,59 @@ def test_two_asset_job():
             op_name="asset2",
             op_description=None,
             job_names=["assets_job"],
+            output_name="result",
+            output_description=None,
+        ),
+    ]
+
+
+def test_two_asset_job_with_group():
+    @asset
+    def asset1():
+        return 1
+
+    @asset
+    def asset2(asset1):
+        assert asset1 == 1
+
+    asset_group = AssetGroup(assets=[asset1, asset2])
+    asset_group_job = build_assets_job(
+        asset_group.all_assets_job_name(),
+        assets=asset_group.assets,
+        source_assets=asset_group.source_assets,
+        resource_defs=asset_group.resource_defs,
+        executor_def=asset_group.executor_def,
+    )
+    assets_job = asset_group.build_job(name="assets_job")
+
+    external_asset_nodes = external_asset_graph_from_defs(
+        [asset_group_job, assets_job], source_assets_by_key={}
+    )
+
+    assert external_asset_nodes == [
+        ExternalAssetNode(
+            asset_key=AssetKey("asset1"),
+            dependencies=[],
+            depended_by=[
+                ExternalAssetDependedBy(
+                    downstream_asset_key=AssetKey("asset2"), input_name="asset1"
+                )
+            ],
+            op_name="asset1",
+            op_description=None,
+            job_names=[AssetGroup.all_assets_job_name(), "assets_job"],
+            output_name="result",
+            output_description=None,
+        ),
+        ExternalAssetNode(
+            asset_key=AssetKey("asset2"),
+            dependencies=[
+                ExternalAssetDependency(upstream_asset_key=AssetKey("asset1"), input_name="asset1")
+            ],
+            depended_by=[],
+            op_name="asset2",
+            op_description=None,
+            job_names=[AssetGroup.all_assets_job_name(), "assets_job"],
             output_name="result",
             output_description=None,
         ),


### PR DESCRIPTION
## Summary
Resolves https://github.com/dagster-io/dagster/issues/7001

Per git blame, it looks like I'm the one that converted dep_by from a dict to a list (https://github.com/dagster-io/dagster/commit/18d1e41c0e06e0e8a314976e6658fdcdb88925c4). Instead of making it a list, I think that I should have fixed this code to key off the depended-by node name instead of the output name.



## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.