### PR TITLE
dagster-snowflake drop 3.6 support

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -458,6 +458,18 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
         ),
     ),
     ModuleBuildSpec(
+        "python_modules/libraries/dagster-snowflake",
+        supported_pythons=(  # dropped python 3.6 support
+            [
+                SupportedPython.V3_7,
+                SupportedPython.V3_8,
+                SupportedPython.V3_9,
+            ]
+            if (branch_name == "master" or is_release_branch(branch_name))
+            else [SupportedPython.V3_9]
+        ),
+    ),
+    ModuleBuildSpec(
         "python_modules/libraries/dagster-postgres", extra_cmds_fn=postgres_extra_cmds_fn
     ),
     ModuleBuildSpec(

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -24,7 +24,6 @@ if __name__ == "__main__":
         description="Package for Snowflake Dagster framework components.",
         url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-snowflake",
         classifiers=[
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
the underyling library we use dropped 3.6 support 
https://pypi.org/project/snowflake-connector-python/


## Test Plan
bk
