### PR TITLE
Ensure telemetry logging dir is created before using logger

### DIFF
--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -281,11 +281,18 @@ def _get_telemetry_logger():
     # (the logger does not do this itself.)
     dagster_home_path = get_or_create_dir_from_dagster_home("logs")
 
+    logging_file_path = os.path.join(dagster_home_path, "event.log")
     logger = logging.getLogger("dagster_telemetry_logger")
+
+    # If the file we were writing to has been overwritten, dump the existing logger and re-open the stream.
+    if not os.path.exists(logging_file_path) and len(logger.handlers) > 0:
+        handler = next(iter(logger.handlers))
+        handler.close()
+        logger.removeHandler(handler)
 
     if len(logger.handlers) == 0:
         handler = RotatingFileHandler(
-            os.path.join(dagster_home_path, "event.log"),
+            logging_file_path,
             maxBytes=MAX_BYTES,
             backupCount=10,
         )

--- a/python_modules/dagster/dagster/core/telemetry.py
+++ b/python_modules/dagster/dagster/core/telemetry.py
@@ -279,13 +279,13 @@ def _get_telemetry_logger():
     # If a concurrently running process deleted the logging directory since the
     # last action, we need to make sure to re-create the directory
     # (the logger does not do this itself.)
-    get_or_create_dir_from_dagster_home("logs")
+    dagster_home_path = get_or_create_dir_from_dagster_home("logs")
 
     logger = logging.getLogger("dagster_telemetry_logger")
 
     if len(logger.handlers) == 0:
         handler = RotatingFileHandler(
-            os.path.join(get_or_create_dir_from_dagster_home("logs"), "event.log"),
+            os.path.join(dagster_home_path, "event.log"),
             maxBytes=MAX_BYTES,
             backupCount=10,
         )

--- a/python_modules/dagster/dagster/core/telemetry_upload.py
+++ b/python_modules/dagster/dagster/core/telemetry_upload.py
@@ -4,7 +4,7 @@ import threading
 import zlib
 from contextlib import contextmanager
 
-from .telemetry import MAX_BYTES, get_dir_from_dagster_home
+from .telemetry import MAX_BYTES, get_or_create_dir_from_dagster_home
 
 
 def get_dagster_telemetry_url():
@@ -45,8 +45,8 @@ def upload_logs(stop_event, raise_errors=False):
 
     try:
         last_run = datetime.datetime.now() - datetime.timedelta(minutes=120)
-        dagster_log_dir = get_dir_from_dagster_home("logs")
-        dagster_log_queue_dir = get_dir_from_dagster_home(".logs_queue")
+        dagster_log_dir = get_or_create_dir_from_dagster_home("logs")
+        dagster_log_queue_dir = get_or_create_dir_from_dagster_home(".logs_queue")
         in_progress = False
         while not stop_event.is_set():
             log_size = 0
@@ -75,8 +75,8 @@ def upload_logs(stop_event, raise_errors=False):
             ):
                 in_progress = True  # Prevent concurrent _upload_logs invocations
                 last_run = datetime.datetime.now()
-                dagster_log_dir = get_dir_from_dagster_home("logs")
-                dagster_log_queue_dir = get_dir_from_dagster_home(".logs_queue")
+                dagster_log_dir = get_or_create_dir_from_dagster_home("logs")
+                dagster_log_queue_dir = get_or_create_dir_from_dagster_home(".logs_queue")
                 _upload_logs(
                     dagster_log_dir, log_size, dagster_log_queue_dir, raise_errors=raise_errors
                 )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -9,7 +9,7 @@ from dagster.cli.pipeline import pipeline_execute_command
 from dagster.core.definitions.reconstruct import get_ephemeral_repository_name
 from dagster.core.telemetry import (
     UPDATE_REPO_STATS,
-    get_dir_from_dagster_home,
+    get_or_create_dir_from_dagster_home,
     hash_name,
     log_workspace_stats,
 )
@@ -83,7 +83,9 @@ def test_dagster_telemetry_disabled(caplog):
                 ],
             )
 
-        assert not os.path.exists(os.path.join(get_dir_from_dagster_home("logs"), "event.log"))
+        assert not os.path.exists(
+            os.path.join(get_or_create_dir_from_dagster_home("logs"), "event.log")
+        )
         assert len(caplog.records) == 0
         assert result.exit_code == 0
 


### PR DESCRIPTION
In dagster 0.13.16, we added telemetry logging to the daemon. The daemon controller is a long-running process, and it potentially uses the same logger for long periods of time. In this time, other concurrent processes, such as dagit, could potentially delete the telemetry logging directory. [The RotatingFileHandler logger that we use is unable to reconstruct this directory](https://stackoverflow.com/questions/32133856/logger-cannot-find-file), resulting in the spurious errors thrown [here](https://github.com/dagster-io/dagster/issues/6972). To fix this, we just need to ensure that the directory is always created upon a request to log.

This seems like a super hard thing to test, unfortunately.