### PR TITLE
Optimize Latest Runs Query

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -223,17 +223,17 @@ def get_latest_asset_run_by_step_key(graphene_info, job_names, asset_nodes):
     }
 
     for asset_node in asset_nodes:
-        job_names = asset_node.job_names
+        asset_job_names = asset_node.job_names
         step_key = asset_node.op_name
 
         total_num_records = sum(
-            [len(run_records_by_job.get(job_name, [])) for job_name in job_names]
+            [len(run_records_by_job.get(job_name, [])) for job_name in asset_job_names]
         )
         if total_num_records == 0:
             latest_run_by_step[step_key] = GrapheneLatestRun(step_key, None)
 
         latest_run = None
-        for job_name in job_names:
+        for job_name in asset_job_names:
             record_step_keys = record_step_keys_by_job.get(job_name, [])
             for i in range(len(record_step_keys)):
                 if step_key in record_step_keys[i]:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -274,13 +274,16 @@ class GrapheneRepository(graphene.ObjectType):
         return get_in_progress_runs_by_step(graphene_info, job_names, asset_node_keys)
 
     def resolve_latestRunByStep(self, graphene_info):
+        job_names = [
+            job.name for job in self._repository.get_all_external_pipelines() if job.is_job
+        ]
+
+        asset_node = [node for node in self._repository.get_external_asset_nodes() if node.op_name]
+
         return get_asset_run_stats_by_step(
             graphene_info,
-            [
-                asset_node
-                for asset_node in self._repository.get_external_asset_nodes()
-                if asset_node.op_name
-            ],
+            job_names,
+            asset_node,
         )
 
 


### PR DESCRIPTION
In order to display materialization warnings in Dagit, we fetch the last 5 runs of each job that an asset belongs in to see if the asset was selected in `step_keys_to_execute`.

Previously, this query would iterate through every job in every asset and deserialize the last 5 runs. This caused the query to run slowly; this PR modifies this query to filter and deserialize the last 5 runs of every job in the repository once, then search for the runs containing the asset.

