### PR TITLE
Allow python objects to be passed as top-level inputs to job

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
@@ -1,5 +1,3 @@
-import re
-
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
 from .graphql_context_test_suite import NonLaunchableGraphQLContextTestMatrix

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_subset.py
@@ -70,10 +70,7 @@ class TestSolidSelections(NonLaunchableGraphQLContextTestMatrix):
         assert result.data
         assert result.data["runConfigSchemaOrError"]["__typename"] == "InvalidSubsetError"
 
-        assert re.match(
-            (
-                r".*DagsterInvalidSubsetError[\s\S]*"
-                r"add a dagster_type_loader for the type 'InputTypeWithoutHydration'"
-            ),
-            result.data["runConfigSchemaOrError"]["message"],
+        assert (
+            "Input 'some_input' of solid 'fail_subset' has no upstream output, no default value, and no dagster type loader"
+            in result.data["runConfigSchemaOrError"]["message"]
         )

--- a/python_modules/dagster/dagster/core/definitions/composition.py
+++ b/python_modules/dagster/dagster/core/definitions/composition.py
@@ -573,7 +573,7 @@ class PendingNodeInvocation:
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
-        input_values: Optional[Mapping[str, Any]] = None,
+        input_values: Optional[Mapping[str, object]] = None,
     ) -> "JobDefinition":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(
@@ -610,7 +610,7 @@ class PendingNodeInvocation:
         resources: Optional[Dict[str, Any]] = None,
         raise_on_error: bool = True,
         run_id: Optional[str] = None,
-        input_values: Optional[Mapping[str, Any]] = None,
+        input_values: Optional[Mapping[str, object]] = None,
     ) -> "ExecuteInProcessResult":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(

--- a/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
@@ -128,6 +128,8 @@ def job(
     hooks: Optional[AbstractSet[HookDefinition]] = ...,
     op_retry_policy: Optional[RetryPolicy] = ...,
     version_strategy: Optional[VersionStrategy] = ...,
+    partitions_def: Optional["PartitionsDefinition"] = ...,
+    input_values: Optional[Mapping[str, Any]] = ...,
 ) -> _Job:
     ...
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
@@ -42,7 +42,7 @@ class _Job:
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
-        input_values: Optional[Mapping[str, Any]] = None,
+        input_values: Optional[Mapping[str, object]] = None,
     ):
         self.name = name
         self.description = description
@@ -129,7 +129,7 @@ def job(
     op_retry_policy: Optional[RetryPolicy] = ...,
     version_strategy: Optional[VersionStrategy] = ...,
     partitions_def: Optional["PartitionsDefinition"] = ...,
-    input_values: Optional[Mapping[str, Any]] = ...,
+    input_values: Optional[Mapping[str, object]] = ...,
 ) -> _Job:
     ...
 
@@ -146,7 +146,7 @@ def job(
     op_retry_policy: Optional[RetryPolicy] = None,
     version_strategy: Optional[VersionStrategy] = None,
     partitions_def: Optional["PartitionsDefinition"] = None,
-    input_values: Optional[Mapping[str, Any]] = None,
+    input_values: Optional[Mapping[str, object]] = None,
 ) -> Union[JobDefinition, _Job]:
     """Creates a job with the specified parameters from the decorated graph/op invocation function.
 

--- a/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
@@ -195,6 +195,8 @@ def job(
         partitions_def (Optional[PartitionsDefinition]): Defines a discrete set of partition keys
             that can parameterize the job. If this argument is supplied, the config argument
             can't also be supplied.
+        input_values (Optional[Mapping[str, Any]]):
+            A dictionary that maps python objects to the top-level inputs of a job.
 
     """
     if callable(name):

--- a/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/core/definitions/decorators/job_decorator.py
@@ -1,5 +1,15 @@
 from functools import update_wrapper
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Dict, Optional, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Union,
+    overload,
+)
 
 from dagster import check
 from dagster.core.decorator_utils import format_docstring_for_description
@@ -32,6 +42,7 @@ class _Job:
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
+        input_values: Optional[Mapping[str, Any]] = None,
     ):
         self.name = name
         self.description = description
@@ -44,6 +55,7 @@ class _Job:
         self.op_retry_policy = op_retry_policy
         self.version_strategy = version_strategy
         self.partitions_def = partitions_def
+        self.input_values = input_values
 
     def __call__(self, fn: Callable[..., Any]) -> JobDefinition:
         check.callable_param(fn, "fn")
@@ -93,6 +105,7 @@ class _Job:
             op_retry_policy=self.op_retry_policy,
             version_strategy=self.version_strategy,
             partitions_def=self.partitions_def,
+            input_values=self.input_values,
         )
         update_wrapper(job_def, fn)
         return job_def
@@ -131,6 +144,7 @@ def job(
     op_retry_policy: Optional[RetryPolicy] = None,
     version_strategy: Optional[VersionStrategy] = None,
     partitions_def: Optional["PartitionsDefinition"] = None,
+    input_values: Optional[Mapping[str, Any]] = None,
 ) -> Union[JobDefinition, _Job]:
     """Creates a job with the specified parameters from the decorated graph/op invocation function.
 
@@ -197,4 +211,5 @@ def job(
         op_retry_policy=op_retry_policy,
         version_strategy=version_strategy,
         partitions_def=partitions_def,
+        input_values=input_values,
     )

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -7,6 +7,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Set,
     Tuple,
@@ -623,6 +624,7 @@ class GraphDefinition(NodeDefinition):
         raise_on_error: bool = True,
         op_selection: Optional[List[str]] = None,
         run_id: Optional[str] = None,
+        input_values: Optional[Mapping[str, Any]] = None,
     ) -> "ExecuteInProcessResult":
         """
         Execute this graph in-process, collecting results in-memory.

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -514,6 +514,8 @@ class GraphDefinition(NodeDefinition):
                 argument can't also be supplied.
             asset_layer (Optional[AssetLayer]): Top level information about the assets this job
                 will produce. Generally should not be set manually.
+            input_values (Optional[Mapping[str, Any]]):
+                A dictionary that maps python objects to the top-level inputs of a job.
 
         Returns:
             JobDefinition
@@ -651,6 +653,8 @@ class GraphDefinition(NodeDefinition):
                 (downstream dependencies) within 3 levels down.
                 * ``['*some_op', 'other_op_a', 'other_op_b+']``: select ``some_op`` and all its
                 ancestors, ``other_op_a`` itself, and ``other_op_b`` and its direct child ops.
+            input_values (Optional[Mapping[str, Any]]):
+                A dictionary that maps python objects to the top-level inputs of the graph.
 
         Returns:
             :py:class:`~dagster.ExecuteInProcessResult`

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -667,6 +667,7 @@ class GraphDefinition(NodeDefinition):
             graph_def=self,
             executor_def=execute_in_process_executor,
             resource_defs=resource_defs,
+            _input_values=input_values,
         ).get_job_def_for_op_selection(op_selection)
 
         run_config = run_config if run_config is not None else {}

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -463,6 +463,7 @@ class GraphDefinition(NodeDefinition):
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
         asset_layer: Optional["AssetLayer"] = None,
+        input_values: Optional[Mapping[str, Any]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -527,6 +528,7 @@ class GraphDefinition(NodeDefinition):
         executor_def = check.opt_inst_param(
             executor_def, "executor_def", ExecutorDefinition, default=multi_or_in_process_executor
         )
+        input_values = check.opt_mapping_param(input_values, "input_values")
 
         if resource_defs and "io_manager" in resource_defs:
             resource_defs_with_defaults = resource_defs
@@ -584,6 +586,7 @@ class GraphDefinition(NodeDefinition):
             version_strategy=version_strategy,
             op_retry_policy=op_retry_policy,
             asset_layer=asset_layer,
+            _input_values=input_values,
         ).get_job_def_for_op_selection(op_selection)
 
     def coerce_to_job(self):
@@ -661,6 +664,7 @@ class GraphDefinition(NodeDefinition):
 
         instance = check.opt_inst_param(instance, "instance", DagsterInstance)
         resources = check.opt_dict_param(resources, "resources", key_type=str)
+        input_values = check.opt_mapping_param(input_values, "input_values")
 
         resource_defs = wrap_resources_for_execution(resources)
 

--- a/python_modules/dagster/dagster/core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/graph_definition.py
@@ -463,7 +463,7 @@ class GraphDefinition(NodeDefinition):
         op_selection: Optional[List[str]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
         asset_layer: Optional["AssetLayer"] = None,
-        input_values: Optional[Mapping[str, Any]] = None,
+        input_values: Optional[Mapping[str, object]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.
@@ -629,7 +629,7 @@ class GraphDefinition(NodeDefinition):
         raise_on_error: bool = True,
         op_selection: Optional[List[str]] = None,
         run_id: Optional[str] = None,
-        input_values: Optional[Mapping[str, Any]] = None,
+        input_values: Optional[Mapping[str, object]] = None,
     ) -> "ExecuteInProcessResult":
         """
         Execute this graph in-process, collecting results in-memory.

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -74,6 +74,7 @@ class JobDefinition(PipelineDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
         asset_layer: Optional[AssetLayer] = None,
+        _input_values: Optional[Dict[str, Any]] = None,
     ):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
@@ -89,6 +90,7 @@ class JobDefinition(PipelineDefinition):
         self._op_selection_data = check.opt_inst_param(
             _op_selection_data, "_op_selection_data", OpSelectionData
         )
+        self._input_values = check.opt_dict_param(_input_values, "_input_values")
 
         super(JobDefinition, self).__init__(
             name=name,

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -74,7 +74,7 @@ class JobDefinition(PipelineDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
         asset_layer: Optional[AssetLayer] = None,
-        _input_values: Optional[Dict[str, Any]] = None,
+        _input_values: Optional[Mapping[str, Any]] = None,
     ):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
@@ -90,7 +90,7 @@ class JobDefinition(PipelineDefinition):
         self._op_selection_data = check.opt_inst_param(
             _op_selection_data, "_op_selection_data", OpSelectionData
         )
-        self._input_values = check.opt_dict_param(_input_values, "_input_values")
+        self._input_values = check.opt_mapping_param(_input_values, "_input_values")
 
         super(JobDefinition, self).__init__(
             name=name,

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -178,6 +178,8 @@ class JobDefinition(PipelineDefinition):
                 (downstream dependencies) within 3 levels down.
                 * ``['*some_op', 'other_op_a', 'other_op_b+']``: select ``some_op`` and all its
                 ancestors, ``other_op_a`` itself, and ``other_op_b`` and its direct child ops.
+            input_values (Optional[Mapping[str, Any]]):
+                A dictionary that maps python objects to the top-level inputs of the job. Input values provided here will override input values that have been provided to the job directly.
         Returns:
             :py:class:`~dagster.ExecuteInProcessResult`
 

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -98,6 +98,12 @@ class JobDefinition(PipelineDefinition):
         self._input_values: Mapping[str, Any] = check.opt_mapping_param(
             _input_values, "_input_values"
         )
+        for input_name in sorted(list(self._input_values.keys())):
+            if not graph_def.has_input(input_name):
+                job_name = name or graph_def.name
+                raise DagsterInvalidDefinitionError(
+                    f"Error when constructing JobDefinition '{job_name}': Input value provided for key '{input_name}', but job has no top-level input with that name."
+                )
 
         super(JobDefinition, self).__init__(
             name=name,

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -79,7 +79,7 @@ class JobDefinition(PipelineDefinition):
         version_strategy: Optional[VersionStrategy] = None,
         _op_selection_data: Optional[OpSelectionData] = None,
         asset_layer: Optional[AssetLayer] = None,
-        _input_values: Optional[Mapping[str, Any]] = None,
+        _input_values: Optional[Mapping[str, object]] = None,
     ):
 
         # Exists for backcompat - JobDefinition is implemented as a single-mode pipeline.
@@ -95,7 +95,7 @@ class JobDefinition(PipelineDefinition):
         self._op_selection_data = check.opt_inst_param(
             _op_selection_data, "_op_selection_data", OpSelectionData
         )
-        self._input_values: Mapping[str, Any] = check.opt_mapping_param(
+        self._input_values: Mapping[str, object] = check.opt_mapping_param(
             _input_values, "_input_values"
         )
         for input_name in sorted(list(self._input_values.keys())):
@@ -157,7 +157,7 @@ class JobDefinition(PipelineDefinition):
         raise_on_error: bool = True,
         op_selection: Optional[List[str]] = None,
         run_id: Optional[str] = None,
-        input_values: Optional[Mapping[str, Any]] = None,
+        input_values: Optional[Mapping[str, object]] = None,
     ) -> "ExecuteInProcessResult":
         """
         Execute the Job in-process, gathering results in-memory.
@@ -360,7 +360,7 @@ class JobDefinition(PipelineDefinition):
             else None
         )
 
-    def get_direct_input_value(self, input_name: str) -> Any:
+    def get_direct_input_value(self, input_name: str) -> object:
         if input_name not in self._input_values:
             raise DagsterInvalidInvocationError(
                 f"On job '{self.name}', attempted to retrieve input value for input named '{input_name}', but no value was provided. Provided input values: {sorted(list(self._input_values.keys()))}"

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -27,7 +27,11 @@ from dagster.core.definitions.dependency import (
 )
 from dagster.core.definitions.node_definition import NodeDefinition
 from dagster.core.definitions.policy import RetryPolicy
-from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
+from dagster.core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
+    DagsterInvalidSubsetError,
+)
 from dagster.core.selector.subset_selector import (
     LeafNodeSelection,
     OpSelectionData,
@@ -35,6 +39,7 @@ from dagster.core.selector.subset_selector import (
 )
 from dagster.core.storage.fs_asset_io_manager import fs_asset_io_manager
 from dagster.core.utils import str_format_set
+from dagster.utils import merge_dicts
 
 from .asset_layer import AssetLayer
 from .config import ConfigMapping
@@ -90,7 +95,9 @@ class JobDefinition(PipelineDefinition):
         self._op_selection_data = check.opt_inst_param(
             _op_selection_data, "_op_selection_data", OpSelectionData
         )
-        self._input_values = check.opt_mapping_param(_input_values, "_input_values")
+        self._input_values: Mapping[str, Any] = check.opt_mapping_param(
+            _input_values, "_input_values"
+        )
 
         super(JobDefinition, self).__init__(
             name=name,
@@ -144,6 +151,7 @@ class JobDefinition(PipelineDefinition):
         raise_on_error: bool = True,
         op_selection: Optional[List[str]] = None,
         run_id: Optional[str] = None,
+        input_values: Optional[Mapping[str, Any]] = None,
     ) -> "ExecuteInProcessResult":
         """
         Execute the Job in-process, gathering results in-memory.
@@ -180,6 +188,12 @@ class JobDefinition(PipelineDefinition):
         run_config = check.opt_dict_param(run_config, "run_config")
         op_selection = check.opt_list_param(op_selection, "op_selection", str)
         partition_key = check.opt_str_param(partition_key, "partition_key")
+        input_values = check.opt_mapping_param(input_values, "input_values")
+
+        # Combine provided input values at execute_in_process with input values
+        # provided to the definition. Input values provided at
+        # execute_in_process will override those provided on the definition.
+        input_values = merge_dicts(self._input_values, input_values)
 
         resource_defs = dict(self.resource_defs)
         logger_defs = dict(self.loggers)
@@ -196,6 +210,7 @@ class JobDefinition(PipelineDefinition):
             op_retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,
             asset_layer=self.asset_layer,
+            _input_values=input_values,
         ).get_job_def_for_op_selection(op_selection)
 
         tags = None
@@ -337,6 +352,13 @@ class JobDefinition(PipelineDefinition):
             else None
         )
 
+    def get_input_value(self, input_name: str) -> Any:
+        if input_name not in self._input_values:
+            raise DagsterInvalidInvocationError(
+                f"On job '{self.name}', attempted to retrieve input value for input named '{input_name}', but no value was provided. Provided input values: {sorted(list(self._input_values.keys()))}"
+            )
+        return self._input_values[input_name]
+
 
 def _swap_default_io_man(resources: Dict[str, ResourceDefinition], job: PipelineDefinition):
     """
@@ -472,7 +494,7 @@ def get_subselected_graph_definition(
         ) from exc
 
 
-def get_input_values_from_job(target: PipelineDefinition) -> Optional[Dict[str, Any]]:
+def get_input_values_from_job(target: PipelineDefinition) -> Optional[Mapping[str, Any]]:
     if target.is_job:
         return cast(JobDefinition, target)._input_values  # pylint: disable=protected-access
     else:

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -474,6 +474,6 @@ def get_subselected_graph_definition(
 
 def get_input_values_from_job(target: PipelineDefinition) -> Optional[Dict[str, Any]]:
     if target.is_job:
-        return cast(JobDefinition, target)._input_values
+        return cast(JobDefinition, target)._input_values  # pylint: disable=protected-access
     else:
         return None

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -470,3 +470,10 @@ def get_subselected_graph_definition(
             f"The attempted subset {str_format_set(resolved_op_selection_dict)} for graph "
             f"{graph.name} results in an invalid graph."
         ) from exc
+
+
+def get_input_values_from_job(target: PipelineDefinition) -> Optional[Dict[str, Any]]:
+    if target.is_job:
+        return cast(JobDefinition, target)._input_values
+    else:
+        return None

--- a/python_modules/dagster/dagster/core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/job_definition.py
@@ -352,7 +352,7 @@ class JobDefinition(PipelineDefinition):
             else None
         )
 
-    def get_input_value(self, input_name: str) -> Any:
+    def get_direct_input_value(self, input_name: str) -> Any:
         if input_name not in self._input_values:
             raise DagsterInvalidInvocationError(
                 f"On job '{self.name}', attempted to retrieve input value for input named '{input_name}', but no value was provided. Provided input values: {sorted(list(self._input_values.keys()))}"
@@ -494,8 +494,8 @@ def get_subselected_graph_definition(
         ) from exc
 
 
-def get_input_values_from_job(target: PipelineDefinition) -> Optional[Mapping[str, Any]]:
+def get_direct_input_values_from_job(target: PipelineDefinition) -> Mapping[str, Any]:
     if target.is_job:
         return cast(JobDefinition, target)._input_values  # pylint: disable=protected-access
     else:
-        return None
+        return {}

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -27,7 +27,7 @@ from dagster.core.storage.root_input_manager import (
     RootInputManagerDefinition,
 )
 from dagster.core.storage.tags import MEMOIZED_RUN_TAG
-from dagster.core.types.dagster_type import DagsterType, DagsterTypeKind
+from dagster.core.types.dagster_type import DagsterType
 from dagster.core.utils import str_format_set
 from dagster.utils import frozentags, merge_dicts
 from dagster.utils.backcompat import experimental_class_warning
@@ -1030,7 +1030,7 @@ def _create_run_config_schema(
     mode_definition: ModeDefinition,
     required_resources: Set[str],
 ) -> "RunConfigSchema":
-    from .job_definition import get_input_values_from_job
+    from .job_definition import get_direct_input_values_from_job
     from .run_config import (
         RunConfigSchemaCreationData,
         construct_config_type_dictionary,
@@ -1066,7 +1066,7 @@ def _create_run_config_schema(
             ignored_solids=ignored_solids,
             required_resources=required_resources,
             is_using_graph_job_op_apis=pipeline_def.is_job,
-            top_level_inputs=get_input_values_from_job(pipeline_def),
+            direct_inputs=get_direct_input_values_from_job(pipeline_def),
         )
     )
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -970,24 +970,6 @@ def _checked_input_resource_reqs_for_mode(
             else:
                 # input is unconnected
                 input_def = handle.input_def
-                if (
-                    not input_def.dagster_type.loader
-                    and not input_def.dagster_type.kind == DagsterTypeKind.NOTHING
-                    and not input_def.root_manager_key
-                    and not input_def.has_default_value
-                ):
-                    raise DagsterInvalidDefinitionError(
-                        "Input '{input_name}' in {described_node} is not connected to "
-                        "the output of a previous node and can not be loaded from configuration, "
-                        "making it impossible to execute. "
-                        "Possible solutions are:\n"
-                        "  * add a dagster_type_loader for the type '{dagster_type}'\n"
-                        "  * connect '{input_name}' to the output of another node\n".format(
-                            described_node=node.describe_node(),
-                            input_name=input_def.name,
-                            dagster_type=input_def.dagster_type.display_name,
-                        )
-                    )
 
                 # If a root manager is provided, it's always used. I.e. it has priority over
                 # the other ways of loading unsatisfied inputs - dagster type loaders and

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -1049,13 +1049,13 @@ def _create_run_config_schema(
     mode_definition: ModeDefinition,
     required_resources: Set[str],
 ) -> "RunConfigSchema":
+    from .job_definition import JobDefinition
     from .run_config import (
         RunConfigSchemaCreationData,
         construct_config_type_dictionary,
         define_run_config_schema_type,
     )
     from .run_config_schema import RunConfigSchema
-    from .job_definition import JobDefinition
 
     # When executing with a subset pipeline, include the missing solids
     # from the original pipeline as ignored to allow execution with
@@ -1085,7 +1085,9 @@ def _create_run_config_schema(
             ignored_solids=ignored_solids,
             required_resources=required_resources,
             is_using_graph_job_op_apis=pipeline_def.is_job,
-            top_level_inputs=cast(JobDefinition, pipeline_def)._input_values,
+            top_level_inputs=cast(JobDefinition, pipeline_def)._input_values
+            if pipeline_def.is_job
+            else None,
         )
     )
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -1049,7 +1049,7 @@ def _create_run_config_schema(
     mode_definition: ModeDefinition,
     required_resources: Set[str],
 ) -> "RunConfigSchema":
-    from .job_definition import JobDefinition
+    from .job_definition import JobDefinition, get_input_values_from_job
     from .run_config import (
         RunConfigSchemaCreationData,
         construct_config_type_dictionary,
@@ -1085,9 +1085,7 @@ def _create_run_config_schema(
             ignored_solids=ignored_solids,
             required_resources=required_resources,
             is_using_graph_job_op_apis=pipeline_def.is_job,
-            top_level_inputs=cast(JobDefinition, pipeline_def)._input_values
-            if pipeline_def.is_job
-            else None,
+            top_level_inputs=get_input_values_from_job(pipeline_def),
         )
     )
 

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     Set,
     Union,
-    cast,
 )
 
 from dagster import check
@@ -1049,7 +1048,7 @@ def _create_run_config_schema(
     mode_definition: ModeDefinition,
     required_resources: Set[str],
 ) -> "RunConfigSchema":
-    from .job_definition import JobDefinition, get_input_values_from_job
+    from .job_definition import get_input_values_from_job
     from .run_config import (
         RunConfigSchemaCreationData,
         construct_config_type_dictionary,

--- a/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/core/definitions/pipeline_definition.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Set,
     Union,
+    cast,
 )
 
 from dagster import check
@@ -1054,6 +1055,7 @@ def _create_run_config_schema(
         define_run_config_schema_type,
     )
     from .run_config_schema import RunConfigSchema
+    from .job_definition import JobDefinition
 
     # When executing with a subset pipeline, include the missing solids
     # from the original pipeline as ignored to allow execution with
@@ -1083,6 +1085,7 @@ def _create_run_config_schema(
             ignored_solids=ignored_solids,
             required_resources=required_resources,
             is_using_graph_job_op_apis=pipeline_def.is_job,
+            top_level_inputs=cast(JobDefinition, pipeline_def)._input_values,
         )
     )
 

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, cast
+from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Set, Tuple, cast
 
 from dagster.config import Field, Permissive, Selector
 from dagster.config.config_type import ALL_CONFIG_BUILTINS, Array, ConfigType
@@ -73,7 +73,7 @@ class RunConfigSchemaCreationData(NamedTuple):
     ignored_solids: List[Node]
     required_resources: Set[str]
     is_using_graph_job_op_apis: bool
-    top_level_inputs: Optional[Dict[str, Any]]
+    direct_inputs: Mapping[str, Any]
 
 
 def define_logger_dictionary_cls(creation_data: RunConfigSchemaCreationData) -> Shape:
@@ -138,7 +138,7 @@ def define_run_config_schema_type(creation_data: RunConfigSchemaCreationData) ->
             dependency_structure=creation_data.dependency_structure,
             resource_defs=creation_data.mode_definition.resource_defs,
             solid_ignored=False,
-            input_values=creation_data.top_level_inputs,
+            direct_inputs=creation_data.direct_inputs,
         ),
     }
 
@@ -180,13 +180,14 @@ def get_inputs_field(
     dependency_structure: DependencyStructure,
     resource_defs: Dict[str, ResourceDefinition],
     solid_ignored: bool,
-    input_values: Dict[str, Any] = None,
+    direct_inputs: Optional[Mapping[str, Any]] = None,
 ):
+    direct_inputs = check.opt_mapping_param(direct_inputs, "direct_inputs")
     inputs_field_fields = {}
     for name, inp in solid.definition.input_dict.items():
         inp_handle = SolidInputHandle(solid, inp)
         has_upstream = input_has_upstream(dependency_structure, inp_handle, solid, name)
-        if input_values and name in input_values and not has_upstream:
+        if name in direct_inputs and not has_upstream:
             input_field = None
         elif inp.root_manager_key and not has_upstream:
             input_field = get_input_manager_input_field(solid, inp, resource_defs)

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -14,7 +14,11 @@ from dagster.core.definitions.output import OutputDefinition
 from dagster.core.errors import DagsterInvalidDefinitionError
 from dagster.core.storage.output_manager import IOutputManagerDefinition
 from dagster.core.storage.root_input_manager import IInputManagerDefinition
-from dagster.core.types.dagster_type import ALL_RUNTIME_BUILTINS, construct_dagster_type_dictionary
+from dagster.core.types.dagster_type import (
+    ALL_RUNTIME_BUILTINS,
+    DagsterTypeKind,
+    construct_dagster_type_dictionary,
+)
 from dagster.utils import check
 
 from .configurable import ConfigurableDefinition
@@ -193,7 +197,12 @@ def get_inputs_field(
             input_field = get_input_manager_input_field(solid, inp, resource_defs)
         elif inp.dagster_type.loader and not has_upstream:
             input_field = get_type_loader_input_field(solid, name, inp)
-        elif not inp.has_default_value and not inp.dagster_type.loader and not has_upstream:
+        elif (
+            not inp.has_default_value
+            and not inp.dagster_type.kind == DagsterTypeKind.NOTHING
+            and not inp.dagster_type.loader
+            and not has_upstream
+        ):
             raise DagsterInvalidDefinitionError(
                 f"Input '{name}' of {solid.describe_node()} has no upstream output, no default value, and no dagster type loader. Must provide a value to this input via either a direct input value mapped from the top-level graph, or a root input manager key. To learn more, see the docs for unconnected inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs."
             )

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -193,6 +193,10 @@ def get_inputs_field(
             input_field = get_input_manager_input_field(solid, inp, resource_defs)
         elif inp.dagster_type.loader and not has_upstream:
             input_field = get_type_loader_input_field(solid, name, inp)
+        elif not inp.dagster_type.loader and not has_upstream:
+            raise DagsterInvalidDefinitionError(
+                f"Input '{name}' of {solid.describe_node()} has no upstream output and no dagster type loader. Must provide a value to this input via either a direct input value mapped from the top-level graph, or a root input manager key. To learn more, see the docs for unconnected inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs."
+            )
         else:
             input_field = None
 

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -193,9 +193,9 @@ def get_inputs_field(
             input_field = get_input_manager_input_field(solid, inp, resource_defs)
         elif inp.dagster_type.loader and not has_upstream:
             input_field = get_type_loader_input_field(solid, name, inp)
-        elif not inp.dagster_type.loader and not has_upstream:
+        elif not inp.has_default_value and not inp.dagster_type.loader and not has_upstream:
             raise DagsterInvalidDefinitionError(
-                f"Input '{name}' of {solid.describe_node()} has no upstream output and no dagster type loader. Must provide a value to this input via either a direct input value mapped from the top-level graph, or a root input manager key. To learn more, see the docs for unconnected inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs."
+                f"Input '{name}' of {solid.describe_node()} has no upstream output, no default value, and no dagster type loader. Must provide a value to this input via either a direct input value mapped from the top-level graph, or a root input manager key. To learn more, see the docs for unconnected inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs."
             )
         else:
             input_field = None

--- a/python_modules/dagster/dagster/core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/core/definitions/run_config.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, cast, Any
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, cast
 
 from dagster.config import Field, Permissive, Selector
 from dagster.config.config_type import ALL_CONFIG_BUILTINS, Array, ConfigType
@@ -73,7 +73,7 @@ class RunConfigSchemaCreationData(NamedTuple):
     ignored_solids: List[Node]
     required_resources: Set[str]
     is_using_graph_job_op_apis: bool
-    top_level_inputs: Dict[str, Any]
+    top_level_inputs: Optional[Dict[str, Any]]
 
 
 def define_logger_dictionary_cls(creation_data: RunConfigSchemaCreationData) -> Shape:

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -500,35 +500,18 @@ class FromRootPlaceholder:
         pass
 
 
-class FromRootInputConfigPlaceholder(FromRootPlaceholder):
-    def __init__(self, top_level_input_name: str):
-        self.top_level_input_name = top_level_input_name
-
-    def to_input_source(self, leaf_input_name: str, node_handle: NodeHandle) -> StepInputSource:
-        return FromRootInputConfig(
-            input_name=self.top_level_input_name,
-            leaf_input_name=leaf_input_name,
-            node_handle=node_handle,
-        )
-
-
 @whitelist_for_serdes
 class FromRootInputConfig(
-    NamedTuple(
-        "_FromRootInputConfig",
-        [("input_name", str), ("leaf_input_name", str), ("node_handle", NodeHandle)],
-    ),
+    NamedTuple("_FromRootInputConfig", [("input_name", str)]),
     StepInputSource,
 ):
-    """This step input source is configuration to be passed to a type loader"""
+    """This root input source is configuration to be passed to a type loader"""
 
-    def __new__(cls, input_name: str, leaf_input_name: str, node_handle: NodeHandle):
-        return super(FromRootInputConfig, cls).__new__(
-            cls, input_name=input_name, leaf_input_name=leaf_input_name, node_handle=node_handle
-        )
+    def __new__(cls, input_name: str):
+        return super(FromRootInputConfig, cls).__new__(cls, input_name=input_name)
 
     def get_input_def(self, pipeline_def: PipelineDefinition) -> InputDefinition:
-        return pipeline_def.get_solid(self.node_handle).input_def_named(self.leaf_input_name)
+        return pipeline_def.graph.input_def_named(self.input_name)
 
     def load_input_object(self, step_context: "StepExecutionContext") -> Any:
         with user_code_error_boundary(

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -504,7 +504,7 @@ class FromDirectInputValue(
     ),
     StepInputSource,
 ):
-    """This input source is for direct python values to be passed to a type loader"""
+    """This input source is for direct python values to be passed as inputs to ops."""
 
     def __new__(cls, input_name: str):
         return super(FromDirectInputValue, cls).__new__(
@@ -526,12 +526,7 @@ class FromDirectInputValue(
             )
 
         job_def = cast(JobDefinition, pipeline_def)
-        with user_code_error_boundary(
-            DagsterTypeLoadingError,
-            msg_fn=lambda: (f'Error occurred while loading top-level input "{self.input_name}": '),
-            log_manager=step_context.log,
-        ):
-            return job_def.get_direct_input_value(self.input_name)
+        return job_def.get_direct_input_value(self.input_name)
 
     def required_resource_keys(self, _pipeline_def: PipelineDefinition) -> Set[str]:
         return set()

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -81,7 +81,7 @@ class StepInput(
             cls,
             name=check.str_param(name, "name"),
             dagster_type_key=check.str_param(dagster_type_key, "dagster_type_key"),
-            source=check.inst_param(source, "source", (StepInputSource, FromRootPlaceholder)),
+            source=check.inst_param(source, "source", StepInputSource),
         )
 
     @property
@@ -474,7 +474,7 @@ class FromConfig(
             return dagster_type.loader.construct_from_config_value(step_context, config_data)
 
     def required_resource_keys(self, pipeline_def: PipelineDefinition) -> Set[str]:
-        input_def = self.get_input_def(pipeline_def)
+        input_def = self.get_associated_input_def(pipeline_def)
         return (
             input_def.dagster_type.loader.required_resource_keys()
             if input_def.dagster_type.loader
@@ -495,104 +495,32 @@ class FromConfig(
         return dagster_type.loader.compute_loaded_input_version(config_data)
 
 
-class FromRootPlaceholder:
-    def to_input_source(self, leaf_input_name: str, node_handle: NodeHandle) -> StepInputSource:
-        pass
-
-
-@whitelist_for_serdes
-class FromRootInputConfig(
-    NamedTuple("_FromRootInputConfig", [("input_name", str)]),
-    StepInputSource,
-):
-    """This root input source is configuration to be passed to a type loader"""
-
-    def __new__(cls, input_name: str):
-        return super(FromRootInputConfig, cls).__new__(cls, input_name=input_name)
-
-    def get_input_def(self, pipeline_def: PipelineDefinition) -> InputDefinition:
-        return pipeline_def.graph.input_def_named(self.input_name)
-
-    def load_input_object(self, step_context: "StepExecutionContext") -> Any:
-        with user_code_error_boundary(
-            DagsterTypeLoadingError,
-            msg_fn=lambda: (f'Error occurred while loading top-level input "{self.input_name}": '),
-            log_manager=step_context.log,
-        ):
-            dagster_type = self.get_input_def(step_context.pipeline_def).dagster_type
-
-            input_config = step_context.resolved_run_config.inputs
-            config_data = input_config.get(self.input_name) if input_config else None
-
-            return dagster_type.loader.construct_from_config_value(step_context, config_data)
-
-    def required_resource_keys(self, pipeline_def: PipelineDefinition) -> Set[str]:
-        input_def = self.get_associated_input_def(pipeline_def)
-        return (
-            input_def.dagster_type.loader.required_resource_keys()
-            if input_def.dagster_type.loader
-            else set()
-        )
-
-    def compute_version(
-        self,
-        step_versions: Dict[str, Optional[str]],
-        pipeline_def: PipelineDefinition,
-        resolved_run_config: ResolvedRunConfig,
-    ) -> Optional[str]:
-
-        config_data = self.get_associated_config(resolved_run_config)
-        input_def = self.get_associated_input_def(pipeline_def)
-        dagster_type = input_def.dagster_type
-        return dagster_type.loader.compute_loaded_input_version(config_data)
-
-
-class FromRootInputValuePlaceholder(
-    FromRootPlaceholder,
-):
-    def __init__(self, top_level_input_name: str, input_value: Any):
-        self.top_level_input_name = top_level_input_name
-        self.input_value = input_value
-
-    def to_input_source(self, leaf_input_name: str, node_handle: NodeHandle) -> StepInputSource:
-        return FromRootInputValue(
-            input_name=self.top_level_input_name,
-            leaf_input_name=leaf_input_name,
-            input_value=self.input_value,
-            node_handle=node_handle,
-        )
-
-
 @whitelist_for_serdes
 class FromRootInputValue(
     NamedTuple(
         "_FromRootInputValue",
         [
             ("input_name", str),
-            ("leaf_input_name", str),
             ("input_value", Any),
-            ("node_handle", NodeHandle),
         ],
     ),
     StepInputSource,
 ):
     """This root input source is for direct python values to be passed to a type loader"""
 
-    def __new__(
-        cls, input_name: str, leaf_input_name: str, input_value: Any, node_handle: NodeHandle
-    ):
+    def __new__(cls, input_name: str, input_value: Any):
         return super(FromRootInputValue, cls).__new__(
             cls,
             input_name=input_name,
-            leaf_input_name=leaf_input_name,
             input_value=input_value,
-            node_handle=node_handle,
         )
 
-    def get_input_def(self, pipeline_def: PipelineDefinition) -> InputDefinition:
-        return pipeline_def.get_solid(self.node_handle).input_def_named(self.leaf_input_name)
+    def get_associated_input_def(self, pipeline_def: PipelineDefinition) -> InputDefinition:
+        return pipeline_def.graph.input_def_named(self.input_name)
 
-    def load_input_object(self, step_context: "StepExecutionContext") -> Any:
+    def load_input_object(
+        self, step_context: "StepExecutionContext", _input_def: InputDefinition
+    ) -> Any:
         with user_code_error_boundary(
             DagsterTypeLoadingError,
             msg_fn=lambda: (f'Error occurred while loading top-level input "{self.input_name}": '),
@@ -1024,7 +952,6 @@ StepInputSourceUnion = Union[
     FromDynamicCollect,
     FromUnresolvedStepOutput,
     FromPendingDynamicStepOutput,
-    FromRootPlaceholder,
 ]
 
 StepInputSourceTypes = StepInputSourceUnion.__args__  # type: ignore

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -576,7 +576,7 @@ class FromRootInputValue(
     ),
     StepInputSource,
 ):
-    """This step input source is configuration to be passed to a type loader"""
+    """This root input source is for direct python values to be passed to a type loader"""
 
     def __new__(
         cls, input_name: str, leaf_input_name: str, input_value: Any, node_handle: NodeHandle

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -497,17 +497,17 @@ class FromConfig(
 
 
 @whitelist_for_serdes
-class FromRootInputValue(
+class FromDirectInputValue(
     NamedTuple(
-        "_FromRootInputValue",
+        "_FromDirectInputValue",
         [("input_name", str)],
     ),
     StepInputSource,
 ):
-    """This root input source is for direct python values to be passed to a type loader"""
+    """This input source is for direct python values to be passed to a type loader"""
 
     def __new__(cls, input_name: str):
-        return super(FromRootInputValue, cls).__new__(
+        return super(FromDirectInputValue, cls).__new__(
             cls,
             input_name=input_name,
         )
@@ -531,7 +531,7 @@ class FromRootInputValue(
             msg_fn=lambda: (f'Error occurred while loading top-level input "{self.input_name}": '),
             log_manager=step_context.log,
         ):
-            return job_def.get_input_value(self.input_name)
+            return job_def.get_direct_input_value(self.input_name)
 
     def required_resource_keys(self, _pipeline_def: PipelineDefinition) -> Set[str]:
         return set()
@@ -548,7 +548,7 @@ class FromRootInputValue(
         pipeline_def: PipelineDefinition,
         resolved_run_config: ResolvedRunConfig,
     ) -> Optional[str]:
-        return str(self.input_value)
+        return str(self.input_name)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/core/execution/plan/inputs.py
@@ -17,6 +17,7 @@ from typing import (
 from dagster import check
 from dagster.core.definitions import InputDefinition, NodeHandle, PipelineDefinition
 from dagster.core.definitions.events import AssetLineageInfo
+from dagster.core.definitions.job_definition import JobDefinition
 from dagster.core.definitions.metadata import MetadataEntry
 from dagster.core.definitions.version_strategy import ResourceVersionContext
 from dagster.core.errors import (
@@ -499,20 +500,16 @@ class FromConfig(
 class FromRootInputValue(
     NamedTuple(
         "_FromRootInputValue",
-        [
-            ("input_name", str),
-            ("input_value", Any),
-        ],
+        [("input_name", str)],
     ),
     StepInputSource,
 ):
     """This root input source is for direct python values to be passed to a type loader"""
 
-    def __new__(cls, input_name: str, input_value: Any):
+    def __new__(cls, input_name: str):
         return super(FromRootInputValue, cls).__new__(
             cls,
             input_name=input_name,
-            input_value=input_value,
         )
 
     def get_associated_input_def(self, pipeline_def: PipelineDefinition) -> InputDefinition:
@@ -521,12 +518,20 @@ class FromRootInputValue(
     def load_input_object(
         self, step_context: "StepExecutionContext", _input_def: InputDefinition
     ) -> Any:
+
+        pipeline_def = step_context.pipeline_def
+        if not pipeline_def.is_job:
+            raise DagsterInvariantViolationError(
+                "Using input values with pipeline API, which is unsupported."
+            )
+
+        job_def = cast(JobDefinition, pipeline_def)
         with user_code_error_boundary(
             DagsterTypeLoadingError,
             msg_fn=lambda: (f'Error occurred while loading top-level input "{self.input_name}": '),
             log_manager=step_context.log,
         ):
-            return self.input_value
+            return job_def.get_input_value(self.input_name)
 
     def required_resource_keys(self, _pipeline_def: PipelineDefinition) -> Set[str]:
         return set()

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -284,7 +284,6 @@ class _PlanBuilder:
                     dependency_structure,
                     handle,
                     parent_step_inputs,
-                    top_level_inputs,
                 )
 
                 # If an input with dagster_type "Nothing" doesn't have a value
@@ -459,7 +458,6 @@ def get_step_input_source(
     parent_step_inputs: Optional[
         List[Union[StepInput, UnresolvedMappedStepInput, UnresolvedCollectStepInput]]
     ],
-    top_level_inputs: Optional[Dict[str, Any]],
 ):
     check.inst_param(plan_builder, "plan_builder", _PlanBuilder)
     check.inst_param(solid, "solid", Node)

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -422,10 +422,7 @@ def get_root_graph_input_source(
 
     input_values = get_input_values_from_job(pipeline_def)
     if input_values and input_name in input_values:
-        return FromRootInputValue(
-            input_name=input_name,
-            input_value=input_values[input_name],
-        )
+        return FromRootInputValue(input_name=input_name)
 
     input_config = plan_builder.resolved_run_config.inputs
 

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict, defaultdict
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     FrozenSet,
@@ -10,7 +11,6 @@ from typing import (
     Set,
     Union,
     cast,
-    Any,
 )
 
 from dagster import check
@@ -54,9 +54,10 @@ from .inputs import (
     FromDynamicCollect,
     FromMultipleSources,
     FromPendingDynamicStepOutput,
-    FromRootInputConfig,
-    FromRootInputValue,
+    FromRootInputConfigPlaceholder,
     FromRootInputManager,
+    FromRootInputValuePlaceholder,
+    FromRootPlaceholder,
     FromStepOutput,
     FromUnresolvedStepOutput,
     StepInput,
@@ -314,7 +315,11 @@ class _PlanBuilder:
                         )
                     )
                 else:
-                    check.inst_param(step_input_source, "step_input_source", StepInputSource)
+                    check.inst_param(
+                        step_input_source,
+                        "step_input_source",
+                        (StepInputSource, FromRootPlaceholder),
+                    )
                     step_inputs.append(
                         StepInput(
                             name=input_name,
@@ -415,18 +420,18 @@ def get_root_graph_input_source(
     input_name: str,
     input_def: InputDefinition,
     pipeline_def: PipelineDefinition,
-) -> Optional[Union[FromRootInputConfig, FromRootInputValue]]:
+) -> Optional[Union[FromRootInputConfigPlaceholder, FromRootInputValuePlaceholder]]:
 
     if pipeline_def.is_job and input_name in cast(JobDefinition, pipeline_def)._input_values:
-        return FromRootInputValue(
-            input_name=input_name,
+        return FromRootInputValuePlaceholder(
+            top_level_input_name=input_name,
             input_value=cast(JobDefinition, pipeline_def)._input_values[input_name],
         )
 
     input_config = plan_builder.resolved_run_config.inputs
 
     if input_config and input_name in input_config:
-        return FromConfig(solid_handle=None, input_name=input_name)
+        return FromRootInputConfigPlaceholder(top_level_input_name=input_name)
 
     if input_def.dagster_type.is_nothing:
         return None
@@ -565,7 +570,11 @@ def get_step_input_source(
         parent_inputs = {step_input.name: step_input for step_input in parent_step_inputs}
         if parent_name in parent_inputs:
             parent_input = parent_inputs[parent_name]
-            return parent_input.source
+            if isinstance(parent_input.source, FromRootPlaceholder):
+                parent_input_source = parent_input.source.to_input_source(input_name, handle)
+            else:
+                parent_input_source = parent_input.source
+            return parent_input_source
         # else fall through to Nothing case or raise
 
     if solid.definition.input_has_default(input_name):

--- a/python_modules/dagster/dagster/core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/plan.py
@@ -10,6 +10,7 @@ from typing import (
     Set,
     Union,
     cast,
+    Any,
 )
 
 from dagster import check
@@ -53,6 +54,8 @@ from .inputs import (
     FromDynamicCollect,
     FromMultipleSources,
     FromPendingDynamicStepOutput,
+    FromRootInputConfig,
+    FromRootInputValue,
     FromRootInputManager,
     FromStepOutput,
     FromUnresolvedStepOutput,
@@ -173,6 +176,7 @@ class _PlanBuilder:
 
             input_source = get_root_graph_input_source(
                 plan_builder=self,
+                pipeline_def=pipeline_def,
                 input_name=input_name,
                 input_def=input_def,
             )
@@ -194,6 +198,9 @@ class _PlanBuilder:
             pipeline_def.solids_in_topological_order,
             pipeline_def.dependency_structure,
             parent_step_inputs=root_inputs,
+            top_level_inputs=cast(JobDefinition, pipeline_def)._input_values
+            if pipeline_def.is_job
+            else None,
         )
 
         step_dict = {step.handle: step for step in self._steps.values()}
@@ -255,6 +262,7 @@ class _PlanBuilder:
         parent_step_inputs: Optional[
             List[Union[StepInput, UnresolvedMappedStepInput, UnresolvedCollectStepInput]]
         ] = None,
+        top_level_inputs: Optional[Dict[str, Any]] = None,
     ):
         asset_layer = self.pipeline.get_definition().asset_layer
         for solid in solids:
@@ -276,6 +284,7 @@ class _PlanBuilder:
                     dependency_structure,
                     handle,
                     parent_step_inputs,
+                    top_level_inputs,
                 )
 
                 # If an input with dagster_type "Nothing" doesn't have a value
@@ -405,7 +414,14 @@ def get_root_graph_input_source(
     plan_builder: _PlanBuilder,
     input_name: str,
     input_def: InputDefinition,
-) -> Optional[FromConfig]:
+    pipeline_def: PipelineDefinition,
+) -> Optional[Union[FromRootInputConfig, FromRootInputValue]]:
+
+    if pipeline_def.is_job and input_name in cast(JobDefinition, pipeline_def)._input_values:
+        return FromRootInputValue(
+            input_name=input_name,
+            input_value=cast(JobDefinition, pipeline_def)._input_values[input_name],
+        )
 
     input_config = plan_builder.resolved_run_config.inputs
 
@@ -437,6 +453,7 @@ def get_step_input_source(
     parent_step_inputs: Optional[
         List[Union[StepInput, UnresolvedMappedStepInput, UnresolvedCollectStepInput]]
     ],
+    top_level_inputs: Optional[Dict[str, Any]],
 ):
     check.inst_param(plan_builder, "plan_builder", _PlanBuilder)
     check.inst_param(solid, "solid", Node)

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_pipeline.py
@@ -1,4 +1,3 @@
-import re
 import sys
 
 import pytest

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_pipeline.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_pipeline.py
@@ -177,11 +177,19 @@ def test_unconfigurable_inputs_pipeline():
     def noop(_):
         pass
 
-    with pytest.raises(DagsterInvalidDefinitionError):
-        # NewType is not connect and can not be provided with config
-        @pipeline
-        def _bad_inputs():
-            noop()
+    @pipeline
+    def _bad_inputs():
+        noop()
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Input '_' of solid 'noop' has no upstream output, no default "
+        "value, and no dagster type loader. Must provide a value to this input "
+        "via either a direct input value mapped from the top-level graph, or a "
+        "root input manager key. To learn more, see the docs for unconnected "
+        "inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs.",
+    ):
+        execute_pipeline(_bad_inputs)
 
 
 def test_dupe_defs_fail():

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1122,3 +1122,33 @@ def test_to_job_input_values():
     )
     assert result.success
     assert result.output_value() == 12
+
+
+def test_input_values_name_not_found():
+    @op
+    def my_op(x, y):
+        return x + y
+
+    @graph
+    def my_graph(x, y):
+        return my_op(x, y)
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Error when constructing JobDefinition 'my_graph': Input value provided for key 'z', but job has no top-level input with that name.",
+    ):
+        my_graph.to_job(input_values={"z": 4})
+
+
+def test_input_values_override_default():
+    @op(ins={"x": In(default_value=5)})
+    def op_with_default_input(x):
+        return x
+
+    @graph
+    def my_graph(x):
+        return op_with_default_input(x)
+
+    result = my_graph.execute_in_process(input_values={"x": 6})
+    assert result.success
+    assert result.output_value() == 6

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -53,8 +53,8 @@ def get_ops():
 
 def test_top_level_inputs_execution():
     @op
-    def the_op(the_in: int):
-        return the_in + 1
+    def the_op(leaf_in: int):
+        return leaf_in + 1
 
     @graph
     def the_graph(the_in):
@@ -63,6 +63,12 @@ def test_top_level_inputs_execution():
     result = the_graph.execute_in_process(input_values={"the_in": 2})
     assert result.success
     assert result.output_value() == 3
+
+    with pytest.raises(
+        DagsterTypeCheckDidNotPass,
+        match='Type check failed for step input "leaf_in" - expected type "Int". Description: Value "bad_value" of python type "str" must be a int.',
+    ):
+        the_graph.execute_in_process(input_values={"the_in": "bad_value"})
 
 
 def test_basic_graph():

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -51,6 +51,20 @@ def get_ops():
     return emit_one, add
 
 
+def test_top_level_inputs_execution():
+    @op
+    def the_op(the_in: int):
+        return the_in + 1
+
+    @graph
+    def the_graph(the_in):
+        return the_op(the_in)
+
+    result = the_graph.execute_in_process(input_values={"the_in": 2})
+    assert result.success
+    assert result.output_value() == 3
+
+
 def test_basic_graph():
     emit_one, add = get_ops()
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -1092,3 +1092,33 @@ def test_graphs_break_type_checks():
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
         repro_2.execute_in_process()
+
+
+def test_to_job_input_values():
+    @op
+    def my_op(x, y):
+        return x + y
+
+    @graph
+    def my_graph(x, y):
+        return my_op(x, y)
+
+    result = my_graph.to_job(input_values={"x": 5, "y": 6}).execute_in_process()
+    assert result.success
+    assert result.output_value() == 11
+
+    result = my_graph.alias("blah").to_job(input_values={"x": 5, "y": 6}).execute_in_process()
+    assert result.success
+    assert result.output_value() == 11
+
+    # Test partial input value specification
+    result = my_graph.to_job(input_values={"x": 5}).execute_in_process(input_values={"y": 6})
+    assert result.success
+    assert result.output_value() == 11
+
+    # Test input value specification override
+    result = my_graph.to_job(input_values={"x": 5, "y": 6}).execute_in_process(
+        input_values={"y": 7}
+    )
+    assert result.success
+    assert result.output_value() == 12

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -200,9 +200,11 @@ def test_dict_type_loader_typing_fail():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Input 'dict_input' in solid "
-        "'emit_dict' is not connected to the output of a previous node and can not be loaded "
-        "from configuration, making it impossible to execute. Possible solutions are:",
+        match="Input 'dict_input' of solid 'emit_dict' has no upstream output "
+        "and no dagster type loader. Must provide a value to this input via "
+        "either a direct input value mapped from the top-level graph, or a root "
+        "input manager key. To learn more, see the docs for unconnected inputs: "
+        "https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs.",
     ):
         execute_solid(
             emit_dict,

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -200,7 +200,7 @@ def test_dict_type_loader_typing_fail():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Input 'dict_input' of solid 'emit_dict' has no upstream output "
+        match="Input 'dict_input' of solid 'emit_dict' has no upstream output, no default value, "
         "and no dagster type loader. Must provide a value to this input via "
         "either a direct input value mapped from the top-level graph, or a root "
         "input manager key. To learn more, see the docs for unconnected inputs: "

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -40,7 +40,9 @@ def create_creation_data(pipeline_def):
         ignored_solids=[],
         required_resources=set(),
         is_using_graph_job_op_apis=pipeline_def.is_job,
-        direct_inputs=pipeline_def._input_values if pipeline_def.is_job else {},
+        direct_inputs=pipeline_def._input_values  # pylint: disable = protected-access
+        if pipeline_def.is_job
+        else {},
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -40,6 +40,7 @@ def create_creation_data(pipeline_def):
         ignored_solids=[],
         required_resources=set(),
         is_using_graph_job_op_apis=pipeline_def.is_job,
+        direct_inputs=pipeline_def._input_values if pipeline_def.is_job else {},
     )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
@@ -335,3 +335,20 @@ def test_dynamic_output_for_node():
     # assertions
     assert result.output_for_node("return_as_tuple", "output1") == {"0": 0, "1": 1, "2": 2}
     assert result.output_for_node("return_as_tuple", "output2") == {"0": 5, "1": 5, "2": 5}
+
+
+def test_execute_in_process_input_values():
+    @op
+    def requires_input_op(x: int):
+        return x + 1
+
+    @graph
+    def requires_input_graph(x):
+        return requires_input_op(x)
+
+    result = requires_input_graph.alias("named_graph").execute_in_process(input_values={"x": 5})
+    assert result.success
+    assert result.output_value() == 6
+    result = requires_input_graph.to_job().execute_in_process(input_values={"x": 5})
+    assert result.success
+    assert result.output_value() == 6


### PR DESCRIPTION
Previously, the only way to provide top-level values to a job was via config. This makes it possible to do so via direct python values. 

In order to do this, had to add the notion of a placeholder step input source, so that we can resolve to the correct underlying input definition at runtime.