### PR TITLE
change backcompat pin to nbconvert

### DIFF
--- a/docs/docs-build-requirements.txt
+++ b/docs/docs-build-requirements.txt
@@ -16,4 +16,3 @@ google-api-python-client<2.0.0
 google-cloud-storage
 paramiko
 papermill>=1.0.0
-ipython_genutils>=0.2.0

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -2,5 +2,6 @@
 markupsafe<=2.0.1
 grpcio-health-checking<1.44.0
 
-# We implicitly depended on this in older versions.
-ipython_genutils>=0.2.0
+# 5.2+ stops pulling in `ipython_genutils`, on which the old version of `nbconvert` we use
+# implicitly depends.
+nbformat<=5.1.3

--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -3,5 +3,5 @@ markupsafe<=2.0.1
 grpcio-health-checking<1.44.0
 
 # 5.2+ stops pulling in `ipython_genutils`, on which the old version of `nbconvert` we use
-# implicitly depends.
+# implicitly depends. Can remove this pin when/if dagit cap on nbconvert is lifted.
 nbformat<=5.1.3

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -47,12 +47,10 @@ if __name__ == "__main__":
             "click>=7.0,<9.0",
             f"dagster{pin}",
             f"dagster-graphql{pin}",
-            # See: https://github.com/mu-editor/mu/pull/1844
-            # ipykernel<6 depends on ipython_genutils, but it isn't explicitly
-            # declared as a dependency. It also depends on traitlets, which
-            # incidentally brought ipython_genutils, but in v5.1 it was dropped, so as
-            # a workaround we need to manually specify it here
-            "ipython_genutils>=0.2.0",
+
+            # 5.2+ stops pulling in `ipython_genutils`, on which the old version of `nbconvert` we use
+            # implicitly depends. Can remove nbformat dependency entirely when/if cap on nbconvert is lifted.
+            "nbformat<=5.1.3",
             "requests",
             # watchdog
             "watchdog>=0.8.3",

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -47,7 +47,6 @@ if __name__ == "__main__":
             "click>=7.0,<9.0",
             f"dagster{pin}",
             f"dagster-graphql{pin}",
-
             # 5.2+ stops pulling in `ipython_genutils`, on which the old version of `nbconvert` we use
             # implicitly depends. Can remove nbformat dependency entirely when/if cap on nbconvert is lifted.
             "nbformat<=5.1.3",


### PR DESCRIPTION
Change backcompat pin to fix `ipython_genutils` error to pin `nbconvert` instead, which is the more proximal cause of the problem.
