### PR TITLE
Fixup ECS docs

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -129,11 +129,9 @@ run_launcher:
   config:
     secrets:
       - name: "MY_API_TOKEN"
-        valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::
+        valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::"
       - name: "MY_PASSWORD"
-        valueFrom: arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::
-  ]
-}
+        valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::"
 ```
 
 Any secret tagged with `dagster` will be included in the environment. `MY_API_TOKEN` and `MY_PASSWORD` will also be included in the environment.


### PR DESCRIPTION
Without the quotes, the YAML fails to parse with:

```
yaml.scanner.ScannerError: mapping values are not allowed here
```

Also, there were a few dangling closing brackets/braces left-over
presumably from copy-pasting this as JSON and reformatting it to YAML.