### PR TITLE
[dagit] If re-executing from failure fails, default to from failure again

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -113,7 +113,11 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   const pipelineError = usePipelineAvailabilityErrorForRun(run);
 
   const selection = stepSelectionWithState(props.selection, metadata);
-  const selectionOfCurrentRun = stepSelectionFromRunTags(run, graph, metadata);
+
+  const currentRunSelection = stepSelectionFromRunTags(run, graph, metadata);
+  const currentRunIsFromFailure = run.tags?.some(
+    (t) => t.key === DagsterTag.IsResumeRetry && t.value === 'true',
+  );
 
   const full: LaunchButtonConfiguration = {
     icon: 'cached',
@@ -126,21 +130,20 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
 
   const same: LaunchButtonConfiguration = {
     icon: 'linear_scale',
-    scope: selectionOfCurrentRun?.query || '*',
+    scope: currentRunSelection?.query || '*',
     title: 'Same Steps',
-    disabled:
-      !selectionOfCurrentRun || !(selectionOfCurrentRun.finished || selectionOfCurrentRun.failed),
+    disabled: !currentRunSelection || !(currentRunSelection.finished || currentRunSelection.failed),
     tooltip: (
       <div>
-        {!selectionOfCurrentRun || !selectionOfCurrentRun.present
+        {!currentRunSelection || !currentRunSelection.present
           ? 'Re-executes the same step subset used for this run if one was present.'
-          : !selectionOfCurrentRun.finished
+          : !currentRunSelection.finished
           ? 'Wait for all of the steps to finish to re-execute the same subset.'
           : 'Re-execute the same step subset used for this run:'}
-        <StepSelectionDescription selection={selectionOfCurrentRun} />
+        <StepSelectionDescription selection={currentRunSelection} />
       </div>
     ),
-    onClick: () => onLaunch({type: 'selection', selection: selectionOfCurrentRun!}),
+    onClick: () => onLaunch({type: 'selection', selection: currentRunSelection!}),
   };
 
   const selected: LaunchButtonConfiguration = {
@@ -209,9 +212,12 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
   const options = [full, same, selected, fromSelected, fromFailure];
   const preferredRerun = selection.present
     ? selected
-    : selectionOfCurrentRun?.present
+    : fromFailureEnabled && currentRunIsFromFailure
+    ? fromFailure
+    : currentRunSelection?.present
     ? same
     : null;
+
   const primary = artifactsPersisted && preferredRerun ? preferredRerun : full;
 
   const tooltip = () => {
@@ -228,7 +234,13 @@ export const RunActionButtons: React.FC<RunActionButtonsProps> = (props) => {
           runCount={1}
           primary={primary}
           options={options}
-          title={primary.scope === '*' ? `Re-execute All (*)` : `Re-execute (${primary.scope})`}
+          title={
+            primary.scope === '*'
+              ? `Re-execute All (*)`
+              : primary.scope
+              ? `Re-execute (${primary.scope})`
+              : `Re-execute ${primary.title}`
+          }
           tooltip={tooltip()}
           icon={pipelineError?.icon}
           disabled={pipelineError?.disabled || !canLaunchPipelineReexecution}


### PR DESCRIPTION
## Summary
This PR fixes https://github.com/dagster-io/dagster/issues/5019! At long last. If you re-execute from failure and your re-execution fails, the button's primary action is to re-execute from failure again rather than the entire pipeline.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.