### PR TITLE
Make it possible to disable memoization from launched runs

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -57,6 +57,7 @@ def create_valid_pipeline_run(graphene_info, external_pipeline, execution_params
         graphene_info, execution_params
     )
 
+    tags = merge_dicts(external_pipeline.tags, execution_params.execution_metadata.tags)
     external_execution_plan = get_external_execution_plan_or_raise(
         graphene_info=graphene_info,
         external_pipeline=external_pipeline,
@@ -64,8 +65,8 @@ def create_valid_pipeline_run(graphene_info, external_pipeline, execution_params
         run_config=execution_params.run_config,
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
+        tags=tags,
     )
-    tags = merge_dicts(external_pipeline.tags, execution_params.execution_metadata.tags)
 
     pipeline_run = graphene_info.context.instance.create_run(
         pipeline_snapshot=external_pipeline.pipeline_snapshot,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -93,6 +93,7 @@ def get_external_execution_plan_or_raise(
     run_config,
     step_keys_to_execute,
     known_state,
+    tags,
 ):
 
     return graphene_info.context.get_external_execution_plan(
@@ -101,6 +102,7 @@ def get_external_execution_plan_or_raise(
         mode=mode,
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
+        tags=tags,
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -353,6 +353,7 @@ def get_execution_plan(graphene_info, selector, run_config, mode):
             run_config=run_config,
             step_keys_to_execute=None,
             known_state=None,
+            tags=external_pipeline.tags,
         )
     )
 

--- a/python_modules/dagster-test/dagster_test/toys/memoization.py
+++ b/python_modules/dagster-test/dagster_test/toys/memoization.py
@@ -1,0 +1,17 @@
+from dagster import SourceHashVersionStrategy, job, op
+
+
+@op(config_schema=str)
+def emit_op(context):
+    return context.op_config
+
+
+@op(config_schema=str)
+def consume_op(context, inp):
+    return inp + context.op_config
+
+
+@job(version_strategy=SourceHashVersionStrategy())
+def memoization_job():
+    consume_op(emit_op())
+    consume_op(emit_op())

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -11,6 +11,7 @@ from dagster_test.toys.log_s3 import log_s3_pipeline
 from dagster_test.toys.log_spew import log_spew
 from dagster_test.toys.longitudinal import longitudinal_pipeline
 from dagster_test.toys.many_events import many_events
+from dagster_test.toys.memoization import memoization_job
 from dagster_test.toys.notebooks import hello_world_notebook_pipeline
 from dagster_test.toys.retries import retry_pipeline
 from dagster_test.toys.sleepy import sleepy_pipeline
@@ -56,6 +57,7 @@ def toys_repository():
             asset_lineage_partition_set,
             model_pipeline,
             hello_world_notebook_pipeline,
+            memoization_job,
         ]
         + get_toys_schedules()
         + get_toys_sensors()

--- a/python_modules/dagster/dagster/api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/api/snapshot_execution_plan.py
@@ -26,6 +26,7 @@ def sync_get_external_execution_plan_grpc(
     step_keys_to_execute: Optional[List[str]] = None,
     known_state: Optional[KnownExecutionState] = None,
     instance: Optional[DagsterInstance] = None,
+    tags: Optional[Mapping[str, object]] = None,
 ) -> ExecutionPlanSnapshot:
     from dagster.grpc.client import DagsterGrpcClient
 
@@ -50,6 +51,7 @@ def sync_get_external_execution_plan_grpc(
                 pipeline_snapshot_id=pipeline_snapshot_id,
                 known_state=known_state,
                 instance_ref=instance.get_ref() if instance and instance.is_persistent else None,
+                tags=tags,
             )
         ),
         (ExecutionPlanSnapshot, ExecutionPlanSnapshotErrorData),

--- a/python_modules/dagster/dagster/cli/pipeline.py
+++ b/python_modules/dagster/dagster/cli/pipeline.py
@@ -545,6 +545,7 @@ def _create_external_pipeline_run(
         step_keys_to_execute=None,
         known_state=None,
         instance=instance,
+        tags=tags,
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 

--- a/python_modules/dagster/dagster/core/execution/api.py
+++ b/python_modules/dagster/dagster/core/execution/api.py
@@ -1,6 +1,6 @@
 import sys
 from contextlib import contextmanager
-from typing import Any, Dict, FrozenSet, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, Iterator, List, Mapping, Optional, Tuple, Union
 
 from dagster import check
 from dagster.core.definitions import IPipeline, JobDefinition, PipelineDefinition
@@ -739,7 +739,7 @@ def create_execution_plan(
     step_keys_to_execute: Optional[List[str]] = None,
     known_state: Optional[KnownExecutionState] = None,
     instance_ref: Optional[InstanceRef] = None,
-    tags: Optional[Dict[str, str]] = None,
+    tags: Optional[Mapping[str, object]] = None,
 ) -> ExecutionPlan:
     pipeline = _check_pipeline(pipeline)
     pipeline_def = pipeline.get_definition()
@@ -748,7 +748,7 @@ def create_execution_plan(
     mode = check.opt_str_param(mode, "mode", default=pipeline_def.get_default_mode_name())
     check.opt_nullable_list_param(step_keys_to_execute, "step_keys_to_execute", of_type=str)
     check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
-    tags = check.opt_dict_param(tags, "tags", key_type=str, value_type=str)
+    tags = check.opt_dict_param(tags, "tags", key_type=str)
 
     resolved_run_config = ResolvedRunConfig.build(pipeline_def, run_config, mode=mode)
 

--- a/python_modules/dagster/dagster/core/execution/backfill.py
+++ b/python_modules/dagster/dagster/core/execution/backfill.py
@@ -261,6 +261,7 @@ def create_backfill_run(
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
         instance=instance,
+        tags=partition_data.tags,
     )
 
     log_action(

--- a/python_modules/dagster/dagster/core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/core/executor/multiprocess.py
@@ -43,6 +43,7 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
         recon_pipeline,
         retry_mode,
         known_state,
+        tags,
     ):
         self.run_config = run_config
         self.pipeline_run = pipeline_run
@@ -52,6 +53,7 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
         self.recon_pipeline = recon_pipeline
         self.retry_mode = retry_mode
         self.known_state = known_state
+        self.tags = tags
 
     def execute(self):
         pipeline = self.recon_pipeline
@@ -63,6 +65,7 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
                 mode=self.pipeline_run.mode,
                 step_keys_to_execute=[self.step_key],
                 known_state=self.known_state,
+                tags=self.tags,
             )
 
             yield instance.report_engine_event(
@@ -201,6 +204,7 @@ class MultiprocessExecutor(Executor):
                                 term_events,
                                 self.retries,
                                 active_execution.get_known_state(),
+                                plan_context.pipeline_run.tags,
                             )
 
                     # process active iterators
@@ -301,6 +305,7 @@ def execute_step_out_of_process(
     term_events,
     retries,
     known_state,
+    tags,
 ):
     command = MultiprocessExecutorChildProcessCommand(
         run_config=step_context.run_config,
@@ -311,6 +316,7 @@ def execute_step_out_of_process(
         recon_pipeline=pipeline,
         retry_mode=retries,
         known_state=known_state,
+        tags=tags,
     )
 
     yield DagsterEvent.engine_event(

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -120,6 +120,7 @@ class RepositoryLocation(AbstractContextManager):
         step_keys_to_execute: Optional[List[str]],
         known_state: Optional[KnownExecutionState],
         instance: Optional[DagsterInstance] = None,
+        tags: Optional[Mapping[str, object]] = None,
     ) -> ExternalExecutionPlan:
         pass
 
@@ -345,6 +346,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         step_keys_to_execute: Optional[List[str]],
         known_state: Optional[KnownExecutionState],
         instance: Optional[DagsterInstance] = None,
+        tags: Optional[Mapping[str, object]] = None,
     ) -> ExternalExecutionPlan:
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         check.dict_param(run_config, "run_config")
@@ -362,6 +364,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
             instance_ref=instance.get_ref() if instance and instance.is_persistent else None,
+            tags=tags,
         )
         return ExternalExecutionPlan(
             execution_plan_snapshot=snapshot_from_execution_plan(
@@ -649,6 +652,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         step_keys_to_execute: Optional[List[str]],
         known_state: Optional[KnownExecutionState],
         instance: Optional[DagsterInstance] = None,
+        tags: Optional[Mapping[str, object]] = None,
     ) -> ExternalExecutionPlan:
         check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
         run_config = check.dict_param(run_config, "run_config")
@@ -667,6 +671,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
             instance=instance,
+            tags=tags,
         )
 
         return ExternalExecutionPlan(execution_plan_snapshot=execution_plan_snapshot_or_error)

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -5,7 +5,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from contextlib import ExitStack
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union, cast
 
 from dagster import check
 from dagster.core.errors import DagsterInvariantViolationError, DagsterRepositoryLocationLoadError
@@ -200,6 +200,7 @@ class BaseWorkspaceRequestContext(IWorkspace):
         mode: str,
         step_keys_to_execute: List[str],
         known_state: KnownExecutionState,
+        tags: Optional[Mapping[str, object]] = None,
     ) -> ExternalExecutionPlan:
         return self.get_repository_location(
             external_pipeline.handle.location_name
@@ -210,6 +211,7 @@ class BaseWorkspaceRequestContext(IWorkspace):
             step_keys_to_execute=step_keys_to_execute,
             known_state=known_state,
             instance=self.instance,
+            tags=tags,
         )
 
     def get_external_partition_config(

--- a/python_modules/dagster/dagster/daemon/sensor.py
+++ b/python_modules/dagster/dagster/daemon/sensor.py
@@ -585,16 +585,6 @@ def _create_sensor_run(
 ):
     from dagster.daemon.daemon import get_telemetry_daemon_session_id
 
-    external_execution_plan = repo_location.get_external_execution_plan(
-        external_pipeline,
-        run_request.run_config,
-        target_data.mode,
-        step_keys_to_execute=None,
-        known_state=None,
-        instance=instance,
-    )
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
-
     pipeline_tags = external_pipeline.tags or {}
     check_tags(pipeline_tags, "pipeline_tags")
     tags = merge_dicts(
@@ -603,6 +593,18 @@ def _create_sensor_run(
     )
     if run_request.run_key:
         tags[RUN_KEY_TAG] = run_request.run_key
+
+    external_execution_plan = repo_location.get_external_execution_plan(
+        external_pipeline,
+        run_request.run_config,
+        target_data.mode,
+        step_keys_to_execute=None,
+        known_state=None,
+        instance=instance,
+        tags=tags,
+    )
+
+    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
     log_action(
         instance,

--- a/python_modules/dagster/dagster/grpc/impl.py
+++ b/python_modules/dagster/dagster/grpc/impl.py
@@ -370,6 +370,7 @@ def get_external_execution_plan_snapshot(recon_pipeline, args):
                 step_keys_to_execute=args.step_keys_to_execute,
                 known_state=args.known_state,
                 instance_ref=args.instance_ref,
+                tags=args.tags,
             ),
             args.pipeline_snapshot_id,
         )

--- a/python_modules/dagster/dagster/grpc/types.py
+++ b/python_modules/dagster/dagster/grpc/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, List, Mapping, NamedTuple, Optional
 
 from dagster import check
 from dagster.core.code_pointer import CodePointer
@@ -29,6 +29,7 @@ class ExecutionPlanSnapshotArgs(
             ("pipeline_snapshot_id", str),
             ("known_state", Optional[KnownExecutionState]),
             ("instance_ref", Optional[InstanceRef]),
+            ("tags", Optional[Mapping[str, object]]),
         ],
     )
 ):
@@ -42,6 +43,7 @@ class ExecutionPlanSnapshotArgs(
         pipeline_snapshot_id: str,
         known_state: Optional[KnownExecutionState] = None,
         instance_ref: Optional[InstanceRef] = None,
+        tags: Optional[Mapping[str, object]] = None,
     ):
         return super(ExecutionPlanSnapshotArgs, cls).__new__(
             cls,
@@ -57,6 +59,7 @@ class ExecutionPlanSnapshotArgs(
             pipeline_snapshot_id=check.str_param(pipeline_snapshot_id, "pipeline_snapshot_id"),
             known_state=check.opt_inst_param(known_state, "known_state", KnownExecutionState),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
+            tags=check.opt_dict_param(tags, "tags", key_type=str),
         )
 
 

--- a/python_modules/dagster/dagster/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/scheduler/scheduler.py
@@ -527,15 +527,6 @@ def _create_scheduler_run(
     run_config = run_request.run_config
     schedule_tags = run_request.tags
 
-    external_execution_plan = repo_location.get_external_execution_plan(
-        external_pipeline,
-        run_config,
-        external_schedule.mode,
-        step_keys_to_execute=None,
-        known_state=None,
-    )
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
-
     pipeline_tags = external_pipeline.tags or {}
     check_tags(pipeline_tags, "pipeline_tags")
     tags = merge_dicts(pipeline_tags, schedule_tags)
@@ -543,6 +534,16 @@ def _create_scheduler_run(
     tags[SCHEDULED_EXECUTION_TIME_TAG] = to_timezone(schedule_time, "UTC").isoformat()
     if run_request.run_key:
         tags[RUN_KEY_TAG] = run_request.run_key
+
+    external_execution_plan = repo_location.get_external_execution_plan(
+        external_pipeline,
+        run_config,
+        external_schedule.mode,
+        step_keys_to_execute=None,
+        known_state=None,
+        tags=tags,
+    )
+    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
     log_action(
         instance,


### PR DESCRIPTION
By setting `{MEMOIZED_RUN_TAG: "false"}`, we espouse that you can disable memoization. However, because we don't thread tags through to all creations of the execution plan, it doesn't actually work from dagit, or out-of-process runs in general, causing the error shown [here](https://github.com/dagster-io/dagster/issues/6311). This PR aims to fix this by threading tags through to all creations of the execution plan.