### PR TITLE
replace internal uses of `MetadataEntry` static api

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/setup.py
@@ -81,6 +81,7 @@ from dagster import (
 from dagster.core.asset_defs import SourceAsset, asset, build_assets_job
 from dagster.core.definitions.decorators.sensor import sensor
 from dagster.core.definitions.executor_definition import in_process_executor
+from dagster.core.definitions.metadata import MetadataValue
 from dagster.core.definitions.reconstructable import ReconstructableRepository
 from dagster.core.definitions.sensor_definition import RunRequest, SkipReason
 from dagster.core.log_manager import coerce_valid_log_level
@@ -694,28 +695,32 @@ def materialization_pipeline():
             asset_key="all_types",
             description="a materialization with all metadata types",
             metadata_entries=[
-                MetadataEntry.text("text is cool", "text"),
-                MetadataEntry.url("https://bigty.pe/neato", "url"),
-                MetadataEntry.fspath("/tmp/awesome", "path"),
-                MetadataEntry.json({"is_dope": True}, "json"),
-                MetadataEntry.python_artifact(MetadataEntry, "python class"),
-                MetadataEntry.python_artifact(file_relative_path, "python function"),
-                MetadataEntry.float(1.2, "float"),
-                MetadataEntry.int(1, "int"),
-                MetadataEntry.float(float("nan"), "float NaN"),
-                MetadataEntry.int(LONG_INT, "long int"),
-                MetadataEntry.pipeline_run("fake_run_id", "pipeline run"),
-                MetadataEntry.asset(AssetKey("my_asset"), "my asset"),
-                MetadataEntry.table(
-                    label="table",
-                    records=[
-                        TableRecord(foo=1, bar=2),
-                        TableRecord(foo=3, bar=4),
-                    ],
+                MetadataEntry("text", value="text is cool"),
+                MetadataEntry("url", value=MetadataValue.url("https://bigty.pe/neato")),
+                MetadataEntry("path", value=MetadataValue.path("/tmp/awesome")),
+                MetadataEntry("json", value={"is_dope": True}),
+                MetadataEntry("python class", value=MetadataValue.python_artifact(MetadataEntry)),
+                MetadataEntry(
+                    "python function", value=MetadataValue.python_artifact(file_relative_path)
                 ),
-                MetadataEntry.table_schema(
-                    label="table_schema",
-                    schema=TableSchema(
+                MetadataEntry("float", value=1.2),
+                MetadataEntry("int", value=1),
+                MetadataEntry("float NaN", value=float("nan")),
+                MetadataEntry("long int", value=LONG_INT),
+                MetadataEntry("pipeline run", value=MetadataValue.pipeline_run("fake_run_id")),
+                MetadataEntry("my asset", value=AssetKey("my_asset")),
+                MetadataEntry(
+                    "table",
+                    value=MetadataValue.table(
+                        records=[
+                            TableRecord(foo=1, bar=2),
+                            TableRecord(foo=3, bar=4),
+                        ],
+                    ),
+                ),
+                MetadataEntry(
+                    "table_schema",
+                    value=TableSchema(
                         columns=[
                             TableColumn(
                                 name="foo",
@@ -1324,18 +1329,20 @@ def backcompat_materialization_pipeline():
             asset_key="all_types",
             description="a materialization with all metadata types",
             metadata_entries=[
-                MetadataEntry.text("text is cool", "text"),
-                MetadataEntry.url("https://bigty.pe/neato", "url"),
-                MetadataEntry.fspath("/tmp/awesome", "path"),
-                MetadataEntry.json({"is_dope": True}, "json"),
-                MetadataEntry.python_artifact(MetadataEntry, "python class"),
-                MetadataEntry.python_artifact(file_relative_path, "python function"),
-                MetadataEntry.float(1.2, "float"),
-                MetadataEntry.int(1, "int"),
-                MetadataEntry.float(float("nan"), "float NaN"),
-                MetadataEntry.int(LONG_INT, "long int"),
-                MetadataEntry.pipeline_run("fake_run_id", "pipeline run"),
-                MetadataEntry.asset(AssetKey("my_asset"), "my asset"),
+                MetadataEntry("text", value="text is cool"),
+                MetadataEntry("url", value=MetadataValue.url("https://bigty.pe/neato")),
+                MetadataEntry("path", value=MetadataValue.path("/tmp/awesome")),
+                MetadataEntry("json", value={"is_dope": True}),
+                MetadataEntry("python class", value=MetadataValue.python_artifact(MetadataEntry)),
+                MetadataEntry(
+                    "python function", value=MetadataValue.python_artifact(file_relative_path)
+                ),
+                MetadataEntry("float", value=1.2),
+                MetadataEntry("int", value=1),
+                MetadataEntry("float NaN", value=float("nan")),
+                MetadataEntry("long int", value=LONG_INT),
+                MetadataEntry("pipeline run", value=MetadataValue.pipeline_run("fake_run_id")),
+                MetadataEntry("my asset", value=AssetKey("my_asset")),
             ],
         )
         yield Output(None)

--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -23,6 +23,7 @@ from dagster.utils.backcompat import experimental_class_param_warning
 
 from .metadata import (
     MetadataEntry,
+    MetadataValue,
     PartitionMetadataEntry,
     RawMetadataValue,
     last_file_comp,
@@ -434,7 +435,7 @@ class AssetMaterialization(
         return AssetMaterialization(
             asset_key=cast(Union[str, AssetKey, List[str]], asset_key),
             description=description,
-            metadata_entries=[MetadataEntry.fspath(path)],
+            metadata_entries=[MetadataEntry("path", value=MetadataValue.path(path))],
         )
 
 
@@ -541,7 +542,7 @@ class Materialization(
         return Materialization(
             label=last_file_comp(path),
             description=description,
-            metadata_entries=[MetadataEntry.fspath(path)],
+            metadata_entries=[MetadataEntry("path", value=MetadataValue.path(path))],
             asset_key=asset_key,
         )
 

--- a/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/core/definitions/metadata/__init__.py
@@ -548,12 +548,8 @@ class JsonMetadataValue(
             # check that the value is JSON serializable
             seven.dumps(data)
         except TypeError:
-            raise DagsterInvalidMetadata(
-                "Value is a dictionary but is not JSON serializable."
-            )
-        return super(JsonMetadataValue, cls).__new__(
-            cls, data
-        )
+            raise DagsterInvalidMetadata("Value is a dictionary but is not JSON serializable.")
+        return super(JsonMetadataValue, cls).__new__(cls, data)
 
 
 @whitelist_for_serdes(storage_name="MarkdownMetadataEntryData")
@@ -714,7 +710,7 @@ class TableMetadataValue(
 
     def __new__(cls, records: List[TableRecord], schema: Optional[TableSchema]):
 
-        check.list_param(records, "records", of_type=TableRecord),
+        check.list_param(records, "records", of_type=TableRecord)
         check.opt_inst_param(schema, "schema", TableSchema)
 
         if len(records) == 0:

--- a/python_modules/dagster/dagster/core/events/__init__.py
+++ b/python_modules/dagster/dagster/core/events/__init__.py
@@ -882,7 +882,7 @@ class DagsterEvent(
                         key,
                         value=MetadataValue.python_artifact(resource_instances[key].__class__),
                     ),
-                    MetadataEntry(f"{key}:init_time_ms", value=resource_init_times[key]),
+                    MetadataEntry(f"{key}:init_time", value=resource_init_times[key]),
                 ]
             )
 
@@ -1026,7 +1026,9 @@ class DagsterEvent(
                 value_name=value_name,
                 address=object_store_operation_result.key,
                 metadata_entries=[
-                    MetadataEntry.path(object_store_operation_result.key, label="key")
+                    MetadataEntry(
+                        "key", value=MetadataValue.path(object_store_operation_result.key)
+                    ),
                 ],
                 version=object_store_operation_result.version,
                 mapping_key=object_store_operation_result.mapping_key,
@@ -1345,9 +1347,9 @@ class EngineEventData(
         pid: int, step_keys_to_execute: Optional[List[str]] = None
     ) -> "EngineEventData":
         return EngineEventData(
-            metadata_entries=[MetadataEntry.text(str(pid), "pid")]
+            metadata_entries=[MetadataEntry("pid", value=str(pid))]
             + (
-                [MetadataEntry.text(str(step_keys_to_execute), "step_keys")]
+                [MetadataEntry("step_keys", value=str(step_keys_to_execute))]
                 if step_keys_to_execute
                 else []
             )
@@ -1356,7 +1358,7 @@ class EngineEventData(
     @staticmethod
     def interrupted(steps_interrupted: List[str]) -> "EngineEventData":
         return EngineEventData(
-            metadata_entries=[MetadataEntry.text(str(steps_interrupted), "steps_interrupted")]
+            metadata_entries=[MetadataEntry("steps_interrupted", value=str(steps_interrupted))]
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/core/executor/multiprocess.py
@@ -70,8 +70,8 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
                 self.pipeline_run,
                 EngineEventData(
                     [
-                        MetadataEntry.text(str(os.getpid()), "pid"),
-                        MetadataEntry.text(self.step_key, "step_key"),
+                        MetadataEntry("pid", value=str(os.getpid())),
+                        MetadataEntry("step_key", value=self.step_key),
                     ],
                     marker_end=DELEGATE_MARKER,
                 ),

--- a/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/core/executor/step_delegating/step_delegating_executor.py
@@ -171,7 +171,9 @@ class StepDelegatingExecutor(Executor):
                             "run will be resumed",
                             EngineEventData(
                                 metadata_entries=[
-                                    MetadataEntry.text(str(running_steps.keys()), "steps_in_flight")
+                                    MetadataEntry(
+                                        "steps_in_flight", value=str(running_steps.keys())
+                                    )
                                 ]
                             ),
                         )

--- a/python_modules/dagster/dagster/core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/core/storage/fs_io_manager.py
@@ -5,7 +5,7 @@ from dagster import check
 from dagster.config import Field
 from dagster.config.source import StringSource
 from dagster.core.definitions.events import AssetKey, AssetMaterialization
-from dagster.core.definitions.metadata import MetadataEntry
+from dagster.core.definitions.metadata import MetadataEntry, MetadataValue
 from dagster.core.errors import DagsterInvariantViolationError
 from dagster.core.execution.context.input import InputContext
 from dagster.core.execution.context.output import OutputContext
@@ -192,7 +192,9 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
 
         return AssetMaterialization(
             asset_key=AssetKey([context.pipeline_name, context.step_key, context.name]),
-            metadata_entries=[MetadataEntry.fspath(os.path.abspath(filepath))],
+            metadata_entries=[
+                MetadataEntry("path", value=MetadataValue.path(os.path.abspath(filepath)))
+            ],
         )
 
     def load_input(self, context):

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -572,7 +572,7 @@ def test_raise_on_error_true_type_check_returns_successful_type_check():
                 == "foo"
             )
             assert (
-                event.event_specific_data.type_check_data.metadata_entries[0].description == "baz"
+                event.event_specific_data.type_check_data.metadata_entries[0]
             )
 
     pipeline_result = execute_pipeline(foo_pipeline, raise_on_error=False)

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -571,9 +571,7 @@ def test_raise_on_error_true_type_check_returns_successful_type_check():
                 event.event_specific_data.type_check_data.metadata_entries[0].entry_data.text
                 == "foo"
             )
-            assert (
-                event.event_specific_data.type_check_data.metadata_entries[0]
-            )
+            assert event.event_specific_data.type_check_data.metadata_entries[0]
 
     pipeline_result = execute_pipeline(foo_pipeline, raise_on_error=False)
     assert pipeline_result.success

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -477,7 +477,6 @@ def test_raise_on_error_true_type_check_returns_unsuccessful_type_check():
         execute_pipeline(foo_pipeline)
     assert e.value.metadata_entries[0].label == "bar"
     assert e.value.metadata_entries[0].entry_data.text == "foo"
-    assert e.value.metadata_entries[0].description == "baz"
     assert isinstance(e.value.dagster_type, DagsterType)
 
     pipeline_result = execute_pipeline(foo_pipeline, raise_on_error=False)

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -384,8 +384,8 @@ def define_custom_dict(name, permitted_key_names):
         return TypeCheck(
             True,
             metadata_entries=[
-                MetadataEntry.text(label="row_count", text=str(len(value))),
-                MetadataEntry.text(label="series_names", text=", ".join(value.keys())),
+                MetadataEntry("row_count", value=str(len(value))),
+                MetadataEntry("series_names", value=", ".join(value.keys())),
             ],
         )
 
@@ -461,7 +461,7 @@ def test_raise_on_error_true_type_check_returns_unsuccessful_type_check():
     FalsyType = DagsterType(
         name="FalsyType",
         type_check_fn=lambda _, _val: TypeCheck(
-            success=False, metadata_entries=[MetadataEntry.text("foo", "bar", "baz")]
+            success=False, metadata_entries=[MetadataEntry("bar", value="foo")]
         ),
     )
 
@@ -550,7 +550,7 @@ def test_raise_on_error_true_type_check_returns_successful_type_check():
     TruthyExceptionType = DagsterType(
         name="TruthyExceptionType",
         type_check_fn=lambda _, _val: TypeCheck(
-            success=True, metadata_entries=[MetadataEntry.text("foo", "bar", "baz")]
+            success=True, metadata_entries=[MetadataEntry("bar", value="foo")]
         ),
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_lineage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_lineage.py
@@ -126,10 +126,10 @@ def test_multiple_definition_fails():
 
 def test_input_definition_multiple_partition_lineage():
 
-    entry1 = MetadataEntry.int(123, "nrows")
-    entry2 = MetadataEntry.float(3.21, "some value")
+    entry1 = MetadataEntry("nrows", value=123)
+    entry2 = MetadataEntry("some value", value=3.21)
 
-    partition_entries = [MetadataEntry.int(123 * i * i, "partition count") for i in range(3)]
+    partition_entries = [MetadataEntry("partition count", value=123 * i * i) for i in range(3)]
 
     @solid(
         output_defs=[
@@ -271,8 +271,8 @@ def test_mixed_asset_definition_lineage():
 
 def test_dynamic_output_definition_single_partition_materialization():
 
-    entry1 = MetadataEntry.int(123, "nrows")
-    entry2 = MetadataEntry.float(3.21, "some value")
+    entry1 = MetadataEntry("nrows", value=123)
+    entry2 = MetadataEntry("some value", value=3.21)
 
     @solid(output_defs=[OutputDefinition(name="output1", asset_key=AssetKey("table1"))])
     def solid1(_):

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_materializations.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_asset_materializations.py
@@ -31,8 +31,8 @@ def check_materialization(materialization, asset_key, parent_assets=None, metada
 
 def test_output_definition_single_partition_materialization():
 
-    entry1 = MetadataEntry.int(123, "nrows")
-    entry2 = MetadataEntry.float(3.21, "some value")
+    entry1 = MetadataEntry("nrows", value=123)
+    entry2 = MetadataEntry("some value", value=3.21)
 
     @solid(output_defs=[OutputDefinition(name="output1", asset_key=AssetKey("table1"))])
     def solid1(_):
@@ -68,10 +68,10 @@ def test_output_definition_single_partition_materialization():
 
 def test_output_definition_multiple_partition_materialization():
 
-    entry1 = MetadataEntry.int(123, "nrows")
-    entry2 = MetadataEntry.float(3.21, "some value")
+    entry1 = MetadataEntry("nrows", value=123)
+    entry2 = MetadataEntry("some value", value=3.21)
 
-    partition_entries = [MetadataEntry.int(123 * i * i, "partition count") for i in range(3)]
+    partition_entries = [MetadataEntry("partition count", value=123 * i * i) for i in range(3)]
 
     @solid(
         output_defs=[
@@ -134,8 +134,8 @@ def test_output_definition_multiple_partition_materialization():
 
 def test_io_manager_single_partition_materialization():
 
-    entry1 = MetadataEntry.int(123, "nrows")
-    entry2 = MetadataEntry.float(3.21, "some value")
+    entry1 = MetadataEntry("nrows", value=123)
+    entry2 = MetadataEntry("some value", value=3.21)
 
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
@@ -191,7 +191,7 @@ def test_partition_specific_fails_on_na_partitions():
     def fail_solid(_):
         yield Output(
             None,
-            metadata_entries=[PartitionMetadataEntry("3", MetadataEntry.int(1, "x"))],
+            metadata_entries=[PartitionMetadataEntry("3", MetadataEntry("x", value=1))],
         )
 
     @pipeline
@@ -207,7 +207,7 @@ def test_partition_specific_fails_on_zero_partitions():
     def fail_solid(_):
         yield Output(
             None,
-            metadata_entries=[PartitionMetadataEntry("3", MetadataEntry.int(1, "x"))],
+            metadata_entries=[PartitionMetadataEntry("3", MetadataEntry("x", value=1))],
         )
 
     @pipeline

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
@@ -190,7 +190,6 @@ def test_input_manager_with_failure():
         assert failure_data.user_failure_data.description == "Foolure"
         assert failure_data.user_failure_data.metadata_entries[0].label == "label"
         assert failure_data.user_failure_data.metadata_entries[0].entry_data.text == "text"
-        assert failure_data.user_failure_data.metadata_entries[0].description == "description"
 
 
 def test_input_manager_with_retries():

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_input_manager.py
@@ -164,9 +164,7 @@ def test_input_manager_with_failure():
     def should_fail(_):
         raise Failure(
             description="Foolure",
-            metadata_entries=[
-                MetadataEntry.text(label="label", text="text", description="description")
-            ],
+            metadata_entries=[MetadataEntry("label", value="text")],
         )
 
     @solid(input_defs=[InputDefinition("_fail_input", root_manager_key="should_fail")])

--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_io_manager.py
@@ -836,7 +836,7 @@ def test_context_logging_metadata():
                 self.values[keys] = obj
 
                 context.add_output_metadata({"foo": "bar"})
-                yield MetadataEntry.text(label="baz", text="baz")
+                yield MetadataEntry("baz", value="baz")
                 context.add_output_metadata({"bar": "bar"})
                 yield materialization
 
@@ -893,7 +893,7 @@ def test_metadata_dynamic_outputs():
             keys = tuple(context.get_output_identifier())
             self.values[keys] = obj
 
-            yield MetadataEntry.text(label="handle_output", text="I come from handle_output")
+            yield MetadataEntry("handle_output", value="I come from handle_output")
 
         def load_input(self, context):
             keys = tuple(context.upstream_output.get_output_identifier())

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -227,7 +227,7 @@ def test_explicit_failure():
     def throws_failure():
         raise DagsterTypeCheckDidNotPass(
             description="Always fails.",
-            metadata_entries=[MetadataEntry.text("why", label="always_fails")],
+            metadata_entries=[MetadataEntry("always_fails", value="why")],
         )
 
     @pipeline
@@ -238,4 +238,4 @@ def test_explicit_failure():
         execute_pipeline(pipe)
 
     assert exc_info.value.description == "Always fails."
-    assert exc_info.value.metadata_entries == [MetadataEntry.text("why", label="always_fails")]
+    assert exc_info.value.metadata_entries == [MetadataEntry("always_fails", value="why")]

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -382,9 +382,7 @@ def test_optional_outputs():
 def throw():
     raise Failure(
         description="it Failure",
-        metadata_entries=[
-            MetadataEntry.text(label="label", text="text", description="description")
-        ],
+        metadata_entries=[MetadataEntry("label", value="text")],
     )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -412,7 +412,6 @@ def test_failure_multiprocessing():
         assert failure_data.user_failure_data.description == "it Failure"
         assert failure_data.user_failure_data.metadata_entries[0].label == "label"
         assert failure_data.user_failure_data.metadata_entries[0].entry_data.text == "text"
-        assert failure_data.user_failure_data.metadata_entries[0].description == "description"
 
 
 @solid

--- a/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
@@ -6,9 +6,7 @@ def test_failure():
     def throw():
         raise Failure(
             description="it Failure",
-            metadata_entries=[
-                MetadataEntry.text(label="label", text="text", description="description")
-            ],
+            metadata_entries=[MetadataEntry("label", value="text")],
         )
 
     @pipeline
@@ -26,5 +24,4 @@ def test_failure():
     # from Failure
     assert failure_data.user_failure_data.description == "it Failure"
     assert failure_data.user_failure_data.metadata_entries[0].label == "label"
-    assert failure_data.user_failure_data.metadata_entries[0].entry_data.text == "text"
-    assert failure_data.user_failure_data.metadata_entries[0].description == "description"
+    assert failure_data.user_failure_data.metadata_entries[0].value.text == "text"

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -190,8 +190,7 @@ def test_bad_json_metadata_value():
 
     assert str(exc_info.value) == (
         'Could not resolve the metadata value for "bad" to a known type. '
-        "Value is a dictionary but is not JSON serializable. "
-        "Consider wrapping the value with the appropriate MetadataValue type."
+        "Value is a dictionary but is not JSON serializable."
     )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -197,15 +197,17 @@ def test_bad_json_metadata_value():
 
 def test_table_metadata_value_schema_inference():
 
-    table_metadata_value = MetadataEntry.table(
-        records=[
-            TableRecord(name="foo", status=False),
-            TableRecord(name="bar", status=True),
-        ],
-        label="foo",
+    table_metadata_entry = MetadataEntry(
+        "foo",
+        value=MetadataValue.table(
+            records=[
+                TableRecord(name="foo", status=False),
+                TableRecord(name="bar", status=True),
+            ],
+        ),
     )
 
-    schema = table_metadata_value.entry_data.schema
+    schema = table_metadata_entry.entry_data.schema  # type: ignore
     assert isinstance(schema, TableSchema)
     assert schema.columns == [
         TableColumn(name="name", type="string"),

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -83,17 +83,17 @@ def test_assets(schema_prefix):
         AssetKey(["some", "prefix", schema_prefix + "bar"]),
         AssetKey(["some", "prefix", schema_prefix + "baz"]),
     }
-    assert MetadataEntry.int(1234, "bytesEmitted") in materializations[0].metadata_entries
-    assert MetadataEntry.int(4321, "recordsCommitted") in materializations[0].metadata_entries
+    assert MetadataEntry("bytesEmitted", value=1234) in materializations[0].metadata_entries
+    assert MetadataEntry("recordsCommitted", value=4321) in materializations[0].metadata_entries
     assert (
-        MetadataEntry.table_schema(
-            TableSchema(
+        MetadataEntry(
+            "schema",
+            value=TableSchema(
                 columns=[
                     TableColumn(name="a", type="str"),
                     TableColumn(name="b", type="int"),
                 ]
             ),
-            "schema",
         )
         in materializations[0].metadata_entries
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -200,8 +200,8 @@ def test_assets():
     materializations = list(generate_materializations(airbyte_output, []))
     assert len(materializations) == 3
 
-    assert MetadataEntry.int(1234, "bytesEmitted") in materializations[0].metadata_entries
-    assert MetadataEntry.int(4321, "recordsCommitted") in materializations[0].metadata_entries
+    assert MetadataEntry("bytesEmitted", value=1234) in materializations[0].metadata_entries
+    assert MetadataEntry("recordsCommitted", value=4321) in materializations[0].metadata_entries
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -232,9 +232,9 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             pipeline_run=run,
             engine_event_data=EngineEventData(
                 [
-                    MetadataEntry.text(arn, "ECS Task ARN"),
-                    MetadataEntry.text(metadata.cluster, "ECS Cluster"),
-                    MetadataEntry.text(run.run_id, "Run ID"),
+                    MetadataEntry("ECS Task ARN", value=arn),
+                    MetadataEntry("ECS Cluster", value=metadata.cluster),
+                    MetadataEntry("Run ID", value=run.run_id),
                 ]
             ),
             cls=self.__class__,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
@@ -4,6 +4,7 @@ from dagster import (
     FileHandle,
     In,
     MetadataEntry,
+    MetadataValue,
     Out,
     Output,
     StringSource,
@@ -74,7 +75,9 @@ def file_handle_to_s3(context, file_handle):
 
         yield AssetMaterialization(
             asset_key=s3_file_handle.s3_path,
-            metadata_entries=[MetadataEntry.path(s3_file_handle.s3_path, label=last_key(key))],
+            metadata_entries=[
+                MetadataEntry(last_key(key), value=MetadataValue.path(s3_file_handle.s3_path))
+            ],
         )
 
         yield Output(value=s3_file_handle, output_name="s3_file_handle")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -82,9 +82,9 @@ def test_default_launcher(
     latest_event = events[-1]
     assert latest_event.message == "[EcsRunLauncher] Launching run in ECS task"
     event_metadata = latest_event.dagster_event.engine_event_data.metadata_entries
-    assert MetadataEntry.text(task_arn, "ECS Task ARN") in event_metadata
-    assert MetadataEntry.text(cluster_arn, "ECS Cluster") in event_metadata
-    assert MetadataEntry.text(run.run_id, "Run ID") in event_metadata
+    assert MetadataEntry("ECS Task ARN", value=task_arn) in event_metadata
+    assert MetadataEntry("ECS Cluster", value=cluster_arn) in event_metadata
+    assert MetadataEntry("Run ID", value=run.run_id) in event_metadata
 
 
 def test_task_definition_registration(

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -256,9 +256,9 @@ def create_docker_task(celery_app, **task_kwargs):
             pipeline_run,
             EngineEventData(
                 [
-                    MetadataEntry.text(step_keys_str, "Step keys"),
-                    MetadataEntry.text(docker_image, "Image"),
-                    MetadataEntry.text(self.request.hostname, "Celery worker"),
+                    MetadataEntry("Step keys", value=step_keys_str),
+                    MetadataEntry("Image", value=docker_image),
+                    MetadataEntry("Celery worker", value=self.request.hostname),
                 ],
                 marker_end=DELEGATE_MARKER,
             ),
@@ -290,8 +290,8 @@ def create_docker_task(celery_app, **task_kwargs):
                 pipeline_run,
                 EngineEventData(
                     [
-                        MetadataEntry.text(docker_image, "Job image"),
-                        MetadataEntry.text(err.stderr, "Docker stderr"),
+                        MetadataEntry("Job image", value=docker_image),
+                        MetadataEntry("Docker stderr", value=err.stderr),
                     ],
                 ),
                 CeleryDockerExecutor,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -331,8 +331,8 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             pipeline_run,
             EngineEventData(
                 [
-                    MetadataEntry.text(celery_worker_name, "Celery worker name"),
-                    MetadataEntry.text(celery_pod_name, "Celery worker Kubernetes Pod name"),
+                    MetadataEntry("Celery worker name", value=celery_worker_name),
+                    MetadataEntry("Celery worker Kubernetes Pod name", value=celery_pod_name),
                 ]
             ),
             CeleryK8sJobExecutor,
@@ -345,7 +345,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 pipeline_run,
                 EngineEventData(
                     [
-                        MetadataEntry.text(step_key, "Step key"),
+                        MetadataEntry("Step key", value=step_key),
                     ]
                 ),
                 CeleryK8sJobExecutor,
@@ -391,13 +391,13 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             pipeline_run,
             EngineEventData(
                 [
-                    MetadataEntry.text(step_key, "Step key"),
-                    MetadataEntry.text(job_name, "Kubernetes Job name"),
-                    MetadataEntry.text(job_config.job_image, "Job image"),
-                    MetadataEntry.text(job_config.image_pull_policy, "Image pull policy"),
-                    MetadataEntry.text(str(job_config.image_pull_secrets), "Image pull secrets"),
-                    MetadataEntry.text(
-                        str(job_config.service_account_name), "Service account name"
+                    MetadataEntry("Step key", value=step_key),
+                    MetadataEntry("Kubernetes Job name", value=job_name),
+                    MetadataEntry("Job image", value=job_config.job_image),
+                    MetadataEntry("Image pull policy", value=job_config.image_pull_policy),
+                    MetadataEntry("Image pull secrets", value=str(job_config.image_pull_secrets)),
+                    MetadataEntry(
+                        "Service account name", value=str(job_config.service_account_name)
                     ),
                 ],
                 marker_end=DELEGATE_MARKER,
@@ -419,8 +419,8 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                     pipeline_run,
                     EngineEventData(
                         [
-                            MetadataEntry.text(step_key, "Step key"),
-                            MetadataEntry.text(job_name, "Kubernetes Job name"),
+                            MetadataEntry("Step key", value=step_key),
+                            MetadataEntry("Kubernetes Job name", value=job_name),
                         ],
                         marker_end=DELEGATE_MARKER,
                     ),
@@ -434,7 +434,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                     pipeline_run,
                     EngineEventData(
                         [
-                            MetadataEntry.text(step_key, "Step key"),
+                            MetadataEntry("Step key", value=step_key),
                         ],
                         error=serializable_error_info_from_exc_info(sys.exc_info()),
                     ),
@@ -462,9 +462,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 pipeline_run,
                 EngineEventData(
                     [
-                        MetadataEntry.text(step_key, "Step key"),
-                        MetadataEntry.text(job_name, "Kubernetes Job name"),
-                        MetadataEntry.text(job_namespace, "Kubernetes Job namespace"),
+                        MetadataEntry("Step key", value=step_key),
+                        MetadataEntry("Kubernetes Job name", value=job_name),
+                        MetadataEntry("Kubernetes Job namespace", value=job_namespace),
                     ]
                 ),
                 CeleryK8sJobExecutor,
@@ -486,7 +486,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 pipeline_run,
                 EngineEventData(
                     [
-                        MetadataEntry.text(step_key, "Step key"),
+                        MetadataEntry("Step key", value=step_key),
                     ],
                     error=serializable_error_info_from_exc_info(sys.exc_info()),
                 ),
@@ -504,7 +504,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 pipeline_run,
                 EngineEventData(
                     [
-                        MetadataEntry.text(step_key, "Step key"),
+                        MetadataEntry("Step key", value=step_key),
                     ],
                     error=serializable_error_info_from_exc_info(sys.exc_info()),
                 ),
@@ -517,7 +517,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
         engine_event = instance.report_engine_event(
             "Retrieving logs from Kubernetes Job pods",
             pipeline_run,
-            EngineEventData([MetadataEntry.text("\n".join(pod_names), "Pod names")]),
+            EngineEventData([MetadataEntry("Pod names", value="\n".join(pod_names))]),
             CeleryK8sJobExecutor,
             step_key=step_key,
         )
@@ -537,7 +537,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                     pipeline_run,
                     EngineEventData(
                         [
-                            MetadataEntry.text(step_key, "Step key"),
+                            MetadataEntry("Step key", value=step_key),
                         ],
                         error=serializable_error_info_from_exc_info(sys.exc_info()),
                     ),

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -225,9 +225,9 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             run,
             EngineEventData(
                 [
-                    MetadataEntry.text(job_name, "Kubernetes Job name"),
-                    MetadataEntry.text(job_namespace, "Kubernetes Namespace"),
-                    MetadataEntry.text(run.run_id, "Run ID"),
+                    MetadataEntry("Kubernetes Job name", value=job_name),
+                    MetadataEntry("Kubernetes Namespace", value=job_namespace),
+                    MetadataEntry("Run ID", value=run.run_id),
                 ]
             ),
             cls=self.__class__,
@@ -239,9 +239,9 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             run,
             EngineEventData(
                 [
-                    MetadataEntry.text(job_name, "Kubernetes Job name"),
-                    MetadataEntry.text(job_namespace, "Kubernetes Namespace"),
-                    MetadataEntry.text(run.run_id, "Run ID"),
+                    MetadataEntry("Kubernetes Job name", value=job_name),
+                    MetadataEntry("Kubernetes Namespace", value=job_namespace),
+                    MetadataEntry("Run ID", value=run.run_id),
                 ]
             ),
             cls=self.__class__,

--- a/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
@@ -47,8 +47,8 @@ def create_task(celery_app, **task_kwargs):
             pipeline_run,
             EngineEventData(
                 [
-                    MetadataEntry("step_keys", step_keys_str),
-                    MetadataEntry("Celery worker", self.request.hostname),
+                    MetadataEntry("step_keys", value=step_keys_str),
+                    MetadataEntry("Celery worker", value=self.request.hostname),
                 ],
                 marker_end=DELEGATE_MARKER,
             ),

--- a/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
@@ -47,8 +47,8 @@ def create_task(celery_app, **task_kwargs):
             pipeline_run,
             EngineEventData(
                 [
-                    MetadataEntry.text(step_keys_str, "step_keys"),
-                    MetadataEntry.text(self.request.hostname, "Celery worker"),
+                    MetadataEntry("step_keys", step_keys_str),
+                    MetadataEntry("Celery worker", self.request.hostname),
                 ],
                 marker_end=DELEGATE_MARKER,
             ),

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -483,7 +483,7 @@ def df_type_check(_, value):
         success=True,
         metadata_entries=[
             # string cast columns since they may be things like datetime
-            MetadataEntry.json({"columns": list(map(str, value.columns))}, "metadata"),
+            MetadataEntry("metadata", value={"columns": list(map(str, value.columns))}),
         ],
     )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/errors.py
@@ -18,7 +18,7 @@ class DagsterDbtCliUnexpectedOutputError(DagsterDbtError):
         line_nos_str = ", ".join(map(str, invalid_line_nos))
         description = f"dbt CLI emitted unexpected output on lines {line_nos_str}"
         metadata_entries = [
-            MetadataEntry.json({"line_nos": invalid_line_nos}, "Invalid CLI Output Line Numbers")
+            MetadataEntry("Invalid CLI Output Line Numbers", value={"line_nos": invalid_line_nos})
         ]
         super().__init__(description, metadata_entries)
         self.invalid_line_nos = invalid_line_nos
@@ -29,17 +29,17 @@ class DagsterDbtCliRuntimeError(DagsterDbtError, ABC):
 
     def __init__(self, description: str, logs: List[Dict[str, Any]], raw_output: str):
         metadata_entries = [
-            MetadataEntry.json(
-                {"logs": logs},
-                label="Parsed CLI Output (JSON)",
+            MetadataEntry(
+                "Parsed CLI Output (JSON)",
+                value={"logs": logs},
             ),
-            MetadataEntry.text(
-                DagsterDbtCliRuntimeError.stitch_messages(logs),
-                label="Parsed CLI Output (JSON) Message Attributes",
+            MetadataEntry(
+                "Parsed CLI Output (JSON) Message Attributes",
+                value=DagsterDbtCliRuntimeError.stitch_messages(logs),
             ),
-            MetadataEntry.text(
-                raw_output,
-                label="Raw CLI Output",
+            MetadataEntry(
+                "Raw CLI Output",
+                value=raw_output,
             ),
         ]
         super().__init__(description, metadata_entries)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/rpc/utils.py
@@ -51,35 +51,33 @@ def raise_for_rpc_error(context: SolidExecutionContext, resp: Response) -> None:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[
-                    MetadataEntry.text(text=str(error["code"]), label="RPC Error Code"),
-                    MetadataEntry.text(
-                        text=error["data"]["cause"]["message"], label="RPC Error Cause"
-                    ),
+                    MetadataEntry("RPC Error Code", value=str(error["code"])),
+                    MetadataEntry("RPC Error Cause", value=error["data"]["cause"]["message"]),
                 ],
             )
         elif error["code"] == DBTErrors.rpc_process_killed_error.value:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[
-                    MetadataEntry.text(text=str(error["code"]), label="RPC Error Code"),
-                    MetadataEntry.text(text=str(error["data"]["signum"]), label="RPC Signum"),
-                    MetadataEntry.text(text=error["data"]["message"], label="RPC Error Message"),
+                    MetadataEntry("RPC Error Code", value=str(error["code"])),
+                    MetadataEntry("RPC Signum", value=str(error["data"]["signum"])),
+                    MetadataEntry("RPC Error Message", value=error["data"]["message"]),
                 ],
             )
         elif error["code"] == DBTErrors.rpc_timeout_error.value:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[
-                    MetadataEntry.text(text=str(error["code"]), label="RPC Error Code"),
-                    MetadataEntry.text(text=str(error["data"]["timeout"]), label="RPC Timeout"),
-                    MetadataEntry.text(text=error["data"]["message"], label="RPC Error Message"),
+                    MetadataEntry("RPC Error Code", value=str(error["code"])),
+                    MetadataEntry("RPC Timeout", value=str(error["data"]["timeout"])),
+                    MetadataEntry("RPC Error Message", value=error["data"]["message"]),
                 ],
             )
         else:
             raise Failure(
                 description=error["message"],
                 metadata_entries=[
-                    MetadataEntry.text(text=str(error["code"]), label="RPC Error Code"),
+                    MetadataEntry("RPC Error Code", value=str(error["code"])),
                 ],
             )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -69,8 +69,8 @@ def test_runtime_metadata_fn():
     ]
     assert len(materializations) == 4
     assert materializations[0].metadata_entries == [
-        MetadataEntry.text(dbt_assets[0].op.name, label="op_name"),
-        MetadataEntry.text(materializations[0].asset_key.path[0], label="dbt_model"),
+        MetadataEntry("op_name", value=dbt_assets[0].op.name),
+        MetadataEntry("dbt_model", value=materializations[0].asset_key.path[0]),
     ]
 
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -190,8 +190,8 @@ class DockerStepHandler(StepHandler):
                 message="Launching step in Docker container",
                 event_specific_data=EngineEventData(
                     [
-                        MetadataEntry.text(step_key, "Step key"),
-                        MetadataEntry.text(step_container.id, "Docker container id"),
+                        MetadataEntry("Step key", value=step_key),
+                        MetadataEntry("Docker container id", value=step_container.id),
                     ],
                 ),
             )

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -9,6 +9,7 @@ from dagster import (
     ExpectationResult,
     InputDefinition,
     MetadataEntry,
+    MetadataValue,
     Noneable,
     Output,
     OutputDefinition,
@@ -100,7 +101,7 @@ def core_ge_validation_factory(
         )
         md_str = " ".join(DefaultMarkdownPageView().render(rendered_document_content_list))
 
-        meta_stats = MetadataEntry.md(md_str=md_str, label="Expectation Results")
+        meta_stats = MetadataEntry("Expectation Results", value=MetadataValue.md(md_str))
         yield ExpectationResult(
             success=res["success"],
             metadata_entries=[
@@ -253,7 +254,7 @@ def core_ge_validation_factory_v3(
         )
         md_str = "".join(DefaultMarkdownPageView().render(rendered_document_content_list))
 
-        meta_stats = MetadataEntry.md(md_str=md_str, label="Expectation Results")
+        meta_stats = MetadataEntry("Expectation Results", value=MetadataValue.md(md_str))
         yield ExpectationResult(
             success=bool(results["success"]),
             metadata_entries=[meta_stats],

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -207,8 +207,8 @@ class K8sStepHandler(StepHandler):
                 message=f"Executing step {step_key} in Kubernetes job {job_name}",
                 event_specific_data=EngineEventData(
                     [
-                        MetadataEntry("Step key", step_key),
-                        MetadataEntry("Kubernetes Job name", job_name),
+                        MetadataEntry("Step key", value=step_key),
+                        MetadataEntry("Kubernetes Job name", value=job_name),
                     ],
                 ),
             )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -207,8 +207,8 @@ class K8sStepHandler(StepHandler):
                 message=f"Executing step {step_key} in Kubernetes job {job_name}",
                 event_specific_data=EngineEventData(
                     [
-                        MetadataEntry.text(step_key, "Step key"),
-                        MetadataEntry.text(job_name, "Kubernetes Job name"),
+                        MetadataEntry("Step key", step_key),
+                        MetadataEntry("Kubernetes Job name", job_name),
                     ],
                 ),
             )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -265,9 +265,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             run,
             EngineEventData(
                 [
-                    MetadataEntry.text(job_name, "Kubernetes Job name"),
-                    MetadataEntry.text(self.job_namespace, "Kubernetes Namespace"),
-                    MetadataEntry.text(run.run_id, "Run ID"),
+                    MetadataEntry("Kubernetes Job name", value=job_name),
+                    MetadataEntry("Kubernetes Namespace", value=self.job_namespace),
+                    MetadataEntry("Run ID", value=run.run_id),
                 ]
             ),
             cls=self.__class__,
@@ -279,9 +279,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             run,
             EngineEventData(
                 [
-                    MetadataEntry.text(job_name, "Kubernetes Job name"),
-                    MetadataEntry.text(self.job_namespace, "Kubernetes Namespace"),
-                    MetadataEntry.text(run.run_id, "Run ID"),
+                    MetadataEntry("Kubernetes Job name", value=job_name),
+                    MetadataEntry("Kubernetes Namespace", value=self.job_namespace),
+                    MetadataEntry("Run ID", value=run.run_id),
                 ]
             ),
             cls=self.__class__,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
@@ -50,15 +50,21 @@ class ConstraintWithMetadataException(Exception):
             )
         )
 
+    def normalize_metadata_json_value(self, val):
+        if isinstance(val, set):
+            return list(val)
+        else:
+            return val
+
     def convert_to_metadata(self):
         return MetadataEntry(
             "constraint-metadata",
             value={
                 "constraint_name": self.constraint_name,
                 "constraint_description": self.constraint_description,
-                "expected": self.expectation,
-                "offending": self.offending,
-                "actual": self.actual,
+                "expected": self.normalize_metadata_json_value(self.expectation),
+                "offending": self.normalize_metadata_json_value(self.offending),
+                "actual": self.normalize_metadata_json_value(self.actual),
             },
         )
 

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
@@ -51,15 +51,15 @@ class ConstraintWithMetadataException(Exception):
         )
 
     def convert_to_metadata(self):
-        return MetadataEntry.json(
-            {
+        return MetadataEntry(
+            "constraint-metadata",
+            value={
                 "constraint_name": self.constraint_name,
                 "constraint_description": self.constraint_description,
                 "expected": self.expectation,
                 "offending": self.offending,
                 "actual": self.actual,
             },
-            "constraint-metadata",
         )
 
     def return_as_typecheck(self):

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -97,9 +97,9 @@ def df_type_check(_, value):
     return TypeCheck(
         success=True,
         metadata_entries=[
-            MetadataEntry.text(str(len(value)), "row_count", "Number of rows in DataFrame"),
+            MetadataEntry("row_count", value=str(len(value))),
             # string cast columns since they may be things like datetime
-            MetadataEntry.json({"columns": list(map(str, value.columns))}, "metadata"),
+            MetadataEntry("metadata", value={"columns": list(map(str, value.columns))}),
         ],
     )
 
@@ -293,9 +293,9 @@ def create_structured_dataframe_type(
             typechecks_succeeded = typechecks_succeeded and result_val
             result_dict = result.metadata_entries[0].entry_data.data
             metadata.append(
-                MetadataEntry.json(
-                    result_dict,
+                MetadataEntry(
                     "{}-constraint-metadata".format(key),
+                    value=result_dict,
                 )
             )
             constraint_clauses.append("{} failing constraints, {}".format(key, result.description))

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
@@ -140,11 +140,10 @@ def test_execute_summary_stats_null_function():
     metadata_entries = _execute_summary_stats(
         "foo",
         DataFrame({"bar": [1, 2, 3]}),
-        lambda value: [MetadataEntry.text("baz", "qux", "quux")],
+        lambda value: [MetadataEntry("qux", value="baz")],
     )
     assert len(metadata_entries) == 1
     assert metadata_entries[0].label == "qux"
-    assert metadata_entries[0].description == "quux"
     assert metadata_entries[0].entry_data.text == "baz"
 
 
@@ -156,7 +155,7 @@ def test_execute_summary_stats_error():
         assert _execute_summary_stats(
             "foo",
             DataFrame({}),
-            lambda value: [MetadataEntry.text("baz", "qux", "quux"), "rofl"],
+            lambda value: [MetadataEntry("qux", value="baz"), "rofl"],
         )
 
 
@@ -277,7 +276,7 @@ def test_custom_dagster_dataframe_parametrizable_input():
 def test_basic_pipeline_with_pandas_dataframe_dagster_type_metadata_entries():
     def compute_event_metadata(dataframe):
         return [
-            MetadataEntry.text(str(max(dataframe["pid"])), "max_pid", "maximum pid"),
+            MetadataEntry("max_pid", value=str(max(dataframe["pid"]))),
         ]
 
     BasicDF = create_dagster_pandas_dataframe_type(

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
@@ -157,7 +157,7 @@ def test_aggregate_constraint():
         raise_or_typecheck=False,
     )
     val = aggregate_val.validate(df, *df.columns).metadata_entries[0].entry_data.data
-    assert {"foo"} == val["offending"]
+    assert ["foo"] == val["offending"]
     assert [1, 2] == val["actual"]["foo"]
 
 

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -108,7 +108,7 @@ def pandera_schema_to_dagster_type(
         name=name,
         description=norm_schema.description,
         metadata_entries=[
-            MetadataEntry.table_schema(tschema, label="schema"),
+            MetadataEntry("schema", value=tschema),
         ],
     )
 

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -21,7 +21,7 @@ from dagster import (
     seven,
 )
 from dagster.core.definitions.events import AssetMaterialization, Failure, RetryRequested
-from dagster.core.definitions.metadata import MetadataEntry
+from dagster.core.definitions.metadata import MetadataEntry, MetadataValue
 from dagster.core.definitions.reconstructable import ReconstructablePipeline
 from dagster.core.definitions.utils import validate_tags
 from dagster.core.execution.context.compute import SolidExecutionContext
@@ -257,7 +257,10 @@ def _dm_compute(
                         asset_key=(asset_key_prefix + [f"{name}_output_notebook"]),
                         description="Location of output notebook in file manager",
                         metadata_entries=[
-                            MetadataEntry.fspath(executed_notebook_materialization_path)
+                            MetadataEntry(
+                                "path",
+                                value=MetadataValue.path(executed_notebook_materialization_path),
+                            )
                         ],
                     )
 

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional
 from dagster import check
 from dagster.config.field import Field
 from dagster.core.definitions.events import AssetKey
-from dagster.core.definitions.metadata import MetadataEntry
+from dagster.core.definitions.metadata import MetadataEntry, MetadataValue
 from dagster.core.execution.context.input import InputContext
 from dagster.core.execution.context.output import OutputContext
 from dagster.core.storage.io_manager import IOManager, io_manager
@@ -49,7 +49,7 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         mkdir_p(os.path.dirname(output_notebook_path))
         with open(output_notebook_path, self.write_mode) as dest_file_obj:
             dest_file_obj.write(obj)
-        yield MetadataEntry.fspath(path=output_notebook_path, label="path")
+        yield MetadataEntry("path", value=MetadataValue.path(output_notebook_path))
 
     def load_input(self, context) -> bytes:
         check.inst_param(context, "context", InputContext)


### PR DESCRIPTION
- Replaces all internal uses of the `MetadataEntry` static API with the equivalent future-supported API calls.
- Moves `TableSchema` normalization logic to `TableSchemaMetadataValue` constructor out of deprecated `MetadataEntry.table_schema` static method.
