### PR TITLE
[dagit] When materializing assets, link to run instead of showing it

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Box,
   ButtonWIP,
-  ButtonLink,
   ColorsWIP,
   CursorPaginationControls,
   Group,
@@ -203,24 +202,16 @@ const BackfillTable = ({backfills, refetch}: {backfills: Backfill[]; refetch: ()
     } else {
       const error = data.resumePartitionBackfill;
       SharedToaster.show({
-        message: (
-          <Group direction="column" spacing={4}>
-            <div>An unexpected error occurred. This backfill was not retried.</div>
-            <ButtonLink
-              color={ColorsWIP.White}
-              underline="always"
-              onClick={() => {
-                showCustomAlert({
-                  body: <PythonErrorInfo error={error} />,
-                });
-              }}
-            >
-              View error
-            </ButtonLink>
-          </Group>
-        ),
+        message: <div>An unexpected error occurred. This backfill was not retried.</div>,
         icon: 'error',
         intent: 'danger',
+        action: {
+          text: 'View error',
+          onClick: () =>
+            showCustomAlert({
+              body: <PythonErrorInfo error={error} />,
+            }),
+        },
       });
     }
   };

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -1,8 +1,8 @@
 import {useMutation} from '@apollo/client';
 import * as React from 'react';
+import {useHistory} from 'react-router';
 
 import {IconName} from '../../../ui/src';
-import {AppContext} from '../app/AppContext';
 import {DISABLED_MESSAGE, usePermissions} from '../app/Permissions';
 import {TelemetryAction, useTelemetryAction} from '../app/Telemetry';
 import {LAUNCH_PIPELINE_EXECUTION_MUTATION, handleLaunchResult} from '../runs/RunUtils';
@@ -17,6 +17,7 @@ import {showLaunchError} from './showLaunchError';
 interface LaunchRootExecutionButtonProps {
   disabled: boolean;
   getVariables: () => undefined | LaunchPipelineExecutionVariables;
+  behavior: 'open' | 'open-in-new-tab' | 'toast';
   pipelineName: string;
   title?: string;
   icon?: IconName;
@@ -27,8 +28,8 @@ export const LaunchRootExecutionButton: React.FC<LaunchRootExecutionButtonProps>
   const [launchPipelineExecution] = useMutation<LaunchPipelineExecution>(
     LAUNCH_PIPELINE_EXECUTION_MUTATION,
   );
-  const {basePath} = React.useContext(AppContext);
   const logTelemetry = useTelemetryAction();
+  const history = useHistory();
 
   const onLaunch = async () => {
     const variables = props.getVariables();
@@ -47,7 +48,7 @@ export const LaunchRootExecutionButton: React.FC<LaunchRootExecutionButtonProps>
     try {
       const result = await launchPipelineExecution({variables});
       logTelemetry(TelemetryAction.LAUNCH_RUN, metadata);
-      handleLaunchResult(basePath, props.pipelineName, result, {});
+      handleLaunchResult(props.pipelineName, result, history, {behavior: props.behavior});
     } catch (error) {
       showLaunchError(error as Error);
     }

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSessionContainer.tsx
@@ -677,6 +677,7 @@ const LaunchpadSessionContainer: React.FC<LaunchpadSessionContainerProps> = (pro
           pipelineName={pipeline.name}
           getVariables={buildExecutionVariables}
           disabled={preview?.isPipelineConfigValid?.__typename !== 'PipelineConfigValidationValid'}
+          behavior="open"
         />
       </div>
     </>

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -13,9 +13,11 @@ import {
   NonIdealState,
   Spinner,
   Tooltip,
+  Mono,
 } from '@dagster-io/ui';
+import {History} from 'history';
 import * as React from 'react';
-import styled from 'styled-components/macro';
+import {useHistory} from 'react-router';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {SharedToaster} from '../app/DomUtils';
@@ -69,6 +71,7 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
   onSubmit: () => void;
   repoAddress: RepoAddress;
 }> = ({partitionSetName, pipelineName, onLaunch, onCancel, onSubmit, repoAddress}) => {
+  const history = useHistory();
   const repositorySelector = repoAddressToSelector(repoAddress);
   const [currentSelectionRange, setCurrentSelectionRange] = React.useState<
     SelectionRange | undefined
@@ -196,24 +199,12 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
   }
 
   const onSuccess = (backfillId: string) => {
-    SharedToaster.show({
-      message: (
-        <div>
-          Created backfill job:{' '}
-          <FilteredRunsLink href="/instance/backfills">{backfillId}</FilteredRunsLink>
-        </div>
-      ),
-      intent: 'success',
-    });
+    showBackfillSuccessToast(history, backfillId);
     onLaunch?.(backfillId, query);
   };
 
   const onError = (data: LaunchPartitionBackfill | null | undefined) => {
-    SharedToaster.show({
-      message: messageForLaunchBackfillError(data),
-      icon: 'error',
-      intent: 'danger',
-    });
+    showBackfillErrorToast(data);
   };
 
   const {
@@ -632,10 +623,6 @@ const LaunchBackfillButton: React.FC<{
   );
 };
 
-const FilteredRunsLink = styled.a`
-  text-decoration: underline;
-`;
-
 const PARTITIONS_BACKFILL_SELECTOR_QUERY = gql`
   query PartitionsBackfillSelectorQuery(
     $partitionSetName: String!
@@ -792,7 +779,7 @@ export const LAUNCH_PARTITION_BACKFILL_MUTATION = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
-export function messageForLaunchBackfillError(data: LaunchPartitionBackfill | null | undefined) {
+function messageForLaunchBackfillError(data: LaunchPartitionBackfill | null | undefined) {
   const result = data?.launchPartitionBackfill;
 
   let errors = <></>;
@@ -830,6 +817,29 @@ export function messageForLaunchBackfillError(data: LaunchPartitionBackfill | nu
       ) : null}
     </Group>
   );
+}
+
+export function showBackfillErrorToast(data: LaunchPartitionBackfill | null | undefined) {
+  SharedToaster.show({
+    message: messageForLaunchBackfillError(data),
+    icon: 'error',
+    intent: 'danger',
+  });
+}
+
+export function showBackfillSuccessToast(history: History<unknown>, backfillId: string) {
+  SharedToaster.show({
+    intent: 'success',
+    message: (
+      <div>
+        Created backfill <Mono>{backfillId}</Mono>
+      </div>
+    ),
+    action: {
+      text: 'View',
+      onClick: () => history.push(`/instance/backfills`),
+    },
+  });
 }
 
 const DaemonNotRunningAlert: React.FC = () => (

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from '@dagster-io/ui';
 import qs from 'qs';
 import * as React from 'react';
+import {useHistory} from 'react-router-dom';
 import * as yaml from 'yaml';
 
 import {AppContext} from '../app/AppContext';
@@ -42,8 +43,9 @@ export const RunActionsMenu: React.FC<{
   const {refetch} = React.useContext(RunsQueryRefetchContext);
   const [visibleDialog, setVisibleDialog] = React.useState<'none' | 'terminate' | 'delete'>('none');
 
-  const {basePath, rootServerURI} = React.useContext(AppContext);
+  const {rootServerURI} = React.useContext(AppContext);
   const {canTerminatePipelineExecution, canDeletePipelineRun} = usePermissions();
+  const history = useHistory();
 
   const [reexecute] = useMutation<LaunchPipelineReexecution>(LAUNCH_PIPELINE_REEXECUTION_MUTATION, {
     onCompleted: refetch,
@@ -144,7 +146,9 @@ export const RunActionsMenu: React.FC<{
                           repositoryName: repoMatch.match.repository.name,
                         }),
                       });
-                      handleLaunchResult(basePath, run.pipelineName, result, {});
+                      handleLaunchResult(run.pipelineName, result, history, {
+                        behavior: 'open',
+                      });
                     }
                   }}
                 />

--- a/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
@@ -1,8 +1,7 @@
 import {useMutation} from '@apollo/client';
 import * as React from 'react';
-import {useLocation} from 'react-router';
+import {useHistory} from 'react-router';
 
-import {AppContext} from '../app/AppContext';
 import {showLaunchError} from '../launchpad/showLaunchError';
 import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
 
@@ -19,13 +18,12 @@ import {
 import {RunFragment} from './types/RunFragment';
 
 export const useJobReExecution = (run: RunFragment | undefined | null) => {
-  const {basePath} = React.useContext(AppContext);
+  const history = useHistory();
   const [launchPipelineReexecution] = useMutation<
     LaunchPipelineReexecution,
     LaunchPipelineReexecutionVariables
   >(LAUNCH_PIPELINE_REEXECUTION_MUTATION);
   const repoMatch = useRepositoryForRun(run);
-  const location = useLocation();
 
   return React.useCallback(
     async (style: ReExecutionStyle) => {
@@ -42,13 +40,14 @@ export const useJobReExecution = (run: RunFragment | undefined | null) => {
 
       try {
         const result = await launchPipelineReexecution({variables});
-        handleLaunchResult(basePath, run.pipelineName, result, {
-          querystring: location.search,
+        handleLaunchResult(run.pipelineName, result, history, {
+          preserveQuerystring: true,
+          behavior: 'open',
         });
       } catch (error) {
         showLaunchError(error as Error);
       }
     },
-    [basePath, launchPipelineReexecution, repoMatch, run, location.search],
+    [history, launchPipelineReexecution, repoMatch, run],
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -89,6 +89,7 @@ export const LaunchAssetExecutionButton: React.FC<{
           disabled={!!disabledReason}
           title={title}
           icon="materialization"
+          behavior="toast"
           getVariables={() => ({
             executionParams: {
               mode: 'default',

--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/useLaunchSingleAssetJob.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/useLaunchSingleAssetJob.tsx
@@ -1,7 +1,7 @@
 import {useMutation} from '@apollo/client';
 import React from 'react';
+import {useHistory} from 'react-router';
 
-import {AppContext} from '../../app/AppContext';
 import {showLaunchError} from '../../launchpad/showLaunchError';
 import {LAUNCH_PIPELINE_EXECUTION_MUTATION, handleLaunchResult} from '../../runs/RunUtils';
 import {LaunchPipelineExecution} from '../../runs/types/LaunchPipelineExecution';
@@ -9,7 +9,7 @@ import {repoAddressToSelector} from '../repoAddressToSelector';
 import {RepoAddress} from '../types';
 
 export const useLaunchSingleAssetJob = () => {
-  const {basePath} = React.useContext(AppContext);
+  const history = useHistory();
   const [launchPipelineExecution] = useMutation<LaunchPipelineExecution>(
     LAUNCH_PIPELINE_EXECUTION_MUTATION,
   );
@@ -30,13 +30,11 @@ export const useLaunchSingleAssetJob = () => {
             },
           },
         });
-        handleLaunchResult(basePath, jobName, result, {
-          openInTab: true,
-        });
+        handleLaunchResult(jobName, result, history, {behavior: 'toast'});
       } catch (error) {
         showLaunchError(error as Error);
       }
     },
-    [basePath, launchPipelineExecution],
+    [history, launchPipelineExecution],
   );
 };


### PR DESCRIPTION
## Summary
https://github.com/dagster-io/dagster/issues/6974

This changes the behavior of the "Materialize" button shown in the global asset graph, asset details page, and asset job page. When you launch a run or a backfill, we show a Toast with a link to view it rather than jumping directly to the page.

I also realized when I was working on this that we were displaying links within toasts a bit inconsistently. There's actually support for a minimal link-button built into the toast component, so I switched callsites rendering their own button to use that.

![image](https://user-images.githubusercontent.com/1037212/157772899-69c28219-a7f2-4492-9ace-2e736248c7e7.png)

(Hover state provided by the component - same as the X, which I think is nice)

![image](https://user-images.githubusercontent.com/1037212/157772933-c0c0dddf-70f2-47cc-9892-194e35ed95e9.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.