### PR TITLE
[multiprocess] tweak preload modules logic

### DIFF
--- a/python_modules/dagster/dagster/core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/core/executor/multiprocess.py
@@ -132,16 +132,16 @@ class MultiprocessExecutor(Executor):
 
             # or if the reconstructable pipeline has a module target, we will use that
             elif pipeline.get_module():
-                preload = [
-                    # we import this module first to avoid user code like
-                    #  pyspark.serializers._hijack_namedtuple from breaking us
-                    "dagster.core.executor.multiprocess",
-                    pipeline.get_module(),
-                ]
+                preload = [pipeline.get_module()]
 
             # base case is to preload the dagster library
             else:
                 preload = ["dagster"]
+
+            # we import this module first to avoid user code like
+            # pyspark.serializers._hijack_namedtuple from breaking us
+            if "dagster.core.executor.multiprocess" not in preload:
+                preload = ["dagster.core.executor.multiprocess"] + preload
 
             multiproc_ctx.set_forkserver_preload(preload)
 

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_resources.py
@@ -1,22 +1,21 @@
 from dagster_pyspark.resources import pyspark_resource
 
-from dagster import ModeDefinition, PipelineDefinition, execute_pipeline, solid
+from dagster import execute_pipeline, job, multiprocess_executor, op, reconstructable
+from dagster.core.test_utils import instance_for_test
 
 
 def assert_pipeline_runs_with_resource(resource_def):
     called = {}
 
-    @solid(required_resource_keys={"some_name"})
-    def a_solid(_):
+    @op(required_resource_keys={"some_name"})
+    def a_op():
         called["yup"] = True
 
-    pipeline_def = PipelineDefinition(
-        name="with_a_resource",
-        solid_defs=[a_solid],
-        mode_defs=[ModeDefinition(resource_defs={"some_name": resource_def})],
-    )
+    @job(resource_defs={"some_name": resource_def})
+    def with_a_resource():
+        a_op()
 
-    result = execute_pipeline(pipeline_def)
+    result = with_a_resource.execute_in_process()
 
     assert result.success
     assert called["yup"]
@@ -30,3 +29,40 @@ def test_pyspark_resource():
 def test_pyspark_resource_escape_hatch():
     pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "1024MB"}})
     assert_pipeline_runs_with_resource(pyspark_resource)
+
+
+@op(required_resource_keys={"pyspark"})
+def its_there(context):
+    assert context.resources.pyspark
+
+
+@job(
+    resource_defs={"pyspark": pyspark_resource},
+    executor_def=multiprocess_executor,
+)
+def multiproc_job():
+    its_there()
+
+
+def test_multiproc_preload():
+    # Assert an multiprocess execution with a pyspark preload works.
+    # This is in place due to pyspark.serializers._hijack_namedtuple causing issues with us if we
+    # don't have defenses in place.
+
+    with instance_for_test() as instance:
+
+        # "smart" module preload
+        result = execute_pipeline(reconstructable(multiproc_job), instance=instance)
+        assert result.success
+
+        # explicit module preload
+        result = execute_pipeline(
+            reconstructable(multiproc_job),
+            run_config={
+                "execution": {
+                    "config": {"start_method": {"forkserver": {"preload_modules": ["pyspark"]}}}
+                }
+            },
+            instance=instance,
+        )
+        assert result.success


### PR DESCRIPTION
The bug that this `pyspark.serializer._hijack_namedtuple` shit causes can manifest in very confusing ways, so I think it's worth always inserting this self module preload in to the front of the list. 

## Test Plan

added test
