### PR TITLE
Be more willing to return serialized errors in schedule/sensor/grpc partition methods

### DIFF
--- a/python_modules/dagster/dagster/grpc/impl.py
+++ b/python_modules/dagster/dagster/grpc/impl.py
@@ -15,7 +15,6 @@ from dagster.core.definitions.reconstructable import (
 from dagster.core.definitions.sensor_definition import SensorEvaluationContext
 from dagster.core.errors import (
     DagsterExecutionInterruptedError,
-    DagsterInvalidSubsetError,
     DagsterRunNotFoundError,
     PartitionExecutionError,
     ScheduleExecutionError,
@@ -212,7 +211,7 @@ def get_external_pipeline_subset_result(
         try:
             sub_pipeline = recon_pipeline.subset_for_execution(solid_selection)
             definition = sub_pipeline.get_definition()
-        except DagsterInvalidSubsetError:
+        except Exception:
             return ExternalPipelineSubsetResult(
                 success=False, error=serializable_error_info_from_exc_info(sys.exc_info())
             )
@@ -254,7 +253,7 @@ def get_external_schedule_execution(
                 "{schedule_name}".format(schedule_name=schedule_def.name),
             ):
                 return schedule_def.evaluate_tick(schedule_context)
-        except ScheduleExecutionError:
+        except Exception:
             return ExternalScheduleExecutionErrorData(
                 serializable_error_info_from_exc_info(sys.exc_info())
             )
@@ -286,7 +285,7 @@ def get_external_sensor_execution(
                 "{sensor_name}".format(sensor_name=sensor_def.name),
             ):
                 return sensor_def.evaluate_tick(sensor_context)
-        except SensorExecutionError:
+        except Exception:
             return ExternalSensorExecutionErrorData(
                 serializable_error_info_from_exc_info(sys.exc_info())
             )
@@ -306,7 +305,7 @@ def get_partition_config(recon_repo, partition_set_name, partition_name):
         ):
             run_config = partition_set_def.run_config_for_partition(partition)
             return ExternalPartitionConfigData(name=partition.name, run_config=run_config)
-    except PartitionExecutionError:
+    except Exception:
         return ExternalPartitionExecutionErrorData(
             serializable_error_info_from_exc_info(sys.exc_info())
         )
@@ -331,7 +330,7 @@ def get_partition_names(recon_repo, partition_set_name):
             return ExternalPartitionNamesData(
                 partition_names=partition_set_def.get_partition_names()
             )
-    except PartitionExecutionError:
+    except Exception:
         return ExternalPartitionExecutionErrorData(
             serializable_error_info_from_exc_info(sys.exc_info())
         )
@@ -349,7 +348,7 @@ def get_partition_tags(recon_repo, partition_set_name, partition_name):
         ):
             tags = partition_set_def.tags_for_partition(partition)
             return ExternalPartitionTagsData(name=partition.name, tags=tags)
-    except PartitionExecutionError:
+    except Exception:
         return ExternalPartitionExecutionErrorData(
             serializable_error_info_from_exc_info(sys.exc_info())
         )
@@ -422,7 +421,7 @@ def get_partition_set_execution_param_data(recon_repo, partition_set_name, parti
 
         return ExternalPartitionSetExecutionParamData(partition_data=partition_data)
 
-    except PartitionExecutionError:
+    except Exception:
         return ExternalPartitionExecutionErrorData(
             serializable_error_info_from_exc_info(sys.exc_info())
         )

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -15,6 +15,7 @@ from dagster import (
 )
 from dagster.core.definitions.decorators.sensor import sensor
 from dagster.core.definitions.sensor_definition import RunRequest
+from dagster.core.errors import DagsterError
 from dagster.core.test_utils import default_mode_def_for_test
 
 
@@ -165,6 +166,11 @@ def sensor_error(_):
     raise Exception("womp womp")
 
 
+@sensor(pipeline_name="foo")
+def sensor_raises_dagster_error(_):
+    raise DagsterError("Dagster error")
+
+
 @repository
 def bar_repo():
     return {
@@ -176,7 +182,11 @@ def bar_repo():
         },
         "schedules": define_bar_schedules(),
         "partition_sets": define_baz_partitions(),
-        "sensors": {"sensor_foo": sensor_foo, "sensor_error": lambda: sensor_error},
+        "sensors": {
+            "sensor_foo": sensor_foo,
+            "sensor_error": lambda: sensor_error,
+            "sensor_raises_dagster_error": lambda: sensor_raises_dagster_error,
+        },
     }
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -28,3 +28,12 @@ def test_external_sensor_error():
                 sync_get_external_sensor_execution_data_ephemeral_grpc(
                     instance, repository_handle, "sensor_error", None, None, None
                 )
+
+
+def test_external_sensor_raises_dagster_error():
+    with get_bar_repo_handle() as repository_handle:
+        with instance_for_test() as instance:
+            with pytest.raises(DagsterUserCodeProcessError, match="Dagster error"):
+                sync_get_external_sensor_execution_data_ephemeral_grpc(
+                    instance, repository_handle, "sensor_raises_dagster_error", None, None, None
+                )


### PR DESCRIPTION
Summary:
Right now if there's an error in these grpc methods that isn't caught, we get these unhelpful messages at the gRPC layer like:

Exception iterating responses: Error executing resource_fn on ResourceDefinition

Being more willing to package up errors and serialize them over the wire will give us better visualization of those errors on the other side.

Even if it's a system error or an invariant error that's our fault, i'd still rather that error be the thing that is displayed in Dagit.

Test Plan:
Existing BK tests that cover schedule/sensor error handling

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.