### PR TITLE
[dagster-airbyte] [dagster-fivetran] cleanup + tests

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -1,11 +1,22 @@
+import pytest
 import responses
-from dagster_airbyte import AirbyteState, airbyte_resource, build_airbyte_assets
+from dagster_airbyte import airbyte_resource, build_airbyte_assets
 
-from dagster import MetadataEntry, build_assets_job, build_init_resource_context
+from dagster import (
+    AssetKey,
+    MetadataEntry,
+    TableColumn,
+    TableSchema,
+    build_assets_job,
+    build_init_resource_context,
+)
+
+from .utils import get_sample_connection_json, get_sample_job_json
 
 
 @responses.activate
-def test_assets():
+@pytest.mark.parametrize("schema_prefix", ["", "the_prefix_"])
+def test_assets(schema_prefix):
 
     ab_resource = airbyte_resource(
         build_init_resource_context(
@@ -15,51 +26,22 @@ def test_assets():
             }
         )
     )
-    ab_assets = build_airbyte_assets("12345", ["foo", "bar"], asset_key_prefix=["some", "prefix"])
+    destination_tables = ["foo", "bar"]
+    if schema_prefix:
+        destination_tables = [schema_prefix + t for t in destination_tables]
+    ab_assets = build_airbyte_assets(
+        "12345",
+        destination_tables=destination_tables,
+        asset_key_prefix=["some", "prefix"],
+    )
 
+    assert ab_assets[0].asset_keys == {AssetKey(["some", "prefix", t]) for t in destination_tables}
     assert len(ab_assets[0].op.output_defs) == 2
 
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/connections/get",
-        json={
-            "name": "xyz",
-            "syncCatalog": {
-                "streams": [
-                    {
-                        "stream": {
-                            "name": "foo",
-                            "jsonSchema": {
-                                "properties": {"a": {"type": "str"}, "b": {"type": "int"}}
-                            },
-                        },
-                        "config": {"selected": True},
-                    },
-                    {
-                        "stream": {
-                            "name": "bar",
-                            "jsonSchema": {
-                                "properties": {
-                                    "c": {"type": "str"},
-                                }
-                            },
-                        },
-                        "config": {"selected": True},
-                    },
-                    {
-                        "stream": {
-                            "name": "baz",
-                            "jsonSchema": {
-                                "properties": {
-                                    "d": {"type": "str"},
-                                }
-                            },
-                        },
-                        "config": {"selected": True},
-                    },
-                ]
-            },
-        },
+        json=get_sample_connection_json(schema_prefix=schema_prefix),
         status=200,
     )
     responses.add(
@@ -71,38 +53,7 @@ def test_assets():
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs/get",
-        json={
-            "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
-            "attempts": [
-                {
-                    "attempt": {
-                        "streamStats": [
-                            {
-                                "streamName": "foo",
-                                "stats": {
-                                    "bytesEmitted": 1234,
-                                    "recordsCommitted": 4321,
-                                },
-                            },
-                            {
-                                "streamName": "bar",
-                                "stats": {
-                                    "bytesEmitted": 1234,
-                                    "recordsCommitted": 4321,
-                                },
-                            },
-                            {
-                                "streamName": "baz",
-                                "stats": {
-                                    "bytesEmitted": 1111,
-                                    "recordsCommitted": 1111,
-                                },
-                            },
-                        ]
-                    }
-                }
-            ],
-        },
+        json=get_sample_job_json(schema_prefix=schema_prefix),
         status=200,
     )
 
@@ -122,20 +73,27 @@ def test_assets():
     res = ab_job.execute_in_process()
 
     materializations = [
-        event
+        event.event_specific_data.materialization
         for event in res.events_for_node("airbyte_sync_12345")
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]
     assert len(materializations) == 3
+    assert {m.asset_key for m in materializations} == {
+        AssetKey(["some", "prefix", schema_prefix + "foo"]),
+        AssetKey(["some", "prefix", schema_prefix + "bar"]),
+        AssetKey(["some", "prefix", schema_prefix + "baz"]),
+    }
+    assert MetadataEntry.int(1234, "bytesEmitted") in materializations[0].metadata_entries
+    assert MetadataEntry.int(4321, "recordsCommitted") in materializations[0].metadata_entries
     assert (
-        MetadataEntry.text("a,b", "columns")
-        in materializations[0].event_specific_data.materialization.metadata_entries
-    )
-    assert (
-        MetadataEntry.int(1234, "bytesEmitted")
-        in materializations[0].event_specific_data.materialization.metadata_entries
-    )
-    assert (
-        MetadataEntry.int(4321, "recordsCommitted")
-        in materializations[0].event_specific_data.materialization.metadata_entries
+        MetadataEntry.table_schema(
+            TableSchema(
+                columns=[
+                    TableColumn(name="a", type="str"),
+                    TableColumn(name="b", type="int"),
+                ]
+            ),
+            "schema",
+        )
+        in materializations[0].metadata_entries,
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -5,6 +5,8 @@ from dagster_airbyte.utils import generate_materializations
 
 from dagster import Failure, MetadataEntry, build_init_resource_context
 
+from .utils import get_sample_connection_json, get_sample_job_json
+
 
 @responses.activate
 def test_trigger_connection():
@@ -51,7 +53,7 @@ def test_sync_and_poll(state):
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/connections/get",
-        json={"name": "some_connection"},
+        json=get_sample_connection_json(),
         status=200,
     )
     responses.add(
@@ -81,7 +83,10 @@ def test_sync_and_poll(state):
 
     else:
         r = ab_resource.sync_and_poll("some_connection", 0)
-        assert r == AirbyteOutput({"job": {"id": 1, "status": state}}, {"name": "some_connection"})
+        assert r == AirbyteOutput(
+            job_details={"job": {"id": 1, "status": state}},
+            connection_details=get_sample_connection_json(),
+        )
 
 
 @responses.activate
@@ -174,44 +179,7 @@ def test_assets():
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/connections/get",
-        json={
-            "name": "xyz",
-            "syncCatalog": {
-                "streams": [
-                    {
-                        "stream": {
-                            "name": "foo",
-                            "jsonSchema": {
-                                "properties": {"a": {"type": "str"}, "b": {"type": "int"}}
-                            },
-                        },
-                        "config": {"selected": True},
-                    },
-                    {
-                        "stream": {
-                            "name": "bar",
-                            "jsonSchema": {
-                                "properties": {
-                                    "c": {"type": "str"},
-                                }
-                            },
-                        },
-                        "config": {"selected": True},
-                    },
-                    {
-                        "stream": {
-                            "name": "baz",
-                            "jsonSchema": {
-                                "properties": {
-                                    "d": {"type": "str"},
-                                }
-                            },
-                        },
-                        "config": {"selected": False},
-                    },
-                ]
-            },
-        },
+        json=get_sample_connection_json(),
         status=200,
     )
     responses.add(
@@ -223,31 +191,7 @@ def test_assets():
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs/get",
-        json={
-            "job": {"id": 1, "status": AirbyteState.SUCCEEDED},
-            "attempts": [
-                {
-                    "attempt": {
-                        "streamStats": [
-                            {
-                                "streamName": "foo",
-                                "stats": {
-                                    "bytesEmitted": 1234,
-                                    "recordsCommitted": 4321,
-                                },
-                            },
-                            {
-                                "streamName": "bar",
-                                "stats": {
-                                    "bytesEmitted": 1234,
-                                    "recordsCommitted": 4321,
-                                },
-                            },
-                        ]
-                    }
-                }
-            ],
-        },
+        json=get_sample_job_json(),
         status=200,
     )
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -80,6 +80,7 @@ def build_fivetran_assets(
             for key in tracked_asset_keys
         },
         required_resource_keys={"fivetran"},
+        compute_kind="fivetran",
     )
     def _assets(context):
         fivetran_output = context.resources.fivetran.sync_and_poll(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -23,6 +23,7 @@ def test_fivetran_asset_keys():
     assert ft_assets[0].asset_keys == {AssetKey(["x", "foo"]), AssetKey(["y", "bar"])}
 
 
+@pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])
 @pytest.mark.parametrize(
     "tables,should_error",
     [
@@ -33,11 +34,14 @@ def test_fivetran_asset_keys():
         (["schema1.tracked", "does.not_exist"], True),
     ],
 )
-def test_fivetran_asset_run(tables, should_error):
+def test_fivetran_asset_run(tables, should_error, schema_prefix):
 
     ft_resource = fivetran_resource.configured({"api_key": "foo", "api_secret": "bar"})
     final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
     api_prefix = f"{FIVETRAN_API_BASE}/{FIVETRAN_CONNECTOR_PATH}{DEFAULT_CONNECTOR_ID}"
+
+    if schema_prefix:
+        tables = [f"{schema_prefix}_{t}" for t in tables]
 
     fivetran_assets = build_fivetran_assets(
         connector_id=DEFAULT_CONNECTOR_ID,
@@ -72,9 +76,17 @@ def test_fivetran_asset_run(tables, should_error):
             ),
         )
         # initial state
-        rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
+        rsps.add(
+            rsps.GET,
+            api_prefix,
+            json=get_sample_connector_response(),
+        )
+
+        final_json = get_sample_connector_response(data=final_data)
+        if schema_prefix:
+            final_json["data"]["config"]["schema_prefix"] = schema_prefix
         # final state will be updated
-        rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
+        rsps.add(rsps.GET, api_prefix, json=final_json)
 
         if should_error:
             with pytest.raises(DagsterStepOutputNotFoundError):
@@ -100,8 +112,15 @@ def test_fivetran_asset_run(tables, should_error):
             found_asset_keys = set(
                 mat.event_specific_data.materialization.asset_key for mat in asset_materializations
             )
-            assert found_asset_keys == {
-                AssetKey(["schema1", "tracked"]),
-                AssetKey(["schema1", "untracked"]),
-                AssetKey(["schema2", "tracked"]),
-            }
+            if schema_prefix:
+                assert found_asset_keys == {
+                    AssetKey(["the_prefix_schema1", "tracked"]),
+                    AssetKey(["the_prefix_schema1", "untracked"]),
+                    AssetKey(["the_prefix_schema2", "tracked"]),
+                }
+            else:
+                assert found_asset_keys == {
+                    AssetKey(["schema1", "tracked"]),
+                    AssetKey(["schema1", "untracked"]),
+                    AssetKey(["schema2", "tracked"]),
+                }


### PR DESCRIPTION
Some minor polishing on these libraries:

- [airbyte] remove redundant "columns" metadata (we have the entire schema available)
- [airbyte] fix bug where we expected field in API response that won't always be there
- [fivetran] added "compute kind" tag to the multi-asset so that it shows up nicely in dagit

For both libraries, added tests to ensure that they responded properly when a schema prefix was specified for a connector/connection. Both already handled this properly (basically, the generated asset keys should reflect that prefix), but wanted to make sure this was under test.

Also refactored the airbyte tests to be less copy-pasta