### PR TITLE
Add Github Action to automatically add issues from dagster repo to OSS Issues project (beta)

### DIFF
--- a/.github/workflows/oss-issues.yml
+++ b/.github/workflows/oss-issues.yml
@@ -1,0 +1,56 @@
+# This is a workflow for automatically adding new issues to the OSS Issues project
+name: OSS Issues Project Automation
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add_issue_to_project:
+    name: Add new issues to OSS Issues project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Github App token
+        id: generate_token
+        uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+        with:
+          app_id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.PROJECT_AUTOMATION_APP_PEM }}
+      
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          ORGANIZATION: dagster-io
+          PROJECT_NUMBER: 2
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add new issue to project
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) { 
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) { 
+                projectNextItem { 
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=${{ github.event.issue.node_id }}


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Add a Github Action to listen to newly opened issues in this repo and add the issue to [OSS Issues project](https://github.com/orgs/dagster-io/projects/2) as it comes.
- This is the recommended pattern to manage projects. See: https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects
- I was told that Github will be rolling out more built-in automation like this, so hopefully we can rely more on the built-in features than customizing our own workflows -- Github currently doesn't have an out-of-box support for project automation but a lot of them are on their roadmap, e.g. https://github.com/github/feedback/discussions/5378.
- I was planning to have a separate repo to manage all automation but it turned out the out-of-box issue listener only works with the issues in the same repo, so I decided to check this in here.

## Test Plan
Tested in https://github.com/dagster-io/verbose-adventure/blob/main/.github/workflows/oss-issues.yml:
- Created an issue
- Action succeeded: https://github.com/dagster-io/verbose-adventure/runs/5606853681?check_suite_focus=true
- The issue showed up in https://github.com/orgs/dagster-io/projects/2: <img width="300" alt="image" src="https://user-images.githubusercontent.com/4531914/159085782-be2893df-53aa-4be3-b1f3-0a251012a304.png">