### PR TITLE
[dagit] Explicitly add the dagster/step_selection tag to asset runs

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/asset-graph/LaunchAssetExecutionButton.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {AssetKey} from '../../assets/types';
 import {LaunchRootExecutionButton} from '../../launchpad/LaunchRootExecutionButton';
+import {DagsterTag} from '../../runs/RunTag';
 import {buildRepoAddress} from '../buildRepoAddress';
 
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
@@ -93,7 +94,14 @@ export const LaunchAssetExecutionButton: React.FC<{
           getVariables={() => ({
             executionParams: {
               mode: 'default',
-              executionMetadata: {},
+              executionMetadata: {
+                tags: [
+                  {
+                    key: DagsterTag.StepSelection,
+                    value: assets.map((o) => o.opName!).join(','),
+                  },
+                ],
+              },
               runConfigData: {},
               stepKeys: assets.map((o) => o.opName!),
               selector: {


### PR DESCRIPTION
## Summary
This addresses the problem highlighted here:
https://github.com/dagster-io/dagster/pull/7189#issuecomment-1080737539

When we launch asset runs we specify step keys, but we do not provide the step selection in a dagster tag, which the Run UI uses to determine the behavior of the Re-execute button. It's unfortunate that both need to be provided explicitly, but one is an array of step keys and the other (could) be a step query string, eg: "step_a++, step_b". 


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Slack. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.