### PR TITLE
[dagit] uvicorn min version

### DIFF
--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             # notebooks support
             "nbconvert>=5.4.0,<6.0.0",
             "starlette",
-            "uvicorn[standard]",
+            "uvicorn[standard]>=0.12.0",
         ],
         entry_points={
             "console_scripts": ["dagit = dagit.cli:main", "dagit-debug = dagit.debug:main"]


### PR DESCRIPTION
there are very early versions of uvicorn that dont work, use `0.12.0` which is the first version to add `[standard]` 


### Test Plan

bk
manually install `uvicorn[standard]==0.12.0` and ensure `dagit` runs

