### PR TITLE
add tick selector index migration 4/5

### DIFF
--- a/python_modules/dagster/dagster/core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/core/storage/migration/utils.py
@@ -285,3 +285,18 @@ def create_instigators_table():
 
     if not has_column("job_ticks", "selector_id"):
         op.add_column("job_ticks", db.Column("selector_id", db.String(255)))
+
+
+def create_tick_selector_index():
+    if not has_table("job_ticks"):
+        # not a schedule storage db
+        return
+
+    indexes = [x.get("name") for x in get_inspector().get_indexes("job_ticks")]
+    if "idx_tick_selector_timestamp" in indexes:
+        # already migrated
+        return
+
+    op.create_index(
+        "idx_tick_selector_timestamp", "job_ticks", ["selector_id", "timestamp"], unique=False
+    )

--- a/python_modules/dagster/dagster/core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/schema.py
@@ -63,3 +63,4 @@ db.Index(
     mysql_length=32,
 )
 db.Index("idx_job_tick_timestamp", JobTickTable.c.job_origin_id, JobTickTable.c.timestamp)
+db.Index("idx_tick_selector_timestamp", JobTickTable.c.selector_id, JobTickTable.c.timestamp)

--- a/python_modules/dagster/dagster/core/storage/schedules/sqlite/alembic/versions/721d858e1dda_add_tick_selector_index.py
+++ b/python_modules/dagster/dagster/core/storage/schedules/sqlite/alembic/versions/721d858e1dda_add_tick_selector_index.py
@@ -1,0 +1,22 @@
+"""add tick selector index
+
+Revision ID: 721d858e1dda
+Revises: c892b3fe0a9f
+Create Date: 2022-03-25 10:28:29.065161
+
+"""
+from dagster.core.storage.migration.utils import create_tick_selector_index
+
+# revision identifiers, used by Alembic.
+revision = "721d858e1dda"
+down_revision = "c892b3fe0a9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_tick_selector_index()
+
+
+def downgrade():
+    pass

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/alembic/versions/d32d1d6de793_add_tick_selector_index.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/alembic/versions/d32d1d6de793_add_tick_selector_index.py
@@ -1,0 +1,22 @@
+"""add tick selector index
+
+Revision ID: d32d1d6de793
+Revises: 5b467f7af3f6
+Create Date: 2022-03-25 10:29:10.895341
+
+"""
+from dagster.core.storage.migration.utils import create_tick_selector_index
+
+# revision identifiers, used by Alembic.
+revision = "d32d1d6de793"
+down_revision = "5b467f7af3f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_tick_selector_index()
+
+
+def downgrade():
+    pass

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/alembic/versions/b601eb913efa_add_tick_selector_index.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/alembic/versions/b601eb913efa_add_tick_selector_index.py
@@ -1,0 +1,22 @@
+"""add tick selector index
+
+Revision ID: b601eb913efa
+Revises: 16e3115a602a
+Create Date: 2022-03-25 10:28:53.372766
+
+"""
+from dagster.core.storage.migration.utils import create_tick_selector_index
+
+# revision identifiers, used by Alembic.
+revision = "b601eb913efa"
+down_revision = "16e3115a602a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_tick_selector_index()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
Adds a table index over selector/timestamp for the ticks table.

We'll need to do this before switching over to do reads by selector.


## Test Plan
BK


