### PR TITLE
refetch the backfill before updating, to avoid clobbering cancels

### DIFF
--- a/python_modules/dagster/dagster/daemon/backfill.py
+++ b/python_modules/dagster/dagster/daemon/backfill.py
@@ -88,11 +88,14 @@ def execute_backfill_iteration(instance, workspace, logger, debug_crash_flags=No
                 _check_for_debug_crash(debug_crash_flags, "BEFORE_SUBMIT")
 
                 if chunk:
-
                     for _run_id in submit_backfill_runs(
                         instance, workspace, repo_location, backfill_job, chunk
                     ):
                         yield
+                        # before submitting, refetch the backfill job to check for status changes
+                        backfill_job = instance.get_backfill(backfill_job.backfill_id)
+                        if backfill_job.status != BulkActionStatus.REQUESTED:
+                            return
 
                 _check_for_debug_crash(debug_crash_flags, "AFTER_SUBMIT")
 

--- a/python_modules/dagster/dagster/daemon/backfill.py
+++ b/python_modules/dagster/dagster/daemon/backfill.py
@@ -48,6 +48,9 @@ def execute_backfill_iteration(instance, workspace, logger, debug_crash_flags=No
     for backfill_job in backfill_jobs:
         backfill_id = backfill_job.backfill_id
 
+        # refetch, in case the backfill was updated in the meantime
+        backfill_job = instance.get_backfill(backfill_id)
+
         if not backfill_job.last_submitted_partition_name:
             logger.info(f"Starting backfill for {backfill_id}")
         else:
@@ -76,8 +79,6 @@ def execute_backfill_iteration(instance, workspace, logger, debug_crash_flags=No
 
             has_more = True
             while has_more:
-                # refetch the backfill job
-                backfill_job = instance.get_backfill(backfill_job.backfill_id)
                 if backfill_job.status != BulkActionStatus.REQUESTED:
                     break
 
@@ -96,6 +97,8 @@ def execute_backfill_iteration(instance, workspace, logger, debug_crash_flags=No
                 _check_for_debug_crash(debug_crash_flags, "AFTER_SUBMIT")
 
                 if has_more:
+                    # refetch, in case the backfill was updated in the meantime
+                    backfill_job = instance.get_backfill(backfill_job.backfill_id)
                     instance.update_backfill(backfill_job.with_partition_checkpoint(checkpoint))
                     yield
                     time.sleep(CHECKPOINT_INTERVAL)


### PR DESCRIPTION
## Summary
The parts of the backfill daemon loop that can take a while is to actually create and submit the runs after reading the partitions from the backfill job.

This diff makes sure to re-fetch the backfill job just before writing state back, to minimize the time window in which the backfill could have been canceled before getting clobbered by the checkpoint write.

Helps address https://github.com/dagster-io/dagster/issues/7090

## Test Plan
BK