### PR TITLE
adding ipython_genutils to requirements for dagit

### DIFF
--- a/examples/deploy_ecs/requirements-dagster.txt
+++ b/examples/deploy_ecs/requirements-dagster.txt
@@ -1,3 +1,4 @@
 dagster
 dagster-aws
 dagster-postgres
+ipython_genutils


### PR DESCRIPTION
## Summary
This is a fix for issue https://github.com/dagster-io/dagster/issues/7023. The requirements-dagit.txt file is missing an important dependency that was causing a failure in the build. 

## Test Plan
Tested by building and running (using docker-compose up) on both local and aws ecs.

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.