### PR TITLE
Add build to list of DBT_RUN_RESULTS_COMMANDS

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/constants.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/constants.py
@@ -5,7 +5,7 @@ DEFAULT_DBT_TARGET_PATH = "target"
 
 # The set of dbt cli commands that result in the creation of a run_results.json output file
 # https://docs.getdbt.com/reference/artifacts/run-results-json
-DBT_RUN_RESULTS_COMMANDS = ["run", "test", "seed", "snapshot", "docs generate"]
+DBT_RUN_RESULTS_COMMANDS = ["run", "test", "seed", "snapshot", "docs generate", "build"]
 
 # The following config fields correspond to flags that apply to all dbt CLI commands. For details
 # on dbt CLI flags, see


### PR DESCRIPTION
"build" is a newish dbt command. It takes the same flags as "run" and produces a run_results.json. It definitely belongs in this list.

https://docs.getdbt.com/reference/commands/build

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.