### PR TITLE
[dagit] Render status page navigation when factory floor loading

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -273,9 +273,15 @@ export const InstanceOverviewPage = () => {
 
   if (!data && loading) {
     return (
-      <Box padding={64}>
-        <Spinner purpose="page" />
-      </Box>
+      <>
+        <PageHeader
+          title={<Heading>Instance status</Heading>}
+          tabs={<InstanceTabs tab="overview" refreshState={refreshState} />}
+        />
+        <Box padding={64}>
+          <Spinner purpose="section" />
+        </Box>
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary

Small UI tweak - displays the Instance Status navbar before the factory floor page has finished loading.