### PR TITLE
[dagit] Add optional close button to Alert component

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Alert.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.stories.tsx
@@ -13,6 +13,13 @@ export default {
 const intents: AlertIntent[] = ['info', 'warning', 'error', 'success'];
 
 export const Intents = () => {
+  const [isClosed, updateClosed] = React.useState<boolean[]>(intents.map(() => false));
+  const setClosed = (index: number, closed: boolean) => {
+    const newClosed = Array.from(isClosed);
+    newClosed[index] = closed;
+    updateClosed(newClosed);
+  };
+
   return (
     <Box flex={{direction: 'column', gap: 8}}>
       {intents.map((intent) => (
@@ -27,6 +34,18 @@ export const Intents = () => {
           }
         />
       ))}
+      {intents.map((intent, i) =>
+        !isClosed[i] ? (
+          <Alert
+            key={`${intent}-closable`}
+            intent={intent}
+            title="You can dismiss me."
+            description="This alert can be dismissed."
+            hasCloseButton={true}
+            onClose={() => setClosed(i, true)}
+          />
+        ) : null,
+      )}
     </Box>
   );
 };

--- a/js_modules/dagit/packages/ui/src/components/Alert.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.stories.tsx
@@ -41,7 +41,6 @@ export const Intents = () => {
             intent={intent}
             title="You can dismiss me."
             description="This alert can be dismissed."
-            hasCloseButton={true}
             onClose={() => setClosed(i, true)}
           />
         ) : null,

--- a/js_modules/dagit/packages/ui/src/components/Alert.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.tsx
@@ -12,10 +12,12 @@ interface Props {
   intent: AlertIntent;
   title: React.ReactNode;
   description?: React.ReactNode;
+  hasCloseButton?: boolean;
+  onClose?: () => void;
 }
 
 export const Alert: React.FC<Props> = (props) => {
-  const {intent, title, description} = props;
+  const {intent, title, description, hasCloseButton, onClose} = props;
 
   const {backgroundColor, borderColor, icon, iconColor, textColor} = React.useMemo(() => {
     switch (intent) {
@@ -62,13 +64,20 @@ export const Alert: React.FC<Props> = (props) => {
       $textColor={textColor}
       padding={{horizontal: 16, vertical: 12}}
     >
-      <Group direction="row" spacing={12} alignItems="flex-start">
-        <IconWIP name={icon as IconName} color={iconColor} />
-        <Group direction="column" spacing={8}>
-          <AlertTitle>{title}</AlertTitle>
-          {description ? <AlertDescription>{description}</AlertDescription> : null}
+      <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+        <Group direction="row" spacing={12} alignItems="flex-start">
+          <IconWIP name={icon as IconName} color={iconColor} />
+          <Group direction="column" spacing={8}>
+            <AlertTitle>{title}</AlertTitle>
+            {description ? <AlertDescription>{description}</AlertDescription> : null}
+          </Group>
         </Group>
-      </Group>
+        {hasCloseButton ? (
+          <div onClick={onClose} style={{cursor: 'pointer'}}>
+            <IconWIP name="close" />
+          </div>
+        ) : null}
+      </Box>
     </AlertContainer>
   );
 };

--- a/js_modules/dagit/packages/ui/src/components/Alert.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.tsx
@@ -74,7 +74,7 @@ export const Alert: React.FC<Props> = (props) => {
         </Group>
         {hasCloseButton ? (
           <div onClick={onClose} style={{cursor: 'pointer'}}>
-            <IconWIP name="close" />
+            <IconWIP name="close" color={textColor} />
           </div>
         ) : null}
       </Box>

--- a/js_modules/dagit/packages/ui/src/components/Alert.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.tsx
@@ -12,12 +12,11 @@ interface Props {
   intent: AlertIntent;
   title: React.ReactNode;
   description?: React.ReactNode;
-  hasCloseButton?: boolean;
   onClose?: () => void;
 }
 
 export const Alert: React.FC<Props> = (props) => {
-  const {intent, title, description, hasCloseButton, onClose} = props;
+  const {intent, title, description, onClose} = props;
 
   const {backgroundColor, borderColor, icon, iconColor, textColor} = React.useMemo(() => {
     switch (intent) {
@@ -72,7 +71,7 @@ export const Alert: React.FC<Props> = (props) => {
             {description ? <AlertDescription>{description}</AlertDescription> : null}
           </Group>
         </Group>
-        {hasCloseButton ? (
+        {!!onClose ? (
           <ButtonWrapper onClick={onClose}>
             <IconWIP name="close" color={textColor} />
           </ButtonWrapper>

--- a/js_modules/dagit/packages/ui/src/components/Alert.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Alert.tsx
@@ -73,9 +73,9 @@ export const Alert: React.FC<Props> = (props) => {
           </Group>
         </Group>
         {hasCloseButton ? (
-          <div onClick={onClose} style={{cursor: 'pointer'}}>
+          <ButtonWrapper onClick={onClose}>
             <IconWIP name="close" color={textColor} />
-          </div>
+          </ButtonWrapper>
         ) : null}
       </Box>
     </AlertContainer>
@@ -85,6 +85,17 @@ export const Alert: React.FC<Props> = (props) => {
 Alert.defaultProps = {
   intent: 'info',
 };
+
+const ButtonWrapper = styled.button`
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  flex-direction: column;
+  height: fit-content;
+`;
 
 const AlertContainer = styled(Box)<{$borderColor: string; $textColor: string}>`
   box-shadow: inset 4px 0 ${({$borderColor}) => $borderColor};


### PR DESCRIPTION
## Summary

Adds an optional close button to the Alert component, which the parent component can use to allow the alert to be dismissed.

![Screen Shot 2022-03-17 at 10 23 37 AM](https://user-images.githubusercontent.com/10215173/158858662-9327bd35-8a7c-4a3c-9d5e-f913c85d207e.png)

## Test Plan

Storybook.