### PR TITLE
RFC: Reconstruct Workspace Snapshot with Cross-Repo Asset Dependencies

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/multiple_repos.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/multiple_repos.py
@@ -1,0 +1,36 @@
+# pylint: disable=redefined-outer-name,unused-argument
+from dagster import AssetGroup, AssetKey, Output, SourceAsset, asset, repository
+
+
+@asset
+def my_source_asset():
+    yield Output(5)
+
+
+@asset
+def second_asset(my_source_asset):
+    yield Output(1)
+
+
+upstream_asset_group = AssetGroup(assets=[my_source_asset, second_asset])
+
+
+@repository
+def upstream_repo():
+    return [upstream_asset_group]
+
+
+my_source_asset = SourceAsset(key=AssetKey("my_source_asset"))
+
+
+@asset
+def downstream_asset(my_source_asset):
+    yield Output(5)
+
+
+asset_group = AssetGroup(assets=[downstream_asset], source_assets=[my_source_asset])
+
+
+@repository
+def downstream_repo():
+    return [asset_group]

--- a/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
+++ b/python_modules/dagster-test/dagster_test/toys/graph_job_repos.py
@@ -8,11 +8,6 @@ from dagster import (
     schedule,
     sensor,
     solid,
-    SourceAsset,
-    Output,
-    AssetGroup,
-    AssetKey,
-    asset,
 )
 from dagster.core.definitions.decorators.graph import graph
 
@@ -129,31 +124,6 @@ process_customer_data_dump_dev = process_customer_data_dump.to_job(
     config={"solids": {"process_customer": {"config": {"customer_id": "test_customer"}}}}
 )
 
-# prod repo
-@asset
-def my_source_asset():
-    yield Output(5)
-
-
-@asset
-def second_asset(my_source_asset):
-    yield Output(1)
-
-
-prod_asset_group = AssetGroup(assets=[my_source_asset, second_asset])
-
-
-# dev repo
-my_source_asset = SourceAsset(key=AssetKey("my_source_asset"))
-
-
-@asset
-def yee_asset(my_source_asset):
-    yield Output(5)
-
-
-asset_group = AssetGroup(assets=[yee_asset], source_assets=[my_source_asset])
-
 
 @repository
 def graph_job_dev_repo():
@@ -163,7 +133,6 @@ def graph_job_dev_repo():
         crm_ingest_dev,
         content_recommender_training_dev,
         process_customer_data_dump_dev,
-        asset_group,
     ]
 
 
@@ -176,5 +145,4 @@ def graph_job_prod_repo():
         crm_ingest_instance2_schedule,
         content_recommender_training_prod,
         process_customer_data_dump,
-        prod_asset_group,
     ]

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -264,7 +264,7 @@ class RepositoryLocation(AbstractContextManager):
         )
 
     @abstractmethod
-    def get_external_repositories_data(self) -> Dict[str, ExternalRepositoryData]:
+    def get_external_repositories_data(self) -> Optional[Mapping[str, ExternalRepositoryData]]:
         pass
 
     @abstractmethod
@@ -478,10 +478,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         check.str_param(notebook_path, "notebook_path")
         return get_notebook_data(notebook_path)
 
-    def get_repository_location_with_asset_data(self, cross_repo_asset_deps):
-        return InProcessRepositoryLocation()
-
-    def get_external_repositories_data(self) -> Dict[str, ExternalRepositoryData]:
+    def get_external_repositories_data(self) -> Optional[Mapping[str, ExternalRepositoryData]]:
         return {
             repo_name: repo_def.external_repository_data
             for repo_name, repo_def in self._repositories.items()
@@ -490,7 +487,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
     def update_external_repositories_data(
         self, new_external_repositories_data: Dict[str, ExternalRepositoryData]
     ):
-        self.external_repositories = {
+        self._repositories = {
             repo_name: ExternalRepository(
                 repo_data,
                 RepositoryHandle(
@@ -498,7 +495,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
                     repository_location=self,
                 ),
             )
-            for repo_name, repo_data in self._external_repositories_data.items()
+            for repo_name, repo_data in new_external_repositories_data.items()
         }
 
 
@@ -814,7 +811,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         check.str_param(notebook_path, "notebook_path")
         return sync_get_streaming_external_notebook_data_grpc(self.client, notebook_path)
 
-    def get_external_repositories_data(self) -> Dict[str, ExternalRepositoryData]:
+    def get_external_repositories_data(self) -> Optional[Mapping[str, ExternalRepositoryData]]:
         return self._external_repositories_data
 
     def update_external_repositories_data(

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -268,7 +268,9 @@ class RepositoryLocation(AbstractContextManager):
         pass
 
     @abstractmethod
-    def update_external_repositories_data(self, new_external_repositories_data):
+    def update_external_repositories_data(
+        self, new_external_repositories_data: Dict[str, ExternalRepositoryData]
+    ):
         pass
 
 
@@ -485,8 +487,9 @@ class InProcessRepositoryLocation(RepositoryLocation):
             for repo_name, repo_def in self._repositories.items()
         }
 
-    def update_external_repositories_data(self, new_external_repositories_data):
-        # TODO: checks to ensure that dict is same len
+    def update_external_repositories_data(
+        self, new_external_repositories_data: Dict[str, ExternalRepositoryData]
+    ):
         self.external_repositories = {
             repo_name: ExternalRepository(
                 repo_data,
@@ -814,10 +817,10 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
     def get_external_repositories_data(self) -> Dict[str, ExternalRepositoryData]:
         return self._external_repositories_data
 
-    def update_external_repositories(self, external_repositories_data):
-        # TODO: checks to ensure that dict is same len
-        # TODO: add try catch
-        self._external_repositories_data = external_repositories_data
+    def update_external_repositories_data(
+        self, new_external_repositories_data: Dict[str, ExternalRepositoryData]
+    ):
+        self._external_repositories_data = new_external_repositories_data
         self.external_repositories = {
             repo_name: ExternalRepository(
                 repo_data,

--- a/python_modules/dagster/dagster/core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/core/host_representation/repository_location.py
@@ -264,11 +264,11 @@ class RepositoryLocation(AbstractContextManager):
         )
 
     @abstractmethod
-    def get_external_repository_data(self) -> ExternalRepositoryData:
+    def get_external_repositories_data(self) -> Dict[str, ExternalRepositoryData]:
         pass
 
     @abstractmethod
-    def update_external_repositories(self, cross_repo_asset_deps):
+    def update_external_repositories_data(self, new_external_repositories_data):
         pass
 
 
@@ -478,6 +478,25 @@ class InProcessRepositoryLocation(RepositoryLocation):
 
     def get_repository_location_with_asset_data(self, cross_repo_asset_deps):
         return InProcessRepositoryLocation()
+
+    def get_external_repositories_data(self) -> Dict[str, ExternalRepositoryData]:
+        return {
+            repo_name: repo_def.external_repository_data
+            for repo_name, repo_def in self._repositories.items()
+        }
+
+    def update_external_repositories_data(self, new_external_repositories_data):
+        # TODO: checks to ensure that dict is same len
+        self.external_repositories = {
+            repo_name: ExternalRepository(
+                repo_data,
+                RepositoryHandle(
+                    repository_name=repo_name,
+                    repository_location=self,
+                ),
+            )
+            for repo_name, repo_data in self._external_repositories_data.items()
+        }
 
 
 class GrpcServerRepositoryLocation(RepositoryLocation):
@@ -796,7 +815,8 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         return self._external_repositories_data
 
     def update_external_repositories(self, external_repositories_data):
-        # add try catch
+        # TODO: checks to ensure that dict is same len
+        # TODO: add try catch
         self._external_repositories_data = external_repositories_data
         self.external_repositories = {
             repo_name: ExternalRepository(

--- a/python_modules/dagster/dagster/core/workspace/context.py
+++ b/python_modules/dagster/dagster/core/workspace/context.py
@@ -1,4 +1,3 @@
-import copy
 import sys
 import threading
 import time
@@ -20,6 +19,7 @@ from dagster.core.host_representation import (
     RepositoryLocation,
     RepositoryLocationOrigin,
 )
+from dagster.core.host_representation.external_data import ExternalAssetNode, ExternalRepositoryData
 from dagster.core.host_representation.grpc_server_registry import (
     GrpcServerRegistry,
     ProcessGrpcServerRegistry,
@@ -29,7 +29,6 @@ from dagster.core.host_representation.grpc_server_state_subscriber import (
     LocationStateChangeEventType,
     LocationStateSubscriber,
 )
-from dagster.core.host_representation.external_data import ExternalAssetNode, ExternalRepositoryData
 from dagster.core.host_representation.origin import GrpcServerRepositoryLocationOrigin
 from dagster.core.instance import DagsterInstance
 from dagster.grpc.server_watcher import create_grpc_watch_thread
@@ -661,7 +660,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         # from the defined assets to downstream assets in other repositories.
         cross_repo_asset_deps = self.get_cross_repo_asset_deps()
 
-        for location_name, location_entry in workspace_snapshot.items():
+        for location_entry in workspace_snapshot.values():
             repo_location = location_entry.repository_location
             if repo_location:
                 external_repos_data = repo_location.get_external_repositories_data()


### PR DESCRIPTION
I wanted to take a stab at building cross-repo asset dependencies (i.e. if an asset is defined in repo `A` and referenced as a `source_asset` in repo `B`, enable Dagit to display that the asset has external dependencies in repo `B`). This started in response to https://github.com/dagster-io/dagster/issues/6820. 

For example:
Full asset graph:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/29110579/160477002-4ec7260a-bf85-4e8d-ac7b-fadf809d33bc.png">
Selecting only upstream repository (existing behavior is that source asset displays no external dependencies):
<img width="744" alt="image" src="https://user-images.githubusercontent.com/29110579/160477058-c50162ad-d376-454c-a69e-aad04cf64744.png">
Selecting only downstream repository (existing behavior is same as the following):
<img width="505" alt="image" src="https://user-images.githubusercontent.com/29110579/160477203-96e8b2ed-e44c-4aca-a0f4-f57b64a0932e.png">

In this PR, after loading all repositories, I reconstructed the `WorkspaceSnapshot` to attach downstream dependencies of `source_asset`s to the `dependencies` arg of the original asset definition, enabling the above functionality. I don't expect to merge this PR, but wanted to get some thoughts on this approach to at least get the ball rolling on this discussion.

Open questions:
- If one repository is reloaded, is it necessary to reload all repositories to build cross-repo dependencies?
- Is there some other mutable object we need to create that can store cross-repo dependencies that can be referenced from the graphql layer?