### PR TITLE
fix docs search: js_render shouldnt be true

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -49,7 +49,6 @@
       "text": ".section p, .section li"
     }
   },
-  "js_render": true,
   "js_wait": 5,
   "nb_hits": 9458
 }

--- a/docs/config.json
+++ b/docs/config.json
@@ -49,6 +49,5 @@
       "text": ".section p, .section li"
     }
   },
-  "js_wait": 5,
   "nb_hits": 9458
 }


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
Before the change, the docs indexing script would only index ~5K records, sometimes ~7K.
With the change, it consistently indexes ~1.2K records.

The non-deterministic behavior before was caused by crawling timeout which was caused by `js_render: true` - according to the [config doc](https://docsearch.algolia.com/docs/legacy/config-file/#js_render-optional), when js_render is true, the indexing script would spawn a Selenium proxy to fetch all web pages assuming them are client side rendered, which is time and resource consuming and therefore caused timeout. But none of our pages to be indexed are client side render, so the fix is to remove this field to speed up the indexing, in order to produce consistent and accurate results.

also removes `js_wait` because [this option has no impact if js_render is set to false](https://docsearch.algolia.com/docs/legacy/config-file/#js_wait-optional).

## Test Plan
search results look right now

