### PR TITLE
[dagit] Load “Launch Asset partitions” modal when it’s opened + every time

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -34,6 +34,7 @@ export function usePartitionHealthData(assetKeys: AssetKey[]) {
     const load = async () => {
       const {data} = await client.query<PartitionHealthQuery, PartitionHealthQueryVariables>({
         query: PARTITION_HEALTH_QUERY,
+        fetchPolicy: 'network-only',
         variables: {
           assetKey: {path: loadKey.path},
         },


### PR DESCRIPTION
## Summary
This is a small PR that patches two undesirable behaviors with the "Materialize Asset..." partitions modal.

1) If you closed and re-opened the modal, the health of partitions was not refetched, meaning executing an upstream item and then coming back to a downstream asset wouldn't show you the correct state. (https://github.com/dagster-io/dagster/issues/7118). I thought that explicit calls to `client.query` where always real requests and it turns out they can return from cache and not make a request at all. (Will audit the codebase for other places this might be bad).

2) The modal was actually fetching the data necessary to display it's content BEFORE it was opened, because the data provider hooks were in the same component that rendered the top level `<Dialog>`. 

Note: This also removes caching from the partition health summary shown on the asset details page and in the asset sidebar. I /think/ this is desirable, but it will result in more requests if you navigate between the same few assets.  This is an ideal use case for a basic `HTTP cache-control: max-age 30s` but there doesn't seem to be an analog for that in apollo that we can do client-side...

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.