### PR TITLE
Rename the InstanceMigratedError to be less pushy about migrating

### DIFF
--- a/python_modules/dagster/dagster/core/errors.py
+++ b/python_modules/dagster/dagster/core/errors.py
@@ -16,7 +16,6 @@ Dagster runtime.
 """
 
 import sys
-import traceback
 from contextlib import contextmanager
 
 from dagster import check
@@ -430,25 +429,17 @@ class DagsterBackfillFailedError(DagsterError):
         super(DagsterBackfillFailedError, self).__init__(*args, **kwargs)
 
 
-class DagsterInstanceMigrationRequired(DagsterError):
+class DagsterInstanceSchemaOutdated(DagsterError):
     """Indicates that the dagster instance must be migrated."""
 
-    def __init__(self, msg=None, db_revision=None, head_revision=None, original_exc_info=None):
-        super(DagsterInstanceMigrationRequired, self).__init__(
-            "Instance is out of date and must be migrated{additional_msg}."
-            "{revision_clause} Please run `dagster instance migrate`.{original_exception_clause}".format(
-                additional_msg=" ({msg})".format(msg=msg) if msg else "",
+    def __init__(self, db_revision=None, head_revision=None):
+        super(DagsterInstanceSchemaOutdated, self).__init__(
+            "Raised an exception that may indicate that the Dagster database needs to be be migrated."
+            "{revision_clause} To migrate, run `dagster instance migrate`.".format(
                 revision_clause=(
                     " Database is at revision {db_revision}, head is "
                     "{head_revision}.".format(db_revision=db_revision, head_revision=head_revision)
                     if db_revision or head_revision
-                    else ""
-                ),
-                original_exception_clause=(
-                    "\n\nOriginal exception:\n\n{original_exception}".format(
-                        original_exception="".join(traceback.format_exception(*original_exc_info))
-                    )
-                    if original_exc_info
                     else ""
                 ),
             )

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -98,11 +98,7 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         engine = create_engine(self._conn_string, poolclass=NullPool)
         conn = engine.connect()
         try:
-            with handle_schema_errors(
-                conn,
-                get_alembic_config(__file__),
-                msg="ConsolidatedSqliteEventLogStorage requires migration",
-            ):
+            with handle_schema_errors(conn, get_alembic_config(__file__)):
                 yield conn
         finally:
             conn.close()

--- a/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/core/storage/event_log/sqlite/sqlite_event_log.py
@@ -200,11 +200,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             conn = engine.connect()
 
             try:
-                with handle_schema_errors(
-                    conn,
-                    get_alembic_config(__file__),
-                    msg="SqliteEventLogStorage for shard {shard}".format(shard=shard),
-                ):
+                with handle_schema_errors(conn, get_alembic_config(__file__)):
                     yield conn
             finally:
                 conn.close()

--- a/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/core/storage/runs/sqlite/sqlite_run_storage.py
@@ -100,11 +100,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         engine = create_engine(self._conn_string, poolclass=NullPool)
         conn = engine.connect()
         try:
-            with handle_schema_errors(
-                conn,
-                get_alembic_config(__file__),
-                msg="Sqlite run storage requires migration",
-            ):
+            with handle_schema_errors(conn, get_alembic_config(__file__)):
                 yield conn
         finally:
             conn.close()

--- a/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -68,7 +68,6 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             with handle_schema_errors(
                 conn,
                 get_alembic_config(__file__),
-                msg="Sqlite schedule storage requires migration",
             ):
                 yield conn
         finally:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -162,11 +162,7 @@ def create_mysql_connection(engine, dunder_file, storage_type_desc=None):
     try:
         # Retry connection to gracefully handle transient connection issues
         conn = retry_mysql_connection_fn(engine.connect)
-        with handle_schema_errors(
-            conn,
-            mysql_alembic_config(dunder_file),
-            msg="MySQL {}storage requires migration".format(storage_type_desc),
-        ):
+        with handle_schema_errors(conn, mysql_alembic_config(dunder_file)):
             yield conn
     finally:
         if conn:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -168,11 +168,7 @@ def create_pg_connection(engine, dunder_file, storage_type_desc=None):
     try:
         # Retry connection to gracefully handle transient connection issues
         conn = retry_pg_connection_fn(engine.connect)
-        with handle_schema_errors(
-            conn,
-            pg_alembic_config(dunder_file),
-            msg="Postgres {}storage requires migration".format(storage_type_desc),
-        ):
+        with handle_schema_errors(conn, pg_alembic_config(dunder_file)):
             yield conn
     finally:
         if conn:


### PR DESCRIPTION
Summary:
A lot of the logic here is from a time when every migration was required - but today lots of migrations are not, and the actual error is just as interesting as whether the alembic revision is out of date.

Rename the error and the language to be more like a warning instead of a "you had better migrate right now or else" error.

Test Plan: BK, manually trigger a SQL error while the db is out of date and view the resulting stack trace in dagit

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.