### PR TITLE
add ipython_genutils as dagit, dagstermill dep

### DIFF
--- a/docs/docs-build-requirements.txt
+++ b/docs/docs-build-requirements.txt
@@ -16,3 +16,4 @@ google-api-python-client<2.0.0
 google-cloud-storage
 paramiko
 papermill>=1.0.0
+ipython_genutils>=0.2.0

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -1,4 +1,6 @@
 # pins for recently released packages that cause problems in older dagster versions
 markupsafe<=2.0.1
 grpcio-health-checking<1.44.0
-mako<1.2.0  # 1.2.0+ drops ipython_genutils that we were implicitly dependent on
+
+# We implicitly depended on this in older versions.
+ipython_genutils>=0.2.0

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -1,3 +1,4 @@
 # pins for recently released packages that cause problems in older dagster versions
 markupsafe<=2.0.1
 grpcio-health-checking<1.44.0
+mako<1.2.0  # 1.2.0+ drops ipython_genutils that we were implicitly dependent on

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -47,6 +47,12 @@ if __name__ == "__main__":
             "click>=7.0,<9.0",
             f"dagster{pin}",
             f"dagster-graphql{pin}",
+            # See: https://github.com/mu-editor/mu/pull/1844
+            # ipykernel<6 depends on ipython_genutils, but it isn't explicitly
+            # declared as a dependency. It also depends on traitlets, which
+            # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
+            # a workaround we need to manually specify it here
+            "ipython_genutils>=0.2.0",
             "requests",
             # watchdog
             "watchdog>=0.8.3",

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -38,15 +38,15 @@ if __name__ == "__main__":
             # https://github.com/nteract/papermill/issues/519,
             # https://github.com/ipython/ipykernel/issues/568
             "ipykernel>=4.9.0,!=5.4.0,!=5.4.1",
-            "scrapbook>=0.5.0",
-            "packaging>=20.5",
-            "papermill>=1.0.0",
             # See: https://github.com/mu-editor/mu/pull/1844
             # ipykernel<6 depends on ipython_genutils, but it isn't explicitly
             # declared as a dependency. It also depends on traitlets, which
             # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
             # a workaround we need to manually specify it here
             "ipython_genutils>=0.2.0",
+            "packaging>=20.5",
+            "papermill>=1.0.0",
+            "scrapbook>=0.5.0",
         ],
         extras_require={
             "test": [

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -41,6 +41,12 @@ if __name__ == "__main__":
             "scrapbook>=0.5.0",
             "packaging>=20.5",
             "papermill>=1.0.0",
+            # See: https://github.com/mu-editor/mu/pull/1844
+            # ipykernel<6 depends on ipython_genutils, but it isn't explicitly
+            # declared as a dependency. It also depends on traitlets, which
+            # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
+            # a workaround we need to manually specify it here
+            "ipython_genutils>=0.2.0",
         ],
         extras_require={
             "test": [


### PR DESCRIPTION
Some recent release of a Jupyter-related package appears to have dropped `ipython_genutils` as a dep. This was an implicit dep of `nbconvert` (which `dagit` depends on) as well as some of the other direct dependencies of dagstermill. Consequently any BK step that relies on dagstermill is failing because it is missing this package.
