### PR TITLE
refactor: rename is_failure to is_failure_or_canceled

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -548,7 +548,7 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
         _do_retry_intermediates_test(graphql_context, run_id, reexecution_run_id)
         reexecution_run = graphql_context.instance.get_run_by_id(reexecution_run_id)
 
-        assert reexecution_run.is_failure
+        assert reexecution_run.is_failure_or_canceled
 
     def test_retry_early_terminate(self, graphql_context):
         instance = graphql_context.instance

--- a/python_modules/dagster/dagster/core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/core/storage/pipeline_run.py
@@ -412,6 +412,10 @@ class PipelineRun(
 
     @property
     def is_failure(self):
+        return self.status == PipelineRunStatus.FAILURE
+
+    @property
+    def is_failure_or_canceled(self):
         return self.status == PipelineRunStatus.FAILURE or self.status == PipelineRunStatus.CANCELED
 
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_execution.py
@@ -702,7 +702,7 @@ def test_pipeline_init_failure():
     event = result.event_list[-1]
     assert event.event_type_value == "PIPELINE_FAILURE"
     assert event.pipeline_failure_data
-    assert mem_instance.get_run_by_id(result.run_id).is_failure
+    assert mem_instance.get_run_by_id(result.run_id).is_failure_or_canceled
 
     with instance_for_test() as fs_instance:
         result = execute_pipeline(
@@ -715,7 +715,7 @@ def test_pipeline_init_failure():
         event = result.event_list[-1]
         assert event.event_type_value == "PIPELINE_FAILURE"
         assert event.pipeline_failure_data
-        assert fs_instance.get_run_by_id(result.run_id).is_failure
+        assert fs_instance.get_run_by_id(result.run_id).is_failure_or_canceled
 
 
 def test_reexecution_fs_storage():


### PR DESCRIPTION
<!--- Hello Dagster contributor! It's great to have you with us! -->
<!-- Make sure to read https://docs.dagster.io/community/contributing -->

## Summary
This could technically break people who are using our internal APIs? considering that this is returned in the results when executing in process. 

- rename existing references of DagsterRun instances invoking `.is_failure` to `.is_failure_or_canceled`
- implement `.is_failure` to only check for failure status


## Test Plan
existing bk



