### PR TITLE
[dagit] Add sensors/schedules to the asset details page

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEntryRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEntryRoot.tsx
@@ -23,12 +23,12 @@ export const AssetEntryRoot = () => {
 
   return queryResult.loading ? (
     <Page>
-      <AssetPageHeader assetKey={{path: currentPath}} repoAddress={null} />
+      <AssetPageHeader assetKey={{path: currentPath}} />
       <Loading queryResult={queryResult}>{() => null}</Loading>
     </Page>
   ) : queryResult.data?.assetOrError.__typename === 'AssetNotFoundError' ? (
     <Page>
-      <AssetPageHeader assetKey={{path: currentPath}} repoAddress={null} />
+      <AssetPageHeader assetKey={{path: currentPath}} />
       <AssetsCatalogTable prefixPath={currentPath} />
     </Page>
   ) : (

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
@@ -1,0 +1,42 @@
+import {gql} from '@apollo/client';
+import {flatMap} from 'lodash';
+import React from 'react';
+
+import {ScheduleOrSensorTag} from '../nav/JobMetadata';
+import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
+import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
+import {RepoAddress} from '../workspace/types';
+
+import {AssetNodeInstigatorsFragment} from './types/AssetNodeInstigatorsFragment';
+
+export const AssetNodeInstigatorTag: React.FC<{
+  assetNode: AssetNodeInstigatorsFragment;
+  repoAddress: RepoAddress;
+}> = ({assetNode, repoAddress}) => {
+  const schedules = flatMap(assetNode.jobs, (j) => j.schedules);
+  const sensors = flatMap(assetNode.jobs, (j) => j.sensors);
+
+  return <ScheduleOrSensorTag repoAddress={repoAddress} schedules={schedules} sensors={sensors} />;
+};
+
+export const ASSET_NODE_INSTIGATORS_FRAGMENT = gql`
+  fragment AssetNodeInstigatorsFragment on AssetNode {
+    id
+    jobs {
+      id
+      name
+      schedules {
+        id
+        __typename
+        ...ScheduleSwitchFragment
+      }
+      sensors {
+        id
+        __typename
+        ...SensorSwitchFragment
+      }
+    }
+  }
+  ${SCHEDULE_SWITCH_FRAGMENT}
+  ${SENSOR_SWITCH_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -1,17 +1,12 @@
 import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
-import {Box, ColorsWIP, PageHeader, TagWIP, Heading} from '@dagster-io/ui';
+import {Box, ColorsWIP, PageHeader, Heading} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {RepositoryLink} from '../nav/RepositoryLink';
-import {RepoAddress} from '../workspace/types';
+type Props = {assetKey: {path: string[]}} & Partial<React.ComponentProps<typeof PageHeader>>;
 
-type Props = {assetKey: {path: string[]}; repoAddress: RepoAddress | null} & Partial<
-  React.ComponentProps<typeof PageHeader>
->;
-
-export const AssetPageHeader: React.FC<Props> = ({assetKey, repoAddress, ...extra}) => {
+export const AssetPageHeader: React.FC<Props> = ({assetKey, ...extra}) => {
   const breadcrumbs = React.useMemo(() => {
     if (assetKey.path.length === 1) {
       return [{text: assetKey.path[0], href: '/instance/assets'}];
@@ -41,15 +36,6 @@ export const AssetPageHeader: React.FC<Props> = ({assetKey, repoAddress, ...extr
             currentBreadcrumbRenderer={({text}) => <Heading>{text}</Heading>}
           />
         </Box>
-      }
-      tags={
-        repoAddress ? (
-          <TagWIP icon="asset">
-            Asset in <RepositoryLink repoAddress={repoAddress} />
-          </TagWIP>
-        ) : (
-          <TagWIP icon="asset">Asset</TagWIP>
-        )
       }
       {...extra}
     />

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -1,5 +1,15 @@
 import {gql, useQuery} from '@apollo/client';
-import {Alert, Box, ButtonLink, ColorsWIP, NonIdealState, Spinner, Tab, Tabs} from '@dagster-io/ui';
+import {
+  Alert,
+  Box,
+  ButtonLink,
+  ColorsWIP,
+  NonIdealState,
+  Spinner,
+  Tab,
+  Tabs,
+  TagWIP,
+} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {
@@ -11,6 +21,7 @@ import {displayNameForAssetKey} from '../app/Util';
 import {Timestamp} from '../app/time/Timestamp';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {RepositoryLink} from '../nav/RepositoryLink';
 import {useDidLaunchEvent} from '../runs/RunUtils';
 import {LaunchAssetExecutionButton} from '../workspace/asset-graph/LaunchAssetExecutionButton';
 import {
@@ -23,6 +34,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetEvents} from './AssetEvents';
 import {AssetNodeDefinition, ASSET_NODE_DEFINITION_FRAGMENT} from './AssetNodeDefinition';
+import {AssetNodeInstigatorTag, ASSET_NODE_INSTIGATORS_FRAGMENT} from './AssetNodeInstigatorTag';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetKey} from './types';
 import {
@@ -109,7 +121,20 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
     <div>
       <AssetPageHeader
         assetKey={assetKey}
-        repoAddress={repoAddress}
+        tags={
+          <>
+            {repoAddress ? (
+              <TagWIP icon="asset">
+                Asset in <RepositoryLink repoAddress={repoAddress} />
+              </TagWIP>
+            ) : (
+              <TagWIP icon="asset">Asset</TagWIP>
+            )}
+            {definition && repoAddress && (
+              <AssetNodeInstigatorTag assetNode={definition} repoAddress={repoAddress} />
+            )}
+          </>
+        }
         tabs={
           <Tabs size="large" selectedTabId={params.view || 'activity'}>
             <Tab
@@ -224,11 +249,14 @@ const ASSET_QUERY = gql`
               name
             }
           }
+
+          ...AssetNodeInstigatorsFragment
           ...AssetNodeDefinitionFragment
         }
       }
     }
   }
+  ${ASSET_NODE_INSTIGATORS_FRAGMENT}
   ${ASSET_NODE_DEFINITION_FRAGMENT}
 `;
 

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeInstigatorsFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeInstigatorsFragment.ts
@@ -1,0 +1,52 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { InstigationStatus } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: AssetNodeInstigatorsFragment
+// ====================================================
+
+export interface AssetNodeInstigatorsFragment_jobs_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface AssetNodeInstigatorsFragment_jobs_schedules {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  cronSchedule: string;
+  scheduleState: AssetNodeInstigatorsFragment_jobs_schedules_scheduleState;
+}
+
+export interface AssetNodeInstigatorsFragment_jobs_sensors_sensorState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface AssetNodeInstigatorsFragment_jobs_sensors {
+  __typename: "Sensor";
+  id: string;
+  jobOriginId: string;
+  name: string;
+  sensorState: AssetNodeInstigatorsFragment_jobs_sensors_sensorState;
+}
+
+export interface AssetNodeInstigatorsFragment_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  schedules: AssetNodeInstigatorsFragment_jobs_schedules[];
+  sensors: AssetNodeInstigatorsFragment_jobs_sensors[];
+}
+
+export interface AssetNodeInstigatorsFragment {
+  __typename: "AssetNode";
+  id: string;
+  jobs: AssetNodeInstigatorsFragment_jobs[];
+}

--- a/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AssetKeyInput, RunStatus } from "./../../types/globalTypes";
+import { AssetKeyInput, InstigationStatus, RunStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: AssetQuery
@@ -34,6 +34,42 @@ export interface AssetQuery_assetOrError_Asset_definition_repository {
   id: string;
   name: string;
   location: AssetQuery_assetOrError_Asset_definition_repository_location;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs_schedules_scheduleState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs_schedules {
+  __typename: "Schedule";
+  id: string;
+  name: string;
+  cronSchedule: string;
+  scheduleState: AssetQuery_assetOrError_Asset_definition_jobs_schedules_scheduleState;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs_sensors_sensorState {
+  __typename: "InstigationState";
+  id: string;
+  status: InstigationStatus;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs_sensors {
+  __typename: "Sensor";
+  id: string;
+  jobOriginId: string;
+  name: string;
+  sensorState: AssetQuery_assetOrError_Asset_definition_jobs_sensors_sensorState;
+}
+
+export interface AssetQuery_assetOrError_Asset_definition_jobs {
+  __typename: "Pipeline";
+  id: string;
+  name: string;
+  schedules: AssetQuery_assetOrError_Asset_definition_jobs_schedules[];
+  sensors: AssetQuery_assetOrError_Asset_definition_jobs_sensors[];
 }
 
 export interface AssetQuery_assetOrError_Asset_definition_metadataEntries_PathMetadataEntry {
@@ -3345,6 +3381,7 @@ export interface AssetQuery_assetOrError_Asset_definition {
   id: string;
   partitionDefinition: string | null;
   repository: AssetQuery_assetOrError_Asset_definition_repository;
+  jobs: AssetQuery_assetOrError_Asset_definition_jobs[];
   description: string | null;
   opName: string | null;
   jobNames: string[];

--- a/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepositoryLink.tsx
@@ -25,12 +25,12 @@ export const RepositoryLink: React.FC<{
   ].join('@');
 
   return (
-    <Box flex={{display: 'inline-flex', direction: 'row', alignItems: 'center'}}>
+    <Box
+      flex={{display: 'inline-flex', direction: 'row', alignItems: 'center'}}
+      title={repoAddressAsString(repoAddress)}
+    >
       {showIcon && <IconWIP name="folder" style={{marginRight: 8}} color={ColorsWIP.Gray400} />}
-      <RepositoryName
-        to={workspacePathFromAddress(repoAddress)}
-        title={repoAddressAsString(repoAddress)}
-      >
+      <RepositoryName to={workspacePathFromAddress(repoAddress)}>
         {repoAddressTruncated}
       </RepositoryName>
       {canReloadRepositoryLocation && showRefresh ? (

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleSwitch.tsx
@@ -87,7 +87,9 @@ export const ScheduleSwitch: React.FC<Props> = (props) => {
   );
 
   return lacksPermission ? (
-    <Tooltip content={DISABLED_MESSAGE}>{switchElement}</Tooltip>
+    <Tooltip content={DISABLED_MESSAGE} display="flex">
+      {switchElement}
+    </Tooltip>
   ) : (
     switchElement
   );

--- a/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorSwitch.tsx
@@ -77,7 +77,9 @@ export const SensorSwitch: React.FC<Props> = (props) => {
   );
 
   return lacksPermission ? (
-    <Tooltip content={DISABLED_MESSAGE}>{switchElement}</Tooltip>
+    <Tooltip content={DISABLED_MESSAGE} display="flex">
+      {switchElement}
+    </Tooltip>
   ) : (
     switchElement
   );

--- a/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
+++ b/js_modules/dagit/packages/ui/src/components/BaseTag.tsx
@@ -40,7 +40,7 @@ export const BaseTag = (props: Props) => {
       {icon || null}
       {label !== undefined && label !== null ? (
         <span
-          data-tooltip={label}
+          data-tooltip={typeof label === 'string' ? label : undefined}
           data-tooltip-style={JSON.stringify({
             ...BaseTagTooltipStyle,
             backgroundColor: fillColor,


### PR DESCRIPTION
## Summary
This PR brings the Sensor / Schedule tag from the jobs page to the asset details page. Currently we don't specify /which/ job the sensor or schedule is linked to. I think we could, but in the typical case of one-job, it may not matter? Curious to get thoughts.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/1037212/158099761-0f9295fb-08ae-46b9-b30b-b228fca6893a.png">


This PR also fixes two small bugs I found while I was working on this:

- The tooltip on the `Asset in repo@location` tag was showing `Asset in [Object object]` in the tooltip. The tooltip also covered the link, preventing you from navigating to the repo. I removed the tooltip so the link is clickable. (The link also has a title tag with the full text)

- In "folder" asset catalog view, navigating in one level from the main screen showed the "Asset" tag in the top bar. (In this case, my asset is `bar > prod` and I'm viewing `bar`. I think this was incorrect and removed it, so the Asset tag only appears on the asset details page.
- 
<img width="540" alt="image" src="https://user-images.githubusercontent.com/1037212/158099887-f032c6f3-1c55-425d-9325-7fc5bd59b3fb.png">




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.