### PR TITLE
[dagit] Keep user-entered tags when changing presets / partitions

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -21,8 +21,8 @@ export interface PipelineRunTag {
 }
 
 export type SessionBase =
-  | {presetName: string}
-  | {partitionsSetName: string; partitionName: string | null};
+  | {presetName: string; tags: PipelineRunTag[] | null}
+  | {partitionsSetName: string; partitionName: string | null; tags: PipelineRunTag[] | null};
 
 export interface IExecutionSession {
   key: string;

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -99,6 +99,7 @@ export const ConfigEditorConfigPicker: React.FC<ConfigEditorConfigPickerProps> =
         base: {
           partitionsSetName: item.name,
           partitionName: null,
+          tags: base ? base.tags : null,
         },
       });
     } else {


### PR DESCRIPTION
## Summary
This PR makes a subtle adjustment to the launchpad - when you choose a new preset or partition, we remove all the tags that were provided by your last preset or partition and keep any that you have added yourself (or manually modified from their preset/partition values)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.