### PR TITLE
IaC prototypes

### DIFF
--- a/examples/infra_example/.coveragerc
+++ b/examples/infra_example/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/examples/infra_example/.gitignore
+++ b/examples/infra_example/.gitignore
@@ -1,0 +1,9 @@
+**/*dist/
+**/*!imports/__init__.py
+**/*.terraform
+**/*cdktf.out
+**/*cdktf.log
+**/*terraform.*.tfstate*
+
+imports
+stacks

--- a/examples/infra_example/README.md
+++ b/examples/infra_example/README.md
@@ -1,0 +1,28 @@
+# infra_example
+
+[requires cdktf cli](https://learn.hashicorp.com/tutorials/terraform/cdktf-install)
+
+## install
+
+for cdktf providers run:
+
+```bash
+cdktf get
+```
+
+which will pull and generate python definitions for cdktf in `infra_example/resources/imports`
+
+## generating tf stacks for the tag_infra_example
+
+```bash
+python generate_templates.py
+```
+
+which will create tf stacks in `stacks/`
+
+each stack dir can then be initialized and deployed
+
+```bash
+terraform init
+terraform apply
+```

--- a/examples/infra_example/cdktf.json
+++ b/examples/infra_example/cdktf.json
@@ -1,0 +1,12 @@
+{
+  "language": "python",
+  "app": "<placeholder>",
+  "projectId": "5055a7b8-567b-4210-80d8-4379d956473b",
+  "terraformProviders": ["aws@~> 4.2.0"],
+  "terraformModules": ["terraform-aws-modules/vpc/aws@3.12.0"],
+  "codeMakerOutput": "infra_example/resources/imports",
+  "context": {
+    "excludeStackIdFromLogicalIds": "true",
+    "allowSepCharsInLogicalIds": "true"
+  }
+}

--- a/examples/infra_example/generate_templates.py
+++ b/examples/infra_example/generate_templates.py
@@ -1,0 +1,23 @@
+import json
+import os
+
+from infra_example.jobs.tag_infra_example import tag_infra_example
+
+
+def write_template(template):
+    _template = json.loads(template)
+    template_file = f'./stacks/{_template["//"]["metadata"]["stackName"]}/cdk.tf.json'
+    os.makedirs(os.path.dirname(template_file), exist_ok=True)
+    with open(template_file, "w") as f:
+        f.write(template)
+
+
+stacks = []
+for tag in tag_infra_example.tags:
+    if tag.startswith("infrastructure/"):
+        write_template(tag_infra_example.tags[tag])
+
+for solid in tag_infra_example.solids:
+    for tag in solid.tags:
+        if tag.startswith("infrastructure/"):
+            write_template(solid.tags[tag])

--- a/examples/infra_example/infra_example/__init__.py
+++ b/examples/infra_example/infra_example/__init__.py
@@ -1,0 +1,1 @@
+from .repository import infra_example

--- a/examples/infra_example/infra_example/jobs/resource_infra_example.py
+++ b/examples/infra_example/infra_example/jobs/resource_infra_example.py
@@ -1,0 +1,18 @@
+from dagster import job, op
+
+from infra_example.resources.terraform import terraform_stack, s3_bucket
+import boto3
+
+client = boto3.client("s3")
+
+
+@op(required_resource_keys={"s3_bucket"})
+def s3_op(context):
+    context.log.info(context.resources.s3_bucket.config)
+    response = client.get_bucket_location(Bucket=context.resources.s3_bucket.config["bucket"])
+    return response["LocationConstraint"]
+
+
+@job(resource_defs={"terraform_stack": terraform_stack, "s3_bucket": s3_bucket})
+def resource_infra_example():
+    s3_op()

--- a/examples/infra_example/infra_example/jobs/tag_infra_example.py
+++ b/examples/infra_example/infra_example/jobs/tag_infra_example.py
@@ -1,0 +1,50 @@
+from dagster import job, op
+
+
+from infra_example.resources.imports.aws.s3 import S3Bucket
+from infra_example.resources.imports.aws import AwsProvider
+from infra_example.resources.imports.aws.iam import IamRole
+
+from cdktf import App, TerraformStack
+
+import boto3
+
+client = boto3.client("s3")
+
+
+class S3Stack(TerraformStack):
+    def __init__(self, _app: App, stack_name: str):
+        self._app = _app
+        super().__init__(_app, stack_name)
+        AwsProvider(self, "Aws", region="us-west-2")
+        S3Bucket(
+            self,
+            id="bucket",
+            bucket="dagster-infra-tag-example",
+        )
+
+
+class RoleStack(TerraformStack):
+    def __init__(self, _app: App, stack_name: str):
+        super().__init__(_app, stack_name)
+        AwsProvider(self, "Aws", region="us-west-2")
+        IamRole(self, id="role", name="example-role", assume_role_policy="{}")
+
+
+app = App()
+
+
+@op(tags={"infrastructure/bucket": S3Stack(app, "s3_infra_example").to_terraform()})
+def tagged_s3_op(context):
+    context.log.info(context.resources.s3_bucket)
+    response = client.get_bucket_location(Bucket=context.resources.s3_bucket.bucket)
+    return response["LocationConstraint"]
+
+
+@job(
+    tags={
+        "infrastructure/role": RoleStack(app, "iam_infra_example").to_terraform(),
+    }
+)
+def tag_infra_example():
+    tagged_s3_op()

--- a/examples/infra_example/infra_example/repository.py
+++ b/examples/infra_example/infra_example/repository.py
@@ -1,0 +1,11 @@
+from dagster import repository
+
+from .jobs.resource_infra_example import resource_infra_example
+from .jobs.tag_infra_example import tag_infra_example
+
+
+@repository
+def infra_example():
+    jobs = [resource_infra_example, tag_infra_example]
+
+    return jobs

--- a/examples/infra_example/infra_example/resources/terraform.py
+++ b/examples/infra_example/infra_example/resources/terraform.py
@@ -1,0 +1,69 @@
+from dagster import resource
+import subprocess
+import os
+import sys
+
+from cdktf import App, TerraformStack
+
+from .imports.aws.s3 import S3Bucket
+from .imports.aws import AwsProvider
+
+
+class Stack(TerraformStack):
+    def __init__(self, app: App, stack_name: str):
+        super().__init__(app, stack_name)
+        AwsProvider(self, "Aws", region="us-west-2")
+        self.app = app
+        self.stack_name = stack_name
+
+    def synth(self):
+        self.app.synth()
+
+    def deploy(self):
+        os.chdir(f"{sys.path[0]}/stacks/{self.stack_name}/")
+        subprocess.call(["terraform", "init"])
+        subprocess.call(["terraform", "apply", "-auto-approve"])
+
+    def destroy(self):
+        os.chdir(f"{sys.path[0]}/stacks/{self.stack_name}/")
+        subprocess.call(["terraform", "destroy", "-auto-approve"])
+
+
+@resource(
+    config_schema={
+        "name": str,
+    }
+)
+def terraform_stack(init_context):
+    app = App(outdir="./")
+    return Stack(app, init_context.resource_config["name"])
+
+
+class Resource:
+    def __init__(self, definition, **kwargs):
+        self.definition = definition(**kwargs)
+        self.config = kwargs
+
+
+@resource(
+    required_resource_keys={"terraform_stack"},
+    config_schema={
+        "id": str,
+        "bucket": str,
+    },
+)
+def s3_bucket(init_context):
+    init_context.log.warn(init_context.resource_config)
+    bucket = Resource(
+        S3Bucket,
+        scope=init_context.resources.terraform_stack,
+        id=init_context.resource_config["id"],
+        bucket=init_context.resource_config["bucket"],
+    )
+    init_context.log.info("synthesizing terraform json...")
+    init_context.resources.terraform_stack.synth()
+    init_context.log.info("deploying terraform stack...")
+    init_context.resources.terraform_stack.deploy()
+    yield bucket
+    init_context.log.info("destroying terraform stack...")
+    init_context.resources.terraform_stack.destroy()

--- a/examples/infra_example/setup.py
+++ b/examples/infra_example/setup.py
@@ -1,0 +1,13 @@
+import setuptools
+
+setuptools.setup(
+    name="infra_example",
+    packages=setuptools.find_packages(exclude=["infra_example_tests"]),
+    install_requires=[
+        "dagster==dev",
+        "dagit==dev",
+        "pytest",
+        "cdktf~=0.9.2",
+        "cdktf-cdktf-provider-aws~=5.0.29",
+    ],
+)

--- a/examples/infra_example/tox.ini
+++ b/examples/infra_example/tox.ini
@@ -1,0 +1,33 @@
+[tox]
+envlist = py{38, 37, 36},pylint,mypy
+
+[testenv]
+pip_version = pip==21.3.1
+passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
+deps =
+  -e ../../python_modules/dagster[test]
+  -e ../../python_modules/libraries/dagster-dbt/
+  -e ../../python_modules/libraries/dagster-aws/
+  -e .
+whitelist_externals =
+  /bin/bash
+  echo
+commands =
+  !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
+  echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
+  pytest -vv
+
+[testenv:pylint]
+whitelist_externals =
+  echo
+  pylint
+commands =
+  echo -e "--- \033[0;32m:lint-roller: Running pylint\033[0m"
+  pylint -j 0 --rcfile=../../.pylintrc infra_example infra_example_tests
+
+[testenv:mypy]
+whitelist_externals =
+  mypy
+commands =
+  echo -e "--- \033[0;32m:mypy: Running mypy\033[0m"
+  mypy -p infra_example -p infra_example_tests --namespace-packages --ignore-missing-imports

--- a/examples/infra_example/workspace.yaml
+++ b/examples/infra_example/workspace.yaml
@@ -1,0 +1,4 @@
+# Workspaces specify where to find user code in order to load it for Dagit and the Dagster CLI.
+# See our documentation overview on Workspaces: https://docs.dagster.io/overview/repositories-workspaces/workspaces
+load_from:
+  - python_package: infra_example


### PR DESCRIPTION
This pr includes 2 prototypes for defining terraform alongside dagster:

1. A metadata approach of having tf stacks captured in job/op metadata(tags) and having a script scrape those and assemble them into cf templates. This keeps tf execution entirely seperate from dagster execution.
2. A resource approach of having the infra exist within the dagster infra system. This makes tf execution happen as part of the dagster resource creation/destruction hooks.

There's some docs in the readme for setting up cdktf, you'll need to have it generate all the python infra defs before things will work.


In terms of issues:
prototype 1 is cleaner and less intrusive for the pipeline code but it doesn't have the same indirection layer that resources have (being defined on the job) that makes deduping and linking tf resources easier.
prototype 2, it won't always make sense to be running tf apply/destroy as part of dagster execution. The dependency relationships between terraform and ops/jobs should be inverted so that you don't need to capture everything at the job level (or have the stack resource defined)
