### PR TITLE
[dagster-databricks] databricks_pyspark_step_launcher supports retries

### DIFF
--- a/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
+++ b/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
@@ -5,6 +5,7 @@ from typing import List
 
 from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.plan.external_step import (
+    PICKLED_ERROR_FILE_NAME,
     PICKLED_EVENTS_FILE_NAME,
     external_instance_from_step_run_ref,
     run_step_from_ref,
@@ -26,6 +27,11 @@ def main(step_run_ref_path: str) -> None:
         )
         # consume entire step iterator
         list(run_step_from_ref(step_run_ref, instance))
+    except Exception as e:
+        error_out_path = os.path.join(os.path.dirname(step_run_ref_path), PICKLED_ERROR_FILE_NAME)
+        with open(error_out_path, "wb") as error_file:
+            pickle.dump(e, error_file)
+        raise e
     finally:
         events_out_path = os.path.join(os.path.dirname(step_run_ref_path), PICKLED_EVENTS_FILE_NAME)
         with open(events_out_path, "wb") as events_file:

--- a/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
+++ b/python_modules/dagster/dagster/core/execution/plan/local_external_step_main.py
@@ -3,10 +3,11 @@ import pickle
 import sys
 from typing import List
 
+from dagster.core.definitions.events import Failure, RetryRequested
 from dagster.core.events.log import EventLogEntry
 from dagster.core.execution.plan.external_step import (
-    PICKLED_ERROR_FILE_NAME,
     PICKLED_EVENTS_FILE_NAME,
+    PICKLED_EXCEPTION_FILE_NAME,
     external_instance_from_step_run_ref,
     run_step_from_ref,
 )
@@ -28,9 +29,13 @@ def main(step_run_ref_path: str) -> None:
         # consume entire step iterator
         list(run_step_from_ref(step_run_ref, instance))
     except Exception as e:
-        error_out_path = os.path.join(os.path.dirname(step_run_ref_path), PICKLED_ERROR_FILE_NAME)
-        with open(error_out_path, "wb") as error_file:
-            pickle.dump(e, error_file)
+        # these exceptions alter control flow, and should be replicated
+        if isinstance(e, (Failure, RetryRequested)):
+            exception_out_path = os.path.join(
+                os.path.dirname(step_run_ref_path), PICKLED_EXCEPTION_FILE_NAME
+            )
+            with open(exception_out_path, "wb") as exception_file:
+                pickle.dump(e, exception_file)
         raise e
     finally:
         events_out_path = os.path.join(os.path.dirname(step_run_ref_path), PICKLED_EVENTS_FILE_NAME)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_plan_tests/test_external_step.py
@@ -9,7 +9,9 @@ import pytest
 from dagster import (
     DynamicOut,
     DynamicOutput,
+    Failure,
     Field,
+    MetadataEntry,
     ModeDefinition,
     ResourceDefinition,
     RetryPolicy,
@@ -80,11 +82,14 @@ def request_retry_local_external_step_launcher(context):
     return RequestRetryLocalExternalStepLauncher(**context.resource_config)
 
 
-def _define_retry_job():
-    @op(required_resource_keys={"step_launcher"}, retry_policy=RetryPolicy(max_retries=3))
+def _define_failing_job(has_policy: bool):
+    @op(
+        required_resource_keys={"step_launcher"},
+        retry_policy=RetryPolicy(max_retries=3) if has_policy else None,
+    )
     def retry_op(context):
         if context.retry_number < 3:
-            raise Exception()
+            raise Failure(description="some failure description", metadata={"foo": 1.23})
         return context.retry_number
 
     @job(
@@ -97,6 +102,14 @@ def _define_retry_job():
         retry_op()
 
     return retry_job
+
+
+def _define_retry_job():
+    return _define_failing_job(has_policy=True)
+
+
+def _define_error_job():
+    return _define_failing_job(has_policy=False)
 
 
 def _define_dynamic_job(launch_initial, launch_final):
@@ -424,6 +437,28 @@ def test_retry_policy():
             )
             assert run.success
             assert run.result_for_solid("retry_op").output_value() == 3
+
+
+def test_explicit_failure():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_config = {
+            "resources": {
+                "step_launcher": {"config": {"scratch_dir": tmpdir}},
+                "io_manager": {"config": {"base_dir": tmpdir}},
+            }
+        }
+        with instance_for_test() as instance:
+            run = execute_pipeline(
+                pipeline=reconstructable(_define_error_job),
+                run_config=run_config,
+                instance=instance,
+                raise_on_error=False,
+            )
+            fd = run.result_for_solid("retry_op").failure_data
+            assert fd.user_failure_data.description == "some failure description"
+            assert fd.user_failure_data.metadata_entries == [
+                MetadataEntry.float(label="foo", value=1.23)
+            ]
 
 
 def test_launcher_requests_retry():

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -265,19 +265,17 @@ def poll_run_state(
             log.info("Run %s completed successfully" % databricks_run_id)
             return True
         else:
-            # attempt to get the actual error, otherwise create a placeholder
+            # attempt to get the serialized exception, otherwise create a placeholder
             error = None
             try:
-                serialized_error = client.read_file(error_path)
-                error = pickle.loads(serialized_error)
-            finally:
-                if not error:
-                    error_message = "Run %s failed with result state: %s. Message: %s" % (
-                        databricks_run_id,
-                        run_state.result_state,
-                        run_state.state_message,
-                    )
-                    error = DatabricksError(error_message)
+                error = pickle.loads(client.read_file(error_path))
+            except Exception:
+                error_message = "Run %s failed with result state: %s. Message: %s" % (
+                    databricks_run_id,
+                    run_state.result_state,
+                    run_state.state_message,
+                )
+                error = DatabricksError(error_message)
             raise error
     else:
         log.info("Run %s in state %s" % (databricks_run_id, run_state))

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -34,7 +34,7 @@ class DatabricksClient:
         """Submit a run directly to the 'Runs Submit' API."""
         return self.client.jobs.submit_run(*args, **kwargs)["run_id"]  # pylint: disable=no-member
 
-    def read_file(self, dbfs_path, block_size=1024 ** 2):
+    def read_file(self, dbfs_path, block_size=1024**2):
         """Read a file from DBFS to a **byte string**."""
 
         if dbfs_path.startswith("dbfs://"):
@@ -51,7 +51,7 @@ class DatabricksClient:
             data += base64.b64decode(jdoc["data"])
         return data
 
-    def put_file(self, file_obj, dbfs_path, overwrite=False, block_size=1024 ** 2):
+    def put_file(self, file_obj, dbfs_path, overwrite=False, block_size=1024**2):
         """Upload an arbitrary large file to DBFS.
 
         This doesn't use the DBFS `Put` API because that endpoint is limited to 1MB.

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -257,7 +257,7 @@ def poll_run_state(
     start_poll_time: float,
     databricks_run_id: int,
     max_wait_time_sec: float,
-    error_path: str,
+    error_path: str = None,
 ):
     run_state = client.get_run_state(databricks_run_id)
     if run_state.has_terminated():
@@ -267,9 +267,12 @@ def poll_run_state(
         else:
             # attempt to get the serialized exception, otherwise create a placeholder
             error = None
-            try:
-                error = pickle.loads(client.read_file(error_path))
-            except Exception:
+            if error_path:
+                try:
+                    error = pickle.loads(client.read_file(error_path))
+                except Exception:
+                    pass
+            if error is None:
                 error_message = "Run %s failed with result state: %s. Message: %s" % (
                     databricks_run_id,
                     run_state.result_state,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -17,6 +17,7 @@ from dagster import Bool, Field, IntSource, StringSource, check, resource
 from dagster.core.definitions.step_launcher import StepLauncher
 from dagster.core.errors import raise_execution_interrupts
 from dagster.core.execution.plan.external_step import (
+    PICKLED_ERROR_FILE_NAME,
     PICKLED_EVENTS_FILE_NAME,
     PICKLED_STEP_RUN_REF_FILE_NAME,
     step_context_to_step_run_ref,
@@ -226,9 +227,12 @@ class DatabricksPySparkStepLauncher(StepLauncher):
                         start,
                         databricks_run_id,
                         self.databricks_runner.max_wait_time_sec,
+                        self._dbfs_path(step_context.run_id, step_key, PICKLED_ERROR_FILE_NAME),
                     )
                 finally:
-                    all_events = self.get_step_events(step_context.run_id, step_key)
+                    all_events = self.get_step_events(
+                        step_context.run_id, step_key, step_context.previous_attempt_count
+                    )
                     # we get all available records on each poll, but we only want to process the
                     # ones we haven't seen before
                     for event in all_events[processed_events:]:
@@ -240,8 +244,9 @@ class DatabricksPySparkStepLauncher(StepLauncher):
 
         step_context.log.info(f"Databricks run {databricks_run_id} completed.")
 
-    def get_step_events(self, run_id: str, step_key: str):
-        path = self._dbfs_path(run_id, step_key, PICKLED_EVENTS_FILE_NAME)
+    def get_step_events(self, run_id: str, step_key: str, retry_number: int):
+        # events for each retry written to a different file
+        path = self._dbfs_path(run_id, step_key, f"{retry_number}{PICKLED_EVENTS_FILE_NAME}")
 
         def _get_step_records():
             serialized_records = self.databricks_runner.client.read_file(path)
@@ -289,7 +294,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         main_local_path = self._main_file_local_path()
         with open(main_local_path, "rb") as infile:
             self.databricks_runner.client.put_file(
-                infile, self._dbfs_path(run_id, step_key, self._main_file_name())
+                infile, self._dbfs_path(run_id, step_key, self._main_file_name()), overwrite=True
             )
 
         log.info("Uploading dagster job to DBFS")
@@ -299,7 +304,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             build_pyspark_zip(zip_local_path, self.local_dagster_job_package_path)
             with open(zip_local_path, "rb") as infile:
                 self.databricks_runner.client.put_file(
-                    infile, self._dbfs_path(run_id, step_key, CODE_ZIP_NAME)
+                    infile, self._dbfs_path(run_id, step_key, CODE_ZIP_NAME), overwrite=True
                 )
 
         log.info("Uploading step run ref file to DBFS")
@@ -310,6 +315,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         self.databricks_runner.client.put_file(
             step_pickle_file,
             self._dbfs_path(run_id, step_key, PICKLED_STEP_RUN_REF_FILE_NAME),
+            overwrite=True,
         )
 
         databricks_config = DatabricksConfig(
@@ -324,6 +330,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         self.databricks_runner.client.put_file(
             databricks_config_file,
             self._dbfs_path(run_id, step_key, PICKLED_CONFIG_FILE_NAME),
+            overwrite=True,
         )
 
     def _log_logs_from_cluster(self, log, run_id):

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -246,7 +246,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
 
     def get_step_events(self, run_id: str, step_key: str, retry_number: int):
         # events for each retry written to a different file
-        path = self._dbfs_path(run_id, step_key, f"{retry_number}{PICKLED_EVENTS_FILE_NAME}")
+        path = self._dbfs_path(run_id, step_key, f"{retry_number}_{PICKLED_EVENTS_FILE_NAME}")
 
         def _get_step_records():
             serialized_records = self.databricks_runner.client.read_file(path)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -17,8 +17,8 @@ from dagster import Bool, Field, IntSource, StringSource, check, resource
 from dagster.core.definitions.step_launcher import StepLauncher
 from dagster.core.errors import raise_execution_interrupts
 from dagster.core.execution.plan.external_step import (
-    PICKLED_ERROR_FILE_NAME,
     PICKLED_EVENTS_FILE_NAME,
+    PICKLED_EXCEPTION_FILE_NAME,
     PICKLED_STEP_RUN_REF_FILE_NAME,
     step_context_to_step_run_ref,
 )
@@ -227,7 +227,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
                         start,
                         databricks_run_id,
                         self.databricks_runner.max_wait_time_sec,
-                        self._dbfs_path(step_context.run_id, step_key, PICKLED_ERROR_FILE_NAME),
+                        self._dbfs_path(step_context.run_id, step_key, PICKLED_EXCEPTION_FILE_NAME),
                     )
                 finally:
                     all_events = self.get_step_events(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -22,6 +22,7 @@ from queue import Empty, Queue
 from threading import Thread
 
 from dagster.core.execution.plan.external_step import (
+    PICKLED_ERROR_FILE_NAME,
     PICKLED_EVENTS_FILE_NAME,
     external_instance_from_step_run_ref,
     run_step_from_ref,
@@ -91,7 +92,20 @@ def main(
             step_run_ref = pickle.load(handle)
         print("Running dagster job")  # noqa pylint: disable=print-call
 
-        events_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
+        step_run_dir = os.path.dirname(step_run_ref_filepath)
+        # write events for each retry to different file
+        events_filepath = os.path.join(
+            step_run_dir, f"{step_run_ref.prior_attempts_count}{PICKLED_EVENTS_FILE_NAME}"
+        )
+        error_filepath = os.path.join(step_run_dir, PICKLED_ERROR_FILE_NAME)
+        stdout_filepath = os.path.join(step_run_dir, "stdout")
+        stderr_filepath = os.path.join(step_run_dir, "stderr")
+
+        # create empty files for the events/error/stdout/stderr
+        with open(events_filepath, "wb"), open(error_filepath, "wb"), open(
+            stdout_filepath, "wb"
+        ), open(stderr_filepath, "wb"):
+            pass
 
         def put_events(events):
             with open(events_filepath, "wb") as handle:
@@ -116,18 +130,20 @@ def main(
                 # consume iterator
                 list(run_step_from_ref(step_run_ref, instance))
             except Exception as e:
-                # ensure that exceptiosn make their way into stdout
                 traceback.print_exc()
+                # pickle the original exception so we can re-raise it in the host process
+                with open(error_filepath, "wb") as handle:
+                    handle.write(pickle.dumps(e))
                 raise e
             finally:
                 events_queue.put(DONE)
                 event_writing_thread.join()
                 # write final stdout and stderr
-                with open(os.path.dirname(step_run_ref_filepath) + "/stderr", "wb") as handle:
+                with open(stderr_filepath, "wb") as handle:
                     stderr_str = stderr.getvalue()
                     sys.stderr.write(stderr_str)
                     handle.write(stderr_str.encode())
-                with open(os.path.dirname(step_run_ref_filepath) + "/stdout", "wb") as handle:
+                with open(stdout_filepath, "wb") as handle:
                     stdout_str = stdout.getvalue()
                     sys.stdout.write(stdout_str)
                     handle.write(stdout_str.encode())

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -96,7 +96,7 @@ def main(
         step_run_dir = os.path.dirname(step_run_ref_filepath)
         # write events for each retry to different file
         events_filepath = os.path.join(
-            step_run_dir, f"{step_run_ref.prior_attempts_count}{PICKLED_EVENTS_FILE_NAME}"
+            step_run_dir, f"{step_run_ref.prior_attempts_count}_{PICKLED_EVENTS_FILE_NAME}"
         )
         exception_filepath = os.path.join(step_run_dir, PICKLED_EXCEPTION_FILE_NAME)
         stdout_filepath = os.path.join(step_run_dir, "stdout")


### PR DESCRIPTION
Resolves: https://github.com/dagster-io/dagster/issues/7122

Step launchers are weird and hard to reason about.

The basic functionality of a step launcher is to:

a) Serialize all of the relevant state about the host environment (so step context, relevant logs, etc.)
b) Ship that state (and the code you want to run) over to some external execution environment
c) Deserialize that state in the external execution environment to match the original environment as closely as possible
d) Run the code in the external environment, keeping track of any state changes
e) Serialize a representation of those state changes and ship it back to the host process
f) Have the host process ingest those changes and "make it seem like" they happened natively in the host process

Prior to this PR, the "keeping track of any state changes" in d) was done by simply recording all of the entries that were added to the event log on the external instance. However, it's not actually the case that any event which alters the control flow of Dagster will have a corresponding representation in the event log. In particular, there are two Dagster-specific exceptions which have special properties in terms of determining how Dagster will run a particular step: `RetryRequested` and `Failure`.

When you set a RetryPolicy on an op, what happens is that the process that executes that op will capture any exception and, depending on the policy, raise a RetryRequested exception telling the dagster framework to retry the step, and how long to wait before the next retry. These exceptions would not get captured / sent over to the host process, meaning that the policy would not be respected. A similar (but less impactful) issue would occur with Failure exceptions.

This PR fixes the underlying issue by exporting these serialized exceptions back to the host process so that they can be raised again.

This doesn't preserve the stack trace of the original exception, but it will at least manage the control flow properly.