### PR TITLE
[dagit] Disallow use of gql from graphql.macro

### DIFF
--- a/js_modules/dagit/packages/core/.eslintrc.js
+++ b/js_modules/dagit/packages/core/.eslintrc.js
@@ -103,6 +103,11 @@ module.exports = {
             message: 'Please import from `@apollo/client`.',
           },
           {
+            name: 'graphql.macro',
+            importNames: ['gql'],
+            message: 'Please import from `@apollo/client`.',
+          },
+          {
             name: 'styled-components',
             message: 'Please import from `styled-components/macro`.',
           },

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -1,5 +1,5 @@
+import {gql} from '@apollo/client';
 import {Box, ColorsWIP, Group, IconWIP, Mono, NonIdealState, Table} from '@dagster-io/ui';
-import {gql} from 'graphql.macro';
 import qs from 'qs';
 import * as React from 'react';
 import {Link} from 'react-router-dom';

--- a/js_modules/dagit/packages/core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/TableSchema.tsx
@@ -1,6 +1,6 @@
+import {gql} from '@apollo/client';
 import {Box, ColorsWIP, TagWIP, Tooltip} from '@dagster-io/ui';
 import {Spacing} from '@dagster-io/ui/src/components/types';
-import {gql} from 'graphql.macro';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 

--- a/js_modules/dagit/packages/ui/.eslintrc.js
+++ b/js_modules/dagit/packages/ui/.eslintrc.js
@@ -90,6 +90,11 @@ module.exports = {
             message: 'Please import from `@apollo/client`.',
           },
           {
+            name: 'graphql.macro',
+            importNames: ['gql'],
+            message: 'Please import from `@apollo/client`.',
+          },
+          {
             name: 'styled-components',
             message: 'Please import from `styled-components/macro`.',
           },


### PR DESCRIPTION
## Summary
We added graphql.macro for some storybooks, and it's become the default autocomplete suggestion for `gql`. This seems harmless enough, but I found that things break in subtle ways when importing a   `graphql.macro.gql` fragment into a `@apollo/client.gql` query. Any sub-fragments included in the graphql.macro fragment are not brought into the query.

I think this is probably caused by a version conflict but I didn't bother investigating since we can add linter rules easily for things like this!


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.