### PR TITLE
Make Output generic

### DIFF
--- a/python_modules/dagster/dagster/core/definitions/events.py
+++ b/python_modules/dagster/dagster/core/definitions/events.py
@@ -7,11 +7,13 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generic,
     List,
     Mapping,
     NamedTuple,
     Optional,
     Sequence,
+    TypeVar,
     Union,
     cast,
 )
@@ -176,6 +178,9 @@ class AssetLineageInfo(
         return super(AssetLineageInfo, cls).__new__(cls, asset_key=asset_key, partitions=partitions)
 
 
+T = TypeVar("T")
+
+
 class Output(
     NamedTuple(
         "_Output",
@@ -184,7 +189,8 @@ class Output(
             ("output_name", str),
             ("metadata_entries", List[Union[PartitionMetadataEntry, MetadataEntry]]),
         ],
-    )
+    ),
+    Generic[T],
 ):
     """Event corresponding to one of a op's outputs.
 
@@ -210,7 +216,7 @@ class Output(
 
     def __new__(
         cls,
-        value: Any,
+        value: T,
         output_name: Optional[str] = DEFAULT_OUTPUT,
         metadata_entries: Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         metadata: Optional[Dict[str, RawMetadataValue]] = None,

--- a/python_modules/dagster/dagster/core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/core/definitions/reconstruct.py
@@ -582,7 +582,7 @@ def def_from_pointer(
     # if its a function invoke it - otherwise we are pointing to a
     # artifact in module scope, likely decorator output
 
-    if seven.get_args(target):
+    if seven.get_arg_names(target):
         raise DagsterInvariantViolationError(
             "Error invoking function at {target} with no arguments. "
             "Reconstructable target must be callable with no arguments".format(

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -68,6 +68,7 @@ def _coerce_solid_compute_fn_to_iterator(fn, output_defs, context, context_arg_p
 
 
 def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
+    from dagster.core.definitions.events import DEFAULT_OUTPUT
 
     if isinstance(result, (AssetMaterialization, Materialization, ExpectationResult)):
         raise DagsterInvariantViolationError(
@@ -110,6 +111,13 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
 
         for output_def, element in zip(output_defs, result):
             if isinstance(element, Output):
+                if (
+                    not element.output_name == DEFAULT_OUTPUT
+                    and not element.output_name == output_def.name
+                ):
+                    raise DagsterInvariantViolationError(
+                        f"Received output named '{element.output_name}', but expected output named '{output_def.name}'."
+                    )
                 yield Output(
                     output_name=output_def.name,
                     value=element.value,

--- a/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/core/execution/plan/compute_generator.py
@@ -109,8 +109,15 @@ def _validate_and_coerce_solid_result_to_iterator(result, context, output_defs):
             )
 
         for output_def, element in zip(output_defs, result):
-            metadata = context.get_output_metadata(output_def.name)
-            yield Output(output_name=output_def.name, value=element, metadata=metadata)
+            if isinstance(element, Output):
+                yield Output(
+                    output_name=output_def.name,
+                    value=element.value,
+                    metadata_entries=element.metadata_entries,
+                )
+            else:
+                metadata = context.get_output_metadata(output_def.name)
+                yield Output(output_name=output_def.name, value=element, metadata=metadata)
     elif result is not None:
         if not output_defs:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -4,11 +4,13 @@ from enum import Enum as PythonEnum
 from functools import partial
 from typing import cast
 
+from typing_compat import get_args, get_origin
+
 from dagster import check
 from dagster.builtins import BuiltinEnum
 from dagster.config.config_type import Array, ConfigType
 from dagster.config.config_type import Noneable as ConfigNoneable
-from dagster.core.definitions.events import TypeCheck
+from dagster.core.definitions.events import Output, TypeCheck
 from dagster.core.definitions.metadata import MetadataEntry, RawMetadataValue, normalize_metadata
 from dagster.core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster.serdes import whitelist_for_serdes
@@ -825,6 +827,8 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     if is_typing_type(dagster_type):
         dagster_type = transform_typing_type(dagster_type)
 
+    if get_origin(dagster_type) == Output:
+        dagster_type = get_args(dagster_type)[0]
     if isinstance(dagster_type, DagsterType):
         return dagster_type
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -823,12 +823,13 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         "Do not pass runtime type classes. Got {}".format(dagster_type),
     )
 
-    # First check to see if it is part of python's typing library
-    if is_typing_type(dagster_type):
-        dagster_type = transform_typing_type(dagster_type)
-
+    # First, check to see if we're using Dagster's generic output type to do the type catching.
     if get_origin(dagster_type) == Output:
         dagster_type = get_args(dagster_type)[0]
+
+    # Then, check to see if it is part of python's typing library
+    if is_typing_type(dagster_type):
+        dagster_type = transform_typing_type(dagster_type)
     if isinstance(dagster_type, DagsterType):
         return dagster_type
 

--- a/python_modules/dagster/dagster/core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/core/types/dagster_type.py
@@ -4,8 +4,6 @@ from enum import Enum as PythonEnum
 from functools import partial
 from typing import cast
 
-from typing_compat import get_args, get_origin
-
 from dagster import check
 from dagster.builtins import BuiltinEnum
 from dagster.config.config_type import Array, ConfigType
@@ -229,9 +227,9 @@ class DagsterType:
 
 
 def _validate_type_check_fn(fn: t.Callable, name: t.Optional[str]) -> bool:
-    from dagster.seven import get_args
+    from dagster.seven import get_arg_names
 
-    args = get_args(fn)
+    args = get_arg_names(fn)
 
     # py2 doesn't filter out self
     if len(args) >= 1 and args[0] == "self":
@@ -806,6 +804,7 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         is_supported_runtime_python_builtin,
         remap_python_builtin_for_runtime,
     )
+    from dagster.seven.typing import get_args, get_origin
     from dagster.utils.typing_api import is_typing_type
 
     from .python_dict import Dict, PythonDict

--- a/python_modules/dagster/dagster/seven/__init__.py
+++ b/python_modules/dagster/dagster/seven/__init__.py
@@ -66,7 +66,7 @@ def is_ascii(str_):
 time_fn = time.perf_counter
 
 
-def get_args(callable_):
+def get_arg_names(callable_):
     return [
         parameter.name
         for parameter in inspect.signature(callable_).parameters.values()

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -828,6 +828,13 @@ def test_output_generic_correct_inner_type():
     result = execute_op_in_graph(the_op_not_using_output)
     assert result.success
 
+    @op
+    def the_op_annotation_not_using_output() -> int:
+        return Output(42)
+
+    result = execute_op_in_graph(the_op_annotation_not_using_output)
+    assert result.success
+
 
 def test_generic_output_tuple_op():
     @op(out={"out1": Out(), "out2": Out()})

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -816,3 +816,23 @@ def test_generic_output_op():
         '"Int". Description: Value "foo" of python type "str" must be a int.',
     ):
         execute_op_in_graph(the_op_bad_type_match)
+
+
+def test_generic_output_tuple_op():
+    @op(out={"out1": Out(), "out2": Out()})
+    def the_op() -> Tuple[Output[str], Output[int]]:
+        return (Output("foo"), Output(5))
+
+    result = execute_op_in_graph(the_op)
+    assert result.success
+
+    @op(out={"out1": Out(), "out2": Out()})
+    def the_op_bad_type_match() -> Tuple[Output[str], Output[int]]:
+        return (Output("foo"), Output("foo"))
+
+    with pytest.raises(
+        DagsterTypeCheckDidNotPass,
+        match='Type check failed for step output "out2" - expected type "Int". '
+        'Description: Value "foo" of python type "str" must be a int.',
+    ):
+        execute_op_in_graph(the_op_bad_type_match)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -836,6 +836,28 @@ def test_output_generic_correct_inner_type():
     assert result.success
 
 
+def test_output_generic_type_mismatches():
+    @op
+    def the_op_annotation_type_mismatch() -> int:
+        return Output("foo")  # type: ignore[return-value]
+
+    with pytest.raises(
+        DagsterTypeCheckDidNotPass,
+        match='Type check failed for step output "result" - expected type "Int". Description: Value "foo" of python type "str" must be a int.',
+    ):
+        execute_op_in_graph(the_op_annotation_type_mismatch)
+
+    @op
+    def the_op_output_annotation_type_mismatch() -> Output[int]:
+        return "foo"  # type: ignore[return-value]
+
+    with pytest.raises(
+        DagsterTypeCheckDidNotPass,
+        match='Type check failed for step output "result" - expected type "Int". Description: Value "foo" of python type "str" must be a int.',
+    ):
+        execute_op_in_graph(the_op_output_annotation_type_mismatch)
+
+
 def test_generic_output_tuple_op():
     @op(out={"out1": Out(), "out2": Out()})
     def the_op() -> Tuple[Output[str], Output[int]]:

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -802,6 +802,8 @@ def test_generic_output_op():
     def the_op() -> Output[str]:
         return Output("foo")
 
+    assert the_op.output_def_named("result").dagster_type.key == "String"
+
     result = execute_op_in_graph(the_op)
     assert result.success
     assert result.output_for_node("the_op") == "foo"
@@ -816,6 +818,15 @@ def test_generic_output_op():
         '"Int". Description: Value "foo" of python type "str" must be a int.',
     ):
         execute_op_in_graph(the_op_bad_type_match)
+
+
+def test_output_generic_correct_inner_type():
+    @op
+    def the_op_not_using_output() -> Output[int]:
+        return 42
+
+    result = execute_op_in_graph(the_op_not_using_output)
+    assert result.success
 
 
 def test_generic_output_tuple_op():
@@ -836,3 +847,12 @@ def test_generic_output_tuple_op():
         'Description: Value "foo" of python type "str" must be a int.',
     ):
         execute_op_in_graph(the_op_bad_type_match)
+
+
+def test_generic_output_tuple_complex_types():
+    @op(out={"out1": Out(), "out2": Out()})
+    def the_op() -> Tuple[Output[List[str]], Output[Dict[str, str]]]:
+        return (Output(["foo"]), Output({"foo": "bar"}))
+
+    result = execute_op_in_graph(the_op)
+    assert result.success

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -1,3 +1,4 @@
+# type: ignore[return-value]
 import time
 from typing import Dict, Generator, List, Tuple
 
@@ -839,7 +840,6 @@ def test_output_generic_correct_inner_type():
 def test_output_generic_type_mismatches():
     @op
     def the_op_annotation_type_mismatch() -> int:
-        # type: ignore[return-value]
         return Output("foo")
 
     with pytest.raises(
@@ -850,7 +850,6 @@ def test_output_generic_type_mismatches():
 
     @op
     def the_op_output_annotation_type_mismatch() -> Output[int]:
-        # type: ignore[return-value]
         return "foo"
 
     with pytest.raises(
@@ -896,6 +895,6 @@ def test_generic_output_name_mismatch():
 
     with pytest.raises(
         DagsterInvariantViolationError,
-        match="Received output named 'out2', but expected output named 'out1'.",
+        match="Bad state: Received a tuple of outputs. An output was explicitly named 'out2', which does not match the output definition specified for position 0: 'out1'.",
     ):
         execute_op_in_graph(the_op)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -795,3 +795,24 @@ def test_args_kwargs_op():
 
     result = the_graph_provides_inputs.execute_in_process()
     assert result.success
+
+
+def test_generic_output_op():
+    @op
+    def the_op() -> Output[str]:
+        return Output("foo")
+
+    result = execute_op_in_graph(the_op)
+    assert result.success
+    assert result.output_for_node("the_op") == "foo"
+
+    @op
+    def the_op_bad_type_match() -> Output[int]:
+        return Output("foo")
+
+    with pytest.raises(
+        DagsterTypeCheckDidNotPass,
+        match='Type check failed for step output "result" - expected type '
+        '"Int". Description: Value "foo" of python type "str" must be a int.',
+    ):
+        execute_op_in_graph(the_op_bad_type_match)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -839,7 +839,8 @@ def test_output_generic_correct_inner_type():
 def test_output_generic_type_mismatches():
     @op
     def the_op_annotation_type_mismatch() -> int:
-        return Output("foo")  # type: ignore[return-value]
+        # type: ignore[return-value]
+        return Output("foo")
 
     with pytest.raises(
         DagsterTypeCheckDidNotPass,
@@ -849,7 +850,8 @@ def test_output_generic_type_mismatches():
 
     @op
     def the_op_output_annotation_type_mismatch() -> Output[int]:
-        return "foo"  # type: ignore[return-value]
+        # type: ignore[return-value]
+        return "foo"
 
     with pytest.raises(
         DagsterTypeCheckDidNotPass,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_op.py
@@ -885,3 +885,15 @@ def test_generic_output_tuple_complex_types():
 
     result = execute_op_in_graph(the_op)
     assert result.success
+
+
+def test_generic_output_name_mismatch():
+    @op(out={"out1": Out(), "out2": Out()})
+    def the_op() -> Tuple[Output[int], Output[str]]:
+        return (Output("foo", output_name="out2"), Output(42, output_name="out1"))
+
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="Received output named 'out2', but expected output named 'out1'.",
+    ):
+        execute_op_in_graph(the_op)

--- a/python_modules/dagster/dagster_tests/general_tests/seven_tests/test_seven.py
+++ b/python_modules/dagster/dagster_tests/general_tests/seven_tests/test_seven.py
@@ -40,14 +40,14 @@ def test_tempdir():
     assert not seven.temp_dir.get_system_temp_directory().startswith("/var")
 
 
-def test_get_args():
+def test_get_arg_names():
     def foo(one, two=2, three=None):  # pylint: disable=unused-argument
         pass
 
-    assert len(seven.get_args(foo)) == 3
-    assert "one" in seven.get_args(foo)
-    assert "two" in seven.get_args(foo)
-    assert "three" in seven.get_args(foo)
+    assert len(seven.get_arg_names(foo)) == 3
+    assert "one" in seven.get_arg_names(foo)
+    assert "two" in seven.get_arg_names(foo)
+    assert "three" in seven.get_arg_names(foo)
 
 
 def test_is_lambda():


### PR DESCRIPTION
This makes it possible to use Output as a generic type annotation, in both the singleton case and the tuple case.

Relies on the `typing_compat` library, which is only available for python >= 3.5. I think we already make use of this though, so hopefully shouldn't be an issue?