### PR TITLE
add tick tooltip info for skipped ticks due to run key idempotence

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1180,6 +1180,7 @@ type InstigationTick {
   status: InstigationTickStatus!
   timestamp: Float!
   runIds: [String!]!
+  runKeys: [String!]!
   error: PythonError
   skipReason: String
   cursor: String

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSchedulesQuery.ts
@@ -117,6 +117,7 @@ export interface InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: InstanceSchedulesQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_ticks_error | null;
 }
 
@@ -242,6 +243,7 @@ export interface InstanceSchedulesQuery_unloadableInstigationStatesOrError_Insti
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: InstanceSchedulesQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceSensorsQuery.ts
@@ -116,6 +116,7 @@ export interface InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_n
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: InstanceSensorsQuery_repositoriesOrError_RepositoryConnection_nodes_sensors_sensorState_ticks_error | null;
 }
 
@@ -246,6 +247,7 @@ export interface InstanceSensorsQuery_unloadableInstigationStatesOrError_Instiga
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: InstanceSensorsQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -39,7 +39,7 @@ export const TickTag: React.FC<{
       if (!tick.runIds.length) {
         return <TagWIP intent="primary">Requested</TagWIP>;
       }
-      return (
+      const tag = (
         <>
           <TagWIP intent="primary" interactive>
             <ButtonLink underline="never" onClick={() => setOpen(true)}>
@@ -61,15 +61,35 @@ export const TickTag: React.FC<{
           </DialogWIP>
         </>
       );
-    case InstigationTickStatus.SKIPPED:
-      if (!tick.skipReason) {
-        return <TagWIP intent="warning">Skipped</TagWIP>;
+      if (tick.runKeys.length > tick.runIds.length) {
+        const message = `${tick.runKeys.length} runs requested, but ${
+          tick.runKeys.length - tick.runIds.length
+        } skipped because the runs already exist for those requested keys.`;
+        return (
+          <Tooltip position="right" content={message}>
+            {tag}
+          </Tooltip>
+        );
       }
-      return (
-        <Tooltip position="right" content={tick.skipReason} targetTagName="div">
-          <TagWIP intent="warning">Skipped</TagWIP>
-        </Tooltip>
-      );
+      return tag;
+
+    case InstigationTickStatus.SKIPPED:
+      if (tick.runKeys) {
+        const message = `${tick.runKeys.length} runs requested, but skipped because the runs already exist for the requested keys.`;
+        return (
+          <Tooltip position="right" content={message}>
+            <TagWIP intent="warning">Skipped</TagWIP>
+          </Tooltip>
+        );
+      }
+      if (tick.skipReason) {
+        return (
+          <Tooltip position="right" content={tick.skipReason} targetTagName="div">
+            <TagWIP intent="warning">Skipped</TagWIP>
+          </Tooltip>
+        );
+      }
+      return <TagWIP intent="warning">Skipped</TagWIP>;
     case InstigationTickStatus.FAILURE:
       if (!tick.error) {
         return <TagWIP intent="danger">Failure</TagWIP>;
@@ -186,6 +206,7 @@ export const TICK_TAG_FRAGMENT = gql`
     timestamp
     skipReason
     runIds
+    runKeys
     error {
       ...PythonErrorFragment
     }

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationStateFragment.ts
@@ -64,6 +64,7 @@ export interface InstigationStateFragment_ticks {
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: InstigationStateFragment_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/instigation/types/SelectedTickQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/SelectedTickQuery.ts
@@ -35,6 +35,7 @@ export interface SelectedTickQuery_instigationStateOrError_InstigationState_tick
   runIds: string[];
   originRunIds: string[];
   error: SelectedTickQuery_instigationStateOrError_InstigationState_tick_error | null;
+  runKeys: string[];
 }
 
 export interface SelectedTickQuery_instigationStateOrError_InstigationState {

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistoryQuery.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistoryQuery.ts
@@ -45,6 +45,7 @@ export interface TickHistoryQuery_instigationStateOrError_InstigationState_ticks
   runs: TickHistoryQuery_instigationStateOrError_InstigationState_ticks_runs[];
   originRunIds: string[];
   error: TickHistoryQuery_instigationStateOrError_InstigationState_ticks_error | null;
+  runKeys: string[];
 }
 
 export interface TickHistoryQuery_instigationStateOrError_InstigationState {

--- a/js_modules/dagit/packages/core/src/instigation/types/TickTagFragment.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickTagFragment.ts
@@ -29,5 +29,6 @@ export interface TickTagFragment {
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: TickTagFragment_error | null;
 }

--- a/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/SchedulerInfoQuery.ts
@@ -111,6 +111,7 @@ export interface SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nod
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SchedulerInfoQuery_repositoriesOrError_RepositoryConnection_nodes_schedules_scheduleState_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/RepositorySchedulesFragment.ts
@@ -76,6 +76,7 @@ export interface RepositorySchedulesFragment_schedules_scheduleState_ticks {
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: RepositorySchedulesFragment_schedules_scheduleState_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleFragment.ts
@@ -70,6 +70,7 @@ export interface ScheduleFragment_scheduleState_ticks {
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: ScheduleFragment_scheduleState_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRootQuery.ts
@@ -70,6 +70,7 @@ export interface ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_ticks 
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: ScheduleRootQuery_scheduleOrError_Schedule_scheduleState_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesRootQuery.ts
@@ -80,6 +80,7 @@ export interface SchedulesRootQuery_repositoryOrError_Repository_schedules_sched
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SchedulesRootQuery_repositoryOrError_Repository_schedules_scheduleState_ticks_error | null;
 }
 
@@ -206,6 +207,7 @@ export interface SchedulesRootQuery_unloadableInstigationStatesOrError_Instigati
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SchedulesRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.ts
@@ -69,6 +69,7 @@ export interface SensorFragment_sensorState_ticks {
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SensorFragment_sensorState_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRootQuery.ts
@@ -73,6 +73,7 @@ export interface SensorRootQuery_sensorOrError_Sensor_sensorState_ticks {
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SensorRootQuery_sensorOrError_Sensor_sensorState_ticks_error | null;
 }
 

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRootQuery.ts
@@ -86,6 +86,7 @@ export interface SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_tic
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SensorsRootQuery_sensorsOrError_Sensors_results_sensorState_ticks_error | null;
 }
 
@@ -194,6 +195,7 @@ export interface SensorsRootQuery_unloadableInstigationStatesOrError_Instigation
   timestamp: number;
   skipReason: string | null;
   runIds: string[];
+  runKeys: string[];
   error: SensorsRootQuery_unloadableInstigationStatesOrError_InstigationStates_results_ticks_error | null;
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -99,6 +99,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
     status = graphene.NonNull(GrapheneInstigationTickStatus)
     timestamp = graphene.NonNull(graphene.Float)
     runIds = non_null_list(graphene.String)
+    runKeys = non_null_list(graphene.String)
     error = graphene.Field(GraphenePythonError)
     skipReason = graphene.String()
     cursor = graphene.String()
@@ -115,6 +116,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
             status=tick.status,
             timestamp=tick.timestamp,
             runIds=tick.run_ids,
+            runKeys=tick.run_keys,
             error=tick.error,
             skipReason=tick.skip_reason,
             originRunIds=tick.origin_run_ids,


### PR DESCRIPTION
## Summary
Context: https://github.com/dagster-io/dagster/issues/3726

User getting degraded DB performance as each sensor evaluation was looping on an increasing number of run fetches for idempotence.  https://github.com/dagster-io/dagster/pull/7094 was just landed to batch the run fetches, but this PR is about surfacing some of this idempotence info on a per-tick basis so that users have a chance of noticing that they might want to rely less on run_keys.

https://user-images.githubusercontent.com/1040172/159081559-3b637dad-fc24-4c0f-bf57-fb35d5e73729.mov

## Test Plan
BK


