### PR TITLE
[dagit] Lower factory floor timeline fidelity to seconds from ms

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceOverviewPage.tsx
@@ -364,10 +364,13 @@ const RunTimelineSection = ({jobs, loading}: {jobs: JobItem[]; loading: boolean}
     }
   }, [loading]);
 
-  const now = nowRef.current;
+  const nowSecs = Math.floor(nowRef.current / 1000);
   const range: [number, number] = React.useMemo(() => {
-    return [now - Number(hourWindow) * ONE_HOUR, now + LOOKAHEAD_HOURS * ONE_HOUR];
-  }, [hourWindow, now]);
+    return [
+      nowSecs * 1000 - Number(hourWindow) * ONE_HOUR,
+      nowSecs * 1000 + LOOKAHEAD_HOURS * ONE_HOUR,
+    ];
+  }, [hourWindow, nowSecs]);
 
   const [start, end] = React.useMemo(() => {
     const [unvalidatedStart, unvalidatedEnd] = range;


### PR DESCRIPTION
## Summary

The factory floor page `RunTimelineSection` detemrines which window of time to show based on the current time, in ms. This changes as the component loads, leading to a different time range being generated. `RunTimelineContainer` passes this range to `useQuery`, meaning the timeline query is made twice as the result is not cached when the range differs.

This PR lowers the fidelity of the range to be in seconds, leading to only one set of ranges being passed in the vast majority of cases, avoiding this extra costly query.

There might be a cleaner fix dealing with the way that the `nowRef` is handled.

## Test Plan

Tested locally.