### PR TITLE
RFC: Add gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,17 @@
+tasks:
+- init: |
+    python3 -m venv /workspace/venv
+    source /workspace/venv/bin/activate
+    make dev_install
+    cd /workspace
+    zip -qr venv.zip venv
+    rm -fr venv
+- command: |
+    cd /workspace
+    unzip -q venv.zip
+    source /workspace/venv/bin/activate
+    cd /workspace/dagster
+
+ports:
+  - port: 3000
+    onOpen: open-browser


### PR DESCRIPTION
## Summary

Setting up your Python environment (especially on an M1 mac) and keeping it up to date can be annoying. This diff adds a `.gitpod.yml` configuration file which sets up a gitpod.io cloud dev environment that's guaranteed to be consistent. Additionally, gitpod will asynchronously install dependencies and build the image, so new contributors can have a dev environment instantly, rather than spending 20 minutes installing dependencies.

If this diff is accepted, we should install the GitPod GitHub app on this repo so we can start building dev environments asynchronously. We can consider adding the "open in gitpod" button to the readme if we think contributors will find it useful.

## Test Plan

I set GitPod up on my fork of Dagster. All tests pass, except for 2 failures. When running Dagster on my local machine, all tests pass except for 2 failures. So this seems close enough as-is to be valuable.