### PR TITLE
run mypy on dagster-graphql

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/module_build_spec.py
@@ -7,7 +7,6 @@ from .utils import get_python_versions_for_branch
 MYPY_EXCLUDES = [
     "python_modules/dagit",
     "python_modules/automation",
-    "python_modules/dagster-graphql",
     "python_modules/libraries/dagster-databricks",
     "python_modules/libraries/dagster-dbt",
     "python_modules/libraries/dagster-docker",

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -106,14 +106,9 @@ class DagsterGraphQLClient:
         repo_connection_status = query_res["__typename"]
         if repo_connection_status == "RepositoryConnection":
             valid_nodes: Iterable[PipelineInfo] = chain(
-                map(PipelineInfo.from_node, query_res["nodes"])
+                *map(PipelineInfo.from_node, query_res["nodes"])
             )
-            return [
-                repo_node_tuple
-                for repo_node_tuple_lst in valid_nodes
-                for repo_node_tuple in repo_node_tuple_lst
-                if repo_node_tuple.pipeline_name == pipeline_name
-            ]
+            return [info for info in valid_nodes if info.pipeline_name == pipeline_name]
         else:
             raise DagsterGraphQLClientError(repo_connection_status, query_res["message"])
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Dict, Mapping
 
 from dagster import AssetKey, DagsterEventType, EventRecordsFilter, check, seven
 from dagster.core.events import ASSET_EVENTS
@@ -64,7 +64,7 @@ def get_asset_nodes_by_asset_key(graphene_info) -> Mapping[AssetKey, "GrapheneAs
 
     from ..schema.asset_graph import GrapheneAssetNode
 
-    asset_nodes_by_asset_key = {}
+    asset_nodes_by_asset_key: Dict[AssetKey, GrapheneAssetNode] = {}
     for location in graphene_info.context.repository_locations:
         for repository in location.get_repositories().values():
             for external_asset_node in repository.get_external_asset_nodes():

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -1,10 +1,12 @@
 import sys
 from collections import namedtuple
+from typing import cast
 
 from graphql.execution.base import ResolveInfo
 
 from dagster import check
 from dagster.core.host_representation import GraphSelector, PipelineSelector
+from dagster.core.workspace.context import BaseWorkspaceRequestContext
 from dagster.utils.error import serializable_error_info_from_exc_info
 
 
@@ -23,7 +25,8 @@ def check_permission(permission):
 def assert_permission(graphene_info: ResolveInfo, permission: str) -> None:
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
-    if not graphene_info.context.has_permission(permission):
+    context = cast(BaseWorkspaceRequestContext, graphene_info.context)
+    if not context.has_permission(permission):
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -160,11 +160,10 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> List[GrapheneMaterializationEvent]:
         from ..implementation.fetch_assets import get_asset_materializations
 
+        beforeTimestampMillis: Optional[str] = kwargs.get("beforeTimestampMillis")
         try:
             before_timestamp = (
-                int(kwargs.get("beforeTimestampMillis")) / 1000.0
-                if kwargs.get("beforeTimestampMillis")
-                else None
+                int(beforeTimestampMillis) / 1000.0 if beforeTimestampMillis else None
             )
         except ValueError:
             before_timestamp = None

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_reload_repository_location.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from dagster_graphql import DagsterGraphQLClientError, ReloadRepositoryLocationStatus
 
@@ -86,13 +88,12 @@ def test_failure_with_query_error(mock_client: MockClient):
         mock_client.python_client.reload_repository_location("foo")
 
 
-class TestReloadRepositoryLocationWithClient(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env()
-        ]
-    )
-):
+BaseTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env()]
+)
+
+
+class TestReloadRepositoryLocationWithClient(BaseTestSuite):
     def test_reload_location_real(self, graphql_client):
         assert (
             graphql_client.reload_repository_location("test").status

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any
 
 from dagster_graphql import ShutdownRepositoryLocationStatus
 
@@ -9,12 +10,12 @@ from ..graphql.graphql_context_test_suite import (
     make_graphql_context_test_suite,
 )
 
+BaseTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_deployed_grpc_env()]
+)
 
-class TestShutdownRepositoryLocation(
-    make_graphql_context_test_suite(
-        context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_deployed_grpc_env()]
-    )
-):
+
+class TestShutdownRepositoryLocation(BaseTestSuite):
     def test_shutdown_repository_location(self, graphql_client, graphql_context):
         origin = next(iter(graphql_context.get_workspace_snapshot().values())).origin
         origin.create_client().heartbeat()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -274,6 +274,140 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetsOrError': {
         '__typename': 'AssetConnection',
@@ -429,6 +563,27 @@ snapshots['TestAssetAwareEventLog.test_asset_op[asset_aware_instance_in_process_
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'definition': {
+            'op': {
+                'description': None,
+                'inputDefinitions': [
+                    {
+                        'name': 'asset_one'
+                    }
+                ],
+                'name': 'asset_two',
+                'outputDefinitions': [
+                    {
+                        'name': 'result'
+                    }
+                ]
+            }
+        }
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         'definition': {
@@ -463,6 +618,18 @@ snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[asset_aware_instanc
 }
 
 snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'assetLineage': [
+                ],
+                'label': 'b'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_asset_key_lineage[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'assetOrError': {
         'assetMaterializations': [
             {
@@ -510,6 +677,18 @@ snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[postgres_wi
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'assetLineage': [
+                ],
+                'label': 'a'
+            }
+        ]
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         'assetMaterializations': [
@@ -534,6 +713,12 @@ snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[postgres_with_def
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        '__typename': 'AssetNotFoundError'
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         '__typename': 'AssetNotFoundError'
@@ -553,6 +738,18 @@ snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_lineage[asset_a
 }
 
 snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_lineage[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'assetLineage': [
+                ],
+                'label': 'b'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_lineage[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'assetOrError': {
         'assetMaterializations': [
             {
@@ -598,6 +795,17 @@ snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'label': 'a',
+                'partition': 'partition_1'
+            }
+        ]
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         'assetMaterializations': [
@@ -610,6 +818,24 @@ snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization
 }
 
 snapshots['TestAssetAwareEventLog.test_op_assets[asset_aware_instance_in_process_env] 1'] = {
+    'repositoryOrError': {
+        'usedSolid': {
+            'definition': {
+                'assetNodes': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'asset_two'
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_op_assets[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
     'repositoryOrError': {
         'usedSolid': {
             'definition': {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -11,7 +11,8 @@ from dagster_graphql.test.utils import (
 from dagster import AssetKey
 from dagster.utils import safe_tempfile_path
 
-from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
+# from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
+from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
 
 GET_ASSET_KEY_QUERY = """
     query AssetKeyQuery {
@@ -270,15 +271,7 @@ def _create_run(graphql_context, pipeline_name, mode="default", step_keys=None):
     return result.data["launchPipelineExecution"]["run"]["runId"]
 
 
-class TestAssetAwareEventLog(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.consolidated_sqlite_instance_managed_grpc_env(),
-            GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env(),
-            GraphQLContextVariant.postgres_with_default_run_launcher_managed_grpc_env(),
-        ]
-    )
-):
+class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
     def test_all_asset_keys(self, graphql_context, snapshot):
         _create_run(graphql_context, "multi_asset_pipeline")
         result = execute_dagster_graphql(graphql_context, GET_ASSET_KEY_QUERY)
@@ -777,14 +770,7 @@ class TestAssetAwareEventLog(
         assert result["asset_2"]["sinceLatestMaterialization"] == False
 
 
-class TestPersistentInstanceAssetInProgress(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env(),
-            GraphQLContextVariant.postgres_with_default_run_launcher_managed_grpc_env(),
-        ]
-    )
-):
+class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
     def test_asset_in_progress(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "hanging_job")
         run_id = "foo"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instance.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from dagster_graphql.test.utils import execute_dagster_graphql
 
 from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
@@ -12,13 +14,14 @@ query InstanceDetailSummaryQuery {
 """
 
 
-class TestInstanceSettings(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.sqlite_with_queued_run_coordinator_managed_grpc_env(),
-        ]
-    )
-):
+BaseTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[
+        GraphQLContextVariant.sqlite_with_queued_run_coordinator_managed_grpc_env(),
+    ]
+)
+
+
+class TestInstanceSettings(BaseTestSuite):
     def test_instance_settings(self, graphql_context):
         results = execute_dagster_graphql(graphql_context, INSTANCE_QUERY)
         assert results.data == {"instance": {"runQueuingSupported": True, "hasInfo": True}}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -8,8 +8,7 @@ from dagster.core.test_utils import create_test_daemon_workspace
 from dagster.daemon import get_default_daemon_logger
 from dagster.daemon.sensor import execute_sensor_iteration
 
-from .graphql_context_test_suite import GraphQLContextVariant  # get_dict_recon_repo,
-from .graphql_context_test_suite import make_graphql_context_test_suite
+from .graphql_context_test_suite import NonLaunchableGraphQLContextTestMatrix
 
 INSTIGATION_QUERY = """
 query JobQuery($instigationSelector: InstigationSelector!) {
@@ -41,11 +40,7 @@ def _create_sensor_tick(graphql_context):
         )
 
 
-class TestNextTickRepository(
-    make_graphql_context_test_suite(
-        context_variants=GraphQLContextVariant.all_non_launchable_variants(),
-    )
-):
+class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
     def test_schedule_next_tick(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
         external_repository = graphql_context.get_repository_location(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 from unittest import mock
 
 from dagster_graphql.test.utils import execute_dagster_graphql
@@ -76,11 +77,20 @@ mutation {
 """
 
 
-class TestReloadWorkspace(
-    make_graphql_context_test_suite(
-        context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_multi_location()]
-    )
-):
+MultiLocationTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_multi_location()]
+)
+OutOfProcessTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env()]
+)
+ManagedTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[
+        GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env(),
+    ]
+)
+
+
+class TestReloadWorkspace(MultiLocationTestSuite):
     def test_reload_workspace(self, graphql_context):
         result = execute_dagster_graphql(graphql_context, RELOAD_WORKSPACE_QUERY)
 
@@ -224,13 +234,7 @@ class TestReloadWorkspace(
             assert "new_location_name" in [node["name"] for node in nodes]
 
 
-class TestReloadRepositoriesOutOfProcess(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env()
-        ]
-    )
-):
+class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
     def test_out_of_process_reload_location(self, graphql_context):
         result = execute_dagster_graphql(
             graphql_context, RELOAD_REPOSITORY_LOCATION_QUERY, {"repositoryLocationName": "test"}
@@ -394,13 +398,7 @@ class TestReloadRepositoriesOutOfProcess(
         )
 
 
-class TestReloadRepositoriesManagedGrpc(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.non_launchable_in_memory_instance_managed_grpc_env(),
-        ]
-    )
-):
+class TestReloadRepositoriesManagedGrpc(ManagedTestSuite):
     def test_managed_grpc_reload_location(self, graphql_context):
         result = execute_dagster_graphql(
             graphql_context, RELOAD_REPOSITORY_LOCATION_QUERY, {"repositoryLocationName": "test"}

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -17,11 +17,7 @@ from dagster.core.storage.tags import RESUME_RETRY_TAG
 from dagster.core.test_utils import poll_for_finished_run
 from dagster.core.utils import make_new_run_id
 
-from .graphql_context_test_suite import (
-    ExecutingGraphQLContextTestMatrix,
-    GraphQLContextVariant,
-    make_graphql_context_test_suite,
-)
+from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
 from .setup import csv_hello_world_solids_config, get_retry_multi_execution_params, retry_config
 from .utils import (
     get_all_logs_for_finished_run_via_subscription,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -544,9 +544,7 @@ def _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id):
     return retry_one
 
 
-class TestRetryExecutionAsyncOnlyBehavior(
-    make_graphql_context_test_suite(context_variants=GraphQLContextVariant.all_executing_variants())
-):
+class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
     def test_retry_requires_intermediates_async_only(self, graphql_context):
         run_id = make_new_run_id()
         reexecution_run_id = make_new_run_id()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import Any
 
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
@@ -63,13 +64,12 @@ mutation TerminatePipeline($runId: String!) {
 """
 
 
-class TestQueuedRunTermination(
-    make_graphql_context_test_suite(
-        context_variants=[
-            GraphQLContextVariant.sqlite_with_queued_run_coordinator_managed_grpc_env()
-        ]
-    )
-):
+QueuedRunCoordinatorTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.sqlite_with_queued_run_coordinator_managed_grpc_env()]
+)
+
+
+class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
     def test_cancel_queued_run(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "infinite_loop_pipeline")
         with safe_tempfile_path() as path:
@@ -131,11 +131,12 @@ class TestQueuedRunTermination(
             assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
 
 
-class TestRunVariantTermination(
-    make_graphql_context_test_suite(
-        context_variants=[GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env()]
-    )
-):
+RunTerminationTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env()]
+)
+
+
+class TestRunVariantTermination(RunTerminationTestSuite):
     def test_basic_termination(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "infinite_loop_pipeline")
         with safe_tempfile_path() as path:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
@@ -20,9 +22,12 @@ query RunQuery($runId: ID!) {
 """
 
 
-class TestBasicLaunch(
-    make_graphql_context_test_suite(context_variants=GraphQLContextVariant.all_executing_variants())
-):
+BaseTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=GraphQLContextVariant.all_executing_variants()
+)
+
+
+class TestBasicLaunch(BaseTestSuite):
     def test_run_launcher(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "no_config_pipeline")
         result = execute_dagster_graphql(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_watch_grpc_server.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_watch_grpc_server.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any
 
 from dagster.core.host_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
@@ -8,12 +9,12 @@ from dagster.core.host_representation.grpc_server_state_subscriber import (
 
 from .graphql_context_test_suite import GraphQLContextVariant, make_graphql_context_test_suite
 
+BaseTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_deployed_grpc_env()]
+)
 
-class TestSubscribeToGrpcServerEvents(
-    make_graphql_context_test_suite(
-        context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_deployed_grpc_env()]
-    )
-):
+
+class TestSubscribeToGrpcServerEvents(BaseTestSuite):
     def test_grpc_server_handle_message_subscription(self, graphql_context):
         events = []
         test_subscriber = LocationStateSubscriber(events.append)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from typing import Any
 from unittest import mock
 
 from dagster_graphql.test.utils import execute_dagster_graphql
@@ -50,12 +51,12 @@ query {
 }
 """
 
+BaseTestSuite: Any = make_graphql_context_test_suite(
+    context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_multi_location()]
+)
 
-class TestLoadWorkspace(
-    make_graphql_context_test_suite(
-        context_variants=[GraphQLContextVariant.non_launchable_in_memory_instance_multi_location()]
-    )
-):
+
+class TestLoadWorkspace(BaseTestSuite):
     def test_load_workspace(self, graphql_context):
         # Add an error origin
         original_origins = location_origins_from_yaml_paths(


### PR DESCRIPTION
## Summary
Enable mypy checking on `dagster-graphql`.

Most of the changes were extracting out a variable because mypy does not support dynamic base classes.

## Test Plan
BK


