### PR TITLE
docs: use word "op" instead of "solid"

### DIFF
--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -86,7 +86,7 @@ do_database_stuff_dev = do_database_stuff.to_job(
 )
 ```
 
-Supplying resources to the <PyObject object="job" decorator />, i.e. when there aren't multiple jobs for the same graph, is also useful. For example, if you want to use an off-the-shelf resource or supply configuration in one place instead of in every solid.
+Supplying resources to the <PyObject object="job" decorator />, i.e. when there aren't multiple jobs for the same graph, is also useful. For example, if you want to use an off-the-shelf resource or supply configuration in one place instead of in every op.
 
 ```python file=/concepts/resources/resources.py startafter=start_job_example endbefore=end_job_example
 from dagster import job


### PR DESCRIPTION
Small change to documentation to use the word "op" instead of "solid"

<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->




## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.