### PR TITLE
Add persisted instance to get_external_execution_plan call in scheduler

### DIFF
--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -532,6 +532,7 @@ def _create_scheduler_run(
         run_config,
         external_schedule.mode,
         step_keys_to_execute=None,
+        instance=instance,
         known_state=None,
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot


### PR DESCRIPTION
Currently, we aren't passing an instance to the external execution plan call in the scheduler. This is leading to [errors in memoized runs](https://github.com/dagster-io/dagster/issues/7046). The solution is to add the instance to the call.

Maybe add a test for this?