### PR TITLE
cross-repo assets toy

### DIFF
--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/cross_repo_assets.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/cross_repo_assets.py
@@ -1,0 +1,26 @@
+# pylint: disable=redefined-outer-name
+from dagster import AssetGroup, AssetKey, SourceAsset, asset
+
+
+@asset
+def upstream_asset():
+    return 5
+
+
+upstream_asset_group = AssetGroup([upstream_asset])
+
+source_assets = [SourceAsset(AssetKey("upstream_asset"))]
+
+
+@asset
+def downstream_asset1(upstream_asset):
+    assert upstream_asset
+
+
+@asset
+def downstream_asset2(upstream_asset):
+    assert upstream_asset
+
+
+downstream_asset_group1 = AssetGroup([downstream_asset1], source_assets)
+downstream_asset_group2 = AssetGroup([downstream_asset2], source_assets)

--- a/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/graph_job_op_toys/repo.py
@@ -6,6 +6,11 @@ from dagster_test.graph_job_op_toys.asset_lineage import (
 from dagster_test.graph_job_op_toys.big_honkin_asset_graph import big_honkin_asset_group
 from dagster_test.graph_job_op_toys.branches import branch_failed_job, branch_job
 from dagster_test.graph_job_op_toys.composition import composition
+from dagster_test.graph_job_op_toys.cross_repo_assets import (
+    downstream_asset_group1,
+    downstream_asset_group2,
+    upstream_asset_group,
+)
 from dagster_test.graph_job_op_toys.dynamic import dynamic_job
 from dagster_test.graph_job_op_toys.error_monster import (
     error_monster_failing_job,
@@ -92,3 +97,18 @@ def big_honkin_assets_repository():
 @repository
 def partitioned_asset_repository():
     return [partitioned_asset_group]
+
+
+@repository
+def upstream_assets_repository():
+    return [upstream_asset_group]
+
+
+@repository
+def downstream_assets_repository1():
+    return [downstream_asset_group1]
+
+
+@repository
+def downstream_assets_repository2():
+    return [downstream_asset_group2]


### PR DESCRIPTION
To use this toy:
```
dagit -w python_modules/dagster-test/dagster_test/graph_job_op_toys/workspace.yaml
```

In the repo-selector, select these three repositories:
* upstream_assets_repository
* downstream_assets_repository1
* downstream_assets_repository2