### PR TITLE
[dagster-databricks] better retry support for step launchers

### DIFF
--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -164,7 +164,9 @@ def _trigger_hook(
             yield DagsterEvent.hook_completed(step_context, hook_def)
 
 
-def _dagster_event_sequence_for_step(step_context: StepExecutionContext) -> Iterator[DagsterEvent]:
+def _dagster_event_sequence_for_step(
+    step_context: StepExecutionContext, force_local_execution: bool = False
+) -> Iterator[DagsterEvent]:
     """
     Yield a sequence of dagster events for the given step with the step context.
 
@@ -214,7 +216,7 @@ def _dagster_event_sequence_for_step(step_context: StepExecutionContext) -> Iter
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
     try:
-        if step_context.step_launcher:
+        if step_context.step_launcher and not force_local_execution:
             # info all on step_context - should deprecate second arg
             step_events = step_context.step_launcher.launch_step(
                 step_context, step_context.previous_attempt_count

--- a/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/core/execution/plan/execute_plan.py
@@ -84,7 +84,7 @@ def inner_plan_execution_iterator(
                         step_context, log_key=step_context.step.key, steps=[step_context.step]
                     )
 
-                for step_event in check.generator(_dagster_event_sequence_for_step(step_context)):
+                for step_event in check.generator(dagster_event_sequence_for_step(step_context)):
                     check.inst(step_event, DagsterEvent)
                     step_event_list.append(step_event)
                     yield step_event
@@ -164,7 +164,7 @@ def _trigger_hook(
             yield DagsterEvent.hook_completed(step_context, hook_def)
 
 
-def _dagster_event_sequence_for_step(
+def dagster_event_sequence_for_step(
     step_context: StepExecutionContext, force_local_execution: bool = False
 ) -> Iterator[DagsterEvent]:
     """
@@ -211,6 +211,11 @@ def _dagster_event_sequence_for_step(
 
     For tools, however, this option should be false, and a sensible error message
     signaled to the user within that tool.
+
+    When we launch a step that has a step launcher, we use this function on both the host process
+    and the remote process. When we run the step in the remote process, to prevent an infinite loop
+    of launching steps that then launch steps, and so on, the remote process will run this with
+    the force_local_execution argument set to True.
     """
 
     check.inst_param(step_context, "step_context", StepExecutionContext)

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -14,7 +14,7 @@ from dagster.core.events import DagsterEvent, DagsterEventType
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.execution.context.system import StepExecutionContext
 from dagster.core.execution.context_creation_pipeline import PlanExecutionContextManager
-from dagster.core.execution.plan.execute_plan import _dagster_event_sequence_for_step
+from dagster.core.execution.plan.execute_plan import dagster_event_sequence_for_step
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.file_manager import LocalFileHandle, LocalFileManager
 from dagster.serdes import deserialize_value
@@ -280,4 +280,4 @@ def run_step_from_ref(
 
     # The step should be forced to run locally with respect to the remote process that this step
     # context is being deserialized in
-    return _dagster_event_sequence_for_step(step_context, force_local_execution=True)
+    return dagster_event_sequence_for_step(step_context, force_local_execution=True)

--- a/python_modules/dagster/dagster/core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/core/execution/plan/external_step.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import shutil
 import subprocess
 import sys
 from typing import TYPE_CHECKING, Iterator, Optional, cast
@@ -13,7 +14,7 @@ from dagster.core.events import DagsterEvent, DagsterEventType
 from dagster.core.execution.api import create_execution_plan
 from dagster.core.execution.context.system import StepExecutionContext
 from dagster.core.execution.context_creation_pipeline import PlanExecutionContextManager
-from dagster.core.execution.plan.execute_step import core_dagster_event_sequence_for_step
+from dagster.core.execution.plan.execute_plan import _dagster_event_sequence_for_step
 from dagster.core.instance import DagsterInstance
 from dagster.core.storage.file_manager import LocalFileHandle, LocalFileManager
 from dagster.serdes import deserialize_value
@@ -52,6 +53,8 @@ class LocalExternalStepLauncher(StepLauncher):
         run_id = step_context.pipeline_run.run_id
 
         step_run_dir = os.path.join(self.scratch_dir, run_id, step_run_ref.step_key)
+        if os.path.exists(step_run_dir):
+            shutil.rmtree(step_run_dir)
         os.makedirs(step_run_dir)
 
         step_run_ref_file_path = os.path.join(step_run_dir, PICKLED_STEP_RUN_REF_FILE_NAME)
@@ -123,14 +126,12 @@ def _upstream_events_and_runs(step_context: StepExecutionContext):
             if output_handle in upstream_output_handles:
                 events.append(r)
                 upstream_output_handles.remove(output_handle)
-        # found all the necessary events
-        if not upstream_output_handles:
-            break
 
         if current_run.parent_run_id is None:
-            step_context.log.warn(
-                f"Could not find outputs in the logs for output handles: {upstream_output_handles}"
-            )
+            if upstream_output_handles:
+                step_context.log.warn(
+                    f"Could not find outputs in the logs for output handles: {upstream_output_handles}"
+                )
             break
 
         # else, keep looking backwards
@@ -267,6 +268,7 @@ def step_run_ref_to_step_context(
     # Since we are launching from a PlanExecutionContext, the type will always be
     # StepExecutionContext.
     step_execution_context = cast(StepExecutionContext, step_execution_context)
+
     return step_execution_context
 
 
@@ -275,4 +277,7 @@ def run_step_from_ref(
 ) -> Iterator[DagsterEvent]:
     check.inst_param(instance, "instance", DagsterInstance)
     step_context = step_run_ref_to_step_context(step_run_ref, instance)
-    return core_dagster_event_sequence_for_step(step_context)
+
+    # The step should be forced to run locally with respect to the remote process that this step
+    # context is being deserialized in
+    return _dagster_event_sequence_for_step(step_context, force_local_execution=True)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -91,7 +91,17 @@ def main(
             step_run_ref = pickle.load(handle)
         print("Running dagster job")  # noqa pylint: disable=print-call
 
-        events_filepath = os.path.dirname(step_run_ref_filepath) + "/" + PICKLED_EVENTS_FILE_NAME
+        step_run_dir = os.path.dirname(step_run_ref_filepath)
+        events_filepath = os.path.join(
+            step_run_dir,
+            f"{step_run_ref.prior_attempts_count}_{PICKLED_EVENTS_FILE_NAME}",
+        )
+        stdout_filepath = os.path.join(step_run_dir, "stdout")
+        stderr_filepath = os.path.join(step_run_dir, "stderr")
+
+        # create empty files
+        with open(events_filepath, "wb"), open(stdout_filepath, "wb"), open(stderr_filepath, "wb"):
+            pass
 
         def put_events(events):
             with open(events_filepath, "wb") as handle:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -133,11 +133,11 @@ def main(
                 events_queue.put(DONE)
                 event_writing_thread.join()
                 # write final stdout and stderr
-                with open(os.path.dirname(step_run_ref_filepath) + "/stderr", "wb") as handle:
+                with open(stderr_filepath, "wb") as handle:
                     stderr_str = stderr.getvalue()
                     sys.stderr.write(stderr_str)
                     handle.write(stderr_str.encode())
-                with open(os.path.dirname(step_run_ref_filepath) + "/stdout", "wb") as handle:
+                with open(stdout_filepath, "wb") as handle:
                     stdout_str = stdout.getvalue()
                     sys.stdout.write(stdout_str)
                     handle.write(stdout_str.encode())


### PR DESCRIPTION
obsoletes: https://github.com/dagster-io/dagster/pull/7165#pullrequestreview-918865002

resolves: https://github.com/dagster-io/dagster/issues/7122

This is essentially just a cleaner solution for the problem resolved in the earlier PR.

Here, we take advantage of the fact that the _dagster_event_sequence_for_step wraps all encountered errors in DagsterEvents, which means that they are automatically serializable. This means that a) we don't have to do anything special to ship errors back to the host process, and b) we get a nice stack trace for any error that's encountered, regardless of if it's a control-flow type error (Failure, RetryRequested), or just some random user code error.

In order to make sure we don't get caught in an infinite loop of step lanchers launching steps that then need to launch steps, etc., we add a parameter to _dagster_event_sequence_for_step to allow it to ignore the presence of the step launcher when it's being executed on a remote instance.