### PR TITLE
Add Map to config type API docs

### DIFF
--- a/docs/sphinx/sections/api/apidocs/config.rst
+++ b/docs/sphinx/sections/api/apidocs/config.rst
@@ -20,6 +20,8 @@ builtin types above.
 
 .. autoclass:: Shape
 
+.. autoclass:: Map
+
 .. autoclass:: Array
 
 .. autoclass:: Noneable

--- a/python_modules/dagster/dagster/config/field_utils.py
+++ b/python_modules/dagster/dagster/config/field_utils.py
@@ -221,7 +221,7 @@ class Permissive(_ConfigHasFields):
     .. code-block:: python
 
         @op(config_schema=Field(Permissive({'required': Field(String)})))
-        def partially_specified_config(context) -> List:
+        def map_config_op(context) -> List:
             return sorted(list(context.op_config.items()))
     """
 


### PR DESCRIPTION
Summary:
This is referenced in https://docs.dagster.io/_apidocs/config#config-types but there is no link.

Test Plan: Load api docs locally

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.