### PR TITLE
Update version placeholder "dev" to "0+dev"

### DIFF
--- a/examples/airline_demo/setup.py
+++ b/examples/airline_demo/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup  # type: ignore
 
 setup(
     name="airline_demo",
-    version="dev",
+    version="0+dev",
     author="Elementl",
     license="Apache-2.0",
     description="Dagster Examples",

--- a/examples/bollinger/setup.py
+++ b/examples/bollinger/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="bollinger",
-    version="dev",
+    version="0+dev",
     packages=find_packages(),
     install_requires=[
         "dagster",

--- a/examples/dbt_example/setup.py
+++ b/examples/dbt_example/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="dbt_example",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=["dbt_example"],
     include_package_data=True,

--- a/examples/ge_example/setup.py
+++ b/examples/ge_example/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="ge_example",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=["ge_example"],
     include_package_data=True,

--- a/examples/hacker_news/setup.py
+++ b/examples/hacker_news/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="hacker_news",
-    version="dev",
+    version="0+dev",
     author="Elementl",
     author_email="hello@elementl.com",
     classifiers=[

--- a/examples/hacker_news_assets/setup.py
+++ b/examples/hacker_news_assets/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="hacker_news_assets",
-    version="dev",
+    version="0+dev",
     author="Elementl",
     author_email="hello@elementl.com",
     classifiers=[

--- a/examples/memoized_development/setup.py
+++ b/examples/memoized_development/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="memoized_development",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=["memoized_development"],  # same as name
     install_requires=["dagster"],  # external packages as dependencies

--- a/examples/modern_data_stack_assets/setup.py
+++ b/examples/modern_data_stack_assets/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="modern_data_stack_assets",
-    version="dev",
+    version="0+dev",
     author="Elementl",
     author_email="hello@elementl.com",
     classifiers=[

--- a/examples/nyt-feed/setup.py
+++ b/examples/nyt-feed/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="nyt_feed",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=find_packages(exclude=["test"]),
     install_requires=[

--- a/examples/run_attribution_example/setup.py
+++ b/examples/run_attribution_example/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="run_attribution_example",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=["run_attribution_example"],  # same as name
     install_requires=["dagster"],  # external packages as dependencies

--- a/examples/software_defined_assets/setup.py
+++ b/examples/software_defined_assets/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="software_defined_assets",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=["software_defined_assets"],  # same as name
     install_requires=["dagster"],  # external packages as dependencies

--- a/examples/user_in_loop/setup.py
+++ b/examples/user_in_loop/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="user_in_loop",
-    version="dev",
+    version="0+dev",
     author_email="hello@elementl.com",
     packages=["user_in_loop"],
     include_package_data=True,

--- a/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/setup.py.tmpl
+++ b/python_modules/automation/automation/scaffold/assets/dagster-library-tmpl/setup.py.tmpl
@@ -13,7 +13,7 @@ def get_version() -> str:
 if __name__ == '__main__':
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name='dagster-{{LIBRARY_NAME}}',
         version=ver,

--- a/python_modules/dagit/dagit/version.py
+++ b/python_modules/dagit/dagit/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -20,7 +20,7 @@ def get_version():
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagit",
         version=ver,

--- a/python_modules/dagster-graphql/dagster_graphql/version.py
+++ b/python_modules/dagster-graphql/dagster_graphql/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-graphql",
         version=ver,

--- a/python_modules/dagster-test/setup.py
+++ b/python_modules/dagster-test/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     setup(
         name="dagster-test",
-        version="dev",
+        version="0+dev",
         author="Elementl",
         author_email="hello@elementl.com",
         license="Apache-2.0",

--- a/python_modules/dagster/dagster/version.py
+++ b/python_modules/dagster/dagster/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/version.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-airbyte",
         version=ver,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/version.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-airflow",
         version=ver,

--- a/python_modules/libraries/dagster-aws/dagster_aws/version.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-aws",
         version=ver,

--- a/python_modules/libraries/dagster-azure/dagster_azure/version.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-azure/setup.py
+++ b/python_modules/libraries/dagster-azure/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-azure",
         version=ver,

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/version.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-celery-docker",
         version=ver,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/version.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-celery-k8s",
         version=ver,

--- a/python_modules/libraries/dagster-celery/dagster_celery/version.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-celery/setup.py
+++ b/python_modules/libraries/dagster-celery/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-celery",
         version=ver,

--- a/python_modules/libraries/dagster-dask/dagster_dask/version.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-dask",
         version=ver,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/version.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-databricks",
         version=ver,

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/version.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-datadog",
         version=ver,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/version.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-dbt",
         version=ver,

--- a/python_modules/libraries/dagster-docker/dagster_docker/version.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-docker",
         version=ver,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/version.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-fivetran",
         version=ver,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/version.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-gcp",
         version=ver,

--- a/python_modules/libraries/dagster-ge/dagster_ge/version.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-ge",
         version=ver,

--- a/python_modules/libraries/dagster-github/dagster_github/version.py
+++ b/python_modules/libraries/dagster-github/dagster_github/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-github",
         version=ver,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -535,7 +535,7 @@ def construct_dagster_k8s_job(
     k8s_common_labels = {
         "app.kubernetes.io/name": "dagster",
         "app.kubernetes.io/instance": "dagster",
-        "app.kubernetes.io/version": dagster_version,
+        "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
         "app.kubernetes.io/part-of": "dagster",
     }
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -16,7 +16,7 @@ def sanitize_k8s_label(label_name: str):
     # Truncate too long label values to fit into 63-characters limit and avoid invalid characters.
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
     label_name = label_name[:63]
-    return re.sub(r"[^a-zA-Z0-9\-_\.]", "-", label_name).strip("-").strip("_")
+    return re.sub(r"[^a-zA-Z0-9\-_\.\+]", "-", label_name).strip("-").strip("_")
 
 
 def retrieve_pod_logs(pod_name, namespace):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -16,7 +16,7 @@ def sanitize_k8s_label(label_name: str):
     # Truncate too long label values to fit into 63-characters limit and avoid invalid characters.
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
     label_name = label_name[:63]
-    return re.sub(r"[^a-zA-Z0-9\-_\.\+]", "-", label_name).strip("-").strip("_")
+    return re.sub(r"[^a-zA-Z0-9\-_\.]", "-", label_name).strip("-").strip("_")
 
 
 def retrieve_pod_logs(pod_name, namespace):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/version.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -7,6 +7,7 @@ from dagster_k8s.job import (
     UserDefinedDagsterK8sConfig,
     get_user_defined_k8s_config,
 )
+from dagster_k8s.utils import sanitize_k8s_label
 
 from dagster import __version__ as dagster_version
 from dagster import graph
@@ -598,7 +599,7 @@ def test_construct_dagster_k8s_job_with_labels():
     common_labels = {
         "app.kubernetes.io/name": "dagster",
         "app.kubernetes.io/instance": "dagster",
-        "app.kubernetes.io/version": dagster_version,
+        "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
         "app.kubernetes.io/part-of": "dagster",
     }
 

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-k8s",
         version=ver,

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/version.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/version.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/version.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-mysql/setup.py
+++ b/python_modules/libraries/dagster-mysql/setup.py
@@ -12,7 +12,7 @@ def get_version():
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-mysql",
         version=ver,

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/version.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-pagerduty",
         version=ver,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/version.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -21,7 +21,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-pandas",
         version=ver,

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/version.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-pandera",
         version=ver,

--- a/python_modules/libraries/dagster-papertrail/dagster_papertrail/version.py
+++ b/python_modules/libraries/dagster-papertrail/dagster_papertrail/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-papertrail",
         version=ver,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/version.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-postgres",
         version=ver,

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/version.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-prometheus",
         version=ver,

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/version.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-pyspark",
         version=ver,

--- a/python_modules/libraries/dagster-shell/dagster_shell/version.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-shell",
         version=ver,

--- a/python_modules/libraries/dagster-slack/dagster_slack/version.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -12,7 +12,7 @@ def get_version():
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-slack",
         version=ver,

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/version.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-snowflake",
         version=ver,

--- a/python_modules/libraries/dagster-spark/dagster_spark/version.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-spark",
         version=ver,

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/version.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-ssh",
         version=ver,

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/version.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagster-twilio",
         version=ver,

--- a/python_modules/libraries/dagstermill/dagstermill/version.py
+++ b/python_modules/libraries/dagstermill/dagstermill/version.py
@@ -1,1 +1,1 @@
-__version__ = "dev"
+__version__ = "0+dev"

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 if __name__ == "__main__":
     ver = get_version()
     # dont pin dev installs to avoid pip dep resolver issues
-    pin = "" if ver == "dev" else f"=={ver}"
+    pin = "" if ver == "0+dev" else f"=={ver}"
     setup(
         name="dagstermill",
         version=ver,


### PR DESCRIPTION
This PR updates the placeholder version `dev` used throughout the repo to be `0+dev` instead. This was done because `"dev"` is not a valid version specifier under [PEP 440](https://peps.python.org/pep-0440/) but `"0+dev"` is. Use of invalid version specifier can cause tools to fail, e.g. `poetry` chokes when trying to do an editable install of a package with version `"dev"`.

## Test Plan

No new tests added-- not sure how to test this.
