### PR TITLE
Don't give up if the terminate() call raises an exception during force-termination

### DIFF
--- a/examples/deploy_docker/tests/test_deploy_docker.py
+++ b/examples/deploy_docker/tests/test_deploy_docker.py
@@ -228,7 +228,7 @@ def test_deploy_docker():
         assert (
             terminate_res["data"]["terminatePipelineExecution"]["__typename"]
             == "TerminateRunSuccess"
-        )
+        ), str(terminate_res)
 
         _wait_for_run_status(hanging_run_id, dagit_host, PipelineRunStatus.CANCELED)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -335,7 +335,7 @@ class GrapheneTerminateRunMutation(graphene.Mutation):
     @check_permission(Permissions.TERMINATE_PIPELINE_EXECUTION)
     def mutate(self, graphene_info, **kwargs):
         return terminate_pipeline_execution(
-            graphene_info,
+            graphene_info.context.instance,
             kwargs["runId"],
             kwargs.get("terminatePolicy", GrapheneTerminateRunPolicy.SAFE_TERMINATE),
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -2,6 +2,7 @@ import os
 import time
 from typing import Any
 
+import pytest
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_pipeline_selector
 
@@ -97,7 +98,9 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
             result = execute_dagster_graphql(
                 graphql_context, RUN_CANCELLATION_QUERY, variables={"runId": run_id}
             )
-            assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
+            assert (
+                result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
+            ), str(result.data)
 
     def test_force_cancel_queued_run(self, graphql_context):
         selector = infer_pipeline_selector(graphql_context, "infinite_loop_pipeline")
@@ -134,6 +137,14 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
 RunTerminationTestSuite: Any = make_graphql_context_test_suite(
     context_variants=[GraphQLContextVariant.sqlite_with_default_run_launcher_managed_grpc_env()]
 )
+
+
+def _exception_terminate(_run_id):
+    raise Exception("FAILED TO TERMINATE")
+
+
+def _return_fail_terminate(_run_id):
+    return False
 
 
 class TestRunVariantTermination(RunTerminationTestSuite):
@@ -215,11 +226,21 @@ class TestRunVariantTermination(RunTerminationTestSuite):
         )
         assert result.data["terminatePipelineExecution"]["__typename"] == "RunNotFoundError"
 
-    def test_terminate_failed(self, graphql_context):
+    @pytest.mark.parametrize(
+        argnames=["new_terminate_method", "terminate_result"],
+        argvalues=[
+            [
+                _return_fail_terminate,
+                "TerminateRunFailure",
+            ],
+            [_exception_terminate, "PythonError"],
+        ],
+    )
+    def test_terminate_failed(self, graphql_context, new_terminate_method, terminate_result):
         selector = infer_pipeline_selector(graphql_context, "infinite_loop_pipeline")
         with safe_tempfile_path() as path:
             old_terminate = graphql_context.instance.run_launcher.terminate
-            graphql_context.instance.run_launcher.terminate = lambda _run_id: False
+            graphql_context.instance.run_launcher.terminate = new_terminate_method
             result = execute_dagster_graphql(
                 graphql_context,
                 LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -245,9 +266,8 @@ class TestRunVariantTermination(RunTerminationTestSuite):
             result = execute_dagster_graphql(
                 graphql_context, RUN_CANCELLATION_QUERY, variables={"runId": run_id}
             )
-            assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunFailure"
-            assert result.data["terminatePipelineExecution"]["message"].startswith(
-                "Unable to terminate run"
+            assert result.data["terminatePipelineExecution"]["__typename"] == terminate_result, str(
+                result.data
             )
 
             result = execute_dagster_graphql(
@@ -265,6 +285,10 @@ class TestRunVariantTermination(RunTerminationTestSuite):
             # Clean up the run process on the gRPC server
             repository_location = graphql_context.repository_locations[0]
             repository_location.client.cancel_execution(CancelExecutionRequest(run_id=run_id))
+
+            assert (
+                graphql_context.instance.get_run_by_id(run_id).status == PipelineRunStatus.CANCELED
+            )
 
     def test_run_finished(self, graphql_context):
         instance = graphql_context.instance


### PR DESCRIPTION
Summary:
The idea with force-terminate is that no matter what the run is moved into a terminal state, but if an exception is raised we give up. this fixes that by logging to the event log if there's an exception, but still moving ahead and force-terminating the run.

Test Plan: BK

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.